### PR TITLE
lets physicians compete with healing magic (maybe)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -53,7 +53,6 @@
 	)
 	ADD_TRAIT(H, TRAIT_EMPATH, "[type]")
 	ADD_TRAIT(H, TRAIT_NOSTINK, "[type]")
-	ADD_TRAIT(H, TRAIT_ROT_EATER, "[type]")
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 5, TRUE)

--- a/code/modules/surgery/surgeries/healing.dm
+++ b/code/modules/surgery/surgeries/healing.dm
@@ -64,8 +64,18 @@
 /datum/surgery_step/heal/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	var/umsg = "You succeed in fixing some of [target]'s wounds" //no period, add initial space to "addons"
 	var/tmsg = "[user] fixes some of [target]'s wounds" //see above
-	var/urhealedamt_brute = brutehealing
-	var/urhealedamt_burn = burnhealing
+	var/healing_multiplier = 1
+	switch(user.mind.get_skill_level(skill_used))
+		if(SKILL_LEVEL_JOURNEYMAN)
+			healing_multiplier = 1.2
+		if(SKILL_LEVEL_EXPERT)
+			healing_multiplier = 1.4
+		if(SKILL_LEVEL_MASTER)
+			healing_multiplier = 1.7
+		if(SKILL_LEVEL_LEGENDARY)
+			healing_multiplier = 2
+	var/urhealedamt_brute = brutehealing * healing_multiplier
+	var/urhealedamt_burn = burnhealing * healing_multiplier
 	if(missinghpbonus)
 		if(target.stat != DEAD)
 			urhealedamt_brute += round((target.getBruteLoss()/ missinghpbonus),0.1)
@@ -111,11 +121,10 @@
 
 /datum/surgery_step/heal/brute/upgraded/femto
 	name = "Tend bruises (Exp.)"
-	brutehealing = 20
+	brutehealing = 10
 	missinghpbonus = 2.5
-	requires_tech = FALSE
+	requires_tech = TRUE
 	replaced_by = null
-	skill_min = SKILL_LEVEL_LEGENDARY
 
 /********************BURN STEPS********************/
 /datum/surgery_step/heal/burn/basic
@@ -134,10 +143,9 @@
 
 /datum/surgery_step/heal/burn/upgraded/femto
 	name = "Tend burns (Exp.)"
-	burnhealing = 20
+	burnhealing = 10
 	missinghpbonus = 2.5
-	requires_tech = FALSE
-	skill_min = SKILL_LEVEL_LEGENDARY
+	requires_tech = TRUE
 	replaced_by = null
 
 /********************COMBO STEPS********************/
@@ -159,11 +167,10 @@
 
 /datum/surgery_step/heal/combo/upgraded/femto
 	name = "Tend damage (Exp.)"
-	brutehealing = 12
-	burnhealing = 12
+	brutehealing = 6
+	burnhealing = 6
 	missinghpbonus = 2.5
-	requires_tech = FALSE
-	skill_min = SKILL_LEVEL_LEGENDARY
+	requires_tech = TRUE
 	replaced_by = null
 
 /datum/surgery_step/heal/combo/upgraded/femto/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/code/modules/surgery/surgeries/healing.dm
+++ b/code/modules/surgery/surgeries/healing.dm
@@ -111,10 +111,11 @@
 
 /datum/surgery_step/heal/brute/upgraded/femto
 	name = "Tend bruises (Exp.)"
-	brutehealing = 10
+	brutehealing = 20
 	missinghpbonus = 2.5
-	requires_tech = TRUE
+	requires_tech = FALSE
 	replaced_by = null
+	skill_min = SKILL_LEVEL_LEGENDARY
 
 /********************BURN STEPS********************/
 /datum/surgery_step/heal/burn/basic
@@ -133,9 +134,10 @@
 
 /datum/surgery_step/heal/burn/upgraded/femto
 	name = "Tend burns (Exp.)"
-	burnhealing = 10
+	burnhealing = 20
 	missinghpbonus = 2.5
-	requires_tech = TRUE
+	requires_tech = FALSE
+	skill_min = SKILL_LEVEL_LEGENDARY
 	replaced_by = null
 
 /********************COMBO STEPS********************/
@@ -157,10 +159,11 @@
 
 /datum/surgery_step/heal/combo/upgraded/femto
 	name = "Tend damage (Exp.)"
-	brutehealing = 6
-	burnhealing = 6
+	brutehealing = 12
+	burnhealing = 12
 	missinghpbonus = 2.5
-	requires_tech = TRUE
+	requires_tech = FALSE
+	skill_min = SKILL_LEVEL_LEGENDARY
 	replaced_by = null
 
 /datum/surgery_step/heal/combo/upgraded/femto/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Reworked with the aid of EvenInDeathIStillServe (they now pretty much did the work) Tend damage surgery steps now use multipliers based off skill level. Base healing is 10
journeyman is 1.2x aka 12 damage per use
Expert is 1.4x
Master is 1.7x
Legendary is 2x 

I've also removed a likely unintended rot eater (Pestra patron blessing) perk from the physician since their patron is no longer locked to Pestra as of PR #474 . Dunno why it doubled up. Don't see why they should get to double up on divine traits. They can obviously still obtain this normally. Seemed unintended to me.

Small note. I originally intended to block this behind a perk that only specific roles got but....that was difficult this is lazy and works well enough. But that would be a better solution if someone's up to it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more becoming immediately overtaxed the moment I have to deal with more then 1 patient. No more being infinitely outclassed by middle click until better.  Makes literally stripping down and being cut into painfully more worth while then just sleeping. (sleeping pretty much heals just as fast if not faster then tend damage prior to this btw)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
