### PR TITLE
Crossbow changes

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -35,39 +35,58 @@
 /datum/intent/shoot/crossbow
 	chargedrain = 0 //no drain to aim a crossbow
 
+/datum/intent/shoot/crossbow/can_charge()
+	if(mastermob)
+		if(mastermob.get_num_arms(FALSE) < 2)
+			return FALSE
+		if(mastermob.get_inactive_held_item())
+			return FALSE
+	return TRUE
+
+
 /datum/intent/shoot/crossbow/get_chargetime()
 	if(mastermob && chargetime)
 		var/newtime = chargetime
 		//skill block
-		newtime = newtime + 18
-		newtime = newtime - (mastermob.mind.get_skill_level(/datum/skill/combat/crossbows) * 3)
+		newtime = newtime + 80
+		newtime = newtime - (mastermob.mind.get_skill_level(/datum/skill/combat/crossbows) * 20)
 		//per block
 		newtime = newtime + 20
-		newtime = newtime - (mastermob.STAPER)
+		newtime = newtime - ((mastermob.STAPER)*1.5)
 		if(newtime > 0)
 			return newtime
 		else
-			return 0.1
+			return 10
 	return chargetime
 
 /datum/intent/arc/crossbow
 	chargetime = 1
 	chargedrain = 0 //no drain to aim a crossbow
 
+
+/datum/intent/arc/crossbow/can_charge()
+	if(mastermob)
+		if(mastermob.get_num_arms(FALSE) < 2)
+			return FALSE
+		if(mastermob.get_inactive_held_item())
+			return FALSE
+	return TRUE
+
 /datum/intent/arc/crossbow/get_chargetime()
 	if(mastermob && chargetime)
 		var/newtime = chargetime
 		//skill block
-		newtime = newtime + 18
-		newtime = newtime - (mastermob.mind.get_skill_level(/datum/skill/combat/crossbows) * 3)
+		newtime = newtime + 80
+		newtime = newtime - (mastermob.mind.get_skill_level(/datum/skill/combat/crossbows) * 20)
 		//per block
 		newtime = newtime + 20
-		newtime = newtime - (mastermob.STAPER)
+		newtime = newtime - ((mastermob.STAPER)*1.5)
 		if(newtime > 0)
 			return newtime
 		else
-			return 1
+			return 10
 	return chargetime
+
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/shoot_with_empty_chamber()
 	if(cocked)
@@ -100,6 +119,10 @@
 
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
+	if(user.get_num_arms(FALSE) < 2)
+		return FALSE
+	if(user.get_inactive_held_item())
+		return FALSE
 	if(user.client)
 		if(user.client.chargedprog >= 100)
 			spread = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This makes it require two hands to fire a crossbow. Skill now plays a much greater role in your aim time. The unskilled will take MUCH longer to effectively use a crossbow now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Crossbows are now a very valuable skill. The trained, elite ranged core of the garrison(and banditos ;3) will now feel like it. Rather than every goober who grabs a crossbow. Additionally. those specializing in melee will no longer ALSO be able to kneecap someone with a crossbow at 0 skill. Also, two handing requirements means you can't dual wield a crossbow/dagger/some other ridiculous combination.  

Before, everyone took about 4 seconds to aim, with skill/per having very little effect. To roughly approximate, the unskilled take about 10 seconds to aim, Journeymen will take about 4-5, and Masters will take cap out at a 1 second charge time. For future roles/changes, Crossbow skill will have to be treated with more value(Did you know, for some reason, stewards have apprentice xbow?), for another PR.
