### PR TITLE
Church stat shifts

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -36,7 +36,7 @@
 			wrists = /obj/item/clothing/wrists/roguetown/wrappings
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/astrata
-		if(/datum/patron/divine/noc) 
+		if(/datum/patron/divine/noc)
 			head = /obj/item/clothing/head/roguetown/nochood
 			neck = /obj/item/clothing/neck/roguetown/psicross/noc
 			wrists = /obj/item/clothing/wrists/roguetown/nocwrappings
@@ -88,9 +88,9 @@
 		H.mind.adjust_skillrank(/datum/skill/magic/holy, 4, TRUE)
 		if(H.age == AGE_OLD)
 			H.mind.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
-		H.change_stat("intelligence", 1)
-		H.change_stat("endurance", 1)
-		H.change_stat("perception", -1)
+		H.change_stat("intelligence", 3)
+		H.change_stat("endurance", 2)
+		H.change_stat("speed", 1)
 		if(H.patron?.type == /datum/patron/divine/necra)
 			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -81,11 +81,9 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)	//May tone down to 2; seems OK.
 		H.change_stat("strength", 3)
-		H.change_stat("perception", 2)
-		H.change_stat("intelligence", 2)
 		H.change_stat("constitution", 2)
 		H.change_stat("endurance", 3)
-		H.change_stat("speed", -1)
+		H.change_stat("speed", -2)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

Did you guys know Templar had the highest stat boon of the town other than Captain? Barely beating out the RG themselves. I learned this while wandering to myself "Wow, my acolyte stats sure feel dogwater!", and went looking.

Summary:
Acolyte-
Intelligence 1->3
Endurance 1->2
Speed 0->1
Removed per penalty
Acolytes, being the booky, educated types of the Church, now are actually smarter than their lumpheaded brethren. The endurance tick helps them cast more miracles, and the Speed bonus hastens them to their needed places, while not being so fast as to make them dodge gamers(The Dark hand of combat creep will NOT take me)

Templar
Str, Con, and End remain the same
Perception/Intelligent bonuses removed
Spd malus increased to -2.
This puts them roughly on par with MAA, being a bit stronger, but slower. They also still have the bonus of being cleric casters.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes Acolytes stats not dog. Severely reigns in Templar, who were for some reason good at everything. I'm of the opinion that the garrison/town combat roles should be toned down overall, but that's another conversation. I greatly resisted the urge to turn Acolytes into Karate Monks with dodge expert as the Dark Hand of Combat-role creep tried to take me.
