### PR TITLE
Fix world/Topic

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -26,7 +26,12 @@
 	var/require_comms_key = FALSE
 
 /datum/world_topic/proc/TryRun(list/input)
-	key_valid = config && (CONFIG_GET(string/comms_key) == input["key"])
+	if(!config)
+		return "Configuration has not initialised yet"
+	var/comms_key = CONFIG_GET(string/comms_key)
+	if(!comms_key) // key was not set
+		return "Commskey disabled"
+	key_valid = comms_key == input["key"]
 	if(require_comms_key && !key_valid)
 		return "Bad Key"
 	input -= "key"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -205,7 +205,6 @@ GLOBAL_VAR(restart_counter)
 	log_runtime(GLOB.revdata.get_log_message())
 
 /world/Topic(T, addr, master, key)
-	return // Disable topics altogether
 	TGS_TOPIC //redirect to server tools if necessary
 
 	var/static/list/topic_handlers = TopicHandlers()


### PR DESCRIPTION
## About The Pull Request
Fix world/Topic being disabled, which causes issues with TGS.

Fixes the exploit that led to it being disabled in the first place, which is that a default commskey meant the password was just blank. Now if the commskey isn't set, secure topic commands will be disabled.

## Why It's Good For The Game
Fixes an exploit and re-enables world/Topic() so that TGS works properly.
