### PR TITLE
knock fix and learning spell tweak

### DIFF
--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -265,7 +265,7 @@
 				head = /obj/item/clothing/head/roguetown/wizhat
 				armor = /obj/item/clothing/suit/roguetown/shirt/robe/wizard
 				H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
-		var/list/spells = list(/obj/effect/proc_holder/spell/invoked/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
+		var/list/spells = list(/obj/effect/proc_holder/spell/self/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
 		for(var/S in spells)
 			H.mind.AddSpell(new S)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -380,6 +380,7 @@
 // adjusts the amount of available spellpoints
 /datum/mind/proc/adjust_spellpoints(points)
 	spell_points += points
+	check_learnspell() //check if we need to add or remove the learning spell
 
 ///Gets the skill's singleton and returns the result of its get_skill_speed_modifier
 /datum/mind/proc/get_skill_speed_modifier(skill)
@@ -905,11 +906,26 @@
 	add_antag_datum(head)
 	special_role = ROLE_REV_HEAD
 
-/datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S)
+/datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S, var/duplicate_override = FALSE)
 	if(!S)
 		return
+	if(!duplicate_override) 
+		if(has_spell(S, TRUE)) //if we have the spell already stop
+			return
+
 	spell_list += S
 	S.action.Grant(current)
+
+/datum/mind/proc/check_learnspell(obj/effect/proc_holder/spell/S)
+	if(!has_spell(/obj/effect/proc_holder/spell/self/learnspell)) //are we missing the learning spell?
+		if((spell_points - used_spell_points) > 0) //do we have points?
+			AddSpell(new /obj/effect/proc_holder/spell/self/learnspell(null)) //put it in
+			return
+
+	if((spell_points - used_spell_points) <= 0) //are we out of points?
+		RemoveSpell(S) //bye bye spell
+		return
+	return
 
 /datum/mind/proc/has_spell(spell_type, specific = FALSE)
 	if(istype(spell_type, /obj/effect/proc_holder))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -52,5 +52,5 @@
 		H.change_stat("constitution", 1)
 		H.change_stat("endurance", -1)
 		H.mind.adjust_spellpoints(1)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/learnspell)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/learnspell)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -9,7 +9,7 @@
 
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
-	spells = list(/obj/effect/proc_holder/spell/invoked/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
+	spells = list(/obj/effect/proc_holder/spell/self/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
 	display_order = JDO_MAGICIAN
 	tutorial = "Your creed is one dedicated to the conquering of the arcane arts and the constant thrill of knowledge. \
 		You owe your life to the Lord, for it was his coin that allowed you to continue your studies in these dark times. \

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -6,7 +6,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	spells = list(/obj/effect/proc_holder/spell/invoked/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+	spells = list(/obj/effect/proc_holder/spell/self/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = ALL_AGES_LIST
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -11,7 +11,7 @@
 
 	tutorial = "Your master once saw potential in you, something you are uncertain if they still do with your recent studies. The path to using magic is something treacherous and untamed, and you are still decades away from calling yourself even a journeyman in the field. Listen and serve, and someday you will earn your hat."
 
-	spells = list(/obj/effect/proc_holder/spell/invoked/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/lightningbolt)
+	spells = list(/obj/effect/proc_holder/spell/self/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/lightningbolt)
 	outfit = /datum/outfit/job/roguetown/wapprentice
 
 	display_order = JDO_MAGEAPPRENTICE

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -177,7 +177,7 @@
 	light_color = "#3FBAFD"
 
 //A spell to choose new spells, upon spawning or gaining levels
-/obj/effect/proc_holder/spell/invoked/learnspell
+/obj/effect/proc_holder/spell/self/learnspell
 	name = "Attempt to learn a new spell"
 	desc = "Weave a new spell"
 	school = "transmutation"
@@ -185,7 +185,7 @@
 	chargedrain = 0
 	chargetime = 0
 
-/obj/effect/proc_holder/spell/invoked/learnspell/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/self/learnspell/cast(list/targets, mob/user = usr)
 	. = ..()
 	//list of spells you can learn, it may be good to move this somewhere else eventually
 	//TODO: make GLOB list of spells, give them a true/false tag for learning, run through that list to generate choices
@@ -222,6 +222,8 @@
 	else
 		user.mind.used_spell_points += item.cost
 		user.mind.AddSpell(new item)
+		addtimer(CALLBACK(user.mind, TYPE_PROC_REF(/datum/mind, check_learnspell), src), 2 SECONDS) //self remove if no points
+		return TRUE
 
 //forcewall
 /obj/effect/proc_holder/spell/invoked/forcewall_weak
@@ -688,6 +690,7 @@
 /obj/effect/proc_holder/spell/invoked/knock/proc/open_door(obj/structure/mineral_door/door)
 	if(istype(door))
 		door.force_open()
+		door.locked = FALSE
 
 /obj/effect/proc_holder/spell/invoked/knock/proc/open_closet(obj/structure/closet/C)
 	C.locked = FALSE


### PR DESCRIPTION
Knock now also unlocks doors when forcing them open (oops!)

The Learning Spell now no longer needs to be invoked, just clicking the icon works (less confusing)
The Learning Spell now automatically removes itself once you have no points left
The Learning Spell now automatically re-adds itself if any more points become available

A mind's AddSpell() proc now no longer spawns duplicate spells unless the code asks for it