### PR TITLE
removes masterwork items starting off polished

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/_anvil_recipe.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/_anvil_recipe.dm
@@ -143,8 +143,6 @@
 		if(BLACKSMITH_LEVEL_LEGENDARY to BLACKSMITH_LEVEL_MAX)
 			I.name = "masterwork [I.name]"
 			modifier = 1.3
-			I.polished = 4
-			I.AddComponent(/datum/component/metal_glint)
 
 	if(!modifier) // Sanity.
 		return


### PR DESCRIPTION
## About The Pull Request

removes masterwork items from starting off with insane polish

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/310c39fb-9328-4d1e-9e75-8fdc913d5482)

imagine this above image but on half the town. this shit fucking reeks. you can still polish armors with the brushes, but masterwork no longer starts off like this. im unsure of how to make masterwork armor unique and cool and fun, but this is not it
