### PR TITLE
Lanternpost & send_ooc_note & fireman carry z-level moving

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -17,7 +17,7 @@
 		for(var/mob/living/carbon/human/X in GLOB.human_list)
 			if(X.real_name in names_to)
 				if(!X.stat)
-					to_chat(X, span_info("[msg]"))
+					to_chat(X, span_biginfo("[msg]"))
 
 SUBSYSTEM_DEF(treasury)
 	name = "treasury"

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -145,6 +145,4 @@
 		pulling.forceMove(newtarg)
 		L.start_pulling(pulling, supress_message = TRUE)
 		if(was_pulled_buckled) // Assume this was a fireman carry since piggybacking is not a thing
-			var/mob/living/pulled_mob = pulling
-			pulled_mob.grippedby(L, TRUE)
 			L.buckle_mob(pulling, TRUE, TRUE, 90, 0, 0)

--- a/code/modules/power/lanternpost.dm
+++ b/code/modules/power/lanternpost.dm
@@ -41,19 +41,6 @@
 		else
 			return PROCESS_KILL
 
-/obj/machinery/light/rogue/lanternpost/attack_hand(mob/user)
-	. = ..()
-	if(.)
-		return
-	if(torchy)
-		if(!istype(user) || !Adjacent(user) || !user.put_in_active_hand(torchy))
-			torchy.forceMove(loc)
-		torchy = null
-		on = FALSE
-		set_light(0)
-		update_icon()
-		playsound(src.loc, 'sound/foley/torchfixturetake.ogg', 100)
-
 /obj/machinery/light/rogue/lanternpost/update_icon()
 	if(torchy)
 		if(on)

--- a/code/modules/roguetown/roguemachine/mail.dm
+++ b/code/modules/roguetown/roguemachine/mail.dm
@@ -171,7 +171,7 @@
 				else
 					visible_message(span_warning("[user] sends something."))
 					playsound(loc, 'sound/misc/disposalflush.ogg', 100, FALSE, -1)
-					send_ooc_note(span_boldwarning("New letter from <b>[sentfrom].</b>"), name = send2place)
+					send_ooc_note("New letter from <b>[sentfrom].</b>", name = send2place)
 					return
 	if(istype(P, /obj/item/roguecoin))
 		if(coin_loaded)


### PR DESCRIPTION
Removing lanterns from lanternposts has been removed

Changes all send_ooc_note messages' span to "biginfo" to make them more noticeable, this affects HERMES letter alerts and also treasury messages.

Removes the behavior where if you moved up and down a z-level while fireman carrying someone you would tighten your grip to an aggressive grab and slow down.