### PR TITLE
Weapons/Armor crafts reduced back to 1 per craft

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -13,14 +13,14 @@
 	name = "Chain Coif"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/iron
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/gorget
-	name = "Gorget x2"
+	name = "Gorget"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/neck/roguetown/gorget
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/ibreastplate
@@ -30,10 +30,10 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
 
 /datum/anvil_recipe/armor/ichainglove
-	name = "Chain Gauntlets x2"
+	name = "Chain Gauntlets"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/gloves/roguetown/chain/iron
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/ichainleg
@@ -43,24 +43,24 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/platemask
-	name = "Mask x2"
+	name = "Iron Mask"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/mask/rogue/facemask
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/wildguard
-	name = "Wildguard Mask x2"
+	name = "Wild guard Mask"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/mask/rogue/wildguard
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/ironboot
-	name = "Plated Boots x2"
+	name = "Plated Boots"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/shoes/roguetown/boots/armor/iron
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/skullcap
@@ -158,10 +158,10 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/chaincoif
-	name = "Chain Coif x2"
+	name = "Chain Coif"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/fchaincoif
@@ -171,17 +171,17 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/chainglove
-	name = "Chain Gauntlets x2"
+	name = "Chain Gauntlets"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/gloves/roguetown/chain
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/plateglove
-	name = "Plate Gauntlets x2"
+	name = "Plate Gauntlets"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/gloves/roguetown/plate
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/chainleg
@@ -229,10 +229,10 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/platebracer
-	name = "Plate Bracers x2"
+	name = "Plate Bracers"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/wrists/roguetown/bracers
-	createditem_num = 2
+	createditem_num = 1
 
 /datum/anvil_recipe/armor/helmetnasal
 	name = "Nasal Helmet"
@@ -259,7 +259,7 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/bervor
-	name = "Bervor"
+	name = "Bevor"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/neck/roguetown/bevor
 	craftdiff = 2
@@ -319,17 +319,17 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/plateboot
-	name = "Plated Boots x2"
+	name = "Plated Boots"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/shoes/roguetown/boots/armor
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/platemask/steel
-	name = "Mask x2"
+	name = "Steel Mask"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/mask/rogue/facemask/steel
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/astratahelm

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
@@ -115,10 +115,10 @@
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/lamptern
-	name = "Lamptern x2"
+	name = "Lamptern x3"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/flashlight/flare/torch/lantern
-	createditem_num = 2
+	createditem_num = 3
 
 /datum/anvil_recipe/tools/cups
 	name = "Cups x3"

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -23,17 +23,17 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/idagger
-	name = "Dagger x2"
+	name = "Dagger"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/huntingknife/idagger
-	createditem_num = 2
+	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/sdagger
-	name = "Dagger x2"
+	name = "Dagger"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/huntingknife/idagger/steel
-	createditem_num = 2
+	createditem_num = 1
 
 /datum/anvil_recipe/weapons/sdaggerparrying
 	name = "Parrying Dagger (+1 Steel)"
@@ -96,10 +96,10 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/hknife
-	name = "Hunting knife x2"
+	name = "Hunting knife"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/huntingknife
-	createditem_num = 2
+	createditem_num = 1
 
 /datum/anvil_recipe/weapons/cleaver
 	name = "Cleaver"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Reduces the amount of items armor and weapon recipes craft back down to one to remove metal bar duplication exploit.

Also increases Lampterns created in a recipe from 2 up to 3, to match similar unsmeltable utilities.

## Why It's Good For The Game

This PR is necessary to avoid a critical metal bar duplication exploit with smelting down excess gear.

I am also, however, against re-adding multiple weapons/armor per craft as it devalues the role of smithing, when we already lack things to do once people get their gear made in a round already.

While this does leave long lines where they are, to put it into the perspective of the smith: We do a lot of standing around. Those lines are the only time we really have much to do. If we are able to churn out items and everyone is geared, what left is there for smiths to do except stand around? The answer is not a lot, and even before this change, smiths did a LOT of standing around waiting for more tasks.

If Legendary Smithing is worked on to provide a late game to smiths to avoid idleness, and if the duplication bug is address, this can be re-added.

But as of now, the precious little work we Smith Mains get to do should not be cut down to virtually nothing for no other reason than to make it so people can get all their gear as quick and cheap as possible.


However, I do agree that lampterns, as a utility (and a nonsmeltable one, at that), should be more accessible and cheaper. And thus, I increased the amount made per bar up to 3, so lampterns should be quick and cheap to obtain early on.
