### PR TITLE
Adds functionality to moonwalking back and forth on tiles, ports pixel shifting

### DIFF
--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -319,7 +319,6 @@
 
 //layer shifting
 
-
 /datum/keybinding/living/pixel_shift_layerup
 	hotkey_keys = list("CtrlShiftNortheast")
 	name = "pixel_shift_layerup"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -269,7 +269,7 @@
 	if(M.pixel_y <= 16 && M.pixelshift_y <= 16 && M.wallpressed == FALSE)
 		M.pixelshifted = TRUE
 		M.pixelshift_y = M.pixelshift_y + 1
-		M.set_mob_offsets("pixel_shift", _x = M.pixelshift_x, _y = M.pixelshift_y)	
+		M.set_mob_offsets("pixel_shift", _x = M.pixelshift_x, _y = M.pixelshift_y)
 	return TRUE
 
 /datum/keybinding/living/pixel_shift_east
@@ -284,7 +284,7 @@
 	if(M.pixel_x <= 16 && M.pixelshift_x <= 16 && M.wallpressed == FALSE)
 		M.pixelshifted = TRUE
 		M.pixelshift_x = M.pixelshift_x + 1
-		M.set_mob_offsets("pixel_shift", _x = M.pixelshift_x, _y = M.pixelshift_y)	
+		M.set_mob_offsets("pixel_shift", _x = M.pixelshift_x, _y = M.pixelshift_y)
 	return TRUE
 
 /datum/keybinding/living/pixel_shift_south
@@ -299,7 +299,7 @@
 	if(M.pixel_y >= -16 && M.pixelshift_y >= -16 && M.wallpressed == FALSE)
 		M.pixelshifted = TRUE
 		M.pixelshift_y = M.pixelshift_y - 1
-		M.set_mob_offsets("pixel_shift", _x = M.pixelshift_x, _y = M.pixelshift_y)		
+		M.set_mob_offsets("pixel_shift", _x = M.pixelshift_x, _y = M.pixelshift_y)
 	return TRUE
 
 /datum/keybinding/living/pixel_shift_west
@@ -314,7 +314,38 @@
 	if(M.pixel_x >= -16 && M.pixelshift_x >= -16 && M.wallpressed == FALSE)
 		M.pixelshifted = TRUE
 		M.pixelshift_x = M.pixelshift_x - 1
-		M.set_mob_offsets("pixel_shift", _x = M.pixelshift_x, _y = M.pixelshift_y)	
+		M.set_mob_offsets("pixel_shift", _x = M.pixelshift_x, _y = M.pixelshift_y)
 	return TRUE
 
+//layer shifting
 
+
+/datum/keybinding/living/pixel_shift_layerup
+	hotkey_keys = list("CtrlShiftNortheast")
+	name = "pixel_shift_layerup"
+	full_name = "Pixel-Shift Layer Up"
+	description = ""
+	var/lastrest = 0
+
+/datum/keybinding/living/pixel_shift_layerup/down(client/user)
+	var/mob/living/M = user.mob
+	if(M.pixelshift_layer <= 0.04)
+		M.pixelshifted = TRUE
+		M.pixelshift_layer = M.pixelshift_layer + 0.01
+		M.layer = 4 + M.pixelshift_layer
+	return TRUE
+
+/datum/keybinding/living/pixel_shift_layerdown
+	hotkey_keys = list("CtrlShiftSoutheast")
+	name = "pixel_shift_layerdown"
+	full_name = "Pixel-Shift Layer Down"
+	description = ""
+	var/lastrest = 0
+
+/datum/keybinding/living/pixel_shift_layerdown/down(client/user)
+	var/mob/living/M = user.mob
+	if(M.pixelshift_layer >= -0.04)
+		M.pixelshifted = TRUE
+		M.pixelshift_layer = M.pixelshift_layer - 0.01
+		M.layer = 4 + M.pixelshift_layer
+	return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1629,8 +1629,8 @@
 		if(!lying_prev)
 			fall(!canstand_involuntary)
 		layer = LYING_MOB_LAYER //so mob lying always appear behind standing mobs
-	if (pixelshifted)
-		layer = 3.99 + pixelshift_layer //So mobs can pixelshift layers while lying down
+		if (pixelshifted)
+			layer = 3.99 + pixelshift_layer //So mobs can pixelshift layers while lying down
 	else
 		if(layer == LYING_MOB_LAYER)
 			layer = initial(layer)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -52,8 +52,8 @@
 
 /mob/living/onZImpact(turf/T, levels)
 	if(HAS_TRAIT(src, TRAIT_NOFALLDAMAGE1))
-		if(levels <= 2)	
-			return 
+		if(levels <= 2)
+			return
 	var/points
 	for(var/i in 2 to levels)
 		i++
@@ -395,7 +395,7 @@
 //		else
 //			if(!supress_message)
 //				AM.visible_message(span_danger("[src] has pulled [AM] from [AM.pulledby]'s grip."), span_danger("[src] has pulled me from [AM.pulledby]'s grip."), null, null, src)
-//								
+//
 //				to_chat(src, span_notice("I pull [AM] from [AM.pulledby]'s grip!"))
 //			log_combat(AM, AM.pulledby, "pulled from", src)
 //			AM.pulledby.stop_pulling() //an object can't be pulled by two mobs at once.
@@ -890,6 +890,8 @@
 	pixelshifted = FALSE
 	pixelshift_x = 0
 	pixelshift_y = 0
+	pixelshift_layer = 0
+	layer = 4
 	reset_offsets("pixel_shift")
 
 /mob/living/Move(atom/newloc, direct, glide_size_override)
@@ -1114,13 +1116,13 @@
 		wrestling_diff += (mind.get_skill_level(/datum/skill/combat/wrestling)) //NPCs don't use this
 	if(L.mind)
 		wrestling_diff -= (L.mind.get_skill_level(/datum/skill/combat/wrestling))
-	
+
 	resist_chance += ((STASTR - L.STASTR) * 10)
-	
+
 	if(!(mobility_flags & MOBILITY_STAND))
-		resist_chance += -20 + min((wrestling_diff * 5), -20) //Can improve resist chance at high skill difference     
+		resist_chance += -20 + min((wrestling_diff * 5), -20) //Can improve resist chance at high skill difference
 	if(pulledby.grab_state >= GRAB_AGGRESSIVE)
-		resist_chance += -20 + max((wrestling_diff * 10), 0) 
+		resist_chance += -20 + max((wrestling_diff * 10), 0)
 		resist_chance = max(resist_chance, 50 + min((wrestling_diff * 5), 0))
 	else
 		resist_chance = max(resist_chance, 70 + min((wrestling_diff * 5), 0))
@@ -1226,7 +1228,7 @@
 	if(check_arm_grabbed(active_hand_index))
 		to_chat(src, span_warning("Someone is grabbing my arm!"))
 		return
-	
+
 	if(istype(src, /mob/living/carbon/spirit))
 		to_chat(src, span_warning("Your hands pass right through \the [what]!"))
 		return
@@ -1627,6 +1629,8 @@
 		if(!lying_prev)
 			fall(!canstand_involuntary)
 		layer = LYING_MOB_LAYER //so mob lying always appear behind standing mobs
+	if (pixelshifted)
+		layer = 3.99 + pixelshift_layer //So mobs can pixelshift layers while lying down
 	else
 		if(layer == LYING_MOB_LAYER)
 			layer = initial(layer)
@@ -1958,7 +1962,7 @@
 	if(!istype(T))
 		return
 	changeNext_move(CLICK_CD_MELEE)
-	
+
 	var/_x = T.x-loc.x
 	var/_y = T.y-loc.y
 	var/dist = get_dist(src, T)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -32,6 +32,7 @@
 	var/pixelshifted = FALSE
 	var/pixelshift_x = 0
 	var/pixelshift_y = 0
+	var/pixelshift_layer = 0
 
 	var/lying = 0			//number of degrees. DO NOT USE THIS IN CHECKS. CHECK FOR MOBILITY FLAGS INSTEAD!!
 	var/lying_prev = 0		//last value of lying on update_mobility

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -22,7 +22,7 @@
 			var/mob/living/M = mover
 			if(M.wallpressed)
 				return !wallpressed
-	return (!density || wallpressed || !(mobility_flags & MOBILITY_STAND))
+	return (!density || wallpressed || (pixelshift_x >= 10 && pixel_x >= 10) || (pixelshift_x <= -10 && pixel_x <= -10) || (pixelshift_y >= 10 && pixel_y >= 10) || (pixelshift_y <= -8 && pixel_y <= -8) || !(mobility_flags & MOBILITY_STAND))
 
 /mob/living/toggle_move_intent()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## About The Pull Request
Does what it says on the tin. By default layer shifting is bound to Ctrl + Shift + Pageup/Pagedown. You will need to set this, just like the pixel-shifting keybind, but you can do so easily by going into your keybinds and just "resetting to defaults", as this is now default. Also, now if you pixel shift 10 or more in most directions or 8 or more downwards, people will be able to move through you!
## Why It's Good For The Game
The ability to decide who's REALLY on top.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
