### PR TITLE
Adds Big People

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -16,6 +16,7 @@
 	/datum/species/dracon,\
 	/datum/species/anthromorph,\
 	/datum/species/anthromorphsmall,\
+	/datum/species/anthromorphbig,\
 	/datum/species/demihuman,\
 	/datum/species/halforc,\
 	/datum/species/kobold,\
@@ -40,6 +41,7 @@
 	/datum/species/tabaxi,\
 	/datum/species/akula,\
 	/datum/species/anthromorph,\
+	/datum/species/anthromorphbig,\
 	/datum/species/demihuman
 
 #define RACES_SHUNNED \
@@ -73,6 +75,7 @@
 	/datum/species/dracon,\
 	/datum/species/anthromorph,\
 	/datum/species/anthromorphsmall,\
+	/datum/species/anthromorphbig,\
 	/datum/species/demihuman,\
 	/datum/species/kobold,\
 	/datum/species/goblinp,\
@@ -95,6 +98,7 @@
 	/datum/species/dracon,\
 	/datum/species/anthromorph,\
 	/datum/species/anthromorphsmall,\
+	/datum/species/anthromorphbig,\
 	/datum/species/demihuman,\
 	/datum/species/halforc,\
 	/datum/species/kobold,\
@@ -116,6 +120,7 @@
 	/datum/species/moth,\
 	/datum/species/dracon,\
 	/datum/species/anthromorph,\
+	/datum/species/anthromorphbig,\
 	/datum/species/demihuman,\
 	/datum/species/halforc,\
 )
@@ -132,6 +137,7 @@
 	/datum/species/moth,\
 	/datum/species/dracon,\
 	/datum/species/anthromorph,\
+	/datum/species/anthromorphbig,\
 	/datum/species/demihuman,\
 )
 #define ALL_CLERIC_PATRONS list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/necra, /datum/patron/divine/pestra, /datum/patron/divine/ravox, /datum/patron/divine/malum, /datum/patron/divine/eora)

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorphbig.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorphbig.dm
@@ -1,0 +1,170 @@
+/mob/living/carbon/human/species/anthromorphbig
+	race = /datum/species/anthromorphbig
+
+/datum/species/anthromorphbig
+	name = "Half-Giant"
+	id = "anthromorphbig"
+	desc = "<b>Half-Giant</b><br>\
+	Mortals born with the blood of Giants in their veins."
+	default_color = "444"
+	species_traits = list(
+		MUTCOLORS,
+		EYECOLOR,
+		LIPS,
+		HAIR,
+	)
+	inherent_traits = list(TRAIT_NOMOBSWAP)
+	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	attack_verb = "slash"
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
+	possible_ages = ALL_AGES_LIST
+	limbs_icon_m = 'icons/mob/species/male.dmi'
+	limbs_icon_f = 'icons/mob/species/female.dmi'
+	dam_icon = 'icons/roguetown/mob/bodies/dam/dam_male.dmi'
+	dam_icon_f = 'icons/roguetown/mob/bodies/dam/dam_female.dmi'
+	soundpack_m = /datum/voicepack/male
+	soundpack_f = /datum/voicepack/female
+	offset_features = list(
+		OFFSET_ID = list(0,1), OFFSET_GLOVES = list(0,1), OFFSET_WRISTS = list(0,1),\
+		OFFSET_CLOAK = list(0,1), OFFSET_FACEMASK = list(0,1), OFFSET_HEAD = list(0,1), \
+		OFFSET_FACE = list(0,1), OFFSET_BELT = list(0,1), OFFSET_BACK = list(0,1), \
+		OFFSET_NECK = list(0,1), OFFSET_MOUTH = list(0,1), OFFSET_PANTS = list(0,1), \
+		OFFSET_SHIRT = list(0,1), OFFSET_ARMOR = list(0,1), OFFSET_HANDS = list(0,1), OFFSET_UNDIES = list(0,1), \
+		OFFSET_ID_F = list(0,-1), OFFSET_GLOVES_F = list(0,0), OFFSET_WRISTS_F = list(0,0), OFFSET_HANDS_F = list(0,0), \
+		OFFSET_CLOAK_F = list(0,0), OFFSET_FACEMASK_F = list(0,-1), OFFSET_HEAD_F = list(0,-1), \
+		OFFSET_FACE_F = list(0,-1), OFFSET_BELT_F = list(0,0), OFFSET_BACK_F = list(0,-1), \
+		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
+		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,0), \
+		)
+	race_bonus = list(STAT_CONSTITUTION = 1)
+	enflamed_icon = "widefire"
+	organs = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain,
+		ORGAN_SLOT_HEART = /obj/item/organ/heart,
+		ORGAN_SLOT_LUNGS = /obj/item/organ/lungs,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
+		ORGAN_SLOT_APPENDIX = /obj/item/organ/appendix,
+		)
+	bodypart_features = list(
+		/datum/bodypart_feature/hair/head,
+		/datum/bodypart_feature/hair/facial,
+	)
+	customizers = list(
+		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/bodypart_feature/hair/head/humanoid,
+		/datum/customizer/bodypart_feature/hair/facial/humanoid,
+		/datum/customizer/bodypart_feature/accessory,
+		/datum/customizer/bodypart_feature/face_detail,
+		/datum/customizer/bodypart_feature/underwear,
+		/datum/customizer/organ/tail/anthro,
+		/datum/customizer/organ/tail_feature/anthro,
+		/datum/customizer/organ/snout/anthro,
+		/datum/customizer/organ/ears/anthro,
+		/datum/customizer/organ/horns/anthro,
+		/datum/customizer/organ/frills/anthro,
+		/datum/customizer/organ/wings/anthro,
+		/datum/customizer/organ/neck_feature/anthro,
+		/datum/customizer/organ/testicles/anthro,
+		/datum/customizer/organ/penis/anthro,
+		/datum/customizer/organ/breasts/animal,
+		/datum/customizer/organ/vagina/anthro,
+		)
+	body_marking_sets = list(
+		/datum/body_marking_set/none,
+		/datum/body_marking_set/belly,
+		/datum/body_marking_set/bellysocks,
+		/datum/body_marking_set/tiger,
+		/datum/body_marking_set/tiger_dark,
+	)
+	body_markings = list(
+		/datum/body_marking/plain,
+		/datum/body_marking/tiger,
+		/datum/body_marking/tiger/dark,
+		/datum/body_marking/sock,
+		/datum/body_marking/socklonger,
+		/datum/body_marking/tips,
+		/datum/body_marking/bellyscale,
+		/datum/body_marking/bellyscaleslim,
+		/datum/body_marking/bellyscalesmooth,
+		/datum/body_marking/bellyscaleslimsmooth,
+		/datum/body_marking/buttscale,
+		/datum/body_marking/belly,
+		/datum/body_marking/bellyslim,
+		/datum/body_marking/butt,
+		/datum/body_marking/tie,
+		/datum/body_marking/tiesmall,
+		/datum/body_marking/backspots,
+		/datum/body_marking/front,
+		/datum/body_marking/drake_eyes,
+		/datum/body_marking/tonage,
+		/datum/body_marking/spotted,
+	)
+	descriptor_choices = list(
+		/datum/descriptor_choice/body,
+		/datum/descriptor_choice/stature,
+		/datum/descriptor_choice/face,
+		/datum/descriptor_choice/face_exp,
+		/datum/descriptor_choice/skin_all,
+		/datum/descriptor_choice/voice,
+		/datum/descriptor_choice/prominent_one,
+		/datum/descriptor_choice/prominent_two,
+	)
+
+/datum/species/anthromorphbig/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+	..()
+	RegisterSignal(C, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+/datum/species/anthromorphbig/after_creation(mob/living/carbon/C)
+	..()
+	C.dna.add_mutation(GIGANTISM)
+
+/datum/species/anthromorphbig/on_species_loss(mob/living/carbon/C)
+	. = ..()
+	UnregisterSignal(C, COMSIG_MOB_SAY)
+
+/datum/species/anthromorphbig/check_roundstart_eligible()
+	return TRUE
+
+/datum/species/anthromorphbig/qualifies_for_rank(rank, list/features)
+	return TRUE
+
+/datum/species/anthromorphbig/get_random_features()
+	var/list/returned = MANDATORY_FEATURE_LIST
+	var/main_color
+	var/second_color
+	var/third_color
+	var/random = rand(1,6)
+	switch(random)
+		if(1)
+			main_color = "FFFFFF"
+			second_color = "333333"
+			third_color = "333333"
+		if(2)
+			main_color = "FFFFDD"
+			second_color = "DD6611"
+			third_color = "AA5522"
+		if(3)
+			main_color = "DD6611"
+			second_color = "FFFFFF"
+			third_color = "DD6611"
+		if(4)
+			main_color = "CCCCCC"
+			second_color = "FFFFFF"
+			third_color = "FFFFFF"
+		if(5)
+			main_color = "AA5522"
+			second_color = "CC8833"
+			third_color = "FFFFFF"
+		if(6)
+			main_color = "FFFFDD"
+			second_color = "FFEECC"
+			third_color = "FFDDBB"
+	returned["mcolor"] = main_color
+	returned["mcolor2"] = second_color
+	returned["mcolor3"] = third_color
+	return returned
+

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2585,6 +2585,7 @@
 #include "code\modules\mob\living\carbon\human\species_types\furry\akula.dm"
 #include "code\modules\mob\living\carbon\human\species_types\furry\anthromorph.dm"
 #include "code\modules\mob\living\carbon\human\species_types\furry\anthromorphsmall.dm"
+#include "code\modules\mob\living\carbon\human\species_types\furry\anthromorphbig.dm"
 #include "code\modules\mob\living\carbon\human\species_types\furry\demihuman.dm"
 #include "code\modules\mob\living\carbon\human\species_types\furry\dracon.dm"
 #include "code\modules\mob\living\carbon\human\species_types\furry\kobold.dm"


### PR DESCRIPTION
TESTED

## About The Pull Request

Adds a half-giant race with some simple one-sentence lore that shouldn't be too offensive, totally willing for it to be updated in the future on whatever direction this server wants to go. 

Basically functions by being a race that gives players gigantism on spawn. It has no effects other than resizing the sprite to 1.25.

Sprite has slight blur to it, I've playtested it and played it on a different server (Hearthstone)- It's not that bad, really. The sprite doesn't go beyond the edges of the tile enough to cover anything up and everything on it is still easily recognizable. 

![Screenshot 2024-10-07 220930](https://github.com/user-attachments/assets/1b0f32b5-1217-41e7-ba41-815faccbd4cd)

This is a random gen char I spawned in as to test it.

## Why It's Good For The Game

More customization! There's a lot of people who want to play larger characters and have that be represented in their sprite. This adds that in a lore-friendly way that isn't too obnoxious.