### PR TITLE
Makes Weapon Names Bold in Examine

### DIFF
--- a/code/game/objects/items/rogueweapons/rogueweapon.dm
+++ b/code/game/objects/items/rogueweapons/rogueweapon.dm
@@ -28,8 +28,8 @@
 	experimental_onhip = TRUE
 	experimental_onback = TRUE
 	embedding = list(
-		"embed_chance" = 20, 
-		"embedded_pain_multiplier" = 1, 
+		"embed_chance" = 20,
+		"embedded_pain_multiplier" = 1,
 		"embedded_fall_chance" = 0,
 	)
 	var/initial_sl
@@ -42,10 +42,13 @@
 		var/yea = pick("[src] is broken!", "[src] is useless!", "[src] is destroyed!")
 		destroy_message = span_warning("[yea]")
 
+/obj/item/rogueweapon/get_examine_string(mob/user, thats = FALSE)
+	return "[thats? "That's ":""]<b>[get_examine_name(user)]</b>"
+
 /obj/item/rogueweapon/get_dismemberment_chance(obj/item/bodypart/affecting, mob/user)
 	if(!get_sharpness() || !affecting.can_dismember(src))
 		return 0
-	
+
 	var/total_dam = affecting.get_damage()
 	var/nuforce = get_complex_damage(src, user)
 	var/pristine_blade = TRUE
@@ -73,7 +76,7 @@
 
 	if(nuforce < 10)
 		return 0
-	
+
 	var/probability = nuforce * (total_dam / affecting.max_damage)
 	var/hard_dismember = HAS_TRAIT(affecting, TRAIT_HARDDISMEMBER)
 	var/easy_dismember = affecting.rotted || affecting.skeletonized || HAS_TRAIT(affecting, TRAIT_EASYDISMEMBER)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -117,6 +117,9 @@
 		visible_message(span_notice("[G] can now fit a new pin, but the old one was destroyed in the process."), null, null, 3)
 		qdel(src)
 
+/obj/item/gun/get_examine_string(mob/user, thats = FALSE)
+	return "[thats? "That's ":""]<b>[get_examine_name(user)]</b>"
+
 /obj/item/gun/examine(mob/user)
 	. = ..()
 //	if(pin)


### PR DESCRIPTION
Have you ever wanted to quickly notice what weapons someone is carrying on their person without having to squint like a bag of nails?

Well, I have just the thing for you! With our patented **GearGlance™** technology, weapon names now leap off the screen like never before. No more straining your eyes or missing that crucial piece of gear. Just one glance, and BAM! You know exactly what they’re packing. Whether it’s a crossbow, a Zweihänder, or a rusty old dagger, you'll spot it faster than ever before.

Say goodbye to guesswork, and say hello to clarity with **GearGlance™**! Grab this pull request now, and revolutionize your examinatory experience today!