### PR TITLE
Armour Unequip Delay Fr Fr

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -12,8 +12,9 @@
 	pickup_sound =  'sound/blank.ogg'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_armor.dmi'
 	sleevetype = "shirt"
-	edelay_type = 1
-	equip_delay_self = 25
+	edelay_type = 0
+	equip_delay_self = 2.5 SECONDS
+	unequip_delay_self = 2.5 SECONDS
 	bloody_icon_state = "bodyblood"
 	boobed = TRUE
 	resistance_flags = FIRE_PROOF
@@ -80,6 +81,7 @@
 	body_parts_covered = CHEST|GROIN
 	anvilrepair = /datum/skill/craft/armorsmithing
 	armor_class = ARMOR_CLASS_LIGHT
+	edelay_type = 1
 
 /obj/item/clothing/suit/roguetown/armor/plate
 	slot_flags = ITEM_SLOT_ARMOR
@@ -96,7 +98,8 @@
 	var/do_sound = TRUE
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
-	equip_delay_self = 40
+	equip_delay_self = 4 SECONDS
+	unequip_delay_self = 4 SECONDS
 	armor_class = ARMOR_CLASS_HEAVY
 
 /obj/item/clothing/suit/roguetown/armor/plate/Initialize()
@@ -128,7 +131,10 @@
 	desc = "Full plate. Leg protecting tassets, groin cup, armored vambraces."
 	icon_state = "plate"
 	body_parts_covered = CHEST|GROIN|VITALS|LEGS|ARMS
-	equip_delay_self = 80
+	equip_delay_self = 12 SECONDS
+	unequip_delay_self = 12 SECONDS
+	equip_delay_other = 3 SECONDS
+	strip_delay = 6 SECONDS
 
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron
 	name = "iron breastplate"
@@ -152,7 +158,7 @@
 	max_integrity = 200
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
-	equip_delay_self = 40
+	equip_delay_self = 4 SECONDS
 	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/suit/roguetown/armor/heartfelt/lord
@@ -203,7 +209,7 @@
 	max_integrity = 350
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
-	equip_delay_self = 40
+	equip_delay_self = 4 SECONDS
 	armor_class = ARMOR_CLASS_HEAVY
 
 /obj/item/clothing/suit/roguetown/armor/brigandine/Initialize()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -870,7 +870,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return TRUE
 	if(HAS_TRAIT(H, TRAIT_CHUNKYFINGERS))
 		return do_after(H, 5 MINUTES, target = H)
-//	H.visible_message(span_notice("[H] start putting on [I]..."), span_notice("I start putting on [I]..."))
+	if(I.equip_delay_self > 10)
+		H.visible_message(span_smallnotice("[H] start putting on [I]..."), span_smallnotice("I start putting on [I]..."))
 	if(I.edelay_type)
 		return move_after(H, minone(I.equip_delay_self-H.STASPD), target = H)
 	else

--- a/modular/code/game/objects/items/items.dm
+++ b/modular/code/game/objects/items/items.dm
@@ -1,0 +1,58 @@
+/obj/item
+	var/unequip_delay_self = 1
+	var/allow_self_unequip = TRUE
+
+/obj/item/allow_attack_hand_drop(mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/C = user
+
+		if(!(src in C.held_items) && !allow_self_unequip)
+			to_chat(C, span_warning("I need help taking this off!"))
+			return FALSE
+
+		if(!(src in C.held_items) && unequip_delay_self)
+			if(unequip_delay_self >= 10)
+				C.visible_message(span_smallnotice("[C] starts taking off [src]..."), span_smallnotice("I start taking off [src]..."))
+			if(edelay_type)
+				if(move_after(C, minone(unequip_delay_self-C.STASPD), target = C))
+					return TRUE
+				else
+					to_chat(C, span_warning("I'm struggling to take it off."))
+					return FALSE
+			else
+				if(do_after(C, minone(unequip_delay_self-C.STASPD), target = C))
+					return TRUE
+				else
+					to_chat(C, span_warning("I'm struggling to take it off."))
+					return FALSE
+
+	return ..()
+
+/obj/item/MouseDrop(atom/over)
+	if(!(loc == usr))
+		return ..()
+
+	if(ishuman(usr))
+		var/mob/living/carbon/human/C = usr
+
+		if(!(src in C.held_items) && !allow_self_unequip)
+			to_chat(C, span_warning("I need help taking this off!"))
+			return FALSE
+
+		if(!(src in C.held_items) && unequip_delay_self)
+			if(unequip_delay_self >= 10)
+				C.visible_message(span_smallnotice("[C] starts taking off [src]..."), span_smallnotice("I start taking off [src]..."))
+			if(edelay_type)
+				if(move_after(C, minone(unequip_delay_self-C.STASPD), target = C))
+					return ..()
+				else
+					to_chat(C, span_warning("I'm struggling to take it off."))
+					return FALSE
+			else
+				if(do_after(C, minone(unequip_delay_self-C.STASPD), target = C))
+					return ..()
+				else
+					to_chat(C, span_warning("I'm struggling to take it off."))
+					return FALSE
+
+	return ..()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3521,6 +3521,7 @@
 #include "modular\code\controllers\subsystem\processing\sex.dm"
 #include "modular\code\datums\character_flaw.dm"
 #include "modular\code\game\objects\pillory.dm"
+#include "modular\code\game\objects\items\items.dm"
 #include "modular\code\game\objects\items\lewd\dildo.dm"
 #include "modular\code\modules\admin\bunker_bypass.dm"
 #include "modular\code\modules\crafting\lewd\dildo_crafting.dm"


### PR DESCRIPTION
Ports https://github.com/Rotwood-Vale/Ratwood-Keep/pull/764

Armours have both an equip and unequip delay now.

Most are at 2.5 seconds.
Half-plate is at 4 seconds.
Cuirasses and scalemail at 4 seconds.
Full plate is at 12 seconds. 3 seconds to equip by others, 6 seconds to strip.

The issue with not being able to unequip storage items was fixed..