### PR TITLE
The knight-errants ride into the Azure Coast

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
@@ -1,0 +1,86 @@
+/datum/advclass/knighterrant
+	name = "Knight-errant"
+	tutorial = "You fashion yourself a knight from a distant land, a scion of a noble house. Whether or not that's true is irrelevant; manner maketh man, bandit. Carry yourself with dignity and remind the land that chivalry still exists, or give everyone a cruel reality check as they decry you as a blackguard under the weight of a steel boot. After selection you receive a choice between a shining knight or a black knight, which is entirely aesthetic."
+	allowed_races = RACES_ALL_KINDS
+	allowed_sexes = list(MALE, FEMALE)
+	outfit = /datum/outfit/job/roguetown/adventurer/knighterrant
+	maximum_possible_slots = 4		
+	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_NOBLE)
+	category_tags = list(CTAG_ADVENTURER)
+
+
+/datum/outfit/job/roguetown/adventurer/knighterrant/pre_equip(mob/living/carbon/human/H)
+	..()
+	H.adjust_blindness(-3)
+	var/classes = list("Normal Knight","Black Knight")
+	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
+
+	switch(classchoice)
+
+		if("Normal Knight")
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight
+			gloves = /obj/item/clothing/gloves/roguetown/plate
+			pants = /obj/item/clothing/under/roguetown/platelegs
+			cloak = /obj/item/clothing/cloak/tabard
+			neck = /obj/item/clothing/neck/roguetown/bervor
+			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+			armor = /obj/item/clothing/suit/roguetown/armor/plate
+			shoes = /obj/item/clothing/shoes/roguetown/boots/armor
+			belt = /obj/item/storage/belt/rogue/leather
+			beltr = /obj/item/rogueweapon/sword/long
+			backr = /obj/item/storage/backpack/rogue/satchel/black
+			backl = /obj/item/rogueweapon/shield/tower/metal
+			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger = 1)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/riding, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
+			H.change_stat("strength", 2)
+			H.change_stat("endurance", 1)
+			H.change_stat("constitution", 2)
+			H.change_stat("intelligence", 1)
+			H.change_stat("speed", 1)
+			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
+
+		if("Black Knight")
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/black
+			gloves = /obj/item/clothing/gloves/roguetown/plate/blk/death
+			pants = /obj/item/clothing/under/roguetown/platelegs/blk
+			cloak = /obj/item/clothing/cloak/tabard/blkknight
+			neck = /obj/item/clothing/neck/roguetown/bervor
+			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/blkknight
+			shoes = /obj/item/clothing/shoes/roguetown/boots/armor/blkknight
+			belt = /obj/item/storage/belt/rogue/leather
+			beltr = /obj/item/rogueweapon/sword/long/death // ow the edge. it's just spraypainted.
+			backr = /obj/item/storage/backpack/rogue/satchel/black
+			backl = /obj/item/rogueweapon/shield/tower/metal
+			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger = 1)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/riding, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
+			H.change_stat("strength", 2)
+			H.change_stat("endurance", 1)
+			H.change_stat("constitution", 2)
+			H.change_stat("intelligence", 1)
+			H.change_stat("speed", 1)
+			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -29,7 +29,7 @@
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
@@ -34,7 +34,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/tanning, 2, TRUE)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2217,6 +2217,7 @@
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\combat\donator\vaquero.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\combat\rare\heartfelt.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\combat\rare\heartfelthand.dm"
+#include "code\modules\jobs\job_types\roguetown\adventurer\types\combat\rare\knighterrant.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\combat\rare\necromancer.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\combat\rare\sentinel.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\combat\rare\treasurehunter.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

i realized i wanted to make a knight but also couldn't, not really.

Similar to Hearthstone, this adds the knight-errant adventurer role. The knight-errant has comparable stats to most of their adventurer kin, maxing out at journeyman. As a martial class they typically would get a bump up in an iconic combat skill, but they trade that with the armor they start with instead. Their statline is the same as warrior's. They unfortunately don't get any unique combat music, and we really need some ren faire ass trumpet bullshit, but I'll leave that to another soul.

The knight also comes with an archetype choice, letting them be a black knight given all the set up was already there. It's aesthetic only, someone just took a black spray can to you.

This also touches up the warrior and steppe merc; it fixes a leftover from previous code that let the warrior get **five** in swords, and the steppe mercenary got the same level of riding as the other dedicated riding classes, like the royal guards and vaquero. Enjoy your turbo horse archers when we map in a stable at some point.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

https://x.com/Gemi_ningen/status/1766391257948115133

![image](https://github.com/user-attachments/assets/acdbc946-e4e5-4447-b1ef-19ee5c5d9601)
![image](https://github.com/user-attachments/assets/7d7b67e4-e266-4395-b4ec-2de360400577)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
