### PR TITLE
Monarchs cannot be vampire lord

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(treasury)
 		var/people_told = 0
 		for(var/mob/living/carbon/human/X in GLOB.human_list)
 			switch(X.job)
-				if("King", "Steward", "Clerk")
+				if("Monarch", "Steward", "Clerk")
 					people_told += 1
 					send_ooc_note("Income from wealth horde: +[amt_to_generate]", name = X.real_name)
 					if(people_told > 3)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -184,7 +184,7 @@ SUBSYSTEM_DEF(vote)
 					if(H.stat != DEAD)
 						vote_power += 3
 					if(H.job)
-						var/list/list_of_powerful = list("King", "Queen Consort", "Priest", "Steward", "Hand")
+						var/list/list_of_powerful = list("Monarch", "Consort", "Priest", "Steward", "Hand")
 						if(H.job in list_of_powerful)
 							vote_power += 5
 						else

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -47,7 +47,7 @@
 	name = "the Lord's crown."
 	targetitem = /obj/item/clothing/head/roguetown/crown/serpcrown
 	difficulty = 3
-	excludefromjob = list("King", "Queen Consort", "Royal Guard")
+	excludefromjob = list("Monarch", "Consort", "Royal Guard")
 
 
 ////////////////////////////////////////////////////////////

--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -100,7 +100,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 	var/lord_dead = FALSE
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
 		if(H.mind)
-			if(H.job == "King")
+			if(H.job == "Monarch")
 				lord_found = TRUE
 				if(H.stat == DEAD)
 					lord_dead = TRUE
@@ -187,8 +187,8 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 /datum/game_mode/chaosmode/proc/pick_bandits()
 	//BANDITS
 	banditgoal = rand(200,400)
-	restricted_jobs = list("King",
-	"Queen Consort",
+	restricted_jobs = list("Monarch",
+	"Consort",
 	"Merchant",
 	"Priest",
 	"Royal Guard")
@@ -323,7 +323,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 	restricted_jobs = list()
 
 /datum/game_mode/chaosmode/proc/pick_maniac()
-	restricted_jobs = list("King", "Queen Consort")
+	restricted_jobs = list("Monarch", "Consort")
 	antag_candidates = get_players_for_role(ROLE_MANIAC)
 	var/datum/mind/villain = pick_n_take(antag_candidates)
 	if(villain)
@@ -345,8 +345,8 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 /datum/game_mode/chaosmode/proc/pick_vampires()
 	var/vampsremaining = 3
 	restricted_jobs = list(
-	"King",
-	"Queen Consort",
+	"Monarch",
+	"Consort",
 	"Dungeoneer",
 	"Inquisitor",
 	"Confessor",
@@ -392,8 +392,8 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 /datum/game_mode/chaosmode/proc/pick_werewolves()
 	// Ideally we want adventurers/pilgrims/towners to roll it
 	restricted_jobs = list(
-	"King",
-	"Queen Consort",
+	"Monarch",
+	"Consort",
 	"Dungeoneer",
 	"Inquisitor",
 	"Confessor",

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -912,7 +912,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 /datum/objective/vampirelord/infiltrate/two/check_completion()
 	var/datum/game_mode/chaosmode/C = SSticker.mode
-	var/list/noblejobs = list("King", "Queen Consort", "Prince", "Princess", "Hand", "Steward")
+	var/list/noblejobs = list("Monarch", "Consort", "Prince", "Princess", "Hand", "Steward")
 	for(var/datum/mind/V in C.vampires)
 		if(V.current.job in noblejobs)
 			return TRUE

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -129,7 +129,7 @@
 /proc/find_lord(required_stat = CONSCIOUS)
 	var/mob/living/lord
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
-		if(!H.mind || H.job != "King" || (H.stat > required_stat))
+		if(!H.mind || H.job != "Monarch" || (H.stat > required_stat))
 			continue
 		lord = H
 		break

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -92,10 +92,10 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 							var/thing = "[player.client.prefs.real_name]"
 							if(istype(job, /datum/job/roguetown/hand))
 								if(player != src)
-									if(client.prefs.job_preferences["King"] == JP_HIGH)
+									if(client.prefs.job_preferences["Monarch"] == JP_HIGH)
 										thing = "<a href='byond://?src=[REF(src)];sethand=[player.client.ckey]'>[player.client.prefs.real_name]</a>"
 								for(var/mob/dead/new_player/Lord in GLOB.player_list)
-									if(Lord.client.prefs.job_preferences["King"] == JP_HIGH)
+									if(Lord.client.prefs.job_preferences["Monarch"] == JP_HIGH)
 										if(Lord.brohand == player.ckey)
 											thing = "*[thing]*"
 											break

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -92,7 +92,7 @@
 				adjust_triumphs(-1)
 
 		switch(job)
-			if("King")
+			if("Monarch")
 				//omen gets added separately, after a few minutes
 				for(var/mob/living/carbon/human/HU in GLOB.player_list)
 					if(!HU.stat && is_in_roguetown(HU))
@@ -132,7 +132,7 @@
 	if(!.)
 		return
 	switch(job)
-		if("King")
+		if("Monarch")
 			removeomen(OMEN_NOLORD)
 		if("Priest")
 			removeomen(OMEN_NOPRIEST)

--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -59,10 +59,10 @@
 	playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
 	var/canread = user.can_read(src, TRUE)
 	var/contents
-	if(SSticker.rulertype == "King")
-		contents += "<center>KING'S DECREES<BR>"
+	if(SSticker.rulertype == "Monarch")
+		contents += "<center>MONARCH'S DECREES<BR>"
 	else
-		contents += "<center>QUEEN'S DECREES<BR>"
+		contents += "<center>MONARCH'S DECREES<BR>"
 	contents += "-----------<BR><BR></center>"
 	for(var/i = GLOB.lord_decrees.len to 1 step -1)
 		contents += "[i]. <span class='info'>[GLOB.lord_decrees[i]]</span><BR>"

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -223,7 +223,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			if(!AM.anchored || istype(AM, /obj/mecha))
 				if(istype(AM, /obj/item/paper/scroll/cargo))
 					var/obj/item/paper/scroll/cargo/C = AM
-					if(C.signedjob in list("Priest", "Court Magician", "Merchant", "King", "Guard Captain","Bailiff"))
+					if(C.signedjob in list("Priest", "Court Magician", "Merchant", "Monarch", "Guard Captain","Bailiff"))
 						for(var/datum/supply_order/SO in C.orders)
 							SSshuttle.shoppinglist += SO
 							C.orders -= SO
@@ -236,7 +236,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 						continue
 					if(istype(thing, /obj/item/paper/scroll/cargo))
 						var/obj/item/paper/scroll/cargo/C = AM
-						if(C.signedjob in list("Priest", "Court Magician", "Merchant", "King", "Guard Captain","Bailiff"))
+						if(C.signedjob in list("Priest", "Court Magician", "Merchant", "Monarch", "Guard Captain","Bailiff"))
 							for(var/datum/supply_order/SO in C.orders)
 								SSshuttle.shoppinglist += SO
 								C.orders -= SO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Just a bunch of fixes for our Monarch change. Monarchs should now be getting updated about the gold income, and can no longer be vampire lord, cannot get the objective to steal the crown - a bunch of little edge cases I missed. Same for "Queen consort" references which are now just "Consort" since we have malewifes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This machine squashes bugs
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
