### PR TITLE
Fixes Tailor not being available

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -360,8 +360,9 @@
 	/datum/job/roguetown/blacksmith,\
 	/datum/job/roguetown/artificer,\
 	/datum/job/roguetown/merchant,\
-	/datum/job/roguetown/scribe,\
-	/datum/job/roguetown/tailor
+	/datum/job/roguetown/tailor,\
+	/datum/job/roguetown/scribe
+
 
 
 #define WANDERER_ROLES \

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -360,7 +360,9 @@
 	/datum/job/roguetown/blacksmith,\
 	/datum/job/roguetown/artificer,\
 	/datum/job/roguetown/merchant,\
-	/datum/job/roguetown/scribe
+	/datum/job/roguetown/scribe,\
+	/datum/job/roguetown/tailor
+
 
 #define WANDERER_ROLES \
 	/datum/job/roguetown/pilgrim,\

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2297,6 +2297,7 @@
 #include "code\modules\jobs\job_types\roguetown\peasants\soilson.dm"
 #include "code\modules\jobs\job_types\roguetown\yeomen\archivist.dm"
 #include "code\modules\jobs\job_types\roguetown\yeomen\artificer.dm"
+#include "code\modules\jobs\job_types\roguetown\yeomen\tailor.dm"
 #include "code\modules\jobs\job_types\roguetown\yeomen\barkeep.dm"
 #include "code\modules\jobs\job_types\roguetown\yeomen\blacksmith.dm"
 #include "code\modules\jobs\job_types\roguetown\yeomen\merchant.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes Tailor not being selectable.

Turns out, it was mainly due to the fact the tailor.dm already existed, but someone removed it from the roguetown.dme by force. I re-added it manually, and it is fine now.

![image](https://github.com/user-attachments/assets/bae1140e-b4aa-4b33-8ae9-d3b839cc4192)


## Why It's Good For The Game

Patch to make it selectable.
