### PR TITLE
Squire Swarm. Hundreds of Squires.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -3,8 +3,8 @@
 	flag = SQUIRE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 4
+	spawn_positions = 4
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a singular, additional squire slot.

## Why It's Good For The Game

Squire is a popular role and 3 is _just_ a bit short for the amount of people that want to play it during main hours.
There is almost IC justification for it in that there are 4 Knights, if you include the captain.

Balance-wise should be fine. Man-at-arms has 8 slots, even though it's overall a much stronger job.

I am slightly biased.