### PR TITLE
Farming skill check for crafting a seedmound by hand

### DIFF
--- a/code/modules/farming/seeds.dm
+++ b/code/modules/farming/seeds.dm
@@ -36,6 +36,9 @@
 		try_plant_seed(user, soil)
 		return
 	else if(istype(T, /turf/open/floor/rogue/dirt))
+		if(!(user.mind.get_skill_level(/datum/skill/labor/farming) >= SKILL_LEVEL_JOURNEYMAN))
+			to_chat(user, span_notice("I don't know enough to work without a tool."))
+			return
 		to_chat(user, span_notice("I begin making a mound for the seeds..."))
 		if(do_after(user, get_farming_do_time(user, 10 SECONDS), target = src))
 			apply_farming_fatigue(user, 30)


### PR DESCRIPTION
Adds a Journeyman-level check for Farming to the process of left-clicking dirt with seeds to make a mound, this can still be done with a hoe at any skill level.