### PR TITLE
[PORT] Grab Rework

### DIFF
--- a/code/game/objects/items/rogueitems/ropechainbola.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola.dm
@@ -136,8 +136,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 1
 	throw_range = 3
-	breakouttime = 1 MINUTES
-	slipouttime = 5 MINUTES
+	breakouttime = 10 SECONDS
+	slipouttime = 2 MINUTES
 	cuffsound = 'sound/blank.ogg'
 	possible_item_intents = list(/datum/intent/tie, /datum/intent/whips)
 	firefuel = null

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -405,10 +405,10 @@
 	chargetime = 0
 	noaa = TRUE
 	rmb_ranged = TRUE
-	releasedrain = 0
-	misscost = 5
+	releasedrain = 10
+	misscost = 8
 	candodge = TRUE
-	canparry = FALSE
+	canparry = TRUE
 	item_d_type = "blunt"
 
 /datum/intent/unarmed/grab/rmb_ranged(atom/target, mob/user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -141,8 +141,12 @@
 				hurt = FALSE
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
-			Paralyze(20)
+			if(IsOffBalanced())
+				Paralyze(20)
+			if(prob(20))
+				emote("scream") // lifeweb reference ?? xd
 			take_bodypart_damage(10,check_armor = TRUE)
+			playsound(src,"genblunt",100,TRUE)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.movement_type & FLYING)
@@ -210,10 +214,7 @@
 					if(!throwable_mob.buckled)
 						thrown_thing = throwable_mob
 						thrown_speed = 1
-						if(STASTR > throwable_mob.STACON)
-							thrown_range = 4
-						else
-							thrown_range = 1
+						thrown_range = max(round((STASTR/throwable_mob.STACON)*2), 1)
 						stop_pulling()
 						if(G.grab_state < GRAB_AGGRESSIVE)
 							return
@@ -222,6 +223,8 @@
 							return
 						var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 						var/turf/end_T = get_turf(target)
+						if(start_T.z != end_T.z && throwable_mob.mobility_flags & MOBILITY_STAND)
+							return
 						if(start_T && end_T)
 							log_combat(src, throwable_mob, "thrown", addition="grab from tile in [AREACOORD(start_T)] towards tile at [AREACOORD(end_T)]")
 				else
@@ -320,7 +323,7 @@
 		return FALSE
 
 /obj/structure
-	var/breakoutextra = 30 SECONDS
+	var/breakoutextra = 10 SECONDS
 
 /mob/living/carbon/resist_buckle()
 	if(restrained())
@@ -382,7 +385,7 @@
 
 /mob/living/carbon/proc/cuff_resist(obj/item/I, breakouttime = 600, cuff_break = 0)
 	if(I.item_flags & BEING_REMOVED)
-		to_chat(src, span_warning("You're already attempting to remove [I]!"))
+		to_chat(src, span_warning("I'm already trying to get out of \the [I]\s!"))
 		return
 	I.item_flags |= BEING_REMOVED
 	breakouttime = I.slipouttime
@@ -392,18 +395,18 @@
 	if(STASTR > 15 || (mind && mind.has_antag_datum(/datum/antagonist/zombie)) )
 		cuff_break = INSTANT_CUFFBREAK
 	if(!cuff_break)
-		to_chat(src, span_notice("I attempt to remove [I]..."))
-		if(do_after(src, breakouttime, 0, target = src))
+		to_chat(src, span_notice("I try to get out of \the [I]\s..."))
+		if(move_after(src, breakouttime, 0, target = src))
 			clear_cuffs(I, cuff_break)
 		else
-			to_chat(src, span_danger("I fail to remove [I]!"))
+			to_chat(src, span_danger("I fail to get out of \the [I]\s!"))
 
 	else if(cuff_break == FAST_CUFFBREAK)
-		to_chat(src, span_notice("I attempt to break [I]..."))
-		if(do_after(src, breakouttime, 0, target = src))
+		to_chat(src, span_notice("I attempt to break \the [I]\s..."))
+		if(move_after(src, breakouttime, 0, target = src))
 			clear_cuffs(I, cuff_break)
 		else
-			to_chat(src, span_danger("I fail to break [I]!"))
+			to_chat(src, span_danger("I fail to break \the [I]\s!"))
 
 	else if(cuff_break == INSTANT_CUFFBREAK)
 		clear_cuffs(I, cuff_break)

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -128,19 +128,42 @@
 		return FALSE
 	if(!valid_check())
 		return FALSE
-	user.changeNext_move(CLICK_CD_MELEE)
+	user.changeNext_move(CLICK_CD_MELEE * 2 - user.STASPD) // 24 - the user's speed
+	var/skill_diff = 0
+	var/combat_modifier = 1
+	if(user.mind)
+		skill_diff += (user.mind.get_skill_level(/datum/skill/combat/wrestling))
+	if(M.mind)
+		skill_diff -= (M.mind.get_skill_level(/datum/skill/combat/wrestling))
+
+	if(M.surrendering)
+		combat_modifier = 2
+
+	if(M.restrained())
+		combat_modifier += 0.25
+
+	if(!(M.mobility_flags & MOBILITY_STAND) && user.mobility_flags & MOBILITY_STAND)
+		combat_modifier += 0.05
+
+	if(user.cmode && !M.cmode)
+		combat_modifier += 0.3
+	else if(!user.cmode && M.cmode)
+		combat_modifier -= 0.3
+
 	switch(user.used_intent.type)
 		if(/datum/intent/grab/upgrade)
 			if(!(M.status_flags & CANPUSH) || HAS_TRAIT(M, TRAIT_PUSHIMMUNE))
 				to_chat(user, span_warning("Can't get a grip!"))
 				return FALSE
+			user.rogfat_add(rand(7,15))
 			M.grippedby(user)
 		if(/datum/intent/grab/choke)
 			if(limb_grabbed && grab_state > 0) //this implies a carbon victim
 				if(iscarbon(M) && M != user)
+					user.rogfat_add(rand(1,3))
 					var/mob/living/carbon/C = M
 					if(get_location_accessible(C, BODY_ZONE_PRECISE_NECK))
-						if(prob(23))
+						if(prob(25))
 							C.emote("choke")
 						C.adjustOxyLoss(user.STASTR)
 					C.visible_message(span_danger("[user] [pick("chokes", "strangles")] [C]!"), \
@@ -149,12 +172,15 @@
 		if(/datum/intent/grab/twist)
 			if(limb_grabbed && grab_state > 0) //this implies a carbon victim
 				if(iscarbon(M))
+					user.rogfat_add(rand(3,8))
 					twistlimb(user)
 		if(/datum/intent/grab/twistitem)
 			if(limb_grabbed && grab_state > 0) //this implies a carbon victim
 				if(ismob(M))
+					user.rogfat_add(rand(3,8))
 					twistitemlimb(user)
 		if(/datum/intent/grab/remove)
+			user.rogfat_add(rand(3,13))
 			if(isitem(sublimb_grabbed))
 				removeembeddeditem(user)
 			else
@@ -167,43 +193,20 @@
 				if(user.loc != M.loc)
 					to_chat(user, span_warning("I must be above them."))
 					return
-				if(src == user.r_grab)
-					if(!user.l_grab || user.l_grab.grabbed != M)
-						to_chat(user, span_warning("I must grab them with both hands."))
-						return
-				if(src == user.l_grab)
-					if(!user.r_grab || user.r_grab.grabbed != M)
-						to_chat(user, span_warning("I must grab them with both hands."))
-						return
-				if(user.STASTR > M.STASTR)
-					M.visible_message(span_danger("[user] pins [M] to the ground!"), \
-									span_userdanger("[user] pins me to the ground!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
-					M.Knockdown(300)
-					M.Immobilize(300)
-					user.Immobilize(30)
-				else
-					if(prob(23))
-						M.visible_message(span_danger("[user] pins [M] to the ground briefly!"), \
-										span_userdanger("[user] pins me to the ground briefly!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
-						M.Knockdown(100)
-						M.Immobilize(100)
-						user.Immobilize(50)
-					else
-						M.visible_message(span_warning("[user] tries to pin [M]!"), \
-										span_danger("[user] tries to pin me down!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
+				user.rogfat_add(rand(1,3))
+				M.visible_message(span_danger("[user] pins [M] to the ground!"), \
+								span_userdanger("[user] pins me to the ground!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
+				M.Stun(max(((65 + (skill_diff * 10) + (user.STASTR * 5) - (M.STASTR * 5)) * combat_modifier), 20))
+				user.Immobilize(20 - skill_diff)
 			else
-				if(user.STASTR > M.STASTR)
+				user.rogfat_add(rand(5,15))
+				if(prob(clamp((((4 + (((user.STASTR - M.STASTR)/2) + skill_diff)) * 10 + rand(-5, 5)) * combat_modifier), 5, 95)))
 					M.visible_message(span_danger("[user] shoves [M] to the ground!"), \
 									span_userdanger("[user] shoves me to the ground!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
-					M.Knockdown(10)
+					M.Knockdown(max(10 + (skill_diff * 2), 1))
 				else
-					if(prob(23))
-						M.visible_message(span_danger("[user] shoves [M] to the ground!"), \
-										span_userdanger("[user] shoves me to the ground!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
-						M.Knockdown(1)
-					else
-						M.visible_message(span_warning("[user] tries to shove [M]!"), \
-										span_danger("[user] tries to shove me!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
+					M.visible_message(span_warning("[user] tries to shove [M]!"), \
+									span_danger("[user] tries to shove me!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
 
 /obj/item/grabbing/proc/twistlimb(mob/living/user) //implies limb_grabbed and sublimb are things
 	var/mob/living/carbon/C = grabbed
@@ -339,6 +342,8 @@
 	candodge = FALSE
 	canparry = FALSE
 	no_attack = TRUE
+	misscost = 2
+	releasedrain = 2
 
 /datum/intent/grab/move
 	name = "grab move"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1116,27 +1116,27 @@
 	. = TRUE
 
 	var/wrestling_diff = 0
-	var/resist_chance = 60
+	var/resist_chance = 40
 	var/mob/living/L = pulledby
+	var/combat_modifier = 1
 
 	if(mind)
 		wrestling_diff += (mind.get_skill_level(/datum/skill/combat/wrestling)) //NPCs don't use this
 	if(L.mind)
 		wrestling_diff -= (L.mind.get_skill_level(/datum/skill/combat/wrestling))
 
-	resist_chance += ((STASTR - L.STASTR) * 7)
+	if(restrained())
+		combat_modifier -= 0.25
 
-	if(!(mobility_flags & MOBILITY_STAND))
-		resist_chance -= clamp(15 - (wrestling_diff * 4), 0, 15)
+	if(!(L.mobility_flags & MOBILITY_STAND) && mobility_flags & MOBILITY_STAND)
+		combat_modifier += 0.2
 
-	if(pulledby.grab_state >= GRAB_AGGRESSIVE)
-		resist_chance -= clamp(15 - (wrestling_diff * 4), 0, 15)
+	if(cmode && !L.cmode)
+		combat_modifier += 0.3
+	else if(!cmode && L.cmode)
+		combat_modifier -= 0.3
 
-	var/minimum_roll = 40
-	if(pulledby.grab_state >= GRAB_AGGRESSIVE || !(mobility_flags & MOBILITY_STAND))
-		minimum_roll = 25
-
-	resist_chance = max(resist_chance, minimum_roll)
+	resist_chance = clamp((((4 + (((STASTR - L.STASTR)/2) + wrestling_diff)) * 10 + rand(-5, 10)) * combat_modifier), 5, 95)
 
 	if(moving_resist && client) //we resisted by trying to move
 		client.move_delay = world.time + 20


### PR DESCRIPTION
Ports https://github.com/Rotwood-Vale/Ratwood-Keep/pull/885 by @GuppyLaxx

> This PR changes the math on pretty much all grab related actions to properly use stats and skills.
> Pinning is no longer a roll, and instead an instant but lesser stunning action, meant to hold someone down while others help you, or to keep someone VERY down if you are much stronger than them.
> Grabbing can now be parried and actually uses stamina properly. The grabber uses more stamina than people resisting out of grabs.
> No more wall stuns, no more throwing up Z-levels unless they're laying down.
> A couple other changes overall!