### PR TITLE
Drug minor rebalance (and very minor crafting name fixes.)

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -28,7 +28,7 @@
 /datum/status_effect/buff/druqks
 	id = "druqks"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/druqks
-	effectedstats = list("endurance" = 3,"speed" = 3,"fortune" = -5)
+	effectedstats = list("intelligence" = 5,"speed" = 3,"fortune" = -5)
 	duration = 10 SECONDS
 
 /datum/status_effect/buff/druqks/on_apply()
@@ -64,8 +64,8 @@
 /datum/status_effect/buff/ozium
 	id = "ozium"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/druqks
-	effectedstats = list("speed" = -99)
-	duration = 10 SECONDS
+	effectedstats = list("speed" = -5, "perception" = 2)
+	duration = 30 SECONDS
 
 /datum/status_effect/buff/ozium/on_apply()
 	. = ..()

--- a/code/modules/cargo/packsrogue/luxury.dm
+++ b/code/modules/cargo/packsrogue/luxury.dm
@@ -11,14 +11,20 @@
 	cost = 3
 	contains = list(/obj/item/clothing/mask/cigarette/rollie/nicotine)
 
+
+/datum/supply_pack/rogue/luxury/ozium
+	name = "Ozium"
+	cost = 5
+	contains = list(/obj/item/reagent_containers/powder/ozium)
+
 /datum/supply_pack/rogue/luxury/moondust
 	name = "Moon Dust"
-	cost = 5
+	cost = 10
 	contains = list(/obj/item/reagent_containers/powder/moondust)
 
 /datum/supply_pack/rogue/luxury/spice
 	name = "Spice"
-	cost = 50
+	cost = 30
 	contains = list(/obj/item/reagent_containers/powder/spice)
 
 /datum/supply_pack/rogue/luxury/mbox

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -245,13 +245,13 @@
 	skillcraft = /datum/skill/craft/carpentry
 
 /datum/crafting_recipe/roguetown/spoon
-	name = "spoon"
+	name = "spoon (x2)"
 	result = list(/obj/item/kitchen/spoon,
 				/obj/item/kitchen/spoon)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
 /datum/crafting_recipe/roguetown/platter
-	name = "platter"
+	name = "platter (x2)"
 	result = list(/obj/item/cooking/platter,
 				/obj/item/cooking/platter)
 	reqs = list(/obj/item/grown/log/tree/small = 1)

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -229,7 +229,7 @@
 	START_PROCESSING(SSroguemachine, src)
 	update_icon()
 	held_items[/obj/item/reagent_containers/powder/spice] = list("PRICE" = rand(41,55),"NAME" = "chuckledust")
-	held_items[/obj/item/reagent_containers/powder/ozium] = list("PRICE" = rand(25,47),"NAME" = "ozium")
+	held_items[/obj/item/reagent_containers/powder/ozium] = list("PRICE" = rand(6,15),"NAME" = "ozium")
 	held_items[/obj/item/reagent_containers/powder/moondust] = list("PRICE" = rand(13,25),"NAME" = "moondust")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/cannabis] = list("PRICE" = rand(12,18),"NAME" = "swampweed zig")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/nicotine] = list("PRICE" = rand(5,10),"NAME" = "zig")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Largely inspired by https://github.com/Rotwood-Vale/Ratwood-Keep/pull/1005. However, moondust was already balanced here. Touching the other two.

-Merchant now sells ozium. Price set to 5. In Purity, ranges from 6 to 15.
-Moondust price increased to 10.
-Spice price decreased to 30.

-Ozium no longer sets your speed to 0, rather it subtracts 5.  Time extended from 10 seconds to 30 seconds.
-Spice now has an added intelligence buff. There is reason to purchase it other than RP... for inspiration, of course. 

Misc change:
-Crafting names for platter and spoons have a (x2) suffix added to properly represent the crafted amount.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds a reason to purchase various drugs rather than moondust being the only one worth really getting. Ozium is a painkiller and a stress relief- actually affordable now. Spice helps with crafting.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
