### PR TITLE
[PORT] Add support for the Auxtools Debugger

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,0 +1,4 @@
+environment = "roguetown.dme"
+
+[debugger]
+engine = "auxtools"

--- a/code/__HELPERS/_auxtools_api.dm
+++ b/code/__HELPERS/_auxtools_api.dm
@@ -1,0 +1,11 @@
+//This is for the auxtools debugger
+
+/proc/auxtools_stack_trace(msg)
+	CRASH(msg)
+
+//The auxtools debugger replaces these at runtime, i. e. the bodies of these procs will be replaced by auxtools, they simply need to be defined.
+/proc/auxtools_expr_stub()
+	CRASH("auxtools not loaded")
+
+/proc/enable_debugging(mode, port)
+	CRASH("auxtools not loaded")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -2,6 +2,22 @@
 
 GLOBAL_VAR(restart_counter)
 
+//This runs before most anything else, for more info see:
+//https://github.com/Cyberboss/tgstation/blob/1afa69d66adfc810ab68c45a4fa5985c780ba6ff/code/game/world.dm#L10
+//But note that not all of this necessarily applies to us(particularly proccalls)
+
+/world/proc/Genesis(tracy_initialized = FALSE)
+	#ifdef USE_BYOND_TRACY
+	#warn USE_BYOND_TRACY is enabled
+	if(!tracy_initialized)
+		init_byond_tracy()
+		Genesis(tracy_initialized = TRUE)
+		return
+	#endif
+
+	init_debugger()
+	//Zirok was here
+
 /**
   * World creation
   *
@@ -445,3 +461,32 @@ GLOBAL_VAR(restart_counter)
 
 /world/proc/on_tickrate_change()
 	SStimer?.reset_buckets()
+
+/world/proc/init_byond_tracy()
+	var/library
+
+	switch (system_type)
+		if (MS_WINDOWS)
+			library = "prof.dll"
+		if (UNIX)
+			library = "libprof.so"
+		else
+			CRASH("Unsupported platform: [system_type]")
+
+	var/init_result = call_ext(library, "init")("block")
+	if (init_result != "0")
+		//para_tracy returns the filename on succesful init so this always runtimes, lol
+		CRASH("Error initializing byond-tracy: [init_result]")
+
+/world/proc/init_debugger()
+	var/dll = GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (dll)
+		call_ext(dll, "auxtools_init")()
+		enable_debugging()
+
+/world/Del()
+	var/dll = GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (dll)
+		call_ext(dll, "auxtools_shutdown")()
+	
+	. = ..()

--- a/modular/ze_genesis_call/genesis_call.dm
+++ b/modular/ze_genesis_call/genesis_call.dm
@@ -1,0 +1,19 @@
+//Shamelessly stolen from https://github.com/tgstation/tgstation/pull/74808 by Dominion
+
+/*
+ * BYOND loves to tell you about its loving spouse /global
+ * But it's actually having a sexy an affair with /static
+ * Specifically statics in procs
+ * Priority is given to these lines of code in REVERSE order of declaration in the .dme
+ * Which is why this file has a funky name
+ * So this is what we use to call world.Genesis()
+ * It's a nameless, no-op function, because it does absolutely nothing
+ * It exists to hold a static var which is initialized to null
+ * It's on /world to hide it from reflection
+ * Painful right? Good, now you share my suffering
+ * Please lock the door on your way out
+ */
+
+//I've put this in (repo_root)/modular rather than somewhere in code/ so that it's at the very end of the dme- if you remove modular/ just make sure this stays at the bottom of the DME
+/world/proc/_()
+	var/static/_ = world.Genesis()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -136,6 +136,7 @@
 #include "code\__DEFINES\dcs\signals_atom_lighting.dm"
 #include "code\__DEFINES\roguetown\rebel.dm"
 #include "code\__DEFINES\roguetown\werewolf.dm"
+#include "code\__HELPERS\_auxtools_api.dm"
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_logging.dm"
 #include "code\__HELPERS\_string_lists.dm"
@@ -3565,4 +3566,5 @@
 #include "modular_hearthstone\code\modules\mob\living\simple_animal\rogue\simple_skeleton.dm"
 #include "modular_hearthstone\code\modules\reagents\reagent_containers\lux.dm"
 #include "modular_hearthstone\code\modules\spells\roguetown\wizard.dm"
+#include "modular\ze_genesis_call\genesis_call.dm"
 // END_INCLUDE


### PR DESCRIPTION
Ports https://github.com/Rotwood-Vale/Ratwood-Keep/pull/936 by @Cyprex

> This PR adds support for the auxtools debugger. All that a user needs to do is have the DM Langserver client extension installed(which comes with the recommended extensions) and run with debugging.
> 
> A reference I used a lot in making this: https://github.com/SpaceManiac/SpacemanDMM/wiki/Setting-up-Debugging
> 
> I've elected to add /world/Genesis() to enable debugging as soon as possible, which allows debugging early init. This is taken directly from tg.
> 
> A note on SpacemanDMM: I've only enabled the debugger here. We should enable the (local on the users PC, NOT on github!) linter part of it too, but that first requires dealing with a ton of linter issues, largely from old tgcode.
> Documentation for its config: https://github.com/SpaceManiac/SpacemanDMM/blob/master/CONFIGURING.md
> 
> There is one thing that needs addressing either before or shortly after this is merged- and that is explaining coders why their game suddenly froze(The debugger defaults to breaking execution on runtimes).