### PR TITLE
Adjusts antagonist rolls so we can roll certain ones

### DIFF
--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -157,27 +157,40 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 					log_game("Major Antagonist: Extended")
 		return TRUE
 
-	if(num_players() >= 10) // Need at least a handful of people before we start throwing ne'er-do-wells into the mix.
+	if(num_players() >= 20) // Need at least a handful of people before we start throwing ne'er-do-wells into the mix.
 		var/major_roll = rand(1,100)
 		switch(major_roll)
+			/* rebels depend a little too much on the main players being exceedingly good roleplayers and lends itself to bad conduct too much to be spawning automatically
 			if(1 to 35)
 				pick_rebels()
 				log_game("Major Antagonist: Rebellion")
-			if(36 to 80)
-				//WWs and Vamps now normally roll together
-				pick_vampires()
+			*/
+			if(1 to 33)
+				pick_bandits()
+				pick_aspirants()
+				log_game("Antagonists: Bandits & Aspirants")
+			if(34 to 66)
+				//"pick_vampires() was removed from here, normally they spawn together
 				pick_werewolves()
-				log_game("Major Antagonist: Vampires and Werewolves")
+				pick_bandits()
+				log_game("Antagonists: Werewolves & Bandits")
+			if(67 to 100)
+				pick_werewolves()
+				pick_aspirants()
+				log_game("Antagonists: Werewolves & Aspirants")
+			/* we've been having a lot of this, we can reimplement a random extended chance after seeing how the antags go
 			if(81 to 100)
 				log_game("Major Antagonist: Extended") //gotta put something here.
+			*/
 
+		/* removing the "minor antagonist" system as we currently need them as major antagonist gamemodes while waiting for our own custom antags
 		if(prob(45))
 			pick_bandits()
 			log_game("Minor Antagonist: Bandit")
 		if(prob(45))
 			pick_aspirants()
 			log_game("Minor Antagonist: Aspirant")
-		/* Rest well, unoriginal LFWB reference. You will not be missed.
+		//Rest well, unoriginal LFWB reference. You will not be missed.
 		if(prob(10))
 			pick_maniac()
 			log_game("Minor Antagonist: Maniac")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This removes vampires and peasant rebels from the automatic antag spawning system, leaving us with Werewolves, Bandits and Aspirants (Maniac is already long gone.) Previously, it would roll for "major" antagonists and then add "minor" antagonists on top at a 40% chance each, potentially allowing for an insane amount of chaos - since we only have 3, I opted to make something a little more stable, and gave us a 1/3 chance of rolling any two antagonists, never all 3.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We can't be around to do manual antags and events all day long and people need drama, intrigue and action, as is plainly obvious by the way our player count looks throughout the day between event times and lowpop.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
