### PR TITLE
Clarifies bone setting text & tent door fix

### DIFF
--- a/code/game/objects/structures/roguetent.dm
+++ b/code/game/objects/structures/roguetent.dm
@@ -7,7 +7,7 @@
 	layer = TABLE_LAYER
 	density = TRUE
 	anchored = TRUE
-	opacity = FALSE
+	opacity = TRUE
 	max_integrity = 100
 	var/base_state = "tent_door"
 	blade_dulling = DULLING_BASHCHOP

--- a/code/modules/surgery/surgeries/fracture.dm
+++ b/code/modules/surgery/surgeries/fracture.dm
@@ -49,7 +49,7 @@
 	return TRUE
 
 /datum/surgery_step/set_bone/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	display_results(user, target, span_notice("I successfully set the bone in [target]'s [parse_zone(target_zone)]."),
+	display_results(user, target, span_notice("I successfully set the bone in [target]'s [parse_zone(target_zone)], they'll need to rest to fully heal now."),
 		span_notice("[user] successfully sets the bone in [target]'s [parse_zone(target_zone)]!"),
 		span_notice("[user] successfully sets the bone in [target]'s [parse_zone(target_zone)]!"))
 	var/obj/item/bodypart/bodypart = target.get_bodypart(check_zone(target_zone))


### PR DESCRIPTION
Clarifies the text for setting bones that it isn't an immediate heal and the patient will need to rest/sleep for it to fully heal since it's not widely known among healers.

Also sets tent doors to be opaque when initializing since they start out closed and thus should block vision.