### PR TITLE
Fix linter failure due to relatively pathed stub

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -359,10 +359,6 @@
 	SSblackbox.record_feedback("tally", "gun_fired", 1, type)
 	return TRUE
 
-obj/item/gun/update_icon()
-	..()
-
-
 /obj/item/gun/proc/reset_semicd()
 	semicd = FALSE
 


### PR DESCRIPTION
## About The Pull Request
Removes a stub override that tripped up linters because it was relatively pathed.

## Why It's Good For The Game
Gets linters working again so that they're not failing on every PR that's been updated to main since the bow PR was merged a few hours ago. All currently open PRs should probably be updated to avoid something like this happening again, to be honest...