### PR TITLE
Simple fixes for simplemob skeletons

### DIFF
--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/simple_skeleton.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/simple_skeleton.dm
@@ -13,8 +13,8 @@
 	STACON = 9
 	STASTR = 9
 	STASPD = 8
-	maxHealth = 65
-	health = 65
+	maxHealth = 100
+	health = 100
 	harm_intent_damage = 10
 	melee_damage_lower = 10
 	melee_damage_upper = 25
@@ -33,7 +33,7 @@
 	defdrain = 20
 	speak_emote = list("grunts")
 	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone,	/obj/item/skull)
-	faction = list("orcs")
+	faction = list("undead")
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	del_on_death = TRUE
 
@@ -68,7 +68,8 @@
 	icon_living = "skeleton_guard"
 	icon_dead = ""
 	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone,	/obj/item/rogueweapon/sword/iron, /obj/item/skull)
-
+	maxHealth = 200
+	health = 200
 
 /mob/living/simple_animal/hostile/rogue/skeleton/bow
 	name = "Skeleton"
@@ -86,8 +87,6 @@
 	check_friendly_fire = 1
 	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone, /obj/item/skull, /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 			 /obj/item/ammo_casing/caseless/rogue/arrow,  /obj/item/ammo_casing/caseless/rogue/arrow,  /obj/item/ammo_casing/caseless/rogue/arrow)
-	maxHealth = 50
-	health = 50
 
 /mob/living/simple_animal/hostile/rogue/skeleton/get_sound(input)
 	switch(input)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Skeletons are no longer part of the "orc" faction. Their health is now widely the same as bare, unarmored orcs, with the armored variant getting 200 (the heaviest-armored variant of simplemob orcs gets 500.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Skeletons not attacking our lich is good. Skeletons not going down in a single hit is even better.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
