### PR TITLE
Fixes bandit/vampire travel tiles

### DIFF
--- a/code/game/objects/structures/traveltile.dm
+++ b/code/game/objects/structures/traveltile.dm
@@ -149,9 +149,9 @@
 		to_chat(AM, "<b>It is a dead end.</b>")
 
 /obj/structure/fluff/traveltile/bandit
-
+	required_trait = TRAIT_BANDITCAMP
 /obj/structure/fluff/traveltile/vampire
-
+	required_trait = TRAIT_VAMPMANSION
 /obj/structure/fluff/traveltile/dungeon
 	name = "gate"
 	desc = "This gate's enveloping darkness is so opressive you dread to step through it."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Antag travel tiles now properly prevent people who do not have the trait associated with them from entering.
In order to get this trait, you need to either be the antag or see someone with the trait enter the travel tile.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Working mechanics yippie!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
