### PR TITLE
Fixes some Lich Spells, adds armor training to them

### DIFF
--- a/code/modules/antagonists/roguetown/villain/lich/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich/lich.dm
@@ -54,6 +54,7 @@
 	ADD_TRAIT(L, TRAIT_SHOCKIMMUNE, "[type]")
 	ADD_TRAIT(L, TRAIT_LIMBATTACHMENT, "[type]")
 	ADD_TRAIT(L, TRAIT_SEEPRICES, "[type]")
+	ADD_TRAIT(L, TRAIT_HEAVYARMOR, "[type]")
 	L.cmode_music = 'sound/music/combat_cult.ogg'
 	L.faction = list("undead")
 	if(L.charflaw)
@@ -109,7 +110,7 @@
 
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/bonechill)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_undead)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/sickness)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_lesser_undead)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fireball)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/bloodlightning)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch)

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -62,7 +62,7 @@
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/raise_undead
-	name = "Raise Undead"
+	name = "Raise Greater Undead"
 	desc = ""
 	clothes_req = FALSE
 	range = 7
@@ -79,22 +79,56 @@
 
 /obj/effect/proc_holder/spell/invoked/raise_undead/cast(list/targets, mob/living/user)
 	. = ..()
-	if(istype(targets[1], /mob/living/carbon/human/species/skeleton/npc))
-		var/mob/living/carbon/target = targets[1]
-		var/list/candidates = pollCandidatesForMob("Do you want to play as a Necromancer's skeleton?", null, null, null, 200, target, POLL_IGNORE_NECROMANCER_SKELETON)
+	var/turf/T = get_turf(targets[1])
+	if(isopenturf(T))
+		var/mob/living/carbon/target = new /mob/living/carbon/human/species/skeleton/npc(T)
+		var/list/candidates = pollCandidatesForMob("Do you want to play as a Necromancer's skeleton?", null, null, null, 100, target, POLL_IGNORE_NECROMANCER_SKELETON)
 		if(LAZYLEN(candidates))
 			var/mob/C = pick(candidates)
 			target.key = C.key
-			target.visible_message(span_warning("[target]'s eyes shine with an eerie glow!"))
+			target.visible_message(span_warning("[target]'s eyes light up with an eerie glow!"))
 		else
-			target.visible_message(span_warning("[target]'s eyes remain dully devoid of life."))
-		return TRUE
-	var/turf/T = get_turf(targets[1])
-	if(isopenturf(T))
-		new /mob/living/carbon/human/species/skeleton/npc(T)
+			target.visible_message(span_warning("[target]'s eyes remain dully devoid of life. The spell failed to capture a soul from the ether."))
 		return TRUE
 	to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))
 	return FALSE
+
+/obj/effect/proc_holder/spell/invoked/raise_lesser_undead
+	name = "Raise Lesser Undead"
+	desc = ""
+	clothes_req = FALSE
+	range = 7
+	overlay_state = "raiseskele"
+	sound = list('sound/magic/magnet.ogg')
+	releasedrain = 40
+	chargetime = 60
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	charging_slowdown = 1
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+	charge_max = 60 SECONDS
+
+/obj/effect/proc_holder/spell/invoked/raise_lesser_undead/cast(list/targets, mob/living/user)
+	. = ..()
+	var/turf/T = get_turf(targets[1])
+	var/skeleton_roll = rand(1,100)
+	if(isopenturf(T))
+		switch(skeleton_roll)
+			if(1 to 20)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T)
+			if(21 to 40)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T)
+			if(41 to 60)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T)
+			if(61 to 80)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T)
+			if(81 to 100)
+				new /mob/living/simple_animal/hostile/rogue/skeleton(T)
+		return TRUE
+	else
+		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))
+		return FALSE
 
 /obj/effect/proc_holder/spell/invoked/projectile/sickness
 	name = "Ray of Sickness"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Firstly, liches spawn with some blacksteel. This gives them the skills to use it properly.
Liches now get a 'summon lesser undead' which spawns a random simplemob skeleton. Whether you get a good one is completely luck of the draw.
'summon undead' is now 'summon greater undead', which will AUTOMATICALLY poll people in the lobby to join as that skeleton without needing to be recast.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Liches are fun and now they work. Now just the subject of their resistances...
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
