### PR TITLE
Grants Bandits and Wardens Longstider

### DIFF
--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -33,6 +33,7 @@
 	ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_COMMIE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
 	H.set_patron(/datum/patron/inhumen/matthios)
 	to_chat(H, span_alertsyndie("I am a BANDIT!"))
 	to_chat(H, span_boldwarning("Long ago I did a crime worthy of my bounty being hung on the wall outside of the local inn. I live now with fellow free men in reverence to MATTHIOS whose idol grants us boons and wishes when fed the money, treasures, and metals of the civilized wretches. I must feed the idol to satisfy my greed!"))

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -70,4 +70,5 @@ Also given some non-combat skills that a peasent would have, just to support the
 		H.verbs |= /mob/proc/haltyell
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_LONGSTRIDER, TRAIT_GENERIC)
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

_Be fleet footed and swift, mire-fox. For thy enemies are many, and thy allies few. Matthios blesses thy step, while blueblooded men lose themselves in the muck._

Grants Longstrider to both Wardens and Bandits. Both masters of their realms. This gives bandits an escape tool in their own turf. Makes Wardens better wildmen, and also sets up Wardens to be their natural answer. Rather than the keep deathball flying into the woods.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bandits currently lack a real escape tool. They often times get stomped by the RG deathball flying into the woods. This should give the brigands of Matthios a good advantage both fighting in fleeing in their own turf. Bluebloods go home. It also sets up Wardens as being *better* than other garrison roles at chase/engaging in the woods. Since tracking does um, unfortunately about nothing.
