### PR TITLE
TOTALLY PEAK: Replaces references to "Rockhill" with Azure Peak, enables femboy Consorts, changes "King" and "Queen", unlinks gendered job equipment and links them to pronouns instead, and more

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -320,7 +320,7 @@
 		if(C.vampire_werewolf() == "vampire")
 			end_reason = "When the Vampires finished sucking the town dry, they moved on to the next one."
 		if(C.vampire_werewolf() == "werewolf")
-			end_reason = "The Werevolves formed an unholy clan, marauding Rockhill until the end of its daes."
+			end_reason = "The Werevolves formed an unholy clan, marauding Azure Peak until the end of its daes."
 
 		if(C.headrebdecree)
 			end_reason = "The peasant rebels took control of the throne, hail the new community!"

--- a/code/datums/gods/faiths/divine_pantheon.dm
+++ b/code/datums/gods/faiths/divine_pantheon.dm
@@ -1,5 +1,5 @@
 /datum/faith/divine
 	name = "Divine Pantheon"
-	desc = "The most accepted religion in Rockhill. May Almighty Psydon and His ten children protect us from Zizo!"
-	worshippers = "Humans and citizens of Rockhill"
+	desc = "The most accepted religion in Azure Peak. May Almighty Psydon and His ten children protect us from Zizo!"
+	worshippers = "Humans and citizens of Azure Peak"
 	godhead = /datum/patron/divine/astrata

--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -41,7 +41,7 @@
 	roles = list(
 		/datum/migrant_role/pilgrim = 4,
 	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Rockhill, looking for refuge and work, finally almost being there, almost..."
+	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Azure Peak, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/pilgrim_down_one
 	name = "Pilgrimage"
@@ -50,7 +50,7 @@
 	roles = list(
 		/datum/migrant_role/pilgrim = 3,
 	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Rockhill, looking for refuge and work, finally almost being there, almost..."
+	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Azure Peak, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/pilgrim_down_two
 	name = "Pilgrimage"
@@ -59,7 +59,7 @@
 	roles = list(
 		/datum/migrant_role/pilgrim = 2,
 	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Rockhill, looking for refuge and work, finally almost being there, almost..."
+	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Azure Peak, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/pilgrim_down_three
 	name = "Pilgrimage"
@@ -67,7 +67,7 @@
 	roles = list(
 		/datum/migrant_role/pilgrim = 1,
 	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Rockhill, looking for refuge and work, finally almost being there, almost..."
+	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to Azure Peak, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/adventurer
 	name = "Adventure Party"
@@ -75,7 +75,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 4,
 	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Rockhill, perhaps getting ourselves into more than what we bargained for."
+	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Azure Peak, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/adventurer_down_one
 	name = "Adventure Party"
@@ -84,7 +84,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 3,
 	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Rockhill, perhaps getting ourselves into more than what we bargained for."
+	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Azure Peak, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/adventurer_down_two
 	name = "Adventure Party"
@@ -93,7 +93,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 2,
 	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Rockhill, perhaps getting ourselves into more than what we bargained for."
+	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Azure Peak, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/adventurer_down_three
 	name = "Adventure Party"
@@ -101,7 +101,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 1,
 	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Rockhill, perhaps getting ourselves into more than what we bargained for."
+	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Azure Peak, perhaps getting ourselves into more than what we bargained for."
 
 
 /datum/migrant_wave/bandit

--- a/code/datums/migrants/migrant_waves/fablefield wave.dm
+++ b/code/datums/migrants/migrant_waves/fablefield wave.dm
@@ -7,7 +7,7 @@
 		/datum/migrant_role/fablefield/goliard = 1,
 		/datum/migrant_role/fablefield/troubadour = 3,
 	)
-	greet_text = "A troupe of troubadours from fair Fablefield, you travel to Rockhill seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
+	greet_text = "A troupe of troubadours from fair Fablefield, you travel to Azure Peak seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
 
 /datum/migrant_wave/fablefield_down_one
 	name = "The Fablefield Troupe"
@@ -17,4 +17,4 @@
 		/datum/migrant_role/fablefield/goliard = 1,
 		/datum/migrant_role/fablefield/troubadour = 2,
 	)
-	greet_text = "A troupe of troubadours from fair Fablefield, you travel to Rockhill seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
+	greet_text = "A troupe of troubadours from fair Fablefield, you travel to Azure Peak seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -152,7 +152,7 @@
 				if(H.job)
 					var/datum/job/J = SSjob.GetJob(H.job)
 					used_title = J.title
-					if(H.gender == FEMALE && J.f_title)
+					if(H.pronouns == SHE_HER && J.f_title)
 						used_title = J.f_title
 				if(!used_title)
 					used_title = "unknown"

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_night = null
 
 /area/rogue/outdoors/rtfield
-	name = "rockhill basin"
+	name = "azure basin"
 	icon_state = "rtfield"
 	soundenv = 19
 	ambush_times = list("night")
@@ -121,7 +121,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 30,
 				/mob/living/carbon/human/species/skeleton/npc/ambush = 50)
-	first_time_text = "ROCKHILL BASIN"
+	first_time_text = "AZURE BASIN"
 	droning_sound = 'sound/music/area/field.ogg'
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
@@ -390,7 +390,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = null
 	droning_sound_night = null
 	converted_type = /area/rogue/outdoors/exposed/manorgarri
-	first_time_text = "THE KEEP OF ROCKHILL"
+	first_time_text = "THE KEEP OF AZURE PEAK"
 /area/rogue/outdoors/exposed/manorgarri
 	icon_state = "manorgarri"
 	droning_sound = 'sound/music/area/manorgarri.ogg'
@@ -542,7 +542,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter/town
-	first_time_text = "THE TOWN OF ROCKHILL"
+	first_time_text = "THE TOWN OF AZURE PEAK"
 /area/rogue/indoors/shelter/town
 	icon_state = "town"
 	droning_sound = 'sound/music/area/townstreets.ogg'

--- a/code/game/gamemodes/objectives_rogue.dm
+++ b/code/game/gamemodes/objectives_rogue.dm
@@ -39,8 +39,8 @@
 
 /datum/objective/werewolf
 	name = "conquer"
-	explanation_text = "Put an end to the vampire scourge in Rockhill, or unite with them against the forces of the Nine."
-	team_explanation_text = "The feud between werewolves and vampires reaches back to the dawn of time. Will the two factions destroy each other, or find a way to coexist and face the mortals of Rockhill together?"
+	explanation_text = "Put an end to the vampire scourge in Azure Peak, or unite with them against the forces of the Nine."
+	team_explanation_text = "The feud between werewolves and vampires reaches back to the dawn of time. Will the two factions destroy each other, or find a way to coexist and face the mortals of Azure Peak together?"
 	triumph_count = 5
 
 /datum/objective/werewolf/check_completion()
@@ -51,8 +51,8 @@
 
 /datum/objective/vampire
 	name = "conquer"
-	explanation_text = "Put an end to the werewolf menace in Rockhill, or unite with them against the forces of the Nine."
-	team_explanation_text = "The feud between werewolves and vampires reaches back to the dawn of time. Will the two factions destroy each other, or find a way to coexist and face the mortals of Rockhill together?"
+	explanation_text = "Put an end to the werewolf menace in Azure Peak, or unite with them against the forces of the Nine."
+	team_explanation_text = "The feud between werewolves and vampires reaches back to the dawn of time. Will the two factions destroy each other, or find a way to coexist and face the mortals of Azure Peak together?"
 	triumph_count = 5
 
 /datum/objective/vampire/check_completion()

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -139,7 +139,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	delete_after_roundstart = FALSE
 
 /obj/effect/landmark/start/lord
-	name = "King"
+	name = "Monarch"
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/knight
@@ -328,7 +328,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/lady
-	name = "Queen Consort"
+	name = "Consort"
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/prince
@@ -336,7 +336,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/prisonerr
-	name = "Prisoner (Rockhill)"
+	name = "Prisoner (Azure Keep)"
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/prisonerb

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -60,7 +60,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/HU = user
 
-		if((HU.job != "King") && (HU.job != "Queen Consort"))
+		if((HU.job != "Monarch") && (HU.job != "Consort"))
 			to_chat(user, span_danger("The rod doesn't obey me."))
 			return
 

--- a/code/game/objects/structures/roguetown/telescope.dm
+++ b/code/game/objects/structures/roguetown/telescope.dm
@@ -35,5 +35,5 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/random_message = pick("you spin the globe!", "You land on Rockhill!", "You land on Zybantine!", "You land on port Ice cube!.", "You land on port Thornvale!", "You land on grenzelhoft!")
+	var/random_message = pick("you spin the globe!", "You land on Azure Peak!", "You land on Zybantine!", "You land on port Ice cube!.", "You land on port Thornvale!", "You land on grenzelhoft!")
 	to_chat(H, span_notice("[random_message]"))

--- a/code/game/objects/structures/walldeco.dm
+++ b/code/game/objects/structures/walldeco.dm
@@ -179,7 +179,7 @@
 	..()
 
 /obj/structure/fluff/walldeco/customflag
-	name = "rockhill flag"
+	name = "Azure Peak flag"
 	desc = ""
 	icon_state = "wallflag"
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -806,7 +806,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			HTML += "<tr bgcolor='#000000'><td width='60%' align='right'>"
 			var/rank = job.title
 			var/used_name = "[job.title]"
-			if(gender == FEMALE && job.f_title)
+			if(pronouns == SHE_HER && job.f_title)
 				used_name = "[job.f_title]"
 			lastJob = job
 			if(is_banned_from(user.ckey, rank))
@@ -997,7 +997,7 @@ Slots: [job.spawn_positions]</span>
 			jpval = null
 		else
 			var/used_name = "[job.title]"
-			if(gender == FEMALE && job.f_title)
+			if(pronouns == SHE_HER && job.f_title)
 				used_name = "[job.f_title]"
 			to_chat(user, "<font color='red'>You have too low PQ for [used_name] (Min PQ: [job.min_pq]), you may only set it to low.</font>")
 			jpval = JP_LOW
@@ -1531,7 +1531,9 @@ Slots: [job.spawn_positions]</span>
 					var pronouns_input = input(user, "Choose your character's pronouns", "Pronouns") as null|anything in GLOB.pronouns_list
 					if(pronouns_input)
 						pronouns = pronouns_input
+						ResetJobs()
 						to_chat(user, "<font color='red'>Your character's pronouns are now [pronouns].")
+						to_chat(user, "<font color='red'><b>Your classes have been reset.</b></font>")
 
 				// LETHALSTONE EDIT: add voice type selection
 				if ("voicetype")
@@ -1799,9 +1801,7 @@ Slots: [job.spawn_positions]</span>
 						pickedGender = "female"
 					if(pickedGender && pickedGender != gender)
 						gender = pickedGender
-						ResetJobs()
 						to_chat(user, "<font color='red'>Your character will now use a [friendlyGenders[pickedGender]] sprite.")
-						to_chat(user, "<font color='red'><b>Your classes have been reset.</b></font>")
 						random_character(gender)
 					genderize_customizer_entries()
 				if("domhand")

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -326,7 +326,7 @@
 	color = CLOTHING_RED
 
 /obj/item/clothing/head/roguetown/crown/serpcrown
-	name = "crown of rockhill"
+	name = "crown of azure peak"
 	desc = ""
 	icon_state = "serpcrown"
 	//dropshrink = 0
@@ -340,7 +340,7 @@
 	SSroguemachine.crown = src
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/proc/anti_stall()
-	src.visible_message(span_warning("The Crown of Rockhill crumbles to dust, the ashes spiriting away in the direction of the Keep."))
+	src.visible_message(span_warning("The Crown of Azure Peak crumbles to dust, the ashes spiriting away in the direction of the Keep."))
 	SSroguemachine.crown = null //Do not harddel.
 	qdel(src) //Anti-stall
 

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -89,6 +89,9 @@
 	name = "formal silks"
 	icon_state = "puritan_shirt"
 	allowed_race = CLOTHED_RACES_TYPES
+	sleeved = 'icons/roguetown/clothing/onmob/shirts.dmi'
+	r_sleeve_status = SLEEVE_NORMAL
+	l_sleeve_status = SLEEVE_NORMAL
 
 /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor
 	icon_state = "sailorblues"

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -184,7 +184,7 @@
 
 	if(H.islatejoin && show_in_credits)
 		var/used_title = title
-		if((H.gender == FEMALE) && f_title)
+		if((H.pronouns == SHE_HER) && f_title)
 			used_title = f_title
 		scom_announce("[H.real_name] the [used_title] arrives from Kingsfield.")
 
@@ -231,7 +231,7 @@
 	var/used_title
 	if(J)
 		used_title = J.title
-		if(gender == FEMALE && J.f_title)
+		if(pronouns == SHE_HER && J.f_title)
 			used_title = J.f_title
 	if(used_title)
 		thename = "[real_name] the [used_title]"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/noble.dm
@@ -24,7 +24,7 @@
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel)
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	id = /obj/item/clothing/ring/silver
-	if(H.gender == FEMALE)
+	if(H.pronouns == SHE_HER && H.gender == FEMALE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
@@ -37,15 +37,15 @@
 		cloak = /obj/item/clothing/cloak/raincloak/purple
 		beltl = /obj/item/storage/belt/rogue/pouch/food
 		pants = /obj/item/clothing/under/roguetown/tights/stockings/silk/random	//Added Silk Stockings for the female nobles
-	if(H.gender == MALE)
+	else
 		H.change_stat("strength", -1)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
-		pants = /obj/item/clothing/under/roguetown/tights/purple
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/purple
-		cloak = /obj/item/clothing/cloak/half
+		pants = /obj/item/clothing/under/roguetown/tights
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
+		cloak = /obj/item/clothing/cloak/raincloak/purple
 		head = /obj/item/clothing/head/roguetown/fancyhat
 	if(H.age == AGE_OLD)
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -112,8 +112,8 @@
 		SSticker.rulermob = HU
 		var/dispjob = mind.assigned_role
 		removeomen(OMEN_NOLORD)
-		say("By the authority of the gods, I pronounce you Ruler of all Rockhill!")
-		priority_announce("[real_name] the [dispjob] has named [HU.real_name] the inheritor of ROCKHILL!", title = "Long Live [HU.real_name]!", sound = 'sound/misc/bell.ogg')
+		say("By the authority of the gods, I pronounce you Ruler of all Azure Peak!")
+		priority_announce("[real_name] the [dispjob] has named [HU.real_name] the inheritor of AZURE PEAK!", title = "Long Live [HU.real_name]!", sound = 'sound/misc/bell.ogg')
 
 /mob/living/carbon/human/proc/churchexcommunicate()
 	set name = "Curse"

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -33,16 +33,7 @@
 		H.change_stat("intelligence", 2)
 		H.change_stat("perception", 2)
 
-	if(H.gender == MALE)
-		pants = /obj/item/clothing/under/roguetown/tights
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-		shoes = /obj/item/clothing/shoes/roguetown/shortboots
-		belt = /obj/item/storage/belt/rogue/leather
-		beltr = /obj/item/keyring/servant
-		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
-		head = /obj/item/clothing/head/roguetown/fancyhat
-	else
+	if(H.pronouns == SHE_HER)
 		switch(H.patron?.type)
 			if(/datum/patron/divine/eora) //Eoran loadouts
 				armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy/black
@@ -58,4 +49,12 @@
 		belt = /obj/item/storage/belt/rogue/leather
 		beltr = /obj/item/keyring/servant
 		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-
+	else
+		pants = /obj/item/clothing/under/roguetown/tights
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		belt = /obj/item/storage/belt/rogue/leather
+		beltr = /obj/item/keyring/servant
+		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
+		head = /obj/item/clothing/head/roguetown/fancyhat

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -1,14 +1,14 @@
 /datum/job/roguetown/lady
-	title = "Queen Consort"
+	title = "Consort"
 	flag = LADY
 	department_flag = NOBLEMEN
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_sexes = list(FEMALE)
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	tutorial = "Picked out of your political value rather than likely any form of love, you have become the King's most trusted confidant and likely friend throughout your marriage. Your loyalty and, perhaps, love; will be tested this day. For the daggers that threaten your beloved are as equally pointed at your own throat."
+	tutorial = "Picked out of your political value rather than likely any form of love, you have become the Monarch's most trusted confidant and likely friend throughout your marriage. Your loyalty and perhaps, love, will be tested this day. For the daggers that threaten your beloved are as equally pointed at your own throat."
 
 	spells = list(/obj/effect/proc_holder/spell/self/convertrole/servant)
 	outfit = /datum/outfit/job/roguetown/lady
@@ -21,7 +21,7 @@
 	allow_custom_genitals = TRUE
 
 /datum/job/roguetown/exlady //just used to change the ladys title
-	title = "Queen Dowager"
+	title = "Consort Dowager"
 	flag = LADY
 	department_flag = NOBLEMEN
 	faction = "Station"
@@ -40,22 +40,31 @@
 	ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NUTCRACKER, TRAIT_GENERIC)
-	beltl = /obj/item/keyring/royal
-	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	belt = /obj/item/storage/belt/rogue/leather/cloth/lady
-	if(isdwarf(H))
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress
-	else
-		if(prob(66))
-			armor = /obj/item/clothing/suit/roguetown/armor/armordress/alt
-		else
-			armor = /obj/item/clothing/suit/roguetown/armor/armordress
-	head = /obj/item/clothing/head/roguetown/hennin
-	pants = /obj/item/clothing/under/roguetown/tights/stockings/silk/random	//Added Silk Stockings for the female nobles
 //		SSticker.rulermob = H
-
-	id = /obj/item/clothing/ring/silver
-	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	if(H.pronouns == SHE_HER)
+		beltl = /obj/item/keyring/royal
+		neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+		belt = /obj/item/storage/belt/rogue/leather/cloth/lady
+		if(isdwarf(H))
+			armor = /obj/item/clothing/suit/roguetown/shirt/dress
+		else
+			if(prob(66))
+				armor = /obj/item/clothing/suit/roguetown/armor/armordress/alt
+			else
+				armor = /obj/item/clothing/suit/roguetown/armor/armordress
+		head = /obj/item/clothing/head/roguetown/hennin
+		pants = /obj/item/clothing/under/roguetown/tights/stockings/silk/random	//Added Silk Stockings for the female nobles
+		id = /obj/item/clothing/ring/silver
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	else
+		pants = /obj/item/clothing/under/roguetown/tights
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
+		armor = /obj/item/clothing/suit/roguetown/armor/chainmail
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		belt = /obj/item/storage/belt/rogue/leather
+		beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
+		backr = /obj/item/storage/backpack/rogue/satchel
+		id = /obj/item/clothing/ring/silver
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -2,8 +2,7 @@ GLOBAL_VAR(lordsurname)
 GLOBAL_LIST_EMPTY(lord_titles)
 
 /datum/job/roguetown/lord
-	title = "King"
-	f_title = "Queen"
+	title = "Monarch"
 	flag = LORD
 	department_flag = NOBLEMEN
 	faction = "Station"
@@ -35,8 +34,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	allow_custom_genitals = TRUE
 
 /datum/job/roguetown/exlord //just used to change the lords title
-	title = "King Emeritus"
-	f_title = "Queen Emeritus"
+	title = "Monarch Emeritus"
 	flag = LORD
 	department_flag = NOBLEMEN
 	faction = "Station"
@@ -56,12 +54,8 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		else
 			GLOB.lordsurname = "of [L.real_name]"
 		SSticker.select_ruler()
-		if(L.gender != FEMALE)
-			to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is King of Rockhill.</span></span></b>")
-			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
-		else
-			to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is Queen of Rockhill.</span></span></b>")
-			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
+		to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is Monarch of Azure Peak.</span></span></b>")
+		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
 
 /datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -72,7 +66,34 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	l_hand = /obj/item/rogueweapon/lordscepter
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
 	id = /obj/item/clothing/ring/active/nomag
-	if(H.gender == MALE)
+	if(H.pronouns == SHE_HER)
+		pants = /obj/item/clothing/under/roguetown/tights/black
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
+		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		if(H.mind)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
+			if(H.age == AGE_OLD)
+				H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+			H.change_stat("strength", 1)
+			H.change_stat("intelligence", 3)
+			H.change_stat("endurance", 3)
+			H.change_stat("speed", 1)
+			H.change_stat("perception", 2)
+			H.change_stat("fortune", 5)
+		H.dna.species.soundpack_m = new /datum/voicepack/male/evil()
+	else
 		pants = /obj/item/clothing/under/roguetown/tights/black
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
@@ -98,35 +119,13 @@ GLOBAL_LIST_EMPTY(lord_titles)
 			H.change_stat("speed", 1)
 			H.change_stat("perception", 2)
 			H.change_stat("fortune", 5)
-		H.dna.species.soundpack_m = new /datum/voicepack/male/evil()
-
-		if(H.wear_mask)
-			if(istype(H.wear_mask, /obj/item/clothing/mask/rogue/eyepatch))
-				qdel(H.wear_mask)
-				mask = /obj/item/clothing/mask/rogue/lordmask
-			if(istype(H.wear_mask, /obj/item/clothing/mask/rogue/eyepatch/left))
-				qdel(H.wear_mask)
-				mask = /obj/item/clothing/mask/rogue/lordmask/l
-	else //Queen, doesn't do anything at the moment as Lord is male-only
-		armor = /obj/item/clothing/suit/roguetown/armor/armordress
-		belt = /obj/item/storage/belt/rogue/leather/plaquegold
-		shoes = /obj/item/clothing/shoes/roguetown/shortboots
-		if(H.mind)
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
-			if(H.age == AGE_OLD)
-				H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-			H.change_stat("intelligence", 3)
-			H.change_stat("endurance", 3)
-			H.change_stat("speed", 2)
-			H.change_stat("perception", 2)
-			H.change_stat("fortune", 5)
+	if(H.wear_mask)
+		if(istype(H.wear_mask, /obj/item/clothing/mask/rogue/eyepatch))
+			qdel(H.wear_mask)
+			mask = /obj/item/clothing/mask/rogue/lordmask
+		if(istype(H.wear_mask, /obj/item/clothing/mask/rogue/eyepatch/left))
+			qdel(H.wear_mask)
+			mask = /obj/item/clothing/mask/rogue/lordmask/l
 
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSEGRAB, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -31,14 +31,13 @@
 	r_hand = /obj/item/bath/soap
 	l_hand = /obj/item/rogue/instrument/harp
 	mouth = /obj/item/roguekey/nightmaiden
-	if(H.gender == MALE)
-		pants =	/obj/item/clothing/under/roguetown/loincloth
-		belt =	/obj/item/storage/belt/rogue/leather/cloth
-	else
+	if(H.pronouns == SHE_HER)
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy
 		pants = /obj/item/clothing/under/roguetown/tights/stockings/fishnet/random //Added fishnet stockings to the wenches
-
+	else
+		pants =	/obj/item/clothing/under/roguetown/loincloth
+		belt =	/obj/item/storage/belt/rogue/leather/cloth
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -41,19 +41,19 @@
 		H.change_stat("constitution", 1)
 		H.change_stat("speed", 1)
 
-	if(H.gender == MALE)
+	if(H.pronouns == SHE_HER)
+		head = /obj/item/clothing/head/roguetown/armingcap
+//		pants = /obj/item/clothing/under/roguetown/trou
+		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+		belt = /obj/item/storage/belt/rogue/leather/rope
+	else
 		head = /obj/item/clothing/head/roguetown/roguehood/random
 		if(prob(50))
 			head = /obj/item/clothing/head/roguetown/strawhat
 		pants = /obj/item/clothing/under/roguetown/tights/random
 		armor = /obj/item/clothing/suit/roguetown/armor/workervest
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
-		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
-		belt = /obj/item/storage/belt/rogue/leather/rope
-	else
-		head = /obj/item/clothing/head/roguetown/armingcap
-//		pants = /obj/item/clothing/under/roguetown/trou
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		belt = /obj/item/storage/belt/rogue/leather/rope

--- a/code/modules/jobs/job_types/roguetown/yeomen/alchemist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/alchemist.dm
@@ -8,7 +8,7 @@
 
 	allowed_races = RACES_ALL_KINDS
 
-	tutorial = "You came to rockhill after hearing that there is a lack of potion-makers outside of the nobility. Stir up potions with your alchemy expertise, of health or death."
+	tutorial = "You came to Azure Peak after hearing that there is a lack of potion-makers outside of the nobility. Stir up potions with your alchemy expertise, of health or death."
 
 	outfit = /datum/outfit/job/roguetown/alchemist
 	display_order = 6

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -30,11 +30,32 @@
 
 /datum/outfit/job/roguetown/prince/pre_equip(mob/living/carbon/human/H)
 	..()
-	if(H.gender == MALE)
+	if(H.pronouns == SHE_HER && H.gender == FEMALE)
+		beltl = /obj/item/roguekey/manor
+		head = /obj/item/clothing/head/roguetown/hennin
+		neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+		belt = /obj/item/storage/belt/rogue/leather/cloth/lady
+		armor = /obj/item/clothing/suit/roguetown/armor/silkcoat
+		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		pants = /obj/item/clothing/under/roguetown/tights/stockings/silk/random	//Added Silk Stockings for the female nobles
+		if(H.mind)
+			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/stealing, 2, TRUE)
+			H.change_stat("perception", 2)
+			H.change_stat("endurance", -2)
+			H.change_stat("strength", -3)
+			H.change_stat("constitution", 1)
+			H.change_stat("speed", 2)
+	else
 		pants = /obj/item/clothing/under/roguetown/tights
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 		armor = /obj/item/clothing/suit/roguetown/armor/chainmail
-		shoes = /obj/item/clothing/shoes/roguetown/nobleboot
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
 		belt = /obj/item/storage/belt/rogue/leather
 		beltl = /obj/item/roguekey/manor
 		beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
@@ -56,25 +77,4 @@
 			H.change_stat("endurance", -1)
 			H.change_stat("constitution", 1)
 			H.change_stat("speed", 1)
-	else
-		beltl = /obj/item/roguekey/manor
-		head = /obj/item/clothing/head/roguetown/hennin
-		neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-		belt = /obj/item/storage/belt/rogue/leather/cloth/lady
-		armor = /obj/item/clothing/suit/roguetown/armor/silkcoat
-		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess
-		shoes = /obj/item/clothing/shoes/roguetown/shortboots
-		pants = /obj/item/clothing/under/roguetown/tights/stockings/silk/random	//Added Silk Stockings for the female nobles
-		if(H.mind)
-			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/stealing, 2, TRUE)
-			H.change_stat("perception", 2)
-			H.change_stat("endurance", -2)
-			H.change_stat("strength", -3)
-			H.change_stat("constitution", 1)
-			H.change_stat("speed", 2)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -33,7 +33,14 @@
 		H.change_stat("intelligence", 1)
 		H.change_stat("perception", 1)
 
-	if(H.gender == MALE)
+	if(H.pronouns == SHE_HER)
+		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
+		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+		cloak = /obj/item/clothing/cloak/apron/waist
+		belt = /obj/item/storage/belt/rogue/leather
+		beltr = /obj/item/keyring/servant
+		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+	else
 		pants = /obj/item/clothing/under/roguetown/tights
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		shoes = /obj/item/clothing/shoes/roguetown/shortboots
@@ -41,10 +48,3 @@
 		beltr = /obj/item/keyring/servant
 		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
-	else
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
-		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
-		cloak = /obj/item/clothing/cloak/apron/waist
-		belt = /obj/item/storage/belt/rogue/leather
-		beltr = /obj/item/keyring/servant
-		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor

--- a/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
@@ -23,17 +23,17 @@
 /datum/outfit/job/roguetown/shophand/pre_equip(mob/living/carbon/human/H)
 	..()
 	ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
-	if(H.gender == MALE)
+	if(H.pronouns == SHE_HER)
 		pants = /obj/item/clothing/under/roguetown/tights
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/blue
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		belt = /obj/item/storage/belt/rogue/leather
 		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 		beltl = /obj/item/keyring/merchant
 		backr = /obj/item/storage/backpack/rogue/satchel
-	if(H.gender == FEMALE)
+	else
 		pants = /obj/item/clothing/under/roguetown/tights
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/blue
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		belt = /obj/item/storage/belt/rogue/leather
 		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor

--- a/code/modules/jobs/job_types/roguetown/youngfolk/smith_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/smith_apprentice.dm
@@ -28,7 +28,16 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-	if(H.gender == MALE)
+	if(H.pronouns == SHE_HER)
+		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
+		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+		belt = /obj/item/storage/belt/rogue/leather/rope
+		beltr = /obj/item/roguekey/blacksmith
+		cloak = /obj/item/clothing/cloak/apron/brown
+		backr = /obj/item/storage/backpack/rogue/satchel
+		backpack_contents = list(/obj/item/rogueweapon/hammer = 1, /obj/item/rogueweapon/tongs = 1)
+	else
 		pants = /obj/item/clothing/under/roguetown/tights/random
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		shirt = null
@@ -38,15 +47,3 @@
 		backr = /obj/item/storage/backpack/rogue/satchel
 		backpack_contents = list(/obj/item/rogueweapon/hammer = 1, /obj/item/rogueweapon/tongs = 1)
 		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	else
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
-		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-		belt = /obj/item/storage/belt/rogue/leather/rope
-		beltr = /obj/item/roguekey/blacksmith
-		cloak = /obj/item/clothing/cloak/apron/brown
-		backr = /obj/item/storage/backpack/rogue/satchel
-		backpack_contents = list(/obj/item/rogueweapon/hammer = 1, /obj/item/rogueweapon/tongs = 1)
-	H.change_stat("strength", 1)
-	H.change_stat("endurance", 1)
-	H.change_stat("constitution", 1)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -19,7 +19,7 @@
 
 /datum/outfit/job/roguetown/squire/pre_equip(mob/living/carbon/human/H)
 	..()
-	if(H.gender == MALE)
+	if(H.pronouns == SHE_HER)
 		pants = /obj/item/clothing/under/roguetown/tights
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 		armor = /obj/item/clothing/suit/roguetown/armor/chainmail
@@ -43,7 +43,7 @@
 			H.change_stat("perception", 1)
 			H.change_stat("constitution", 1)
 			H.change_stat("speed", 1)
-	if(H.gender == FEMALE)
+	else
 		pants = /obj/item/clothing/under/roguetown/tights
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 		armor = /obj/item/clothing/suit/roguetown/armor/chainmail

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -60,8 +60,8 @@ GLOBAL_LIST_INIT(nonhuman_positions, list(
 	ROLE_PAI))
 
 GLOBAL_LIST_INIT(noble_positions, list(
-	"King",
-	"Queen Consort",
+	"Monarch",
+	"Consort",
 	"Prince",
 	"Guard Captain",
 	"Bailiff",

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -665,7 +665,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 					if(job in GLOB.noble_positions)
 						command_bold = " command"
 					var/used_name = job_datum.title
-					if(client.prefs.gender == FEMALE && job_datum.f_title)
+					if(client.prefs.pronouns == SHE_HER && job_datum.f_title)
 						used_name = job_datum.f_title
 					if(job_datum in SSjob.prioritized_jobs)
 						dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'><span class='priority'>[used_name] ([job_datum.current_positions])</span></a>"

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -112,7 +112,7 @@
 		"Grenzelhoft" = SKIN_COLOR_GRENZELHOFT,
 		"Hammerhold" = SKIN_COLOR_HAMMERHOLD,
 		"Avar" = SKIN_COLOR_AVAR,
-		"Rockhill" = SKIN_COLOR_ROCKHILL,
+		"Azure Peak" = SKIN_COLOR_ROCKHILL,
 		"Otava" = SKIN_COLOR_OTAVA,
 		"Etrusca" = SKIN_COLOR_ETRUSCA,
 		"Gronn" = SKIN_COLOR_GRONN,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -70,7 +70,7 @@
 		"Grenzelhoft" = SKIN_COLOR_GRENZELHOFT,
 		"Hammerhold" = SKIN_COLOR_HAMMERHOLD,
 		"Avar" = SKIN_COLOR_AVAR,
-		"Rockhill" = SKIN_COLOR_ROCKHILL,
+		"Azure Peak" = SKIN_COLOR_ROCKHILL,
 		"Otava" = SKIN_COLOR_OTAVA,
 		"Etrusca" = SKIN_COLOR_ETRUSCA,
 		"Gronn" = SKIN_COLOR_GRONN,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -11,7 +11,7 @@
 	Most commonly, Aasimar are similar to Humans, albeit taller, and possess uncanny beauty. \
 	They have strangely colored skin and are more physically frail than the average Human. \
 	Because of their upbringing, they make for natural conduits for godly powers. \
-	Rockhills populace holds them with a mixture of uneasy fear or, and respect. \
+	Azure Peak's populace holds them with a mixture of uneasy fear or, and respect. \
 	It is also widely believed that an Aasimars death is a bad omen..."
 
 	skin_tone_wording = "Craft"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -11,7 +11,7 @@
 	more common visitors to fur trading posts and prospecting camps, eventually leading to half-orcs \
 	being born in these rough places otherwise devoid of a fairer sex. Your mother-clan is in thrall \
 	to the Ironmask, true orcs would kill you as a mongrel dog and your father’s people cannot decide \
-	between mere distrust and disgust. Yet somehow your wandering feet came to Rockhill, where \
+	between mere distrust and disgust. Yet somehow your wandering feet came to Azure Peak, where \
 	half-orcs ply muscle and their hardiness in the rough underbelly or outer reaches of society."
 
 	skin_tone_wording = "Clan"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -977,7 +977,7 @@
 	else if(job)
 		var/datum/job/J = SSjob.GetJob(job)
 		used_title = J.title
-		if(J.f_title && (gender == FEMALE))
+		if(J.f_title && (pronouns == SHE_HER))
 			used_title = J.f_title
 		if(J.advjob_examine)
 			used_title = advjob

--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -181,7 +181,7 @@
 
 	if(signedname)
 		info += "SIGNED,<br/>"
-		info += "<font face=\"[FOUNTAIN_PEN_FONT]\" color=#27293f>[signedname] the [signedjob] of Rockhill</font>"
+		info += "<font face=\"[FOUNTAIN_PEN_FONT]\" color=#27293f>[signedname] the [signedjob] of Azure Peak</font>"
 
 /obj/item/paper/confession
 	name = "confession"

--- a/code/modules/roguetown/roguejobs/fisher/fish.dm
+++ b/code/modules/roguetown/roguejobs/fisher/fish.dm
@@ -80,7 +80,7 @@
 
 /obj/item/reagent_containers/food/snacks/fish/clownfish
 	name = "clownfish"
-	desc = "This fish brings vibrant hues to the dark world of Rockhill."
+	desc = "This fish brings vibrant hues to the dark world of Azure Peak."
 	icon_state = "clownfish"
 	sellprice = 40
 	fried_type = /obj/item/reagent_containers/food/snacks/rogue/fryfish/clownfish

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -1,6 +1,6 @@
 /obj/structure/roguemachine/atm
 	name = "SHYLOCK"
-	desc = "Stores and withdraws currency for accounts managed by the Kingdom of Rockhill."
+	desc = "Stores and withdraws currency for accounts managed by the Kingdom of Azure Peak."
 	icon = 'icons/roguetown/misc/machines.dmi'
 	icon_state = "atm"
 	density = FALSE

--- a/code/modules/roguetown/roguemachine/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward.dm
@@ -60,7 +60,7 @@
 		var/amt = D.get_import_price()
 		SStreasury.treasury_value -= amt
 		SStreasury.log_to_steward("-[amt] imported [D.name]")
-		scom_announce("Rockhill imports [D.name] for [amt] mammon.", )
+		scom_announce("Azure Peak imports [D.name] for [amt] mammon.", )
 		D.raise_demand()
 		addtimer(CALLBACK(src, PROC_REF(do_import), D.type), 10 SECONDS)
 	if(href_list["export"])
@@ -82,7 +82,7 @@
 
 		SStreasury.treasury_value += amt
 		SStreasury.log_to_steward("+[amt] exported [D.name]")
-		scom_announce("Rockhill exports [D.name] for [amt] mammon.")
+		scom_announce("Azure Peak exports [D.name] for [amt] mammon.")
 		D.lower_demand()
 	if(href_list["togglewithdraw"])
 		var/datum/roguestock/D = locate(href_list["togglewithdraw"]) in SStreasury.stockpile_datums

--- a/modular_azurepeak/code/game/objects/structures/fartravel.dm
+++ b/modular_azurepeak/code/game/objects/structures/fartravel.dm
@@ -28,7 +28,7 @@
 		return
 	if(user.incapacitated() || QDELETED(departing_mob) || (departing_mob != user && departing_mob.client) || get_dist(src, dropping) > 2 || get_dist(src, user) > 2)
 		return //Things have changed since the alert happened.
-	user.visible_message("<span class='warning'>[user] [departing_mob == user ? "is trying to depart from Rockhill!" : "is trying to send [departing_mob] away!"]</span>", "<span class='notice'>You [departing_mob == user ? "are trying to depart from Rockhill." : "are trying to send [departing_mob] away."]</span>")
+	user.visible_message("<span class='warning'>[user] [departing_mob == user ? "is trying to depart from Azure Peak!" : "is trying to send [departing_mob] away!"]</span>", "<span class='notice'>You [departing_mob == user ? "are trying to depart from Azure Peak." : "are trying to send [departing_mob] away."]</span>")
 	in_use = TRUE
 	if(!do_after(user, 50, target = src))
 		in_use = FALSE
@@ -53,6 +53,6 @@
 	if(departing_mob.stat == DEAD)
 		departing_mob.visible_message("<span class='notice'>[user] sends the body of [departing_mob] away. They're someone else's problem now.</span>")
 	else
-		departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] leaves Rockhill.</span>")
+		departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] leaves Azure Peak.</span>")
 	qdel(departing_mob)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This really snowballed out of control but I really do not want to repeatedly overwrite previous changes to the same stupid goddamn files.
—At administration's request, changes "King" and "Queen" to the more ambiguous "Monarch"
—Changes "Queen Consort" to "Consort" in the enabling of male and thembo consorts.
—Gives consorts that aren't she/her a loadout (basically the prince's)
—Notice I said "she/her" and not female? Gendered loadouts like the prince's and princess's are now mainly tied to PRONOUNS. If you aren't she/her, you get the "male" loadout, as a shirt and tights doesn't really scream "man" the way a dress screams "woman". Certain roles that get dresses which don't work currently on masculine body types must still also be of a feminine bodytype (noble pilgrims, consorts and princesses, to my knowledge.)
—Makes some small changes to a couple roundstart equipment loadouts (princes now get shortboots because nobleboots don't work on the feminine sprite. non-female noble pilgrims get clothing that just looks better, including white tights to indicate nobility like male members of the royal family.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Malewives and ladybosses.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
