### PR TITLE
Evil Farmer Traps Innocent Verevolf In Mud: Adjusts skill changes and traits to soiler and miner

### DIFF
--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -2,7 +2,7 @@
 	force = 10
 	force_wielded = 15
 	possible_item_intents = list(MACE_STRIKE)
-	gripped_intents = list(MACE_STRIKE,/datum/intent/flailthresh)
+	gripped_intents = list(/datum/intent/flailthresh,MACE_STRIKE)
 	name = "thresher"
 	desc = "A shredding tool for farmers."
 	icon_state = "flail"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -1,7 +1,7 @@
 /datum/advclass/miner
 	name = "Miner"
 	tutorial = "You are a Miner, you mine for the local blacksmith, gathering rare ores. \
-	there are tales of ambitious dwarf miners building great forts in the lavalands, to harvest all of it's hardly touched ores"
+	there are tales of ambitious dwarf miners building great forts in the lavalands, to harvest all of its hardly touched ores"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/miner
@@ -38,12 +38,11 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/engineering, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/craft/masonry, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/masonry, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/mining, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/smelting, 4, TRUE)
 		H.change_stat("strength", 2)
-		H.change_stat("intelligence", -1)
 		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 2)
 		H.change_stat("fortune", 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -46,3 +46,4 @@
 		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 2)
 		H.change_stat("fortune", 2)
+		ADD_TRAIT(H, TRAIT_NOCSIGHT, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -60,7 +60,6 @@
 		H.ambushable = FALSE
 
 	ADD_TRAIT(H, TRAIT_SEEDKNOW, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_spells(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -60,6 +60,7 @@
 		H.ambushable = FALSE
 
 	ADD_TRAIT(H, TRAIT_SEEDKNOW, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_spells(H)
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -10,7 +10,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 
-	tutorial = "Your's is the simple, pastoral life, but the land is kin to you. The world is perfect to you, and you are perfect back; you know a good day's work, the sweat on your brow your own. A master of flora and fauna both, till the soil, care for the animals and harvest them when ready. The town looks to you for food, and the church blesses you are something greater than a simple farmer."
+	tutorial = "It is a simple life you live, your basic understanding of life is something many would be envious of if they knew how perfect it was. You know a good day's work, the sweat on your brow is yours: Famines and plague may take its toll, but you know how to celebrate life well. Till the soil and produce fresh food for those around you, and maybe you'll be more than an unsung hero someday."
 
 
 	f_title = "Soilbride"
@@ -23,12 +23,11 @@
 /datum/outfit/job/roguetown/farmer/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, , TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/farming, 5, TRUE)
@@ -46,6 +45,9 @@
 		H.change_stat("strength", 1)
 		H.change_stat("constitution", 1)
 		H.change_stat("speed", 1)
+		ADD_TRAIT(H, TRAIT_SEEDKNOW, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
 
 	if(H.pronouns == SHE_HER)
 		head = /obj/item/clothing/head/roguetown/armingcap


### PR DESCRIPTION
## About The Pull Request

- Soilers spawn with Longstrider, No Stink and Seed Know trait, no slowdown from rough terrain and not affected by odour.
- Soilers have a new description from Stone Keep.
- Druids spawn with Longstrider trait.
- Miners spawn with Noc Sight trait.
- Thresh intent is set to 1st on two handed thresher.
- Skill adjustments:

**Miner**
1 Masonry -> 3 Masonry
-1 INT debuff removed.

**Soiler**
3 Knives -> 1 Knives
2 Polearms -> 4 Polearms
1 Wrestling -> 3 Wrestling
1 Unarmed -> 3 Unarmed
2 Archery -> 0


## Why It's Good For The Game
Miners should know quite a lot about the rocks they mine and how to use them. Strengthens their niche in the wake of masoner's removal. Being in dark tunnels adjusts their eyes' to be a bit better than others.

Soilers are Mud Wizards. They shouldn't have issues traversing the land they farm on. Soilers are also not archers or rogues. Skill change strengthens focus on being practical, rough & tough farmers wielding pitchforks. They're usually the first to be fragged on antag heavy rounds, so this will give them a fighting chance to defend their hood.

![image](https://github.com/user-attachments/assets/e2b65ab1-b818-4e8e-abbd-3e0c78866a11)