### PR TITLE
Buffs Arrows/Bolts

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -18,9 +18,9 @@
 */
 /obj/projectile/bullet/reusable/bolt
 	name = "bolt"
-	damage = 35
+	damage = 70
 	damage_type = BRUTE
-	armor_penetration = 35
+	armor_penetration = 50
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "bolt_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/bolt
@@ -29,7 +29,7 @@
 	embedchance = 100
 	woundclass = BCLASS_STAB
 	flag = "bullet"
-	speed = 0.3
+	speed = 0.5
 /*
 /obj/projectile/bullet/reusable/bolt/poison
 	name = "poisoned bolt"
@@ -69,9 +69,9 @@
 
 /obj/projectile/bullet/reusable/arrow
 	name = "arrow"
-	damage = 35
+	damage = 50
 	damage_type = BRUTE
-	armor_penetration = 10
+	armor_penetration = 40
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow
@@ -112,7 +112,7 @@
 
 /obj/projectile/bullet/reusable/arrow/poison
 	name = "poison arrow"
-	damage = 35
+	damage = 50
 	damage_type = BRUTE
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Buffs arrows and bolts with higher AP and damage.

Bolts
Damage 35->70
AP 35->50

Arrows
Damage 35->50
AP 10->40

## Why It's Good For The Game
Long ago, someone was neck-critted by a bow and dumpstered ranged weapons doing damage. No longer. Carry a shield, and for the rangers amongst you, you are now valuable. Restores ranged weapons into relevancy. This is pretty much just porting the same changes Hstone made about a month or two ago. Values can be adjusted
