### PR TITLE
Balance Patch - 03/10/2024

### DIFF
--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -216,6 +216,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	sharpness = IS_BLUNT
+	associated_skill = /datum/skill/combat/polearms
 	//dropshrink = 0.8
 	wlength = 33
 	var/list/forked = list()

--- a/code/modules/jobs/job_types/roguetown/yeomen/artificer.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/artificer.dm
@@ -33,7 +33,6 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/smelting, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 
 	head = /obj/item/clothing/head/roguetown/hatfur

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -2,7 +2,8 @@
 /obj/item
 	var/smeltresult
 	var/smelt_bar_num = 1 //variable for tracking how many bars things smelt back into for multi-bar items
-	
+// MULTIBAR SMELTING WAS DISABLED FOR BALANCE REASONS
+// DO NOT RE-ENABLE IT UNTIL FURTHER NOTICE
 /obj/machinery/light/rogue/smelter
 	icon = 'icons/roguetown/misc/forge.dmi'
 	name = "stone furnace"
@@ -127,11 +128,14 @@
 				if(cooking == 20)
 					for(var/obj/item/I in ore)
 						if(I.smeltresult)
-							while(I.smelt_bar_num)
-								I.smelt_bar_num--
-								var/obj/item/R = new I.smeltresult(src, ore[I])
-								ore += R
-							ore -= I
+//							while(I.smelt_bar_num)
+//								I.smelt_bar_num--
+//	DISABLED FOR NOW			var/obj/item/R = new I.smeltresult(src, ore[I])
+//								ore += R
+//							ore -= I
+							var/obj/item/R = new I.smeltresult(src, ore[I])
+							ore -= R
+							ore += I
 							qdel(I)
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message(span_notice("\The [src] finished smelting."))
@@ -208,11 +212,14 @@
 					else
 						for(var/obj/item/I in ore)
 							if(I.smeltresult)
-								while(I.smelt_bar_num)
-									I.smelt_bar_num--
-									var/obj/item/R = new I.smeltresult(src, ore[I])
-									ore += R
-								ore -= I
+//								while(I.smelt_bar_num)
+//									I.smelt_bar_num--
+//									var/obj/item/R = new I.smeltresult(src, ore[I])
+//									ore += R
+//								ore -= I
+								var/obj/item/R = new I.smeltresult(src, ore[I])
+								ore -= R
+								ore += I
 								qdel(I)
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message(span_notice("\The [src] finished smelting."))

--- a/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
+++ b/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
@@ -79,14 +79,14 @@
 /obj/item/bodypart/r_arm/prosthetic/bronzeright
 	name = "Bronze right arm"
 	desc = "A replacement right arm, engineered out of bronze."
-	icon = 'icons/roguetown/items/misc.dmi' //CHANGE THIS
-	icon_state = "prarm" //THIS TOO
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "prarm" //UPDATE THIS WITH SPRITE SOON
 	resistance_flags = FIRE_PROOF
 	obj_flags = CAN_BE_HIT
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 100
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30

--- a/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
+++ b/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
@@ -86,7 +86,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 100
+	max_damage = 110
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Patches a few overlooked issues with recent updates:
- Artificers no longer have novice medical skill
- Bronze Prosthetics now have 110 HP, 10 higher than a normal arm, instead of 20. Weaknesses and restrictions to healing are in the works as downsides to this.
- Pitchforks count as polearms
- Reverted Multi-bar smelting: Due to the mining update, this buff to smelting is no longer needed.

## Why It's Good For The Game

Necessary changes for balance discussed with maintainer team.
