### PR TITLE
darkvision, haste, forcewall, repulse & backend bugfixes

### DIFF
--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -265,7 +265,7 @@
 				head = /obj/item/clothing/head/roguetown/wizhat
 				armor = /obj/item/clothing/suit/roguetown/shirt/robe/wizard
 				H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
-		var/list/spells = list(/obj/effect/proc_holder/spell/self/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
+		var/list/spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
 		for(var/S in spells)
 			H.mind.AddSpell(new S)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -906,13 +906,9 @@
 	add_antag_datum(head)
 	special_role = ROLE_REV_HEAD
 
-/datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S, var/duplicate_override = FALSE)
+/datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S)
 	if(!S)
 		return
-	if(!duplicate_override) 
-		if(has_spell(S, TRUE)) //if we have the spell already stop
-			return
-
 	spell_list += S
 	S.action.Grant(current)
 

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -185,7 +185,7 @@
 /datum/status_effect/buff/darkvision
 	id = "darkvision"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/darkvision
-	duration = 10 MINUTES
+	duration = 1 HOURS
 
 /datum/status_effect/buff/darkvision/on_apply()
 	. = ..()
@@ -205,8 +205,11 @@
 /datum/status_effect/buff/haste
 	id = "haste"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/haste
-	effectedstats = list("speed" = 3)
+	effectedstats = list("speed" = 5)
 	duration = 1 MINUTES
+
+/datum/status_effect/buff/haste/nextmove_modifier()
+	return 0.85
 
 /atom/movable/screen/alert/status_effect/buff/longstrider
 	name = "Longstrider"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
@@ -114,7 +114,6 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/learnspell)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 			H.mind.adjust_spellpoints(1)
 			head = /obj/item/clothing/head/roguetown/bardhat

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -52,5 +52,4 @@
 		H.change_stat("constitution", 1)
 		H.change_stat("endurance", -1)
 		H.mind.adjust_spellpoints(1)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/learnspell)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -9,7 +9,7 @@
 
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
-	spells = list(/obj/effect/proc_holder/spell/self/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
+	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater)
 	display_order = JDO_MAGICIAN
 	tutorial = "Your creed is one dedicated to the conquering of the arcane arts and the constant thrill of knowledge. \
 		You owe your life to the Lord, for it was his coin that allowed you to continue your studies in these dark times. \

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -6,7 +6,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	spells = list(/obj/effect/proc_holder/spell/self/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = ALL_AGES_LIST
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -11,7 +11,7 @@
 
 	tutorial = "Your master once saw potential in you, something you are uncertain if they still do with your recent studies. The path to using magic is something treacherous and untamed, and you are still decades away from calling yourself even a journeyman in the field. Listen and serve, and someday you will earn your hat."
 
-	spells = list(/obj/effect/proc_holder/spell/self/learnspell, /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/lightningbolt)
+	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation, /obj/effect/proc_holder/spell/invoked/projectile/lightningbolt)
 	outfit = /datum/outfit/job/roguetown/wapprentice
 
 	display_order = JDO_MAGEAPPRENTICE

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -270,7 +270,7 @@
 		QDEL_IN(src, timeleft) //delete after it runs out
 
 /obj/effect/proc_holder/spell/invoked/forcewall_weak/cast(list/targets,mob/user = usr)
-	var/turf/front = get_step(user, user.dir)
+	var/turf/front = get_turf(targets[1])
 	new wall_type(front, user)
 	if(user.dir == SOUTH || user.dir == NORTH)
 		new wall_type(get_step(front, WEST), user)
@@ -406,7 +406,7 @@
 /obj/effect/proc_holder/spell/invoked/push_spell
 	name = "Repulse"
 	desc = "Conjure forth a wave of energy, repelling anyone around you."
-	cost = 2
+	cost = 1
 	xp_gain = TRUE
 	releasedrain = 50
 	chargedrain = 1
@@ -589,7 +589,7 @@
 
 /obj/item/melee/touch_attack/darkvision
 	name = "\improper arcyne focus"
-	desc = "Touch a creature to grant them Darkvision for 10 minutes."
+	desc = "Touch a creature to grant them Darkvision for an hour."
 	catchphrase = null
 	possible_item_intents = list(INTENT_HELP)
 	icon = 'icons/mob/roguehudgrabs.dmi'
@@ -646,7 +646,7 @@
 	desc = "Cause a target to be magically hastened."
 	cost = 2
 	xp_gain = TRUE
-	releasedrain = 25
+	releasedrain = 60
 	chargedrain = 1
 	chargetime = 4 SECONDS
 	charge_max = 5 MINUTES


### PR DESCRIPTION
Fixes weird interaction between learning Fireball when you already have Greater Fireball.
Removes manually adding Learnspell to jobs since they'll get it automatically
Reverts buggy tweak to AddSpell()

Buffs Darkvision.
Buffs Haste.
Forcewall now places the wall on your targeted turf.
Reduces Repulse cost.