### PR TITLE
removes duplicate padded dress recipe

### DIFF
--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -200,13 +200,6 @@
 	craftdiff = 3
 	sellprice = 20
 
-/datum/crafting_recipe/roguetown/sewing/armordress
-	name = "padded dress"
-	result = /obj/item/clothing/suit/roguetown/armor/armordress
-	reqs = list(/obj/item/natural/cloth = 5,
-				/obj/item/natural/fibers = 2)
-	craftdiff = 3
-
 /datum/crafting_recipe/roguetown/sewing/paddedcap
 	name = "padded Cap"
 	result = /obj/item/clothing/head/roguetown/paddedcap


### PR DESCRIPTION
The "padded dress" item has two recipes with the same path, one using purely cloth and the other a mix of cloth and hide and fibers, this removes the non-functional pure cloth recipe in favor of the leather recipe, given that the item's descriptions mentions leather.