### PR TITLE
Tweak human AI, readd stamina to NPCs, misc. optimisations

### DIFF
--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -9,8 +9,6 @@ SUBSYSTEM_DEF(mobs)
 	var/static/list/clients_by_zlevel[][]
 	var/static/list/dead_players_by_zlevel[][] = list(list()) // Needs to support zlevel 1 here, MaxZChanged only happens when z2 is created and new_players can login before that.
 	var/static/list/cubemonkeys = list()
-	var/list/dead_mobs = list()
-	var/amt2process = 5
 
 
 /datum/controller/subsystem/mobs/stat_entry()
@@ -42,10 +40,6 @@ SUBSYSTEM_DEF(mobs)
 	if (!resumed)
 		src.currentrun = GLOB.mob_living_list.Copy()
 
-	var/createnewdm = FALSE
-	if(!dead_mobs.len)
-		createnewdm = TRUE
-
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
 	var/times_fired = src.times_fired
@@ -56,22 +50,8 @@ SUBSYSTEM_DEF(mobs)
 			GLOB.mob_living_list.Remove(L)
 			continue
 		if(L.stat == DEAD)
-			if(createnewdm)
-				dead_mobs |= L
+			L.DeadLife()
 		else
 			L.Life(seconds, times_fired)
-		if (MC_TICK_CHECK)
-			return
-
-	var/ye = 0
-	while(dead_mobs.len)
-		if(ye > amt2process)
-			return
-		ye++
-		var/mob/living/L = dead_mobs[dead_mobs.len]
-		dead_mobs.len--
-		if(!L || QDELETED(L))
-			continue
-		L.DeadLife()
 		if (MC_TICK_CHECK)
 			return

--- a/code/controllers/subsystem/rogue/humannpc.dm
+++ b/code/controllers/subsystem/rogue/humannpc.dm
@@ -28,6 +28,10 @@ SUBSYSTEM_DEF(humannpc)
 
 /datum/controller/subsystem/humannpc/proc/try_process_ai(mob/living/carbon/human/thing)
 	set waitfor = FALSE
+	if(thing.ai_currently_active)
+		return // Already running from another tick, don't do another action!
+	thing.ai_currently_active = TRUE
 	. = thing.process_ai()
+	thing.ai_currently_active = FALSE
 	if(.)
 		STOP_PROCESSING(src, thing)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -117,7 +117,7 @@
 			healing -= 0.1
 			break //Only count the first bedsheet
 		if(health_ratio > 0.8)
-			owner.adjustToxLoss(healing * 0.5, TRUE, TRUE)
+			owner.adjustToxLoss(healing * 0.5, FALSE, TRUE)
 		owner.adjustStaminaLoss(healing)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds

--- a/code/game/objects/inhands_rogue.dm
+++ b/code/game/objects/inhands_rogue.dm
@@ -1,5 +1,6 @@
 /obj/item
-	var/list/onprop = list()
+	/// A lazylist to store inhands data.
+	var/list/onprop
 	var/d_type = "blunt"
 //#ifdef TESTSERVER
 	var/force_reupdate_inhand = TRUE
@@ -736,16 +737,10 @@ GLOBAL_LIST_EMPTY(icon_state_cache)
 		if(!used_cat)
 			used_cat = "gen"
 
-		for(var/X in I.onprop)
-			if(X == used_cat)
-				var/list/L = I.onprop[X]
-				if(L.len)
-					if(!needtofind in L)
-						L += needtofind
-					for(var/P in L)
-						if(P == needtofind)
-							L[P] += 0.1
-							to_chat(LI, "[needtofind] = [L[P]]")
+		if(length(I.onprop?[used_cat]))
+			var/list/L = I.onprop[used_cat]
+			L[needtofind] += 0.1
+			to_chat(LI, "[needtofind] = [L[needtofind]]")
 	LI.update_inv_hands()
 	LI.update_inv_belt()
 	LI.update_inv_back()
@@ -780,16 +775,10 @@ GLOBAL_LIST_EMPTY(icon_state_cache)
 		if(!used_cat)
 			used_cat = "gen"
 
-		for(var/X in I.onprop)
-			if(X == used_cat)
-				var/list/L = I.onprop[X]
-				if(L.len)
-					if(!needtofind in L)
-						L += needtofind
-					for(var/P in L)
-						if(P == needtofind)
-							L[P] -= 0.1
-							to_chat(LI, "[needtofind] = [L[P]]")
+		if(length(I.onprop?[used_cat]))
+			var/list/L = I.onprop[used_cat]
+			L[needtofind] -= 0.1
+			to_chat(LI, "[needtofind] = [L[needtofind]]")
 	LI.update_inv_hands()
 	LI.update_inv_belt()
 	LI.update_inv_back()

--- a/code/game/objects/inhands_rogue.dm
+++ b/code/game/objects/inhands_rogue.dm
@@ -34,6 +34,8 @@
 	var/static/list/onmob_sprites = list()
 	var/icon/onmob = onmob_sprites["[tag][behind][mirrored][used_index]"]
 	if(!onmob || force_reupdate_inhand)
+		if(force_reupdate_inhand)
+			has_behind_state = null
 		onmob = fcopy_rsc(generateonmob(tag, prop, behind, mirrored))
 		onmob_sprites["[tag][behind][mirrored][used_index]"] = onmob
 	return onmob
@@ -70,6 +72,26 @@
 		if(0.7)
 			return 1
 
+// For checking if we have a specific icon state in an icon.
+// Cached cause asking icons is expensive. This is still expensive, so avoid using it if
+// you can reasonably expect the icon_state to exist beforehand, or if you can cache the
+// value somewhere.
+GLOBAL_LIST_EMPTY(icon_state_cache)
+/proc/check_state_in_icon(var/checkstate, var/checkicon)
+	// isicon() is apparently quite expensive so short-circuit out early if we can.
+	if(!istext(checkstate) || isnull(checkicon) || !(isfile(checkicon) || isicon(checkicon)))
+		return FALSE
+	var/checkkey = "\ref[checkicon]"
+	var/list/check = GLOB.icon_state_cache[checkkey]
+	if(!check)
+		check = list()
+		for(var/istate in icon_states(checkicon))
+			check[istate] = TRUE
+		GLOB.icon_state_cache[checkkey] = check
+	. = check[checkstate]
+
+/obj/item/var/has_behind_state
+
 /obj/item/proc/generateonmob(tag, prop, behind, mirrored)
 	var/list/used_prop = prop
 	var/UH = 64
@@ -79,18 +101,14 @@
 	var/icon/blended
 	var/skipoverlays = FALSE
 	if(behind)
-		var/icon/J = new(icon)
-		var/list/istates = J.IconStates()
-		if(istates.Find("[icon_state]_behind"))
+		if(isnull(has_behind_state))
+			has_behind_state = check_state_in_icon(icon, "[icon_state]_behind")
+		if(has_behind_state)
 			blended=icon("icon"=icon, "icon_state"="[icon_state]_behind")
 			skipoverlays = TRUE
 		else
-		//	blended=icon("icon"=icon, "icon_state"=icon_state)
-//			blended=getFlatIcon(src)
 			blended=icon("icon"=icon, "icon_state"=icon_state)
 	else
-	//	blended=icon("icon"=icon, "icon_state"=icon_state)
-//		blended=getFlatIcon(src)
 		blended=icon("icon"=icon, "icon_state"=icon_state)
 
 	if(!blended)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -48,49 +48,48 @@
 			for(var/datum/mutation/human/HM in dna.mutations) // Handle active genes
 				HM.on_life()
 
-		if(mode == AI_OFF)
-			handle_vamp_dreams()
-			if(IsSleeping())
-				if(health > 0)
-					if(has_status_effect(/datum/status_effect/debuff/sleepytime))
-						remove_status_effect(/datum/status_effect/debuff/sleepytime)
-						remove_stress(/datum/stressevent/sleepytime)
-						if(mind)
-							mind.sleep_adv.advance_cycle()
-							if(!mind.antag_datums || !mind.antag_datums.len)
-								allmig_reward++
-								adjust_triumphs(1)
-								to_chat(src, span_danger("Nights Survived: \Roman[allmig_reward]"))
-			if(leprosy == 1)
-				adjustToxLoss(2)
-			else if(leprosy == 2)
-				if(client)
-					if(check_blacklist(client.ckey))
-						ADD_TRAIT(src, TRAIT_NOPAIN, TRAIT_GENERIC)
-						leprosy = 1
-						var/obj/item/bodypart/B = get_bodypart(BODY_ZONE_HEAD)
-						if(B)
-							B.sellprice = rand(16, 33)
-					else
-						leprosy = 3
-			//heart attack stuff
-			handle_heart()
-			handle_liver()
-			update_rogfat()
-			update_rogstam()
-			if(charflaw && !charflaw.ephemeral)
-				charflaw.flaw_on_life(src)
-			if(health <= 0)
-				adjustOxyLoss(0.5)
-			if(!client && !HAS_TRAIT(src, TRAIT_NOSLEEP))
-				if(mob_timers["slo"])
-					if(world.time > mob_timers["slo"] + 90 SECONDS)
-						Sleeping(100)
+		handle_vamp_dreams()
+		if(IsSleeping())
+			if(health > 0)
+				if(has_status_effect(/datum/status_effect/debuff/sleepytime))
+					remove_status_effect(/datum/status_effect/debuff/sleepytime)
+					remove_stress(/datum/stressevent/sleepytime)
+					if(mind)
+						mind.sleep_adv.advance_cycle()
+						if(!mind.antag_datums || !mind.antag_datums.len)
+							allmig_reward++
+							adjust_triumphs(1)
+							to_chat(src, span_danger("Nights Survived: \Roman[allmig_reward]"))
+		if(leprosy == 1)
+			adjustToxLoss(2)
+		else if(leprosy == 2)
+			if(client)
+				if(check_blacklist(client.ckey))
+					ADD_TRAIT(src, TRAIT_NOPAIN, TRAIT_GENERIC)
+					leprosy = 1
+					var/obj/item/bodypart/B = get_bodypart(BODY_ZONE_HEAD)
+					if(B)
+						B.sellprice = rand(16, 33)
 				else
-					mob_timers["slo"] = world.time
+					leprosy = 3
+		//heart attack stuff
+		handle_heart()
+		handle_liver()
+		update_rogfat()
+		update_rogstam()
+		if(charflaw && !charflaw.ephemeral)
+			charflaw.flaw_on_life(src)
+		if(health <= 0)
+			adjustOxyLoss(0.5)
+		if(mode != AI_ON && !client && !HAS_TRAIT(src, TRAIT_NOSLEEP))
+			if(mob_timers["slo"])
+				if(world.time > mob_timers["slo"] + 90 SECONDS)
+					Sleeping(100)
 			else
-				if(mob_timers["slo"])
-					mob_timers["slo"] = null
+				mob_timers["slo"] = world.time
+		else
+			if(mob_timers["slo"])
+				mob_timers["slo"] = null
 
 		if(dna?.species)
 			dna.species.spec_life(src) // for mutantraces

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -81,7 +81,7 @@
 			charflaw.flaw_on_life(src)
 		if(health <= 0)
 			adjustOxyLoss(0.5)
-		if(mode != AI_ON && !client && !HAS_TRAIT(src, TRAIT_NOSLEEP))
+		if(mode == AI_OFF && !client && !HAS_TRAIT(src, TRAIT_NOSLEEP))
 			if(mob_timers["slo"])
 				if(world.time > mob_timers["slo"] + 90 SECONDS)
 					Sleeping(100)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -22,6 +22,7 @@
 	var/next_seek = 0
 	var/flee_in_pain = FALSE
 	var/stand_attempts = 0
+	var/ai_currently_active = FALSE
 
 	var/returning_home = FALSE
 
@@ -52,18 +53,19 @@
 			walk_to(src,0)
 			resist()
 			resisting = FALSE
-		if(!(mobility_flags & MOBILITY_STAND) && (stand_attempts < 3))
-			resisting = TRUE
-			npc_stand()
-			resisting = FALSE
-		else
-			stand_attempts = 0
-			if(!handle_combat())
-				if(mode == AI_IDLE && !pickupTarget)
-					npc_idle()
-					if(del_on_deaggro && last_aggro_loss && (world.time >= last_aggro_loss + del_on_deaggro))
-						if(deaggrodel())
-							return TRUE
+		if(!resisting)
+			if(!(mobility_flags & MOBILITY_STAND) && (stand_attempts < 3))
+				resisting = TRUE
+				npc_stand()
+				resisting = FALSE
+			else
+				stand_attempts = 0
+				if(!handle_combat())
+					if(mode == AI_IDLE && !pickupTarget)
+						npc_idle()
+						if(del_on_deaggro && last_aggro_loss && (world.time >= last_aggro_loss + del_on_deaggro))
+							if(deaggrodel())
+								return TRUE
 	else
 		walk_to(src,0)
 		return TRUE

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -727,10 +727,10 @@ There are several things that need to be remembered:
 			if(beltr.experimental_onhip)
 				var/list/prop
 				if(beltr.force_reupdate_inhand)
-					prop = beltr.onprop["onbelt"]
+					prop = beltr?.onprop["onbelt"]
 					if(!prop)
-						beltr.onprop["onbelt"] = beltr.getonmobprop("onbelt")
-						prop = beltr.onprop["onbelt"]
+						prop = beltr.getonmobprop("onbelt")
+						LAZYSET(beltr.onprop, "onbelt", prop)
 				else
 					prop = beltr.getonmobprop("onbelt")
 				if(prop)

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -138,10 +138,10 @@
 				used_prop = "gen"
 				prop = I.getonmobprop(used_prop)
 			if(I.force_reupdate_inhand)
-				if(I.onprop[used_prop])
+				if(I.onprop?[used_prop])
 					prop = I.onprop[used_prop]
 				else
-					I.onprop[used_prop] = prop
+					LAZYSET(I.onprop, used_prop, prop)
 			if(!prop)
 				continue
 			var/flipsprite = FALSE

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -76,11 +76,9 @@
 	if(stat != DEAD)
 		return 1
 
-/mob/living
-	var/last_deadlife
-
 /mob/living/proc/DeadLife()
 	set invisibility = 0
+	set waitfor = FALSE
 	if (notransform)
 		return
 	if(!loc)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -130,9 +130,20 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(!operating)
 		return
 	use_power(6)
-	// Who the fuck put this on a 1ds delay? It happens every 2s, what does it matter
-	for(var/atom/movable/A as anything in loc)
+	if(!isturf(loc)) // We're nowhere!
+		return
+	var/turf/turf_loc = loc
+	var/list/cached_contents = loc.contents - src - turf_loc.lighting_object
+	if(!length(cached_contents)) // nothing to convey, don't waste time creating a timer!
+		return
+	// This is on a one-decisecond delay to prevent conveyors from chaining movement into each other.
+	addtimer(CALLBACK(src, PROC_REF(convey), cached_contents), 0.1 SECONDS)
+
+/obj/machinery/conveyor/proc/convey(list/atom/movable/cached_contents)
+	for(var/atom/movable/A as anything in cached_contents)
 		if(A == src)
+			continue
+		if(A.anchored)
 			continue
 		A.ConveyorMove(movedir)
 


### PR DESCRIPTION
## About The Pull Request
- AI-controlled mobs now regenerate stamina (and do some other misc. processing).
- Human NPCs will no longer take actions while busy (i.e. getting up).
- Tries to optimise build_appearance_list.
- Makes the sleeping status effect slightly less expensive by removing a redundant update_health call.
- Optimises inhand generation by cacheing an IconStates call.
- Removes the indefatigable trait from NPCs.
- Fixes me breaking conveyors because I didn't understand something.

## Why It's Good For The Game
The AI should be less overpowered, and the game should run a good bit faster. Also fixes conveyors moving you at lightspeed LMAO