### PR TITLE
[PORT] Swimming, bows and crossbows leveling + Quiver Scooping

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -30,6 +30,23 @@
 	woundclass = BCLASS_STAB
 	flag = "bullet"
 	speed = 0.5
+
+/obj/projectile/bullet/reusable/bolt/on_hit(atom/target)
+	. = ..()
+
+	var/mob/living/L = firer
+	if(!L || !L.mind) return
+
+	var/skill_multiplier = 0
+
+	if(isliving(target)) // If the target theyre shooting at is a mob/living
+		var/mob/living/T = target
+		if(T.stat != DEAD) // If theyre alive
+			skill_multiplier = 4
+
+	if(skill_multiplier && can_train_combat_skill(L, /datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT))
+		L.mind.add_sleep_experience(/datum/skill/combat/crossbows, L.STAINT * skill_multiplier)
+
 /*
 /obj/projectile/bullet/reusable/bolt/poison
 	name = "poisoned bolt"
@@ -81,6 +98,22 @@
 	woundclass = BCLASS_STAB
 	flag = "bullet"
 	speed = 0.4
+
+/obj/projectile/bullet/reusable/arrow/on_hit(atom/target)
+	. = ..()
+
+	var/mob/living/L = firer
+	if(!L || !L.mind) return
+
+	var/skill_multiplier = 0
+
+	if(isliving(target)) // If the target theyre shooting at is a mob/living
+		var/mob/living/T = target
+		if(T.stat != DEAD) // If theyre alive
+			skill_multiplier = 4
+
+	if(skill_multiplier && can_train_combat_skill(L, /datum/skill/combat/bows, SKILL_LEVEL_EXPERT))
+		L.mind.add_sleep_experience(/datum/skill/combat/bows, L.STAINT * skill_multiplier)
 
 /obj/projectile/bullet/reusable/arrow/iron
 	name = "iron arrow"

--- a/code/game/objects/items/rogueweapons/ranged/bows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/bows.dm
@@ -18,7 +18,6 @@
 	verbage = "nock"
 	cartridge_wording = "arrow"
 	load_sound = 'sound/foley/nockarrow.ogg'
-	associated_skill = /datum/skill/combat/bows
 	var/damfactor = 1
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/getonmobprop(tag)

--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -18,7 +18,6 @@
 	cartridge_wording = "bolt"
 	load_sound = 'sound/foley/nockarrow.ogg'
 	fire_sound = 'sound/combat/Ranged/crossbow-small-shot-02.ogg'
-	associated_skill = /datum/skill/combat/crossbows
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel
 	var/damfactor = 2

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -80,6 +80,7 @@
 					return
 			if(user.mind && !user.buckled)
 				var/drained = max(15 - (user.mind.get_skill_level(/datum/skill/misc/swimming) * 5), 1)
+				user.mind.add_sleep_experience(/datum/skill/misc/swimming, user.STAINT * 0.5)
 //				drained += (user.checkwornweight()*2)
 				if(!user.check_armor_skill())
 					drained += 40

--- a/code/modules/clothing/rogueclothes/quiver.dm
+++ b/code/modules/clothing/rogueclothes/quiver.dm
@@ -19,6 +19,26 @@
 	var/list/arrows = list()
 	sewrepair = TRUE
 
+/obj/item/quiver/attack_turf(turf/T, mob/living/user)
+	if(arrows.len >= max_storage)
+		to_chat(user, span_warning("Your [src.name] is full!"))
+		return
+	to_chat(user, span_notice("You begin to gather the ammunition..."))
+	for(var/obj/item/ammo_casing/caseless/rogue/arrow in T.contents)
+		if(do_after(user, 5))
+			if(!eatarrow(arrow))
+				break
+
+/obj/item/quiver/proc/eatarrow(obj/A)
+	if(A.type in subtypesof(/obj/item/ammo_casing/caseless/rogue))
+		if(arrows.len < max_storage)
+			A.forceMove(src)
+			arrows += A
+			update_icon()
+			return TRUE
+		else
+			return FALSE
+
 /obj/item/quiver/attackby(obj/A, loc, params)
 	if(A.type in subtypesof(/obj/item/ammo_casing/caseless/rogue))
 		if(arrows.len < max_storage)


### PR DESCRIPTION
Ports https://github.com/Tree445/Hearthstone/pull/483 by @EtheoBoxxman

Bows and crossbows no longer levelable by hitting a dummy or hitting someone with it.
Hitting living things with bolts and arrows levels the respective skill now.
Can scoop up bolts and arrows with quivers by clicking the tile with them.
Swimming now trainable.