### PR TITLE
Legendary Farming Mini-Perks

### DIFF
--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -17,8 +17,14 @@
 	bundletype = /obj/item/natural/bundle/fibers
 
 /obj/item/natural/fibers/attack_right(mob/user)
+	var/is_legendary = FALSE
+	if(user.mind.get_skill_level(/datum/skill/labor/farming) == SKILL_LEVEL_LEGENDARY) //check if the user has legendary farming skill
+		is_legendary = TRUE //they do
+	var/work_time = 1 SECONDS //time to gather fibers
+	if(is_legendary)
+		work_time = 2 //if legendary skill, the move_after is fast, 0.2 seconds
 	to_chat(user, span_warning("I start to collect [src]..."))
-	if(move_after(user, 1 SECONDS, target = src))
+	if(move_after(user, work_time, target = src))
 		var/fibercount = 0
 		for(var/obj/item/natural/fibers/F in get_turf(src))
 			fibercount++

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -212,17 +212,24 @@
 
 /obj/item/rogueweapon/hoe/attack_turf(turf/T, mob/living/user)
 	if(user.used_intent.type == /datum/intent/till)
+		var/is_legendary = FALSE
+		if(user.mind.get_skill_level(/datum/skill/labor/farming) == SKILL_LEVEL_LEGENDARY) //check if the user has legendary farming skill
+			is_legendary = TRUE //they do
+		var/work_time = 3 SECONDS //define the time it takes to make new soil or till soil
+		if(is_legendary)
+			work_time = 5 //if legendary skill, do_afters take half a second instead of 3
+
 		user.changeNext_move(CLICK_CD_MELEE)
 		if(istype(T, /turf/open/floor/rogue/grass))
 			playsound(T,'sound/items/dig_shovel.ogg', 100, TRUE)
-			if (do_after(user, 3 SECONDS, target = src))
+			if (do_after(user, work_time, target = src))
 				apply_farming_fatigue(user, 10)
 				T.ChangeTurf(/turf/open/floor/rogue/dirt, flags = CHANGETURF_INHERIT_AIR)
 				playsound(T,'sound/items/dig_shovel.ogg', 100, TRUE)
 			return
 		if(istype(T, /turf/open/floor/rogue/dirt))
 			playsound(T,'sound/items/dig_shovel.ogg', 100, TRUE)
-			if(do_after(user, 3 SECONDS, target = src))	
+			if(do_after(user, work_time, target = src))	
 				playsound(T,'sound/items/dig_shovel.ogg', 100, TRUE)
 				var/obj/structure/soil/soil = get_soil_on_turf(T)
 				if(soil)


### PR DESCRIPTION
If someone has Legendary farming skill:

Fiber collecting is reduced to .2 seconds from 1 second.
All hoe actions like clearing grass, making new soil and tilling the soil take .5 seconds.
Harvesting a non-perennial plant resets it to zero growth as if it had just been planted, health, water, and nutrition unaffected.