### PR TITLE
Fixes Smelting not working

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -134,8 +134,8 @@
 //								ore += R
 //							ore -= I
 							var/obj/item/R = new I.smeltresult(src, ore[I])
-							ore -= R
-							ore += I
+							ore -= I
+							ore += R
 							qdel(I)
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message(span_notice("\The [src] finished smelting."))
@@ -212,14 +212,9 @@
 					else
 						for(var/obj/item/I in ore)
 							if(I.smeltresult)
-//								while(I.smelt_bar_num)
-//									I.smelt_bar_num--
-//									var/obj/item/R = new I.smeltresult(src, ore[I])
-//									ore += R
-//								ore -= I
 								var/obj/item/R = new I.smeltresult(src, ore[I])
-								ore -= R
-								ore += I
+								ore -= I
+								ore += R
 								qdel(I)
 					playsound(src,'sound/misc/smelter_fin.ogg', 100, FALSE)
 					visible_message(span_notice("\The [src] finished smelting."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

When reverting multi-bar smelting, the product and ore were backwards, which led to smelting being entirely broken.

Oops. I was tired when I reverted it because I was asked to, so have mercy on me for this one.. (I am a smith main so I suffered most.)

## Why It's Good For The Game

Critical bugfix.
