### PR TITLE
Message tweaks, span fixes, forcewall tweak, featherfall buff, new longstrider spell

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -29,6 +29,7 @@
 #define TRAIT_NASTY_EATER "Inhumen Digestion" //can eat rotten food, organs, poison berries, and drink murky water
 #define TRAIT_WILD_EATER "Beastly Digestion" //can eat raw and rotten food and drink murky water
 #define TRAIT_NOFALLDAMAGE1 "Minor fall damage immunity"
+#define TRAIT_NOFALLDAMAGE2 "Total fall damage immunity"
 #define TRAIT_MISSING_NOSE "Missing Nose" //halved stamina regeneration
 #define TRAIT_DISFIGURED "Disfigured"
 #define TRAIT_SPELLCOCKBLOCK "Bewitched" //prevents spellcasting
@@ -112,6 +113,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_NASTY_EATER = span_dead("I can eat bad food, and water that would be toxic to humen will not affect me."),
 	TRAIT_WILD_EATER = span_info("I can eat raw food and drink from dirty water."),
 	TRAIT_NOFALLDAMAGE1 = span_warning("I can easily handle minor falls."),
+	TRAIT_NOFALLDAMAGE2 = span_warning("I can handle a fall from any height."),
 	TRAIT_DISFIGURED = span_warning("No one can recognize me..."),
 	TRAIT_MISSING_NOSE = span_warning("I struggle to breathe."),
 	TRAIT_SPELLCOCKBLOCK = span_warning("I cannot cast any spells."),

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -364,6 +364,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define INNATE_TRAIT "innate"
 
 // unique trait sources, still defines
+#define TRAIT_LONGSTRIDER "longstrider"
 #define TRAIT_DARKVISION "darkvision"
 #define CLONING_POD_TRAIT "cloning-pod"
 #define STATUE_MUTE "statue"

--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -212,7 +212,7 @@
 	visible_message("[src] kneels their head in prayer to the Gods.", "I kneel my head in prayer to [devotion.patron.name].")
 	for(var/i in 1 to 50)
 		if(devotion.devotion >= devotion.max_devotion)
-			to_chat(src, "<span class='warning'>I have reached the limit of my devotion...</warning>")
+			to_chat(src, span_warning("I have reached the limit of my devotion..."))
 			break
 		if(!do_after(src, 30))
 			break

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -207,3 +207,23 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/haste
 	effectedstats = list("speed" = 3)
 	duration = 1 MINUTES
+
+/atom/movable/screen/alert/status_effect/buff/longstrider
+	name = "Longstrider"
+	desc = "I can easily walk through rough terrain."
+	icon_state = "buff"
+
+/datum/status_effect/buff/longstrider
+	id = "longstrider"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/longstrider
+	duration = 15 MINUTES
+
+/datum/status_effect/buff/longstrider/on_apply()
+	. = ..()
+	to_chat(owner, span_warning("I am unburdened by the terrain."))
+	ADD_TRAIT(owner, TRAIT_LONGSTRIDER, MAGIC_TRAIT)
+
+/datum/status_effect/buff/longstrider/on_remove()
+	. = ..()
+	to_chat(owner, span_warning("The rough floors slow my travels once again."))
+	REMOVE_TRAIT(owner, TRAIT_LONGSTRIDER, MAGIC_TRAIT)

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -170,12 +170,12 @@
 /datum/status_effect/buff/featherfall/on_apply()
 	. = ..()
 	to_chat(owner, span_warning("I feel lighter."))
-	ADD_TRAIT(owner, TRAIT_NOFALLDAMAGE1, MAGIC_TRAIT)
+	ADD_TRAIT(owner, TRAIT_NOFALLDAMAGE2, MAGIC_TRAIT)
 
 /datum/status_effect/buff/featherfall/on_remove()
 	. = ..()
 	to_chat(owner, span_warning("The feeling of lightness fades."))
-	REMOVE_TRAIT(owner, TRAIT_NOFALLDAMAGE1, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_NOFALLDAMAGE2, MAGIC_TRAIT)
 
 /atom/movable/screen/alert/status_effect/buff/darkvision
 	name = "Darkvision"

--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -195,12 +195,21 @@
 
 /turf/open/floor/rogue/dirt/get_slowdown(mob/user)
 	var/returned = slowdown
+	var/negate_slowdown = FALSE
+
 	for(var/obj/item/I in user.held_items)
 		if(I.walking_stick)
 			if(!I.wielded)
 				var/mob/living/L = user
 				if(!L.cmode)
-					returned = max(returned-2, 0)
+					negate_slowdown = TRUE
+
+	if(HAS_TRAIT(user, TRAIT_LONGSTRIDER))
+		negate_slowdown = TRUE
+	
+	if(negate_slowdown)
+		returned = max(returned-2, 0)
+	
 	return returned
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -152,7 +152,7 @@
 			take_bodypart_damage(10,check_armor = TRUE)
 			if(victim.IsOffBalanced())
 				victim.Knockdown(30)
-			visible_message("<span class='danger'>[src] crashes into [victim]!",\
+			visible_message(span_danger("[src] crashes into [victim]!"),\
 				span_danger("I violently crash into [victim]!"))
 		playsound(src,"genblunt",100,TRUE)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -51,6 +51,8 @@
 	med_hud_set_status()
 
 /mob/living/onZImpact(turf/T, levels)
+	if(HAS_TRAIT(src, TRAIT_NOFALLDAMAGE2))
+		return
 	if(HAS_TRAIT(src, TRAIT_NOFALLDAMAGE1))
 		if(levels <= 2)
 			return

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -204,6 +204,7 @@
 		/obj/effect/proc_holder/spell/invoked/haste,
 		/obj/effect/proc_holder/spell/invoked/featherfall,
 		/obj/effect/proc_holder/spell/targeted/touch/darkvision,
+		/obj/effect/proc_holder/spell/invoked/longstrider,
 	)
 	for(var/i = 1, i <= spell_choices.len, i++)
 		choices["[spell_choices[i].name]: [spell_choices[i].cost]"] = spell_choices[i]

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -277,6 +277,7 @@
 	else
 		new wall_type(get_step(front, NORTH), user)
 		new wall_type(get_step(front, SOUTH), user)
+	user.visible_message("[user] mutters an incantation and a wall of arcyne force manifests out of thin air!")
 	return TRUE
 
 /obj/structure/forcefield_weak
@@ -712,7 +713,30 @@
 	if(istype(W))
 		W.force_open()
 
+/obj/effect/proc_holder/spell/invoked/longstrider
+	name = "Longstrider"
+	desc = "Grant yourself and any creatures adjacent to you free movement through rough terrain."
+	cost = 1
+	xp_gain = TRUE
+	school = "transmutation"
+	releasedrain = 50
+	chargedrain = 0
+	chargetime = 4 SECONDS
+	charge_max = 2 MINUTES
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	charging_slowdown = 1
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
 
+/obj/effect/proc_holder/spell/invoked/longstrider/cast(list/targets, mob/user = usr)
+
+	user.visible_message("[user] mutters an incantation and a dim pulse of light radiates out from them.")
+
+	for(var/mob/living/L in range(1, usr))
+		L.apply_status_effect(/datum/status_effect/buff/longstrider)
+
+	return TRUE
 
 #undef PRESTI_CLEAN
 #undef PRESTI_SPARK

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -196,7 +196,7 @@
 		/obj/effect/proc_holder/spell/invoked/projectile/spitfire,
 		/obj/effect/proc_holder/spell/invoked/forcewall_weak,
 		/obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe,
-		/obj/effect/proc_holder/spell/invoked/message,
+		/obj/effect/proc_holder/spell/self/message,
 		/obj/effect/proc_holder/spell/invoked/push_spell,
 		/obj/effect/proc_holder/spell/invoked/blade_burst,
 		/obj/effect/proc_holder/spell/targeted/touch/nondetection,
@@ -269,13 +269,14 @@
 		QDEL_IN(src, timeleft) //delete after it runs out
 
 /obj/effect/proc_holder/spell/invoked/forcewall_weak/cast(list/targets,mob/user = usr)
-	new wall_type(get_turf(user),user)
+	var/turf/front = get_step(user, user.dir)
+	new wall_type(front, user)
 	if(user.dir == SOUTH || user.dir == NORTH)
-		new wall_type(get_step(user, EAST),user)
-		new wall_type(get_step(user, WEST),user)
+		new wall_type(get_step(front, WEST), user)
+		new wall_type(get_step(front, EAST), user)
 	else
-		new wall_type(get_step(user, NORTH),user)
-		new wall_type(get_step(user, SOUTH),user)
+		new wall_type(get_step(front, NORTH), user)
+		new wall_type(get_step(front, SOUTH), user)
 	return TRUE
 
 /obj/structure/forcefield_weak
@@ -347,27 +348,23 @@
 /obj/effect/temp_visual/slowdown_spell_aoe/long
 	duration = 3 SECONDS
 
-/obj/effect/proc_holder/spell/invoked/message
+/obj/effect/proc_holder/spell/self/message
 	name = "Message"
 	desc = "Latch onto the mind of one who is familiar to you, whispering a message into their head."
 	cost = 2
 	xp_gain = TRUE
 	releasedrain = 30
-	chargedrain = 1
-	chargetime = 5 SECONDS
 	charge_max = 60 SECONDS
 	warnie = "spellwarning"
-	no_early_release = TRUE
-	movement_interrupt = TRUE
-	charging_slowdown = 3
-	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "message"
+	var/identify_difficulty = 15 //the stat threshold needed to pass the identify check
 
-/obj/effect/proc_holder/spell/invoked/message/cast(list/targets, mob/user)
+/obj/effect/proc_holder/spell/self/message/cast(list/targets, mob/user)
 	. = ..()
 	var/input = stripped_input(user, "Who are you trying to contact?")
 	if(!input)
+		revert_cast()
 		return
 	if(!user.key)
 		to_chat(user, span_warning("I sense a body, but the mind does not seem to be there."))
@@ -381,13 +378,28 @@
 		if(HL.real_name == input)
 			var/message = stripped_input(user, "You make a connection. What are you trying to say?")
 			if(!message)
+				revert_cast()
 				return
-			to_chat(HL, "Arcyne whispers fill the back of my head, resolving into a clear, if distant, voice: </span><font color=#7246ff>\"[message]\"</font>")
+			if(alert(user, "Send anonymously?", "", "Yes", "No") == "No") //yes or no popup, if you say No run this code
+				identify_difficulty = 0 //anyone can clear this
+
+			var/identified = FALSE
+			if(HL.STAPER >= identify_difficulty) //quick stat check
+				if(HL.mind)
+					if(HL.mind.do_i_know(name=user.real_name)) //do we know who this person is?
+						identified = TRUE // we do
+						to_chat(HL, "Arcyne whispers fill the back of my head, resolving into [user]'s voice: </span><font color=#7246ff>\"[message]\"</font>")
+
+			if(!identified) //we failed the check OR we just dont know who that is
+				to_chat(HL, "Arcyne whispers fill the back of my head, resolving into an unknown [user.gender == FEMALE ? "woman" : "man"]'s voice: </span><font color=#7246ff>\"[message]\"</font>")
+
+			user.whisper(message)
 			log_game("[key_name(user)] sent a message to [key_name(HL)] with contents [message]")
 			// maybe an option to return a message, here?
 			return TRUE
 	to_chat(user, span_warning("I seek a mental connection, but can't find [input]."))
 	revert_cast()
+	return
 
 /obj/effect/proc_holder/spell/invoked/push_spell
 	name = "Repulse"


### PR DESCRIPTION
Message now gives you the option to be anonymous when sending, if you choose not to be anonymous AND the reciever knows who you are they'll recognize your voice, if you choose to be anonymous, they can still pass a Perception check just like the Scrying Orb. (this SHOULD work but I wasn't able to test it well enough on my own even with the dual client set-up, praying)

Forcewall now spawns infront of the caster

Featherfall now protects from ANY fall damage instead of just one z-level's worth.

Some span fixes to badly formatted strings

LONGSTRIDER:
Give the caster and all creatures in a 3x3 cube around them the LONGSTRIDER trait which means they get no slowdown from rough terrain (like the rough forest dirt floors) for 15 minutes, costs 1 point.