### PR TITLE
Farm key added to soilbride spawn

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -54,6 +54,7 @@
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		belt = /obj/item/storage/belt/rogue/leather/rope
+		beltl = /obj/item/roguekey/farm
 	else
 		head = /obj/item/clothing/head/roguetown/roguehood/random
 		if(prob(50))


### PR DESCRIPTION
## About The Pull Request
Adds farm key to fem soiler loadout because I forgot loadouts are gendered.

## Why It's Good For The Game
Can't get inside the farm without it.