### PR TITLE
Flavor Text Now Required + More

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -391,11 +391,6 @@
 /obj/item/inhand_tester,
 /turf/open/floor/rogue/blocks,
 /area/rogue)
-"aR" = (
-/obj/item/roguekey/lord,
-/obj/item/roguekey/lord,
-/turf/open/floor/rogue/blocks,
-/area/rogue)
 "aS" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -673,10 +668,6 @@
 	aportalloc = "latespawn"
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue)
-"bx" = (
-/obj/item/roguekey/lord,
-/turf/open/floor/rogue/cobble,
 /area/rogue)
 "by" = (
 /obj/structure/table/wood{
@@ -1482,7 +1473,6 @@
 	},
 /obj/item/rogueweapon/flail/sflail,
 /obj/item/rogueweapon/flail/sflail,
-/obj/item/roguekey/lord,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
 "jQ" = (
@@ -1527,7 +1517,6 @@
 /obj/item/rogueweapon/greatsword,
 /obj/item/rogueweapon/greatsword,
 /obj/item/rogueweapon/greatsword,
-/obj/item/roguekey/lord,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
 "la" = (
@@ -3575,7 +3564,7 @@ vP
 vP
 vP
 vP
-aR
+hQ
 hQ
 hQ
 hQ
@@ -4228,7 +4217,7 @@ ad
 aV
 lw
 bo
-bx
+lw
 vl
 vP
 bX

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -1,3 +1,5 @@
+#define MINIMUM_FLAVOR_TEXT		200
+
 
 //Preference toggles
 #define SOUND_ADMINHELP			(1<<0)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -331,7 +331,7 @@
 	light_color = "#da8c45"
 	on_damage = 10
 	flags_1 = null
-	possible_item_intents = list(/datum/intent/hit, /datum/intent/use)
+	possible_item_intents = list(/datum/intent/use, /datum/intent/hit)
 	slot_flags = ITEM_SLOT_HIP
 	var/datum/looping_sound/torchloop/soundloop
 	max_integrity = 200

--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -70,10 +70,7 @@
 		return
 	if(G.base_type != base_type)
 		return
-	if(user)
-		if(user.get_inactive_held_item() != G && !isturf(G.loc))
-			return
-	
+
 	var/amt_to_merge = min(G.quantity, MAX_COIN_STACK_SIZE - quantity)
 	if(amt_to_merge <= 0)
 		return
@@ -131,7 +128,7 @@
 		drop_sound = 'sound/foley/coins1.ogg'
 	else
 		drop_sound = 'sound/foley/coinphy (1).ogg'
-		
+
 	if(quantity == 1)
 		name = initial(name)
 		desc = initial(desc)
@@ -165,7 +162,7 @@
 /obj/item/roguecoin/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/roguecoin))
 		var/obj/item/roguecoin/G = I
-		G.merge(src, user)
+		merge(G, user)
 		return
 	return ..()
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -10,7 +10,7 @@
 	max_integrity = 250
 	integrity_failure = 0.1
 	custom_materials = list(/datum/material/iron = 2000)
-	var/buildstacktype
+	var/buildstacktype = /obj/item/grown/log/tree/small
 	var/buildstackamount = 1
 	var/item_chair = /obj/item/chair // if null it can't be picked up
 	layer = OBJ_LAYER

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -29,7 +29,7 @@
 	var/buildstackamount = 1
 	var/framestackamount = 2
 	var/deconstruction_ready = 1
-	custom_materials = list(/datum/material/iron = 2000)
+	custom_materials = null
 	max_integrity = 100
 	integrity_failure = 0.33
 	smooth = SMOOTH_TRUE
@@ -37,6 +37,7 @@
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
 	blade_dulling = DULLING_BASHCHOP
+	debris = list(/obj/item/grown/log/tree/small = 1)
 
 /obj/structure/table/examine(mob/user)
 	. = ..()
@@ -312,10 +313,11 @@
 	max_integrity = 70
 	smooth = 0
 	climb_offset = 10
+	buildstack = /obj/item/grown/log/tree/small
 
 /obj/structure/table/wood/crafted/Initialize()
 	. = ..()
-	icon_state = pick("tablewood2", "tablewood1")
+	icon_state = "tablewood1"
 
 /obj/structure/table/wood/narsie_act(total_override = TRUE)
 	if(!total_override)
@@ -329,6 +331,7 @@
 	max_integrity = 300
 	smooth = 0
 	climb_offset = 10
+	debris = list(/obj/item/natural/stone = 1)
 
 /obj/structure/table/church/OnCrafted(dirin, user)
 	if(dirin == NORTH || dirin == SOUTH)

--- a/code/game/objects/structures/traveltile.dm
+++ b/code/game/objects/structures/traveltile.dm
@@ -83,8 +83,8 @@
 				var/atom/movable/pullingg = L.pulling
 				L.recent_travel = world.time
 				if(pullingg)
-					pullingg.forceMove(T.loc)
 					pullingg.recent_travel = world.time
+					pullingg.forceMove(T.loc)
 				L.forceMove(T.loc)
 				if(pullingg)
 					L.start_pulling(pullingg, supress_message = TRUE)
@@ -137,8 +137,8 @@
 				var/atom/movable/pullingg = L.pulling
 				L.recent_travel = world.time
 				if(pullingg)
-					pullingg.forceMove(T.loc)
 					pullingg.recent_travel = world.time
+					pullingg.forceMove(T.loc)
 				L.forceMove(T.loc)
 				if(pullingg)
 					L.start_pulling(pullingg, supress_message = TRUE)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -413,7 +413,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		log_admin("[key_name(usr)] admin ghosted.")
 		message_admins("[key_name_admin(usr)] admin ghosted.")
 		var/mob/body = mob
-//		body.invisibility = INVISIBILITY_MAXIMUM
+		body.invisibility = INVISIBILITY_MAXIMUM
 		body.density = 0
 		body.ghostize(TRUE, admin = TRUE)
 		if(body && !body.key)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -68,8 +68,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	mob.log_talk(raw_msg, LOG_OOC)
 
 	var/keyname = ckey
-	if(ckey in GLOB.anonymize)
-		keyname = get_fake_key(ckey)
+	/*if(ckey in GLOB.anonymize)
+		keyname = get_fake_key(ckey)*/
 //	if(prefs.unlock_content)
 //		if(prefs.toggles & MEMBER_PUBLIC)
 //			keyname = "<font color='[prefs.ooccolor ? prefs.ooccolor : GLOB.normal_ooc_colour]'>[icon2html('icons/member_content.dmi', world, "blag")][keyname]</font>"
@@ -167,9 +167,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	mob.log_talk(raw_msg, LOG_OOC)
 
-	var/keyname = ckey
-	if(ckey in GLOB.anonymize)
-		keyname = get_fake_key(ckey)
+	var/keyname = key
+	/*if(ckey in GLOB.anonymize)
+		keyname = get_fake_key(ckey)*/
 //	if(prefs.unlock_content)
 //		if(prefs.toggles & MEMBER_PUBLIC)
 //			keyname = "<font color='[prefs.ooccolor ? prefs.ooccolor : GLOB.normal_ooc_colour]'>[icon2html('icons/member_content.dmi', world, "blag")][keyname]</font>"

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -20,8 +20,8 @@
 				entry += " <i>(as [C.holder.fakekey])</i>"
 			if (isnewplayer(C.mob))
 				entry += " - <font color='darkgray'><b>In Lobby</b></font>"
-				if(C.ckey in GLOB.anonymize)
-					entry += " (as [get_fake_key(C.ckey)])"
+				/*if(C.ckey in GLOB.anonymize)
+					entry += " (as [get_fake_key(C.ckey)])"*/
 			else
 				if(ishuman(C.mob))
 					var/mob/living/carbon/human/H = C.mob
@@ -76,9 +76,9 @@
 //				WL = TRUE
 //			if(C.holder)
 //				continue
-			var/usedkey = C.ckey
-			if(C.ckey in GLOB.anonymize)
-				usedkey = get_fake_key(C.ckey)
+			var/usedkey = C.key
+			/*if(C.ckey in GLOB.anonymize)
+				usedkey = get_fake_key(C.ckey)*/
 /*			if(WL)
 				Lines += span_biginfo("[usedkey]")
 			else
@@ -99,7 +99,7 @@
 	set category = "Admin"
 	set name = "Adminwho"
 	set desc = "Lists all admins currently online."
-	
+
 	var/datum/admins/A = GLOB.deadmins[ckey]
 	if(!A)
 		if(!check_rights(R_ADMIN))

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -100,7 +100,7 @@
 			backl = /obj/item/rogueweapon/shield/wood
 		if("Billhook & Cudgel")
 			beltr = /obj/item/rogueweapon/mace/cudgel
-			backl = /obj/item/rogueweapon/spear/billhook
+			r_hand = /obj/item/rogueweapon/spear/billhook
 
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
 	H.verbs |= /mob/proc/haltyell

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -39,6 +39,7 @@
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/princess
 		shoes = /obj/item/clothing/shoes/roguetown/shortboots
 		pants = /obj/item/clothing/under/roguetown/tights/stockings/silk/random	//Added Silk Stockings for the female nobles
+		backr = /obj/item/storage/backpack/rogue/satchel
 	else
 		pants = /obj/item/clothing/under/roguetown/tights
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -40,13 +40,13 @@
 					shown_patreon_level = "Lord"
 			to_chat(src, span_info("Donator Level: [shown_patreon_level]"))
 		client.recent_changelog()
-
+/*
 	if(CONFIG_GET(flag/usewhitelist))
 		if(!client.whitelisted())
 			to_chat(src, span_info("You are not on the whitelist."))
 		else
 			to_chat(src, span_info("You are on the whitelist."))
-
+*/
 //	if(motd)
 //		to_chat(src, "<B>If this is your first time here,</B> <a href='byond://?src=[REF(src)];rpprompt=1'>read this lore primer.</a>", handle_whitespace=FALSE)
 
@@ -72,7 +72,7 @@
 		to_chat(src, "The game will start [postfix].")
 		if(client)
 			var/usedkey = ckey(key)
-			if(usedkey in GLOB.anonymize)
-				usedkey = get_fake_key(usedkey)
+			/*if(usedkey in GLOB.anonymize)
+				usedkey = get_fake_key(usedkey)*/
 			var/list/thinz = list("takes a seat.", "settles in.", "joins the session", "joins the table.", "becomes a player.")
 			SEND_TEXT(world, span_notice("[usedkey] [pick(thinz)]"))

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -162,6 +162,9 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			if(SSticker.job_change_locked)
 				return
 		if(SSticker.current_state <= GAME_STATE_PREGAME)
+			if(tready == PLAYER_READY_TO_PLAY && length(client.prefs.flavortext) < MINIMUM_FLAVOR_TEXT)
+				to_chat(src, span_boldwarning("You need a minimum of [MINIMUM_FLAVOR_TEXT] characters in your flavor text in order to play."))
+				return
 			if(ready != tready)
 				ready = tready
 		//if it's post initialisation and they're trying to observe we do the needful
@@ -256,6 +259,10 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 
 		if(client && client.prefs.is_active_migrant())
 			to_chat(usr, span_boldwarning("You are in the migrant queue."))
+			return
+
+		if(length(client.prefs.flavortext) < MINIMUM_FLAVOR_TEXT)
+			to_chat(usr, span_boldwarning("You need a minimum of [MINIMUM_FLAVOR_TEXT] characters in your flavor text in order to play."))
 			return
 
 		AttemptLateSpawn(href_list["SelectedJob"])

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -297,8 +297,6 @@
 		if(beltr || beltl)
 			dropItemToGround(beltr, TRUE, silent = FALSE)
 			dropItemToGround(beltl, TRUE, silent = FALSE)
-		var/obj/item/storage/S = I
-		S.emptyStorage()
 		belt = null
 		if(!QDELETED(src))
 			update_inv_belt()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1135,6 +1135,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				user.visible_message(span_warning("[user] stole [target]'s [I.name]!"),
 								span_notice("I stole [target]'s [I.name]!"), null, null, target)
 				to_chat(target, span_danger("[user] stole my [I.name]!"))*/
+		var/def_zone = check_zone(user.zone_selected)
+		var/obj/item/bodypart/affecting = target.get_bodypart(def_zone)
+		for(var/obj/item/embedded in affecting.embedded_objects)
+			target.grabbedby(user, 1, item_override = embedded)
+			return TRUE
 		target.grabbedby(user)
 		return TRUE
 

--- a/code/modules/power/roguelighting.dm
+++ b/code/modules/power/roguelighting.dm
@@ -160,12 +160,16 @@
 	var/cookonme = FALSE
 	var/crossfire = TRUE
 	var/can_damage = FALSE
+	var/start_fuel //Override for fueluse. Mostly used for smelters.
+	var/fuel_modifier = 1 //Modifier for firefuel
 
 /obj/machinery/light/rogue/Initialize()
 	if(soundloop)
 		soundloop = new soundloop(list(src), FALSE)
 		soundloop.start()
 	GLOB.fires_list += src
+	if(start_fuel)
+		fueluse = start_fuel
 	if(fueluse)
 		fueluse = fueluse - (rand(fueluse*0.1,fueluse*0.3))
 	update_icon()
@@ -296,19 +300,21 @@
 		if(initial(fueluse))
 			if(fueluse > initial(fueluse) - 5 SECONDS)
 				to_chat(user, span_warning("The fire is fully fueled."))
-				return
+				return FALSE
 		else
 			if(!on)
 				return
 		if (alert(usr, "Feed [W] to the fire?", "ROGUETOWN", "Yes", "No") != "Yes")
 			return
+		if(!W)
+			return
 		qdel(W)
 		user.visible_message(span_warning("[user] feeds [W] to [src]."))
 		if(initial(fueluse))
-			fueluse = fueluse + W.firefuel
+			fueluse = fueluse + W.firefuel*fuel_modifier
 			if(fueluse > initial(fueluse)) //keep it at the max
 				fueluse = initial(fueluse)
-		return
+		return TRUE
 	else
 		if(on)
 			if(istype(W, /obj/item/natural/dirtclod))

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -41,6 +41,13 @@
 				/obj/item/natural/fibers = 2)
 	sellprice = 30
 
+/datum/crafting_recipe/roguetown/leather/belt
+	name = "leather belt"
+	result = /obj/item/storage/belt/rogue/leather
+	reqs = list(/obj/item/natural/hide = 2,
+				/obj/item/natural/fibers = 2)
+	sellprice = 30
+
 /datum/crafting_recipe/roguetown/leather/gloves
 	name = "leather gloves"
 	result = list(/obj/item/clothing/gloves/roguetown/leather,

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -19,10 +19,10 @@
 		M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_MAXIMUM)
 	if(wCount.len > 0)
 		//some peeps dislike the church, this allows an alternative thats not a doctor or sleep.
-		M.heal_wounds(2) //at a motabalism of .5 U a tick this translates to 80WHP healing with 20 U Most wounds are unsewn 15-100. This is powerful on single wounds but rapidly weakens at multi wounds.
+		M.heal_wounds(3) //at a motabalism of .5 U a tick this translates to 120WHP healing with 20 U Most wounds are unsewn 15-100. This is powerful on single wounds but rapidly weakens at multi wounds.
 		M.update_damage_overlays()
-	M.adjustBruteLoss(-0.5*REM, 0)
-	M.adjustFireLoss(-0.5*REM, 0)
+	M.adjustBruteLoss(-1*REM, 0)
+	M.adjustFireLoss(-1*REM, 0)
 	M.adjustOxyLoss(-1, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1*REM)
 	M.adjustCloneLoss(-1*REM, 0)

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -248,11 +248,11 @@
 	var/atom/current_parent = parent
 	if(istype(current_parent.loc,/turf) || istype(current_parent.loc, /mob/living))
 		if(prob(25))
-			new /obj/effect/temp_visual/armor_glint(parent)
+			new /obj/effect/temp_visual/armor_glint(current_parent.loc)
 		if(prob(15))
-			new /obj/effect/temp_visual/armor_glint(parent, 2)
+			new /obj/effect/temp_visual/armor_glint(current_parent.loc, 2)
 		if(prob(5))
-			new /obj/effect/temp_visual/armor_glint(parent, 3)
+			new /obj/effect/temp_visual/armor_glint(current_parent.loc, 3)
 
 /datum/component/metal_glint/proc/stop_process()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -18,7 +18,9 @@
 	var/maxore = 1
 	var/cooking = 0
 	var/actively_smelting = FALSE // Are we currently smelting?
-	fueluse = 5 MINUTES
+	fueluse = 30 MINUTES
+	start_fuel = 5 MINUTES
+	fuel_modifier = 0.33
 	crossfire = FALSE
 
 /obj/machinery/light/rogue/smelter/attackby(obj/item/W, mob/living/user, params)
@@ -48,8 +50,9 @@
 			to_chat(user, span_warning("\The [src] is currently smelting. Wait for it to finish, or douse it with water to retrieve items from it."))
 			return
 
-	if(istype(W, /obj/item/rogueore/coal) && fueluse <= 0)
-		return ..()
+	if(W.firefuel)
+		if (..())
+			return
 	if(W.smeltresult)
 		if(ore.len < maxore)
 			user.dropItemToGround(W)
@@ -145,7 +148,6 @@
 	anchored = TRUE
 	density = TRUE
 	maxore = 4
-	fueluse = 5 MINUTES
 	climbable = FALSE
 
 /obj/machinery/light/rogue/smelter/great/process()

--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -55,7 +55,7 @@
 	name = "coal"
 	desc = "Dark lumps that become smoldering embers later in life."
 	icon_state = "orecoal1"
-	firefuel = 60 MINUTES
+	firefuel = 30 MINUTES
 	smeltresult = /obj/item/rogueore/coal
 	sellprice = 1
 

--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -17,6 +17,7 @@
 	var/scom_number
 	var/obj/structure/roguemachine/scomm/calling = null
 	var/obj/structure/roguemachine/scomm/called_by = null
+	var/spawned_rat = FALSE
 
 /obj/structure/roguemachine/scomm/OnCrafted(dirin, mob/user)
 	. = ..()
@@ -244,6 +245,14 @@
 			if(calling.calling == src)
 				calling.repeat_message(raw_message, src, usedcolor, message_language)
 			return
+		if(length(raw_message) > 100) //When these people talk too much, put that shit in slow motion, yeah
+			if(length(raw_message) > 200)
+				if(!spawned_rat)
+					visible_message(span_warning("An angered rous emerges from the SCOMlines!"))
+					new /mob/living/simple_animal/hostile/retaliate/rogue/bigrat(get_turf(src))
+					spawned_rat = TRUE
+				return
+			raw_message = "<small>[raw_message]</small>"
 		for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
 			if(!S.calling)
 				S.repeat_message(raw_message, src, usedcolor, message_language)
@@ -298,16 +307,22 @@
 	var/speaking = TRUE
 	sellprice = 100
 //wip
-/obj/item/scomstone/attack_right(mob/user)
+/obj/item/scomstone/attack_right(mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(input_text)
+		var/usedcolor = user.voice_color
+		if(user.voicecolor_override)
+			usedcolor = user.voicecolor_override
+		user.whisper(input_text)
+		if(length(input_text) > 100) //When these people talk too much, put that shit in slow motion, yeah
+			input_text = "<small>[input_text]</small>"
 		for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
-			S.repeat_message(input_text)
+			S.repeat_message(input_text, src, usedcolor)
 		for(var/obj/item/scomstone/S in SSroguemachine.scomm_machines)
-			S.repeat_message(input_text)
+			S.repeat_message(input_text, src, usedcolor)
 		for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)//make the listenstone hear scomstone
-			S.repeat_message(input_text)
+			S.repeat_message(input_text, src, usedcolor)
 
 /obj/item/scomstone/MiddleClick(mob/user)
 	if(.)

--- a/modular/Neu_Food/code/raw/NeuFood_meat.dm
+++ b/modular/Neu_Food/code/raw/NeuFood_meat.dm
@@ -87,9 +87,13 @@
 
 /*	.............   Pork, spidermeat, birdmeat   ................ */
 /obj/item/reagent_containers/food/snacks/rogue/meat/fatty //pork
-	slices_num = 4
+	name = "raw pigflesh"
+	icon_state = "meatcutlet"
+	color = "#f093c3"
+	slices_num = 2
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/meat/bacon
 	chopping_sound = TRUE
+	become_rot_type = /obj/item/reagent_containers/food/snacks/rotten/bacon
 
 /obj/item/reagent_containers/food/snacks/rogue/meat/bacon
 	name = "raw bacon"
@@ -99,6 +103,7 @@
 	fried_type = /obj/item/reagent_containers/food/snacks/rogue/meat/bacon/fried
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/meat/bacon/fried
 	filling_color = "#8a0000"
+	become_rot_type = /obj/item/reagent_containers/food/snacks/rotten/bacon
 
 
 /obj/item/reagent_containers/food/snacks/rogue/meat/spider // Low-nutrient, kind of gross. Survival food.

--- a/modular/Neu_Food/code/raw/NeuFood_meat.dm
+++ b/modular/Neu_Food/code/raw/NeuFood_meat.dm
@@ -93,7 +93,6 @@
 	slices_num = 2
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/meat/bacon
 	chopping_sound = TRUE
-	become_rot_type = /obj/item/reagent_containers/food/snacks/rotten/bacon
 
 /obj/item/reagent_containers/food/snacks/rogue/meat/bacon
 	name = "raw bacon"
@@ -103,7 +102,6 @@
 	fried_type = /obj/item/reagent_containers/food/snacks/rogue/meat/bacon/fried
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/meat/bacon/fried
 	filling_color = "#8a0000"
-	become_rot_type = /obj/item/reagent_containers/food/snacks/rotten/bacon
 
 
 /obj/item/reagent_containers/food/snacks/rogue/meat/spider // Low-nutrient, kind of gross. Survival food.

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -128,6 +128,18 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Fishnet Stockings"
 	path = /obj/item/clothing/under/roguetown/tights/stockings/fishnet
 
+/datum/loadout_item/spectacles
+	name = "Spectacles"
+	path = /obj/item/clothing/mask/rogue/spectacles
+
+/datum/loadout_item/ragmask
+	name = "Rag Mask"
+	path = /obj/item/clothing/mask/rogue/ragmask
+
+/datum/loadout_item/halfmask
+	name = "Halfmask"
+	path = /obj/item/clothing/mask/rogue/shepherd
+
 /datum/loadout_item/feather
 	name = "Feather"
 	path = /obj/item/natural/feather


### PR DESCRIPTION
You now require a minimum of 200 characters in your flavour text in order to join the game.

Grabbing a limb will grab any embedded item in it.

Adds spectacles, halfmasks, and rag masks to the loadout.

Talking too much on a SCOM will make your speech smaller. If you REALLY talk too much, the rats will have something to say in response.

You can fill up smelters with fuel up to 30 minutes. One coal is 10 minutes.

Health potion healing doubled for raw damage, increased by 50% for wound healing.

Default intent for torches is now use.

You can merge coins in bags. Merging coins will transfer coins from your hand to the target stack instead of the other way around.

Crafting wooden tables will always make the "nice" type.

Using a travel tile with a grabbed target will correctly teleport the both of you.

Admins aghosting will be invisible once again.

Whom and OOC will always display the keys of the player. Roundend character list will still be anonymized if you have it toggled on.

Manor guards will correctly get their billhook.

Princesses get a satchel.

Leather belts now craftable. 2 hide, 2 fibres.

Items in belts will no longer be dropped when it is taken off. Will fix the issue with keys dropping out when using far-travels.