### PR TITLE
Confessor Devotion Fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/church/confessor.dm
@@ -11,7 +11,7 @@
 	tutorial = "Confessors are shady agents of the church hired to spy on the populace and keep them moral. As the most fanatical members of the clergy, their main concern is assisting the local Puritan with their work in extracting confessions of sin as well as hunting night beasts and cultists that hide in plain sight."
 
 	outfit = /datum/outfit/job/roguetown/shepherd
-	spells = list(/obj/effect/proc_holder/spell/invoked/heal, /obj/effect/proc_holder/spell/invoked/shepherd)
+	spells = list(/obj/effect/proc_holder/spell/invoked/shepherd)
 	whitelist_req = TRUE
 	display_order = JDO_SHEPHERD
 	give_bank_account = 3
@@ -59,3 +59,6 @@
 		var/datum/antagonist/new_antag = new /datum/antagonist/purishep()
 		H.mind.add_antag_datum(new_antag)
 	H.verbs |= /mob/living/carbon/human/proc/faith_test
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_spells_churchling(H)
+	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)


### PR DESCRIPTION
Confessor got spells but no cleric tab. So now they get a max of 100 devotion, lesser heal, diagnose and their shepherd spell that lets them swap places with a target.