### PR TITLE
The Bandit Culling

### DIFF
--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -202,7 +202,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 	"Royal Guard")
 	var/num_bandits = 0
 	if(num_players() >= 10)
-		num_bandits = CLAMP(round(num_players() / 5), 4, 8)
+		num_bandits = CLAMP(round(num_players() / 5), 4, 6)
 		var/datum/job/bandit_job = SSjob.GetJob("Bandit")
 		bandit_job.total_positions = num_bandits
 		bandit_job.spawn_positions = num_bandits

--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -202,7 +202,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 	"Royal Guard")
 	var/num_bandits = 0
 	if(num_players() >= 10)
-		num_bandits = CLAMP(round(num_players() / 2), 25, 30)
+		num_bandits = CLAMP(round(num_players() / 5), 4, 8)
 		var/datum/job/bandit_job = SSjob.GetJob("Bandit")
 		bandit_job.total_positions = num_bandits
 		bandit_job.spawn_positions = num_bandits

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
@@ -9,7 +9,6 @@
 	)
 	outfit = /datum/outfit/job/roguetown/mercenary/blackoak
 	category_tags = list(CTAG_MERCENARY)
-	maximum_possible_slots = 5
 
 /datum/outfit/job/roguetown/mercenary/blackoak/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/condottiero.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/condottiero.dm
@@ -5,7 +5,6 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/condottiero
 	category_tags = list(CTAG_MERCENARY)
-	maximum_possible_slots = 5
 
 /datum/outfit/job/roguetown/mercenary/condottiero/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -5,7 +5,6 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/desert_rider
 	category_tags = list(CTAG_MERCENARY)
-	maximum_possible_slots = 6
 	cmode_music = 'sound/music/combat_desertrider.ogg' //GREATEST COMBAT TRACK IN THE GAME SO FAR BESIDES MAYBE MANIAC2.OGG
 
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -5,7 +5,6 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/grenzelhoft
 	category_tags = list(CTAG_MERCENARY)
-	maximum_possible_slots = 6
 	cmode_music = 'sound/music/combat_grenzelhoft.ogg'
 
 /datum/outfit/job/roguetown/mercenary/grenzelhoft/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
@@ -5,7 +5,6 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/steppesman
 	category_tags = list(CTAG_MERCENARY)
-	maximum_possible_slots = 6
 	cmode_music = 'sound/music/combat_steppe.ogg'
 
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
@@ -10,7 +10,6 @@
 	)
 	outfit = /datum/outfit/job/roguetown/mercenary/underdweller
 	category_tags = list(CTAG_MERCENARY)
-	maximum_possible_slots = 5
 
 /datum/outfit/job/roguetown/mercenary/underdweller/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -5,7 +5,6 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar
 	category_tags = list(CTAG_MERCENARY)
-	maximum_possible_slots = 3
 	cmode_music = 'sound/music/warscholar.ogg'
 
 /datum/outfit/job/roguetown/mercenary/warscholar/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
@@ -3,8 +3,8 @@
 	flag = MERCENARY
 	department_flag = MERCENARIES
 	faction = "Station"
-	total_positions = 6		//Was 3 Grenz and 3 Desert, merging together to 6 total.
-	spawn_positions = 6
+	total_positions = 8
+	spawn_positions = 8
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Blood stains your hands and the coins you hold. You are a sell-sword, a mercenary, a contractor of war. Where you come from, what you are, who you serve.. none of it matters. What matters is that the mammon flows to your pocket."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -46,17 +46,15 @@ Difficulty: Medium
 	friendly_verb_continuous = "stares down"
 	friendly_verb_simple = "stare down"
 	speak_emote = list("roars")
-	armor_penetration = 40
-	melee_damage_lower = 40
-	melee_damage_upper = 40
+	armor_penetration = 30
+	melee_damage_lower = 45
+	melee_damage_upper = 70
 	speed = 5
 	move_to_delay = 5
 	ranged = TRUE
 	pixel_x = -16
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/dragon/crusher)
-	loot = list(/obj/structure/closet/crate/necropolis/dragon)
-	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
-	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/ashdrake = 10)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 20,
+						/obj/item/natural/hide = 20, /obj/item/natural/bundle/bone/full = 4)
 	var/swooping = NONE
 	var/player_cooldown = 0
 	gps_name = "Fiery Signal"

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -14,14 +14,13 @@
 	see_in_dark = 6
 	move_to_delay = 3
 	base_intents = list(/datum/intent/simple/bite)
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 2,
-						/obj/item/natural/hide = 2,
-						/obj/item/natural/fur = 1, /obj/item/natural/bone = 4)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 20,
+						/obj/item/natural/hide = 20, /obj/item/natural/bundle/bone/full = 4)
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	health = 2500
 	maxHealth = 2500
-	melee_damage_lower = 19
-	melee_damage_upper = 29
+	melee_damage_lower = 45
+	melee_damage_upper = 70
 	vision_range = 7
 	aggro_vision_range = 9
 	environment_smash = ENVIRONMENT_SMASH_NONE


### PR DESCRIPTION
So, funny thing. The minimum number of bandit slots was 25. Isn't that crazy? Haha.

Anyways, when bandits roll, the minimum is now 4, increased by 1 for every 5 players readied up beyond 20, with a maximum of 6 bandits.

Buffed dragon damage. Gave them proper butcher results. Removed the necropolis chest from the boss version.

Mercenary slots increased to 8. There are no more class slot maximums for mercs.