### PR TITLE
Add Roguetown roles to roleban menu

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -46,6 +46,7 @@
 #define ROLE_DEATHSQUAD			"Deathsquad"
 #define ROLE_LAVALAND			"Lavaland"
 #define ROLE_INTERNAL_AFFAIRS	"Internal Affairs Agent"
+#define ROLE_NECRO_SKELETON		"Necromancer Skeleton" // RT role
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -233,44 +233,14 @@
 				banned_from += query_get_banned_roles.item[1]
 			qdel(query_get_banned_roles)
 		var/break_counter = 0
-		output += "<div class='row'><div class='column'><label class='rolegroup command'><input type='checkbox' name='Command' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_dep\")'" : ""]>Command</label><div class='content'>"
-		//all heads are listed twice so have a javascript call to toggle both their checkboxes when one is pressed
-		//for simplicity this also includes the captain even though it doesn't do anything
-		for(var/job in GLOB.command_positions)
-			if(break_counter > 0 && (break_counter % 3 == 0))
-				output += "<br>"
-			output += {"<label class='inputlabel checkbox'>[job]
-						<input type='checkbox' id='[job]_com' name='[job]' class='Command' value='1'[usr.client.prefs.tgui_fancy ? " onClick='toggle_head(this, \"_dep\")'" : ""]>
-						<div class='inputbox[(job in banned_from) ? " banned" : ""]'></div></label>
-			"}
-			break_counter++
-		output += "</div></div>"
-		//standard departments all have identical handling
-		var/list/job_lists = list("Security" = GLOB.security_positions,
-							"Engineering" = GLOB.engineering_positions,
-							"Medical" = GLOB.medical_positions,
-							"Science" = GLOB.science_positions,
-							"Supply" = GLOB.supply_positions)
-		for(var/department in job_lists)
-			//the first element is the department head so they need the same javascript call as above
-			output += "<div class='column'><label class='rolegroup [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
-			output += {"<label class='inputlabel checkbox'>[job_lists[department][1]]
-						<input type='checkbox' id='[job_lists[department][1]]_dep' name='[job_lists[department][1]]' class='[department]' value='1'[usr.client.prefs.tgui_fancy ? " onClick='toggle_head(this, \"_com\")'" : ""]>
-						<div class='inputbox[(job_lists[department][1] in banned_from) ? " banned" : ""]'></div></label>
-			"}
-			break_counter = 1
-			for(var/job in job_lists[department] - job_lists[department][1]) //skip the first element since it's already been done
-				if(break_counter % 3 == 0)
-					output += "<br>"
-				output += {"<label class='inputlabel checkbox'>[job]
-							<input type='checkbox' name='[job]' class='[department]' value='1'>
-							<div class='inputbox[(job in banned_from) ? " banned" : ""]'></div></label>
-				"}
-				break_counter++
-			output += "</div></div>"
+		//note to future developers: RT doesn't have command staff so toggle_head was removed, go back in the git history if you need to readd it
 		//departments/groups that don't have command staff would throw a javascript error since there's no corresponding reference for toggle_head()
-		var/list/headless_job_lists = list("Silicon" = GLOB.nonhuman_positions,
-										"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC"))
+		var/list/headless_job_lists = list("Nobles" = GLOB.noble_positions,
+							"Courtiers" = GLOB.courtier_positions,
+							"Garrison" = GLOB.garrison_positions,
+							"Church" = GLOB.church_positions,
+							"Mercenaries" = GLOB.mercenary_positions,
+							"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC"))
 		for(var/department in headless_job_lists)
 			output += "<div class='column'><label class='rolegroup [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			break_counter = 0
@@ -283,15 +253,14 @@
 				"}
 				break_counter++
 			output += "</div></div>"
-		var/list/long_job_lists = list("Civilian" = GLOB.civilian_positions,
-									"Ghost and Other Roles" = list(ROLE_BRAINWASHED, ROLE_DEATHSQUAD, ROLE_DRONE, ROLE_LAVALAND, ROLE_MIND_TRANSFER, ROLE_POSIBRAIN, ROLE_SENTIENCE),
-									"Antagonist Positions" = list(ROLE_ABDUCTOR, ROLE_ALIEN, ROLE_BLOB,
-									ROLE_BROTHER, ROLE_CHANGELING, ROLE_CULTIST,
-									ROLE_DEVIL, ROLE_INTERNAL_AFFAIRS, ROLE_MALF,
-									ROLE_MONKEY, ROLE_NINJA, ROLE_OPERATIVE,
-									ROLE_OVERTHROW, ROLE_REV, ROLE_REVENANT,
-									ROLE_REV_HEAD, ROLE_SYNDICATE,
-									ROLE_TRAITOR, ROLE_WIZARD, ROLE_HIVE)) //ROLE_REV_HEAD is excluded from this because rev jobbans are handled by ROLE_REV
+		var/list/long_job_lists = list("Peasants" = GLOB.peasant_positions,
+									"Yeomen" = GLOB.yeoman_positions,
+									"Youngfolk" = GLOB.youngfolk_positions,
+									"Ghost and Other Roles" = list(ROLE_NECRO_SKELETON),
+									"Antagonist Positions" = list(ROLE_MANIAC, ROLE_WEREWOLF,
+									ROLE_VAMPIRE, ROLE_NBEAST, ROLE_BANDIT,
+									ROLE_DELF, ROLE_PREBEL, ROLE_ASPIRANT,
+									ROLE_LICH, ROLE_ASCENDANT))
 		for(var/department in long_job_lists)
 			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			break_counter = 0

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -82,7 +82,7 @@
 	var/turf/T = get_turf(targets[1])
 	if(isopenturf(T))
 		var/mob/living/carbon/human/target = new /mob/living/carbon/human/species/skeleton/no_equipment(T)
-		var/list/candidates = pollCandidatesForMob("Do you want to play as a Necromancer's skeleton?", null, null, null, 100, target, POLL_IGNORE_NECROMANCER_SKELETON)
+		var/list/candidates = pollCandidatesForMob("Do you want to play as a Necromancer's skeleton?", ROLE_NECRO_SKELETON, null, null, 100, target, POLL_IGNORE_NECROMANCER_SKELETON)
 		if(LAZYLEN(candidates))
 			var/mob/C = pick(candidates)
 			if(istype(C,/mob/dead/new_player))

--- a/html/admin/banpanel.css
+++ b/html/admin/banpanel.css
@@ -44,48 +44,56 @@
     text-align: center;
 }
 
-.command {
-    background-color: #948f02;
+.nobles {
+    background-color: #aa83b9;
+    color: #443a39;
 }
 
-.security {
-    background-color: #a30000;
+.courtier {
+    background-color: #81adc8;
+    color: #443a39;
 }
 
-.engineering {
-    background-color: #fb5613;
+.church {
+    background-color: #c0ba8d;
+    color: #443a39;
 }
 
-.medical {
-    background-color: #337296;
+.garrison {
+    background-color: #b18484;
+    color: #443a39;
 }
 
-.science {
-    background-color: #993399;
+.yeomen {
+    background-color: #819e82;
+    color: #443a39;
 }
 
-.supply {
-    background-color: #a8732b;
+.peasants {
+    background-color: #b09262;
+    color: #443a39;
 }
 
-.silicon {
-    background-color: #ff00ff;
+.mercenaries {
+    background-color: #c86e3a;
+    color: #443a39;
+}
+
+.youngfolk {
+    background-color: #ffc0cb;
+    color: #443a39;
 }
 
 .abstract {
-    background-color: #708090;
-}
-
-.civilian {
-    background-color: #6eaa2c;
+    background-color: #374048;
 }
 
 .ghostandotherroles {
-    background-color: #5c00e6;
+    background-color: #2e0073;
 }
 
 .antagonistpositions {
-    background-color: #6d3f40;
+    background-color: #361f1f;
 }
 
 .inputbox {


### PR DESCRIPTION
Adds Roguetown roles to the roleban menu. Removes the base SS13 roles, including antags. Adds a roleban type define for necromancer skeletons. Tweaks the banning panel CSS to be easier to read.

I can't actually test this very much locally because I don't have a database set up, but I didn't get Javascript errors when I clicked the buttons or anything, at least. You could testmerge it I guess. Maybe back up the database just in case?