### PR TITLE
Wooo descriptions!

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -1,5 +1,5 @@
 /datum/job/roguetown/captain
-	title = "Guard Captain"
+	title = "Knight Captain"
 	flag = GUARD_CAPTAIN
 	department_flag = NOBLEMEN
 	faction = "Station"

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -1,5 +1,5 @@
 /datum/job/roguetown/knight
-	title = "Royal Guard"		//Knights, but their role is far more clear this way.
+	title = "Knight"		//Knights, but their role is far more clear this way.
 	flag = KNIGHT
 	department_flag = NOBLEMEN
 	faction = "Station"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -18,7 +18,8 @@
 	leads the race towards technological advacement as they continue \
 	to improve their craft through powerful mechanization and forging \
 	Dwarves are hearty, but are not known for their speed or eyesight... \
-	Each dwarf hails from a ancient fortress named after the most plentiful mineral."
+	Each dwarf hails from a ancient fortress named after the most plentiful mineral. \
+	+1 Constitution."
 
 	skin_tone_wording = "Dwarf Fortress"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -11,7 +11,8 @@
     Their culture and entire lives normally involve serving the evil gods of the inhumen pantheon. \
     Previously rare but in recent times, more and more dark elfs can be seen on the surface. \
     The ones who aren't overtly cruel and bloodthirsty, tend to flee to the surface lest they get culled by their own society, \
-    while some more sinister ones abandon their cities in search of new and greater power."
+    while some more sinister ones abandon their cities in search of new and greater power. \
+	+1 Perception"
 
 /*
 	Former RT Desc: These guys were undead which doesn't really fit considering now you have a ton of them walking around.

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -15,7 +15,8 @@
 	many humans and elves from forming relationships, which are capable of producing child.\
 	Elves are known for their intelligence and sharp eyes, but their graceful nature does \
 	not lend itself to the concepts of strength or durability... \
-	There are elves from a small smattering of tribes in these parts."
+	There are elves from a small smattering of tribes in these parts.\
+	+1 Speed, -1 Constitution."
 
 	skin_tone_wording = "Tribal Identity"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -11,7 +11,8 @@
 	the opposite is true. Humen come from a vast swathe of cultures and ethnicity, most of which\
 	have historically been at odds with one another. Being the eldest of the weeping God, humen\
 	tend to find fortune easier than the other races, and are so diverse that no other racial trait\
-	are dominant in their species..."
+	are dominant in their species... \
+	+1 Intelligence."
 
 	skin_tone_wording = "Ancestry"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -12,7 +12,8 @@
 	They have strangely colored skin and are more physically frail than the average Human. \
 	Because of their upbringing, they make for natural conduits for godly powers. \
 	Azure Peak's populace holds them with a mixture of uneasy fear or, and respect. \
-	It is also widely believed that an Aasimars death is a bad omen..."
+	It is also widely believed that an Aasimars death is a bad omen... \
+	+1 Fortune, -1 Perception."
 
 	skin_tone_wording = "Craft"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -13,7 +13,8 @@
 	and it is widely considered that Half-Elf culture is simply a melting pot of \
 	various other cultures condensing into one vibrant entity. \
 	Due to their heritage, Half-Elves tend to gain racial traits depending on how strong their fathers, or mothers, genes were. \
-	Half-Elves also typically try to find identity in one of two regions they have similarities towards."
+	Half-Elves also typically try to find identity in one of two regions they have similarities towards. \
+	+1 Perception." 
 
 	skin_tone_wording = "Identity"
 	default_color = "FFFFFF"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -12,7 +12,8 @@
 	being born in these rough places otherwise devoid of a fairer sex. Your mother-clan is in thrall \
 	to the Ironmask, true orcs would kill you as a mongrel dog and your father’s people cannot decide \
 	between mere distrust and disgust. Yet somehow your wandering feet came to Azure Peak, where \
-	half-orcs ply muscle and their hardiness in the rough underbelly or outer reaches of society."
+	half-orcs ply muscle and their hardiness in the rough underbelly or outer reaches of society. \
+	+1 Strength, -1 Intelligence."
 
 	skin_tone_wording = "Clan"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -15,7 +15,8 @@
 	and leading to most seeking a solitary life outside the watchful eyes of others. \
 	Tiefling cannot reproduce with mortals, and so no half-breed exists. \
 	Tiefling tend to be extremely perceptive and paranoid, as luck is rarely on their side \
-	and their unique biology makes them extremely susceptible to injury."
+	and their unique biology makes them extremely susceptible to injury. \
+	+1 Intelligence."
 
 	skin_tone_wording = "Progenitor"
 


### PR DESCRIPTION
Adds racial stats to their descriptions for clarity
Changes knights back to actually being knights. I understand the original premise but this is a little silly. They are knights, everyone knows them as knights, people roleplay them as knights and they have squires. If there's a player issue, that should be seen to IMO rather than using an inaccurate word that may just confuse new players.
