### PR TITLE
Fixes the FUCKING church table

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -3477,7 +3477,7 @@
 "uYu" = (/obj/structure/closet/crate/roguecloset,/obj/item/storage/roguebag,/turf/open/floor/rogue/blocks,/area/rogue/under/town/basement)
 "uYx" = (/obj/structure/chair/wood/rogue{dir = 1},/obj/effect/landmark/start/villager{dir = 1},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/town/tavern)
 "uYE" = (/turf/open/floor/rogue/tile{icon_state = "bfloorz"},/area/rogue/indoors/town/manor)
-"uZa" = (/obj/structure/table/church{dir = 1},/turf/open/floor/rogue/churchmarble,/area/rogue/indoors/town/church/chapel)
+"uZa" = (/obj/structure/table/church{icon_state = "churchtable_end"},/turf/open/floor/rogue/churchmarble,/area/rogue/indoors/town/church/chapel)
 "uZk" = (/obj/structure/bars,/turf/closed/wall/mineral/rogue/craftstone,/area/rogue/under/town/basement)
 "uZy" = (/turf/closed/wall/mineral/rogue/decostone/end{dir = 8},/area/rogue/indoors/town/church)
 "uZC" = (/obj/structure/chair/wood/rogue{dir = 8},/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/hexstone,/area/rogue/indoors/town/church)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -335,6 +335,11 @@
 		icon_state = "churchtable_mid"
 	. = ..()
 
+/obj/structure/table/church/OnCrafted(dirin, user)
+	if(dirin == EAST)
+		icon_state = "churchtable_end"
+	. = ..()
+
 /obj/structure/table/church/m
 	icon = 'icons/roguetown/misc/tables.dmi'
 	icon_state = "churchtable_mid"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Why was it like this?! You can also now craft the rightward facing table part by simply facing east when making the stone table.

![dreamseeker_tcJyyaFLiT](https://github.com/user-attachments/assets/645171b1-1ac7-487c-92e5-c4ce10c7883d)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tables that look like one cohesive object are better for ERPing me on top of - even altar tables in the middle of churches.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
