### PR TITLE
Locks heir bedrooms behind new key

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -1413,7 +1413,7 @@
 "kSm" = (/obj/machinery/light/rogue/firebowl/standing/blue,/turf/open/floor/rogue/hexstone,/area/rogue/indoors/town/bath)
 "kSx" = (/obj/structure/table/wood{dir = 5; icon_state = "largetable"},/obj/item/rogueweapon/huntingknife/cleaver,/turf/open/floor/rogue/cobble,/area/rogue/indoors/town/garrison)
 "kSP" = (/obj/structure/rack/rogue/shelf/big,/obj/item/clothing/suit/roguetown/shirt/robe/eora{pixel_y = 8},/obj/item/clothing/suit/roguetown/shirt/robe/eora{pixel_y = 8},/turf/open/floor/rogue/cobble,/area/rogue/indoors/town/church/chapel)
-"kTg" = (/obj/structure/mineral_door/wood{icon_state = "wcv"; locked = 1; lockid = "manor"},/turf/open/floor/rogue/ruinedwood{icon_state = "weird1"},/area/rogue/indoors/town/manor)
+"kTg" = (/obj/structure/mineral_door/wood{icon_state = "wcv"; locked = 1; lockid = "heir"},/turf/open/floor/rogue/ruinedwood{icon_state = "weird1"},/area/rogue/indoors/town/manor)
 "kTh" = (/obj/structure/mineral_door/wood/deadbolt{dir = 1},/turf/open/floor/rogue/twig,/area/rogue/outdoors/rtfield)
 "kTz" = (/obj/effect/landmark/start/orphan,/turf/open/floor/rogue/dirt/road,/area/rogue/outdoors/rtfield)
 "kTB" = (/obj/machinery/light/rogue/wallfire/candle,/turf/open/floor/rogue/ruinedwood{icon_state = "weird1"},/area/rogue/indoors/town/garrison)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -300,3 +300,6 @@
 
 /obj/item/storage/keyring/lord
 	keys = list(/obj/item/roguekey/hand, /obj/item/roguekey/steward, /obj/item/roguekey/tavern, /obj/item/roguekey/church, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard, /obj/item/roguekey/royal)
+
+/obj/item/storage/keyring/heir
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/heir)

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -82,6 +82,12 @@
 	icon_state = "mazekey"
 	lockid = "manor"
 
+/obj/item/roguekey/heir
+	name = "heir room key"
+	desc = "A highly coveted key belonging to the doors of the heirs of this monarchy."
+	icon_state = "hornkey"
+	lockid = "heir"
+
 /obj/item/roguekey/garrison
 	name = "town watch key"
 	desc = "This key belongs to the town guards."

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -31,7 +31,7 @@
 /datum/outfit/job/roguetown/prince/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.pronouns == SHE_HER && H.gender == FEMALE)
-		beltl = /obj/item/roguekey/manor
+		beltl = /obj/item/storage/keyring/heir
 		head = /obj/item/clothing/head/roguetown/hennin
 		neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 		belt = /obj/item/storage/belt/rogue/leather/cloth/lady
@@ -46,7 +46,7 @@
 		armor = /obj/item/clothing/suit/roguetown/armor/chainmail
 		shoes = /obj/item/clothing/shoes/roguetown/shortboots
 		belt = /obj/item/storage/belt/rogue/leather
-		beltl = /obj/item/roguekey/manor
+		beltl = /obj/item/storage/keyring/heir
 		beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 		backr = /obj/item/storage/backpack/rogue/satchel
 	if(H.mind)


### PR DESCRIPTION
## About The Pull Request
Heir bedrooms were locked to the "manor" lockid, now they're locked to the "heir" lockid which corresponds to the new heir room key. Only heirs spawn with the key alongside their usual manor key, thus they get a keyring now.

## Why It's Good For The Game
Knights and courtiers should probably stop using the heir beds to sleep in because they're too lazy to find their own beds. Isn't that kind of weird? Anyways, heirs get up to weird highjinks all the time so enabling them [a layer of privacy](https://youtu.be/-mTZbuUMNwY) just fits imo.