### PR TITLE
Comments out Grenzelhoft's most egregious word-bleed replacements pending new system

### DIFF
--- a/strings/german_replacement.json
+++ b/strings/german_replacement.json
@@ -64,6 +64,7 @@
 		"vampire": "vampir",
 		"black": "schwarz",
 		"church": "kirche",
+		//"no":  "nein",
 		//"is": "ist", 
 		//"queen": "königin", (for consistency. king wont be changed during this time, queen shouldn't either.)
 		"town": "stadt",

--- a/strings/german_replacement.json
+++ b/strings/german_replacement.json
@@ -51,8 +51,8 @@
 		"young": "jung",
 		"soldier": "soldat",
 		"knight": "ritter",
-		"kingdom": "keengdum",
-		"king": "keeng",
+		"kingdom": "königreich",
+		//"king": "könig", (pending new system, grenz accent changes that might bleed into other words will be commented out. when new system is implemented, the accent will be overhauled.)
 		"princess": "prinzess",
 		"prince": "prinz",
 		"dwarf": "zwarf",
@@ -64,10 +64,10 @@
 		"vampire": "vampir",
 		"black": "schwarz",
 		"church": "kirche",
-		"is": "ist",
-		"queen": "kween",
+		//"is": "ist", 
+		//"queen": "königin", (for consistency. king wont be changed during this time, queen shouldn't either.)
 		"town": "stadt",
-		"an": "eine",
+		//"an": "eine",
 		"colleague": "kollege"
 	}
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Look at the diffs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pending a new system, the Grenzelhoft accent has a lot of fucky replacements that bleed into each other and make certain words unintelligible due to how the Grenzelhoft accent was constructed. This should help with that in the meantime, and is better than outright deleting word changes like what I did before, sorry.

Hammerhold and the Half-Orc one probably have similar issues, but... nobody uses those, so...
If people want I will look through those ones too but it shouldn't be *too* long until a new system is devised.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
