### PR TITLE
Townie Butcher's key replaced with cleaver

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/butcher.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/butcher.dm
@@ -28,7 +28,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/butchering, 5, TRUE)
-	beltl = /obj/item/roguekey/butcher
+	beltl = /obj/item/rogueweapon/huntingknife/cleaver
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
 	backl = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

When I turned the butcher doors into farm-coded ones I forgot about the Butcher's key apparently. As it's a townie/pilgrim role they won't get _inherent_ access to the place, but instead they get a cleaver.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

working keys

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
