### PR TITLE
adds crops and recipes

### DIFF
--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -230,3 +230,103 @@
 	grind_results = list(/datum/reagent/drug/space_drugs = 5)
 	eat_effect = /datum/status_effect/debuff/badmeal
 
+/obj/item/reagent_containers/food/snacks/grown/carrot
+	seed = /obj/item/seeds/carrot
+	name = "carrot"
+	desc = "A carrot is a root vegetable known for its vibrant orange color, although it can also be found in purple, red, yellow, and white varieties. It has a crisp texture and a sweet, slightly earthy flavor. The dirtier the better"
+	icon = 'icons/roguetown/items/produce.dmi'
+	icon_state = "carrot"
+	gender = PLURAL
+	filling_color = "#f55b0f"
+	bitesize_mod = 5
+	fried_type = /obj/item/reagent_containers/food/snacks/carrotfried
+	cooked_type = /obj/item/reagent_containers/food/snacks/carrotfried
+	foodtype = VEGETABLES
+	tastes = list("carrot" = 1)
+//	can_distill = TRUE//
+//	distill_reagent = /datum/reagent/consumable/ethanol/spirit//
+//	distill_amt = 24//
+//	grind_results = list(/datum/reagent/grated_carrot = 10)//
+
+/obj/item/reagent_containers/food/snacks/grown/beet
+	seed = /obj/item/seeds/beetroot
+	name = "beet"
+	desc = "A versatile root vegetable known for its vibrant, deep red or golden roots and green, leafy tops. The root has a sweet, earthy flavor and can be roasted, boiled, or eaten raw"
+	icon = 'icons/roguetown/items/produce.dmi'
+	icon_state = "beet"
+	gender = PLURAL
+	filling_color = "#8a1151"
+	bitesize_mod = 4
+	foodtype = VEGETABLES
+	tastes = list("beet" = 1)
+
+/obj/item/reagent_containers/food/snacks/grown/cabbage
+	seed = /obj/item/seeds/carrot
+	name = "carrot"
+	desc = "A leafy vegetable known for its dense, round head of crisp, green or purple leaves. It grows in a compact, rosette shape and is a staple in many cuisines around the world."
+	icon = 'icons/roguetown/items/produce.dmi'
+	icon_state = "cabbage"
+	gender = PLURAL
+	filling_color = "#8ae346"
+	bitesize_mod = 6
+	foodtype = VEGETABLES
+
+	tastes = list("cabbage" = 1)
+
+/obj/item/reagent_containers/food/snacks/grown/leek
+	seed = /obj/item/seeds/leek
+	name = "leek"
+	desc = "A leafy vegetable known for its dense, round head of crisp, green or purple leaves. It grows in a compact, rosette shape and is a staple in many cuisines around the world."
+	icon = 'icons/roguetown/items/produce.dmi'
+	icon_state = "leek"
+	gender = PLURAL
+	filling_color = "#97de73"
+	bitesize_mod = 4
+	fried_type = /obj/item/reagent_containers/food/snacks/leekfried
+	cooked_type = /obj/item/reagent_containers/food/snacks/leekfried
+	foodtype = VEGETABLES
+	tastes = list("leek" = 1)
+
+/obj/item/reagent_containers/food/snacks/grown/potato
+	seed = /obj/item/seeds/potato
+	name = "potato"
+	desc = "A hearty tuber-producing plant known for its starchy, edible underground bulbs. It features broad, green leaves and small white or purple flowers. Potatoes are a staple food, prized for their versatility and nutritional value, and can be prepared in numerous ways, including baking, boiling, and frying."
+	icon = 'icons/roguetown/items/produce.dmi'
+	icon_state = "potato"
+	gender = PLURAL
+	filling_color = "#f2f18f"
+	bitesize_mod = 4
+	cooked_type = /obj/item/reagent_containers/food/snacks/potatofried
+	fried_type = /obj/item/reagent_containers/food/snacks/potatofried
+	foodtype = VEGETABLES
+	tastes = list("potato" = 1)
+//	can_distill = TRUE//
+//	distill_reagent = /datum/reagent/consumable/ethanol/vodka//
+//	distill_amt = 24//
+//	grind_results = list(/datum/reagent/grated_potato = 10)//
+
+/obj/item/reagent_containers/food/snacks/grown/rice
+	seed = /obj/item/seeds/rice
+	name = "rice"
+	desc = "Rice is a staple grain cultivated in flooded fields known as paddies. It comes in various types, including white, brown, and jasmine, each with distinct flavors and textures."
+	icon = 'icons/roguetown/items/produce.dmi'
+	icon_state = "rice"
+	gender = PLURAL
+	filling_color = "#e6e5da"
+	bitesize_mod = 2
+	foodtype = GRAIN
+	tastes = list("rice" = 1)
+//	can_distill = TRUE//
+//	distill_reagent = /datum/reagent/consumable/ethanol/sake//
+//	distill_amt = 24//
+//	grind_results = list(/datum/reagent/rice_flour = 10)//
+
+///obj/item/reagent_containers/food/snacks/grown/potato
+//	icon = 'icons/roguetown/items/produce.dmi'
+//	eat_effect = /datum/status_effect/debuff/uncookedfood
+//	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
+//	name = "potato"
+//	icon_state = "potato"
+//	slice_batch = FALSE
+//	filling_color = "#8f433a"
+//	rotprocess = 60 MINUTES

--- a/code/modules/farming/seeds.dm
+++ b/code/modules/farming/seeds.dm
@@ -89,3 +89,26 @@
 	seed_identity = "berry seeds"
 	plant_def_type = /datum/plant_def/berry_poison
 
+/obj/item/seeds/carrot
+	seed_identity = "carrot seeds"
+	plant_def_type = /datum/plant_def/carrot
+
+/obj/item/seeds/cabbage
+	seed_identity = "cabbage seeds"
+	plant_def_type = /datum/plant_def/cabbage
+
+/obj/item/seeds/potato
+	seed_identity = "potato seeds"
+	plant_def_type = /datum/plant_def/potato
+
+/obj/item/seeds/beetroot
+	seed_identity = "beet seeds"
+	plant_def_type = /datum/plant_def/beetroot
+
+/obj/item/seeds/leek
+	seed_identity = "leek seeds"
+	plant_def_type = /datum/plant_def/leek
+
+/obj/item/seeds/rice
+	seed_identity = "rice seeds"
+	plant_def_type = /datum/plant_def/rice

--- a/code/modules/roguetown/roguejobs/cook/ingredients/meat.dm
+++ b/code/modules/roguetown/roguejobs/cook/ingredients/meat.dm
@@ -31,10 +31,21 @@
 	name = "minced meat"
 	desc = "With an irregular and coarse texture, makes you hungrier just by looking at it."
 	icon_state = "meatmince"
+	fried_type = /obj/item/reagent_containers/food/snacks/rogue/meat/mince/fried
+	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/meat/mince/fried
 	ingredient_size = 2
 	slice_path = null
 	slices_num = 0
 	filling_color = "#8a0000"
+
+/obj/item/reagent_containers/food/snacks/rogue/meat/mince/fried
+	eat_effect = null
+	slices_num = 0
+	name = "fried mince"
+	desc = "A portion of fried mince, yum."
+	icon_state = "friedmince"
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 15)
+	desc = ""
 
 /obj/item/reagent_containers/food/snacks/rogue/meat/mince/beef
 	name = "mince"
@@ -227,6 +238,29 @@
 		icon_state = "[initial(M.icon_state)]dried"
 		qdel(M)
 
+<<<<<<< HEAD
+/obj/item/reagent_containers/food/snacks/rawschnitzel
+	eat_effect = /datum/status_effect/debuff/uncookedfood
+	name = "raw floured meat"
+	desc = "A piece of smashed meat covered in flour"
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "meatflour"
+	ingredient_size = 1
+	fried_type = /obj/item/reagent_containers/food/snacks/rogue/schnitzel
+	slices_num = 0
+	cooked_type = null
+
+/obj/item/reagent_containers/food/snacks/rogue/schnitzel
+	eat_effect = null
+	slices_num = 0
+	name = "schnitzel"
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "schnitzel"
+	desc = ""
+	bitesize = 3
+	fried_type = null
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 10)
+=======
 /obj/item/reagent_containers/food/snacks/rogue/meat/crabmeat
 	name = "crab meat"
 	desc = "A chunk of raw crab meat, absolutely wonderful."
@@ -245,3 +279,4 @@
 	icon_state = "crabmeat"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 5)
 	desc = ""
+>>>>>>> 0e927c6c7548fec167d5c29055386d66a70437ef

--- a/code/modules/roguetown/roguejobs/cook/ingredients/misc.dm
+++ b/code/modules/roguetown/roguejobs/cook/ingredients/misc.dm
@@ -103,7 +103,6 @@
 /obj/item/reagent_containers/food/snacks/rogue/cheddarslice
 	name = "slice of cheese"
 	desc = "A soft, creamy slice of cheddar cheese."
-	icon = 'icons/roguetown/items/food.dmi'
 	icon_state = "cheese_slice"
 	bitesize = 1
 	list_reagents = list(/datum/reagent/consumable/nutriment = 1)

--- a/code/modules/roguetown/roguejobs/cook/ingredients/vegetables.dm
+++ b/code/modules/roguetown/roguejobs/cook/ingredients/vegetables.dm
@@ -1,0 +1,32 @@
+/obj/item/reagent_containers/food/snacks/potatofried
+	name = "roasted potato"
+	desc = "A couple of fried potato slices cut in wedges."
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "potatoc"
+	bitesize = 3
+	tastes = list("fried potato" = 1)
+	filling_color = "##bdbc55"
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 8)
+	desc = ""
+
+/obj/item/reagent_containers/food/snacks/carrotfried
+	name = "roasted carrot"
+	desc = "A piece of roasted carrot, the edges have been cut off."
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "carrotc"
+	bitesize = 3
+	tastes = list("fried carrot" = 1)
+	filling_color = "#db7516"
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 8)
+	desc = ""
+
+/obj/item/reagent_containers/food/snacks/leekfried
+	eat_effect = null
+	slices_num = 0
+	name = "grilled leek"
+	icon = 'icons/roguetown/items/food.dmi'
+	icon_state = "leekc"
+	desc = "A piece of leek, cut in half and grilled to a medium rare."
+	bitesize = 3
+	fried_type = null
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 8)

--- a/code/modules/roguetown/roguejobs/cook/recipes/meat.dm
+++ b/code/modules/roguetown/roguejobs/cook/recipes/meat.dm
@@ -73,3 +73,13 @@
 	craftdiff = 0
 	subtype_reqs = TRUE
 	structurecraft = /obj/structure/fluff/dryingrack
+
+/datum/crafting_recipe/roguetown/cooking/rawschnitzel
+	name = "raw schnitzel"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 1,
+			/obj/item/reagent_containers/food/snacks/egg = 1,
+		/obj/item/reagent_containers/powder/flour= 1)
+	result = /obj/item/reagent_containers/food/snacks/rawschnitzel
+	req_table = TRUE
+	craftdiff = 0

--- a/code/modules/roguetown/roguejobs/cook/recipes/plates.dm
+++ b/code/modules/roguetown/roguejobs/cook/recipes/plates.dm
@@ -1,4 +1,4 @@
-/obj/item/reagent_containers/food/snacks/rogue/peppersteak
+ /obj/item/reagent_containers/food/snacks/rogue/peppersteak
 	icon = 'icons/roguetown/items/food.dmi'
 	list_reagents = list(/datum/reagent/consumable/nutriment = 25)
 	tastes = list("steak" = 1, "pepper" = 1)
@@ -6,6 +6,7 @@
 	desc = ""
 	icon_state = "peppersteak"
 	foodtype = MEAT
+	trash = /obj/item/reagent_containers/glass/bowl
 	warming = 5 MINUTES
 	rotprocess = 30 MINUTES
 	eat_effect = /datum/status_effect/buff/foodbuff
@@ -14,6 +15,7 @@
 /datum/crafting_recipe/roguetown/cooking/peppersteak
 	name = "peppersteak"
 	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
 		/obj/item/reagent_containers/food/snacks/rogue/meat/steak/fried = 1,
 		/datum/reagent/consumable/blackpepper = 1
 	)
@@ -23,11 +25,12 @@
 /obj/item/reagent_containers/food/snacks/rogue/spicedeggs
 	icon = 'icons/roguetown/items/food.dmi'
 	list_reagents = list(/datum/reagent/consumable/nutriment = 15)
-	tastes = list("steak" = 1, "pepper" = 1)
+	tastes = list("friedegg" = 2, "pepper" = 1, "bowl" = 1)
 	name = "spiced eggs"
 	desc = ""
 	icon_state = "spicedeggs"
 	foodtype = MEAT
+	trash = /obj/item/reagent_containers/glass/bowl
 	warming = 5 MINUTES
 	rotprocess = 30 MINUTES
 	eat_effect = /datum/status_effect/buff/foodbuff
@@ -36,6 +39,7 @@
 /datum/crafting_recipe/roguetown/cooking/spicedeggs
 	name = "spiced eggs"
 	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
 		/obj/item/reagent_containers/food/snacks/rogue/friedegg = 2,
 		/datum/reagent/consumable/blackpepper = 1
 	)
@@ -128,5 +132,76 @@
 		/obj/item/reagent_containers/food/snacks/rogue/meat/salami/slice = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/rogue/sandwich
+	craftdiff = 0
+	subtype_reqs = TRUE
+
+/obj/item/reagent_containers/food/snacks/rogue/potatoschnitzel
+	icon = 'icons/roguetown/items/food.dmi'
+	list_reagents = list(/datum/reagent/consumable/nutriment = 25)
+	tastes = list("meat" = 1, "crispy bread" = 1, "potatoes" = 1)
+	name = "roasted potato and schnitzel"
+	desc = ""
+	icon_state = "potatoschniztel"
+	foodtype = MEAT
+	trash = /obj/item/reagent_containers/glass/bowl
+
+	warming = 5 MINUTES
+	rotprocess = 30 MINUTES
+	eat_effect = /datum/status_effect/buff/foodbuff
+	drop_sound = 'sound/foley/dropsound/gen_drop.ogg'
+
+/datum/crafting_recipe/roguetown/cooking/potatoschnitzel
+	name = "Potato and Schnitzel"
+	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
+		/obj/item/reagent_containers/food/snacks/rogue/schnitzel = 1,
+		/obj/item/reagent_containers/food/snacks/potatofried = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/rogue/potatoschnitzel
+	skillcraft = null
+
+/obj/item/reagent_containers/food/snacks/rogue/boiledrice
+	icon = 'icons/roguetown/items/food.dmi'
+	list_reagents = list(/datum/reagent/consumable/nutriment = 15)
+	tastes = list("rice" = 1,"salt" = 1)
+	name = "boiled rice"
+	desc = "a plate of steaming boiled rice"
+	icon_state = "boiledrice"
+	trash = /obj/item/reagent_containers/glass/bowl
+	foodtype = GRAIN
+	warming = 5 MINUTES
+	rotprocess = 40 MINUTES
+
+/datum/crafting_recipe/roguetown/cooking/boiledrice
+	name = "boiled rice"
+	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
+		/obj/item/reagent_containers/food/snacks/grown/rice = 1,
+		/obj/item/reagent_containers/powder/salt = 1,
+	)
+	result = /obj/item/reagent_containers/food/snacks/rogue/boiledrice
+	craftdiff = 0
+	subtype_reqs = TRUE
+
+/obj/item/reagent_containers/food/snacks/rogue/oatporridge
+	icon = 'icons/roguetown/items/food.dmi'
+	list_reagents = list(/datum/reagent/consumable/nutriment = 15)
+	tastes = list("rice" = 1,"salt" = 1)
+	name = "oat porridge"
+	desc = "a plate of steaming porridge made out of oats and apple slices"
+	icon_state = "appleporridge"
+	trash = /obj/item/reagent_containers/glass/bowl
+	foodtype = GRAIN
+	warming = 5 MINUTES
+	rotprocess = 40 MINUTES
+
+/datum/crafting_recipe/roguetown/cooking/porridge
+	name = "oat porridge"
+	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
+		/obj/item/reagent_containers/food/snacks/grown/oat = 1,
+		/obj/item/reagent_containers/food/snacks/grown/apple = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/rogue/oatporridge
 	craftdiff = 0
 	subtype_reqs = TRUE

--- a/code/modules/roguetown/roguejobs/cook/tools/cookingpot.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/cookingpot.dm
@@ -1,0 +1,21 @@
+/obj/item/cooking/cookingpot
+	force = 20
+	throwforce = 15
+	possible_item_intents = list(/datum/intent/mace/strike/shovel)
+	name = "steel cooking pot"
+	desc = "Two in one: Cook and smash heads."
+	icon_state = "cookingpan"
+	icon = 'icons/roguetown/items/cooking.dmi'
+	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
+	wlength = WLENGTH_SHORT
+	sharpness = IS_BLUNT
+	//dropshrink = 0.8
+	slot_flags = ITEM_SLOT_HIP
+	can_parry = FALSE
+	drop_sound = 'sound/foley/dropsound/shovel_drop.ogg'
+	wdefense = 5
+	ingsize = 3
+
+/obj/item/cooking/pan/examine(mob/user)
+	. = ..()


### PR DESCRIPTION

NEW CROPS -

*CABBAGE - OBSOLETE can only be eaten raw for now
*BEET - OBSOLETE can only be eaten raw for now
*LEEK - Fried in the pan/oven 
*POTATO - Roasted in pan/oven
*CARROT - Roasted in pan/oven
*RICE - Used in dishes, seeds sold by merchant

DISHES -

*Boiled rice - Combine 1 rice 1 bowl (Subject to change, cooking needs to be reintroduced)
*Schnitzel - Craft 1 steak - 1 egg - 1 flour (Grenzelholfter dish)
*Roasted potato and Schnitzel - Requires bowl, craft with roasted potatoes and fried schnitzel (Gives filling meal buff)
*Sweet Oat Porridge - Requires bowl, combine 1 oat and 1 apple (WIP)
*Spiced eggs now require a bowl
*Peppersteak now requires a bowl