### PR TITLE
Long Bow Crafting Correction

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -110,7 +110,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/longbowpartial
-	name = "unstrung recurve bow"
+	name = "unstrung long bow"
 	result = /obj/item/grown/log/tree/bowpartial/longbow
 	reqs = list(
 		/obj/item/grown/log/tree = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Just corrects the Unstrung Long Bow crafting name, it was called Unstrung Recurve Bow by accident.

## Why It's Good For The Game

Because I said so.