### PR TITLE
De-Chuddifies skin color selection

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -122,15 +122,15 @@
 
 /datum/species/demihuman/get_skin_list()
 	return list(
-		"Grenzelhoft" = SKIN_COLOR_GRENZELHOFT,
-		"Hammerhold" = SKIN_COLOR_HAMMERHOLD,
-		"Avar" = SKIN_COLOR_AVAR,
-		"Rockhill" = SKIN_COLOR_ROCKHILL,
-		"Otava" = SKIN_COLOR_OTAVA,
-		"Etrusca" = SKIN_COLOR_ETRUSCA,
-		"Gronn" = SKIN_COLOR_GRONN,
-		"Giza" = SKIN_COLOR_GIZA,
-		"Shalvistine" = SKIN_COLOR_SHALVISTINE,
-		"Lalvestine" = SKIN_COLOR_LALVESTINE,
-		"Ebon" = SKIN_COLOR_EBON,
+		"Skin Color 1" = SKIN_COLOR_GRENZELHOFT,
+		"Skin Color 2" = SKIN_COLOR_HAMMERHOLD,
+		"Skin Color 3" = SKIN_COLOR_AVAR,
+		"Skin Color 4" = SKIN_COLOR_ROCKHILL,
+		"Skin Color 5" = SKIN_COLOR_OTAVA,
+		"Skin Color 6" = SKIN_COLOR_ETRUSCA,
+		"Skin Color 7" = SKIN_COLOR_GRONN,
+		"Skin Color 8" = SKIN_COLOR_GIZA,
+		"Skin Color 9" = SKIN_COLOR_SHALVISTINE,
+		"Skin Color 10" = SKIN_COLOR_LALVESTINE,
+		"Skin Color 11" = SKIN_COLOR_EBON,
 	)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -84,15 +84,15 @@
 
 /datum/species/dwarf/mountain/get_skin_list()
 	return list(
-		"Platinum" = SKIN_COLOR_PLATINUM,
-		"Aurum" = SKIN_COLOR_AURUM,
-		"Quicksilver" = SKIN_COLOR_QUICKSILVER,
-		"Brass" = SKIN_COLOR_BRASS,
-		"Iron" = SKIN_COLOR_IRON,
-		"Malachite" = SKIN_COLOR_MALACHITE,
-		"Obsidian" = SKIN_COLOR_OBSIDIAN,
-		"Brimstone" = SKIN_COLOR_BRIMSTONE,
-		"Jade" = SKIN_COLOR_JADE
+		"Skin Color 1" = SKIN_COLOR_PLATINUM,
+		"Skin Color 2" = SKIN_COLOR_AURUM,
+		"Skin Color 3" = SKIN_COLOR_QUICKSILVER,
+		"Skin Color 4" = SKIN_COLOR_BRASS,
+		"Skin Color 5" = SKIN_COLOR_IRON,
+		"Skin Color 6" = SKIN_COLOR_MALACHITE,
+		"Skin Color 7" = SKIN_COLOR_OBSIDIAN,
+		"Skin Color 8" = SKIN_COLOR_BRIMSTONE,
+		"Skin Color 9" = SKIN_COLOR_JADE
 	)
 
 /datum/species/dwarf/mountain/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -105,13 +105,13 @@
 
 /datum/species/elf/dark/get_skin_list()
 	return list(
-		"Commorah" = SKIN_COLOR_COMMORAH,
-		"Gloomhaven" = SKIN_COLOR_GLOOMHAVEN,
-		"Darkpila" = SKIN_COLOR_DARKPILA,
-		"Sshanntynlan" = SKIN_COLOR_SSHANNTYNLAN,
-		"Llurth Dreir" = SKIN_COLOR_LLURTH_DREIR,
-		"Tafravma" = SKIN_COLOR_TAFRAVMA,
-		"Yuethindrynn" = SKIN_COLOR_YUETHINDRYNN,
+		"Skin Color 1" = SKIN_COLOR_COMMORAH,
+		"Skin Color 2" = SKIN_COLOR_GLOOMHAVEN,
+		"Skin Color 3" = SKIN_COLOR_DARKPILA,
+		"Skin Color 4" = SKIN_COLOR_SSHANNTYNLAN,
+		"Skin Color 5" = SKIN_COLOR_LLURTH_DREIR,
+		"Skin Color 6" = SKIN_COLOR_TAFRAVMA,
+		"Skin Color 7" = SKIN_COLOR_YUETHINDRYNN,
 	)
 
 /datum/species/elf/dark/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -92,14 +92,14 @@
 
 /datum/species/elf/wood/get_skin_list()
 	return list(
-		"Dandelion Creek" = SKIN_COLOR_DANDELION_CREEK,
-		"Roseveil" = SKIN_COLOR_ROSEVEIL,
-		"Azuregrove" = SKIN_COLOR_AZUREGROVE,
-		"Arborshome" = SKIN_COLOR_ARBORSHOME,
-		"Almondvalle" = SKIN_COLOR_ALMONDVALLE,
-		"Walnut Woods" = SKIN_COLOR_WALNUT_WOODS,
-		"Timberborn" = SKIN_COLOR_TIMBERBORN,
-		"Lotus Coast" = SKIN_COLOR_LOTUS_COAST
+		"Skin Color 1" = SKIN_COLOR_DANDELION_CREEK,
+		"Skin Color 2" = SKIN_COLOR_ROSEVEIL,
+		"Skin Color 3" = SKIN_COLOR_AZUREGROVE,
+		"Skin Color 4" = SKIN_COLOR_ARBORSHOME,
+		"Skin Color 5" = SKIN_COLOR_ALMONDVALLE,
+		"Skin Color 6" = SKIN_COLOR_WALNUT_WOODS,
+		"Skin Color 7" = SKIN_COLOR_TIMBERBORN,
+		"Skin Color 8" = SKIN_COLOR_LOTUS_COAST
 	)
 
 /datum/species/elf/wood/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -67,18 +67,18 @@
 
 /datum/species/human/northern/get_skin_list()
 	return list(
-		"Grenzelhoft" = SKIN_COLOR_GRENZELHOFT,
-		"Hammerhold" = SKIN_COLOR_HAMMERHOLD,
-		"Avar" = SKIN_COLOR_AVAR,
-		"Rockhill" = SKIN_COLOR_ROCKHILL,
-		"Otava" = SKIN_COLOR_OTAVA,
-		"Etrusca" = SKIN_COLOR_ETRUSCA,
-		"Gronn" = SKIN_COLOR_GRONN,
-		"Giza" = SKIN_COLOR_GIZA,
-		"Shalvistine" = SKIN_COLOR_SHALVISTINE,
-		"Lalvestine" = SKIN_COLOR_LALVESTINE,
-		"Ebon" = SKIN_COLOR_EBON,
-		"Kazengun" = SKIN_COLOR_KAZENGUN
+		"Skin Color 1" = SKIN_COLOR_GRENZELHOFT,
+		"Skin Color 2" = SKIN_COLOR_HAMMERHOLD,
+		"Skin Color 3" = SKIN_COLOR_AVAR,
+		"Skin Color 4" = SKIN_COLOR_ROCKHILL,
+		"Skin Color 5" = SKIN_COLOR_OTAVA,
+		"Skin Color 6" = SKIN_COLOR_ETRUSCA,
+		"Skin Color 7" = SKIN_COLOR_GRONN,
+		"Skin Color 8" = SKIN_COLOR_GIZA,
+		"Skin Color 9" = SKIN_COLOR_SHALVISTINE,
+		"Skin Color 10" = SKIN_COLOR_LALVESTINE,
+		"Skin Color 11" = SKIN_COLOR_EBON,
+		"Skin Color 12" = SKIN_COLOR_KAZENGUN
 	)
 
 /datum/species/human/northern/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -98,15 +98,15 @@
 
 /datum/species/halforc/get_skin_list()
 	return list(
-		"Shellcrest" = SKIN_COLOR_SHELLCREST,
-		"Bloodaxe" = SKIN_COLOR_BLOOD_AXE,
-		"Splitjaw" = SKIN_COLOR_GROONN, //Changed name from Gronn, which no longer aligned with lore here or elsewhere.
-		"Blackhammer" = SKIN_COLOR_BLACK_HAMMER,
-		"Skullseeker" = SKIN_COLOR_SKULL_SEEKER,
-		"Crescent Fang" = SKIN_COLOR_CRESCENT_FANG,
-		"Murkwalker" = SKIN_COLOR_MURKWALKER,
-		"Shatterhorn" = SKIN_COLOR_SHATTERHORN,
-		"Spirit Crusher" = SKIN_COLOR_SPIRITCRUSHER
+		"Skin Color 1" = SKIN_COLOR_SHELLCREST,
+		"Skin Color 2" = SKIN_COLOR_BLOOD_AXE,
+		"Skin Color 3" = SKIN_COLOR_GROONN,
+		"Skin Color 4" = SKIN_COLOR_BLACK_HAMMER,
+		"Skin Color 5" = SKIN_COLOR_SKULL_SEEKER,
+		"Skin Color 6" = SKIN_COLOR_CRESCENT_FANG,
+		"Skin Color 7" = SKIN_COLOR_MURKWALKER,
+		"Skin Color 8" = SKIN_COLOR_SHATTERHORN,
+		"Skin Color 9" = SKIN_COLOR_SPIRITCRUSHER
 	)
 
 /datum/species/halforc/get_hairc_list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Most races now have generic names for their skin colors.
The only ones not changed are Aasimar, Tiefling, and Lupian. Lupian because I don't know how to change the character menu to not refer to skin colors as your "clan", Aasimar and Tiefling because they are unique. This is how it was in old rogue, btw.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You don't need to be from a desert to have tanned skin.
The more Blackstone changes removed from the game, the better. I could say more, but GitHub would probably suspend my account if I did.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
