### PR TITLE
Gives the Sheriff heavy armour so they can wear their outfit.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -59,7 +59,7 @@
 		H.change_stat("speed", 1)
 		H.change_stat("fortune", 1)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	H.verbs |= /mob/proc/haltyell
 	H.verbs |= list(/mob/living/carbon/human/proc/request_outlaw, /mob/living/carbon/human/proc/request_law, /mob/living/carbon/human/proc/request_law_removal, /mob/living/carbon/human/proc/request_purge)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The recent Bailiff-Sheriff merge kept the brigandine of the Sheriff, but didn't give this class the heavy armour support required to actually wear it. Thus, the Sheriff can now wear heavy armour.
I considered making _this specifc_ brigandine medium armour, and I still could do that instead, if it's preferred.

## Why It's Good For The Game

A class being unable to wear the armour they're supposed to spawn wearing is obviously an oversight and should be remedied.
