### PR TITLE
Adventure Time: points of interest and dungeons for adventurers.

### DIFF
--- a/_maps/map_files/dun_manor/azure_coast.dmm
+++ b/_maps/map_files/dun_manor/azure_coast.dmm
@@ -1,6 +1,9 @@
+"ag" = (/obj/structure/rack/rogue,/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "ah" = (/obj/structure/fluff/railing/border{dir = 10; icon_state = "border"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"an" = (/obj/structure/closet/crate/chest/wicker,/obj/effect/decal/cleanable/cobweb,/obj/effect/spawner/lootdrop/roguetown/dungeon/food,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "aq" = (/obj/structure/mineral_door/wood{locked = 1},/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
 "aw" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"ax" = (/mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/spear,/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "ay" = (/obj/effect/landmark/mapGenerator/sunlights,/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/beach/forest)
 "aC" = (/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/obj/machinery/light/rogue/wallfire/candle/blue/l,/turf/open/floor/rogue/ruinedwood/chevron,/area/rogue/indoors/shelter)
 "aE" = (/obj/structure/closet/crate/roguecloset,/obj/item/clothing/ring/active/nomag,/turf/open/floor/carpet/purple,/area/rogue/indoors/shelter)
@@ -22,27 +25,36 @@
 "bW" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "bX" = (/obj/machinery/light/rogue/torchholder/l,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "bY" = (/turf/closed/wall/mineral/rogue/wood,/area/rogue/outdoors/beach)
+"cd" = (/obj/structure/fluff/statue/knight/interior/r,/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "ce" = (/obj/structure/bed/rogue/inn/hay,/mob/living/carbon/human/species/human/northern/searaider/ambush,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
+"cg" = (/obj/structure/fermenting_barrel/random/water,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "ck" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 5; icon_state = "border"},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/outdoors/beach)
 "cl" = (/obj/structure/chair/bench/church/r,/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach)
 "cp" = (/obj/effect/decal/cleanable/blood/tracks{dir = 6},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/cave)
+"cr" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/obj/item/reagent_containers/glass/cup/wooden{pixel_y = 4; pixel_x = 6},/obj/item/reagent_containers/glass/cup/wooden{pixel_x = -8},/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "cx" = (/turf/open/floor/rogue/rooftop/green/corner1,/area/rogue/outdoors/beach/forest)
 "cE" = (/obj/structure/mineral_door/wood/deadbolt{dir = 1; icon_state = "wooddir"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "cH" = (/obj/structure/mineral_door/wood/deadbolt{dir = 8},/turf/open/floor/rogue/woodturned/nosmooth,/area/rogue/indoors/shelter)
 "cI" = (/obj/structure/stairs/stone{dir = 8; icon_state = "stonestairs"},/turf/open/floor/rogue/ruinedwood/chevron,/area/rogue/indoors/shelter)
 "cN" = (/obj/structure/bed/rogue/inn/wool,/obj/item/bedsheet/rogue/cloth,/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
 "cW" = (/obj/structure/rack/rogue/shelf/biggest,/obj/item/rogueweapon/sword/sabre/dec,/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
+"cX" = (/obj/structure/closet/crate/chest/old_crate,/obj/item/reagent_containers/glass/bottle/rogue/redwine,/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "de" = (/turf/closed/wall/mineral/rogue/tent{dir = 8},/area/rogue/outdoors/beach/forest)
 "dn" = (/turf/closed/wall/mineral/rogue/tent,/area/rogue/indoors/cave)
+"do" = (/obj/item/reagent_containers/food/snacks/crow,/turf/open/floor/rogue/rooftop{dir = 1},/area/rogue/outdoors/beach/forest)
 "dA" = (/obj/structure/mineral_door/wood/deadbolt{dir = 1; icon_state = "wooddir"},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/cave)
+"dB" = (/obj/effect/decal/cobbleedge{dir = 5},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "dK" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
+"dO" = (/obj/structure/fluff/railing/border,/obj/item/roguecoin/copper,/turf/open/water/sewer,/area/rogue/indoors/cave)
 "dX" = (/obj/structure/fluff/railing/border{dir = 6},/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
 "ea" = (/obj/structure/stairs/stone{dir = 8; icon_state = "stonestairs"},/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
 "ec" = (/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
+"ej" = (/obj/structure/mineral_door/wood/red,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "ep" = (/obj/effect/decal/remains/human,/turf/open/floor/rogue/wood,/area/rogue/under/town/basement)
 "es" = (/obj/item/roguegem/blue,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "ex" = (/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
 "ey" = (/obj/structure/mineral_door/wood/deadbolt,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/cave)
+"ez" = (/obj/structure/rack/rogue,/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "eC" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/cave)
 "eF" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "eH" = (/obj/structure/fluff/railing/wood{dir = 1; layer = 2.7; pixel_y = 7},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
@@ -53,6 +65,7 @@
 "eZ" = (/turf/closed/wall/mineral/rogue/wooddark/end,/area/rogue/outdoors/beach)
 "fa" = (/obj/machinery/light/rogue/oven/south,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "fg" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach)
+"fi" = (/mob/living/simple_animal/hostile/retaliate/rogue/orc,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "fm" = (/obj/structure/boatbell/fluff{pixel_y = 16; desc = "."},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/outdoors/beach)
 "fy" = (/obj/structure/fluff/railing/border{dir = 5},/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/obj/structure/fluff/traveltile{aportalgoesto = "vikingshipout"; aportalid = "vikingshipin"},/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "fA" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
@@ -65,17 +78,22 @@
 "fS" = (/turf/closed/wall/mineral/rogue/stone/blue_moss,/area/rogue/indoors/shelter)
 "fT" = (/turf/closed/wall/mineral/rogue/wooddark/horizontal,/area/rogue/indoors/shelter)
 "fU" = (/obj/structure/chair/wood/rogue/chair3,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
+"fZ" = (/obj/structure/bars,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "gb" = (/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "gc" = (/obj/effect/decal/cobbleedge{dir = 1; icon_state = "borderfall"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "gg" = (/obj/structure/rack/rogue/shelf/big,/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/random,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "gk" = (/obj/structure/chair/wood/rogue,/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
+"gm" = (/obj/structure/closet/crate/chest/wicker,/obj/effect/spawner/lootdrop/roguetown/dungeon/food,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
+"go" = (/mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "gu" = (/obj/effect/decal/remains/saiga,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "gx" = (/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "gy" = (/obj/item/roguecoin/copper/pile,/obj/structure/closet/crate/chest,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "gz" = (/obj/structure/closet/crate/chest/neu,/obj/machinery/light/rogue/wallfire/candle,/obj/item/natural/cloth,/obj/item/natural/cloth,/obj/item/natural/cloth,/obj/item/roguecoin/copper/pile,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
+"gC" = (/turf/closed/wall/mineral/rogue/stone/blue_moss,/area/rogue/outdoors/beach/forest)
 "gE" = (/obj/structure/fluff/traveltile{aallmig = "rwfieldbog"; aportalgoesto = "bogrtout_cave"; aportalid = "bogrtin_cave"},/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "gG" = (/turf/open/water/ocean,/area/rogue/outdoors/beach)
 "gN" = (/obj/structure/closet/crate/chest,/obj/item/reagent_containers/food/snacks/rogue/meat/steak,/obj/item/reagent_containers/food/snacks/rogue/meat/steak,/turf/open/floor/rogue/dirt/road,/area/rogue/under/town/basement)
+"gT" = (/obj/structure/fluff/grindwheel,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "gX" = (/obj/item/rogueweapon/huntingknife/cleaver,/obj/structure/rack/rogue,/turf/open/floor/rogue/dirt/road,/area/rogue/under/town/basement)
 "gY" = (/obj/structure/table/wood{icon_state = "longtable"},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "hr" = (/obj/structure/stairs{dir = 1; icon_state = "stairs"},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
@@ -93,6 +111,8 @@
 "iA" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
 "iN" = (/obj/structure/closet/crate/roguecloset,/obj/item/paper,/obj/item/paper,/obj/item/paper,/turf/open/floor/rogue/wood,/area/rogue/under/town/basement)
 "iU" = (/obj/structure/mineral_door/wood/deadbolt{locked = 1},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
+"iW" = (/turf/open/water/sewer,/area/rogue/indoors/cave)
+"iX" = (/obj/structure/table/wood{dir = 1; icon_state = "longtable"},/obj/item/clothing/neck/roguetown/psicross,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "ja" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "jc" = (/mob/living/carbon/human/species/goblin/npc/sea,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "jd" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
@@ -101,6 +121,9 @@
 "jB" = (/turf/open/floor/rogue/rooftop/green{dir = 8},/area/rogue/outdoors/beach/forest)
 "jD" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/woodturned,/area/rogue/outdoors/beach)
 "jE" = (/obj/structure/fluff/railing/wood{dir = 4; icon_state = "woodrailing"; pixel_x = 8},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
+"jF" = (/obj/item/natural/rock,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
+"jX" = (/obj/structure/mineral_door/wood/red,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
+"kb" = (/obj/structure/spider/stickyweb,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "ke" = (/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "kj" = (/turf/closed/wall/mineral/rogue/wooddark/vertical,/area/rogue/indoors/cave)
 "kn" = (/obj/item/fishingrod,/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/cave)
@@ -119,15 +142,21 @@
 "lo" = (/obj/structure/rack/rogue,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
 "lq" = (/obj/structure/fluff/railing/border{dir = 9},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "lz" = (/obj/structure/closet/crate/chest/old_crate,/obj/item/roguecoin/gold/pile,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
+"lC" = (/mob/living/simple_animal/hostile/retaliate/rogue/spider,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
+"lI" = (/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "lJ" = (/obj/structure/mineral_door/wood/deadbolt{dir = 8; icon_state = "wooddir"},/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/beach)
 "lQ" = (/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/under/town/basement)
 "lS" = (/obj/structure/roguewindow/openclose{dir = 4; icon_state = "woodwindowdir"},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"lU" = (/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "lW" = (/obj/machinery/light/rogue/hearth,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "ma" = (/obj/machinery/light/rogue/forge,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
+"mb" = (/obj/effect/decal/remains/human,/obj/effect/spawner/lootdrop/roguetown,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
 "md" = (/obj/structure/mineral_door/wood/deadbolt,/turf/open/floor/rogue/wood/nosmooth,/area/rogue/indoors/shelter)
 "me" = (/mob/living/carbon/human/species/goblin/npc/sea,/turf/open/floor/rogue/grass,/area/rogue/outdoors/beach/forest)
 "mh" = (/obj/structure/roguetent,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"ml" = (/obj/structure/closet/crate/chest,/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "mo" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 9},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/outdoors/beach)
+"mq" = (/obj/structure/closet/crate/chest/wicker,/obj/item/reagent_containers/food/snacks/rogue/meat/spider,/obj/item/reagent_containers/food/snacks/rogue/meat/spider,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "ms" = (/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
 "mt" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "mJ" = (/turf/closed/wall/mineral/rogue/tent{dir = 8},/area/rogue/outdoors/beach)
@@ -138,6 +167,7 @@
 "nd" = (/obj/structure/fluff/railing/border,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "nj" = (/mob/living/carbon/human/species/human/northern/searaider/ambush,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "nk" = (/obj/structure/fluff/railing/border,/obj/structure/fluff/railing/wood,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"nl" = (/mob/living/simple_animal/hostile/retaliate/rogue/orc/spear,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "nm" = (/obj/structure/table/wood{icon_state = "tablewood1"},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "nr" = (/obj/structure/fluff/statue/tdummy,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "nt" = (/obj/structure/chair/wood/rogue/fancy{dir = 1},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
@@ -148,7 +178,9 @@
 "nM" = (/obj/structure/fluff/railing/wood,/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach/forest)
 "nO" = (/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
 "nR" = (/obj/structure/bed/rogue/inn/wooldouble,/obj/item/bedsheet/rogue/double_pelt,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
+"nS" = (/obj/structure/spider/stickyweb,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
 "oa" = (/obj/structure/closet/crate/roguecloset/inn,/turf/open/floor/rogue/woodturned/nosmooth,/area/rogue/indoors/shelter)
+"ob" = (/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "oe" = (/obj/structure/mineral_door/wood/deadbolt{dir = 4},/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/outdoors/beach)
 "on" = (/obj/structure/stairs/stone{dir = 8; icon_state = "stonestairs"},/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter)
 "oq" = (/obj/effect/decal/remains/saiga,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
@@ -162,7 +194,7 @@
 "pa" = (/turf/open/floor/rogue/grass,/area/rogue/outdoors/beach/forest)
 "ph" = (/obj/structure/mineral_door/wood/deadbolt{dir = 8},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "pk" = (/obj/structure/closet/crate/chest,/obj/item/roguecoin/copper/pile,/turf/open/floor/rogue/dirt/road,/area/rogue/under/town/basement)
-"pm" = (/obj/structure/stairs{dir = 8},/obj/structure/mineral_door/wood/red,/obj/effect/decal/cleanable/blood/tracks{dir = 4},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
+"pm" = (/obj/structure/stairs{dir = 8},/obj/structure/mineral_door/wood/red{locked = 1},/obj/effect/decal/cleanable/blood/tracks{dir = 4},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "po" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/ocean,/area/rogue/outdoors/beach)
 "ps" = (/turf/open/transparent/openspace,/area/rogue/indoors/shelter)
 "pt" = (/turf/closed/wall/mineral/rogue/tent{dir = 4},/area/rogue/indoors/cave)
@@ -170,11 +202,13 @@
 "pA" = (/obj/structure/fermenting_barrel/random/beer,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "pB" = (/obj/structure/fluff/railing/border{dir = 6},/obj/structure/chair/wood/rogue/chair3,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "pC" = (/obj/structure/stairs,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/outdoors/beach)
+"pE" = (/obj/structure/stairs/stone{dir = 8},/turf/open/transparent/openspace,/area/rogue/indoors/cave)
 "pL" = (/obj/structure/chair/bench/ultimacouch,/turf/open/floor/rogue/wood/nosmooth,/area/rogue/indoors/shelter)
 "pM" = (/obj/structure/stairs{dir = 8; icon_state = "stairs"},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "pN" = (/obj/structure/fluff/railing/wood{pixel_y = -8},/obj/structure/fluff/railing/wood{dir = 4; icon_state = "woodrailing"; pixel_x = 8},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "pX" = (/obj/structure/fluff/railing/wood{dir = 4; icon_state = "woodrailing"; pixel_x = 8},/obj/structure/fluff/railing/wood{pixel_y = -8},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "pZ" = (/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/beach/forest)
+"qe" = (/obj/structure/fluff/statue/knight/interior,/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "qr" = (/obj/structure/mineral_door/wood/deadbolt,/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/beach)
 "qu" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "qE" = (/obj/structure/fluff/railing/wood,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
@@ -202,12 +236,14 @@
 "rT" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/obj/item/roguecoin/copper/pile,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "rU" = (/obj/effect/decal/remains/human,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "rV" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"rX" = (/mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder,/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "rY" = (/obj/structure/mineral_door/wood/deadbolt,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "rZ" = (/obj/structure/table/wood{icon_state = "longtable"},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "sa" = (/turf/open/floor/rogue/cobblerock,/area/rogue/indoors/shelter)
 "sf" = (/turf/closed/wall/mineral/rogue/wooddark/horizontal,/area/rogue/outdoors/beach/forest)
 "sm" = (/obj/structure/mineral_door/wood/deadbolt,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "ss" = (/turf/closed/wall/mineral/rogue/wooddark/end{dir = 8},/area/rogue/outdoors/beach/forest)
+"su" = (/obj/structure/table/wood{dir = 1; icon_state = "longtable"},/obj/item/cooking/pan,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "sv" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "sA" = (/turf/closed/wall/mineral/rogue/stone,/area/rogue/indoors/cave)
 "sC" = (/turf/closed/wall/mineral/rogue/wooddark/window,/area/rogue/outdoors/beach)
@@ -229,6 +265,7 @@
 "tw" = (/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
 "ty" = (/obj/structure/closet/crate/chest/old_crate,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
 "tA" = (/obj/structure/fluff/railing/wood,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach/forest)
+"tC" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "tO" = (/turf/closed/wall/mineral/rogue/stone/moss,/area/rogue/indoors/cave)
 "tP" = (/obj/structure/closet/crate/chest/neu_fancy,/obj/item/roguecoin/gold/pile,/obj/item/roguestatue/gold,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "tU" = (/obj/effect/decal/cleanable/blood/tracks{dir = 4},/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
@@ -236,6 +273,7 @@
 "ub" = (/turf/open/floor/rogue/rooftop{dir = 1},/area/rogue/outdoors/beach/forest)
 "uf" = (/obj/structure/stairs/stone{dir = 4},/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
 "uo" = (/obj/structure/fluff/railing/wood{dir = 4; icon_state = "woodrailing"; pixel_x = 8},/obj/structure/fluff/railing/wood{pixel_y = -8},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"ur" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "uG" = (/obj/structure/chair/bench/church,/turf/open/floor/rogue/woodturned,/area/rogue/outdoors/beach)
 "uH" = (/obj/item/book/rogue/abyssor,/obj/structure/rack/rogue/shelf/biggest,/turf/open/floor/rogue/woodturned,/area/rogue/outdoors/beach)
 "uI" = (/obj/structure/closet/crate/chest/neu_iron,/obj/item/rogueweapon/mace/steel/morningstar,/obj/item/rogueweapon/flail/sflail,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
@@ -244,12 +282,14 @@
 "uN" = (/obj/structure/chair/wood/rogue/chair3,/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach/forest)
 "uS" = (/obj/structure/mineral_door/wood/violet{locked = 1},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "vd" = (/turf/closed/wall/mineral/rogue/wooddark/end{dir = 1; icon_state = "endwooddark"},/area/rogue/outdoors/beach)
+"vf" = (/obj/item/roguebin/water/gross,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "vg" = (/obj/effect/decal/cleanable/food/salt,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "vh" = (/obj/structure/toilet,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "vk" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "vq" = (/obj/structure/closet/crate/roguecloset/inn,/turf/open/floor/rogue/wood/nosmooth,/area/rogue/indoors/shelter)
 "vr" = (/obj/structure/bed/rogue/inn,/obj/item/bedsheet/rogue/cloth,/turf/open/floor/rogue/woodturned/nosmooth,/area/rogue/indoors/shelter)
 "vt" = (/obj/machinery/light/rogue/torchholder{dir = 1},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
+"vu" = (/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "vv" = (/obj/structure/closet/crate/roguecloset,/obj/item/needle/thorn,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "vy" = (/mob/living/carbon/human/species/human/northern/searaider/ambush,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "vF" = (/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
@@ -258,6 +298,7 @@
 "vJ" = (/obj/structure/mineral_door/wood/violet{locked = 1},/turf/open/floor/rogue/tile{icon_state = "greenstone"},/area/rogue/indoors/shelter)
 "vQ" = (/obj/machinery/light/rogue/torchholder/l,/obj/structure/fermenting_barrel/random/beer,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "vR" = (/obj/structure/fluff/railing/border{dir = 5},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"we" = (/obj/structure/table/wood{dir = 1; icon_state = "longtable"},/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "wi" = (/obj/structure/fluff/railing/border{dir = 8; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 10; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
 "wk" = (/obj/structure/flora/roguegrass/water/reeds,/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/ocean,/area/rogue/outdoors/beach)
 "wl" = (/turf/closed/wall/mineral/rogue/wood,/area/rogue/indoors/cave)
@@ -270,6 +311,7 @@
 "wE" = (/obj/structure/bookcase,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "wL" = (/obj/item/natural/stone,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "wM" = (/obj/effect/decal/cleanable/blood/tracks{dir = 4},/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
+"wN" = (/obj/structure/gravemarker,/obj/structure/closet/dirthole/grave,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "xg" = (/obj/structure/closet/crate/chest/old_crate,/obj/item/rogueweapon/mace/cudgel,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "xl" = (/obj/structure/stairs/stone{dir = 4},/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "xn" = (/turf/closed/wall/mineral/rogue/wooddark/horizontal,/area/rogue/outdoors/beach)
@@ -278,12 +320,15 @@
 "xu" = (/obj/structure/ladder,/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
 "xx" = (/obj/item/natural/rock,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "xA" = (/obj/machinery/light/rogue/torchholder/c,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"xF" = (/obj/effect/decal/remains/human,/turf/open/floor/rogue/naturalstone,/area/rogue/indoors/cave)
 "xJ" = (/obj/effect/decal/cleanable/blood/tracks{dir = 4},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "xK" = (/obj/structure/fluff/railing/fence{dir = 1; icon_state = "fence"},/obj/structure/fluff/railing/fence{dir = 4; icon_state = "fence"},/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "xM" = (/obj/machinery/light/rogue/firebowl/stump,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
 "xP" = (/obj/effect/decal/remains/human,/obj/item/clothing/head/roguetown/helmet,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "xU" = (/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 5; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
+"yf" = (/obj/structure/table/wood{icon_state = "longtable"},/obj/item/reagent_containers/glass/cup/silver,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "yh" = (/turf/open/floor/rogue/rooftop/green{dir = 1},/area/rogue/outdoors/beach/forest)
+"yn" = (/obj/structure/fermenting_barrel/random/beer,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "yq" = (/obj/item/reagent_containers/glass/bucket/wooden,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/rogue/blocks,/area/rogue/indoors/shelter)
 "yr" = (/obj/machinery/light/rogue/firebowl/stump,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "yD" = (/obj/structure/closet/crate/chest/gold,/obj/item/roguecoin/gold/pile,/obj/item/roguestatue/gold/loot,/obj/item/roguecoin/gold/pile,/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach)
@@ -294,6 +339,7 @@
 "yV" = (/turf/closed/mineral/random/rogue/med,/area/rogue/outdoors/beach)
 "yW" = (/turf/open/water/ocean/deep,/area/rogue/outdoors/beach)
 "yZ" = (/obj/structure/bed/rogue/inn/hay,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
+"zh" = (/obj/item/restraints/legcuffs/beartrap/armed,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "zj" = (/turf/open/floor/rogue/rooftop{dir = 8},/area/rogue/outdoors/beach/forest)
 "zk" = (/obj/structure/closet/crate/chest,/obj/item/roguecoin/copper/pile,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "zm" = (/obj/structure/stairs{dir = 4; icon_state = "stairs"},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/under/town/basement)
@@ -304,15 +350,19 @@
 "zK" = (/turf/closed/wall/mineral/rogue/stone,/area/rogue/indoors/shelter)
 "zL" = (/obj/machinery/light/rogue/torchholder/l,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
 "zM" = (/obj/structure/fluff/railing/wood{dir = 8; icon_state = "woodrailing"; pixel_x = -4},/obj/structure/stairs{dir = 1; icon_state = "stairs"},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
+"zN" = (/obj/structure/spider/stickyweb,/turf/open/floor/rogue/naturalstone,/area/rogue/indoors/cave)
 "zO" = (/turf/open/floor/rogue/woodturned,/area/rogue/indoors/cave)
 "zR" = (/mob/living/carbon/human/species/goblin/npc/ambush/sea,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
 "zS" = (/turf/closed/wall/mineral/rogue/stone/red_moss,/area/rogue/indoors/shelter)
 "zU" = (/obj/structure/bed/rogue/inn/double,/obj/item/bedsheet/rogue/fabric_double,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "zY" = (/obj/item/chair/rogue{dir = 1},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"Ai" = (/obj/structure/fluff/statue/small,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "Ao" = (/turf/open/floor/rogue/dirt/road,/area/rogue/under/town/basement)
 "Ax" = (/obj/effect/decal/remains/human,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "AD" = (/obj/effect/landmark/mapGenerator/rogue/beach,/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/beach/forest)
 "AF" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/obj/item/rogueweapon/huntingknife/cleaver,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
+"AL" = (/obj/structure/closet/crate/chest/wicker,/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
+"AR" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "AX" = (/turf/open/floor/rogue/woodturned,/area/rogue/outdoors/beach/forest)
 "AY" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 5},/obj/structure/closet/crate/chest/wicker,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "Ba" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
@@ -324,15 +374,22 @@
 "BC" = (/obj/structure/roguetent,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "BL" = (/obj/structure/fluff/railing/border{dir = 9},/obj/structure/fluff/railing/border{dir = 10; icon_state = "border"},/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "BN" = (/obj/machinery/light/rogue/smelter,/turf/open/floor/rogue/cobblerock,/area/rogue/indoors/shelter)
+"BT" = (/obj/effect/spawner/lootdrop/roguetown,/obj/structure/closet/crate/chest,/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "BU" = (/obj/structure/closet/crate/roguecloset,/obj/item/clothing/cloak/stabard/bog,/obj/item/clothing/suit/roguetown/shirt/shortshirt/bog,/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
 "BZ" = (/obj/item/chair/rogue{dir = 1},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"Cb" = (/obj/structure/fluff/railing/border,/turf/open/water/sewer,/area/rogue/indoors/cave)
 "Cg" = (/obj/structure/mineral_door/wood/violet{locked = 1},/turf/open/floor/rogue/ruinedwood/chevron,/area/rogue/indoors/shelter)
 "Cl" = (/obj/effect/decal/remains/human,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "Cx" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/obj/structure/stairs{dir = 4; icon_state = "stairs"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"CB" = (/obj/structure/chair/wood/rogue,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "CC" = (/turf/open/floor/rogue/rooftop/green,/area/rogue/outdoors/beach/forest)
 "CH" = (/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"CI" = (/obj/effect/decal/cleanable/cobweb,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
+"CK" = (/obj/structure/closet/crate/roguecloset,/obj/item/clothing/cloak/raincloak/mortus,/obj/item/rogueweapon/shovel,/obj/effect/spawner/lootdrop/roguetown/dungeon/money,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
+"CP" = (/obj/item/roguebin/water/gross,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "CT" = (/obj/structure/mineral_door/bars,/turf/open/floor/rogue/blocks,/area/rogue/indoors/shelter)
 "CV" = (/obj/structure/closet/crate/roguecloset,/obj/item/rogueweapon/huntingknife/cleaver,/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
+"CW" = (/obj/effect/decal/cleanable/cobweb,/obj/item/roguebin/water/gross,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "Dh" = (/mob/living/carbon/human/species/goblin/npc/sea,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
 "Di" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "Dp" = (/obj/machinery/light/rogue/oven/south,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
@@ -343,6 +400,7 @@
 "DF" = (/obj/structure/stairs,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "DG" = (/turf/closed/wall/mineral/rogue/wood,/area/rogue/indoors/shelter)
 "DJ" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/wood,/area/rogue/under/town/basement)
+"DS" = (/mob/living/simple_animal/hostile/retaliate/rogue/spider,/turf/open/floor/rogue/naturalstone,/area/rogue/indoors/cave)
 "DZ" = (/obj/structure/ladder,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "Ee" = (/obj/effect/decal/remains/wolf,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/rogue/dirt/road,/area/rogue/under/town/basement)
 "Eg" = (/obj/item/rogueweapon/pitchfork,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
@@ -354,12 +412,15 @@
 "Eu" = (/obj/structure/bed/rogue/shit,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/outdoors/beach)
 "Ez" = (/obj/structure/closet/crate/chest/wicker,/obj/item/seeds/wheat,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "EB" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"EC" = (/obj/effect/spawner/lootdrop/roguetown/dungeon/money,/turf/open/water/sewer,/area/rogue/indoors/cave)
 "EI" = (/obj/structure/stairs,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "EJ" = (/obj/structure/mineral_door/wood/deadbolt{dir = 8; locked = 1},/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "EL" = (/obj/effect/decal/cleanable/blood/tracks{dir = 1},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/cave)
 "EM" = (/obj/machinery/light/rogue/wallfire/candle,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "EO" = (/obj/structure/closet/crate/chest,/obj/item/reagent_containers/food/snacks/rogue/fryfish/angler,/obj/item/reagent_containers/food/snacks/rogue/fryfish/eel,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
 "EW" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 10; icon_state = "border"},/turf/open/floor/rogue/blocks,/area/rogue/indoors/shelter)
+"Fb" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/grass,/area/rogue/outdoors/beach/forest)
+"Ff" = (/obj/machinery/light/rogue/forge,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "Fj" = (/obj/structure/table/wood{dir = 1; icon_state = "longtable"},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "Fk" = (/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/obj/structure/chair/wood/rogue/chair3{dir = 1},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "Fo" = (/obj/structure/mineral_door/wood/deadbolt{dir = 8},/turf/open/floor/rogue/wood/nosmooth,/area/rogue/indoors/shelter)
@@ -374,6 +435,7 @@
 "FU" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/cave)
 "FV" = (/obj/structure/stairs,/turf/open/floor/rogue/wood,/area/rogue/under/town/basement)
 "FZ" = (/obj/machinery/light/rogue/torchholder/r,/obj/structure/closet/crate/chest/wicker,/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
+"Gk" = (/obj/structure/closet/crate/chest/wicker,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "Gp" = (/obj/structure/table/vtable/v2,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "Gr" = (/obj/structure/boatbell/fluff{desc = ""},/turf/closed/wall/mineral/rogue/wooddark/vertical,/area/rogue/indoors/shelter)
 "Gv" = (/turf/closed/wall/mineral/rogue/stone/moss,/area/rogue/under/town/basement)
@@ -381,13 +443,16 @@
 "GD" = (/obj/machinery/light/rogue/firebowl/stump,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "GE" = (/obj/structure/fermenting_barrel/random/beer,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/cave)
 "GJ" = (/obj/machinery/light/rogue/hearth,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
+"GQ" = (/mob/living/simple_animal/hostile/rogue/skeleton/guard,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "GS" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/blocks,/area/rogue/indoors/shelter)
+"GX" = (/obj/effect/decal/cobbleedge{dir = 10},/obj/effect/decal/cobbleedge{dir = 6},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "Hf" = (/obj/structure/fluff/clock,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "Hh" = (/obj/structure/fluff/railing/border{dir = 5; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
 "Hu" = (/obj/structure/mineral_door/wood/window,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "Hx" = (/obj/item/roguegem/green,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "HA" = (/turf/closed/wall/mineral/rogue/wooddark/end{dir = 4},/area/rogue/outdoors/beach)
 "HI" = (/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter)
+"HV" = (/obj/structure/closet/crate/chest/old_crate,/obj/item/reagent_containers/food/snacks/rogue/meat/spider,/obj/item/reagent_containers/food/snacks/rogue/meat/spider,/obj/item/reagent_containers/food/snacks/rogue/meat/spider,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "HW" = (/obj/structure/closet/crate/drawer/inn,/obj/item/clothing/cloak/apron/brown,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "HY" = (/obj/structure/mineral_door/wood/red{locked = 1},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "Ic" = (/obj/structure/chair/wood/rogue/chair3,/obj/effect/decal/cleanable/blood/old,/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
@@ -399,27 +464,40 @@
 "IA" = (/obj/structure/mineral_door/wood/deadbolt,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "II" = (/turf/closed/wall/mineral/rogue/wooddark/end{dir = 4; icon_state = "endwooddark"},/area/rogue/outdoors/beach/forest)
 "IL" = (/obj/item/reagent_containers/glass/cup/wooden,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"IP" = (/obj/structure/mineral_door/wood/deadbolt{dir = 4; locked = 1},/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "IU" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/cave)
 "IW" = (/obj/structure/table/wood{icon_state = "longtable"; dir = 1},/obj/item/candle/skull/lit,/obj/item/roguestatue/gold{pixel_x = -16; pixel_y = 1},/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach)
 "IX" = (/turf/closed/wall/mineral/rogue/tent{dir = 1},/area/rogue/indoors/cave)
 "Jg" = (/turf/closed/wall/mineral/rogue/wooddark,/area/rogue/outdoors/beach/forest)
+"Jk" = (/mob/living/simple_animal/hostile/retaliate/rogue/orc,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
+"Jl" = (/mob/living/simple_animal/hostile/retaliate/rogue/mossback,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
+"Ju" = (/obj/item/restraints/legcuffs/beartrap/armed,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "Jv" = (/obj/structure/stairs{dir = 4; icon_state = "stairs"},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "JA" = (/obj/structure/closet/crate/chest/wicker,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "JB" = (/obj/structure/fluff/railing/border,/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "JG" = (/mob/living/carbon/human/species/goblin/npc/ambush/sea,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "JH" = (/obj/machinery/anvil/crafted,/turf/open/floor/rogue/cobblerock,/area/rogue/indoors/shelter)
+"JQ" = (/obj/structure/table/wood{icon_state = "longtable"},/obj/item/rogueweapon/huntingknife/cleaver{pixel_x = -7},/obj/item/book/rogue/yeoldecookingmanual{pixel_y = 7; pixel_x = 14},/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
+"JR" = (/obj/structure/roguerock,/turf/open/floor/rogue/naturalstone,/area/rogue/indoors/cave)
 "JX" = (/obj/structure/flora/newtree,/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "Ka" = (/obj/structure/closet/crate/chest/gold,/obj/item/roguecoin/gold,/obj/item/roguecoin/gold,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "Kb" = (/obj/machinery/light/rogue/wallfire/candle/blue/r,/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
+"Kg" = (/obj/machinery/light/rogue/wallfire/candle/blue/l,/obj/structure/chair/wood/rogue{dir = 4},/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "Kp" = (/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/obj/item/reagent_containers/glass/bottle,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "Kt" = (/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/beach)
 "KA" = (/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach)
 "KB" = (/obj/structure/ladder,/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach)
 "KD" = (/obj/machinery/light/rogue/oven/south,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
 "KF" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
+"KM" = (/obj/structure/table/wood,/obj/item/roguestatue/iron,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
+"KQ" = (/obj/structure/mineral_door/wood/red{locked = 1},/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "KR" = (/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
+"KS" = (/obj/item/restraints/legcuffs/beartrap/armed,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "KY" = (/obj/structure/composter/full,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"La" = (/mob/living/simple_animal/hostile/retaliate/rogue/orc/ranged,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "Lh" = (/obj/effect/decal/remains/human,/turf/open/floor/rogue/wood,/area/rogue/indoors/cave)
+"Lk" = (/obj/item/roguecoin/copper,/turf/open/water/sewer,/area/rogue/indoors/cave)
+"Ll" = (/obj/structure/mineral_door/wood/red{locked = 1},/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "Lm" = (/obj/structure/closet/crate/chest/wicker,/obj/item/reagent_containers/food/snacks/grown/wheat,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "Lo" = (/obj/machinery/loom,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "LE" = (/obj/structure/fluff/railing/border{dir = 8; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
@@ -436,13 +514,16 @@
 "Mu" = (/obj/structure/mineral_door/wood/violet,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "My" = (/obj/item/rogueweapon/sword/iron/short,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "MC" = (/obj/structure/bed/rogue/shit,/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/outdoors/beach)
+"ME" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "MJ" = (/obj/structure/mineral_door/wood,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
+"MN" = (/obj/item/reagent_containers/food/snacks/smallrat,/turf/open/floor/rogue/naturalstone,/area/rogue/indoors/cave)
 "MU" = (/obj/structure/fluff/railing/wood{pixel_y = -8},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "Na" = (/obj/effect/decal/cleanable/blood/tracks{dir = 9},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "Nb" = (/obj/structure/table/vtable,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "Nc" = (/turf/open/floor/rogue/rooftop/green{dir = 4},/area/rogue/outdoors/beach/forest)
 "Ne" = (/obj/structure/fluff/railing/border{dir = 9},/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
 "Nx" = (/obj/structure/table/wood{dir = 1; icon_state = "longtable_mid"},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
+"NA" = (/obj/structure/fluff/statue/gargoyle,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "NB" = (/obj/structure/fluff/walldeco/innsign{alpha = 200; layer = 4.1; level = 2; pixel_y = -15},/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter)
 "NE" = (/obj/structure/mineral_door/wood/deadbolt{locked = 1},/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "NG" = (/obj/structure/fluff/railing/border{dir = 8; icon_state = "border"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
@@ -450,6 +531,7 @@
 "NQ" = (/obj/structure/fluff/railing/fence{dir = 4; icon_state = "fence"},/obj/structure/fluff/railing/fence,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "NR" = (/turf/closed/wall/mineral/rogue/stone,/area/rogue/outdoors/beach)
 "NT" = (/obj/structure/stairs{dir = 8; icon_state = "stairs"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
+"NU" = (/obj/structure/closet/crate/chest/wicker,/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "NX" = (/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/beach)
 "Oa" = (/obj/item/natural/rock/salt,/obj/item/reagent_containers/powder/salt,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "Oc" = (/obj/structure/stairs{dir = 4; icon_state = "stairs"},/turf/open/floor/rogue/dirt/road,/area/rogue/under/town/basement)
@@ -460,15 +542,20 @@
 "Ov" = (/obj/structure/mineral_door/wood,/obj/effect/decal/cleanable/blood/tracks{dir = 4},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/cave)
 "OB" = (/obj/structure/fluff/railing/fence{dir = 1},/obj/structure/fluff/railing/fence{dir = 4; icon_state = "fence"},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "OF" = (/obj/structure/mineral_door/wood/window,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"OJ" = (/obj/structure/bars,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "OK" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 8; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 9},/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "OO" = (/obj/item/chair/rogue,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "OP" = (/turf/closed/wall/mineral/rogue/wooddark,/area/rogue/outdoors/beach)
 "OY" = (/obj/structure/stairs{dir = 4; icon_state = "stairs"},/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
+"OZ" = (/obj/structure/fluff/statue/small,/obj/effect/decal/cleanable/cobweb,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "Pe" = (/turf/closed/wall/mineral/rogue/tent{dir = 8},/area/rogue/indoors/cave)
 "Ph" = (/obj/machinery/light/rogue/firebowl/stump,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "Pi" = (/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/cave)
 "Ps" = (/turf/closed/wall/mineral/rogue/tent{dir = 1},/area/rogue/outdoors/beach)
+"PA" = (/obj/item/reagent_containers/food/snacks/crow{dir = 1; icon_state = "crow"},/turf/open/floor/rogue/rooftop{dir = 1},/area/rogue/outdoors/beach/forest)
 "PE" = (/obj/structure/closet/crate/chest/wicker,/obj/item/reagent_containers/food/snacks/grown/wheat,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/cave)
+"PI" = (/obj/machinery/light/rogue/wallfire/candle/blue/l,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
+"PK" = (/obj/machinery/anvil/crafted,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "PM" = (/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/outdoors/beach)
 "PR" = (/obj/effect/decal/cleanable/blood/old,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "PX" = (/obj/structure/closet/crate/chest,/turf/open/floor/rogue/wood,/area/rogue/under/town/basement)
@@ -477,6 +564,7 @@
 "Qb" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
 "Qe" = (/turf/closed/mineral/random/rogue,/area/rogue/outdoors/beach)
 "Qk" = (/obj/structure/fluff/railing/border,/turf/open/transparent/openspace,/area/rogue/outdoors/beach)
+"Qm" = (/obj/structure/fluff/statue/spider,/turf/open/floor/rogue/church,/area/rogue/indoors/cave)
 "Qs" = (/obj/effect/decal/cleanable/blood/tracks{dir = 1},/obj/effect/decal/cleanable/blood/tracks{dir = 1},/obj/machinery/light/rogue/torchholder/l,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/cave)
 "Qt" = (/obj/structure/closet/crate/chest/neu,/obj/item/rogueore/coal,/obj/item/rogueore/coal,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "Qx" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/obj/item/reagent_containers/glass/bottle/rogue/wine,/turf/open/floor/rogue/wood,/area/rogue/under/town/basement)
@@ -508,14 +596,20 @@
 "Sn" = (/obj/structure/table/wood{dir = 1; icon_state = "longtable_mid"},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "Sr" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "Ss" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
+"SB" = (/obj/machinery/light/rogue/torchholder/l,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
+"SG" = (/obj/structure/closet/dirthole/closed/loot,/obj/structure/gravemarker,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "SK" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "SN" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "ST" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
+"SU" = (/obj/structure/mineral_door/bars,/turf/open/floor/rogue/blocks,/area/rogue/indoors/cave)
 "SW" = (/turf/closed/wall/mineral/rogue/decowood,/area/rogue/indoors/shelter)
+"Ti" = (/turf/closed/wall/mineral/rogue/stone/blue_moss,/area/rogue/indoors/cave)
 "Tk" = (/obj/structure/table/wood{dir = 10; icon_state = "largetable"},/turf/open/floor/carpet/red,/area/rogue/indoors/shelter)
 "Tn" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
+"Tr" = (/obj/structure/mineral_door/wood/red{locked = 1},/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "Tv" = (/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach)
 "TA" = (/obj/structure/bars,/turf/open/floor/rogue/blocks,/area/rogue/indoors/shelter)
+"TB" = (/obj/structure/fluff/psycross,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "TI" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/shelter)
 "TK" = (/obj/structure/stairs{dir = 1; icon_state = "stairs"},/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "TO" = (/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/cave)
@@ -525,6 +619,7 @@
 "Ul" = (/obj/effect/decal/cleanable/blood/tracks{dir = 10},/obj/item/chair/rogue,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "Uq" = (/obj/structure/table/wood{dir = 1; icon_state = "longtable"},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
 "Uw" = (/obj/structure/stairs{dir = 4; icon_state = "stairs"},/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
+"Uy" = (/obj/structure/rack/rogue,/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "UK" = (/obj/structure/table/wood{icon_state = "longtable"},/obj/item/rogueweapon/tongs,/obj/item/rogueweapon/surgery/scalpel,/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
 "UQ" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/rooftop,/area/rogue/outdoors/beach/forest)
 "UR" = (/turf/closed/mineral/rogue/bedrock,/area/rogue/indoors/cave)
@@ -534,10 +629,13 @@
 "Vb" = (/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/turf/open/floor/rogue/cobble,/area/rogue/indoors/shelter)
 "Vd" = (/obj/structure/fluff/railing/border{dir = 5; icon_state = "border"},/obj/structure/fluff/railing/border,/turf/open/floor/rogue/blocks,/area/rogue/indoors/shelter)
 "Ve" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
+"Vg" = (/obj/machinery/light/rogue/oven/west,/turf/open/floor/rogue/ruinedwood/spiral,/area/rogue/indoors/cave)
 "Vj" = (/obj/structure/bed/rogue/shit,/mob/living/carbon/human/species/human/northern/searaider/ambush,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter)
 "Vq" = (/turf/open/floor/rogue/woodturned,/area/rogue/outdoors/beach)
 "Vs" = (/obj/item/natural/stone,/obj/item/natural/stone,/obj/item/natural/stone,/obj/item/natural/stone,/obj/item/rogueore/coal,/turf/open/floor/rogue/cobblerock,/area/rogue/indoors/shelter)
+"Vw" = (/obj/machinery/light/rogue/firebowl/standing/blue,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach/forest)
 "VE" = (/obj/structure/fluff/statue/scare,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
+"VI" = (/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "VK" = (/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "VX" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
 "VZ" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/obj/structure/stairs{dir = 8; icon_state = "stairs"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
@@ -547,10 +645,12 @@
 "WF" = (/turf/closed/wall/mineral/rogue/wooddark/vertical,/area/rogue/indoors/shelter)
 "WL" = (/obj/structure/bed/rogue/inn,/obj/item/bedsheet/rogue/cloth,/turf/open/floor/rogue/wood/nosmooth,/area/rogue/indoors/shelter)
 "WM" = (/obj/structure/chair/wood/rogue/chair3{dir = 8},/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
+"WU" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "WY" = (/obj/structure/fluff/traveltile{aportalgoesto = "forestdecapout"; aportalid = "forestdecapin"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach/forest)
 "Xb" = (/obj/structure/bed/rogue/inn/hay,/obj/item/bedsheet/rogue/pelt,/turf/open/floor/rogue/wood,/area/rogue/indoors/shelter)
 "Xd" = (/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "Xe" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter)
+"Xi" = (/mob/living/simple_animal/pet/cat,/turf/open/floor/rogue/woodturned,/area/rogue/indoors/shelter)
 "Xk" = (/obj/structure/fluff/railing/fence{dir = 1; icon_state = "fence"},/obj/structure/fluff/railing/fence{dir = 8; icon_state = "fence"},/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach/forest)
 "Xr" = (/mob/living/simple_animal/hostile/retaliate/rogue/mole,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "Xw" = (/obj/structure/toilet,/turf/open/floor/rogue/dirt,/area/rogue/indoors/cave)
@@ -570,11 +670,14 @@
 "Yv" = (/turf/open/water/cleanshallow,/area/rogue/indoors/cave)
 "Yw" = (/obj/structure/fluff/railing/border,/turf/open/floor/rogue/ruinedwood/chevron,/area/rogue/indoors/shelter)
 "YD" = (/turf/closed/wall/mineral/rogue/wooddark/vertical,/area/rogue/outdoors/beach)
-"YE" = (/obj/effect/decal/remains/human,/turf/open/floor/carpet/purple,/area/rogue/indoors/shelter)
+"YE" = (/obj/effect/decal/remains/human,/mob/living/simple_animal/hostile/rogue/skeleton/guard,/turf/open/floor/carpet/purple,/area/rogue/indoors/shelter)
 "YR" = (/obj/structure/closet/crate/chest/wicker,/obj/item/reagent_containers/food/snacks/fish/carp,/turf/open/floor/rogue/blocks,/area/rogue/outdoors/beach)
 "YS" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/obj/structure/ladder,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "YZ" = (/turf/closed/wall/mineral/rogue/stone,/area/rogue/under/town/basement)
+"Zc" = (/obj/structure/table/wood{icon_state = "longtable"},/obj/item/roguestatue/gold{pixel_y = 16; pixel_x = 15},/turf/open/floor/rogue/herringbone,/area/rogue/indoors/cave)
 "Ze" = (/turf/open/floor/rogue/rooftop,/area/rogue/outdoors/beach/forest)
+"Zh" = (/mob/living/simple_animal/hostile/retaliate/rogue/mossback,/turf/open/water/ocean,/area/rogue/outdoors/beach)
+"Zl" = (/obj/structure/stairs/stone{dir = 8},/turf/open/floor/rogue/cobble,/area/rogue/indoors/cave)
 "Zx" = (/obj/item/roguecoin/copper/pile,/obj/structure/closet/crate/chest/old_crate,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/cave)
 "ZF" = (/turf/open/floor/rogue/rooftop/green/corner1{dir = 1},/area/rogue/outdoors/beach/forest)
 "ZH" = (/turf/open/floor/rogue/blocks,/area/rogue/indoors/shelter)
@@ -609,7 +712,7 @@ FPURURURURURURURURURURURURURURURURURURURURURURURURwlPiPiTOtZbYbfbfbfgGpogGgGgGyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURwlwlPiTOTOlJbfbfgGgGgGpogGyWNXNXNXNXNXyWyWyWyWbfeZVqVqKAKAeZbfbfyWyWyWyWyWyWyWNXNXNXgGgGpogGgGgGbfQeQeQeRLRLRLQeQeQeQeQeQeQeQeQeQebfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURwlwlwlwlbYSNbfgGgGgGgGgGyWNXNXNXNXNXyWyWyWyWbfOPFrbKrtHAOPbfbfyWyWyWyWyWyWyWNXNXgGgGgGgGpogGbfbfQeQeQeRLRLRLRLRLRLRLRLRLQeQeQeQebfbfgGgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURbfbfbfpogGgGgGyWyWNXNXNXNXNXyWyWyWyWyWyrbfbfbfbfyrbfyWyWyWyWyWyWyWNXNXNXgGgGgGgGgGgGbfQeQeQeQeRLRLRLRLRLRLRLRLRLRLRLRLQeQebfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURNXOPEjbfgGgGgGpogGyWyWyWNXNXyWyWyWyWyWyWyWyWbfVqVqbfyWyWyWyWyWyWyWyWyWNXNXyWgGpogGgGgGbfbfQeQeQeQeRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQebfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURNXOPEjbfgGgGgGpogGyWyWyWNXNXyWyWyWyWyWyWyWyWbfVqVqbfyWyWyWyWyWyWyWyWyWNXNXyWgGpogGZhgGbfbfQeQeQeQeRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQebfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURNXNXbfbfgGgGgGwkgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWVqVqyWyWyWyWyWyWyWyWyWyWyWyWgGgGgGgGgGgGbfQeQeQeQeQetktktktkRLRLRLRLRLRLRLRLRLRLQeQeQebfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURXNzkURwlwlbYbfbfbfgGpogGgGgGyWyWyWyWbfbfbfbfbfyWyWyWyWyWVqVqyWyWyWyWyWyWNXNXyWyWyWyWgGgGgGpogGbfbfQeQeQeQeRLtktktktkRLRLRLRLRLRLRLRLRLRLQeQeQeQeQebfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWgGgGgGgGgGgGyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURsTsToLTOtZlJbfbfgGgGgGgGgGgGyWyWyWbfOPNRNRNRNROPyrbfyWbfVqVqbfyWyWyWyWyWNXNXNXyWyWyWgGgGpogGgGbfQeQeQeQeQetktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQebfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWgGgGgGgGgGgGgGgGgGyWyWyWyWyWyWyW
@@ -672,23 +775,23 @@ FPURURURURURURURURURURURURURURURURURURURURURURURmsmsmssTmsmsmsRLRLRLRLRLURURURsT
 FPURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmsmsRLRLRLRLURmssTsTsTtktksTsTtktktktktktktkURURRLRLRLRLQeQeQeQeQeQeNXNXOPEnBCEnOPNXNXNXNXNXNXTvTvTvTvTvNXXdsTsTsTsTsTmsmsmsmsURURURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURmssTmssTmsmsRLRLRLmsmssTsTURtktksTsTtktktksTestktkURURURRLRLrBrBrBrBrBRLRLNXNXmJRkbfbfjaNXNXURNXNXTvNXNXNXNXNXNXNXURURURURsTsTmsmsmsmsURURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmssTmsmsmsRLRLRLsTsTsTURURtktktksTsTsTtkFHsTtktkURURURURrBrBrBrBrBrBRLRLNXNXmJbfbfbfquOPNXURNXNXNXNXNXNXNXNXNXNXURURURURURURsTmsmsmsURURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmssTmsmsmsmssTURURURURtktksTsTtksTsTsTXrsTtkURURURrBrBrBrBrBrBrBrBRLNXNXmJjabfceNXNXNXURURURURURURURURURURURURURURURURUREmmsmsmsmsURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURsTsTmssTsTsTmsURURURURURURtktksTtksTsTtksTsTestkURURURrBtktktktkrBrBrBRLNXNXOPEnNXNXNXNXNXURURURURURURURURURURURURURURURURUREmmsmsmsmsmsURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmssTsTmsmsmsURURURURtksTsTXrsTsTtksTtktkURURrBrBtktktktktkrBrBURURURURURURURURURURURURURURURURURURURURURURURURURURURURsTmsmsmsmsURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmssTmssTmsURURmsURtktktktktktksTHxtktkURURrBtktktktktktktkrBURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTURURURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmssTmsmssTsTmsmsmsmsURURURURtktktktktktktkURrBrBrBrBrBtktktktkrBURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTURURURURURURURURbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTsTmsmsmsmsmsmsURURURURURURURURURrBrBrBrBrBrBrBtktkrBURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmssTURURURURURURURURbfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmssTmssTmsmsmsmsURURURURURURURrBrBrBrBrBrBrBrBtkURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmssTURURURURURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmssTsTsTmsmsmsmsURURURURURrBrBrBrBrBrBrBrBrBrBURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTsTURURURURURURURURURNXbfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmssTmsmsmssTURURrBrBRovgotsTRorBrBrBrBURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsURURURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmssTmsmsmsmsmsmsmssTrBrBsTRosTOarBrBrBURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTmsURURURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmssTsTmssTmsmssTmsotsTsTvgrBrBrBURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTmsURURURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTmssTmssTmsmsmsmsmsotRorBrBrBURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmsURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmssTmssTsTmsmsmsmsmsmsmsrBrBURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmsURURURURURURURURNXNXbfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmssTmsmsmsmsmssTmsmsrBmsmsmsURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmsmsmsURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmsmssTsTmssTsTmsmsmsmsmsmsmsmsURURURURURURURURURURURURURURURURURURURURURmsURmsmsmsmsmsURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsURmsmsmsmsmssTsTmsmsmsmsmsmssTsTmsmsmsmsURURURURURURURURURURURURURURURURURURURURURURmsmssTURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmsmsmsmsmsmsmsmsmssTsTmsmsmsmsURURURURURURURURURURURURURURURURURURURURURmsmssTURURURURURURURURNXNXbfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmssTmsmsmsmssTURURURURtktksTsTtksTsTsTXrsTtkURURURrBrBrBrBrBrBrBrBRLNXNXmJjabfceNXNXNXURURURURURsAsAsAsAsAsAURURURURURUREmmsmsmsmsURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURsTsTmssTsTsTmsURURURURURURtktksTtksTsTtksTsTestkURURURrBtktktktkrBrBrBRLNXNXOPEnNXNXNXNXNXURURURURURsAqeZcwecdsAURURURURURUREmmsmsmsmsmsURURURURNXbfbfbfgGZhgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmssTsTmsmsmsURURURURtksTsTXrsTsTtksTtktkURURrBrBtktktktktkrBrBURURURURURURURURURURTiTiTisAsAsABTVIVItCsAURURURURURURURsTmsmsmsmsURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmssTmssTmsURURmsURtktktktktktksTHxtktkURURrBtktktktktktktkrBURURURURURURURURURTiTivuvuvuvusABTVIVIrXsAURURURURURURmsmssTURURURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmssTmsmssTsTmsmsmsmsURURURURtktktktktktktkURrBrBrBrBrBtktktktkrBURURURURURURURURsAsAcgvusAsALlsAsAsAVIVIsAURURURURURURmsmssTURURURURURURURURbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTsTmsmsmsmsmsmsURURURURURURURURURrBrBrBrBrBrBrBtktkrBURsAsAsAsATisAsAsAmqvuvusAanobJQsusAaxVIsAURURURURURmsmsmssTURURURURURURURURbfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmssTmssTmsmsmsmsURURURURURURURrBrBrBrBrBrBrBrBtkURURsAZlvuvuvuvuvuzhvuvuMEsAobobJkVgsAsAKQsAURURURURmsmsmssTURURURURURURURURURNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmssTsTsTmsmsmsmsURURURURURrBrBrBrBrBrBrBrBrBrBURURsAZlvuvuvuvuvuvuvuvuTisAynobobobsAsAVIsAURURURURmsmssTsTURURURURURURURURURNXbfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmssTmsmsmssTURURrBrBRovgotsTRorBrBrBrBURURsAsAsAsAvuMEsAsAsAsAsAsAsAHVynobLlVItCsAURURURmsmsmsmsURURURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmssTmsmsmsmsmsmsmssTrBrBsTRosTOarBrBrBURURURURURURsAvuvusAsAsAsAsAsAsAsAsAsAsAsAVIsAURURURmsmssTmsURURURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmssTsTmssTmsmssTmsotsTsTvgrBrBrBURURURURURURsAvuGXsAsAOZsAAisAsAUyCPsAsAsAjXsAURURURmsmssTmsURURURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTmssTmssTmsmsmsmsmsotRorBrBrBURURURURURURsAvudBKSobobobobobobobLajXvugTvuagsAURURmsmsmsmsmsmsURURURURURURURURNXNXbfJlbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmssTmssTsTmsmsmsmsmsmsmsrBrBURURURURURURsAsAobobobobobobobobobursAvuvunlvusAURURmsmsmsmsmsmsURURURURURURURURNXNXbfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmssTmsmsmsmsmssTmsmsrBmsmsmsURURURURsAsAsAsAAisAAisAsAsAsAsASBgoPKezsAURURmsmsmsmsmsmsmsmsURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmsmssTsTmssTsTmsmsmsmsmsmsmsmsURURURURsAsAsAsAsAURURsAmlvuvufiFfsAURURURmsURmsmsmsmsmsURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsURmsmsmsmsmssTsTmsmsmsmsmsmssTsTmsmsmsmsURURURURURURURURURsAmlvuvuvuvfsAURURURURURURmsmssTURURURURURURURURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmsmsmsmsmsmsmsmsmsmsmssTsTmsmsmsmsURURURURURURURURsAsAsAsAsAsAsAURURURURURURmsmssTURURURURURURURURNXNXbfbfbfgGgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsURURURURmsmsmsmsmsmsmsmsmsmsmsmsmsURURURURURURURURURURURURURURURURURmsmsmssTURURURURURURURURNXNXbfbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTsTmsmsmsmsmsmsURURURURURURURURURURURURURURURURmsmsmsmsURURURURURURURURNXNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsmssTsTsTmsmsmsmsURURURURURURURURURURURURURmsmsmsmssTURURURURRLURURURNXNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
@@ -696,7 +799,7 @@ FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURUR
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsURURURURmsmsmsmsmsRLRLURURURURURURURRLRLRLmsmsmsmsURURRLRLRLRLRLRLRLURNXNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmsmsRLRLRLRLRLURURRLRLRLRLRLmsmsmsmssTRLRLRLRLRLRLRLRLRLRLQeNXbfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURmsmssTsTmsRLRLRLRLRLtktkRLRLmsmsmsmsmsRLRLRLRLRLRLtktkRLRLQeQebfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
-FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURRLRLmsmssTsTmsRLRLRLRLtktkRLRLmsmsmsmsmsRLRLRLRLtktktktkRLRLQeQebfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
+FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURRLRLmsmssTsTmsRLRLRLRLtktkRLRLmsmsmsmsmsRLRLRLRLtktktktkRLRLQeQebfJlbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURRLRLmsmsmssTmsmsmsRLRLtktkRLRLmsmssTmsRLRLRLRLRLtktktktkRLRLQeQebfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURRLRLRLRLRLmsmsmssTmsmsRLRLtkRLRLmsmssTmsmsmsRLRLtktktktkRLRLRLQeQebfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
 FPURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURURRLRLRLRLRLRLmsmssTmsmsRLRLRLRLRLmsmssTmsmsmsRLRLtktktkRLRLRLRLQeQebfbfbfgGgGgGyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyWyW
@@ -806,33 +909,33 @@ FPURURURURURURURURRLRLRLRLRLRLmsmsRLmsmsmsmsmsmsmsRLRLRLRLRLRLRLRLRLRLRLRLRLRLtk
 FPURURURURURURURURRLRLRLRLRLRLmsmsZRZRmsmsmszRmsmsmsmsRLsTRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLmssTEmkNURRLRLRLRLRLRLNXNTXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURURURURURURURURRLRLRLRLRLZRZRZRZRZRZRsTsTsTDhmsmsmssTURURURURRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLmsRLRLRLRLRLRLRLRLRLQeXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURURURURURURURURRLRLRLRLRLZRZRZRZRZRZRsTsTsTsTmsmssTsTsTsTsTURRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLZRZRZRZRZRZRsTsTsTsTsTsTsTsTsTsTUwURRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLZRZRZRZRZRZRmsmsRdsTsTmsmssTsTsTUwURRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLZRZRZRZRZRZRmsmsJGsTmsmsmsmssTsTURURRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLZRZRZRZRZRmsmssTsTmsmsmsmssTsTRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLmsmsZRZRmsmsmsmssTRLmsmssTsTsTsTRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeXdXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLmsmsmsRLmsRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLmsRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeXdXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeQeXdXdNXtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeQeXdXdNTtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLZRZRZRZRZRZRsTsTsTsTsTsTsTsTsTsTUwURRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLnSnSmsRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLZRZRZRZRZRZRmsmsRdsTsTmsmssTsTsTUwURRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLsAsAsAsAsAsARLRLRLRLRLRLRLRLRLRLRLRLRLnSjFmsmsmsnSnSRLRLRLRLRLRLRLRLRLRLRLQeXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLZRZRZRZRZRZRmsmsJGsTmsmsmsmssTsTURURRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLsAvuvupEkNsARLRLRLRLRLRLRLRLRLRLRLRLRLkMDSkMkMJRlCnSRLRLRLRLRLRLRLRLRLRLRLQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLZRZRZRZRZRmsmssTsTmsmsmsmssTsTRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktktkRLRLRLRLsAvuvupEkNsARLRLRLRLRLRLRLRLRLRLRLRLRLzNkMkMmskMkMkMmsRLRLRLRLRLRLRLRLRLRLQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLmsmsZRZRmsmsmsmssTRLmsmssTsTsTsTRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAvuvusAsAsARLRLRLRLRLRLRLRLRLRLRLRLRLRLkMDSkMkMkMDSkMRLRLRLRLRLRLRLRLRLRLQeXdXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLmsmsmsRLmsRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAvuvusAsAsAsAsAsAsAsAsARLRLRLRLRLRLRLkMsAlUxFkMkMkMkMnSRLRLRLRLRLRLRLRLRLQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLmsRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAsAsAsAsARLsAvuMEsAsAALWUgmWUvuWUsARLRLRLRLRLRLRLkblUlUlUkMDSmskMRLmbRLRLRLRLRLRLRLRLQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAECiWLksARLsAvuvusAsASBvuvuvufivusARLRLRLRLRLRLRLsASUsAfZsARLRLmsmsmsRLRLRLRLRLRLRLRLQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAiWQmiWsARLsAvufisAsAWUGkWUvuvuMEsARLRLRLRLRLRLlUlUlUlUlUlURLRLRLRLRLRLRLRLRLRLRLRLRLQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsACbdOdOsAsAsAvuvusAsAsAsAsAsAvuvusARLsAsAsAsAsAsAlUlUiWiWiWlURLRLRLRLRLRLRLRLRLRLRLRLQeQeXdXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAlUlUlUNUsAsAvuvusARLRLRLRLsAvuvusARLsACWCBvuvusAsAPIiWNAiWlURLRLRLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAsAlUlUJuejvuvuvusAsAsAsAsAsATrsAsAsAsAKgcrvuvuvusAlULkiWiWlUsARLRLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAlUlUlUsAsAvuvuvuvuvuvuvuvuvuvuvuvuvuvuvuvuzhvuTrlUlUlUlUlUsARLRLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAsAsAsAsAsAvuvuvuvuvuvuvuvuvuvuvuvuvuvuvuvuvuvusAsAsAfZlUfZsAsARLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAsAsAsAsAsAsAsAsAsAsAsAsAsAsAsAsAsAsAsARLsAlUlUlUlUsARLRLRLRLRLRLRLRLRLRLQeQeQeXdXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAsAPIARlUsAsARLRLRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLsAsAlUlUlUsARLRLRLkMkMRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLsAlUlUlUsARLRLRLkMkMMNkMRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLsAkMARlUsACIkMkMkMJRkMkMkMkMXdXdXdXdXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLkMkMlUlUKMfZkMkMkMkMkMkMkMkMkMXdXdXdXdXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLkMkMRLkMsAsAsAsAkMlUkMkMkMkMkMRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLkMkMRLRLRLRLRLsAkMkMkMRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLkMRLRLRLRLRLRLkMkMkMkMRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLkMkMRLRLRLRLRLkMRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLkMRLRLRLRLkMkMRLRLRLRLRLRLRLQeQeQeQeXdXdXdtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLkMkMRLRLRLkMkMRLRLRLRLRLRLRLQeQeQeQeQeXdXdNXtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLkMkMkMkMkMkMRLRLRLRLRLRLRLRLQeQeQeQeQeXdXdNTtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURURURURURURURURRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeQeQeXdNTtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeQeQeQeNXtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktktktktktktktktktktktktktktkRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLQeQeQeQeQeQeQeQetwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
@@ -881,7 +984,7 @@ FPURRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzRLRLRLRLpzpzpzpzDGxrgxCHCHCHCHuKDGpzXKXKkBfT
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzRLRLRLRLRLpzpzpzDGaJgxCHCHCHCHuMDGpzXKpzWFragggzkeLoWFpzvRCxnMnMtAnMnMVZlqpzpzpapapzpzXKXKXKnrXKJgRbJgpzpzpzpzpzGBpzpzpzpzpzpzpzXKXKXKXKXKpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzBABABABApzpzpzpzzKtmgbgbzKzKgxxlfSpzpzpztwtwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzRLRLRLRLpzpzpzkBDGNEkBDGDGyEDGkBpzXKpzXSVKVKkekevvWFpzXKeVgcgcgcgcgceVXKpzpzpzpapzpzXKXKXKXKpzsfIIsfGBpzpzpzpzpzpzpzpzvFpzpzpzpzXKXKXKXKpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKBABAXKXKXKXKXKvJtmSTSTuSgxfEDyzKpzpzpztwtwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzRLRLpzpzpzpzDGrUAxDGVsRJsasasaXKXKXKWFVKVKkekefAWFpzXKXKvGvGXKXKBZXKXKpzpzpzpzpzpzXKXKXKnrpzsfhusfpzpzpzpzpapapzpzpzpzvFpzpzpzXKXKXKXKXKpzpzpzpzpzXKXKXKXKXKXKXKpzpzXKXKBABABABApzpzXKXKfStmgbgbzKzKgxMgzKpzpzpztwtwtwtw
-FPURRLRLRLRLRLRLRLRLRLRLRLRLpzRLRLRLpzpzpzRLpzpzpzpzDGnRYfDGJHsasasasaXKXKXKkBNxNxkBfTfTkBpzXKXKOOXKXKvGXKXKXKpzpzpzXKXKXKXKXKXKXKpzJgRbJgpzpzpzpzpapapapzpzpzpzpzpzpzXKXKXKXKXKpzpzpzpzXKXKXKXKXKpzpzpzpzpzpzBABABABABApzpzpzpzfSljtmgbzKVdEWzszKpzpzpztwtwtwtw
+FPURRLRLRLRLRLRLRLRLRLRLRLRLpzRLRLRLpzpzpzRLpzpzpzpzDGnRYfDGJHsasasasaXKXKXKkBNxNxkBfTfTkBpzXKXKOOXKXKvGXKXKXKpzpzpzXKXKXKXKXKXKXKpzJgRbJgpzpzpzpzpapapapzpzpzpzpzpzpzXKXKXKXKXKGDpzpzpzXKXKXKXKXKpzpzpzpzpzpzBABABABABApzpzpzpzfSljtmgbzKVdEWzszKpzpzpztwtwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLpzRLRLRLpzpzpzpzpzpzpzpzkBDGDGkBbhsaBNBNkBXKXKXKXKXKXKpzpzpzpzpzXKXKXKXKXKXKXKXKXKpzpzXKXKXKDGDGDGDGXKpzsfIIsfpzpzpzpapapapapzvFvFpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzBABABABABABABABABApzpzzKjqtmtmzKpsufzSzKpzpztwtwtwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLpzpzRLRLpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKDGDGDppBDGDGXKsfhusfpzpzGBpzpapapapapzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzBABABABABABABABABABApzpzpzHIQJhzzKzSzSzSpzpzpztwtwtwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzJXpzpzpzpzGBpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKpzpzXKXKXKXKXKXKDGDGDGmdDGXKaZCHVKKppsDGXKJgRbJgpzpzpzpzpapapapapzpzpzpzpzpzpzXKXKXKXKXKXKXKpzpzpzpzpzvFpzpztwtwtwtwtwtwtwtwtwtwtwtwpzpzxxpzPZpzpzpzpzpzpztwtwtwtwtwtw
@@ -908,7 +1011,7 @@ FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzURURURRLRLRLRL
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzpzpzURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLURURURURURURURURpzpzpzpapapapapapapapapzpzpzvFpzpzXKXKXKXKpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwkzPMPMPMPMPMPMPMPMPMLEtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzRLRLRLpzpzpzpzpzpzpzURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLURURURURURURURpzpzvFpapapapzpapzpapapzpzpzpzpzpzXKXKXKXKpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwHhOPpCpCOPPMOPpCpCOPNetw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzRLRLRLRLpzvFpzpzpzpzpzURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLURURURURURURURURpzvFpzpzpapapapapapapapzpzpzpzpzXKXKXKXKpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwkBkBkBkBHukBkBkBkBtwtw
-FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzRLRLRLRLpzpzpzpzpzpzURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLURURURURURURURURpzpzpzpzpzpapapapzpapapzpzpzpzpzpzXKXKXKpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwkBlzgbgbgbgbgbzUkBtwtw
+FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzRLRLRLRLpzpzpzpzpzpzURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLURURURURURURURURpzpzpzpzpzpapapapzpapapzpzpzpzGDpzXKXKXKpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwkBlzgbgbgbgbgbzUkBtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzRLRLRLRLpzpzpzpzpzpzURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLURURURURURURURURURpzpzpapzpapzpapzpapzpzpzvFpzpzpzXKXKXKpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwkBkBgbgYSnUqgbkBkBtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzRLRLRLpzpzpzvFpzpzURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLURURURURURURpzpzpzpapapapzpapapzpzpzpzpzpzXKXKXKpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwXSgbgbntnjgbXStwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzRLRLpzpzpzpzpzpzpzURURURURURURURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtktktktkURURpzpzpzpapapapapapzpzpzpzvFpzpzXKXKXKXKpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwkBkBkBkBkBkBkBtwtwtw
@@ -930,7 +1033,7 @@ FPURRLRLRLRLRLRLRLRiyGjcpzpzpzXKXKXKpzPedKsTRdptURURRLRLsTsTsTsTsTsTRLRLRLRLRLRL
 FPURRLRLRLRLRLRLRLRiyGXKXKXKXKXKXKpapzRidnFEdnRiURURRLRLRLRLsTsTsTsTRLRLRLRLRLRLRLtktkRLRLRLRLRLRLRLRLRLRLURURsTsTsTsTsTUwURURURURURURpzpzpzpapzpapapzpzpapapapapzpapapzpzpzpzvFpzpzpzpzXKXKpzpzpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLRLRipzpzXKXKXKXKpaQBpaXKXKXKURURURRLRLRLRLRLRLRLsTsTsTRLRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLURURURsTsTsTsTUwURURURURURpzpzpzpzpapapzpapzpapapapzpapzpzpapzpzpzpzpzpzpzpzpzXKXKXKpzpzpzvFpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLRLJgoXJgXKXKXKpzmepaXKXKXKXKURdKsTRLRLRLRLRLRLRLRLsTsTRLRLRLRLRLtktktktktktkRLRLRLRLRLRLRLURURURURURURURURURURURURURpzpzpzpzpapzpzpzpapapapzpzpapapapapapzpzpzpzpzpzpzpzXKXKXKpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLdeVemhXKXKXKpzpapapzpzpzsTEJsTClRLRLRLRLRLRLRLRLsTsTRLRLRLRLRLtktktktktktktkRLRLRLRLRLRLURURURURURURURURURURURURURpzvFvFvFpzpapapapapapapapzpzpapapapapzpzpzpzpzpzpzpzXKXKXKXKpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLdeVemhXKXKXKpzpapapzpzpzsTEJsTClRLRLRLRLRLRLRLRLsTsTRLRLRLRLRLtktktktktktktkRLRLRLRLRLRLURURURURURURURURURURURURURpzvFvFvFpzpapapapapapapapzpzpapapapapzpzpzpzpzpzpzpzXKXKXKXKGDpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLRLJgRTJgpzXKXKpapapzpzpzpzyMsTsTsTsTRLRLRLRLRLRLRLsTsTJGRLRLRLRLtktktktktktktkRLRLRLRLRLURURURURURURURURURURURURURpzpzpzpzvFpzpzpapapzpapapapzpapzpapzpapapzpzpzpzpzpzpzpzXKXKXKpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLRLeMeMeMNQcEcEYetceMeMeMURrmsTsTsTyZRLRLRLRLRLRLRLsTsTsTRLRLRLRLtktktktktktktkRLRLRLRLRLURURURURURURURURURURURURURpzpzpzpapapapapapzpapapapapzpapzpzpapzpzpzpzpzpzpzpzpzpzXKXKXKpzpzqXtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLpzpzpzpzpzXKXKpzpzpzpzpzURURRLousTRLRLRLRLRLRLRLRLsTsTRLRLRLRLRLtktktktktkRLRLRLRLRLRLRLURURURURURURURURURURURURpzpzpzpapapapapzpapzpapapzpapapapapapapapzpzpzpzpzvFpzpzpzXKXKXKpzpzqXtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
@@ -948,24 +1051,24 @@ FPURRLRLRLRLpzpzpzpzpzpzpzpzpzpzpapzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpz
 FPURRLRLRLRLpzpzpzpzpzpzpzpzpzpzpapapapzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFvFvFpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFvFpzpzpzpzvFvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLpzvFvFpzpzvFvFpzpzpzpapapapapapzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLpzpzvFpzpzpzpzpzpzpzpapapapapapapzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKpzpzpzpzpzvFpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLpzpzpzpzpzpzpzpzpzpzpapapapapapapapapzpzpzpzpzpzpzpzpzpzvFvFpzpzpzpzpzpzpzvFpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzXKXKXKpzpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLpzpzpzpzpzpzpzpzvFpzpzpzpapapaXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzXKXKXKpzpzpzvFpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLpzpzpzpzpzpzpzpzpzpzpapapapapapapapapzpzpzpzpzpzpzpzpzpzvFvFpzpzpzpzpzpzpzvFpzpzpzpzGDXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzXKXKXKpzpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLpzpzpzpzpzpzpzpzvFpzpzpzpapapaXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzGDXKXKXKpzpzpzvFpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpatwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzvFvFpzpzpzpzpzpzpzpzvFvFpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpapatwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLpzpzpzpzvFvFpzpzpzpzpzpzpzpzpzpzpzXKpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzvFvFpzpzpzpzpzpzpzpzpzvFpzpzvFpzpzpzvFpzpzpzpzpzXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpapatwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpzpzpzpzpzpzXKXKXKXKXKXKpzpzpzpzpzpzpzpzpapatwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzvFpzpzpzGDpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpzpzpzpzpzpzXKXKXKXKXKXKpzpzpzpzpzpzpzpzpapatwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLRLpzpzpzpzvFpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpapzpzpzpzpzpzpzpzpzpzpapapzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKpzpzpzvFpzpzpzpzpapatwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpapapapapzpzpapzpzpzpzpzpapapapapapzpapapapzpzpzvFpzpzpzpzpzpzXKXKXKXKpzpzpzpzpzpzvFpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpapapapapapapapapzpzvFvFpzpzpzpzpzpzpapapapapapzpzpzpzpzpzpzpzpzXKXKXKXKpzpzpzpzpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLURyGXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpzpzpzpapapapapapapapzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzDFDFDFDFpzpzpzpzpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLURyGXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpapapapapapapapapapzpzpzpzpzpzpzpzpzpzpzpzvFvFpzpzpzpzpzvFpzRLRLRLRLRLURURURURRLRLRLRLpzvFpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLURyGXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzvFpzvFpzpzpzvFpzpzpzpzvFpzpzpzpzpzvFpzpzpzpzpzpzpzpapapapapapapapapapapzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzvFvFvFpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpapapapapapapapapapapapapapzpzvFpzpzpzpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwURtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpapapapapapapapapapapzpapapzpzvFpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpapapapapzpapapapzpapapzpzpzpzvFpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpzpzpzpzpzpzpapapapapapapzpzpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
-FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpzpzpzpzpzpapapzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpapapapapapapzpzpapzpzpzpzpzpapapapapapzpapapapzpzpzvFpzpzpzpzpzpzXKXKXKXKpzpzpzpzpzpzvFpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpapapapapapapapapapapapzpzvFvFpzpzpzpzpzpzpapapapapapzpzpzpzpzpzpzpzpzXKXKXKXKpzpzpzpzpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLURyGXKXKXKXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpapapapamKmKmKmKgCgCpapapzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzDFDFDFDFpzpzpzpzpzpzpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLURyGXKXKXKXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpawNpapamKTByfiXTBgCFbpzpzpzpzpzpzpzpzpzpzpzvFvFpzpzpzpzpzvFpzRLRLRLRLRLURURURURRLRLRLRLpzvFpzpzpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLURyGXKXKXKXKXKXKXKXKXKpzpzpzpzpzpzvFpzvFpzpzpzvFpzpzpzpzvFpzpzpzpzpzvFpzpzpzpzpzpzpzpapapamKmKlIlIlIlImKpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpztwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzvFvFvFpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpapapaSGpamKcXlIlIGQlIgCpapzpzvFpzpzpzpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwURtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpapapapapzIPlIlIlIlImKgCpapzpzvFpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpapaFbpawNpzmKCKlIlIVwmKpzpzpzvFpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpzpzpzpzpzpzpzmKmKmKlImKmKpzpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
+FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpzpzpzpzmKOJmKpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzvFvFpzpzpzpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
 FPURRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtwtw
@@ -995,7 +1098,7 @@ pZrbrbrbrbrbrbrbrbrbpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzrbrbrbrbBABABABABABA
 pZrbrbrbrbrbrbrbrbrbpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzrbpzpzrbrbrbBABABABABABABABABABABABABABASWWLvqSWHfVKCHxACHVKSWBABABABABABABABAAXAXAXBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
 pZrbrbrbrbrbrbrbrbrbpzpzpzpzpzpzpzpzpzpzpzrbrbrbrbrbrbrbrbpzrbrbBABABABABABABABABABABABABABABAlSaOZUphVKVKlililiVKSWBABABABABABABABAAXAXAXBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
 pZrbrbrbrbrbrbrbrbrbpzpzpzrbrbrbrbrbpzpzpzrbrbrbrbrbrbrbrbpzrbBABABABABABABABABABABABABABABABAkBSWSWkBbXWBpspspszMSWBABABABABABABABAAXAXAXBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
-pZrbrbrbrbrbrbrbrbpzpzpzrbrbrbrbrbrbpzpzpzrbrbrbrbrbrbrbrbpzpzBABABABABABABABABABABABABABABABASWWLvqSWVKWBpspspspsSWBABABABABABABABAzKKRrfBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
+pZrbrbrbrbrbrbrbrbpzpzpzrbrbrbrbrbrbpzpzpzrbrbrbrbrbrbrbrbpzpzBABABABABABABABABABABABABABABABASWWLvqSWXiWBpspspspsSWBABABABABABABABAzKKRrfBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
 pZrbrbrbrbrbrbrbrbpzpzrbrbrbrbrbrbrbpzpzpzrbrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABAlSZUZUFoVKWBpspsOppsSWBABABABABABABAzKzKKRrfzKBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
 pZrbrbrbrbrbrbrbrbpzpzrbrbrbrbrbrbpzpzrbrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABAkBSWSWkBbXWBpspspspsSWBABABABABABABAXSKRKRKRXSBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
 pZrbrbrbrbrbrbrbrbpzpzpzrbrbpzpzpzpzrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABASWvroaSWVKVKkBSWSWSWkBBABABABABABABAzKrfKRrfrfBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
@@ -1088,16 +1191,16 @@ pZpZpzXKXKXKpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
 pZpZpzpzXKXKpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
 pZpZpzpzXKXKXKpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
 pZpZpzpzXKXKXKXKpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
-pZpZpzpzpzXKXKXKXKXKyGBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
-pZpZpzpzpzpapaXKXKXKyGBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABApzpzpzpzpzpzDFDFDFDFpzpzpzrbBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
-pZpZpZpzpapapapapaXKyGBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABArbrbpzpzpapapzpzXKXKXKXKpzpzpzrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABABABABABABA
-pZpZpZpzpapapapapzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABArbrbrbrbrbrbrbpzpzpzpapzpzXKXKXKXKpzpzpzpzrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABABABA
-pZpZpZpzpzpzpapapapapzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABApzpzrbrbrbrbrbrbrbrbrbpzpzpapzpzpzXKXKXKXKpzpzpzpzpzrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABABA
-pZpZpZpzpzpzpzpapapapapzvFpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABApzpzpzrbrbrbrbrbrbrbrbrbrbpzpzpapzpzpzXKXKXKXKXKpzpzpzpzpzrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABA
-pZpZpZpZpzpzpzpzpapapapapapzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABApzpzpzpzpzrbrbrbrbrbrbrbrbrbrbpzpzpzpzpzpzXKXKXKXKXKQBpzpzpaparbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
-pZpZpZpZpZpZpzpzpapapapapapapzpzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABApzpzpzpzpzpzpzpzpzrbrbrbrbrbrbrbrbrbrbrbpapapapzpzpzXKXKXKXKpzpzpapaparbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
+pZpZpzpzpzXKXKXKXKXKyGBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAububububububBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
+pZpZpzpzpzpapaXKXKXKyGBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAubububBAububBABABABABABABABABABABABABABABABABABABABApzpzpzpzpzpzDFDFDFDFpzpzpzrbBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA
+pZpZpZpzpapapapapaXKyGBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAubububububububBABABABABABABABABABABABABABABABABABArbrbpzpzpapapzpzXKXKXKXKpzpzpzrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABABABABABABA
+pZpZpZpzpapapapapzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAubububBABABAubBABABABABABABABABABABABABArbrbrbrbrbrbrbpzpzpzpapzpzXKXKXKXKpzpzpzpzrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABABABA
+pZpZpZpzpzpzpapapapapzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAubBAubBABAububBABABABABABABABABABApzpzrbrbrbrbrbrbrbrbrbpzpzpapzpzpzXKXKXKXKpzpzpzpzpzrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABABA
+pZpZpZpzpzpzpzpapapapapzvFpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAubBABAubububBABABABABABABABABApzpzpzrbrbrbrbrbrbrbrbrbrbpzpzpapzpzpzXKXKXKXKXKpzpzpzpzpzrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABABA
+pZpZpZpZpzpzpzpzpapapapapapzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAububdoubububBABABABABABABApzpzpzpzpzrbrbrbrbrbrbrbrbrbrbpzpzpzpzpzpzXKXKXKXKXKQBpzpzpaparbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
+pZpZpZpZpZpZpzpzpapapapapapapzpzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAububPABABABABApzpzpzpzpzpzpzpzpzrbrbrbrbrbrbrbrbrbrbrbpapapapzpzpzXKXKXKXKpzpzpapaparbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
 pZpZpZpZpZpZpZpzpzpzpapapapapzvFpzvFpzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABApzpzpzpzpzpzpzpzpzpzrbrbrbrbrbrbrbrbrbrbrbrbrbpapapzpzpzXKXKXKXKpzpzpapaparbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
-pZpZpZpZpZpZpZpZpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABApzpzpzpzpzpzpzpzpzpzpzpzrbrbrbrbrbrbrbrbrbrbrbrbrbpapapapzpzXKXKXKXKpzpzpzpzpzrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
+pZpZpZpZpZpZpZpZpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzBABABABABABABABABABABABABABABABABABABABABABABABABABABApzpzpzpzpzSGpzpzpzpzpzpzrbrbrbrbrbrbrbrbrbrbrbrbrbpapapapzpzXKXKXKXKpzpzpzpzpzrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
 pZpZpZpZpZpZpZpZpZpZpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzrbrbrbrbrbrbrbrbrbrbrbrbrbrbpapapzQBXKXKXKXKpzpzpzpzpzrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
 pZpZpZpZpZpZpZpZpZpZpZpZpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzvFpzpzpzpzpzpzrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbpapapzpzXKXKXKXKpzpzpzpzrbrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA
 pZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpZpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzpzrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbpzpzQRQRQRQRpzpzpzrbrbrbrbrbrbrbrbrbBABABABABABABABABABABABABABABABABABABABABABA

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -7,58 +7,77 @@
 "aG" = (/obj/machinery/conveyor/auto{dir = 6; color = "#755f48"},/turf/open/floor/rogue/metal/barograte,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "aH" = (/obj/structure/fluff/railing/wood{dir = 8},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "aI" = (/obj/structure/spacevine,/turf/open/water/swamp,/area/rogue/under/cave)
+"aJ" = (/obj/item/grown/log/tree/small{pixel_y = 7},/obj/item/grown/log/tree/small{pixel_x = 16},/obj/item/grown/log/tree/small{pixel_y = -9; pixel_x = -11},/obj/item/grown/log/tree,/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "aK" = (/turf/open/floor/rogue/herringbone,/area/rogue/outdoors/mountains)
 "aM" = (/obj/structure/spacevine,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "aP" = (/obj/item/grown/log/tree,/turf/open/floor/rogue/dirt,/area/rogue/indoors/shelter/woods)
 "aW" = (/turf/open/water/river{icon_state = "rockwd"; dir = 1},/area/rogue/outdoors/woods)
 "bb" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/mountains)
+"bd" = (/obj/structure/mineral_door/wood/donjon{dir = 1; locked = 1},/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "bk" = (/obj/structure/spider/stickyweb,/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane)
+"bn" = (/obj/item/flashlight/flare/torch/lantern,/turf/open/transparent/openspace,/area/rogue/indoors)
 "bp" = (/obj/machinery/door/airlock/grunge{color = "#755f48"},/turf/open/floor/rogue/metal{icon_state = "plating2"},/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "br" = (/obj/structure/ladder,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
 "bs" = (/obj/machinery/light/rogue/torchholder/l,/obj/effect/decal/cobbleedge{dir = 8},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "bv" = (/obj/structure/stairs/stone,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "bw" = (/obj/effect/decal/remains/human,/obj/structure/spider/stickyweb,/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
+"bA" = (/obj/structure/closet/crate/chest/wicker,/obj/item/reagent_containers/food/snacks/grown/wheat,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
+"bD" = (/obj/structure/roguerock,/obj/structure/spacevine,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "bH" = (/obj/structure/bars/steel{max_integrity = 500},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "bI" = (/obj/machinery/door/airlock/grunge{color = "#755f48"},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "bL" = (/obj/machinery/door/airlock/grunge{color = "#755f48"},/turf/open/floor/rogue/metal{icon_state = "plating2"},/area/rogue/under/cave/dungeon1/gethsmane)
 "bN" = (/obj/machinery/conveyor/auto{dir = 1; color = "#755f48"},/obj/structure/spacevine,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "bR" = (/obj/structure/rack/rogue,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
 "bS" = (/turf/closed/wall/mineral/rogue/decowood,/area/rogue/indoors)
+"bT" = (/turf/closed/wall/mineral/rogue/stone/window/blue_moss,/area/rogue/under/cave)
 "cd" = (/obj/structure/bars/pipe{dir = 8; pixel_x = 11; pixel_y = -8},/turf/open/lava/acid,/area/rogue/under/cave/dungeon1/gethsmane)
 "cg" = (/obj/item/grown/log/tree/small,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "cl" = (/obj/structure/bars/pipe{pixel_x = 8},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane)
+"cv" = (/obj/structure/bars/passage{redstone_id = "puzzle2"; max_integrity = 9000},/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "cw" = (/obj/structure/spacevine,/obj/structure/bars/pipe{dir = 1; pixel_x = 25},/obj/structure/glowshroom,/turf/open/water/sewer,/area/rogue/under/cave)
 "cz" = (/obj/structure/roguewindow,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
+"cA" = (/turf/closed/wall/mineral/rogue/wooddark,/area/rogue/outdoors/beach)
 "cC" = (/turf/closed/wall/mineral/rogue/decowood,/area/rogue/outdoors/mountains)
 "cD" = (/obj/item/wallframe/firealarm{color = "#755f48"; pixel_x = -30},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "cM" = (/obj/structure/bars/passage/shutter{redstone_id = "golgothaone"},/obj/machinery/conveyor/auto{dir = 4; color = "#755f48"},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "cN" = (/obj/effect/decal/cobbleedge{dir = 8},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "cO" = (/obj/structure/flora/roguegrass/water,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "cV" = (/obj/structure/fluff/railing/fence,/obj/structure/fluff/railing/fence{dir = 8},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
+"cX" = (/obj/structure/spacevine{opacity = 1},/turf/open/water/swamp/deep,/area/rogue/under/cave)
+"cY" = (/turf/closed/wall/mineral/rogue/wooddark/window,/area/rogue/outdoors/woods)
+"cZ" = (/obj/structure/chair/stool/rogue,/mob/living/carbon/human/species/human/northern/searaider/ambush,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "dc" = (/obj/machinery/conveyor/auto{dir = 8; color = "#755f48"},/obj/item/restraints/legcuffs/beartrap/armed/camouflage,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "di" = (/obj/machinery/light/rogue/firebowl/stump,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "dk" = (/obj/structure/bars/passage/shutter{redstone_id = "golgothaone"},/obj/structure/bars/passage/shutter{redstone_id = "golgothaone"},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"dr" = (/obj/structure/spacevine{opacity = 1},/turf/closed/wall/mineral/rogue/stone/blue_moss,/area/rogue/under/cave)
 "ds" = (/obj/structure/fluff/railing/border{dir = 5},/turf/open/transparent/openspace,/area/rogue/outdoors/mountains)
 "dA" = (/obj/structure/flora/roguetree/stump/log,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "dC" = (/obj/machinery/door/airlock/grunge{color = "#755f48"},/obj/structure/bars/steel{max_integrity = 500},/turf/open/floor/rogue/metal{icon_state = "plating2"},/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "dE" = (/obj/structure/flora/roguegrass/water,/turf/open/water/river{icon_state = "rockwd"; dir = 4},/area/rogue/outdoors/woods)
 "dF" = (/obj/item/chair/stool/bar/rogue/crafted,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "dP" = (/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
+"dV" = (/obj/structure/bars/passage{density = 0; icon_state = "passage1"; redstone_id = "puzzle1"; max_integrity = 9000},/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
+"ef" = (/obj/structure/glowshroom,/turf/open/water/swamp,/area/rogue/under/cave)
+"en" = (/obj/structure/roguerock,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "ep" = (/turf/open/floor/rogue/metal,/area/rogue/under/cave/dungeon1/gethsmane)
 "er" = (/obj/structure/fermenting_barrel/random/water,/turf/open/floor/rogue/hexstone,/area/rogue/under/cave)
 "ew" = (/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
 "ey" = (/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter/woods)
+"ez" = (/mob/living/carbon/human/species/human/northern/searaider/ambush,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "eA" = (/obj/structure/bed/rogue/shit,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
 "eC" = (/obj/effect/spawner/lootdrop/roguetown/dungeon,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "eD" = (/obj/effect/spawner/lootdrop/roguetown/dungeon,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
 "eI" = (/obj/effect/landmark/start/adventurerlate{icon_state = "arrow"; dir = 4},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "eK" = (/obj/structure/fluff/railing/border{dir = 8; icon_state = "border"},/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
+"eQ" = (/obj/structure/chair/wood/rogue/chair3{dir = 8},/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "eT" = (/obj/structure/stairs,/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/mountains)
 "eU" = (/obj/structure/rack/rogue/shelf/biggest,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "fa" = (/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/mountains)
 "fd" = (/turf/closed/mineral/random/rogue/med,/area/rogue/under/cave)
 "fj" = (/mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
+"fp" = (/obj/structure/spacevine,/turf/closed/wall/mineral/rogue/stone/blue_moss,/area/rogue/under/cave)
 "fr" = (/turf/closed/wall/mineral/rogue/stone/moss,/area/rogue/under/cave/dungeon1/gethsmane)
+"ft" = (/obj/structure/glowshroom,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "fu" = (/obj/item/restraints/legcuffs/beartrap/armed/camouflage,/turf/open/water/swamp,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fv" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/woods)
 "fw" = (/turf/open/floor/rogue/metal/barograte,/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -71,7 +90,10 @@
 "fY" = (/obj/effect/decal/cobbleedge,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
 "gb" = (/obj/machinery/conveyor/auto{color = "#755f48"},/obj/item/natural/stone,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "gc" = (/obj/structure/fluff/railing/border{dir = 9},/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
+"ge" = (/obj/item/reagent_containers/food/snacks/rogue/meat/steak,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"gg" = (/obj/effect/decal/cleanable/blood/gibs,/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "gk" = (/obj/effect/landmark/start/adventurerlate{icon_state = "arrow"; dir = 8},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
+"gq" = (/obj/item/roguecoin/copper,/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "gr" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "gs" = (/obj/structure/bars/steel,/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane)
 "gu" = (/obj/structure/stairs/stone{dir = 1; icon_state = "stonestairs"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
@@ -87,24 +109,33 @@
 "hh" = (/turf/open/floor/rogue/rooftop{dir = 2; icon_state = "roofg"},/area/rogue/outdoors/town/roofs)
 "hk" = (/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hl" = (/obj/machinery/light/rogue/smelter/great{name = "ancyent engine"; color = "#485775"; desc = ""},/turf/open/floor/rogue/metal/barograte/open,/area/rogue/under/cave/dungeon1/gethsmane)
+"hp" = (/obj/item/book/rogue/fishing,/obj/structure/table/wood/crafted,/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/woods)
 "hq" = (/obj/machinery/light/small{mouse_opacity = 0; dir = 1; color = "#b51d12"; light_color = "#b51d12"},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "hu" = (/obj/effect/turf_decal/trimline/yellow/filled/line,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
+"hG" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/woods)
 "hI" = (/turf/open/floor/rogue/twig,/area/rogue/outdoors/woods)
 "hT" = (/obj/structure/flora/rogueshroom,/turf/open/floor/rogue/dirt,/area/rogue/under/cave)
 "hZ" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/mountains)
 "ij" = (/turf/open/water/river{icon_state = "rockwd"; dir = 8},/area/rogue/outdoors/woods)
 "ik" = (/obj/structure/fluff/railing/fence{dir = 1},/obj/structure/fluff/railing/fence{dir = 4},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "iq" = (/obj/structure/table/wood/crafted,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter/woods)
+"iw" = (/obj/structure/glowshroom,/turf/open/floor/rogue/blocks,/area/rogue/under/cave)
 "iB" = (/obj/structure/bed/rogue/shit,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter/woods)
+"iC" = (/obj/structure/spacevine{opacity = 1},/turf/open/water/swamp,/area/rogue/under/cave)
 "iF" = (/obj/structure/stairs/stone,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/mountains)
 "iR" = (/obj/machinery/conveyor/auto{dir = 4; color = "#755f48"},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jj" = (/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jx" = (/obj/structure/closet/dirthole/closed/loot,/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
 "jy" = (/obj/item/restraints/legcuffs/beartrap/armed,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "jA" = (/obj/structure/table/wood{dir = 9; icon_state = "largetable"},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
+"jD" = (/obj/machinery/light/rogue/torchholder/c,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
+"jG" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/obj/structure/closet/crate/chest,/obj/effect/spawner/lootdrop/roguetown/dungeon,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"jI" = (/obj/structure/bars/passage{redstone_id = "puzzle1"; max_integrity = 9000},/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
+"jQ" = (/obj/structure/spacevine{opacity = 1},/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "jR" = (/obj/structure/bars/steel,/obj/structure/bars/pipe{dir = 4},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jW" = (/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "jX" = (/turf/open/water/swamp,/area/rogue/indoors/shelter/woods)
+"kk" = (/obj/structure/bars/tough,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "ko" = (/turf/open/water/sewer,/area/rogue/under/cave)
 "kr" = (/obj/structure/stairs/stone{dir = 4},/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "kz" = (/turf/open/water/cleanshallow,/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -112,11 +143,13 @@
 "kI" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
 "kM" = (/obj/effect/decal/cobbleedge{dir = 1},/obj/structure/fluff/railing/border,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "kR" = (/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,/turf/open/floor/rogue/metal{icon_state = "plating2"},/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"kT" = (/obj/structure/bars/passage{redstone_id = "puzzle1"; max_integrity = 9000},/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "kU" = (/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
 "kY" = (/turf/open/floor/rogue/dirt/road,/area/rogue/indoors)
 "lc" = (/obj/structure/spider/stickyweb,/mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,/turf/open/floor/rogue/metal/barograte/open,/area/rogue/under/cave/dungeon1/gethsmane)
 "lf" = (/obj/item/natural/rock,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lg" = (/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
+"lh" = (/mob/living/simple_animal/hostile/retaliate/rogue/wolf,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "li" = (/obj/structure/flora/roguegrass/water,/turf/open/water/swamp/deep,/area/rogue/outdoors/woods)
 "lj" = (/obj/machinery/conveyor/auto{dir = 9; color = "#755f48"},/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "lm" = (/turf/open/water/swamp/deep,/area/rogue/outdoors/woods)
@@ -124,20 +157,28 @@
 "lw" = (/turf/closed/wall/mineral/rogue/pipe,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lz" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/river{icon_state = "rockwd"; dir = 4},/area/rogue/outdoors/woods)
 "lF" = (/turf/open/floor/rogue/naturalstone,/area/rogue/indoors)
+"lN" = (/obj/structure/rack/rogue{density = 0; pixel_y = 18},/obj/item/rogueweapon/sword/long,/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "lS" = (/obj/structure/fluff/railing/fence{dir = 4},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "lW" = (/turf/open/floor/rogue/metal{icon_state = "plating2"},/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lY" = (/obj/machinery/conveyor/auto{dir = 8; color = "#755f48"},/obj/item/natural/stone,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "lZ" = (/obj/structure/bars/steel{name = "blacksteel bars"; color = "#675340"; max_integrity = 20000},/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane)
 "mb" = (/obj/structure/bars/pipe{dir = 8; pixel_x = 8},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane)
 "mc" = (/obj/structure/stairs,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors)
+"ml" = (/obj/structure/closet/crate/chest/wicker,/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
+"my" = (/obj/item/natural/stone,/obj/structure/spacevine{opacity = 1},/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
+"mD" = (/obj/structure/bed/rogue/shit,/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "mE" = (/obj/structure/fermenting_barrel/random,/obj/structure/spider/stickyweb,/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
+"mG" = (/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
+"mJ" = (/obj/structure/bars/passage{redstone_id = "puzzle3"; max_integrity = 9000},/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "mK" = (/obj/structure/sign/warning/radiation/rad_area{color = "#755f48"; name = "\improper ancient signage"},/turf/closed/wall/mineral/rogue/pipe,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "mQ" = (/obj/item/natural/cloth,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "mW" = (/obj/structure/spacevine,/obj/structure/flora/roguegrass/maneater/real,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "na" = (/turf/closed/wall/mineral/rogue/wooddark,/area/rogue/outdoors/mountains)
+"nb" = (/obj/structure/fermenting_barrel/random/beer,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "nh" = (/turf/open/water/swamp/deep,/area/rogue/indoors/shelter/woods)
 "no" = (/obj/structure/fluff/signage{name = "AZURE PEAK - NORTHEAST"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "nt" = (/turf/open/floor/rogue/grass,/area/rogue/outdoors/woods)
+"nE" = (/obj/structure/flora/roguetree/stump/log{pixel_x = -10},/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "nH" = (/obj/structure/fluff/railing/border{dir = 10; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
 "nI" = (/obj/structure/fluff/railing/fence{dir = 1},/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/woods)
 "nQ" = (/obj/effect/landmark/mapGenerator/rogue/forest{endTurfY = 155; endTurfX = 155},/turf/closed/mineral/rogue/bedrock,/area/rogue/under/cave)
@@ -147,13 +188,21 @@
 "ow" = (/obj/structure/bars/pipe{dir = 1; pixel_x = 25},/turf/open/lava/acid,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "oy" = (/obj/machinery/conveyor/auto{dir = 6; color = "#755f48"},/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "oS" = (/obj/machinery/conveyor/auto{dir = 8; color = "#755f48"},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"pj" = (/obj/item/natural/stone,/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "pk" = (/obj/structure/bed/rogue/inn/wool,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
+"pp" = (/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "pq" = (/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "ps" = (/obj/structure/fermenting_barrel/random,/turf/open/floor/rogue/hexstone,/area/rogue/under/cave)
+"pv" = (/obj/structure/glowshroom,/obj/structure/spacevine,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"px" = (/obj/structure/spacevine{opacity = 1},/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"pB" = (/obj/effect/decal/cleanable/cobweb{icon_state = "cobweb2"},/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "pC" = (/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/woods)
 "pE" = (/obj/structure/crabnest,/turf/open/water/swamp/deep,/area/rogue/outdoors/woods)
+"pG" = (/obj/structure/mineral_door/wood/donjon{locked = 1},/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "pJ" = (/obj/machinery/conveyor/auto{dir = 4; color = "#755f48"},/turf/open/water/swamp/deep,/area/rogue/under/cave)
+"pS" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
 "qc" = (/obj/structure/fluff/traveltile{aportalgoesto = "forestout_cave"; aportalid = "forestin_cave"},/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"qd" = (/turf/closed/wall/mineral/rogue/stone/blue_moss,/area/rogue/under/cave)
 "qj" = (/obj/effect/landmark/start/adventurerlate{icon_state = "arrow"; dir = 1},/turf/open/floor/rogue/grass,/area/rogue/outdoors/woods)
 "qm" = (/obj/machinery/conveyor/auto{dir = 6; color = "#755f48"},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "qo" = (/obj/structure/glowshroom,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
@@ -165,17 +214,25 @@
 "qH" = (/obj/machinery/light/rogue/campfire/densefire,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
 "qJ" = (/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "rf" = (/obj/effect/landmark/mapGenerator/rogue/mountain{endTurfX = 155; endTurfY = 155},/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/mountains)
+"rg" = (/obj/item/restraints/legcuffs/beartrap/armed/camouflage,/turf/open/water/swamp,/area/rogue/under/cave)
+"ri" = (/obj/structure/fermenting_barrel/random,/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "rj" = (/turf/open/transparent/openspace,/area/rogue/outdoors/mountains)
 "rk" = (/obj/effect/landmark/start/adventurerlate{icon_state = "arrow"; dir = 1},/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "rt" = (/obj/machinery/conveyor/auto{color = "#755f48"},/obj/structure/spacevine,/obj/machinery/light/small{mouse_opacity = 0; dir = 4},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "rv" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "rz" = (/turf/closed/wall/mineral/rogue/wood,/area/rogue/outdoors/mountains)
+"rE" = (/obj/structure/mineral_door/wood/donjon{dir = 8},/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"rI" = (/obj/structure/spacevine,/obj/structure/spacevine,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "rJ" = (/turf/open/floor/rogue/cobble,/area/rogue/outdoors/mountains)
+"rM" = (/obj/structure/mineral_door/wood/donjon{dir = 8},/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "rR" = (/turf/open/water/river{icon_state = "rockwd"; dir = 1},/area/rogue/under/cave)
 "rS" = (/obj/structure/bars/pipe{pixel_x = -11},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"rT" = (/obj/structure/table/wood,/obj/item/book/rogue/law{pixel_y = 10},/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "rY" = (/obj/structure/table/wood{icon_state = "tablewood1"; dir = 1},/obj/structure/statue/bronze/marx{pixel_y = 19; pixel_x = 9; name = "ancient bust"; color = "#675340"},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
+"sa" = (/mob/living/carbon/human/species/human/northern/searaider/ambush,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "sb" = (/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
 "sh" = (/obj/structure/bars/pipe{dir = 5; pixel_x = -11},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane)
+"si" = (/turf/closed/wall/mineral/rogue/tent{dir = 1},/area/rogue/outdoors/beach)
 "so" = (/turf/closed/wall/mineral/rogue/pipe{icon_state = "iron_line"},/area/rogue/under/cave/dungeon1/gethsmane)
 "sq" = (/obj/machinery/light/small{mouse_opacity = 0; dir = 8},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ss" = (/obj/structure/bars/steel{name = "blacksteel bars"; color = "#675340"; max_integrity = 20000},/turf/open/water/swamp,/area/rogue/under/cave/dungeon1/gethsmane)
@@ -187,18 +244,27 @@
 "tb" = (/obj/effect/decal/cobbleedge{dir = 6},/turf/open/floor/rogue/cobblerock,/area/rogue/outdoors/woods)
 "td" = (/obj/machinery/conveyor/auto{dir = 9; color = "#755f48"},/obj/structure/spacevine,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "th" = (/obj/structure/table/wood{dir = 1; icon_state = "largetable"},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
+"ti" = (/obj/item/reagent_containers/food/snacks/rogue/meat/mince,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "tj" = (/turf/open/water/river{icon_state = "rockwd"},/area/rogue/outdoors/woods)
 "ty" = (/obj/structure/table/wood{dir = 5; icon_state = "largetable"},/obj/item/reagent_containers/glass/cup,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "tN" = (/turf/open/lava/acid,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"tQ" = (/obj/structure/closet/crate/chest/wicker,/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "tS" = (/obj/item/natural/stone{pixel_x = -5; pixel_y = 9},/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
+"tT" = (/obj/structure/bed/rogue/inn/hay,/obj/item/reagent_containers/glass/bottle/rogue/healthpot,/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "tU" = (/obj/structure/spacevine,/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane)
+"tW" = (/obj/structure/chair/wood/rogue{dir = 4; pixel_x = -7},/turf/open/floor/rogue/blocks,/area/rogue/under/cave)
 "ug" = (/obj/machinery/light/rogue/torchholder/c{pixel_y = -32},/obj/item/flashlight/flare/torch,/turf/open/floor/rogue/grass,/area/rogue/indoors/shelter/woods)
 "um" = (/turf/open/water/swamp,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ur" = (/obj/structure/bars/pipe{dir = 1; pixel_x = 25},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ut" = (/obj/structure/bed/rogue/shit,/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
+"uw" = (/obj/structure/chair/wood/rogue/chair3{dir = 4},/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"uC" = (/obj/structure/fluff/walldeco/chains,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
+"uD" = (/obj/item/roguegem/random,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "uI" = (/turf/closed/wall/mineral/rogue/pipe{icon_state = "iron_corner"},/area/rogue/under/cave/dungeon1/gethsmane)
+"uX" = (/obj/structure/fermenting_barrel/random/water,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "va" = (/obj/structure/flora/roguetree,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "vb" = (/obj/structure/roguerock,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
+"vd" = (/obj/structure/closet/crate/chest/wicker,/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "vj" = (/obj/machinery/conveyor/auto{dir = 4; color = "#755f48"},/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "vk" = (/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach)
 "vl" = (/obj/item/natural/stone,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
@@ -207,30 +273,38 @@
 "vp" = (/turf/closed/wall/mineral/rogue/stone/moss,/area/rogue/under/cave)
 "vq" = (/obj/structure/bars/steel{name = "blacksteel bars"; color = "#675340"; max_integrity = 20000},/obj/machinery/conveyor/auto{color = "#755f48"},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "vt" = (/obj/machinery/light/rogue/oven/east,/turf/open/floor/rogue/cobble,/area/rogue/indoors)
+"vu" = (/mob/living/simple_animal/hostile/retaliate/rogue/mossback,/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "vE" = (/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter/woods)
 "vI" = (/obj/structure/roguetent,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
+"vJ" = (/obj/item/roguegem/random,/turf/open/floor/rogue/dirt,/area/rogue/under/cave)
 "vW" = (/obj/machinery/conveyor/auto{color = "#755f48"},/obj/structure/bars/steel{name = "blacksteel bars"; color = "#675340"; max_integrity = 20000},/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "vX" = (/obj/structure/spacevine,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "wa" = (/obj/machinery/conveyor/auto{dir = 1; color = "#755f48"},/obj/structure/bars/steel{name = "blacksteel bars"; color = "#675340"; max_integrity = 20000},/turf/open/water/sewer,/area/rogue/under/cave)
 "we" = (/turf/open/water/swamp/deep,/area/rogue/under/cave)
+"wi" = (/obj/effect/spawner/lootdrop/roguetown/dungeon/money,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "wk" = (/obj/item/grown/log/tree/small,/turf/open/floor/rogue/cobble,/area/rogue/indoors)
 "wt" = (/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/woods)
 "wv" = (/turf/open/transparent/openspace,/area/rogue/outdoors/town/roofs)
 "wz" = (/obj/structure/rack/rogue,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
+"wB" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "wD" = (/obj/item/restraints/legcuffs/beartrap/armed,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "wE" = (/obj/structure/fluff/railing/border,/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
+"wH" = (/obj/item/fishingrod,/turf/open/floor/rogue/twig,/area/rogue/outdoors/woods)
 "wJ" = (/turf/closed/wall/mineral/rogue/pipe{dir = 4; icon_state = "iron_line"},/area/rogue/under/cave/dungeon1/gethsmane)
 "wK" = (/obj/machinery/light/rogue/firebowl/stump,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "wN" = (/obj/item/chair/rogue,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter/woods)
+"wQ" = (/obj/structure/rack/rogue{density = 0; pixel_y = 18},/obj/effect/spawner/lootdrop/roguetown/dungeon,/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "xi" = (/obj/structure/bars/pipe,/turf/open/water/sewer,/area/rogue/under/cave)
 "xk" = (/turf/open/water/river{icon_state = "rockwd"; dir = 4},/area/rogue/under/cave)
 "xs" = (/obj/structure/stairs/stone{dir = 1; icon_state = "stonestairs"},/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
+"xU" = (/obj/structure/closet/crate/chest/wicker,/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,/turf/open/floor/rogue/twig,/area/rogue/outdoors/woods)
 "xY" = (/obj/structure/fluff/railing/fence{dir = 4},/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/woods)
 "xZ" = (/obj/item/natural/stone{pixel_x = 6; pixel_y = 9},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "yj" = (/obj/structure/bars/passage/shutter{redstone_id = "golgothaone"},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ym" = (/obj/structure/flora/newtree,/obj/structure/flora/newtree,/obj/structure/flora/newtree,/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "yo" = (/turf/open/water/swamp,/area/rogue/outdoors/woods)
 "yC" = (/mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
+"yL" = (/obj/structure/bars/passage{redstone_id = "puzzle3"; max_integrity = 9000},/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "yO" = (/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/beach)
 "yR" = (/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,/turf/open/floor/rogue/metal,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "yY" = (/turf/closed/mineral/rogue,/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -240,18 +314,25 @@
 "zo" = (/turf/closed/wall/mineral/rogue/pipe{icon_state = "iron_corner"; dir = 8},/area/rogue/under/cave/dungeon1/gethsmane)
 "zs" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/mountains)
 "zv" = (/obj/machinery/conveyor/auto{color = "#755f48"},/turf/open/floor/rogue/metal/barograte,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"zG" = (/obj/structure/bars/passage{redstone_id = "puzzle1"; max_integrity = 9000},/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "zM" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "zO" = (/obj/structure/fluff/railing/border,/turf/open/transparent/openspace,/area/rogue/outdoors/mountains)
+"zR" = (/obj/structure/closet/crate/chest/lootbox,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
+"zS" = (/obj/effect/decal/remains/bigrat,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
+"zV" = (/obj/machinery/light/rogue/torchholder/c,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "zX" = (/obj/structure/stairs/stone{dir = 1; icon_state = "stonestairs"},/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
 "zY" = (/obj/structure/table/wood{icon_state = "largetable"},/obj/structure/spider/stickyweb,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "Ad" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors)
 "Af" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/grass,/area/rogue/outdoors/woods)
 "Ai" = (/turf/closed/mineral/rogue/bedrock,/area/rogue/under/cave/dungeon1/gethsmane)
+"Aj" = (/obj/structure/flora/roguegrass/water,/turf/open/water/swamp,/area/rogue/under/cave)
 "Ak" = (/obj/effect/decal/remains/human,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "Al" = (/obj/item/restraints/legcuffs/beartrap/armed/camouflage,/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"Ar" = (/obj/structure/closet/crate/chest,/obj/effect/spawner/lootdrop/roguetown/dungeon/materials,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "As" = (/obj/structure/bars/steel,/turf/open/water/swamp,/area/rogue/under/cave)
 "AB" = (/obj/machinery/conveyor/auto{dir = 1; color = "#755f48"},/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "AD" = (/obj/structure/fluff/railing/wood{dir = 4},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"AE" = (/obj/structure/spacevine{opacity = 1},/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/water/swamp,/area/rogue/under/cave)
 "AF" = (/turf/open/floor/rogue/metal/barograte,/area/rogue/under/cave/dungeon1/gethsmane)
 "AG" = (/obj/effect/decal/cobbleedge{dir = 4},/turf/open/floor/rogue/cobblerock,/area/rogue/outdoors/woods)
 "AH" = (/obj/structure/glowshroom,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/mountains)
@@ -264,8 +345,10 @@
 "Bm" = (/obj/structure/crabnest,/turf/open/water/cleanshallow,/area/rogue/outdoors/woods)
 "Bt" = (/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/obj/structure/fluff/railing/border,/turf/open/transparent/openspace,/area/rogue/outdoors/mountains)
 "Bv" = (/obj/structure/fluff/railing/border,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors)
+"Bx" = (/obj/machinery/light/rogue/torchholder/l,/turf/open/water/ocean,/area/rogue/outdoors/beach)
 "By" = (/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "Bz" = (/obj/structure/fluff/railing/border{dir = 8; icon_state = "border"},/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors/shelter/woods)
+"BA" = (/obj/item/reagent_containers/glass/bottle/rogue/healthpot,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "BC" = (/obj/effect/decal/cobbleedge{dir = 9},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "BI" = (/turf/open/lava/acid,/area/rogue/under/cave/dungeon1/gethsmane)
 "BP" = (/obj/structure/fluff/railing/border{dir = 8; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
@@ -274,10 +357,15 @@
 "BY" = (/obj/item/grown/log/tree/small,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors)
 "Cd" = (/obj/structure/fluff/railing/fence,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "Cf" = (/obj/structure/spacevine,/obj/structure/bars/pipe,/turf/open/water/sewer,/area/rogue/under/cave)
+"Cg" = (/obj/structure/mineral_door/wood/donjon,/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "Ci" = (/obj/effect/decal/cobbleedge{dir = 5},/obj/structure/rack/rogue/shelf,/obj/structure/table/wood/crafted,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors)
 "Cn" = (/mob/living/carbon/human/species/skeleton/npc,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
+"Co" = (/obj/item/chair/rogue,/mob/living/simple_animal/hostile/rogue/skeleton/guard,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
+"Cy" = (/obj/structure/lever/wall{redstone_id = "puzzle2"},/turf/closed/wall/mineral/rogue/stone,/area/rogue/under/cave)
 "CB" = (/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,/turf/open/water/swamp,/area/rogue/outdoors/woods)
+"CC" = (/obj/structure/closet/crate/chest,/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "CL" = (/turf/open/water/river{dir = 4; icon_state = "rockwd"},/area/rogue/outdoors/woods)
+"CM" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "CN" = (/obj/structure/stairs,/turf/open/transparent/openspace,/area/rogue/indoors/shelter/woods)
 "CP" = (/turf/closed/wall/mineral/rogue/pipe{icon_state = "iron_corner"; dir = 1},/area/rogue/under/cave/dungeon1/gethsmane)
 "CY" = (/obj/structure/flora/roguegrass/water,/turf/open/water/cleanshallow,/area/rogue/outdoors/woods)
@@ -300,30 +388,39 @@
 "Ec" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/cleanshallow,/area/rogue/under/cave)
 "Ek" = (/obj/structure/flora/newtree,/turf/open/floor/rogue/grass,/area/rogue/outdoors/woods)
 "Eo" = (/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
+"EQ" = (/obj/structure/flora/roguegrass/water,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"ET" = (/obj/effect/decal/cleanable/blood/gibs/limb,/turf/open/floor/rogue/church,/area/rogue/under/cave)
+"EU" = (/obj/structure/fluff/statue/gargoyle/moss/candles,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "Fg" = (/obj/item/restraints/legcuffs/beartrap/armed,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "Fm" = (/turf/open/water/river{icon_state = "rockwd"},/area/rogue/under/cave)
-"Fr" = (/obj/structure/chair/stool/rogue,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/beach)
+"Fr" = (/turf/closed/wall/mineral/rogue/decowood,/area/rogue/outdoors/woods)
 "Ft" = (/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
+"Fx" = (/obj/machinery/light/rogue/firebowl/standing/blue,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "Fz" = (/obj/structure/bars/steel,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "FE" = (/obj/structure/table/wood{dir = 1; icon_state = "tablewood1"},/obj/item/flashlight/flare/torch/lantern,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
 "FL" = (/obj/item/chair/stool/bar/rogue/crafted,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter/woods)
 "FO" = (/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,/turf/open/floor/rogue/grass,/area/rogue/outdoors/woods)
 "FQ" = (/obj/effect/spawner/lootdrop/roguetown/dungeon,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"FS" = (/obj/effect/decal/remains/human,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "FW" = (/obj/structure/table/wood{icon_state = "tablewood1"; dir = 1},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "FZ" = (/obj/structure/spacevine,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ge" = (/obj/structure/rack/rogue/shelf/biggest,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors)
 "Gg" = (/obj/machinery/conveyor/auto{color = "#755f48"},/obj/structure/spacevine,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Gi" = (/turf/open/transparent/openspace,/area/rogue/under/town/basement)
 "Gp" = (/obj/item/grown/log/tree/small,/turf/open/transparent/openspace,/area/rogue/indoors)
+"Gv" = (/turf/open/floor/rogue/blocks,/area/rogue/under/cave)
 "Gx" = (/obj/structure/bars/pipe{dir = 4},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"GE" = (/obj/structure/spacevine{opacity = 1},/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "GF" = (/obj/item/rogueweapon/hammer,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "GH" = (/turf/closed/mineral/random/rogue,/area/rogue/under/cave)
 "GK" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
+"GL" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
+"GT" = (/turf/open/water/ocean,/area/rogue/under/cave)
 "GX" = (/obj/structure/flora/roguetree,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "GZ" = (/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ha" = (/obj/machinery/conveyor/auto{dir = 1; color = "#755f48"},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
-"Hf" = (/obj/structure/flora/newtree,/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
-"Hm" = (/obj/item/grown/log/tree/small,/obj/structure/closet/crate/drawer,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
+"Hf" = (/obj/structure/fluff/railing/border,/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach)
+"Hm" = (/obj/structure/closet/crate/drawer,/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "Hp" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "Hq" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/swamp/deep,/area/rogue/outdoors/woods)
 "Hr" = (/turf/closed/wall/mineral/rogue/pipe,/area/rogue/under/cave)
@@ -333,6 +430,7 @@
 "Hz" = (/obj/effect/decal/cobbleedge{dir = 1},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
 "HC" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
 "HD" = (/obj/machinery/light/small{mouse_opacity = 0; dir = 8},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
+"HE" = (/obj/structure/bars/tough,/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "HF" = (/obj/structure/stairs,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
 "HG" = (/obj/structure/spacevine,/turf/open/water/sewer,/area/rogue/under/cave)
 "HK" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/cleanshallow,/area/rogue/outdoors/woods)
@@ -341,10 +439,12 @@
 "HP" = (/mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "HR" = (/obj/effect/decal/cobbleedge{dir = 8},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "HU" = (/obj/item/natural/stone{pixel_y = -9; pixel_x = 8},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"HY" = (/obj/structure/bars/passage{density = 0; icon_state = "passage1"; redstone_id = "puzzle2"; max_integrity = 9000},/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "Ii" = (/obj/item/restraints/legcuffs/beartrap/armed,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Io" = (/obj/machinery/light/rogue/hearth,/turf/open/floor/rogue/cobble,/area/rogue/indoors)
 "It" = (/obj/machinery/conveyor/auto{dir = 4; color = "#755f48"},/obj/item/natural/bone,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "Iu" = (/obj/structure/fluff/signage{name = "AZURE PEAK - NORTH"},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
+"Iz" = (/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "II" = (/obj/structure/mineral_door/wood,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
 "IK" = (/turf/open/floor/rogue/dirt,/area/rogue/under/cave)
 "IO" = (/obj/structure/bars/steel{max_integrity = 500},/turf/open/floor/rogue/metal{icon_state = "plating2"},/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -355,16 +455,23 @@
 "Jj" = (/obj/structure/glowshroom,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Jk" = (/obj/structure/fluff/signage{name = "AZURE PEAK - NORTH"},/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "Jn" = (/obj/effect/decal/cobbleedge{dir = 5},/obj/item/grown/log/tree/small,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors)
+"Ju" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "Jx" = (/obj/structure/spider/stickyweb,/turf/open/floor/rogue/metal/barograte,/area/rogue/under/cave/dungeon1/gethsmane)
 "JB" = (/turf/open/floor/rogue/hexstone,/area/rogue/under/cave)
 "JF" = (/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"JH" = (/obj/structure/closet/crate/chest/neu,/obj/item/rope/chain,/obj/item/rope/chain,/obj/item/rope/chain,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "JL" = (/obj/structure/bars/steel,/obj/structure/bars/pipe,/obj/structure/bars/pipe,/obj/effect/turf_decal/trimline/yellow/filled,/turf/open/floor/rogue/metal,/area/rogue/under/cave/dungeon1/gethsmane)
+"JM" = (/turf/open/floor/rogue/ruinedwood{icon_state = "horzw"},/area/rogue/under/cave)
 "JO" = (/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/obj/machinery/light/rogue/firebowl/standing,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors)
+"JT" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/ocean,/area/rogue/under/cave)
+"JZ" = (/obj/item/roguebin/water/gross,/turf/open/floor/rogue/blocks,/area/rogue/under/cave)
 "Kj" = (/obj/structure/stairs/stone{dir = 4},/turf/open/floor/rogue/dirt,/area/rogue/outdoors/mountains)
 "Ko" = (/obj/structure/spider/stickyweb,/obj/structure/spider/stickyweb,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
+"Ks" = (/obj/structure/fluff/statue/gargoyle/moss{pixel_y = 20},/turf/open/floor/rogue/blocks,/area/rogue/under/cave)
 "Kt" = (/obj/effect/landmark/mapGenerator/rogue/mountain{endTurfX = 155; endTurfY = 155},/obj/effect/landmark/mapGenerator/sunlights{endTurfX = 155; endTurfY = 155},/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/mountains)
 "Ku" = (/obj/machinery/conveyor/auto{dir = 1; color = "#755f48"},/obj/item/restraints/legcuffs/beartrap/armed/camouflage,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "Kw" = (/obj/machinery/conveyor/auto{dir = 5; color = "#755f48"},/turf/open/water/swamp/deep,/area/rogue/under/cave)
+"Ky" = (/obj/structure/bed/rogue/inn/hay,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "KB" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/sewer,/area/rogue/under/cave)
 "KG" = (/turf/closed/wall/mineral/rogue/stonebrick,/area/rogue/indoors)
 "KI" = (/obj/effect/landmark/start/adventurerlate,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
@@ -373,17 +480,23 @@
 "KM" = (/obj/item/chair/stool/bar/rogue/crafted,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
 "KO" = (/obj/structure/flora/roguegrass/water,/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "KQ" = (/obj/structure/fluff/alch,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
+"KW" = (/mob/living/simple_animal/hostile/retaliate/rogue/cavetroll,/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "La" = (/obj/structure/glowshroom,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
+"Lc" = (/obj/item/chair/rogue,/turf/open/floor/rogue/twig,/area/rogue/outdoors/woods)
+"Ld" = (/mob/living/simple_animal/hostile/retaliate/rogue/trufflepig,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter/woods)
 "Lh" = (/obj/machinery/conveyor/auto{color = "#755f48"},/turf/open/floor/rogue/dirt,/area/rogue/under/cave)
 "Li" = (/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
+"Lp" = (/obj/structure/spacevine,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "Lr" = (/obj/structure/flora/newtree,/turf/open/water/swamp,/area/rogue/outdoors/woods)
 "Lv" = (/obj/machinery/conveyor/auto{dir = 4; color = "#755f48"},/obj/structure/spacevine,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"Lz" = (/obj/structure/closet/crate/chest/neu,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
 "LA" = (/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "LC" = (/obj/structure/flora/roguetree,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
 "LG" = (/obj/structure/fluff/railing/wood{dir = 1},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "LH" = (/turf/closed/wall/mineral/rogue/pipe{icon_state = "iron_corner"; dir = 4},/area/rogue/under/cave/dungeon1/gethsmane)
 "LK" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/river{icon_state = "rockwd"},/area/rogue/outdoors/woods)
 "LQ" = (/obj/item/grown/log/tree/small,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
+"LS" = (/obj/structure/spacevine{opacity = 1},/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "LW" = (/obj/structure/stairs/stone,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "LX" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/river{icon_state = "rockwd"; dir = 4},/area/rogue/under/cave)
 "LY" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -391,8 +504,12 @@
 "Md" = (/obj/structure/spacevine,/turf/closed/wall/mineral/rogue/stone/moss,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Mf" = (/obj/structure/flora/roguegrass/water,/obj/structure/flora/roguegrass/water,/turf/open/water/sewer,/area/rogue/under/cave)
 "Mg" = (/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"Ml" = (/obj/structure/lever/wall{redstone_id = "puzzle3"},/turf/closed/wall/mineral/rogue/stone,/area/rogue/under/cave)
 "Mn" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/herringbone,/area/rogue/outdoors/mountains)
+"Ms" = (/obj/structure/roguetent,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
+"Mw" = (/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
 "MD" = (/obj/item/grown/log/tree/stick,/turf/open/floor/rogue/rooftop{dir = 2; icon_state = "roofg"},/area/rogue/outdoors/town/roofs)
+"ME" = (/obj/structure/fluff/railing/border{dir = 1; icon_state = "border"},/turf/open/floor/rogue/wood,/area/rogue/outdoors/beach)
 "MK" = (/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "MU" = (/obj/structure/fluff/alch,/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
 "MW" = (/obj/machinery/conveyor/auto{dir = 1; color = "#755f48"},/obj/structure/bars/steel{name = "blacksteel bars"; color = "#675340"; max_integrity = 20000},/turf/open/water/swamp/deep,/area/rogue/under/cave)
@@ -409,6 +526,7 @@
 "NX" = (/obj/structure/bars/pipe,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane)
 "Oa" = (/obj/structure/spider/stickyweb,/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
 "Oe" = (/obj/structure/fluff/railing/fence{dir = 1},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
+"Om" = (/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "OK" = (/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors)
 "OM" = (/obj/machinery/conveyor/auto{dir = 8; color = "#755f48"},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "OU" = (/obj/structure/flora/roguegrass/water/reeds,/obj/structure/flora/roguegrass/maneater/real,/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -418,6 +536,7 @@
 "Pp" = (/obj/structure/closet/crate/chest/neu,/obj/item/reagent_containers/glass/bottle/rogue/healthpot,/obj/item/reagent_containers/glass/bottle/rogue/wine,/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
 "Pq" = (/obj/machinery/light/rogue/firebowl/stump,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
 "Pz" = (/obj/structure/spacevine,/turf/closed/wall/mineral/rogue/stone/moss,/area/rogue/under/cave)
+"PC" = (/obj/item/roguebin/water/gross,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
 "PN" = (/obj/structure/bars/pipe{dir = 4},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "Qf" = (/obj/item/grown/log/tree/small,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter/woods)
 "Qi" = (/obj/structure/bars/pipe,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -427,6 +546,7 @@
 "Qt" = (/obj/structure/fluff/railing/border{dir = 8; icon_state = "border"},/obj/structure/fluff/railing/border,/turf/open/transparent/openspace,/area/rogue/outdoors/woods)
 "Qv" = (/obj/structure/mineral_door/wood/window,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "Qy" = (/obj/structure/stairs/stone,/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
+"QC" = (/mob/living/simple_animal/hostile/retaliate/rogue/wolf,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "QI" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
 "QJ" = (/obj/structure/fluff/railing/wood,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "QQ" = (/turf/open/floor/rogue/rooftop{dir = 2; icon_state = "roofg"},/area/rogue/outdoors/mountains)
@@ -434,33 +554,43 @@
 "QX" = (/obj/structure/bars/pipe{dir = 8},/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
 "QY" = (/obj/structure/spacevine,/obj/structure/bars/pipe{dir = 4},/turf/open/water/sewer,/area/rogue/under/cave)
 "Ra" = (/obj/structure/table/wood{icon_state = "tablewood1"; dir = 1},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"Rf" = (/obj/machinery/light/rogue/torchholder/r,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
+"Rm" = (/mob/living/simple_animal/hostile/retaliate/rogue/mossback,/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "Rp" = (/obj/item/grown/log/tree/small,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors)
 "Rt" = (/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "Ru" = (/turf/open/transparent/openspace,/area/rogue/under/cave)
 "Rv" = (/obj/structure/mineral_door/wood/deadbolt,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "Rx" = (/turf/open/water/ocean,/area/rogue/outdoors/beach)
+"Ry" = (/obj/item/roguegem/green,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "RB" = (/obj/structure/flora/newtree,/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "RG" = (/turf/closed/wall/mineral/rogue/wooddark/window,/area/rogue/indoors/shelter/woods)
 "RI" = (/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
+"RO" = (/obj/machinery/light/rogue/campfire/densefire,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "RQ" = (/obj/structure/bars/pipe/left,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"RX" = (/obj/structure/mineral_door/wood/donjon{dir = 4; locked = 1},/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "Se" = (/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/mountains)
 "Sh" = (/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/mountains)
 "Si" = (/obj/structure/flora/roguegrass/water,/turf/open/water/sewer,/area/rogue/under/cave)
+"Sq" = (/obj/structure/rack/rogue,/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "Sy" = (/obj/effect/landmark/mapGenerator/rogue/cave{endTurfX = 155; endTurfY = 155},/turf/closed/mineral/rogue/bedrock,/area/rogue/under/cave)
 "SF" = (/obj/structure/spacevine,/turf/closed/wall/mineral/rogue/pipe{dir = 4; icon_state = "iron_line"},/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"SG" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
 "SI" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "SK" = (/obj/machinery/light/rogue/torchholder/l,/turf/open/floor/rogue/hexstone,/area/rogue/under/cave)
 "SO" = (/obj/structure/flora/roguegrass/water,/turf/open/water/swamp,/area/rogue/outdoors/woods)
 "SW" = (/obj/machinery/conveyor/auto{color = "#755f48"},/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "SX" = (/obj/structure/stairs/stone{dir = 1; icon_state = "stonestairs"},/turf/open/floor/rogue/cobblerock,/area/rogue/outdoors/woods)
+"SY" = (/obj/effect/decal/cleanable/blood/gibs/torso,/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "Ta" = (/mob/living/simple_animal/hostile/retaliate/rogue/cow,/turf/open/floor/rogue/grass,/area/rogue/outdoors/woods)
 "Tf" = (/mob/living/carbon/human/species/skeleton/npc/ambush,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
+"Ti" = (/obj/structure/spacevine,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "To" = (/obj/structure/mineral_door/wood/donjon{dir = 8},/turf/open/floor/rogue/hexstone,/area/rogue/under/cave)
 "Tp" = (/turf/open/water/ocean/deep,/area/rogue/outdoors/beach)
 "Tq" = (/obj/effect/decal/cobbleedge{dir = 4},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "Ts" = (/obj/structure/bars/pipe{dir = 4},/obj/structure/spacevine,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "Tt" = (/obj/structure/flora/roguegrass,/obj/machinery/light/small{mouse_opacity = 0; dir = 8; color = "#b51d12"; light_color = "#b51d12"},/turf/open/water/sewer,/area/rogue/under/cave)
 "Tv" = (/obj/machinery/light/rogue/campfire/densefire,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
+"Ty" = (/obj/effect/decal/remains/human,/obj/effect/spawner/lootdrop/roguetown/dungeon/money,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "TC" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/water/river{icon_state = "rockwd"; dir = 1},/area/rogue/under/cave)
 "TD" = (/obj/structure/spider/stickyweb,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "TF" = (/obj/effect/decal/cobbleedge,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
@@ -471,33 +601,45 @@
 "Ug" = (/turf/open/floor/rogue/dirt,/area/rogue/outdoors/mountains)
 "Ui" = (/obj/machinery/conveyor/auto{dir = 4; color = "#755f48"},/turf/open/floor/rogue/metal/barograte,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Up" = (/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/beach)
+"Uu" = (/turf/open/floor/rogue/rooftop{dir = 2; icon_state = "roofg"},/area/rogue/outdoors/woods)
+"Uv" = (/obj/effect/decal/remains/human,/obj/effect/spawner/lootdrop/roguetown/dungeon/money,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "UE" = (/obj/structure/spider/stickyweb,/obj/effect/spawner/lootdrop/roguetown/dungeon,/turf/open/floor/rogue/metal/barograte,/area/rogue/under/cave/dungeon1/gethsmane)
 "UF" = (/obj/item/restraints/legcuffs/beartrap/armed/camouflage,/obj/machinery/conveyor/auto{dir = 8; color = "#755f48"},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "UL" = (/obj/machinery/conveyor/auto{dir = 1; color = "#755f48"},/obj/structure/spacevine,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "UM" = (/obj/structure/rack/rogue/shelf,/obj/structure/table/wood/crafted,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors)
 "UT" = (/obj/structure/ladder,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
+"UW" = (/obj/structure/flora/roguegrass/water/reeds,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "Vd" = (/obj/structure/bars/pipe,/obj/structure/bars/pipe{dir = 6},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Vh" = (/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "Vi" = (/obj/structure/table/wood/crafted,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors/shelter/woods)
+"Vl" = (/obj/machinery/light/rogue/hearth,/turf/open/floor/rogue/churchmarble,/area/rogue/under/cave)
 "Vm" = (/obj/structure/rack/rogue/shelf,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "Vn" = (/turf/open/water/cleanshallow,/area/rogue/outdoors/woods)
+"Vp" = (/obj/machinery/light/rogue/torchholder/l,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "Vs" = (/obj/structure/roguerock,/turf/open/water/cleanshallow,/area/rogue/outdoors/woods)
+"Vu" = (/obj/effect/decal/remains/bigrat,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "Vw" = (/obj/item/reagent_containers/glass/bucket/wooden{pixel_y = 15},/obj/item/bath/soap,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "Vx" = (/turf/open/water/river{icon_state = "rockwd"; dir = 4},/area/rogue/outdoors/beach)
 "Vy" = (/obj/structure/flora/roguetree/stump/log,/turf/open/floor/rogue/grass,/area/rogue/outdoors/woods)
 "VA" = (/obj/structure/rack/rogue/shelf/biggest,/obj/item/natural/feather,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "VE" = (/obj/machinery/conveyor/auto{color = "#755f48"},/obj/item/natural/rock,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "VF" = (/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane)
+"VG" = (/mob/living/simple_animal/hostile/retaliate/rogue/wolf,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "VP" = (/obj/effect/decal/cobbleedge{dir = 10},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "VT" = (/obj/machinery/conveyor/auto{dir = 10; color = "#755f48"},/obj/item/restraints/legcuffs/beartrap/armed/camouflage,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "VV" = (/obj/structure/mineral_door/wood,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors)
+"VZ" = (/obj/effect/decal/remains/human,/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
 "We" = (/obj/structure/spider/stickyweb,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
 "Wk" = (/obj/structure/mineral_door/wood,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors/shelter/woods)
+"Wp" = (/mob/living/simple_animal/hostile/retaliate/rogue/mossback,/turf/open/water/swamp,/area/rogue/under/cave)
 "Wz" = (/obj/structure/fluff/railing/fence,/obj/structure/fluff/railing/fence{dir = 4},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "WN" = (/obj/structure/flora/roguegrass/water,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "WT" = (/obj/item/rogueore/coal{pixel_x = 9; pixel_y = 8},/obj/item/reagent_containers/powder/salt,/obj/structure/table/wood{icon_state = "tablewood1"; dir = 1},/turf/open/floor/rogue/hexstone,/area/rogue/under/town/basement)
 "WU" = (/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave/dungeon1/gethsmane)
+"WX" = (/obj/structure/rack/rogue{density = 0; pixel_y = 18},/obj/effect/spawner/lootdrop/roguetown/dungeon,/obj/item/reagent_containers/glass/bottle/rogue/healthpot,/turf/open/floor/rogue/cobble,/area/rogue/under/cave)
+"WZ" = (/mob/living/simple_animal/hostile/retaliate/rogue/mossback,/turf/open/water/cleanshallow,/area/rogue/outdoors/woods)
 "Xf" = (/obj/structure/glowshroom,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
+"Xg" = (/obj/structure/closet/crate/chest/wicker,/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "Xh" = (/obj/effect/decal/cobbleedge{dir = 9},/obj/structure/fluff/railing/border{dir = 6; icon_state = "border"},/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "Xk" = (/turf/closed/wall/mineral/rogue/pipe{dir = 1; icon_state = "iron_corner"},/area/rogue/under/cave/dungeon1/gethsmane)
 "Xm" = (/obj/machinery/conveyor/auto{color = "#755f48"},/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -507,6 +649,9 @@
 "XC" = (/turf/open/floor/rogue/grass,/area/rogue/indoors/shelter/woods)
 "XI" = (/obj/structure/fluff/traveltile{aportalgoesto = "forestout"; aportalid = "forestin"},/turf/open/floor/rogue/cobblerock,/area/rogue/outdoors/woods)
 "XP" = (/obj/structure/closet/crate/drawer,/obj/item/clothing/shoes/roguetown/boots/furlinedboots,/turf/open/floor/rogue/dirt,/area/rogue/indoors/shelter/woods)
+"XQ" = (/mob/living/simple_animal/hostile/retaliate/rogue/mossback,/turf/open/water/swamp/deep,/area/rogue/under/cave)
+"XT" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/obj/effect/decal/remains/human,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
+"Yh" = (/obj/structure/lever/wall{name = "puzzle1"},/turf/closed/wall/mineral/rogue/stone,/area/rogue/under/cave)
 "Yi" = (/turf/open/floor/rogue/cobblerock,/area/rogue/outdoors/woods)
 "Yj" = (/obj/item/natural/rock,/obj/item/natural/rock,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
 "Yk" = (/obj/structure/bars/pipe,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
@@ -514,6 +659,7 @@
 "Yw" = (/obj/structure/flora/newtree,/obj/structure/flora/newtree,/obj/structure/flora/newtree,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/woods)
 "Yx" = (/obj/effect/decal/cobbleedge{dir = 6},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/mountains)
 "YG" = (/obj/structure/roguewindow,/turf/open/floor/rogue/ruinedwood,/area/rogue/outdoors/mountains)
+"YQ" = (/obj/structure/boatbell/fluff,/turf/closed/wall/mineral/rogue/wooddark,/area/rogue/outdoors/beach)
 "YS" = (/obj/structure/bars/pipe,/obj/structure/bars/pipe{dir = 4},/turf/open/floor/rogue/greenstone,/area/rogue/under/cave)
 "YV" = (/obj/machinery/conveyor/auto{dir = 1; color = "#755f48"},/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "YY" = (/obj/machinery/conveyor/auto{color = "#755f48"},/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -526,6 +672,7 @@
 "ZB" = (/obj/effect/landmark/start/adventurerlate{icon_state = "arrow"; dir = 8},/turf/open/floor/rogue/grass,/area/rogue/outdoors/woods)
 "ZD" = (/obj/structure/mineral_door/wood/fancywood,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors)
 "ZH" = (/obj/item/flint,/obj/structure/bed/rogue/shit,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
+"ZK" = (/obj/structure/table/wood{icon_state = "tablewood1"},/obj/effect/spawner/lootdrop/roguetown/dungeon,/turf/open/floor/rogue/dirt/road,/area/rogue/under/cave)
 "ZM" = (/obj/machinery/light/rogue/firebowl/stump,/turf/open/floor/rogue/dirt,/area/rogue/outdoors/mountains)
 "ZN" = (/turf/open/transparent/openspace,/area/rogue/indoors)
 "ZO" = (/obj/effect/landmark/start/adventurerlate{icon_state = "arrow"; dir = 4},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
@@ -545,23 +692,23 @@ gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgU
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgU
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAIKgUgUgUgUgUgUzbgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgU
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUvbgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAgUgUgUgUgUgUzbJFJFzbgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgU
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAgUgUgUgUgUJFJFJFJFJFumumumumumumgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgU
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglguDlglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAgUgUgUgUgUJFJFJFJFJFumumumumumumgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgU
 gUgUgUgUgUgUgUgUhTIKIKgUgUgUlglglggUgUgUlgXfgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAgUgUgUgUgUzbJFJFJFJFJFJFJFJFJFumumumgUgUgUgUgUwegUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgU
-gUgUgUgUgUgUgUgUIKIKhTIKgUlglglgXfgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKgUgUgUgUzbJFJFHLHLJFJFJFJFJFJFumumumumgUgUgUgUKwpJpJpJpJpJpJItoygUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIgUgUgUgUgUgUgUgUgUgU
+gUgUgUgUgUgUgUgUIKvJhTIKgUlglglgXfgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKgUgUgUgUzbJFJFHLHLJFJFJFJFJFJFumumumumgUgUgUgUKwpJpJpJpJpJpJItoygUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIgUgUgUgUgUgUgUgUgUgU
 gUgUgUgUgUgUgUgUgUIKIKlglglglglggUgUgUlglglglglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKgUgUgUgUgUJFJFJFjjHLHLHLHLHLHLHLMgumumumumgUgUgUDKvpvpvpvpvpvpvpvWvpvpgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIgUgUgUgUgUgUgU
-gUgUgUgUgUgUgUgUgUIKlglggUgUlglglgvblglggvlgvbgUgUlglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAgUgUgUgUHLHLumjjjjHLHLjjjjjjjjjjHLMgMgumumumgUgUvpYVvpweweweweIKweSWgUwegUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIgUgUgUgUgU
-gUgUgUgUgUgUgUgUgUlglggvgUgUgUXflglglglglglggUgUgUXflglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKgUzbzbzbHLMgumjjjjjjjjjjjjjjjjHLHLMgeCMgumumgUgUvpMWvpaMaMvpweweIKVEwegUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIRIRIgUgUgUgU
-gUgUgUgUgUgUgUgUgUlglggUgUgUgUgUgUgUgUlgvbgUgUgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKgUgUzbzbzbHLumumjjjjjjjjjjjjjjHLHLHLHLHLgUgUgUvpvpkoDzIKIKTskovpweweVEwewegUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIRIRIRIRIgUgU
-gUgUgUgUgUgUgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKaAIKIKgUgUzbzbzbJFumjjjjJFjjMgMgMgvmvmQJQJvmHLgUgUvpvpCfxiDzCfCfYSxikFvpweLhgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRxRx
-gUgUgUgUgUgUgUgUgUlggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUXflglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKIKIKgUgUzbzbzbJFjjjjjjjjjjADkzkzaHADkzkzaHHLgUgUvpHGHGkoHavXHGPNkokokolsDQlsgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRxRx
-gUgUgUgUgUgUgUgUlglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKIKIKgUgUgUHLHLHLHLjjjjjjjjDFADkzkzaHADkzkzaHHLHLHLHLTtHGvXULvXlsQYlskokogrDQlsgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRxRxTp
-gUgUgUgUgUgUgUvblglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKIKIKgUgUgUvpHLvmhkvmjjvmLGLGvmvmLGLGvmvmLGLGvmIOvmvmbpMfcOvXDzkogrPNHGHGHGlsgblsgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRxRxTp
-gUgUgUgUgUgUgUgUgUlglglggUgUgUgUgUgUgUgUgUgUIKIKgUgUgUlglglglgXfgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKIKIKIKgUgUgUvpvmvmQJQJvmvmQJQJvmvmQJQJvmhkQJQJvmIOvmvmbpSimWHGKulsHGQYHGHGkoweSWvpgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRxRxTp
-gUgUgUgUgUgUgUlglglglglggUgUgUgUgUgUgUgUgUIKIKIKIKgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKIKIKIKgUgUgUgUvpsqADkzkzaHADkzkzaHADkzkzaHADkzkzaHHLHLHLHLKBvXHGHaHGHGPNkokoHGweSWvpgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIRIRIRIRIRIRIRIRIRxRxRxTp
+gUgUgUgUgUgUgUgUgUIKlglggUgUlglglgvblglggvlgvbgUgUlglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAgUgUgUgUHLHLumjjjjHLHLjjjjjjjjjjHLMgMgumumumgUgUvpYVvpweweweweIKweSWgUwegUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRfcAMssicARIRIgUgUgUgUgU
+gUgUgUgUgUgUgUgUgUlglggvgUgUgUXflglglglglglggUgUgUXflglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKgUzbzbzbHLMgumjjjjjjjjjjjjjjjjHLHLMgeCMgumumgUgUvpMWvpaMaMvpweweIKVEwegUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIezRIsiMwnbsiRIRIRIgUgUgUgU
+gUgUgUgUgUgUgUgUgUlglggUgUgUgUgUgUgUgUuDvbgUgUgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKgUgUzbzbzbHLumumjjjjjjjjjjjjjjHLHLHLHLHLgUgUgUvpvpkoDzIKIKTskovpweweVEwewegUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIsiMwCCcAsisicAvduXgUgU
+gUgUgUgUgUgUgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKaAIKIKgUgUzbzbzbJFumjjjjJFjjMgMgMgvmvmQJQJvmHLgUgUvpvpCfxiDzCfCfYSxikFvpweLhgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIcAsisicARIRIsisaMwjDArArsiRIRIRxRx
+gUgUgUgUgUgUgUgUgUlggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUXflglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKIKIKgUgUzbzbzbJFjjjjjjjjjjADkzkzaHADkzkzaHHLgUgUvpHGHGkoHavXHGPNkokokolsDQlsgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIsimlKysiRIRIsitQsaMwMwbAsiRIRIRxRx
+gUgUgUgUgUgUgUgUlglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKIKIKgUgUgUHLHLHLHLjjjjjjjjDFADkzkzaHADkzkzaHHLHLHLHLTtHGvXULvXlsQYlskokogrDQlsgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIsiMwMwMsRIRIcAsisiMssisicARIRxRxTp
+gUgUgUgUgUgUgUvblglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKIKIKgUgUgUvpHLvmhkvmjjvmLGLGvmvmLGLGvmvmLGLGvmIOvmvmbpMfcOvXDzkogrPNHGHGHGlsgblsgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIsiKyMwsiRIRIRIXgRIRIRIRIzVRIRxRxTp
+gUgUgUgUgUgUgUgUgURylglggUgUgUgUgUgUgUgUgUgUIKIKgUgUgUlglglglgXfgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKIKIKIKgUgUgUvpvmvmQJQJvmvmQJQJvmvmQJQJvmhkQJQJvmIOvmvmbpSimWHGKulsHGQYHGHGkoweSWvpgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIcAsisicAVpRIRIRIRIRIRIRIRIRIRxRxTp
+gUgUgUgUgUgUgUlglglglglggUgUgUgUgUgUgUgUgUIKIKIKIKgUgUgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAIKIKIKIKgUgUgUgUvpsqADkzkzaHADkzkzaHADkzkzaHADkzkzaHHLHLHLHLKBvXHGHaHGHGPNkokoHGweSWvpgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIRIRIRIRIezRIRIRIezRIRIRIRxRxRxTp
 gUgUgUgUgUgUgUgUlglggUlggUgUgUgUgUgUgUgUgUIKIKIKIKIKgUgUgUlggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKIKgUgUgUgUgUgUgUvpvmADkzkzaHADkzkzaHADkzkzaHADkzkzaHHLgUgUvpKBHGkoHaHGlsPNkokokolsSWvpgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIvkRIRIRIRIRIRIRIRIRIRIRIRIRxRxTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKIKgUgUgUgUgUgUgUgUvpvmvmLGLGvmvmLGLGvmvmLGLGvmvmLGLGvmHLgUgUvpKBHGkoDzHGHGQYHGkowevpSWgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIyORIvkRIRIRIRIRIRIRIRIRIRIRxRxTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKIKIKIKgUgUgUgUgUgUgUgUumumumvmvmvmQJQJvmhkvmzbzbzbzbzbzbzbgUgUvpcwHGPzwagUgUgUgUgUwevpSWgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIvkvkvkvkRIRIRIRIRIRIRIRIRIRxRxTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKIKgUgUgUgUgUgUgUgUgUgUgUumumvmvmvmADkzkzaHvmHLzbzbzbzbzbzbzbgUgUvpkowevpYVgUweweweweweweSWgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIvkvkvkvkRIRIRIRIRIRIRIRIRIRxRxTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKgUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAIKIKgUgUgUgUgUgUgUgUvpvmvmLGLGvmvmLGLGvmvmLGLGvmvmLGLGvmHLgUgUvpKBHGkoDzHGHGQYHGkowevpSWgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURIyORIvkRIRIRIRIRIRORIRIuXYQBxRxTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAaAlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKIKIKIKgUgUgUgUgUgUgUgUumumumvmvmvmQJQJvmhkvmzbzbzbzbzbzbzbgUgUvpcwHGPzwagUgUgUgUgUwevpSWgUgUgUgUgUgUgUgUgUgUgUgUgUgURIRIvkvkvkvkRIRIRIRIRIRIRIRIRIMEMEMETpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKIKgUgUgUgUgUgUgUgUgUgUgUumumvmvmvmADkzkzaHvmHLzbzbzbzbzbzbzbgUgUvpkowevpYVgUweweweweweweSWgUgUgUgUgUgUgUgUgUgUgUgUgURIRIRIvkvkvkvkRIRIezRIRIRIRIRIRIHfHfHfTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAIKIKaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKIKgUgUIKgUgUgUgUgUgUgUumumumvmJFMgvmADkzkzaHYpvmHLHLHLHLHLgUgUgUgUvpwewevpljlYNIdcNINININIVTgUgUgUgUgUgUgUgUgUgUgUDtDtRIRIRIvkvkvkvkRIRIRIRIRIRIRIRIRxRxRxTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKIKgUgUgUgUgUgUgUgUumfuumJFJFJFJFJFMgMgSILGLGvmvmvmfwUiUiaGHLgUgUgUgUvpvpvpvpweIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtRIRIRIvkvkvkvkvkRIRIRIRIRIRIRIRIRxRxTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKaAIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKaAaAIKIKIKgUIKIKgUgUgUgUumJFJFJFJFAlJFJFJFMgvmvmvmvmvmHLHLfwfwfwzvHLgUgUgUgUgUgUgUgUIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtDtDtRIRIRIRIvkvkyOvkRIRIRIRIRIRIRIRIRxRxTpTpTpTp
@@ -574,9 +721,9 @@ gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAIKIKgUgUgUgUgUgU
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUadSKJBTolggTaAIKIKgTgTgTgUgUgUgUgUgUgUgUgUgUgUgUHLHLgUgUHLXmXmHLMdbNjjJjvmvmvmvmvmrtHLJFJFJFHLlWzvHLgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtDtDtRIRIRIRIRIRIvkvkvkRIvkRIRIRIRIRxRxRxTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUadXwXwadlggTgTgTwewewevpgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUHLXmXmHLMdayjjjjvmjjvmvmjjGgHLHLJFJFHLlWzvHLgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtDtDtDtRIRIRIRIRIRIvkvkRIvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgTgUgUgUadadadadaAgTwewewegTgTvpadgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUHLvqJeHLjjtdUFOMoSoSOMOMOMDbHLvmJFJFHLlWzvHLzbMggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtDtDtDtRIRIUpUpRIvkvkvkvkvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgTgTgTgUgUgUgUgTgTgTwewegUadgTgTgTadadgUgUgUgUgUgUgUgUgUgUgUgUgUgUHLjjYYyjIijjjjRQurjjurjjjjvmjjJFJFJFHLlWzvHLzbMggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtFrDtDtRIRIUpRIRIvkvkvkRIvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgTgTgTgUgUgUgUgTgTgTwewegUadgTgTgTadadgUgUgUgUgUgUgUgUgUgUgUgUgUgUHLjjYYyjIijjjjRQurjjurjjjjvmjjJFJFJFHLlWzvHLzbMggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtcZDtDtRIRIUpRIRIvkvkvkRIvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAIKIKIKgUgUgUgUgUgUgUgUgUgUgTgTgTwegTgTgTwegTgTwewewegUgUvpaIweTDaMgUgUgUgUgUgUgUgUgUgUgUHLHLHLHLHLXmXmHLHLHLHLjRFzMdSFHLyjdkyjHLHLHLHLHLQsHLzbMggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtDtqHDtDtRIRIRIRIRIvkvkvkvkyORIRIRIRIRxRxTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAIKIKgUgUgUgUgUgUgUgUgTgTwegTgTwewegTgTwewewegUgUgUvpvpAsVFgsNLgUgUgUgUgUgUgUgUgUgUgUHLiRiRiRqwvjiRcMvjiRiRGxvjiRiRiRjjiRqmjjjjIOJFvmvmvmMgMggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtFrDtDtDtRIRIRIRIvkvkvkvkvkvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAIKIKgUgUgUgUgUgUgUgUgTgTwegTgTwewegTgTwewewegUgUgUvpvpAsVFgsNLgUgUgUgUgUgUgUgUgUgUgUHLiRiRiRqwvjiRcMvjiRiRGxvjiRiRiRjjiRqmjjjjIOJFvmvmvmMgMggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtcZDtDtDtRIRIRIRIvkvkvkvkvkvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAIKIKIKgUgUgUgUIKIKgTgTgTgTgTHrwegTwewegUgUvpvpfrfrtUtUVFVFMXgUgUgUgUgUgUgUgUgUgUgUHLfrfrfrfrZSZSHLjjjjjjGxjjjjjjjjjjjjjjjjjjIOJFvmvmvmMggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtDtDtDtDtRIUpUpRIvkvkvkvkvkvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAIKIKIKIKIKgUIKIKIKIKwegTgTgTwegTgTwegUgUgUvpVFbkVFVFVFVFMXzafXshRtRtNKBIQXeDgUgUgUgUfrvltSfrZSABHLQiQiQiVdrSQiQiQiQiQiQiQijjIOvmvmvmMgMggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUDtDtDtDtDtRIUpUpUpvkvkvkvkvkvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKaAaAIKIKIKIKIKIKIKIKgTgTwewewegTgUgUgUgUgUvpvpfrVFVFtUzazazafXmbzaFtNKBIcdBIgUgUgUfrfrYjaFfrfrzbHLHLHLFzFzHLHLHLFzFZMdHLFzFzHLvpgUgUMggUgUgUgUgUaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUDtDtDtDtDtRIRIUpUpvkvkvkvkvkvkRIRIRIRIRxRxTpTpTpTpTpTpTpTp
@@ -606,65 +753,65 @@ gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUIK
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKaAaAIKIKIKaAaAaAaAIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKaAaAaAIKIKIKIKIKIKIKgUgUgUgUgUgUaAaAlglglglglgxkxkxkrRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKIKIKIKIKIKaAIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKIKIKaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAIKIKIKIKIKIKIKIKIKgUgUgUgUgUgUgUlglglgxkxkLXxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKgUgUIKIKIKIKIKaAIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKgUgUgUgUgUgUgUxkxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKgUgUgUgUIKIKaAaAIKIKIKIKIKIKIKIKgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKgUgUgULXxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKgUgUIKIKaAaAIKIKIKIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKgUgUxkxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKgUgUgUIKaAIKIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKgUxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKgUgUgUgUIKaAIKIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUxkxkxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUlglgxkxkxkxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUlglgxkxkLXxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKIKgUgUgUgUgUlglgxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKgUgUgUgUgUlglgxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKIKgUgUgUlglgxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKaAaAIKgUIKIKIKIKgUgUlgLXxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAaAgUgUIKIKIKgUgUZvxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKIKaAaAgUgUIKIKgUgUrRrRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKIKIKaAaAaAaAIKgUgUrRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAgUgUgUgUgUgUgUaAIKxkrRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAgUgUgUgUgUgUgUgUaAaArRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKgUgUgUgUgUgUgUgUIKIKrRrRIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUgUgUgUgUgUgUIKIKrRrRIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKgUgUgUgUgUgUgUgUgUgUIKrRrRIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRopIKaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRvbIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUTCrRrRopIKIKaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgrRrRrRgUIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglgrRrRrRopIKaAaAgUIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRopIKaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRIKaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRgUIKaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUTCrRgUgUIKaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKgUaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRlglgIKaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKgUgUgUgUIKIKaAaAIKIKIKIKIKIKIKIKgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKgUgUgULXxkxkxkxkxkxkxkxkxkrRlgLSaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKgUgUIKIKaAaAIKIKIKIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKIKgUgUxkxkxkxkxkxkxkxkxkxkrRgUlglglglgaApxgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKgUgUgUIKaAIKIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKgUxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUqdpxaAaApxgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKgUgUgUgUIKaAIKIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUxkxkxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUqdIzaApxgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUlglgxkxkxkxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdjQIzqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUlglgxkxkLXxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzIzqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKIKgUgUgUgUgUlglgxkxkxkxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdpjIzqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKgUgUgUgUgUlglgxkxkxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzIzqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKIKaAIKIKIKIKIKIKIKgUgUgUlglgxkxkxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzmyqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKIKIKIKaAaAIKgUIKIKIKIKgUgUlgLXxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzIzqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAaAgUgUIKIKIKgUgUZvxkxkrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdjQIzqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKIKaAaAgUgUIKIKgUgUrRrRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzIzqdgUgUgUgTgTgUgTgTgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKIKIKaAaAaAaAIKgUgUrRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzIzqdgUgUgUgTiCcXcXWpgTgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAgUgUgUgUgUgUgUaAIKxkrRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdjQIziCgTgUgTgTXQcXwecXwegUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAgUgUgUgUgUgUgUgUaAaArRrRgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzIziCiCcXcXgTAEgTgTgTgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKgUgUgUgUgUgUgUgUIKIKrRrRIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzIzcXwecXwecXgTlglgqdqdgUgUgUgUgUgUgUgUgUgUgUgUgUvpvpvpvpRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUgUgUgUgUgUgUIKIKrRrRIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzIzgTiCgTgTgTlgvuIzmDqdgUgUgUgUgUgUgUgUgUvpvpvpvpvpvpvpFxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKgUgUgUgUgUgUgUgUgUgUIKrRrRIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdIzjQdrgUgUqdqdIzIzIzIzqdgUgUgUgUgUgUgUgUvpvpgTiCgTlgvpVulgRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUadgTdrIzIzqdqdqdadadadqdqdbdqdqdgUgUgUgUgUgUvpvpaIgTGHiCgTrMlglgRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUadiCqdIzIzqdqdcXgTgTwepBqdaAgeqdqdqdqdgUgUvpvpJZaApvgTgTiCvpvpFxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdqdqdqdqdppqdqdpGqdppppiCGEgTXQqdaAtiCMCMEQqdqdGHGHiwGvweweEQaAftvpGHlgRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRopIKaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUadwQlNWXbTppqdIzIzqdwecXppaAweaMqdqdaAaAETtiEQqdqdgTgTgTweGHweEQnEvpGHGHRxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRvbIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUadmGSGmGbTppppaAaAwecXcXaAUWgTGvKsaAppppRmppppGHqdGvefgTefGvgTgTGHvpGHGHgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUTCrRrRopIKIKaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdmGmGmGqdGHGEGHaAwecXXQweiCgTgTGHfpggppppppCMaArEtWGHrgefGvGvgTGHGHGHGHgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgrRrRrRgUIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAGLaAaArEpxpxaApxwewecXwegTAjgTGHqdqdqdqdSYppEQfpGvgTgTgTefgTgTGHGHGHGHgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglgrRrRrRopIKaAaAgUIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdppaAaAweXQweweqdqdqdqdqdqdgUgUqdSqqdqdqdGvGvGvGvGHGHGHGHGHGHGHgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRopIKaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdGEppqdweweGHqdqdgUgUgUgUgUgUgUqdqdqdGHqdfpqdGHGHGHGHGHGHgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRIKaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdqdqdCgqdqdqdqdqdqdgUgUgUgUgUgUgUgUgUgUgUGHGHGHGHGHGHGHgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdaJJMaABAJMjGqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRgUIKaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdVlJMaAJMJMaAqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUTCrRgUgUIKaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdriJMJMuwZKeQqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKgUaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRlglgIKaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUqdqdqdqdqdqdqdqdgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKgUgUIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRlgIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKgUaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgxkrRrRrRlgIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUvblgrRrRrRlgIKaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglgrRrRrRIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgxkrRrRIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgxkrRrRIKIKaAaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgrRTCIKIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUxkrRrRIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKaAaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgrRrRIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgrRrRlgIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgTCrRlgaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgrRrRlgaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRlglgaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRoplgaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAadadadadgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgxkrRrRIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKadOmOmvpadgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgxkrRrRIKIKaAaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKIKRXOmOmOmvpadYhCyMladgUgUgUgUgUlggUgUgUgUgUlgrRTCIKIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKgUadadadOmOmvpOmOmOmadadadadlglgvbgUgUgUgUgUxkrRrRIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKgUgUgUadadOmvpOmCorTadadmGmGmGlggUgUgUgUgUgUrRrRrRIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUJHOmOmOmOmOmOmmJmGKWlglggUgUgUgUgUgUrRrRIKaAaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUHEyLHEHEHEjIHEHEmGmGmGadgUgUgUgUgUgUrRrRIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKIKgUgUgUadmGOmmGHEmGmGgqadadkTadadgUgUgUgUgUgUrRrRIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUadmGOmOmHYmGmGmGtTadmGgUgUgUgUgUgUgUlgrRrRIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAgUgUgUadHEdVHEHEHEmJHEHEHEmGlhOmgUgUgUgUgUlgrRrRlgIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUvpOmOmOmHEwiOmOmOmzGlglglgVGgUgUgUgUlgTCrRlgaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUvpOmwBOmcvOmwiTylgkkgUlgvblggUgUgUgUlgrRrRlgaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUvpuCJuOmHEOmwiOmwigUgUVGlglggUgUgUgUgUrRrRlglgaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUvpvpvpvpgUgUgUgUgUgUgUlggUgUgUgUgUgUgUrRrRoplgaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgaAaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRlgIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRlgaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlggUlglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRlgIKaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRlgIKaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRopIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglglgDqgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRTCrRrRIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglgDqgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRTCrRaAIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRaAIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglgDqgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRTCrRaAIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUEUlglggURxRxRxTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRaAIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglgGTJTGTGTRxRxTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRaAIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgJTGTGTGTGTRxRxTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTp
@@ -692,28 +839,28 @@ gUSygUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgU
 pCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
 pCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCXIXIXIXIpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
 pCxkxkxkxkxkxkxkxkxkxkxkxkFmpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCVhYiYiYiYiVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCVhYiYiYiVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCVhYiYiYiVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmgUlglglglglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCByByjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCVhYiYiYiYiVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCGHGHGHGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmlglglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWByByByjWjWjWjWjWjWjWpCpCpCpCpCpCpCpCVhVhYiYiYiVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmgUlglglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWByByByjWjWjWjWjWjWjWjWjWjWjWpCVhVhpCpCVhVhYiYiVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmlgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWByByjWjWjWjWByByjWjWjWjWjWjWMKMKVhVhVhwKVhYiYiVhwKMKpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkFmFmlglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWByjWjWByjWByRBByjWByByjWjWjWjWMKMKMKMKMKYiYiYiMKMKMKjWpCpCpCpCpCpCjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCGHGHfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHGHGHGHGHGHlglggUgUgUgUFmFmFmlglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWByByjWjWByByjWRBjWjWjWjWjWjWjWjWMKMKYiYiMKMKMKjWjWjWjWjWpCpCjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCGHfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHGHGHlglggUgUgUFmFmFmgUlglgpCVhVhVhVhVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWByjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKYiYiMKMKjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCGHfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHGHGHlglggUgUFmFmFmgUgUlgVhVhVhVhpCpCVhVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWByjWByjWByjWjWjWByjWjWjWjWjWjWjWjWjWjWGXjWjWjWMKYiYiMKjWjWjWjWjWntntjWjWByjWjWjWjWjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCXTVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCVhYiYiYiVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCLpVhVhpCpCpCpCVhQCVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCVhYiYiYiVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmgUlglglglglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCUvVhenQCLppCpCVhVhVhVhbDpCpCpCpCpCpCpCpCpCpCpCpCpCByByjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCVhYiYiYiYiVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCGHGHGHGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmlglglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCVhVhVhVhVhVhVhVhVhVhVhVhVhpCpCpCpCpCpCpCpCpCpCjWByByByjWjWjWjWjWjWjWpCpCpCpCpCpCpCpCVhVhYiYiYiVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmgUlglglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCVhQCVhVhVhVhpCpCpCLpVhVhFSpCpCpCpCpCpCpCpCpCjWByByByjWjWjWjWjWjWjWjWjWjWjWpCVhVhpCpCVhVhYiYiVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkxkxkxkxkxkxkxkFmlgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCVhVhVhVZpCpCpCpCpCrILpjWVhpCpCpCpCpCpCpCjWjWjWByByjWjWjWjWByByjWjWjWjWjWjWMKMKVhVhVhwKVhYiYiVhwKMKpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHGHxkxkxkxkxkxkxkFmFmlglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCLppCpCpCpCpCpCpCpCpCjWjWpCpCpCpCpCjWjWjWjWjWByjWjWByjWByRBByjWByByjWjWjWjWMKMKMKMKMKYiYiYiMKMKMKjWpCpCpCpCpCpCjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCGHGHfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHGHGHGHGHGHlglggUgUgUgUFmFmFmlglgpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWpCpCpCjWjWjWjWjWjWjWjWjWByByjWjWByByjWRBjWjWjWjWjWjWjWjWMKMKYiYiMKMKMKjWjWjWjWjWpCpCjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCGHfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHGHGHlglggUgUgUFmFmFmgUlglgpCVhVhVhVhVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWTijWjWjWjWjWjWByjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKYiYiMKMKjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCGHfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHGHGHlglggUgUFmFmFmgUgUlgVhVhVhVhpCpCVhVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCTizSjWjWjWjWjWjWjWByjWByjWByjWjWjWByjWjWjWjWjWjWjWjWjWjWGXjWjWjWMKYiYiMKjWjWjWjWjWntntjWjWByjWjWjWjWjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
 pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHGHGHGHVhVhVnVntjtjtjVnVnVnVnVnVnVnpCpCpCVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWjWjWjWjWByByByjWRBByjWjWByjWjWByjWjWjWjWjWjWGXjWjWjWjWYiYiYijWjWjWjWjWjWntntntjWjWByByjWByjWjWjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
 pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHGHGHVhVhVnVnVntjtjtjVnVnVnVnVnVnVnVnVnpCpCVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCByRBByjWjWjWjWjWjWjWjWByjWjWByjWByjWjWByjWjWByByjWjWjWjWByByjWjWGXjWjWjWjWjWjWjWjWYiYiMKjWjWjWjWByjWjWntntjWjWjWjWjWByjWntntntntjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
 pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHpCpCVhVnVnVnVnijtjCLVnVnVnVnVnHKVnVnVnVnpCVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWRBByjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWByByByjWjWByByByjWjWvEvEvEgXgXgXgXgXMKYiYijWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWntntntntntjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHpCVhVhVnVnVnVnVntjHKVnVnVnVnVnVnVnVnVnVnVnVhVhVhpCpCjWjWpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWByjWjWjWjWjWjWjWjWByjWjWjWRBByjWjWByByByjWjWvEvEvEvEEoEoEogXMKYiYijWjWByjWjWByjWjWjWByjWjWjWntntntjWjWjWntntntntjWjWjWjWjWjWewewpCpCpCpCpCpCpCpCpCpCpCpC
+pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHpCVhVhVnVnVnVnVntjHKVnVnVnVnVnVnVnVnVnVnVnVhVhVhpCpCjWjWpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWByjWjWjWjWjWjWjWjWByjWjWjWRBByjWjWByByByjWjWvEvEvEvEEoeAEogXMKYiYijWjWByjWjWByjWjWjWByjWjWjWntntntjWjWjWntntntntjWjWjWjWjWjWewewpCpCpCpCpCpCpCpCpCpCpCpC
 pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHGHVhVhVnVnVnHKVnVnVnVnVnHKVnVnVnVnVnVnVnVnVnVnjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWRBjWjWjWjWByByjWjWByjWjWByjWyoyoyojWByjWjWjWByByjWGXjWgXvEvEvEvEEoEogXMKYiYijWjWjWByjWjWjWjWjWjWjWjWjWntntntjWjWByntntntntntjWjWjWewewewewpCpCpCpCpCpCpCpCpCpCpCpC
-pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHVhVhVnVnVnVnVnVnVnVnVnVnVnVnHKVnVnVnVnVnVnVnVnjWntntntntntjWjWjWjWjWjWjWjWjWjWjWByjWjWjWByjWjWByByByjWjWjWjWjWjWjWjWjWByyoyontntntyojWjWjWjWByjWjWjWjWgXvEvEvEvEvEEogXMKYiYijWjWjWjWjWByjWByjWjWjWByjWjWjWjWjWjWjWjWntntntntjWjWewewewewewewewewewewpCpCpCpCpCpCpC
-pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHVhVhVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnjWntntntntntntjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWByByjWjWjWjWByjWjWByjWjWyontntntyojWjWjWjWjWjWjWjWjWjWgXEovEvEvEvEEogXMKYiMKjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWntntntntjWjWewewewewewewewewewewewewewewewpCpC
-pCpCfdfdfdfdfdfdgUgUgUgUgUgUfdfdfdfdfdfdfdGHGHGHGHVhVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnjWjWntntntntjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWByjWjWjWjWjWjWByjWjWjWjWjWjWjWyoyoyoyoyojWjWjWjWjWjWjWjWjWjWgXEoEoEoEoEoEoIIMKYiMKMKMKMKMKjWjWjWjWjWjWByjWjWjWjWjWjWjWByjWntntntjWjWewewewewewewewewewewewewewewewewewew
-pCpCfdfdfdfdgUgUgUXflggUgUgUfdfdfdfdfdfdGHGHGHGHVhVhVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnHKVnVnVnVnjWjWjWntntntjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWByjWjWjWjWjWjWyojWjWByjWjWjWByjWjWjWjWByjWjWjWjWGXjWjWgXgXgXgXgXgXgXgXMKYiMKgXgXgXgXgXjWjWjWjWjWjWjWjWjWjWjWjWByjWjWntntntjWjWewewewewewewewewewewewewewewewewewew
-pCpCfdfdgUgUgUvblglglglggUgUfdfdfdfdGHGHGHGHGHGHVhjWjWVnVnVnVnVnVnVnHKVnVnVnVnVnVnHKVnVnVnVnVnVnjWByByjWjWntntjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWyoyojWByByjWjWjWjWjWyojWByByByjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXjWjWMKMKMKgXEoEoEogXjWGXjWjWjWjWjWjWntntjWjWByjWjWjWjWntjWjWewewewewewewewewewewewewewewewewewew
-pCpCpCpCgUlglglglglglglglggUfdfdGHGHGHGHGHGHGHjWjWjWjWVnVnVnVnHKVnVnVnVnVnVnHKVnVnVnVnVnVnVnVnjWGXjWjWjWjWntntjWjWjWjWjWjWByByjWjWByByjWjWjWjWByjWyoyojWjWByjWByByjWjWjWjWjWjWjWjWjWByByjWjWjWByRBjWjWjWjWjWjWjWjWgXgXgXgXMKMKMKgXEovEvEgXjWjWjWjWjWjWjWntntntjWjWByjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewew
-pCpCpCpClgXflglglgRulglglggUfdfdGHGHGHGHGHGHjWjWByByjWjWVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWByjWjWjWjWByByjWyojWjWByjWjWjWjWByjWjWjWjWyojWjWjWjWByjWjWjWByByByjWjWjWjWjWjWjWgXEovEvEMKMKMKIIEoEovEvojWjWjWjWByjWjWntntntjWjWjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewew
+pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHGHVhVhVnVnVnVnVnVnVnVnVnVnVnVnHKVnVnVnVnVnVnVnVnjWntntntntntjWjWjWjWjWjWjWjWjWjWjWByjWjWjWByjWjWByByByjWjWjWjWjWjWjWjWjWByyoyontntntyojWjWjWjWByjWjWjWjWgXvEvEvEvEvEEogXMKYiYijWjWjWjWjWByjWByjWjWjWByjWjWjWjWjWjWjWjWntntntntjWjWewewewewewewUuUuUuUupCpCpCpCpCpCpC
+pCpCfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdfdGHGHGHVhVhVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnjWntntntntntntjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWByByjWjWjWjWByjWjWByjWjWyontntntyojWjWjWjWjWjWjWjWjWjWgXEovEvEvEvEEogXMKYiMKjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWntntntntjWjWewewewewewewUuUuUuUuUuUuUuewewpCpC
+pCpCfdfdfdfdfdfdgUgUgUgUgUgUfdfdfdfdfdfdfdGHGHGHGHVhVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnjWjWntntntntjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWByjWjWjWjWjWjWByjWjWjWjWjWjWjWyoyoyoyoyojWjWjWjWjWjWjWjWjWjWgXEoEoEoEoEoEoIIMKYiMKMKMKMKMKjWjWjWjWjWjWByjWjWjWjWjWjWjWByjWntntntjWjWewUuUuUuUuewewUuUuUuUuUuUuUuewewewew
+pCpCfdfdfdfdgUgUgUXflggUgUgUfdfdfdfdfdfdGHGHGHGHVhVhVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnHKVnVnVnVnjWjWjWntntntjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWByjWjWjWjWjWjWyojWjWByjWjWjWByjWjWjWjWByjWjWjWjWGXjWjWgXgXgXgXgXgXgXgXMKYiMKgXgXgXgXgXjWjWjWjWjWjWjWjWjWjWjWjWByjWjWntntntjWjWewUuUuUuUuewewUuUuUuUuUuUuUuewewewew
+pCpCfdfdgUgUgUvblglglglggUgUfdfdfdfdGHGHGHGHGHGHVhjWjWVnVnVnVnVnVnVnHKVnVnVnVnVnVnHKVnVnVnVnVnVnjWByByjWjWntntjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWyoyojWByByjWjWjWjWjWyojWByByByjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXjWjWMKMKMKgXEoEoLzgXjWGXjWjWjWjWjWjWntntjWjWByjWjWjWjWntjWjWewUuUuUuUuewewUuUuUuUuUuUuUuewewewew
+pCpCpCpCgUlglglglglglglglggUfdfdGHGHGHGHGHGHGHjWjWjWjWVnVnVnVnHKVnVnVnVnVnVnHKVnVnVnVnVnVnVnVnjWGXjWjWjWjWntntjWjWjWjWjWjWByByjWjWByByjWjWjWjWByjWyoyojWjWByjWByByjWjWjWjWjWjWjWjWjWByByjWjWjWByRBjWjWjWjWjWjWjWjWgXgXgXgXMKMKMKgXEovEvEgXjWjWjWjWjWjWjWntntntjWjWByjWjWjWjWjWjWewewUuUuUuUuewewewewewewewewewewewewew
+pCpCpCpClgXflglglgRulglglggUfdfdGHGHGHGHGHGHjWjWByByjWjWVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnVnjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWByjWjWjWjWByByjWyojWjWByjWjWjWjWByjWjWjWjWyojWjWjWjWByjWjWjWByByByjWjWjWjWjWjWjWgXVivEvEMKMKMKIIEoEovEvojWjWjWjWByjWjWntntntjWjWjWjWjWjWjWjWjWewewUuUuUuUuewewewewewewewewewewewewew
 pCpCpCpClglglgRuRuRulglgXfgUfdGHGHGHGHGHGHjWjWByjWByjWjWjWVnVnVnVnVnVnVnVnVnVnVnVnHKVnVnVnVnjWjWntntntntjWByRBByjWjWjWjWjWjWjWByjWjWjWjWjWByByByjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWByjWjWjWvEEoEogXMKjWMKgXgXgXgXgXjWjWjWjWjWjWjWntntjWjWByjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewew
 pCpCpCpCvblglglgRuRulglglggUfdGHGHGHGHGHjWjWjWByjWjWjWjWjWVnCYVnVnVnVnVnHKVnVnVnVnVnVnVnCYVnjWjWntntntntjWjWjWjWjWjWjWjWByjWByByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWByjWByjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWgXgXgXgXMKjWMKfxMKjWGXjWjWByjWjWjWjWjWntjWjWjWjWjWjWjWByjWjWjWewewewewewewewewewewewewewewewewewewew
 pCpCpCpClggvlglglglglglgvbgUGHGHGHGHGHjWjWjWjWjWjWjWjWjWMKjWjWCYVnVnVnVnVnVnVnVnVnVnVnCYjWjWGXjWntntntntjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWByjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWGXjWMKjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWByjWjWjWewewewewewewewewewewewewewewewewewewew
@@ -721,7 +868,7 @@ pCpCpCpCgUvblglglglgXfgUgUgUGHGHGHGHjWjWjWjWjWByByjWjWMKMKjWjWjWjWjWVnVnVnVnjWjW
 pCpCpCpCgUgUlglggUgUgUgUgUgUGHGHGHjWjWByjWByjWjWjWjWMKjWjWjWByjWjWjWVntjVnVnMKMKjWjWGXjWjWjWjWjWjWntntjWjWjWjWByByjWjWjWjWjWjWByjWjWjWjWjWByjWjWyojWByjWyojWjWjWjWjWjWjWyojWRBRBByjWjWjWByjWjWjWjWByjWjWjWjWjWByjWjWByjWjWjWMKMKjWjWjWjWjWByjWjWjWjWjWByjWjWjWjWjWjWByByjWjWjWewewewewewewewewewewewewewewewewewewewew
 pCpCpCpCgUgUlggUgUGHGHGHGHGHGHGHGHjWjWjWjWByjWjWjWjWjWjWjWjWByjWjWjWVntjVnHKMKjWjWjWByjWjWjWjWByByjWjWjWjWjWjWjWByByjWByjWjWjWjWByByjWjWjWByjWyoyoyoyoyojWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWMKMKjWjWGXjWjWByjWntjWntjWjWjWjWjWjWjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewewew
 pCpCpCpCgUlglggUGHGHGHGHGHGHGHGHjWjWByjWjWjWMKjWMKjWByjWjWjWjWjWjWjWVntjVnVnjWjWjWjWjWjWjWjWjWjWByjWByByByjWjWjWjWjWjWjWjWjWjWjWRBByjWjWjWjWjWyolmlmyoyojWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWByjWByjWjWjWjWByjWGXjWMKMKjWjWjWjWjWjWjWntntntntntntntntntntntntntjWjWjWewewewewewewewewewewewewewewewewewewewew
-pCpCpCpClglggUgUGHGHGHGHGHGHGHGHjWjWjWLAjWMKjWMKjWjWjWjWByByjWjWjWjWVntjVnVnjWMKByjWByByjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWByByjWByjWjWjWjWyoyoyoyojWjWByByjWByjWByByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKMKjWjWGXjWjWjWjWjWntntntjWjWjWjWjWntntntntjWjWjWewewewewewewewewewewHfewewewewewewewewew
+pCpCpCpClglggUgUGHGHGHGHGHGHGHGHjWjWjWLAjWMKjWMKjWjWjWjWByByjWjWjWjWVntjVnVnjWMKByjWByByjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWByByjWByjWjWjWjWyoyoyoyojWjWByByjWByjWByByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKMKjWjWGXjWjWjWjWjWntntntjWjWjWjWjWntntntntjWjWjWewewewewewewewewewewewewewewewewewewewew
 pCpCpCpClglggUgUGHGHGHGHGHGHGHjWjWjWjWjWjWMKjWjWjWjWByjWjWByjWjWjWjWVntjVnVnjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWyojWyoyojWjWByByjWByByByjWByByjWjWjWjWjWByjWjWjWRBRBByByjWjWjWjWjWByjWjWGXMKMKjWjWjWjWjWjWjWjWjWjWjWByjWByjWjWjWntntjWjWjWewewewewewewewewewewewewewewewewewewewewew
 pCpCpCpCXflggUgUGHGHGHGHGHGHjWjWjWMKjWMKByjWjWjWByjWjWByjWjWjWjWjWGXVntjVnVnjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWByByjWjWByjWjWjWjWjWjWjWjWjWjWByByByjWjWjWyojWjWjWjWjWjWjWjWjWjWByByjWjWByByjWjWjWjWjWByByjWjWjWByjWjWByjWjWjWMKMKjWjWGXjWjWjWByjWjWjWByjWjWjWByjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewewewew
 pCpCpCpCpCIKIKgUgUgUGHGHGHGHjWjWMKMKjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXjWVntjVnVnjWMKjWjWjWjWjWByjWjWByjWByjWRBjWjWjWjWjWjWjWjWjWRBByByjWByjWjWjWjWByjWByjWjWjWjWjWjWntntjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWGXGXMKMKjWjWjWByjWjWjWByjWjWByByjWjWByjWjWjWByjWjWjWewewewewewewewewewewewewewewewewewewewewew
@@ -762,12 +909,12 @@ pCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWByjWjWjWjWntntntjWjWVntjtjVnCYjWjWjW
 pCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWByByjWjWntjWntjWGXDxVntjVnVnjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWMKMKMKMKjWjWByByByByByRBjWjWjWjWjWjWMKByByByByByByByRBjWByByjWjWMKjWByByjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWntntntjWntntjWjWByByjWjWjWjWjWjWjWewewewewewewewewewewewewewew
 pCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWjWjWByjWntntjWjWjWVntjtjVnjWjWjWByByByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWMKMKMKjWjWjWByByByByRBjWjWjWjWjWjWjWMKMKByByjWjWjWByjWjWjWjWByjWByMKMKjWjWjWjWjWjWjWByByByRBjWjWjWVnjWjWjWntntntntntntjWjWByByjWjWjWjWjWjWjWewewewewewewewewewewewewewew
 pCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWVnVntjVnVnjWjWByByByjWjWjWjWjWjWGXjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKMKjWjWjWjWByByByByByByGXjWjWjWjWByByjWjWByMKMKjWMKByjWjWjWjWyojWyoByjWjWjWjWjWjWByjWjWByByByByByjWVnjWByjWByntntntjWjWjWjWjWjWByjWByjWjWjWewewewewewewewewewewewewewewew
-pCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWHKtjtjVnjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXgXgXaPvojWjWjWjWMKMKMKjWjWjWGXGXRBByByGXjWByByByjWjWRBRBRBjWByjWMKByjWMKMKMKjWjWyojWyojWjWByMKByByByjWjWjWjWjWjWByByByjWjWjWByByByjWntntjWjWjWjWjWjWjWjWjWjWjWjWewewewewewewewewewewewewewewew
-pCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWVnVntjVnjWjWjWjWjWjWjWjWjWByByByjWjWGXjWjWjWjWjWjWjWgXvEvEvojWGXjWMKMKMKjWjWjWByByRBByByjWjWjWjWByByRBjWRBjWjWMKjWjWjWByByjWjWjWjWjWyoyoyojWMKMKMKByByjWjWjWjWjWjWjWjWByjWjWByjWjWjWByjWjWjWjWByjWjWjWjWjWjWjWjWjWjWewewewewewewewewewewewewewewew
-pCpCpCpCpCpCpCpCpCpCpCpCpCjWByByjWjWjWjWByjWByjWjWjWByjWjWByByjWjWjWjWVntjVnVnjWjWjWjWjWjWjWByRBByByjWjWjWByjWjWjWjWGXjWgXEoeygXjWjWMKMKMKjWjWGXGXjWjWntntntMKMKMKMKMKMKMKMKMKMKMKjWjWjWjWyoByByjWjWjWjWyoyoyoByjWjWjWjWjWjWByByjWjWByByjWByjWjWjWjWByjWjWjWjWjWjWjWntntntntntjWjWjWjWjWewewewewewewewewewewewewewewew
-pCpCpCpCpCpCpCpCpCpCpCjWjWjWByByByByjWjWByjWByjWjWByjWjWjWjWByByjWjWGXVntjtjVnjWjWjWjWjWjWByByByjWjWjWjWjWjWjWjWyojWdAjWgXgXEogXjWjWMKMKMKjWGXGXjWGXntntntMKMKMKjWjWByByByjWMKMKMKjWByjWjWyolmByByjWByByMKMKjWjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWByjWjWjWntntntntntjWntntjWjWewewewewewewewewewewewewewewewew
-pCpCpCpCpCpCpCpCpCjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWVnVntjVnjWjWjWjWjWByByByjWjWjWjWjWjWjWjWGXGXByByjWjWgXvEjWjWMKMKMKjWGXByByjWntntntntVnVnVnVnGXjWByRBByByMKjWByByjWjWyolmlmjWjWByByMKMKByjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWntntntntntjWjWntntjWjWewewewewewewewewewewewewewewewew
-pCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXVnVntjVnjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWByjWGXjWjWjWGXMKMKMKjWjWByjWntTantFOVnVnVnVnVnVnNwByByjWjWMKMKjWjWjWByjWyoyoyojWjWjWjWjWjWjWRBjWByjWRBjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWntjWjWjWewewewewewewewewewewewewewewewew
+pCpCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWHKtjtjVnjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXgXgXaPvojWjWjWjWMKMKMKjWjWjWGXGXRBByByGXjWByByByjWjWRBRBRBjWByjWMKByjWMKMKMKjWjWyojWyojWjWByMKByByByjWjWjWjWjWjWByByByjWjWjWByByByjWntntjWjWjWFrFrcYFrMKMKMKhIwHBPewewewewewewewewewewewewewew
+pCpCpCpCpCpCpCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWVnVntjVnjWjWjWjWjWjWjWjWjWByByByjWjWGXjWjWjWjWjWjWjWgXvEvEvojWGXjWMKMKMKjWjWjWByByRBByByjWjWjWjWByByRBjWRBjWjWMKjWjWjWByByjWjWjWjWjWyoyoyojWMKMKMKByByjWjWjWjWjWjWjWjWByjWjWByjWjWjWByjWjWjWjWByjWFrhGMKMKhIhIMKhILcBPewewewewewewewewewewewewewew
+pCpCpCpCpCpCpCpCpCpCpCpCpCjWByByjWjWjWjWByjWByjWjWjWByjWjWByByjWjWjWjWVntjVnVnjWjWjWjWjWjWjWByRBByByjWjWjWByjWjWjWjWGXjWgXEoeygXjWjWMKMKMKjWjWGXGXjWjWntntntMKMKMKMKMKMKMKMKMKMKMKjWjWjWjWyoByByjWjWjWjWyoyoyoByjWjWjWjWjWjWByByjWjWByByjWByjWjWjWjWByjWjWjWjWjWjWjWntFrwtwtMKFrhIhIxUhIBPewewewewewewewewewewewewewew
+pCpCpCpCpCpCpCpCpCpCpCjWjWjWByByByByjWjWByjWByjWjWByjWjWjWjWByByjWjWGXVntjtjVnjWjWjWjWjWjWByByByjWjWjWjWjWjWjWjWyojWdAjWgXgXEogXjWjWMKMKMKjWGXGXjWGXntntntMKMKMKjWjWByByByjWMKMKMKjWByjWjWyolmByByjWByByMKMKjWjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWByjWjWjWntntFrwtwtMKMKntjWjWHCgcewewewewewewewewewewewewewew
+pCpCpCpCpCpCpCpCpCjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWVnVntjVnjWjWjWjWjWByByByjWjWjWjWjWjWjWjWGXGXByByjWjWgXvEjWjWMKMKMKjWGXByByjWntntntntVnVnVnVnGXjWByRBByByMKjWByByjWjWyolmlmjWjWByByMKMKByjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWntntntFrhpwtwtcYntjWjWewewewewewewewewewewewewewewewew
+pCpCpCpCpCpCpCjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXVnVntjVnjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWByjWGXjWjWjWGXMKMKMKjWjWByjWntTantFOVnVnVnVnVnVnNwByByjWjWMKMKjWjWjWByjWyoyoyojWjWjWjWjWjWjWRBjWByjWRBjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWFrFrFrMKFrjWjWjWewewewewewewewewewewewewewewewew
 pCpCpCpCpCjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWByjWjWjWByjWjWjWByjWjWjWjWjWVntjtjVnjWjWByByByjWjWjWjWjWjWByByByjWjWjWByyoyojWjWjWjWMKMKMKGXjWGXGXntntntVnVnBmVnVnVnVnntByByjWjWByByMKjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWByRBByByByByjWjWjWjWjWjWjWjWRBByByByByjWjWjWjWjWjWjWjWByjWjWjWjWjWewewewewewewewewewewewewewewewew
 pCpCpCjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWByByjWjWjWjWjWjWVnVntjVnjWjWByByByjWjWjWByjWByByByjWjWjWGXjWjWyojWjWGXjWMKMKMKjWjWByByntntVnVnVnVnVnVnVnntntByByjWjWByRBMKMKjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWByjWByByByRBjWjWjWjWjWjWByByByByByjWjWByByjWjWjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewew
 pCpCjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWGXjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWVntjtjVnGXRBjWjWjWjWjWByByRBByjWjWjWjWjWjWyojWjWjWGXjWjWMKMKjWjWByByjWntntVnVnDxVnntntntjWByjWjWjWGXGXjWMKjWjWjWjWjWjWByjWjWjWntntntntntntjWjWjWjWjWByRBByjWjWByjWjWjWjWByByByjWjWjWjWByjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewew
@@ -776,17 +923,17 @@ pCpCMKjWjWjWjWjWByByjWjWjWjWjWByjWjWjWjWgXwNvEvEvEGXjWjWjWjWByByByjWByjWjWjWjWVn
 pCMKMKjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWgXiqeyvERGjWjWjWjWjWjWjWjWjWjWjWjWjWjWVnLKtjtjVnjWByByjWjWjWjWjWjWjWByByByByByyoyolmyoyojWjWMKMKMKjWjWByByByByByByByByByjWjWjWjWByjWMKMKMKMKMKMKMKMKMKMKMKMKMKMKMKjWjWjWjWntntntntjWjWjWjWjWjWjWByjWjWjWntntntjWByjWjWjWByjWntntjWjWewewewewewewewewewewewewewewewewewewewewew
 pCMKMKjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWBygXgXgXgXgXjWjWjWjWjWjWjWjWByjWjWjWjWjWVnVntjtjVnjWByByjWjWByjWByjWjWByByByjWjWyoyolmyoyoGXjWMKMKMKjWjWByByByByByjWGXByjWByjWjWMKMKMKMKMKMKfxjWMKMKMKMKMKMKMKMKMKMKMKMKMKMKMKjWjWjWjWByjWByjWjWjWByjWjWjWjWjWjWjWjWjWjWsyByjWjWjWjWewewewewewewewewewewewewewewewewewewewewewew
 gUGHMKMKjWjWjWByjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXjWjWjWjWjWjWjWjWjWjWGXjWVntjtjVnjWjWByjWjWByByByjWjWByByjWjWjWjWyoyoyojWjWfxIuMKMKMKjWByByjWGXjWMKMKMKMKjWByMKMKMKMKMKjWjWjWjWjWjWjWjWjWMKMKyojWyojWjWjWMKMKMKjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewewewewewew
-gUGHGHMKMKjWjWjWjWjWjWjWjWjWjWjWGXjWjWGXjWjWgXvEvEgXjWjWjWjWByjWjWjWjWjWjWjWjWjWVnVntjtjVnjWByjWjWjWByjWjWjWByjWjWjWjWjWGXjWjWjWjWjWjWMKMKMKjWjWMKMKMKMKMKMKMKMKMKMKMKMKjWyoyoyoyojWjWByjWjWByjWjWyoLrLryoyojWjWjWMKMKjWjWjWjWjWjWByjWjWjWjWjWjWjWByjWjWjWjWVnjWjWjWjWewewewewewewewewewewewewewewewewewewewewewewewew
+gUGHGHMKMKjWjWjWjWjWjWjWjWjWjWjWGXjWjWGXjWjWgXLdvEgXjWjWjWjWByjWjWjWjWjWjWjWjWjWVnVntjtjVnjWByjWjWjWByjWjWjWByjWjWjWjWjWGXjWjWjWjWjWjWMKMKMKjWjWMKMKMKMKMKMKMKMKMKMKMKMKjWyoyoyoyojWjWByjWjWByjWjWyoLrLryoyojWjWjWMKMKjWjWjWjWjWjWByjWjWjWjWjWjWjWByjWjWjWjWVnjWjWjWjWewewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHMKjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWgXvEvEgXjWjWjWjWByjWByjWjWByjWjWjWjWGXVntjtjVnjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKMKMKjWMKMKMKMKMKMKMKMKMKMKMKMKMKjWyoyoyolmlmlmyojWjWByjWjWyoyoyoyoyoyoLryoyojWjWMKMKMKMKjWjWjWjWjWjWGXntntntjWjWjWByByjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHMKMKjWjWjWjWByjWjWjWjWjWjWgXgXgXgXjWgXvEeAgXjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWVntjtjVnjWjWjWjWyoyoyoyoyojWjWjWjWGXjWMKMKMKMKMKjWjWjWjWMKMKMKjWjWjWjWMKMKvajWjWyoyoyoyojWlmlmyoyojWjWjWyoyoyontntlmyoyoyoyojWjWGXMKMKMKMKjWjWjWjWjWjWntntntntntjWjWjWByjWjWntjWjWewewewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHMKjWjWjWjWjWjWByjWjWjWGXjWgXiqvEgXjWgXgXgXgXjWjWjWjWjWjWjWjWByjWjWjWjWjWjWVntjtjVnGXjWjWjWjWjWyoyojWjWjWMKMKMKMKjWjWjWjWjWjWjWjWjWjWjWMKjWByjWjWjWGXjWjWyoyoyoyoyoyolmjWlmlmjWjWByyoyontntntntntntntyojWjWjWjWMKMKMKMKMKjWjWjWjWjWntntntntntjWjWjWjWjWntntjWewewewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHjWMKjWjWjWjWjWByjWjWjWByjWgXvEvEvEjWjWjWGXjWjWByjWjWjWjWjWjWjWjWjWjWByByByjWVntjtjVnjWjWjWByjWjWjWjWMKMKjWjWjWjWjWjWjWjWjWjWjWGXjWjWMKMKjWjWjWjWjWjWjWyoyojWjWyojWjWjWjWjWlmjWjWjWhIhIntgXgXgXgXXCgXyoyoyojWGXjWMKMKMKMKMKMKjWjWjWjWntntntntntjWjWjWntntntjWewewewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHjWjWjWMKjWjWjWjWByjWjWjWjWgXgXgXgXjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWVnLKtjVnjWjWjWjWMKjWMKjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWMKjWjWjWjWGXjWjWjWyoyojWjWjWByyoyoyoyojWByjWyohIntgXKQbRgXEogXgXyoyojWjWjWjWjWjWMKMKMKByjWjWjWjWjWjWntntjWjWjWntntntjWewewewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHGHjWjWMKjWjWjWjWByByjWjWjWjWjWjWjWGXjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWGXVntjtjtjVnjWMKjWjWjWjWjWjWjWjWGXjWjWGXjWjWByjWjWjWjWGXjWjWMKMKjWjWjWGXjWjWByjWyolmlmyoyolmlmyoyojWjWjWyojWntgXEoqAVnEoEowtyoyojWjWjWjWGXGXjWMKMKMKMKjWByjWjWjWjWjWjWjWjWntntjWjWewewewewewewewewewewewewewewewewewewewewewewewewew
-gUGHGHGHGHjWjWMKMKMKjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWjWjWVntjtjVnMKjWjWjWyojWyojWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKjWjWjWjWjWjWjWjWyoyoyolmlmlmyoyojWjWjWyogXXCgXgXgXVnEoEoHFgXlmjWjWyojWjWjWjWjWjWMKMKMKMKByByjWjWjWByjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewewewewewewewew
+gUGHGHGHGHjWjWMKMKMKjWjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWsyjWjWjWVntjtjVnMKjWjWjWyojWyojWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKjWjWjWjWjWjWjWjWyoyoyolmlmlmyoyojWjWjWyogXXCgXgXgXVnEoEoHFgXlmjWjWyojWjWjWjWjWjWMKMKMKMKByByjWjWjWByjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHGHjWMKjWjWjWMKjWjWjWjWjWjWjWjWjWjWjWjWjWByjWByjWjWjWjWjWjWjWjWjWMKMKMKMKMKMKMKVntjtjVnjWjWjWjWjWyojWYwByjWjWjWByjWjWjWjWjWByjWjWjWGXjWjWMKjWjWjWjWjWjWjWjWjWjWyoyoyoyoyojWjWjWjWyogXXCvoNNVnVnVnfvgXgXlmGXjWjWjWjWjWjWjWGXjWMKMKMKMKByjWjWjWjWjWjWjWjWByjWjWewewewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHGHMKjWjWMKjWjWjWMKjWjWByByByjWjWjWjWjWRBjWjWjWjWjWjWjWjWMKMKMKMKMKjWjWjWjWjWGXVstjtjVnjWGXjWByjWjWjWjWByRBjWjWjWjWjWByjWjWjWByjWByjWjWjWMKjWjWGXjWjWByjWjWRBjWjWByjWByByjWjWjWjWyogXXPuggXEoEoEovonhnhlmByjWjWyojWjWjWjWjWjWjWByMKMKfxjWjWjWjWntjWjWjWByjWjWjWewewewewewewewewewewewewewewewewewewewewewewewew
-gUGHGHGHZOjWjWjWjWMKjWjWjWMKjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKMKjWjWjWjWjWjWjWjWjWjWjWjWjWVntjLKVnjWjWjWjWByjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWgXgXgXgXgXgXgXjXgXgXyoyoGXjWyojWjWjWjWjWjWByjWjWMKMKjWjWjWntntjWjWjWjWByjWjWjWewewewewewewewewewewewewewewewewewewewewewewew
+gUGHGHGHZOjWjWjWjWMKjWjWjWMKjWjWjWjWjWsyjWjWjWjWjWjWjWjWjWMKMKjWjWjWjWjWjWjWjWjWjWjWjWjWVntjLKVnjWjWjWjWByjWjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWjWgXgXgXgXgXgXgXjXgXgXyoyoGXjWyojWjWjWjWjWjWByjWjWMKMKjWjWjWntntjWjWjWjWByjWjWjWewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHZOMKjWjWjWjWjWMKjWjWjWMKjWjWjWjWMKMKMKjWjWjWMKMKMKjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWVntjtjVnjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWGXjWjWjWjWjWMKjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWGXlmyontntntyolmlmyoyoyoByjWjWyojWjWjWjWjWByjWjWjWMKMKjWjWjWntntntjWjWjWByjWjWjWewewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHGHMKMKjWjWjWjWjWjWjWjWMKMKMKMKjWjWjWMKjWjWjWjWjWjWjWjWByjWjWjWjWjWByByByjWjWyoyoVntjtjVnjWjWByjWjWjWjWjWjWjWjWByjWjWjWByjWjWjWjWjWjWjWMKMKjWGXjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWGXGXlmlmlmyontntyolmyoyoyoByjWjWjWjWGXjWjWjWjWjWjWjWjWjWMKMKjWjWntVyntntjWjWjWjWjWjWjWewewewewewewewewewewewewewewewewewewewewewew
 gUGHGHGHGHMKMKjWMKMKjWMKMKMKjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWByjWjWByyoyoyoyoyoyoyoyojWVntjtjVnjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWMKjWGXjWjWjWByjWjWjWjWjWjWjWByjWjWjWGXjWyolmlmlmlmyoyoyoyoyoyojWjWjWByjWjWjWjWjWjWjWjWjWGXjWjWMKMKMKjWjWjWntntjWjWjWByjWjWjWewewewewewewewewewewewewewewewewewewewewewew
@@ -812,7 +959,7 @@ gUGHGHGHGHGHGHjWjWMKjWjWjWyojWjWjWyojWjWjWyolmHqlmyojWjWAJjWjWjWpCpCpCpCpCpCpCpC
 gUGHGHGHGHGHGHjWMKMKjWjWjWSOyoyoyoyojWjWjWyolmlmlmjWjWjWAJjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCVhVnVnVnVnVnVnVnVnVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWlSjWjWByjWjWjWjWjWjWjWyoyoyojWjWjWjWjWntntntjWjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWjWjWjWjWjWjWjWMKMKMKMKjWByByjWjWjWewewewewewewewewewewewewewewewewew
 gUGHGHGHGHGHGHjWjWMKjWByjWyoyoHqlmjWByjWyoyoyoyoNhyojWjWAJjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCpCVhVnVnVnVnVnVnHKVnVhVhVhLaVhVhpCpCpCpCpCpCpCpCpCpCpCpCpCpCjWlSjWjWjWjWjWjWjWjWjWjWjWjWyojWGXjWjWjWntntntjWjWByjWjWjWjWjWjWjWjWjWjWjWntjWjWjWByjWjWjWjWjWjWjWjWjWByjWMKMKjWjWjWjWjWgXvEgXgXewLiwEnHewewewewewewewewewew
 gUGHGHGHGHGHGHjWMKjWjWjWjWyolmlmyojWByjWyoyoyoyoyojWjWjWAJjWjWjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCVhVhVsVnVnVnVnVnVnVnVnVnVnVnVnVhVhVhVhpCpCpCpCpCpCpCpCpCpCjWjWlSjWByjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWntntntjWjWjWjWjWjWjWjWjWjWjWjWjWjWntntntntjWjWjWjWjWByjWjWjWjWByjWjWMKMKjWjWjWjWjWgXvEVigXgXgXhIQtnHewewewewewewewewew
-gUGHGHGHGHGHGHByMKjWjWjWjWyoHqpEyoNhyojWyoyojWjWjWjWjWjWAJjWntntjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCLaVhVnVnHKVnVnVnVnVnVnVnVnVngCVnVnpCVhpCpCpCpCpCpCpCpCVhVhjWjWlSjWjWByjWjWjWjWByByjWjWjWjWjWjWjWjWntjWntjWByjWjWjWjWjWjWjWRBjWjWjWjWntntntntjWjWjWjWjWjWjWjWjWjWjWjWjWMKMKByjWjWjWjWgXvEQfEoEoLQhIBfBPewewewewewewewewew
+gUGHGHGHGHGHGHByMKjWjWjWjWyoHqpEyoNhyojWyoyojWjWjWjWjWjWAJjWntntjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCLaVhVnVnHKVnWZVnVnVnVnVnVnVngCVnVnpCVhpCpCpCpCpCpCpCpCVhVhjWjWlSjWjWByjWjWjWjWByByjWjWjWjWjWjWjWjWntjWntjWByjWjWjWjWjWjWjWRBjWjWjWjWntntntntjWjWjWjWjWjWjWjWjWjWjWjWjWMKMKByjWjWjWjWgXvEQfEoEoLQhIBfBPewewewewewewewewew
 gUGHGHGHGHGHGHjWMKjWjWjWByjWyoyoyoyoyoyoyojWjWjWByjWjWjWAJjWntntntjWjWpCpCpCpCpCpCpCpCpCpCpCpCpCVhVnVnVnVnVnVnVsVnVnVnVnVngCgCgCVnVhVhVhVhVhVhVhVhVhVhVhpCjWlSjWjWjWjWjWjWjWjWjWjWjWByByByjWjWjWjWjWjWjWByjWjWjWjWjWjWByjWjWjWjWjWjWntntntjWjWjWByByjWjWjWjWjWjWjWjWMKMKMKMKMKjWMKWkvEeAgXgXgXhIeKgcewewewewewewewewew
 gUGHGHGHGHGHGHjWjWMKjWjWjWjWyoNhjWjWByyojWjWByjWjWjWjWjWAJjWntntAfjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCVhVnVnVnVnVnVnHKVnVhVhLaVhVngCgCgCVnVnVnVnVnVnVnVnVnpCpCpChIxYjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByjWjWjWByjWjWjWByjWjWjWjWjWjWjWntjWjWjWjWjWjWjWjWjWjWjWjWjWByMKMKjWjWjWjWjWgXgXQfgXewqqHCgcewewewewewewewewewew
 gUGHGHGHGHGHGHjWMKMKjWjWjWjWjWSOjWjWjWyoyojWjWjWjWjWjWjWAJjWntntntntjWjWjWpCpCpCpCpCpCpCpCpCpCpCpCVhVnVnVnVnVnVnVhVhVhpCVhVhVnVngCgCgCgCgCgCgCgCgCgCVnVnVnhIxYVnVnjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWjWjWjWjWByByjWjWjWjWjWMKMKfxjWjWjWjWjWjWjWewewewewewewewewewewewewewewew
@@ -960,17 +1107,17 @@ SeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgrjrjrjrjrjrjrjrjUgUgrjrjrjrjrjUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjUgUgUgUgrjrjrjUgUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
-SeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
+SeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgzsUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgrzoaoaoaoarzUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
-SeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgoabrdPdPdPoaUgUgUgAHUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
+SeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgoabrdPdPpSoaUgUgUgAHUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgoadPdPQIdPoaUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgsXUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgoadPdPdPdPoasXUgUgUgUgUgUgUgUgUgUgUgUgzsUgUgUgUgUgUgUgrzoaoaoarzrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
-SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgrzoavIvIoarzUgUgUgUgUgUgUgUgsXUgUgUgUgUgUgUgUgUgUgUgUgoadPrzrzoaUgUgrjrjUgrjUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
+SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgrzoavIvIoarzUgUgUgUgUgUgUgUgsXUgUgUgUgUgUgUgUgUgUgUgUgoapSrzrzoaUgUgrjrjUgrjUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgZMUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgAHUgUgUgUgUgUgUgUgoadPguguoaUgAHiFiFAHUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
-SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgUgUgUgUgUgUgAHUgUgUgUgUgUgUgUgUgUgUgUgUgoadPdPdPoaUgUgdPdPUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrjrjrj
+SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgzsUgUgUgUgUgAHUgUgUgUgUgUgUgUgUgUgUgUgUgoadPdPdPoaUgUgdPdPUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgsXHOHOHOUgUgrzoaoaoarzdPdPdPrzUgUgdPdPUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgUgUgUgAHUgUgUgUgUgUgHOfEHOUgUgvIdPdPdPdPdPdPdPoaUgIPUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrj
-SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgsXUgUgUgUgUgUgUgUgUgUgUgUgUgUgHOHOHOUgUgvIdPdPdPdPQIdPdPoaUgUgUgUgUgUgUgUgUgSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrj
+SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgsXUgUgUgUgUgUgUgUgUgUgUgUgUgUgHOHOHOUgUgvIdPdPdPdPQIdPPCoaUgUgUgUgUgUgUgUgUgSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgAHUgUgUgZMUgUgUgUgUgUgUgUgZMrzoaoaoarzoaoaoarzUgUgUgUgUgUgUgUgUgSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjhhhhhhhhrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjUgUgUgUgUgUgUgrzUgUgrzUgUgUgUgzsUgUgUgUgUgUgUgUgUgsXUgUgUgUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjAHUgUgUgUgUgsXoaguguoaUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
@@ -1050,7 +1197,7 @@ SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjbSqJZNqJqJbSbSbSBSbSbSrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjBSZNGpqJqJZDZkOKBvQnbSrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjfazOzObSbSbSbSbSbSZNDIZNZNbSrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
-SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjfaBtsbAMBSZkZNZNZNZkZkDIZNZNbSrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
+SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjfaBtsbAMBSZkbnZNZNZkZkDIZNZNbSrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjShsbAMsbQvZkZkZkZkZkZkJOmcmcbSrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjShsbAMsbBSZNZNZNZkZkZkZkZkZkbSrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjShsbsbsbbSbSBSbSbSbSbSbSBSbSbSrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
@@ -1127,7 +1274,7 @@ SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjsbsbsbrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjkIrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjoasbrjrjoarjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjsbrjrjrjrjrjrjrjrjrjrjrjrjrjrjPqrjrjrjrjrzoaoaoarzsbsbsboarjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjsbsbsbrjrjrjrjrjrjrjrjrjrjrjsbsbsbsbrjrjsbsbsbsbsbsbsbsbsboarjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
-SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjsbrjrjrjrjrjrjrjrjrjrjrjrjsbrjrjrjrjrjoasbsbsbsbsbsbsboarjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
+SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjsbrjrjrjrjrjrjrjrjrjrjrjrjsbrjrjrjrjrjoazRsbsbsbsbsbsboarjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjsbrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrzoaoaoasbkIsboarzrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjsbrjrjsbsbsbsbsbsbsbrjrjrjrjrjrjrjrjrjrjrjrjrjsbrjsbrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj
 SeSeSeSeSeSeSerjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjsbsbsbsbrjrjsbrjrjrjrjrjrjrjrjrjrjsbsbsbrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrjrj

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -149,7 +149,7 @@
 "lc" = (/obj/structure/spider/stickyweb,/mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,/turf/open/floor/rogue/metal/barograte/open,/area/rogue/under/cave/dungeon1/gethsmane)
 "lf" = (/obj/item/natural/rock,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lg" = (/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
-"lh" = (/mob/living/simple_animal/hostile/retaliate/rogue/wolf,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
+"lh" = (/mob/living/simple_animal/hostile/rogue/skeleton/guard,/turf/open/floor/rogue/dirt,/area/rogue/under/cave)
 "li" = (/obj/structure/flora/roguegrass/water,/turf/open/water/swamp/deep,/area/rogue/outdoors/woods)
 "lj" = (/obj/machinery/conveyor/auto{dir = 9; color = "#755f48"},/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "lm" = (/turf/open/water/swamp/deep,/area/rogue/outdoors/woods)
@@ -360,7 +360,7 @@
 "Cg" = (/obj/structure/mineral_door/wood/donjon,/turf/open/floor/rogue/church,/area/rogue/under/cave)
 "Ci" = (/obj/effect/decal/cobbleedge{dir = 5},/obj/structure/rack/rogue/shelf,/obj/structure/table/wood/crafted,/turf/open/floor/rogue/dirt/road,/area/rogue/indoors)
 "Cn" = (/mob/living/carbon/human/species/skeleton/npc,/turf/open/floor/rogue/twig,/area/rogue/outdoors/mountains)
-"Co" = (/obj/item/chair/rogue,/mob/living/simple_animal/hostile/rogue/skeleton/guard,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
+"Co" = (/obj/item/chair/rogue,/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "Cy" = (/obj/structure/lever/wall{redstone_id = "puzzle2"},/turf/closed/wall/mineral/rogue/stone,/area/rogue/under/cave)
 "CB" = (/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,/turf/open/water/swamp,/area/rogue/outdoors/woods)
 "CC" = (/obj/structure/closet/crate/chest,/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,/turf/open/floor/rogue/ruinedwood{icon_state = "wooden_floort"},/area/rogue/outdoors/beach)
@@ -567,7 +567,7 @@
 "RI" = (/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "RO" = (/obj/machinery/light/rogue/campfire/densefire,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/beach)
 "RQ" = (/obj/structure/bars/pipe/left,/turf/open/water/sewer,/area/rogue/under/cave/dungeon1/gethsmane/inner)
-"RX" = (/obj/structure/mineral_door/wood/donjon{dir = 4; locked = 1},/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
+"RX" = (/obj/structure/mineral_door/wood/donjon{dir = 4; pixel_x = 0; pixel_y = 0},/turf/open/floor/rogue/cobble/mossy,/area/rogue/under/cave)
 "Se" = (/turf/closed/mineral/rogue/bedrock,/area/rogue/outdoors/mountains)
 "Sh" = (/obj/structure/fluff/railing/border{dir = 4; icon_state = "border"},/turf/open/transparent/openspace,/area/rogue/outdoors/mountains)
 "Si" = (/obj/structure/flora/roguegrass/water,/turf/open/water/sewer,/area/rogue/under/cave)
@@ -624,7 +624,6 @@
 "VA" = (/obj/structure/rack/rogue/shelf/biggest,/obj/item/natural/feather,/turf/open/floor/rogue/ruinedwood,/area/rogue/indoors)
 "VE" = (/obj/machinery/conveyor/auto{color = "#755f48"},/obj/item/natural/rock,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "VF" = (/turf/open/water/swamp/deep,/area/rogue/under/cave/dungeon1/gethsmane)
-"VG" = (/mob/living/simple_animal/hostile/retaliate/rogue/wolf,/turf/open/floor/rogue/naturalstone,/area/rogue/under/cave)
 "VP" = (/obj/effect/decal/cobbleedge{dir = 10},/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/woods)
 "VT" = (/obj/machinery/conveyor/auto{dir = 10; color = "#755f48"},/obj/item/restraints/legcuffs/beartrap/armed/camouflage,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "VV" = (/obj/structure/mineral_door/wood,/turf/open/floor/rogue/ruinedwood/turned,/area/rogue/indoors)
@@ -651,7 +650,7 @@
 "XP" = (/obj/structure/closet/crate/drawer,/obj/item/clothing/shoes/roguetown/boots/furlinedboots,/turf/open/floor/rogue/dirt,/area/rogue/indoors/shelter/woods)
 "XQ" = (/mob/living/simple_animal/hostile/retaliate/rogue/mossback,/turf/open/water/swamp/deep,/area/rogue/under/cave)
 "XT" = (/obj/effect/spawner/lootdrop/roguetown/sewers,/obj/effect/decal/remains/human,/turf/open/floor/rogue/naturalstone,/area/rogue/outdoors/woods)
-"Yh" = (/obj/structure/lever/wall{name = "puzzle1"},/turf/closed/wall/mineral/rogue/stone,/area/rogue/under/cave)
+"Yh" = (/obj/structure/lever/wall{name = null; redstone_id = "puzzle1"},/turf/closed/wall/mineral/rogue/stone,/area/rogue/under/cave)
 "Yi" = (/turf/open/floor/rogue/cobblerock,/area/rogue/outdoors/woods)
 "Yj" = (/obj/item/natural/rock,/obj/item/natural/rock,/turf/open/floor/rogue/dirt,/area/rogue/under/cave/dungeon1/gethsmane)
 "Yk" = (/obj/structure/bars/pipe,/turf/open/floor/rogue/greenstone,/area/rogue/under/cave/dungeon1/gethsmane)
@@ -791,17 +790,17 @@ gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKIKIKgU
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglgrRrRrRIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAadadadadgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgxkrRrRIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKadOmOmvpadgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgxkrRrRIKIKaAaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKIKRXOmOmOmvpadYhCyMladgUgUgUgUgUlggUgUgUgUgUlgrRTCIKIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAlhIKRXOmOmOmvpadYhCyMladgUgUgUgUgUlggUgUgUgUgUlgrRTCIKIKIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKgUadadadOmOmvpOmOmOmadadadadlglgvbgUgUgUgUgUxkrRrRIKIKIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAIKgUgUgUadadOmvpOmCorTadadmGmGmGlggUgUgUgUgUgUrRrRrRIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUJHOmOmOmOmOmOmmJmGKWlglggUgUgUgUgUgUrRrRIKaAaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUHEyLHEHEHEjIHEHEmGmGmGadgUgUgUgUgUgUrRrRIKaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAIKIKgUgUgUadmGOmmGHEmGmGgqadadkTadadgUgUgUgUgUgUrRrRIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKIKgUgUgUgUadmGOmOmHYmGmGmGtTadmGgUgUgUgUgUgUgUlgrRrRIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAgUgUgUadHEdVHEHEHEmJHEHEHEmGlhOmgUgUgUgUgUlgrRrRlgIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUvpOmOmOmHEwiOmOmOmzGlglglgVGgUgUgUgUlgTCrRlgaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKIKaAaAgUgUgUadHEdVHEHEHEmJHEHEHEmGOmOmgUgUgUgUgUlgrRrRlgIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUIKaAaAgUgUgUvpOmOmOmHEwiOmOmOmzGlglglglggUgUgUgUlgTCrRlgaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUvpOmwBOmcvOmwiTylgkkgUlgvblggUgUgUgUlgrRrRlgaAIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
-gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUvpuCJuOmHEOmwiOmwigUgUVGlglggUgUgUgUgUrRrRlglgaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
+gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUvpuCJuOmHEOmwiOmwigUgUlglglggUgUgUgUgUrRrRlglgaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUaAaAaAaAgUgUvpvpvpvpgUgUgUgUgUgUgUlggUgUgUgUgUgUgUrRrRoplgaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlgaAaAaAgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRlgIKIKIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxRxTpTpTpTpTpTpTpTpTpTpTpTpTp
 gUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUlglglggUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUrRrRrRlgaAaAIKgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgUgURxRxTpTpTpTpTpTpTpTpTpTpTpTpTp


### PR DESCRIPTION

## About The Pull Request

Adds some points of interest and two dungeons to the azure coast and bog, so adventures have more actual adventuring to do. Also adds a few braziers to the Azure Coast's roads, to make it a little easier to traverse. I've tried to use spawners whenever possible for loot, to prevent metaknowledge letting players have too much of an edge over those who don't. Below is a summary of all additions. If you wish to find them and experience them yourself, watch out for spoilers! 

### Dungeons

![image](https://github.com/user-attachments/assets/96c2613b-88f1-4c24-840f-e518ff57143b)
![image](https://github.com/user-attachments/assets/2e11bf28-6435-4446-ab8c-531e54845602)

On the azure coast, some orcs have set up a little spider farming operation in an abandoned temple. Contains some puzzles and combat encounters. Nothing too spicy. Has two entrances: players can enter through a cave on the coastside cliffs, or mine in through the spider pen. 

![image](https://github.com/user-attachments/assets/4a09789b-ecc9-4aea-aea3-ba85a2926fc4)

A port-homage of the sunken chapel from the Rockhill map. The sunken chapel was the first dungeon I ever encountered in the rogue codebase and I'm charmed with it. I think having an homage to it here lends the sort of misremembered-misplaced locations vibe that dark souls sometimes has. This version is filled with mossbacks, also! Located beneath the bog.

![image](https://github.com/user-attachments/assets/8908c5ea-3078-4423-b972-0902263fdcd8)

You know those fake mobile game puzzle ads? Yeah, well that's in Azure Peak now. The puzzle is designed to be completed with two people, to encourage bringing a buddy. Individuals trying to clear solo will have to deal with a cave troll in close quarters. This one's in the caves in the bog, kinda below the skeleton fort. I also threw a few loot-crates in the skeleton fort, so there's actually a reward for clearing it.

### Points of interest.

![image](https://github.com/user-attachments/assets/1b699c9a-93d1-4235-b2bf-36031819936b)

Small fishing house ruin on the coast of the bog.

![image](https://github.com/user-attachments/assets/eeaf28ee-2b0b-43ed-a465-aa976cc6ac2c)

Sea raider camp on the beach in the bog. It was an empty area, felt like the sort of spot you'd run into them. 

![image](https://github.com/user-attachments/assets/64bcd7d1-53f2-4682-b536-0b236598cdc5)

An adventuring classic: the wolf den! Located in the bog.

![image](https://github.com/user-attachments/assets/4ab259a2-43d9-4b10-a4a4-a29221780780)

A small abandoned chapel, on the coast.

### Other changes

There's a few other small changes - cosmetic details to some ruins, adding rewards to encounters that didn't have any (clearing moles now nets you a few gems at least), mossbacks can now be found along the coast and anywhere there's water. There's probably a few more things I forgot, but there shouldn't be any big gamebreaking items laying around. 

## Why It's Good For The Game

Hopefully this will help the world feel more alive and a little less empty. More loot out in the world will also allow players to collect money in a way that's more engaging than just collecting 100 apples or logs. One concern I have is that bad guy AI is pretty bad right now - decreasing the delay on their actions/letting them have more actions per turn would make them a little more dangerous, which would allow us to offer players some better rewards. 