### PR TITLE
Simplemob Skeleton tiny features and Lich Greater (Player) Skeleton changes

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton.dm
@@ -102,6 +102,54 @@
 	else
 		r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
 
+/datum/outfit/job/roguetown/greater_skeleton/pre_equip(mob/living/carbon/human/H) //equipped onto Summon Greater Skeleton players
+	..()
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+	if(prob(50))
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
+	else
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant/l
+	if(prob(50))
+		pants = /obj/item/clothing/under/roguetown/tights/vagrant
+	else
+		pants = /obj/item/clothing/under/roguetown/tights/vagrant/l
+	head = /obj/item/clothing/head/roguetown/helmet/leather
+
+	H.STASTR = rand(14,16)
+	H.STASPD = 8
+	H.STACON = 9
+	H.STAEND = 15
+	H.STAINT = 1
+
+	//light labor skills for skeleton manual labor and some warrior-adventurer skills, equipment is still bad probably
+	H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/masonry, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+
+	H.possible_rmb_intents = list(/datum/rmb_intent/feint,\
+	/datum/rmb_intent/aimed,\
+	/datum/rmb_intent/strong,\
+	/datum/rmb_intent/swift,\
+	/datum/rmb_intent/riposte,\
+	/datum/rmb_intent/weak)
+	H.swap_rmb_intent(num=1) //dont want to mess with base NPCs too much out of fear of breaking them so I assigned the intents in the outfit
+
+	if(prob(50))
+		r_hand = /obj/item/rogueweapon/sword
+	else
+		r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
+
 /mob/living/carbon/human/species/skeleton/npc/no_equipment
     skel_outfit = null
 

--- a/code/modules/mob/living/carbon/human/npc/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton.dm
@@ -102,7 +102,7 @@
 	else
 		r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
 
-/datum/outfit/job/roguetown/greater_skeleton/pre_equip(mob/living/carbon/human/H) //equipped onto Summon Greater Skeleton players
+/datum/outfit/job/roguetown/greater_skeleton/pre_equip(mob/living/carbon/human/H) //equipped onto Summon Greater Undead player skeletons only after the mind is added
 	..()
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
@@ -110,11 +110,9 @@
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
 	else
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant/l
-	if(prob(50))
-		pants = /obj/item/clothing/under/roguetown/tights/vagrant
-	else
-		pants = /obj/item/clothing/under/roguetown/tights/vagrant/l
+	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 	head = /obj/item/clothing/head/roguetown/helmet/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots
 
 	H.STASTR = rand(14,16)
 	H.STASPD = 8

--- a/code/modules/mob/living/carbon/human/npc/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton.dm
@@ -10,6 +10,7 @@
 	ambushable = FALSE
 	rot_type = null
 	possible_rmb_intents = list()
+	cmode_music = 'sound/music/combat_weird.ogg'
 
 /mob/living/carbon/human/species/skeleton/npc
 	aggressive = 1
@@ -124,6 +125,8 @@
 	H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/masonry, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+
 	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
@@ -134,6 +137,8 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+
+	H.set_patron(/datum/patron/inhumen/zizo)
 
 	H.possible_rmb_intents = list(/datum/rmb_intent/feint,\
 	/datum/rmb_intent/aimed,\

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -101,6 +101,11 @@
 			return pick('sound/vo/mobs/skel/skeleton_idle (1).ogg','sound/vo/mobs/skel/skeleton_idle (2).ogg','sound/vo/mobs/skel/skeleton_idle (3).ogg')
 
 
+/mob/living/simple_animal/hostile/rogue/skeleton/Initialize(mapload, mob/user)
+	. = ..()
+	if(user)
+		friends += user
+
 /mob/living/simple_animal/hostile/rogue/skeleton/Life()
 	. = ..()
 	if(!target)
@@ -113,6 +118,23 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/taunted(mob/user)
 	emote("aggro")
 	GiveTarget(user)
+	return
+
+/mob/living/simple_animal/hostile/rogue/skeleton/beckoned(mob/user)
+	if(user in friends)
+		for(var/mob/living/simple_animal/hostile/rogue/skeleton/target in viewers(user))
+			if(!(user in target.friends))
+				return
+			target.LoseTarget()
+			target.search_objects = 2
+	return
+
+/mob/living/simple_animal/hostile/rogue/skeleton/shood(mob/user)
+	if(user in friends)
+		for(var/mob/living/simple_animal/hostile/rogue/skeleton/target in viewers(user))
+			if(!(user in target.friends))
+				return
+			target.RegainSearchObjects()
 	return
 
 

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -81,7 +81,7 @@
 	. = ..()
 	var/turf/T = get_turf(targets[1])
 	if(isopenturf(T))
-		var/mob/living/carbon/target = new /mob/living/carbon/human/species/skeleton/npc(T)
+		var/mob/living/carbon/human/target = new /mob/living/carbon/human/species/skeleton/no_equipment(T)
 		var/list/candidates = pollCandidatesForMob("Do you want to play as a Necromancer's skeleton?", null, null, null, 100, target, POLL_IGNORE_NECROMANCER_SKELETON)
 		if(LAZYLEN(candidates))
 			var/mob/C = pick(candidates)
@@ -91,10 +91,14 @@
 			target.key = C.key
 			target.visible_message(span_warning("[target]'s eyes light up with an eerie glow!"))
 			target.mind.AddSpell(new /obj/effect/proc_holder/spell/self/suicidebomb/lesser)
+			target.equipOutfit(/datum/outfit/job/roguetown/greater_skeleton)
 		else
-			target.visible_message(span_warning("[target]'s eyes remain dully devoid of life. The spell failed to capture a soul from the ether."))
+			target.visible_message(span_warning("[target]'s form crumbles into dust."))
+			qdel(target)
+			revert_cast()
 		return TRUE
 	to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))
+	revert_cast()
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/raise_lesser_undead
@@ -120,15 +124,15 @@
 	if(isopenturf(T))
 		switch(skeleton_roll)
 			if(1 to 20)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T, user)
 			if(21 to 40)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T, user)
 			if(41 to 60)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T, user)
 			if(61 to 80)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T, user)
 			if(81 to 100)
-				new /mob/living/simple_animal/hostile/rogue/skeleton(T)
+				new /mob/living/simple_animal/hostile/rogue/skeleton(T, user)
 		return TRUE
 	else
 		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))


### PR DESCRIPTION
Simplemob Skeletons will now go into retaliate-only mode if a mob in their "friends" list uses the Beckon emote on them, and go back to normal if a "friend" uses the Shoo emote.
This targets any Simplemob Skeletons that can see the emoting mob.

Summon Lesser Undead now adds the caster to the simplemob's "friends" list.

Summon Greater Undead will now delete the blank Skeleton mob if no player accepts the offer and skip the cooldown.

Summon Greater Undead's summoned Player Skeletons' now have intents.

Summon Greater Undead's summoned Player Skeletons' now recieve a custom outfit when spawning:
Novice skills in Carpentry, Crafting, Masonry and Sewing to let them work as manual labor.
9 CON instead of 4.
Various weapon skills approximating the Warrior Adventurer class.
Armor randomization aspects severely reduced. (It isn't a roll for them to spawn with bracers, armor, or a helmet, it's guaranteed)
They also get regular boots and iron chain pants.
They get Heavy Armor Training (if they somehow acquire any).
Their patron is assigned to Zizo.

Skeletons now use zombies' combat music. (combat_weird.ogg)