### PR TITLE
Allows Using Sacks on Barrels and Composters

### DIFF
--- a/code/game/objects/items/rogueitems/bags.dm
+++ b/code/game/objects/items/rogueitems/bags.dm
@@ -11,6 +11,11 @@
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	max_integrity = 300
 
+/obj/item/storage/roguebag/examine(mob/user)
+	. = ..()
+	if(contents.len)
+		. += span_notice("[contents.len] things in the sack.")
+
 /obj/item/storage/roguebag/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot == SLOT_HEAD)

--- a/code/game/objects/items/rogueitems/bags.dm
+++ b/code/game/objects/items/rogueitems/bags.dm
@@ -14,7 +14,7 @@
 /obj/item/storage/roguebag/examine(mob/user)
 	. = ..()
 	if(contents.len)
-		. += span_notice("[contents.len] things in the sack.")
+		. += span_notice("[contents.len] thing[contents.len > 1 ? "s" : ""] in the sack.")
 
 /obj/item/storage/roguebag/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
@@ -73,6 +73,7 @@
 	STR.allow_quick_gather = TRUE
 	STR.allow_quick_empty = TRUE
 	STR.allow_look_inside = FALSE
+	STR.allow_dump_out = TRUE
 	STR.display_numerical_stacking = TRUE
 
 

--- a/code/modules/farming/composter.dm
+++ b/code/modules/farming/composter.dm
@@ -74,7 +74,7 @@
 	flipped_compost += flip_amount
 	update_icon()
 
-/obj/structure/composter/proc/try_handle_adding_compost(obj/item/attacking_item, mob/user, params)
+/obj/structure/composter/proc/try_handle_adding_compost(obj/item/attacking_item, mob/user, batch_process)
 	var/compost_value = 0
 	if(istype(attacking_item, /obj/item/reagent_containers/food/snacks))
 		compost_value = 150
@@ -83,17 +83,19 @@
 	if(istype(attacking_item, /obj/item/trash/applecore))
 		compost_value = 50
 	if(compost_value > 0)
-		if(compost_value + get_total_compost() >= MAXIMUM_TOTAL_COMPOST)
-			to_chat(user, span_warning("There's too much compost!"))
-			return TRUE
-		unflipped_compost += compost_value
-		to_chat(user, span_notice("I add \the [attacking_item] to \the [src]"))
+		if(get_total_compost() >= MAXIMUM_TOTAL_COMPOST)
+			if(!batch_process)
+				to_chat(user, span_warning("There's too much compost!"))
+			return FALSE
+		unflipped_compost += min(compost_value, MAXIMUM_TOTAL_COMPOST - get_total_compost())
+		if(!batch_process)
+			to_chat(user, span_notice("I add \the [attacking_item] to \the [src]"))
 		qdel(attacking_item)
 		update_icon()
 		return TRUE
 	return FALSE
 
-/obj/structure/composter/proc/try_handle_removing_compost(obj/item/attacking_item, mob/living/user, params)
+/obj/structure/composter/proc/try_handle_removing_compost(obj/item/attacking_item, mob/living/user)
 	if(ready_compost < COMPOST_PER_PRODUCED_ITEM)
 		to_chat(user, span_warning("There's not enough processed compost!"))
 		return TRUE
@@ -113,6 +115,22 @@
 
 /obj/structure/composter/attackby(obj/item/attacking_item, mob/user, params)
 	user.changeNext_move(CLICK_CD_FAST)
+	if(istype(attacking_item,/obj/item/storage/roguebag) && attacking_item.contents.len)
+		if(get_total_compost() >= MAXIMUM_TOTAL_COMPOST)
+			to_chat(user, span_warning("There's too much compost!"))
+			return
+		var/success
+		for(var/obj/item/bagged_item in attacking_item.contents)
+			if(try_handle_adding_compost(bagged_item, user, params))
+				success = TRUE
+				if(get_total_compost() >= MAXIMUM_TOTAL_COMPOST)
+					break
+		if(success)
+			to_chat(user, span_info("I dump all the compostables inside [attacking_item] into [src]."))
+			attacking_item.update_icon()
+		else
+			to_chat(user, span_warning("There's nothing in [attacking_item] that can be composted."))
+		return TRUE
 	if(try_handle_adding_compost(attacking_item, user, params))
 		return
 	. = ..()

--- a/code/modules/farming/fermenting_barrel.dm
+++ b/code/modules/farming/fermenting_barrel.dm
@@ -35,20 +35,38 @@
 		reagents.add_reagent(fruit.distill_reagent, fruit.distill_amt)
 	qdel(fruit)
 	playsound(src, "bubbles", 100, TRUE)
+	return TRUE
 
 /obj/structure/fermenting_barrel/attackby(obj/item/I, mob/user, params)
-	var/obj/item/reagent_containers/food/snacks/grown/fruit = I
-	if(istype(fruit))
-		if(!fruit.can_distill)
-			to_chat(user, span_warning("I can't ferment this into anything."))
+	if(istype(I,/obj/item/reagent_containers/food/snacks/grown))
+		if(try_ferment(I, user))
 			return TRUE
-		else if(!user.transferItemToLoc(I,src))
-			to_chat(user, span_warning("[I] is stuck to my hand!"))
-			return TRUE
-		to_chat(user, span_info("I place [I] into [src]."))
-		addtimer(CALLBACK(src, PROC_REF(makeWine), fruit), rand(1 MINUTES, 3 MINUTES))
+	if(istype(I,/obj/item/storage/roguebag) && I.contents.len)
+		var/success
+		for(var/obj/item/reagent_containers/food/snacks/grown/bagged_fruit in I.contents)
+			if(try_ferment(bagged_fruit, user, TRUE))
+				success = TRUE
+		if(success)
+			to_chat(user, span_info("I dump the contents of [I] into [src]."))
+			I.update_icon()
+		else
+			to_chat(user, span_warning("There's nothing in [I] that I can ferment."))
 		return TRUE
 	..()
+
+/obj/structure/fermenting_barrel/proc/try_ferment(obj/item/reagent_containers/food/snacks/grown/fruit, mob/user, batch_process)
+	if(!fruit.can_distill)
+		if(!batch_process)
+			to_chat(user, span_warning("I can't ferment this into anything."))
+		return FALSE
+	else if(!user.transferItemToLoc(fruit,src))
+		if(!batch_process)
+			to_chat(user, span_warning("[fruit] is stuck to my hand!"))
+		return FALSE
+	if(!batch_process)
+		to_chat(user, span_info("I place [fruit] into [src]."))
+	addtimer(CALLBACK(src, PROC_REF(makeWine), fruit), rand(1 MINUTES, 3 MINUTES))
+	return TRUE
 
 //obj/structure/fermenting_barrel/attack_hand(mob/user)
 //	open = !open


### PR DESCRIPTION
Allows using sack bags on barrels and composters so you don't have to process things one at a time.

Also lets you examine the sack to see how many things are inside, along with letting you mousedrop it on the floor to dump it out on a different tile.