### PR TITLE
Bad eyesight flaw actually applies its reading bonus

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -120,12 +120,6 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	name = "Bad Eyesight"
 	desc = "I need spectacles to see normally from my years spent reading books."
 
-/datum/charflaw/badsight/on_mob_creation(mob/user)
-	. = ..()
-	var/mob/living/carbon/human/H = user
-	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-
 /datum/charflaw/badsight/flaw_on_life(mob/user)
 	if(!ishuman(user))
 		return
@@ -154,6 +148,13 @@ GLOBAL_LIST_INIT(character_flaws, list(
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/rogue/spectacles(H), SLOT_WEAR_MASK)
 	else
 		new /obj/item/clothing/mask/rogue/spectacles(get_turf(H))
+	
+	// we don't seem to have a mind when on_mob_creation fires, so set up a timer to check when we probably will
+	addtimer(CALLBACK(src, PROC_REF(apply_reading_skill), H), 5 SECONDS)
+
+/datum/charflaw/badsight/proc/apply_reading_skill(mob/living/carbon/human/H)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 
 /datum/charflaw/paranoid
 	name = "Paranoid"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Turns out that character flaws are attached to a mob before it has a mind in almost all circumstances, meaning that the +1 reading buff that the bad eyesight flaw was *supposed* to give hasn't been applying. Possibly ever.

Ten second dirty fix to make this happen: it now checks 5 seconds after mob creation to see if a mind is attached.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Fixes a bug, albeit a minor one, and allows people to use a flaw to give their characters access to reading (as apparently intended) in exchange for a particularly gruesome downside. 

Did you know that not having your glasses imposes a permanent screen blur, -20 PER and -5 SPD?
