### PR TITLE
Fixes Severe Roundstart Delay

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -542,14 +542,6 @@ SUBSYSTEM_DEF(ticker)
 			player.new_player_panel()
 		CHECK_TICK
 
-/datum/controller/subsystem/ticker/proc/select_ruler()
-	for(var/mob/living/carbon/human/K in world)
-		if(istype(K, /mob/living/carbon/human/dummy))
-			continue
-		if(K.job == "Monarch")
-			rulermob = K
-			return
-
 /datum/controller/subsystem/ticker/proc/collect_minds()
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/P = i

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 			GLOB.lordsurname = jointext(chopped_name, " ")
 		else
 			GLOB.lordsurname = "of [L.real_name]"
-		SSticker.select_ruler()
+		SSticker.rulermob = L
 		to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is Monarch of Azure Peak.</span></span></b>")
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
 


### PR DESCRIPTION
so apparently when the lord spawns in, it fucking loops through the ENTIRE WORLD to FIND the LORD and assign them as the LORD for the ROUND.

tahts stupid as fuck. it assigns the lord directly now