### PR TITLE
Shield updates, parrying dagger nerf

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -198,7 +198,9 @@
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 	name = "steel parrying dagger"
-	desc = "This is a parrying dagger made of solid steel, used to catch opponent's weapons in the handguard."
+	force = 12
+	throwforce = 12
+	desc = "This is a parrying dagger made of solid steel, used to catch opponent's weapons in the handguard. It's a bit more dull, however."
 	icon_state = "spdagger"
 	wdefense = 6
 

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -75,7 +75,6 @@
 	desc = "A sturdy wooden shield. Will block anything you can imagine."
 	icon_state = "woodsh"
 	dropshrink = 0.8
-	wdefense = 15
 	coverage = 40
 
 /obj/item/rogueweapon/shield/wood/attack_right(mob/user)
@@ -114,7 +113,7 @@
 	throw_range = 3
 	wlength = WLENGTH_NORMAL
 	resistance_flags = FLAMMABLE
-	wdefense = 15
+	wdefense = 6
 	coverage = 70
 	parrysound = list('sound/combat/parry/shield/towershield (1).ogg','sound/combat/parry/shield/towershield (2).ogg','sound/combat/parry/shield/towershield (3).ogg')
 	max_integrity = 200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

When Rebel was porting over their various shield adjustments they unfortunately missed a wild value on the wooden shield proper, giving it three times the intended defense _ontop_ of the parrying skill. Also missed adjusting the wooden tower shield.

I have my reservations about a wood _tower_ shield having that low of a defense, but I am bringing it inline with the intended changes as seen on other sibling servers.

While I am touching it, I also nerfed the parrying dagger. It still is an incredible tool for parry defense, if without the other perks of a shield so a buckler is still superior, but it isn't _also_ just a steel dagger and thus the best in show. You'll want to carry the parry dagger in your off hand and do your work with the main one. Given a dagger can fit comfortably in your belt or, heck, a pouch, this is more then fair.

It might be prudent to reduce a parrying dagger's wdefense some given knife skill enhances it, but I'll leave it be. It isn't quite as good as a metal shield, but you have the perk of being able to hide it with ease.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

that silly little wooden shield goblins drop is no longer the most defensible thing in all the land

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
