### PR TITLE
Three new classes for the Hand: you could say things are getting out of h-*I am torn apart by wild vulfs*

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -213,6 +213,7 @@ GLOBAL_LIST_EMPTY(job_respawn_delays)
 #define CTAG_MENATARMS		"CAT_MENATARMS"		// Men-at-Arms class - Handles Men-at-Arms class selector
 #define CTAG_ROYALGUARD		"CAT_ROYALGUARD"	// Royal Guard class - Handles Royal Guard class selector
 #define CTAG_MERCENARY		"CAT_MERCENARY"		// Mercenary class - Handles Mercenary class selector
+#define CTAG_HAND			"CAT_HAND"			// Hand class - Handles Hand class selector
 
 /*
 	Defines for the triumph buy datum categories

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -9,6 +9,7 @@
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/hand
+	advclass_cat_rolls = list(CTAG_HAND = 20)
 	display_order = JDO_HAND
 	tutorial = "You owe everything to your liege. Once, you were just a humble friend- now you are one of the most important men within the kingdom itself. You have played spymaster and confidant to the Noble-Family for so long that you are a vault of intrigue, something you exploit with potent conviction. Let no man ever forget whose ear you whisper into. You've killed more men with those lips than any blademaster could ever claim to. \
 		\
@@ -32,13 +33,30 @@
 				return TRUE
 */
 
-/datum/outfit/job/roguetown/hand/pre_equip(mob/living/carbon/human/H)
-	..()
+/datum/outfit/job/roguetown/hand
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/hand
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	belt = /obj/item/storage/belt/rogue/leather/hand
+
+/datum/job/roguetown/hand/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.advsetup = 1
+		H.invisibility = INVISIBILITY_MAXIMUM
+		H.become_blind("advsetup")
+
+/datum/advclass/hand/hand
+	name = "Hand"
+	tutorial = " You have played blademaster and strategist to the Noble-Family for so long that you are a master tactician, something you exploit with potent conviction. Let no man ever forget whose ear you whisper into. You've killed more men with swords than any spymaster could ever claim to."
+	outfit = /datum/outfit/job/roguetown/hand/handclassic
+
+	category_tags = list(CTAG_HAND)
+
+//Classical hand start - same as before, nothing changed. 
+/datum/outfit/job/roguetown/hand/handclassic/pre_equip(mob/living/carbon/human/H)
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/keyring/hand = 1)
 	if(H.mind)
@@ -59,3 +77,75 @@
 		H.change_stat("intelligence", 3)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+
+/datum/advclass/hand/spymaster
+	name = "Spymaster"
+	tutorial = " You have played spymaster and confidant to the Noble-Family for so long that you are a vault of intrigue, something you exploit with potent conviction. Let no man ever forget whose ear you whisper into. You've killed more men with those lips than any blademaster could ever claim to."
+	outfit = /datum/outfit/job/roguetown/hand/spymaster
+
+	category_tags = list(CTAG_HAND)
+
+//Spymaster start. More similar to the rogue adventurer - loses heavy armor and sword skills for more sneaky stuff. 
+/datum/outfit/job/roguetown/hand/spymaster/pre_equip(mob/living/carbon/human/H)
+	cloak = /obj/item/clothing/cloak/raincloak/mortus //cool spymaster cloak
+	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/keyring/hand = 1, /obj/item/lockpickring/mundane)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 6, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 5, TRUE) // not like they're gonna break into the vault.
+	H.change_stat("strength", -1)
+	H.change_stat("perception", 2)
+	H.change_stat("speed", 4)
+	H.change_stat("intelligence", 2)
+	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+
+/datum/advclass/hand/advisor
+	name = "Advisor"
+	tutorial = " You have played researcher and confidant to the Noble-Family for so long that you are a vault of knowledge, something you exploit with potent conviction. Let no man ever forget the knowledge you wield. You've read more books than any blademaster or spymaster could ever claim to."
+	outfit = /datum/outfit/job/roguetown/hand/advisor
+
+	category_tags = list(CTAG_HAND)
+
+//Advisor start. Trades combat skills for more knowledge and skills - for older hands, hands that don't do combat - people who wanna play wizened old advisors. 
+/datum/outfit/job/roguetown/hand/advisor/pre_equip(mob/living/carbon/human/H)
+	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/keyring/hand = 1, /obj/item/reagent_containers/glass/bottle/rogue/poison = 1) //starts with a vial of poison, like all wizened evil advisors do!
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 4, TRUE)
+		H.change_stat("intelligence", rand(4,5))
+		H.change_stat("perception", 3)
+	if(H.age == AGE_OLD)
+		H.change_stat("speed", -1)
+		H.change_stat("strength", -1)
+		H.change_stat("intelligence", 1)
+		H.change_stat("perception", 1)
+
+	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
+

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -63,6 +63,7 @@ GLOBAL_LIST_INIT(noble_positions, list(
 	"Monarch",
 	"Consort",
 	"Prince",
+	"Hand",
 	"Guard Captain",
 	"Sheriff",
 	"Councillor",


### PR DESCRIPTION
## About The Pull Request

Gives the hand three new classes and makes them latejoinable. The hand has always felt kinda weird as they're described as a cunning spymaster but statwise they're a heavy armor blademaster: they very type of dude their description makes fun of. 

The three new classes are Hand, Spymaster, and Advisor. The 'Hand' class is your classical Hand class - same as before, nothing's changed. Spymaster gets sneaky skills, vaguely similar to the rogue adventurer class. However, they lose out on the heavy armor the standard Hand gets. The Advisor is the final class, made for people who want to play the Hand like a wizened old advisor instead of a spymaster or combat man. They lose most of their combat stats, but gain a lot more skills and intelligence, able to do alchemy and some medicine. They also start with a vial of deadly poison, as all good evil advisors do.

Also makes Hands latejoinable, so we actually see more of them. I think un-latejoinable Hands is an old lifeweb carryover from when the Baron could decide the Hand at roundstart. 

![image](https://github.com/user-attachments/assets/53ca3880-2e47-4c99-bcac-4543851e8087)

![image](https://github.com/user-attachments/assets/a6dc6cff-8d61-4c07-ab90-508f4d7eb771)

![image](https://github.com/user-attachments/assets/a3c779f0-d2ec-4e4c-8e52-0d9c8e86bc43)

## Why It's Good For The Game

More class system content allows people to play a more diverse and interesting range of characters, instead of each court being filled with the same 5-6 actors. There's a little overlap between advisor and archivist, but if we are continuing to want to cut down job bloat, I think using classes is an excellent solution to that. Honestly I am a fan of archivist and I tried to keep them distinct from advisor (archivist is still smarter and has magic, advisor doesn't and has SOME combat ability.) 

Fixes a minor latejoin oversight. No real reason people should have to camp for roundstart to play what they want - a late Hand doesn't really disrupt the round much. In fact, the spymaster showing up late because they were off on a mission makes pretty good sense. 

Most importantly, adds poison to the court intrigue scene - something we've been desperately lacking. 