### PR TITLE
Fixes Reach Swings

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -264,7 +264,7 @@
 
 	// Allows you to click on a box's contents, if that box is on the ground, but no deeper than that
 	if(isturf(A) || isturf(A.loc) || (A.loc && isturf(A.loc.loc)))
-		if(A.Adjacent(src))
+		if(CanReach(A) || CanReach(A, W))
 			if(isopenturf(A))
 				var/turf/T = A
 				if(used_intent.noaa)

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -58,6 +58,8 @@
 	inspec += "<br><span class='notice'><b>[name]</b> intent</span>"
 	if(desc)
 		inspec += "\n[desc]"
+	if(reach != 1)
+		inspec += "\n<b>Reach:</b> [reach]"
 	if(damfactor != 1)
 		inspec += "\n<b>Damage:</b> [damfactor]"
 	if(penfactor)


### PR DESCRIPTION
Reach weapons will correctly swing even if you're not clicking on a mob. Port from Stonekeep by the excellent @maaacha

Added weapon reach listing to intent examine. Did you know you can examine item intents with shift-click to see their stats? Well, now you know.