### PR TITLE
Explosions Throw People

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -218,14 +218,14 @@ GLOBAL_LIST_EMPTY(explosions)
 			T.ex_act(dist)
 			exploded_this_tick += T
 
-		//--- THROW ITEMS AROUND ---
+		//--- THROW STUFF AROUND ---
 
 		var/throw_dir = get_dir(epicenter,T)
-		for(var/obj/item/I in T)
-			if(!I.anchored)
+		for(var/atom/movable/A in T)
+			if(!A.anchored)
 				var/throw_range = rand(throw_dist, max_range)
-				var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-				I.throw_at(throw_at, throw_range, EXPLOSION_THROW_SPEED)
+				var/turf/throw_at = get_ranged_target_turf(A, throw_dir, throw_range)
+				A.throw_at(throw_at, throw_range, EXPLOSION_THROW_SPEED)
 
 		//wait for the lists to repop
 		var/break_condition

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -705,6 +705,10 @@
 	else
 		T = get_turf(target)
 	explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, soundin = explode_sound)
+	if(ismob(target))
+		var/mob/living/M = target
+		var/atom/throw_target = get_edge_target_turf(M, angle2dir(Angle))
+		M.throw_at(throw_target, exp_light, EXPLOSION_THROW_SPEED)
 
 /obj/projectile/magic/aoe/fireball/infernal
 	name = "infernal fireball"


### PR DESCRIPTION
Pretty much only relevant to greater fireball.

Fireball and greater fireball will both yeet you on indirect hits. Only greater fireball will yeet you on direct hits, knocking you away like 4 tiles, and out of the firezone.

Greater fireball firestacks might need balance tweaks to compensate. It does not give "big fire icon" fire stacks when hitting someone.