### PR TITLE
Dun Manor JSON readability improvements

### DIFF
--- a/_maps/dun_manor.json
+++ b/_maps/dun_manor.json
@@ -7,7 +7,10 @@
 	"azure_forest.dmm",
 	"azure_coast.dmm"
 	],
-	"traits": [{"Name": "Dun Manor", "Up": 1}, {"Up": 1, "Down": -1}, {"Up": 1, "Down": -1}, {"Down": -1}, {"Name": "Magma Crater"}, {"Name": "Azure Forest", "Up": 1}, {"Up": 1, "Down": -1}, {"Up": 1, "Down": -1}, {"Down": -1}, {"Name": "Azure Coast", "Up": 1}, {"Up": 1, "Down": -1}, {"Up": 1, "Down": -1}, {"Down": -1}],
+	"traits": [{"Name": "Dun Manor", "Up": 1}, {"Up": 1, "Down": -1}, {"Up": 1, "Down": -1}, {"Down": -1},
+	{"Name": "Magma Crater"},
+	{"Name": "Azure Forest", "Up": 1}, {"Up": 1, "Down": -1}, {"Up": 1, "Down": -1}, {"Down": -1},
+	{"Name": "Azure Coast", "Up": 1}, {"Up": 1, "Down": -1}, {"Up": 1, "Down": -1}, {"Down": -1}],
 	"minetype": null,
 	"space_empty_levels": 0,
 	"space_ruin_levels": 0,


### PR DESCRIPTION
separates the z level trait entries into their own lines by map, so that hopefully the list is more readable to contributors than whatever it is now.

this should not affect gameplay in any way, it is only to improve the look of the file and hopefully disambiguate how map files and z levels are to be formatted.