### PR TITLE
Spellbuying preview

### DIFF
--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -1,7 +1,7 @@
 
 /obj/effect/proc_holder/spell/invoked/projectile/lightningbolt
 	name = "Bolt of Lightning"
-	desc = ""
+	desc = "Emit a bolt of lightning that burns and stuns a target."
 	clothes_req = FALSE
 	overlay_state = "lightning"
 	sound = 'sound/magic/lightning.ogg'
@@ -156,7 +156,7 @@
 
 /obj/effect/proc_holder/spell/invoked/projectile/fireball
 	name = "Fireball"
-	desc = ""
+	desc = "Shoot out a ball of fire that emits a light explosion on impact, setting the target alight."
 	clothes_req = FALSE
 	range = 8
 	projectile_type = /obj/projectile/magic/aoe/fireball/rogue
@@ -204,7 +204,7 @@
 
 /obj/effect/proc_holder/spell/invoked/projectile/fireball/greater
 	name = "Greater Fireball"
-	desc = ""
+	desc = "Shoot out an immense ball of fire that explodes on impact."
 	clothes_req = FALSE
 	range = 8
 	projectile_type = /obj/projectile/magic/aoe/fireball/rogue/great
@@ -232,7 +232,7 @@
 
 /obj/effect/proc_holder/spell/invoked/projectile/spitfire
 	name = "Spitfire"
-	desc = ""
+	desc = "Shoot out a low-powered ball of fire that shines brightly on impact, potentially blinding a target."
 	clothes_req = FALSE
 	range = 8
 	projectile_type = /obj/projectile/magic/aoe/fireball/rogue2
@@ -267,7 +267,7 @@
 
 /obj/effect/proc_holder/spell/invoked/projectile/fetch
 	name = "Fetch"
-	desc = ""
+	desc = "Shoot out a magical bolt that draws in the target struck towards the caster."
 	clothes_req = FALSE
 	range = 15
 	projectile_type = /obj/projectile/magic/fetch

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -213,12 +213,14 @@
 	var/obj/effect/proc_holder/spell/item = choices[choice]
 	if(!item) 
 		return     // user canceled; 
+	if(alert(user, "[item.desc]", "[item.name]", "Learn", "Cancel") == "Return") //gives a preview of the spell's description to let people know what a spell does
+		return
 	for(var/obj/effect/proc_holder/spell/knownspell in user.mind.spell_list)
 		if(knownspell.type == item.type)
 			to_chat(user,span_warning("You already know this one!"))
 			return	//already know the spell
 	if(item.cost > user.mind.spell_points - user.mind.used_spell_points)
-		to_chat(user,span_warning("You do not have enough experience to create a new spell"))
+		to_chat(user,span_warning("You do not have enough experience to create a new spell."))
 		return		// not enough spell points
 	else
 		user.mind.used_spell_points += item.cost
@@ -300,7 +302,7 @@
 // no slowdown status effect defined, so this just immobilizes for now
 /obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe
 	name = "Ensnare"
-	desc = "Tendrils of arcyne force hold anyone in a small area in place"
+	desc = "Tendrils of arcyne force hold anyone in a small area in place for a short while."
 	cost = 1
 	xp_gain = TRUE
 	releasedrain = 20
@@ -462,7 +464,7 @@
 
 /obj/effect/proc_holder/spell/invoked/blade_burst
 	name = "Blade Burst"
-	desc = "summon a storm of arcyne force in an area, wounding anything in that location"
+	desc = "Summon a storm of arcyne force in an area, wounding anything in that location after a delay."
 	cost = 1
 	xp_gain = TRUE
 	releasedrain = 30
@@ -509,7 +511,7 @@
 
 /obj/effect/proc_holder/spell/targeted/touch/nondetection
 	name = "Nondetection"
-	desc = "Shroud a target that you touch from divination magic for 1 hour."
+	desc = "Consume a handful of ash and shroud a target that you touch from divination magic for 1 hour."
 	clothes_req = FALSE
 	drawmessage = "I prepare to form a magical shroud."
 	dropmessage = "I release my arcyne focus."
@@ -575,7 +577,7 @@
 
 /obj/effect/proc_holder/spell/targeted/touch/darkvision
 	name = "Darkvision"
-	desc = "Enhance the night vision of a target you touch."
+	desc = "Enhance the night vision of a target you touch for an hour."
 	clothes_req = FALSE
 	drawmessage = "I prepare to grant Darkvision."
 	dropmessage = "I release my arcyne focus."


### PR DESCRIPTION
When selecting a spell to buy it gives a little pop-up with the spell's name and description and a "Learn" or "Cancel" option so it isn't obscure and confusing to players exploring the system

![image](https://github.com/user-attachments/assets/9e22c6c4-c158-4d4b-a718-c6cdcb2e2eb2)
