### PR TITLE
Fixes hay crafting

### DIFF
--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -230,7 +230,7 @@
 /datum/crafting_recipe/roguetown/turfs/hay
 	name = "hay"
 	result = /turf/open/floor/rogue/hay
-	reqs = list(/obj/item/natural/chaff = 2)
+	reqs = list(/obj/item/natural/chaff/wheat = 2)
 	skillcraft = /datum/skill/craft/crafting
 	verbage_simple = "assemble"
 	verbage = "assembles"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds /wheat to requirement path because apparently this pink thing's called chaff.

![image](https://github.com/user-attachments/assets/3e61f9c3-73f7-4818-bcf3-adb8307ec17c)


## Why It's Good For The Game
Can actually craft hay now.
