### PR TITLE
Proper barrel unit range.

### DIFF
--- a/code/modules/farming/fermenting_barrel.dm
+++ b/code/modules/farming/fermenting_barrel.dm
@@ -100,11 +100,11 @@
 
 /obj/structure/fermenting_barrel/random/water/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/water, rand(0,300))
+	reagents.add_reagent(/datum/reagent/water, rand(0,900))
 
 /obj/structure/fermenting_barrel/random/beer/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer, rand(0,300))
+	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer, rand(0,900))
 
 /obj/structure/fermenting_barrel/water
 	name = "water barrel"
@@ -112,14 +112,14 @@
 
 /obj/structure/fermenting_barrel/water/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/water,300)
+	reagents.add_reagent(/datum/reagent/water,900)
 
 /obj/structure/fermenting_barrel/beer
 	desc = "A barrel containing a generic housebrewed small-beer."
 
 /obj/structure/fermenting_barrel/beer/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer,300)
+	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer,900)
 
 /obj/item/roguebin/water/Initialize()
 	. = ..()
@@ -136,18 +136,18 @@
 
 /obj/structure/fermenting_barrel/zagul/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer/zagul,300)
+	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer/zagul,900)
 
 /obj/structure/fermenting_barrel/blackgoat
 	desc = "A barrel marked with the Black Goat Kriek emblem. A fruit-sour beer brewed with jackberries for a tangy taste."
 
 /obj/structure/fermenting_barrel/blackgoat/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer/blackgoat,300)
+	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer/blackgoat,900)
 
 /obj/structure/fermenting_barrel/hagwoodbitter
 	desc = "A barrel marked with the Hagwood Bitters emblem. The least bitter thing to be exported from the Grenzelhoft occupied state of Zorn."
 
 /obj/structure/fermenting_barrel/hagwoodbitter/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer/hagwoodbitter,300)
+	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer/hagwoodbitter,900)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Alright, this one might be controversial, or it might not be. 

Basically, 1oz corresponds to 3u on the back end. Barrels that were supposed to be full or random either were filled to 300u or from 0 to 300u- meaning they were filled with 100oz and the range of 0-100oz respectfully. A "full" barrel was never full. This fixes that.

On the other hand, is a barrel half-full a good thing? I invite discussion. Personally, I hate filling water barrels. It's one of the most boring parts of the game in my mind.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an oversight, potentially good for QoL. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
