### PR TITLE
I Can See Sounds: Buffs Noc Sight

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -82,7 +82,7 @@
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
 #define LIGHTING_PLANE_ALPHA_LESSER_NV_TRAIT 243
 #define LIGHTING_PLANE_ALPHA_NV_TRAIT 235
-#define LIGHTING_PLANE_ALPHA_DARKVISION 220
+#define LIGHTING_PLANE_ALPHA_DARKVISION 215
 #define LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE 192
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128 //For lighting alpha, small amounts lead to big changes. even at 128 its hard to figure out what is dark and what is light, at 64 you almost can't even tell.
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -769,7 +769,7 @@
 		see_in_dark = max(see_in_dark, 8)
 
 	if(HAS_TRAIT(src, TRAIT_NOCSIGHT))
-		E.lighting_alpha = 215
+		E.lighting_alpha = 225
 		E.see_in_dark = 8
 
 	if(see_override)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -769,8 +769,8 @@
 		see_in_dark = max(see_in_dark, 8)
 
 	if(HAS_TRAIT(src, TRAIT_NOCSIGHT))
-		E.lighting_alpha = LIGHTING_PLANE_ALPHA_LESSER_NV_TRAIT
-		E.see_in_dark = 7
+		E.lighting_alpha = 215
+		E.see_in_dark = 8
 
 	if(see_override)
 		see_invisible = see_override


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
* Buffs Noc Sight trait from 243 to 225.
* Buffs Dark Vision (the spell) from 220 to 215.

![image](https://github.com/user-attachments/assets/01b7a499-5c02-4528-912b-bb80d7e9d97a)

## Why It's Good For The Game
Noc Sight wasn't actually all that sightly, you couldn't see much and most resort to raise the gamma on their monitors. This should hopefully kill some of the incentive to do so, while properly playing into the thematics of a Noc worshipper.
