### PR TITLE
Silver Weapon Refactor

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -404,6 +404,42 @@
 	return "body"
 
 /obj/item/proc/funny_attack_effects(mob/living/target, mob/living/user, nodmg)
+	if(is_silver)
+		if(world.time < src.last_used + 120)
+			to_chat(user, span_notice("The silver effect is on cooldown."))
+			return
+
+		if(ishuman(target) && target.mind)
+			var/mob/living/carbon/human/s_user = user
+			var/mob/living/carbon/human/H = target
+			var/datum/antagonist/werewolf/W = H.mind.has_antag_datum(/datum/antagonist/werewolf/)
+			var/datum/antagonist/vampirelord/lesser/V = H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser)
+			var/datum/antagonist/vampirelord/V_lord = H.mind.has_antag_datum(/datum/antagonist/vampirelord/)
+			if(V)
+				if(V.disguised)
+					H.visible_message("<font color='white'>The silver weapon weakens the curse temporarily!</font>")
+					to_chat(H, span_userdanger("I'm hit by my BANE!"))
+					H.apply_status_effect(/datum/status_effect/debuff/silver_curse)
+					src.last_used = world.time
+				else
+					H.visible_message("<font color='white'>The silver weapon weakens the curse temporarily!</font>")
+					to_chat(H, span_userdanger("I'm hit by my BANE!"))
+					H.apply_status_effect(/datum/status_effect/debuff/silver_curse)
+					src.last_used = world.time
+			if(V_lord)
+				if(V_lord.vamplevel < 4 && !V)
+					H.visible_message("<font color='white'>The silver weapon weakens the curse temporarily!</font>")
+					to_chat(H, span_userdanger("I'm hit by my BANE!"))
+					H.apply_status_effect(/datum/status_effect/debuff/silver_curse)
+					src.last_used = world.time
+				if(V_lord.vamplevel == 4 && !V)
+					to_chat(s_user, "<font color='red'> The silver weapon fails!</font>")
+					H.visible_message(H, span_userdanger("This feeble metal can't hurt me, I AM ANCIENT!"))
+			if(W && W.transformed == TRUE)
+				H.visible_message("<font color='white'>The silver weapon weakens the curse temporarily!</font>")
+				to_chat(H, span_userdanger("I'm hit by my BANE!"))
+				H.apply_status_effect(/datum/status_effect/debuff/silver_curse)
+				src.last_used = world.time
 	return
 
 /mob/living/attacked_by(obj/item/I, mob/living/user)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -201,7 +201,7 @@
 	if(!nodmg)
 		playsound(src, "smallslash", 100, TRUE, -1)
 		if(ishuman(src) && user.mind)
-			if(istype(H.dna.species, /datum/species/werewolf))
+			if(istype(user.dna.species, /datum/species/werewolf))
 				caused_wound?.werewolf_infect_attempt()
 				if(prob(30))
 					user.werewolf_feed(src, 10)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -201,7 +201,7 @@
 	if(!nodmg)
 		playsound(src, "smallslash", 100, TRUE, -1)
 		if(ishuman(src) && user.mind)
-			if(user.mind.has_antag_datum(/datum/antagonist/werewolf))
+			if(istype(H.dna.species, /datum/species/werewolf))
 				caused_wound?.werewolf_infect_attempt()
 				if(prob(30))
 					user.werewolf_feed(src, 10)

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -41,7 +41,8 @@
 /datum/status_effect/debuff/silver_curse
 	id = "silver_curse"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/silver_curse
-	duration = 5 SECONDS
+	effectedstats = list("strength" = -2,"perception" = -2, "constitution" = -2, "endurance" = -2,"speed" = -2)
+	duration = 45 SECONDS
 
 /atom/movable/screen/alert/status_effect/debuff/silver_curse
 	name = "Silver Curse"

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -41,7 +41,7 @@
 /datum/status_effect/debuff/silver_curse
 	id = "silver_curse"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/silver_curse
-	effectedstats = list("strength" = -2,"perception" = -2,"intelligence" = -2 "constitution" = -2, "endurance" = -2,"speed" = -2)
+	effectedstats = list("strength" = -2,"perception" = -2,"intelligence" = -2, "constitution" = -2, "endurance" = -2,"speed" = -2)
 	duration = 45 SECONDS
 
 /atom/movable/screen/alert/status_effect/debuff/silver_curse

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -41,7 +41,7 @@
 /datum/status_effect/debuff/silver_curse
 	id = "silver_curse"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/silver_curse
-	effectedstats = list("strength" = -2,"perception" = -2, "constitution" = -2, "endurance" = -2,"speed" = -2)
+	effectedstats = list("strength" = -2,"perception" = -2,"intelligence" = -2 "constitution" = -2, "endurance" = -2,"speed" = -2)
 	duration = 45 SECONDS
 
 /atom/movable/screen/alert/status_effect/debuff/silver_curse

--- a/code/game/objects/inhands_rogue.dm
+++ b/code/game/objects/inhands_rogue.dm
@@ -5,6 +5,7 @@
 	var/force_reupdate_inhand = TRUE
 	var/smelted = FALSE // Sanity for smelteries to avoid runtimes, if this is a bar smelted through ore for exp gain
 	var/is_silver = FALSE
+	var/last_used = 0
 //#else
 //	var/force_reupdate_inhand = FALSE
 //#endif

--- a/code/game/objects/inhands_rogue.dm
+++ b/code/game/objects/inhands_rogue.dm
@@ -4,6 +4,7 @@
 //#ifdef TESTSERVER
 	var/force_reupdate_inhand = TRUE
 	var/smelted = FALSE // Sanity for smelteries to avoid runtimes, if this is a bar smelted through ore for exp gain
+	var/is_silver = FALSE
 //#else
 //	var/force_reupdate_inhand = FALSE
 //#endif

--- a/code/game/objects/items/rogueitems/cup.dm
+++ b/code/game/objects/items/rogueitems/cup.dm
@@ -48,7 +48,7 @@
 	desc = "A silver goblet, its surface adorned with intricate carvings and runes."
 	icon_state = "silver"
 	sellprice = 30
-	var/last_used = 0
+	last_used = 0
 	is_silver = TRUE
 
 /obj/item/reagent_containers/glass/cup/silver/pickup(mob/user)

--- a/code/game/objects/items/rogueitems/cup.dm
+++ b/code/game/objects/items/rogueitems/cup.dm
@@ -49,33 +49,7 @@
 	icon_state = "silver"
 	sellprice = 30
 	var/last_used = 0
-
-/obj/item/reagent_containers/glass/cup/silver/funny_attack_effects(mob/living/target, mob/living/user = usr, nodmg)
-	if(world.time < src.last_used + 120)
-		to_chat(user, span_notice("The silver effect is on cooldown."))
-		return
-
-	. = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(H.dna && H.dna.species)
-			if(istype(H.dna.species, /datum/species/werewolf))
-				H.Paralyze(10)
-				H.Stun(10)
-				H.adjustFireLoss(10)
-				H.fire_act(1,10)
-				to_chat(H, span_userdanger("I'm bonked by my BANE!"))
-				src.last_used = world.time
-	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/vampirelord))
-		var/datum/antagonist/vampirelord/VD = target.mind.has_antag_datum(/datum/antagonist/vampirelord)
-		var/mob/living/carbon/human/H = target
-		if(!VD.disguised)
-			H.Paralyze(10)
-			H.Stun(10)
-			H.adjustFireLoss(10)
-			H.fire_act(1,10)
-			to_chat(H, span_userdanger("I'm bonked by my BANE!"))
-			src.last_used = world.time
+	is_silver = TRUE
 
 /obj/item/reagent_containers/glass/cup/silver/pickup(mob/user)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -212,7 +212,7 @@
 	smeltresult = null
 	sellprice = 50
 	smeltresult = /obj/item/ingot/silver
-	var/last_used = 0
+	last_used = 0
 	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/pickup(mob/user)
@@ -284,12 +284,14 @@
 	force = 19
 	icon_state = "elfdagger"
 	item_state = "elfdag"
+	last_used = 0
 	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/elvish/drow
 	name = "nite elf dagger"
 	desc = "This ominous, dark handled silver dagger was crafted by the assassin race of nite elves."
 	force = 25
+	last_used = 0
 	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/navaja

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -213,6 +213,7 @@
 	sellprice = 50
 	smeltresult = /obj/item/ingot/silver
 	var/last_used = 0
+	var/is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/pickup(mob/user)
 	. = ..()
@@ -266,61 +267,6 @@
 			H.fire_act(1,10)
 
 
-/obj/item/rogueweapon/huntingknife/idagger/silver/funny_attack_effects(mob/living/target, mob/living/user = usr, nodmg)
-	if(world.time < src.last_used + 120)
-		to_chat(user, span_notice("The silver effect is on cooldown."))
-		return
-
-	. = ..()
-	if(ishuman(target) && target.mind)
-		var/mob/living/carbon/human/s_user = user
-		var/mob/living/carbon/human/H = target
-		var/datum/antagonist/werewolf/W = H.mind.has_antag_datum(/datum/antagonist/werewolf/)
-		var/datum/antagonist/vampirelord/lesser/V = H.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser)
-		var/datum/antagonist/vampirelord/V_lord = H.mind.has_antag_datum(/datum/antagonist/vampirelord/)
-		if(V)
-			if(V.disguised)
-				H.Knockdown(10)
-				H.Paralyze(10)
-				H.visible_message("<font color='white'>The silver weapon manifests the [H] curse!</font>")
-				to_chat(H, span_userdanger("I'm hit by my BANE!"))
-				H.adjustFireLoss(25)
-				H.fire_act(1,10)
-				H.apply_status_effect(/datum/status_effect/debuff/silver_curse)
-				src.last_used = world.time
-			else
-				to_chat(H, span_userdanger("I'm hit by my BANE!"))
-				H.Knockdown(10)
-				H.Paralyze(10)
-				H.adjustFireLoss(25)
-				H.fire_act(1,10)
-				H.apply_status_effect(/datum/status_effect/debuff/silver_curse)
-				src.last_used = world.time
-		if(V_lord)
-			if(V_lord.vamplevel < 4 && !V)
-				H.Knockdown(10)
-				H.Paralyze(10)
-				to_chat(H, span_userdanger("I'm hit by my BANE!"))
-				H.adjustFireLoss(25)
-				H.fire_act(1,10)
-				src.last_used = world.time
-			if(V_lord.vamplevel == 4 && !V)
-				s_user.Stun(10)
-				s_user.Paralyze(10)
-				s_user.adjustFireLoss(25)
-				s_user.fire_act(1,10)
-				to_chat(s_user, "<font color='red'> The silver weapon fails!</font>")
-				H.visible_message(H, span_userdanger("This feeble metal can't hurt me, I AM THE ANCIENT!"))
-		if(W && W.transformed == TRUE)
-			H.adjustFireLoss(25)
-			H.Paralyze(10)
-			H.Stun(10)
-			H.adjustFireLoss(25)
-			H.fire_act(1,10)
-			to_chat(H, span_userdanger("I'm hit by my BANE!"))
-			src.last_used = world.time
-
-
 /obj/item/rogueweapon/huntingknife/stoneknife
 	possible_item_intents = list(/datum/intent/dagger/cut,/datum/intent/dagger/chop)
 	name = "stone knife"
@@ -334,15 +280,17 @@
 /obj/item/rogueweapon/huntingknife/idagger/silver/elvish
 	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut,  /datum/intent/dagger/thrust/pick)
 	name = "elvish dagger"
-	desc = "This beautiful dagger is of intricate, elvish design. Sharper, too."
+	desc = "This beautiful silver dagger is of intricate, elvish design. Sharper, too."
 	force = 19
 	icon_state = "elfdagger"
 	item_state = "elfdag"
+	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/elvish/drow
 	name = "nite elf dagger"
-	desc = "This ominous, dark handled dagger was crafted by the assassin race of nite elves."
+	desc = "This ominous, dark handled silver dagger was crafted by the assassin race of nite elves."
 	force = 25
+	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/navaja
 	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut,  /datum/intent/dagger/thrust/pick)

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -213,7 +213,7 @@
 	sellprice = 50
 	smeltresult = /obj/item/ingot/silver
 	var/last_used = 0
-	var/is_silver = TRUE
+	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/pickup(mob/user)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -496,3 +496,4 @@
 	item_state = "esaber"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	is_silver = TRUE

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -496,4 +496,5 @@
 	item_state = "esaber"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
+	last_used = 0
 	is_silver = TRUE

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -102,8 +102,8 @@
 /mob/living/carbon/human/proc/werewolf_feed(mob/living/carbon/human/target, healing_amount = 10)
 	if(!istype(target))
 		return
-	if(user.has_status_effect(/datum/status_effect/debuff/silver_curse))
-		to_chat(user, span_notice("My power is weakened, I cannot heal!"))
+	if(src.has_status_effect(/datum/status_effect/debuff/silver_curse))
+		to_chat(src, span_notice("My power is weakened, I cannot heal!"))
 		return
 	if(target.mind)
 		if(target.mind.has_antag_datum(/datum/antagonist/zombie))

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -102,6 +102,9 @@
 /mob/living/carbon/human/proc/werewolf_feed(mob/living/carbon/human/target, healing_amount = 10)
 	if(!istype(target))
 		return
+	if(user.has_status_effect(/datum/status_effect/debuff/silver_curse))
+		to_chat(user, span_notice("My power is weakened, I cannot heal!"))
+		return
 	if(target.mind)
 		if(target.mind.has_antag_datum(/datum/antagonist/zombie))
 			to_chat(src, span_warning("I should not feed on rotten flesh."))

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -15,10 +15,9 @@
 	var/times_used = 0 //Number of times it's been used.
 	var/burnt_out = FALSE     //Is the flash burnt out?
 	var/burnout_resistance = 0
-	var/last_used = 0 //last world.time it was used.
+	last_used = 0 //last world.time it was used.						
 	var/cooldown = 0
 	var/last_trigger = 0 //Last time it was successfully triggered.
-
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(burnt_out)
 		user.visible_message(span_suicide("[user] raises \the [src] up to [user.p_their()] eyes and activates it ... but it's burnt out!"))

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -429,7 +429,7 @@
 		playsound(C.loc, "smallslash", 100, FALSE, -1)
 		var/datum/wound/caused_wound = limb_grabbed.bodypart_attacked_by(BCLASS_BITE, damage, user, sublimb_grabbed, crit_message = TRUE)
 		if(user.mind)
-			if(user.mind.has_antag_datum(/datum/antagonist/werewolf))
+			if(istype(H.dna.species, /datum/species/werewolf))
 				caused_wound?.werewolf_infect_attempt()
 				if(prob(30))
 					user.werewolf_feed(C)

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -429,7 +429,7 @@
 		playsound(C.loc, "smallslash", 100, FALSE, -1)
 		var/datum/wound/caused_wound = limb_grabbed.bodypart_attacked_by(BCLASS_BITE, damage, user, sublimb_grabbed, crit_message = TRUE)
 		if(user.mind)
-			if(istype(H.dna.species, /datum/species/werewolf))
+			if(istype(user.dna.species, /datum/species/werewolf))
 				caused_wound?.werewolf_infect_attempt()
 				if(prob(30))
 					user.werewolf_feed(C)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -195,6 +195,9 @@
 	playsound(user.loc, "smallslash", 100, FALSE, -1)
 	user.next_attack_msg.Cut()
 	if(stat == DEAD)
+		if(user.has_status_effect(/datum/status_effect/debuff/silver_curse))
+			to_chat(user, span_notice("My power is weakened, I cannot heal!"))
+			return
 		if(user.mind && istype(user, /mob/living/carbon/human/species/werewolf))
 			visible_message(span_danger("The werewolf ravenously consumes the [src]!"))
 			to_chat(src, span_warning("I feed on succulent flesh. I feel reinvigorated."))

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -151,7 +151,7 @@
 /obj/item/bodypart/onbite(mob/living/carbon/human/user)
 	if((user.mind && user.mind.has_antag_datum(/datum/antagonist/zombie)) || istype(user.dna.species, /datum/species/werewolf))
 		if(user.has_status_effect(/datum/status_effect/debuff/silver_curse))
-			to_chat(span_notice("My power is weakened, I cannot heal!"), user)
+			to_chat(user, span_notice("My power is weakened, I cannot heal!"))
 			return
 		if(do_after(user, 50, target = src))
 			user.visible_message(span_warning("[user] consumes [src]!"),\

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -150,6 +150,9 @@
 
 /obj/item/bodypart/onbite(mob/living/carbon/human/user)
 	if((user.mind && user.mind.has_antag_datum(/datum/antagonist/zombie)) || istype(user.dna.species, /datum/species/werewolf))
+		if(user.has_status_effect(/datum/status_effect/debuff/silver_curse))
+			to_chat(span_notice("My power is weakened, I cannot heal!"), user)
+			return
 		if(do_after(user, 50, target = src))
 			user.visible_message(span_warning("[user] consumes [src]!"),\
 							span_notice("I consume [src]!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Refactors the silver weapon code, assigning all silver weapons a var that calls on a proc to be used. The code is no longer assigned specifically to the silver dagger.

Or in Layman's terms, it makes it so we can now assign things as silver weapons, and they will work against werewolves and vampires. 
This means that the Elvish Saber, being made of silver, will now work against those two.

However, I also nerfed silver, removing the stun, knockdown, and fire effect on hit. It now purely locks regeneration of the werewolf/vampire it hits, since we all know that is all silver needs to do, and with silver soon becoming more available, this change is needed.

This code refactor also opens the path to creating new silver weapons in the future. If you are a spriter and have something in mind, now is the time. After all, a true silver sword for the holy would be a sight to behold..

-------------------------------------------------------------------------------------------------------------------------------------

**UPDATE:** After feedback and suggestions and a bit of brainstorming with Sigma (who reminded me that the silver curse debuff didn't do what I thought) I made it so silver against werewolves and vampires applies a debuff that gives -2 to all stats and blocks healing and regeneration from their abilities for 45 seconds

Also I fixed werewolves being able to infect people while not transformed. You're welcome!

## Why It's Good For The Game

Cleaner and more modular code that allows for bigger expansion on the silver weapon arsenal.

Nerfing the very overpowered effects of silver on those antags also opens the way to allowing more silver to flow in the town, without making life a living hell for those antags.
