### PR TITLE
I Got Bars

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -386,6 +386,10 @@
 	return !density
 	..()
 
+/obj/structure/bars/shop
+	icon_state = "barsbent"
+	layer = BELOW_OBJ_LAYER
+
 /obj/structure/bars/chainlink
 	icon_state = "chainlink"
 
@@ -1285,7 +1289,7 @@
 	icon = 'icons/roguetown/items/natural.dmi'
 	icon_state = "headstake"
 	density = FALSE
-	anchored = TRUE	
+	anchored = TRUE
 	dir = SOUTH
 	var/obj/item/grown/log/tree/stake/stake
 	var/obj/item/bodypart/head/victim
@@ -1299,7 +1303,7 @@
 	stake = locate(/obj/item/grown/log/tree/stake) in parts_list
 
 ///obj/structure/fluff/headstake/Initialize()
-//	. = ..()	
+//	. = ..()
 
 /obj/structure/fluff/headstake/OnCrafted(dirin, user)
 	dir = SOUTH

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -305,7 +305,7 @@
 
 /datum/crafting_recipe/roguetown/structure/headstake
 	name = "head stake"
-	result = /obj/structure/fluff/headstake	
+	result = /obj/structure/fluff/headstake
 	reqs = list(/obj/item/grown/log/tree/stake = 1,
 				/obj/item/bodypart/head = 1)
 	parts = list(/obj/item/bodypart/head = 1,
@@ -313,7 +313,7 @@
 	verbage_simple = "set up"
 	verbage = "sets up"
 	craftdiff = 0
-	
+
 
 /datum/crafting_recipe/roguetown/structure/fencealt
 	name = "palisade (small log)"
@@ -510,6 +510,22 @@
 	verbage = "constructs"
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/structure/bars
+	name = "metal bars"
+	result = /obj/structure/bars
+	reqs = list(/obj/item/ingot/iron = 1)
+	verbage_simple = "engineer"
+	verbage = "engineers"
+	skillcraft = /datum/skill/craft/engineering
+
+/datum/crafting_recipe/roguetown/structure/shopbars
+	name = "shop bars"
+	result = /obj/structure/bars/shop
+	reqs = list(/obj/item/ingot/iron = 1)
+	verbage_simple = "engineer"
+	verbage = "engineers"
+	skillcraft = /datum/skill/craft/engineering
 
 /datum/crafting_recipe/roguetown/structure/passage
 	name = "passage"


### PR DESCRIPTION
Are you tired of unruly customers jumping over your counter? Sick of those pesky prisoners escaping from your makeshift cells? Well, do I have the solution for you! Introducing craftable _Shop Bars_ and _Jail Bars_! Need to keep those eager shoppers on the other side of the counter? Craft some _Shop Bars_ with just one iron ingot and slap it right on top of your table! Now they can’t jump over, but they can still slide items across for trade. It’s a win-win!

But wait, there’s more! Need to lock up those no-good troublemakers? Put together some _Jail Bars_ and build yourself a real cell! These bars aren’t just for show – they’re the real deal, perfect for keeping the riff-raff in check.

So what are you waiting for? Get your _Shop Bars_ and _Jail Bars_ today, lest you find your stockpile barren when you return!