### PR TITLE
Knight-errant's limbs on the chain now

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
@@ -19,12 +19,13 @@
 
 		if("Normal Knight")
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight
-			gloves = /obj/item/clothing/gloves/roguetown/plate
-			pants = /obj/item/clothing/under/roguetown/platelegs
+			gloves = /obj/item/clothing/gloves/roguetown/chain
+			pants = /obj/item/clothing/under/roguetown/chainlegs
 			cloak = /obj/item/clothing/cloak/tabard
 			neck = /obj/item/clothing/neck/roguetown/bervor
 			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 			armor = /obj/item/clothing/suit/roguetown/armor/plate
+			wrists = /obj/item/clothing/wrists/roguetown/bracers
 			shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/rogueweapon/sword/long
@@ -53,12 +54,13 @@
 
 		if("Black Knight")
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/black
-			gloves = /obj/item/clothing/gloves/roguetown/plate/blk/death
-			pants = /obj/item/clothing/under/roguetown/platelegs/blk
+			gloves = /obj/item/clothing/gloves/roguetown/chain/blk
+			pants = /obj/item/clothing/under/roguetown/chainlegs/blk
 			cloak = /obj/item/clothing/cloak/tabard/blkknight
 			neck = /obj/item/clothing/neck/roguetown/bervor
 			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/blkknight
+			wrists = /obj/item/clothing/wrists/roguetown/bracers
 			shoes = /obj/item/clothing/shoes/roguetown/boots/armor/blkknight
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/rogueweapon/sword/long/death // ow the edge. it's just spraypainted.
@@ -84,3 +86,9 @@
 			H.change_stat("intelligence", 1)
 			H.change_stat("speed", 1)
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
+
+/obj/item/clothing/gloves/roguetown/chain/blk
+		color = CLOTHING_BLACK
+
+/obj/item/clothing/under/roguetown/chainlegs/blk
+		color = CLOTHING_BLACK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Host request! I maintain that I don't think it was that powerful, but nonetheless; the knight-errant role has their start armor dropped down to be directly in line with the royal guard's, the local knight. This takes the form of their gloves and pants going from plate to chain.

The black knight found more spray paint to get their new clothes dark, too.

![image](https://github.com/user-attachments/assets/05f4c96d-6798-4c71-9a97-17f37687da33)

ow the edge

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

:)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
