### PR TITLE
Spellbooks can be made with magic stones + non-arcyne study buffs

### DIFF
--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -137,6 +137,8 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 	slot_flags = ITEM_SLOT_MOUTH
 	obj_flags = null
 	w_class = WEIGHT_CLASS_TINY
+	/// If our stone is magical, this lets us know -how- magical. Maximum is 15.
+	var/magic_power = 0
 
 /obj/item/natural/stone/Initialize()
 	. = ..()
@@ -201,16 +203,21 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			stone_title = "[picked_name] [stone_title]" // Prefix and then stone
 			stone_desc += " [picked_desc]" // We put the descs after the original one
 
+	var/personality_modifier = 0
 	switch(stone_personality_rating)
 		if(10 to 22)
 			if(prob(3)) // Stone has a 3 percent chance to have a personality despite missing its roll
 				stone_title = "[stone_title] of [pick(GLOB.stone_personalities)]"
 				stone_desc += " [pick(GLOB.stone_personality_descs)]"
-				bonus_force += rand(1,5) // Personality gives a stone some more power too
+				personality_modifier += rand(1,5) // Personality gives a stone some more power too
 		if(23 to 25)
 			stone_title = "[stone_title] of [pick(GLOB.stone_personalities)]"
 			stone_desc += " [pick(GLOB.stone_personality_descs)]"
-			bonus_force += rand(1,5) // Personality gives a stone some more power too
+			personality_modifier += rand(1,5) // Personality gives a stone some more power too
+			
+	if (personality_modifier)
+		bonus_force += personality_modifier
+		magic_power += personality_modifier
 
 	var/max_force_range = sharpness_rating + bluntness_rating // Add them together
 	//max_force_range = round(max_force_range/2) // Divide by 2 and round jus incase
@@ -223,6 +230,7 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 		stone_title = "[pick(GLOB.stone_magic_names)] [stone_title] +[magic_force]"
 		stone_desc += " [pick(GLOB.stone_magic_descs)]"
 		bonus_force += magic_force // Add on the magic force modifier
+		magic_power += magic_force
 
 	if(extra_intent_list.len)
 		for(var/i in 1 to min(4, extra_intent_list.len))

--- a/modular_azurepeak/code/game/objects/items/spellbooks.dm
+++ b/modular_azurepeak/code/game/objects/items/spellbooks.dm
@@ -310,7 +310,7 @@
 		if (the_rock.magic_power)
 			if(isturf(loc) && (found_table))
 				var/crafttime = ((130 - the_rock.magic_power) - ((user.mind?.get_skill_level(/datum/skill/magic/arcane))*5))
-				if(do_after(user, crafttime, taraget = src))
+				if(do_after(user, crafttime, target = src))
 					if (isarcyne(user))
 						playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 						user.visible_message(span_warning("[user] crushes [user.p_their()] [P]! Its powder seeps into the [src]."), \

--- a/modular_azurepeak/code/game/objects/items/spellbooks.dm
+++ b/modular_azurepeak/code/game/objects/items/spellbooks.dm
@@ -25,6 +25,7 @@
 	var/list/allowed_readers = list()
 	var/stored_gem = FALSE
 	var/picked // if the book has had it's style picked or not
+	var/born_of_rock = FALSE // was a magical stone used to make it instead of a gem?
 
 /obj/item/book/granter/spellbook/getonmobprop(tag)
 	. = ..()
@@ -152,7 +153,12 @@
 		chance2learn += stored_gem
 		stored_gem = FALSE
 	if(!isarcyne(user))
-		chance2learn = 1
+		if (gamer != owner) // if you didn't make this book, get fucked.
+			chance2learn = 1
+	if (born_of_rock)
+		// the rock tomes are a *lot* easier to make, so we make them worse by them reducing your chances by 20% and capping it to a maximum of 15% overall
+		// we do this because we don't want literally everybody being able to access arcane magic in a round.
+		chance2learn *= 0.5
 	testing("chance to learn is [chance2learn]")
 	if(prob(chance2learn))
 		user.visible_message(span_warning("[user] is filled with arcyne energy! You witness [user.p_their()] body convulse and spark brightly."), \
@@ -272,29 +278,68 @@
 			if(do_after(user, crafttime, target = src))
 				if(isarcyne(user))
 					playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
-					user.visible_message(span_warning("[user] crushes [user.p_their()] [P]! It's powder seeps into the [src]."), \
-						span_notice("I run my arcyne energy into the crystal. It shatters and seeps into the cover of the tome! Runes and symbols of an unknowable language cover it's pages now..."))
+					user.visible_message(span_warning("[user] crushes [user.p_their()] [P]! Its powder seeps into the [src]."), \
+						span_notice("I run my arcyne energy into the crystal. It shatters and seeps into the cover of the tome! Runes and symbols of an unknowable language cover its pages now..."))
 					var/obj/item/book/granter/spellbook/newbook = new /obj/item/book/granter/spellbook(loc)
 					newbook.owner = user
+					newbook.desc += " Traces of [P] dust linger in its margins."
 					qdel(P)
 					qdel(src)
 				else
 					if(prob(1))
 						playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
-						user.visible_message(span_warning("[user] crushes [user.p_their()] [P]! It's powder seeps into the [src]."), \
+						user.visible_message(span_warning("[user] crushes [user.p_their()] [P]! Its powder seeps into the [src]."), \
 							span_notice("By the Ten! That gem just exploded -- and my useless tome is filled with gleaming energy and strange letters!"))
 						var/obj/item/book/granter/spellbook/newbook = new /obj/item/book/granter/spellbook(loc)
 						newbook.owner = user
+						newbook.desc += " Traces of [P] dust linger in its margins."
 						qdel(P)
 						qdel(src)
 					else
 						playsound(loc, 'modular_azurepeak/sound/spellbooks/icicle.ogg', 100, TRUE)
-						user.visible_message(span_warning("[user] crushes [user.p_their()] [P]! It's powder just kind of sits on top of the [src]. Awkward."), \
+						user.visible_message(span_warning("[user] crushes [user.p_their()] [P]! Its powder just kind of sits on top of the [src]. Awkward."), \
 							span_notice("... why and how did I just crush this gem into a worthless scroll-book? What a WASTE of mammon!"))
 						qdel(P)
 					return ..()
 		else
 			to_chat(user, "<span class='warning'>You need to put the [src] on a table to work on it.</span>")
+	else if (istype(P, /obj/item/natural/stone))
+		var/obj/item/natural/stone/the_rock = P
+		if (the_rock.magic_power)
+			if(isturf(loc) && (found_table))
+				var/crafttime = ((130 - the_rock.magic_power) - ((user.mind?.get_skill_level(/datum/skill/magic/arcane))*5))
+				if(do_after(user, crafttime, taraget = src))
+					if (isarcyne(user))
+						playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
+						user.visible_message(span_warning("[user] crushes [user.p_their()] [P]! Its powder seeps into the [src]."), \
+							span_notice("I join my arcyne energy with that of the magical stone in my hands, which shudders briefly before dissolving into motes of ash. Runes and symbols of an unknowable language cover its pages now..."))
+						to_chat(user, span_notice("...yet even for an enigma of the arcyne, these characters are unlike anything I've seen before. They're going to be -much- harder to understand..."))
+						var/obj/item/book/granter/spellbook/newbook = new /obj/item/book/granter/spellbook(loc)
+						newbook.owner = user
+						newbook.born_of_rock = TRUE
+						newbook.desc += " Traces of multicolored stone limn its margins."
+						qdel(P)
+						qdel(src)
+					else
+						if (prob(the_rock.magic_power)) // for reference, this is never higher than 15 and usually significantly lower
+							playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
+							user.visible_message(span_warning("[user] carefully sets down [the_rock] upon [src]. Nothing happens for a moment or three, then suddenly, the glow surrounding the stone becomes as liquid, seeps down and soaks into the tome!"), \
+							span_notice("I knew this stone was special! Its colourful magick has soaked into my tome and given me gift of mystery!"))
+							to_chat(user, span_notice("...what in the world does any of this scribbling possibly mean?"))
+							var/obj/item/book/granter/spellbook/newbook = new /obj/item/book/granter/spellbook(loc)
+							newbook.owner = user
+							newbook.born_of_rock = TRUE
+							newbook.desc += " Traces of multicolored stone limn its margins."
+							qdel(P)
+							qdel(src)
+						else
+							user.visible_message(span_warning("[user] sets down [the_rock] upon the surface of [src] and watches expectantly. Without warning, the rock violently pops like a squashed gourd!"), \
+							span_notice("No! My precious stone! It musn't have wanted to share its mysteries with me..."))
+							user.electrocute_act(5, src)
+							qdel(P)
+		else
+			to_chat(user, span_notice("This is a mere rock - it has no arcyne potential. Bah!"))
+			return ..()
 	else
 		return ..()
 
@@ -323,7 +368,7 @@
 	icon_state = "amethyst"
 	sellprice = 18
 	arcyne_potency = 25
-	desc = "A deep lavender crystal, it surges with magical energy, yet it's artificial nature means it's worth little."
+	desc = "A deep lavender crystal, it surges with magical energy, yet it's artificial nature means it is worth little."
 
 /obj/item/book/granter/spellbook/attackby(obj/item/P, mob/living/carbon/human/user, params)
 	if(istype(P, /obj/item/roguegem))
@@ -357,7 +402,7 @@
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/arcyne
 	name = "glowing purple silver dagger"
-	desc = "This dagger glows a faint purple. Powder runs across it's blade."
+	desc = "This dagger glows a faint purple. Powder runs across its blade."
 	var/is_bled = FALSE
 	var/rune_to_scribe = /obj/effect/roguerune/
 

--- a/modular_azurepeak/code/game/objects/items/spellbooks.dm
+++ b/modular_azurepeak/code/game/objects/items/spellbooks.dm
@@ -155,10 +155,12 @@
 	if(!isarcyne(user))
 		if (gamer != owner) // if you didn't make this book, get fucked.
 			chance2learn = 1
+		else
+			chance2learn *= 0.5
+			chance2learn = min(chance2learn, 15) 
 	if (born_of_rock)
-		// the rock tomes are a *lot* easier to make, so we make them worse by them reducing your chances by 20% and capping it to a maximum of 15% overall
-		// we do this because we don't want literally everybody being able to access arcane magic in a round.
-		chance2learn *= 0.5
+		// the rock tomes are a *lot* easier to make, so we make them worse by them reducing your chances by 20%
+		chance2learn *= 0.8
 	testing("chance to learn is [chance2learn]")
 	if(prob(chance2learn))
 		user.visible_message(span_warning("[user] is filled with arcyne energy! You witness [user.p_their()] body convulse and spark brightly."), \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Expanding upon the amazing work laid out in https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/473 (and with the author's blessing), this PR adds/changes the following:

- Spellbooks can now also be made with magic stones (the funny glowing & traited stones sometimes lying around). A +10 stone with a high personality score gives a maximum of 15% chance in this manner, up from the 1% chance **per gem** previously. You can also still make them with gems.
    - Making spellbooks with magic stones causes a 20% reduction in your success chance when studying them, applied multiplicatively (20% becomes 16%). The stones are fickle and their power is untested. Gems will always be better.
- Non-arcyne characters using a spellbook that they themselves created have their success chance reduced by 50% multiplicatively and capped at 15% total, instead of the flat 1% chance previously.
    - With 14 int, 3 reading skill and the swampweed bonus, this comes out to a roughly 10% chance **per sleep cycle** to gain access to arcyne magic, after which you are treated like a normal arcyne character. Given there are anywhere from 4 to 6 sleep cycles in a standard round, it is decently unlikely that most non-arcyne characters will gain access to magic this way - and it is entirely intended.
 
Administrators may also note that the `magic_power` this PR adds to stones can be modified freely with VV to provide reward rocks during events if they want to hand out *potential* access to arcane magic, as described above.

## Why It's Good For The Game

This makes spellbooks significantly easier to make and realistically use for mundane characters - the previous 1-in-100 chance for *making* the spellbook (using gemstones each time, which are very rare) coupled with the 1-in-100 chance *again* to even learn a single arcane magic point successfully meant that spellbooks were functionally unusable for these characters.

With these changes, you can now realistically play a "pre-apprentice" of sorts across multiple rounds with a believable mechanical incentive. It is unlikely that you'll actually get access to magic, but there's at least a somewhat reasonable chance that you *might*.
