### PR TITLE
Removes full keyset from apothecaries

### DIFF
--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -12,6 +12,7 @@
 
 	outfit = /datum/outfit/job/roguetown/archivist
 	display_order = JDO_ARCHIVIST
+	give_bank_account = 15
 	min_pq = 0
 	max_pq = null
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
@@ -28,7 +28,7 @@
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/storage/belt/rogue/surgery_bag/full/physician
-	beltr = /obj/item/storage/keyring/physician
+	beltr = /obj/item/roguekey/physician
 	id = /obj/item/scomstone/bad
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	backr = /obj/item/storage/backpack/rogue/satchel


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

A seperate, atomized PR as I know some people will dislike it, but;

This removes the full physician keychain from the court physician's underlings, instead just keeping their bespoke key. The keychain has access to the manor and garrison like any full court character, which is somewhat of a byproduct of when the physician lived in the keep. They don't, of course, on Dun Manor. The physician is still nominally a court position, but the apothecary is _not_.

## Why It's Good For The Game

get the FUCK OUT OF MY KEEP AND MY BEDS YOU FUCKING RATS YOU HAVE YOUR OWN HOME

I understand there's appeal of visiting the keep to get involved in the round events, but far too many help themselves in and snootily go "mm, yes, I'm a courtier you know" before sleeping in a heir's bed. (No longer possible, but.) They can be invited in or chaperoned by their boss, as otherwise they are not significant enough to have keys to the place - and the armory, for that matter.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
