### PR TITLE
Changes only some of the accents to do in-word changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
@@ -29,10 +29,18 @@
 /datum/species/proc/get_accent_start(mob/living/carbon/human)
 	return
 
-/datum/species/proc/get_accent_any(mob/living/carbon/human/H)
+/datum/species/proc/get_accent_any(mob/living/carbon/human/H) //determines if accent replaces in-word text
 	switch(H.char_accent)
+		if("Dark Elf accent")
+			return strings("french_replacement.json", "french")
 		if("Elf accent")
 			return strings("russian_replacement.json", "russian")
+		if("Lizard accent")
+			return strings("brazillian_replacement.json", "brazillian")
+		if("Tiefling accent")
+			return strings("spanish_replacement.json", "spanish")
+		if("Dwarf Gibberish accent")
+			return strings("dwarf_replacement.json", "dwarf_gibberish")
 
 #define REGEX_STARTWORD 1
 #define REGEX_FULLWORD 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Elf, Dark Elf, Tiefling, and Dwarf Gibberish now do in-word syllable-ized changes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The accents that don't work when in-word changes are turned off now work without breaking the other ones. +dwarf gibberish is more unintelligible as it should be

A new system is still needed to make this system perfect but this is good enough
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
