### PR TITLE
Fixes Revivals

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -136,7 +136,7 @@
 		if (QDELETED(src))
 			return
 		handle_wounds()
-		handle_embedded_objects()
+		//handle_embedded_objects()
 		handle_blood()
 
 	check_cremation()

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -80,6 +80,7 @@
 			target.visible_message(span_danger("[target] is unmade by holy light!"), span_userdanger("I'm unmade by holy light!"))
 			target.gib()
 			return TRUE
+		target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 		if(!target.revive(full_heal = FALSE))
 			to_chat(user, span_warning("Nothing happens."))
 			return FALSE

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -41,6 +41,7 @@
 		"[user] works the lux into [target]'s innards.",
 		"[user] works the lux into [target]'s innards.")
 		return FALSE
+	target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 	if(!target.revive(full_heal = FALSE))
 		display_results(user, target, span_notice("The lux refuses to meld with [target]'s heart. Their damage must be too severe still."),
 			"[user] works the lux into [target]'s innards, but nothing happens.",


### PR DESCRIPTION
Revivals, both Astratan and surgically, didn't work for people who died from blood loss or had their heart cut out because their health was impossibly low from oxy damage. Revivals now cure all suffocation damage.

Also disables embed damage for corpses. Because you'd clamp bleeders with forceps in someones chest and it would _keep damaging them infinitely_.