### PR TITLE
Buffs Swords and Axes a little bit.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -84,7 +84,7 @@
 	attack_verb = list("cuts", "slashes")
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
 	animname = "cut"
-	penfactor = 10
+	penfactor = 20
 	chargetime = 0
 	item_d_type = "slash"
 
@@ -95,16 +95,15 @@
 	attack_verb = list("chops", "hacks")
 	animname = "chop"
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
-	penfactor = 20
+	penfactor = 50
 	swingdelay = 10
 	item_d_type = "slash"
 
 /datum/intent/axe/chop/battle
-	penfactor = 30
 	damfactor = 1.2 //36 on battleaxe
 
 /datum/intent/axe/cut/battle
-	penfactor = 15
+	penfactor = 25
 
 /obj/item/rogueweapon/stoneaxe/battle
 	force = 25

--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -95,12 +95,13 @@
 	attack_verb = list("chops", "hacks")
 	animname = "chop"
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
-	penfactor = 50
+	penfactor = 35
 	swingdelay = 10
 	item_d_type = "slash"
 
 /datum/intent/axe/chop/battle
 	damfactor = 1.2 //36 on battleaxe
+	penfactor = 40
 
 /datum/intent/axe/cut/battle
 	penfactor = 25

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -351,9 +351,9 @@
 	animname = "chop"
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
-	penfactor = 50
+	penfactor = 30
 	swingdelay = 8
-	damfactor = 0.8
+	damfactor = 1.0
 	item_d_type = "slash"
 
 /obj/item/rogueweapon/sword/long/exe

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1,7 +1,7 @@
 
 /obj/item/rogueweapon/sword
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
-	force = 18
+	force = 22
 	force_wielded = 25
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust)
@@ -67,6 +67,7 @@
 	chargetime = 0
 	hitsound = list('sound/combat/hits/bladed/genslash (1).ogg', 'sound/combat/hits/bladed/genslash (2).ogg', 'sound/combat/hits/bladed/genslash (3).ogg')
 	swingdelay = 0
+	damfactor = 1.1
 	item_d_type = "slash"
 
 /datum/intent/sword/thrust

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -351,7 +351,7 @@
 	animname = "chop"
 	blade_class = BCLASS_CHOP
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
-	penfactor = 10
+	penfactor = 50
 	swingdelay = 8
 	damfactor = 0.8
 	item_d_type = "slash"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Increases the armor penetration of axes when cutting from 10 --> 20
Increases the ~~armor penetration of axes when chopping from 20 --> 50~~ (This attack has long swing delay.)
Increases the armor penetration of the battleaxe when cutting from 15 --> 25

Increases the one-handed force of the steel sword and it's children from 18 --> 22. The two-handed force remains unchanged.
Increases the damage factor of cutting with swords from 1.0 --> 1.1
Increases the ~~armor penetration of swords when chopping from 10 --> 50~~ (This attack also has a long swing delay and 0.8 damage mod)

EDITS:
Axe chop to 35
Battleaxe chop to 40
Sword chop to 30 but removes its damage malus. Making it deal normal damage instead of 0.8 damage.

## Why It's Good For The Game

Swords and axes are some of the least whelming weapons in the game right now.
I believe none of these buffs particularly change the status quo of what the best strategies in the game are right now.
I will explain the reasoning behind each.

CHOPPING for both swords and axes has had it's armor penetration increased from a pitifully small number, to a more reasonable number for an attack with swing delay. This was not increased all the way to 80 to match PICK and SMASH, as those numbers, especially in the case of PICK might already be overtuned. This change is especially needed in the case of swords, as the CHOP on a sword had both a damage nerf /and/ lower armor penetration than the sword's usual STAB ability, making the attack almost completely redundant.

The gap between the one-handed and two-handed force of the basic swords has been lessened, to make pairing it with a shield in the offhand a more viable strategy, as well as make it not literally hit weaker than a one-handed dagger with EVEN LESS armor penetration and speed. It now has 2 points more than a dagger... and still has less armor penetration and speed.

CUTTING with the sword has been given a 1.1 damage factor. This might be foolish, but it gives the player a reason to actually swap to CUT once in a while, considering CUT has no armor penetration to speak of.

Meanwhile the armor penetration of CUTTING with axes has been increased to 20 for normal axes and 25 for the battleaxe. Axes are specialized in CUTTING and it doesn't make sense for them to have less armor penetration than the stab of a sword. I would actually like to increase these numbers to more in the 30/35 range. But I don't want to get too crazy with it.

Please feel free to tell me if I'm a big dumb idiot. The main argument I can see against these changes is to keep these weapons weak intentionally since they're quite common. But I feel that since players actually ENJOY using swords and axes, having them be more valid weapons to use is more important.
