### PR TITLE
Tiny Monk Rebalance

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/monk.dm
@@ -38,7 +38,7 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 		H.change_stat("strength", 3)
-		H.change_stat("constitution", 1)
+		H.change_stat("endurance", 1)
 		H.change_stat("speed", 2)
 		H.change_stat("perception", -1)
 		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Extremely small balance patch - gives monks, a dodge based class, a point of END at the cost of their point of CON. Made at the request of our dear monk main, Saxobeet.

## Why It's Good For The Game

~~bloats my ROGUEDEV level so valx stops making fun of me~~ Monk's primary means of defense is dodging, which uses stamina, however they have no bonus to endurance so they can run out of stamina quite fast. Constitution, on the other hand, isn't incredibly useful or flavorful for them. 
