### PR TITLE
Wildkin and Halfkin lore.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -4,7 +4,7 @@
 /datum/species/anthromorph
 	name = "Wild-Kin"
 	id = "anthromorph"
-	desc = "A product of Dendor's madness, or something else? It's lost to history; a menagrie of people with bestial features."
+	desc = "A product of Dendor's enigmatic meddling in mortals races. The average wild-kin suffers from animalistic urges that vary in severity, from simply avoiding certain foods to smoldering desires to howl at the moon or chase prey. Usually these urges are tied to the animal that the wild-kin is melded with, making them rather predictable. Despite this, the way each wild-kin approaches their bizarre physiology and psychology varies, creating a diverse race of people who may not even empathise with one another. (Wild-kin are not a template race to play your own custom race, if you play a wild-kin, you are expected to roleplay to the setting and the race's lore.)"
 	default_color = "444"
 	species_traits = list(
 		MUTCOLORS,

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -4,7 +4,7 @@
 /datum/species/demihuman
 	name = "Half-Kin"
 	id = "demihuman"
-	desc = "The inevitable union between wildkin and some form of humanity or another, and while they also experience animalistic tendancies akin to their full-blooded ancestors, their intermingling with others has stemmed the intensity. (Half-kin are not a template race to play your own custom race, if you play a half-kin, you are expected to roleplay to the setting and the race's lore.)"
+	desc = "The inevitable union between wildkin and some form of humanity or another, and while they also experience animalistic tendencies akin to their full-blooded ancestors, their intermingling with others has stemmed the intensity. (Half-kin are not a template race to play your own custom race, if you play a half-kin, you are expected to roleplay to the setting and the race's lore.)"
 	skin_tone_wording = "Ancestry"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,MUTCOLORS_PARTSONLY)

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -4,7 +4,7 @@
 /datum/species/demihuman
 	name = "Half-Kin"
 	id = "demihuman"
-	desc = "The inevitable union between wildkin and some form of humanity or another, they've become quite common these days. Perhaps they'll be the dominant species some day."
+	desc = "The inevitable union between wildkin and some form of humanity or another, and while they also experience animalistic tendancies akin to their full-blooded ancestors, their intermingling with others has stemmed the intensity. (Half-kin are not a template race to play your own custom race, if you play a half-kin, you are expected to roleplay to the setting and the race's lore.)"
 	skin_tone_wording = "Ancestry"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,MUTCOLORS_PARTSONLY)


### PR DESCRIPTION
Adds a little more depth to the wildkin race descriptions and adds a stipulation to discourage using them to play custom races. I've personally seen some pretty egregious use of wildkin to play furry oc's and such which aren't made for the setting. Ignoring the setting to play your OC might be fun for you but it overall damages the integrity of the setting overall. People playing wild-kin should be held to the same standard as all other races.

**Wildkin**
"A product of Dendor's enigmatic meddling in mortals races. The average wild-kin suffers from animalistic urges that vary in severity, from simply avoiding certain foods to smoldering desires to howl at the moon or chase prey. Usually these urges are tied to the animal that the wild-kin is melded with, making them rather predictable. Despite this, the way each wild-kin approaches their bizarre physiology and psychology varies, creating a diverse race of people who may not even empathise with one another. (Wild-kin are not a template race to play your own custom race, if you play a wild-kin, you are expected to roleplay to the setting and the race's lore.)"

**Half-kin**
"The inevitable union between wildkin and some form of humanity or another, and while they also experience animalistic tendencies akin to their full-blooded ancestors, their intermingling with others has stemmed the intensity. (Half-kin are not a template race to play your own custom race, if you play a half-kin, you are expected to roleplay to the setting and the race's lore.)"