### PR TITLE
Removes the no monarch omen, changes the number of people required for antags

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -146,7 +146,7 @@ SUBSYSTEM_DEF(vote)
 			if("endround")
 				if(. == "Continue Playing")
 					log_game("LOG VOTE: CONTINUE PLAYING AT [REALTIMEOFDAY]")
-					addomen(OMEN_ROUNDSTART)
+					//addomen(OMEN_ROUNDSTART) not fun or roleplay having random goblins spawn every time round gets extended
 					GLOB.round_timer = GLOB.round_timer + ROUND_EXTENSION_TIME
 				else
 					log_game("LOG VOTE: ELSE  [REALTIMEOFDAY]")

--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -111,7 +111,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 			missing_lord_time = world.time
 		if(world.time > missing_lord_time + 10 MINUTES)
 			missing_lord_time = world.time
-			addomen(OMEN_NOLORD)
+			//addomen(OMEN_NOLORD) not really fun or roleplay tbh
 		return FALSE
 	else
 		return TRUE
@@ -157,7 +157,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 					log_game("Major Antagonist: Extended")
 		return TRUE
 
-	if(num_players() >= 20) // Need at least a handful of people before we start throwing ne'er-do-wells into the mix.
+	if(num_players() >= 10) // Need at least a handful of people before we start throwing ne'er-do-wells into the mix.
 		var/major_roll = rand(1,100)
 		switch(major_roll)
 			/* rebels depend a little too much on the main players being exceedingly good roleplayers and lends itself to bad conduct too much to be spawning automatically


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removes the event that endlessly spawns goblin portals when there's no monarch, as a consideration for pop given we may be using the roguemode game mode more often from now on. Also changes the roundstart requirement for antags down to 10 to account for cowards who don't ready up - 10 people readied seems to roughly accompany about 20 people actually playing, which is what was intended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
goblussy is a kingdomwide health crisis
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
