### PR TITLE
Disables bog guard

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -3,8 +3,8 @@
 	flag = BOGGUARD
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 10
-	spawn_positions = 10
+	total_positions = 0
+	spawn_positions = 0
 	selection_color = JCOLOR_SOLDIER
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogmaster.dm
@@ -3,8 +3,8 @@
 	flag = BOGMASTER
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_patrons = ALL_DIVINE_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/garrison/sheriff.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sheriff.dm
@@ -9,7 +9,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	display_order = JDO_SHERIFF
-	tutorial = "Crime has always been a constant of your life, and you always chose the side of justice. You rose up through the ranks as a watchman, and now rule over them - Ensure that they enforce the laws of this land properly."
+	tutorial = "Crime has always been a constant of your life, and you always chose the side of justice. You rose up through the ranks as a watchman, and are now a sargeant under the Guard Captain. Ensure the watch runs without stopping."
 	whitelist_req = FALSE
 	outfit = /datum/outfit/job/roguetown/sheriff
 	give_bank_account = 26

--- a/code/modules/jobs/job_types/roguetown/garrison/sheriff.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sheriff.dm
@@ -9,7 +9,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	display_order = JDO_SHERIFF
-	tutorial = "Crime has always been a constant of your life, and you always chose the side of justice. You rose up through the ranks as a watchman, and are now a sargeant under the Guard Captain. Ensure the watch runs without stopping."
+	tutorial = "Crime has always been a constant of your life, and you always chose the side of justice. You rose up through the ranks as a watchman, and are now a sargent under the Guard Captain. Ensure the watch runs without stopping."
 	whitelist_req = FALSE
 	outfit = /datum/outfit/job/roguetown/sheriff
 	give_bank_account = 26

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -3,8 +3,8 @@
 	flag = GUARDSMAN
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 8
-	spawn_positions = 8
+	total_positions = 12
+	spawn_positions = 12
 	selection_color = JCOLOR_SOLDIER
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS // same as town guard

--- a/strings/accent_universal.json
+++ b/strings/accent_universal.json
@@ -89,6 +89,7 @@
 		"wolves": "volfs",
 		"lolth": "graggar",
 		"wolfpit": "volfpit",
-		"PQ": "reputation"
-	}
+		"PQ": "reputation",
+		"sergant":  "sargeant"
+    }
 }

--- a/strings/accent_universal.json
+++ b/strings/accent_universal.json
@@ -90,6 +90,6 @@
 		"lolth": "graggar",
 		"wolfpit": "volfpit",
 		"PQ": "reputation",
-		"sergant":  "sargeant"
+		"sergant":  "sargent"
     }
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This PR:
Disables bog guard and bog master.
Increases the amount of townwatch slots by 4.
Reflavors sheriff to explicitly be referred to as a sargent underneath the Guard Captain.
Adds sergeant -> sargent to the universal accent 'cause it's funny.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Bog Guard, with the release of the new map, is exclusively bloat. They serve no purpose at all and are simply a slightly worse version of the town watch. Furthermore, people referring to the guards as the watch more often is !kino!, and I don't use the word kino lightly.

Sheriff and Guard Captain may be merged at some point, but for right now I don't think its that big of a deal for the Captain to have someone to delegate command to. Not that Guard Captain players ever actually pay attention to the guards, fucking... fuhhghghhhh...
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
