### PR TITLE
Dragon fixes and general mount decap adjustments

### DIFF
--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -1,4 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aJ" = (
+/obj/structure/closet/dirthole/closed,
+/mob/living/carbon/human/species/skeleton/npc,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/mountains)
 "aL" = (
 /obj/structure/lever/wall{
 	dir = 8;
@@ -15,6 +20,15 @@
 /obj/item/rogueweapon/sword/rapier/dec,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
+"aX" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains/decap)
+"aY" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "bn" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -41,6 +55,7 @@
 "bA" = (
 /obj/structure/closet/crate/chest/lootbox,
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/tile{
 	icon_state = "chess"
 	},
@@ -203,15 +218,14 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/mountains/decap)
 "ge" = (
-/obj/item/clothing/ring/diamonds,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/under/cave)
+/obj/structure/closet/dirthole/closed/loot,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/mountains)
 "gn" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/under/cave/dungeon1)
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/mountains)
 "gT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/silver{
@@ -274,6 +288,7 @@
 /area/rogue/outdoors/mountains/decap)
 "jP" = (
 /obj/structure/closet/crate/chest/lootbox,
+/obj/item/roguegem/random,
 /turf/open/floor/rogue/tile{
 	icon_state = "chess"
 	},
@@ -317,7 +332,7 @@
 /area/rogue/under/cave/dungeon1)
 "lh" = (
 /obj/structure/closet/crate/coffin,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap)
 "lu" = (
@@ -451,6 +466,10 @@
 /obj/item/reagent_containers/glass/cup/golden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
+"rQ" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "se" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -529,6 +548,11 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
+"uz" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 4
+	},
+/area/rogue/outdoors/mountains/decap)
 "uJ" = (
 /obj/structure/stairs/stone{
 	dir = 1;
@@ -783,11 +807,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "Dn" = (
-/obj/item/roguegem/random,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
-/area/rogue/under/cave/dungeon1)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
+/area/rogue/outdoors/mountains/decap)
 "Dp" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/blocks,
@@ -817,7 +838,6 @@
 /area/rogue/under/cave/dungeon1)
 "Eg" = (
 /obj/structure/bed/rogue/shit,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "Er" = (
@@ -842,6 +862,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/dungeon1)
+"Fs" = (
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "Fv" = (
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/blocks,
@@ -917,9 +941,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
 "Hb" = (
-/mob/living/simple_animal/hostile/megafauna/dragon/lesser{
+/mob/living/simple_animal/hostile/megafauna/dragon{
+	health = 1500;
 	faction = list("wolfs");
-	health = 1200;
 	name = "dragon broodmother"
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -993,6 +1017,11 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap)
+"Jx" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/roguestatue/gold/loot,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "Jy" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/dirt,
@@ -1007,6 +1036,11 @@
 "JT" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/mountains/decap)
+"JU" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
+	},
 /area/rogue/outdoors/mountains/decap)
 "JV" = (
 /obj/structure/rack/rogue,
@@ -1023,7 +1057,7 @@
 /area/rogue/outdoors/dungeon1)
 "Kf" = (
 /obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "Ku" = (
@@ -1039,6 +1073,10 @@
 /area/rogue/under/cave/dungeon1)
 "KL" = (
 /obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/mountains)
+"KZ" = (
+/obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "Lh" = (
@@ -1236,18 +1274,19 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 "Tt" = (
-/obj/item/clothing/ring/sapphires,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/dungeon1)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 8
+	},
+/area/rogue/outdoors/mountains/decap)
 "TA" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 "TD" = (
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "TW" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap)
@@ -1310,7 +1349,7 @@
 /area/rogue/under/cave)
 "VR" = (
 /obj/structure/closet/crate/chest/crate,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/obj/item/clothing/ring/sapphires,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/dungeon1)
 "Wl" = (
@@ -1347,6 +1386,9 @@
 /mob/living/carbon/human/species/goblin/npc/hell,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/dungeon1)
+"XG" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/outdoors/mountains/decap)
 "XQ" = (
 /obj/structure/mineral_door/bars,
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
@@ -1378,7 +1420,6 @@
 	icon_state = "border"
 	},
 /obj/structure/closet/crate/chest/old_crate,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 
@@ -2049,7 +2090,7 @@ ej
 PZ
 ej
 ej
-ge
+Ky
 Oj
 Oj
 yp
@@ -2178,7 +2219,7 @@ IA
 Ky
 Ky
 IA
-Dg
+Jx
 ej
 Oj
 Oj
@@ -4922,11 +4963,11 @@ yp
 yp
 yp
 yp
-hW
+uz
 qr
 TZ
 qr
-hW
+uz
 yp
 yp
 yp
@@ -5052,11 +5093,11 @@ yp
 yp
 yp
 yp
-hW
+JU
 oF
 oF
 oF
-hW
+JU
 yp
 yp
 yp
@@ -5182,11 +5223,11 @@ yp
 yp
 yp
 yp
-hW
+JU
 oF
 oF
 oF
-hW
+JU
 yp
 yp
 yp
@@ -5312,11 +5353,11 @@ yp
 yp
 yp
 yp
-hW
+JU
 lh
 JE
 dk
-hW
+JU
 yp
 yp
 yp
@@ -5442,11 +5483,11 @@ yp
 yp
 yp
 yp
-hW
-hW
-hW
-hW
-hW
+Tt
+Dn
+XG
+Dn
+Tt
 yp
 yp
 yp
@@ -9494,7 +9535,7 @@ Ke
 gV
 Ke
 wM
-wM
+Hp
 xS
 TW
 TW
@@ -9741,7 +9782,7 @@ TW
 xS
 xS
 Hp
-Tt
+Hp
 CX
 xV
 pS
@@ -9881,7 +9922,7 @@ xS
 Hp
 Ke
 Ke
-gV
+wM
 Ke
 Ke
 IM
@@ -10369,7 +10410,7 @@ wu
 Dq
 Dq
 Dq
-Dq
+Fs
 Dq
 Dq
 Dq
@@ -10493,8 +10534,8 @@ lv
 lv
 lv
 gb
-wu
-wu
+gb
+gb
 gb
 mx
 Dq
@@ -10623,8 +10664,8 @@ lv
 lv
 lv
 gb
-wu
-wu
+gb
+gb
 gb
 Dq
 Dq
@@ -10651,7 +10692,7 @@ TW
 xS
 vN
 Az
-VR
+WX
 VR
 xS
 fS
@@ -10757,7 +10798,7 @@ mx
 Dq
 gb
 gb
-Dq
+rQ
 Dq
 Dq
 Dq
@@ -10766,7 +10807,7 @@ Dq
 Dq
 vw
 Dq
-Dq
+Fs
 Dq
 Dq
 wu
@@ -11407,7 +11448,7 @@ mx
 Dq
 gb
 gb
-Dq
+rQ
 Dq
 Dq
 rb
@@ -11416,7 +11457,7 @@ Dq
 Dq
 Dq
 Dq
-Dq
+TD
 Dq
 Dq
 wu
@@ -11533,8 +11574,8 @@ lv
 lv
 lv
 gb
-wu
-wu
+gb
+gb
 gb
 Go
 Dq
@@ -11663,8 +11704,8 @@ lv
 lv
 lv
 gb
-wu
-wu
+gb
+gb
 gb
 Dq
 Dq
@@ -11799,7 +11840,7 @@ wu
 Dq
 Dq
 Dq
-Dq
+TD
 Dq
 Dq
 Dq
@@ -13968,8 +14009,8 @@ SA
 IL
 zO
 pT
-MP
-SA
+pv
+HQ
 IL
 MP
 IL
@@ -14485,7 +14526,7 @@ IL
 IL
 sw
 IL
-SA
+aJ
 zO
 zO
 IL
@@ -14615,8 +14656,8 @@ pT
 pT
 pT
 pT
-pT
-Ku
+gn
+zO
 zO
 pT
 pT
@@ -14679,7 +14720,7 @@ yp
 Ry
 Wl
 oF
-lu
+aX
 oF
 Wl
 Ry
@@ -14744,13 +14785,13 @@ pT
 IL
 MP
 IL
-MP
+pv
 IL
 zO
 zO
 IL
 IL
-MP
+ge
 IL
 IL
 pT
@@ -14877,7 +14918,7 @@ zO
 pT
 zO
 zO
-TD
+zO
 pT
 zO
 zO
@@ -15006,7 +15047,7 @@ zO
 KL
 zO
 zO
-pT
+KZ
 zO
 zO
 zO
@@ -15270,7 +15311,7 @@ zO
 zO
 IL
 IL
-MP
+pv
 IL
 MP
 pT
@@ -15841,7 +15882,7 @@ Oj
 Oj
 Hh
 yl
-gn
+yl
 yl
 wy
 hz
@@ -15970,9 +16011,9 @@ Oj
 Oj
 Oj
 Hh
-Dn
 yl
-gn
+yl
+yl
 wy
 hz
 hz
@@ -17531,7 +17572,7 @@ WA
 Oj
 Oj
 Oj
-iq
+aY
 ej
 Oj
 Oj

--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -1,9 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aJ" = (
-/obj/structure/closet/dirthole/closed,
-/mob/living/carbon/human/species/skeleton/npc,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/mountains)
 "aL" = (
 /obj/structure/lever/wall{
 	dir = 8;
@@ -20,15 +15,6 @@
 /obj/item/rogueweapon/sword/rapier/dec,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
-"aX" = (
-/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains/decap)
-"aY" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave)
 "bn" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -79,6 +65,10 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
+"co" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains/decap)
 "cq" = (
 /mob/living/carbon/human/species/goblin/npc/hell,
 /turf/open/floor/rogue/concrete,
@@ -214,16 +204,23 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
+"fU" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/dragon{
+	faction = list("wolfs");
+	health = 400
+	},
+/turf/open/lava,
+/area/rogue/outdoors/mountains/decap)
 "gb" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/mountains/decap)
 "ge" = (
-/obj/structure/closet/dirthole/closed/loot,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
+	},
+/area/rogue/outdoors/mountains/decap)
 "gn" = (
-/obj/machinery/light/rogue/firebowl/stump,
+/obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "gT" = (
@@ -248,6 +245,7 @@
 /area/rogue/under/cave/dungeon1)
 "hF" = (
 /obj/item/natural/bundle/bone,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
 "hW" = (
@@ -357,6 +355,11 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
+"mT" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/roguestatue/gold/loot,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "nm" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/cobble,
@@ -408,6 +411,11 @@
 /obj/structure/gravemarker,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"py" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 4
+	},
+/area/rogue/outdoors/mountains/decap)
 "pS" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/dungeon1)
@@ -466,10 +474,6 @@
 /obj/item/reagent_containers/glass/cup/golden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
-"rQ" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains/decap)
 "se" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
@@ -533,6 +537,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/dungeon1)
+"ub" = (
+/obj/machinery/light/rogue/firebowl/stump,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/mountains)
 "ud" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/cobble,
@@ -548,11 +556,6 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
-"uz" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 4
-	},
-/area/rogue/outdoors/mountains/decap)
 "uJ" = (
 /obj/structure/stairs/stone{
 	dir = 1;
@@ -577,6 +580,10 @@
 /area/rogue/outdoors/mountains/decap)
 "vw" = (
 /obj/item/clothing/head/helmet/skull,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
+"vx" = (
+/obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
 "vC" = (
@@ -757,6 +764,10 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/dungeon1)
+"AX" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "Bo" = (
 /obj/structure/bed/rogue/inn/double{
 	dir = 4
@@ -862,10 +873,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/dungeon1)
-"Fs" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains/decap)
 "Fv" = (
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/blocks,
@@ -1017,11 +1024,6 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap)
-"Jx" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/item/roguestatue/gold/loot,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/under/cave)
 "Jy" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/dirt,
@@ -1036,11 +1038,6 @@
 "JT" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/mountains/decap)
-"JU" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
-	dir = 1
-	},
 /area/rogue/outdoors/mountains/decap)
 "JV" = (
 /obj/structure/rack/rogue,
@@ -1073,10 +1070,6 @@
 /area/rogue/under/cave/dungeon1)
 "KL" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/mountains)
-"KZ" = (
-/obj/item/rogueweapon/shovel,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "Lh" = (
@@ -1149,6 +1142,12 @@
 "NN" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/dungeon1)
+"Of" = (
+/obj/structure/bars/passage/steel{
+	redstone_id = "dragonentry2"
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "Og" = (
 /obj/structure/bars/passage/steel{
 	redstone_id = "secretdoor1"
@@ -1167,6 +1166,12 @@
 "Ox" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/dungeon1)
+"OJ" = (
+/obj/structure/statue/bone/rib{
+	dir = 1
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "OQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -1184,6 +1189,14 @@
 	icon_state = "chess"
 	},
 /area/rogue/under/cave/dungeon1)
+"PC" = (
+/obj/structure/lever/wall{
+	pixel_x = -24;
+	redstone_id = "dragonentry2";
+	dir = 1
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "PD" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
@@ -1247,6 +1260,17 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
+"Rn" = (
+/obj/structure/closet/dirthole/closed,
+/mob/living/carbon/human/species/skeleton/npc,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/mountains)
+"Rr" = (
+/obj/structure/bars/passage/steel{
+	redstone_id = "dragonentry1"
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "Rw" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/closet/crate/chest/lootbox,
@@ -1273,19 +1297,24 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
-"Tt" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 8
-	},
+"Tj" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
+"Tt" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "TA" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 "TD" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/naturalstone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 8
+	},
 /area/rogue/outdoors/mountains/decap)
 "TW" = (
 /turf/open/floor/rogue/dirt,
@@ -1386,9 +1415,6 @@
 /mob/living/carbon/human/species/goblin/npc/hell,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/dungeon1)
-"XG" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red,
-/area/rogue/outdoors/mountains/decap)
 "XQ" = (
 /obj/structure/mineral_door/bars,
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
@@ -1399,6 +1425,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
+"Za" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
 "Zd" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap)
@@ -1410,6 +1440,21 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
+"Zn" = (
+/obj/structure/lever/wall{
+	pixel_x = 24;
+	redstone_id = "dragonentry1"
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains/decap)
+"Zs" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/outdoors/mountains/decap)
+"Zy" = (
+/obj/structure/closet/dirthole/closed/loot,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/mountains)
 "ZC" = (
 /obj/structure/fluff/walldeco/painting/queen,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -2219,7 +2264,7 @@ IA
 Ky
 Ky
 IA
-Jx
+mT
 ej
 Oj
 Oj
@@ -4963,11 +5008,11 @@ yp
 yp
 yp
 yp
-uz
+py
 qr
 TZ
 qr
-uz
+py
 yp
 yp
 yp
@@ -5093,11 +5138,11 @@ yp
 yp
 yp
 yp
-JU
+ge
 oF
 oF
 oF
-JU
+ge
 yp
 yp
 yp
@@ -5223,11 +5268,11 @@ yp
 yp
 yp
 yp
-JU
+ge
 oF
 oF
 oF
-JU
+ge
 yp
 yp
 yp
@@ -5353,11 +5398,11 @@ yp
 yp
 yp
 yp
-JU
+ge
 lh
 JE
 dk
-JU
+ge
 yp
 yp
 yp
@@ -5483,11 +5528,11 @@ yp
 yp
 yp
 yp
-Tt
+TD
 Dn
-XG
+Zs
 Dn
-Tt
+TD
 yp
 yp
 yp
@@ -9891,10 +9936,10 @@ HW
 HW
 HW
 HW
-HW
-HW
-HW
-HW
+Zn
+Dq
+Dq
+Dq
 HW
 HW
 HW
@@ -10021,10 +10066,10 @@ HW
 HW
 HW
 gb
-wu
-wu
-wu
-wu
+gb
+Rr
+Rr
+gb
 gb
 HW
 HW
@@ -10150,12 +10195,12 @@ HW
 HW
 Dq
 Dq
-wu
+gb
 Dq
 Dq
 Dq
 Dq
-wu
+gb
 Dq
 HW
 HW
@@ -10277,16 +10322,16 @@ HW
 HW
 HW
 gb
-wu
-wu
-wu
+gb
+gb
+gb
 gb
 mx
 Dq
 Dq
 Dq
 gb
-wu
+gb
 gb
 HW
 HW
@@ -10406,18 +10451,18 @@ lv
 HW
 HW
 Dq
-wu
+gb
 Dq
 Dq
 Dq
-Fs
-Dq
-Dq
+vx
 Dq
 Dq
 Dq
 Dq
-wu
+vx
+Dq
+gb
 Dq
 HW
 HW
@@ -10539,16 +10584,16 @@ gb
 gb
 mx
 Dq
-rb
 Dq
 Dq
 Dq
 Dq
 Dq
 Dq
+Za
 Dq
-wu
-Dq
+gb
+gb
 Dq
 HW
 HW
@@ -10669,7 +10714,7 @@ gb
 gb
 Dq
 Dq
-Dq
+Za
 tv
 Dq
 Dq
@@ -10677,10 +10722,10 @@ vC
 Dq
 Dq
 Dq
+Dq
 gb
-wu
-wu
 gb
+Dq
 HW
 HW
 pd
@@ -10798,19 +10843,19 @@ mx
 Dq
 gb
 gb
-rQ
+AX
 Dq
-Dq
+OJ
 Dq
 Dq
 Dq
 Dq
 vw
 Dq
-Fs
 Dq
 Dq
-wu
+gb
+gb
 Dq
 HW
 pd
@@ -10926,8 +10971,8 @@ wu
 wu
 Dq
 tv
-wu
-wu
+gb
+gb
 Dq
 Dq
 Dq
@@ -10939,8 +10984,8 @@ Dq
 Dq
 Dq
 Dq
-Dq
-wu
+gb
+gb
 Dq
 HW
 pd
@@ -11062,14 +11107,14 @@ Dq
 Dq
 vC
 Dq
+Za
 Dq
 Dq
 Dq
+OJ
 Dq
 Dq
-rb
-Dq
-Dq
+wu
 wu
 Dq
 HW
@@ -11199,7 +11244,7 @@ Dq
 Dq
 Dq
 Dq
-Dq
+wu
 wu
 Dq
 HW
@@ -11316,21 +11361,21 @@ wu
 wu
 Dq
 Dq
-wu
-wu
+gb
+gb
 Dq
 Dq
 Dq
 Dq
 Dq
+Za
 Dq
 Dq
+Za
 Dq
 Dq
-Dq
-Dq
-Dq
-wu
+gb
+gb
 Dq
 HW
 HW
@@ -11448,7 +11493,7 @@ mx
 Dq
 gb
 gb
-rQ
+AX
 Dq
 Dq
 rb
@@ -11457,10 +11502,10 @@ Dq
 Dq
 Dq
 Dq
-TD
 Dq
 Dq
-wu
+gb
+gb
 Dq
 HW
 pd
@@ -11587,10 +11632,10 @@ Dq
 vC
 Dq
 Dq
+Dq
 gb
-wu
-wu
 gb
+Dq
 HW
 HW
 HW
@@ -11710,15 +11755,15 @@ gb
 Dq
 Dq
 Dq
-Dq
+Za
 Ub
 Dq
 Dq
 Dq
 Dq
 Dq
-wu
-Dq
+gb
+gb
 Dq
 HW
 HW
@@ -11836,18 +11881,18 @@ lv
 HW
 HW
 Dq
-wu
+gb
 Dq
 Dq
 Dq
-TD
-Dq
-Dq
+Tj
 Dq
 Dq
 Dq
 Dq
-wu
+Tj
+Dq
+gb
 Dq
 HW
 HW
@@ -11967,16 +12012,16 @@ HW
 HW
 HW
 gb
-wu
-wu
-wu
+gb
+gb
+gb
 gb
 mx
 Dq
 Dq
 Dq
 gb
-wu
+gb
 gb
 Dq
 HW
@@ -12100,12 +12145,12 @@ HW
 Dq
 Dq
 Dq
-wu
+gb
 Dq
 Dq
 Dq
 Dq
-wu
+gb
 Dq
 Dq
 HW
@@ -12231,10 +12276,10 @@ HW
 HW
 HW
 gb
-wu
-wu
-wu
-wu
+gb
+Of
+Of
+gb
 gb
 HW
 HW
@@ -12361,10 +12406,10 @@ pd
 HW
 HW
 HW
+PC
 Dq
 Dq
 Dq
-HW
 HW
 HW
 HW
@@ -12495,7 +12540,7 @@ HW
 HW
 HW
 HW
-pd
+HW
 pd
 pd
 pd
@@ -13265,7 +13310,7 @@ lv
 lv
 pd
 pd
-pd
+fU
 HW
 HW
 HW
@@ -14526,7 +14571,7 @@ IL
 IL
 sw
 IL
-aJ
+Rn
 zO
 zO
 IL
@@ -14656,7 +14701,7 @@ pT
 pT
 pT
 pT
-gn
+ub
 zO
 zO
 pT
@@ -14700,8 +14745,8 @@ HW
 HW
 pd
 pd
-pd
-pd
+HW
+HW
 HW
 HW
 pd
@@ -14720,7 +14765,7 @@ yp
 Ry
 Wl
 oF
-aX
+co
 oF
 Wl
 Ry
@@ -14791,7 +14836,7 @@ zO
 zO
 IL
 IL
-ge
+Zy
 IL
 IL
 pT
@@ -15047,7 +15092,7 @@ zO
 KL
 zO
 zO
-KZ
+gn
 zO
 zO
 zO
@@ -17572,7 +17617,7 @@ WA
 Oj
 Oj
 Oj
-aY
+Tt
 ej
 Oj
 Oj

--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -204,13 +204,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
-"fU" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/dragon{
-	faction = list("wolfs");
-	health = 400
-	},
-/turf/open/lava,
-/area/rogue/outdoors/mountains/decap)
 "gb" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/mountains/decap)
@@ -13310,7 +13303,7 @@ lv
 lv
 pd
 pd
-fU
+pd
 HW
 HW
 HW

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -52,7 +52,11 @@ Difficulty: Medium
 	speed = 5
 	move_to_delay = 5
 	ranged = TRUE
+	move_force = MOVE_FORCE_NORMAL
+	move_resist = MOVE_FORCE_NORMAL
+	pull_force = MOVE_FORCE_NORMAL
 	pixel_x = -16
+	base_intents = list(/datum/intent/simple/bite)
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 20,
 						/obj/item/natural/hide = 20, /obj/item/natural/bundle/bone/full = 4)
 	var/swooping = NONE
@@ -66,8 +70,7 @@ Difficulty: Medium
 	footstep_type = FOOTSTEP_MOB_HEAVY
 	attack_action_types = list(/datum/action/innate/megafauna_attack/fire_cone,
 							   /datum/action/innate/megafauna_attack/fire_cone_meteors,
-							   /datum/action/innate/megafauna_attack/mass_fire,
-							   /datum/action/innate/megafauna_attack/lava_swoop)
+							   /datum/action/innate/megafauna_attack/mass_fire)
 	small_sprite_type = /datum/action/small_sprite/megafauna/drake
 
 /datum/action/innate/megafauna_attack/fire_cone
@@ -579,6 +582,9 @@ Difficulty: Medium
 	melee_damage_lower = 30
 	mouse_opacity = MOUSE_OPACITY_ICON
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
+	move_force = MOVE_FORCE_NORMAL
+	move_resist = MOVE_FORCE_NORMAL
+	pull_force = MOVE_FORCE_NORMAL
 	loot = list()
 	crusher_loot = list()
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -57,6 +57,7 @@ Difficulty: Medium
 	pull_force = MOVE_FORCE_NORMAL
 	pixel_x = -16
 	base_intents = list(/datum/intent/simple/bite)
+	damage_coeff = list(BRUTE = 1, BURN = 0.2, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 20,
 						/obj/item/natural/hide = 20, /obj/item/natural/bundle/bone/full = 4)
 	var/swooping = NONE

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -14,8 +14,11 @@
 	see_in_dark = 6
 	move_to_delay = 3
 	base_intents = list(/datum/intent/simple/bite)
+	minbodytempp = 0
+	maxbodytemp = INFINITY
+	damage_coeff = list(BRUTE = 1, BURN = 0.2, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 20,
-						/obj/item/natural/hide = 20, /obj/item/natural/bundle/bone/full = 4)
+						/obj/item/natural/hide = 10, /obj/item/natural/bundle/bone/full = 4)
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	health = 2500
 	maxHealth = 2500

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -14,7 +14,7 @@
 	see_in_dark = 6
 	move_to_delay = 3
 	base_intents = list(/datum/intent/simple/bite)
-	minbodytempp = 0
+	minbodytemp = 0
 	maxbodytemp = INFINITY
 	damage_coeff = list(BRUTE = 1, BURN = 0.2, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 20,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

PR fixes the dragons on mount decap and stops them from breaking out of their own arena. Also disables the lava swoop ability, which had a tendency to permanently break tiles because some of the sprites related to the ability were missing.

I also made a few small adjustments to loot spawns and reduced the amount of random money spawners around mount decap, since there were a few too many in hindsight.

## Why It's Good For The Game

The dragon broodmother was breaking out of its arena/dungeon area every round; which was silly. This should fix that!
