### PR TITLE
Tweaks to improve werewolf

### DIFF
--- a/code/game/gamemodes/objectives_rogue.dm
+++ b/code/game/gamemodes/objectives_rogue.dm
@@ -39,8 +39,8 @@
 
 /datum/objective/werewolf
 	name = "conquer"
-	explanation_text = "Put an end to the vampire scourge in Azure Peak, or unite with them against the forces of the Nine."
-	team_explanation_text = "The feud between werewolves and vampires reaches back to the dawn of time. Will the two factions destroy each other, or find a way to coexist and face the mortals of Azure Peak together?"
+	explanation_text = "You are touched by the Mad God of the Wilds, Dendor - be it through a bite... Or a terrible blessing. And you are SO, SO VERY HUNGRY. The form Dendor promises will be fearsome, but the transition will be agonizing. Fear not the full moon - and let the feast begin."
+	team_explanation_text = "Lycanthropy is a terrible disease that's been recorded in scattered accounts going back hundreds of years. Whatever madness drove Dendor to create such an aberration is beyond mortal minds - and whatever the reason, he has been unwilling or unable to undo it. Nightly transformations and prodigious increses in mass drive the body into an active state of insatiable starvation, driving animalistic, rabid behavior."
 	triumph_count = 5
 
 /datum/objective/werewolf/check_completion()

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -46,13 +46,13 @@
             if(!untransforming)
                 untransforming = world.time // Start untransformation phase
 
-            if (world.time >= untransforming + 25 SECONDS) // Untransform
+            if (world.time >= untransforming + 30 SECONDS) // Untransform
                 H.emote("rage", forced = TRUE)
                 H.werewolf_untransform()
                 transformed = FALSE
                 untransforming = FALSE // Reset untransforming phase
 
-            else if (world.time >= untransforming + 10 SECONDS) // Alert player
+            else if (world.time >= untransforming) // Alert player
                 H.flash_fullscreen("redflash1")
                 to_chat(H, span_warning("Daylight shines around me... the curse begins to fade."))
 

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -188,7 +188,24 @@
 					span_danger("\The [M] [pick(M.a_intent.attack_verb)] me![next_attack_msg.Join()]"), null, COMBAT_MESSAGE_RANGE)
 		next_attack_msg.Cut()
 
-
+/mob/living/simple_animal/onbite(mob/living/carbon/human/user)
+	var/damage = 10*(user.STASTR/20)
+	if(HAS_TRAIT(user, TRAIT_STRONGBITE))
+		damage = damage*2
+	playsound(user.loc, "smallslash", 100, FALSE, -1)
+	user.next_attack_msg.Cut()
+	if(stat == DEAD)
+		if(user.mind && istype(user, /mob/living/carbon/human/species/werewolf))
+			visible_message(span_danger("The werewolf ravenously consumes the [src]!"))
+			to_chat(src, span_warning("I feed on succulent flesh. I feel reinvigorated."))
+			user.reagents.add_reagent(/datum/reagent/medicine/healthpot, 3)
+			gib()
+		return
+	if(src.apply_damage(damage, BRUTE))
+		if(istype(user, /mob/living/carbon/human/species/werewolf))
+			visible_message(span_danger("The werewolf bites into [src] and thrashes!"))
+		else
+			visible_message(span_danger("[user] bites [src]! What is wrong with them?"))
 
 /mob/living/simple_animal/onkick(mob/M)
 	var/mob/living/simple_animal/target = src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Improves werewolf lore. Gives werewolves more warning in advance as to when they're untransforming. Gives werewolves something to do other than tearing off people's limbs and eating them - they can ALSO eat LIVESTOCK to heal now!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why does the transition take 25 seconds when sunrise begins, but players only get 15 seconds of warning out of it?
Players having more goals and alternative methods to achieve their goals other than pure ultraviolence good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
