### PR TITLE
PORT: Cloistered Devout, new Cleric subclass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -34,7 +34,7 @@
 
 	// CLASS ARCHETYPES
 	H.adjust_blindness(-3)
-	var/classes = list("Life Cleric","War Cleric",)
+	var/classes = list("Life Cleric","War Cleric", "Cloistered Devout")
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)
@@ -91,6 +91,23 @@
 			H.change_stat("constitution", 2)
 			H.change_stat("endurance", 2) // Stronger but less intelligent/quick compared to life clerics.
 			H.change_stat("speed", -1)
+		// HEARTHSTONE ADD: cloistered cleric subclass (lighter armored and equipped)
+		if("Cloistered Devout")
+			// Devout start without the typical cleric medium/heavy armor shtick and without much in the way of weapons or skills to use them.
+			// They're better with miracles and regenerate devotion passively like the Priest does, however.
+			H.set_blindness(0)
+			to_chat(H, span_warning("You are a cloistered cleric, eschewing arms and armor for the weapon of word and greater connection to your chosen patron."))
+			H.mind.adjust_skillrank(/datum/skill/magic/holy, 5, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.change_stat("intelligence", 4)
+			H.change_stat("strength", -2)
+			H.change_stat("perception", 2)
+			H.change_stat("speed", 1)
+		// HEARTHSTONE ADDITION END
 
 	armor = /obj/item/clothing/suit/roguetown/armor/plate
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
@@ -102,10 +119,56 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/shield/wood
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife)
+	// everything about this sucks - we should really make a subclass datum or something
 
+	// HEARTHSTONE ADD: cloistered devout custom outfits
+	if (classchoice == "Cloistered Devout")
+		// do the generic stuff first then replace it w/ patron specific things... if it exists
+		// for reference, cloistered devouts are lightly armored/unarmored but get patron-specific stuff (if applicable) and a devo regen
+		head = /obj/item/clothing/head/roguetown/roguehood/black
+		armor = /obj/item/clothing/suit/roguetown/shirt/robe
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+		wrists = null
+		beltr = null
+		backr = /obj/item/rogueweapon/woodstaff
+		pants = /obj/item/clothing/under/roguetown/tights
+		shoes = /obj/item/clothing/shoes/roguetown/boots
+		// apply patron-specific outfit alterations
+		switch(H.patron?.type)
+			if(/datum/patron/divine/astrata)
+				head = /obj/item/clothing/head/roguetown/roguehood/astrata
+				armor = /obj/item/clothing/suit/roguetown/shirt/robe/astrata
+				beltr = /obj/item/flashlight/flare/torch/lantern // you are the lightbringer
+			if(/datum/patron/divine/noc)
+				head =  /obj/item/clothing/head/roguetown/nochood
+				armor = /obj/item/clothing/suit/roguetown/shirt/robe/noc
+				pants = /obj/item/clothing/under/roguetown/tights/black
+				belt = /obj/item/storage/belt/rogue/leather/black
+			if(/datum/patron/divine/necra)
+				head = /obj/item/clothing/head/roguetown/necrahood
+				armor = /obj/item/clothing/suit/roguetown/shirt/robe/necra
+				pants = /obj/item/clothing/under/roguetown/trou/leather/mourning
+			if(/datum/patron/divine/dendor)
+				head = /obj/item/clothing/head/roguetown/dendormask
+				armor = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
+				pants = /obj/item/clothing/under/roguetown/loincloth
+				belt = /obj/item/storage/belt/rogue/leather/rope
+				shoes = /obj/item/clothing/shoes/roguetown/sandals
+			if(/datum/patron/divine/eora)
+				armor = /obj/item/clothing/suit/roguetown/shirt/robe/eora
+	// HEARTHSTONE ADDITION END
 
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells(H)
+	// HEARTHSTONE ADDITION: cloistered devout devo regen & tier buff
+	if (classchoice == "Cloistered Devout")
+		// start with passive devo gain and ability to gain up to T3 spells
+		C.passive_devotion_gain += 0.5
+		C.max_progression = CLERIC_REQ_3
+		C.max_devotion = CLERIC_REQ_3
+		C.grant_spells(H) // don't give churn as an extra spell to cloistered since they get their patron's full spell list (up to t3)
+	else
+		C.grant_spells(H)
+	// HEARTHSTONE ADDITION END
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -6,7 +6,6 @@
 	allowed_races = RACES_ALL_KINDS
 	vampcompat = FALSE
 	outfit = /datum/outfit/job/roguetown/adventurer/cleric
-	traits_applied = list(TRAIT_HEAVYARMOR)
 	category_tags = list(CTAG_ADVENTURER)
 
 /datum/outfit/job/roguetown/adventurer/cleric
@@ -97,14 +96,21 @@
 			// They're better with miracles and regenerate devotion passively like the Priest does, however.
 			H.set_blindness(0)
 			to_chat(H, span_warning("You are a cloistered cleric, eschewing arms and armor for the weapon of word and greater connection to your chosen patron."))
-			H.mind.adjust_skillrank(/datum/skill/magic/holy, 5, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/magic/holy, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
-			H.change_stat("intelligence", 4)
-			H.change_stat("strength", -2)
+			H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+			H.change_stat("intelligence", 2)
+			H.change_stat("strength", -1)
 			H.change_stat("perception", 2)
 			H.change_stat("speed", 1)
 		// HEARTHSTONE ADDITION END
@@ -156,19 +162,15 @@
 				shoes = /obj/item/clothing/shoes/roguetown/sandals
 			if(/datum/patron/divine/eora)
 				armor = /obj/item/clothing/suit/roguetown/shirt/robe/eora
-	// HEARTHSTONE ADDITION END
-
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	// HEARTHSTONE ADDITION: cloistered devout devo regen & tier buff
-	if (classchoice == "Cloistered Devout")
-		// start with passive devo gain and ability to gain up to T3 spells
+				// HEARTHSTONE ADDITION: cloistered devout devo regen & tier buff
+		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.passive_devotion_gain += 0.5
 		C.max_progression = CLERIC_REQ_3
 		C.max_devotion = CLERIC_REQ_3
 		C.grant_spells(H) // don't give churn as an extra spell to cloistered since they get their patron's full spell list (up to t3)
 	else
+// HEARTHSTONE ADDITION END
+		ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.grant_spells(H)
-	// HEARTHSTONE ADDITION END
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -165,8 +165,6 @@
 				// HEARTHSTONE ADDITION: cloistered devout devo regen & tier buff
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.passive_devotion_gain += 0.5
-		C.max_progression = CLERIC_REQ_3
-		C.max_devotion = CLERIC_REQ_3
 		C.grant_spells(H) // don't give churn as an extra spell to cloistered since they get their patron's full spell list (up to t3)
 	else
 // HEARTHSTONE ADDITION END

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 6
 
 	allowed_races = RACES_ALL_KINDS
-	allowed_patrons = ALL_ACOLYTE_PATRONS
+	allowed_patrons = ALL_DIVINE_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/monk
 	tutorial = "Chores, some more chores- Even more chores.. Oh how the life of a humble cleric is exhausting… You have faith, but even you know you gave up a life of adventure for that of the security in the Church. Assist the Priest in their daily tasks, maybe today will be the day something interesting happens. (Currently Astrata, Eora, Noc, Necra, and Pestra are supported.)"
@@ -21,7 +21,7 @@
 	name = "Acolyte"
 	jobtype = /datum/job/roguetown/monk
 
-	allowed_patrons = list(/datum/patron/divine/pestra, /datum/patron/divine/astrata, /datum/patron/divine/eora, /datum/patron/divine/noc, /datum/patron/divine/necra) //Eora content from Stonekeep
+	allowed_patrons = ALL_DIVINE_PATRONS
 
 
 /datum/outfit/job/roguetown/monk/pre_equip(mob/living/carbon/human/H)
@@ -67,11 +67,10 @@
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/eora
 		else
-			head = /obj/item/clothing/head/roguetown/roguehood/astrata
-			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
-			wrists = /obj/item/clothing/wrists/roguetown/wrappings
+			head = /obj/item/clothing/head/roguetown/roguehood
+			neck = /obj/item/clothing/neck/roguetown/psicross
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
-			armor = /obj/item/clothing/suit/roguetown/shirt/robe/astrata
+			armor = /obj/item/clothing/suit/roguetown/shirt/robe
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 6
 
 	allowed_races = RACES_ALL_KINDS
-	allowed_patrons = ALL_DIVINE_PATRONS
+	allowed_patrons = ALL_ACOLYTE_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/monk
 	tutorial = "Chores, some more chores- Even more chores.. Oh how the life of a humble cleric is exhausting… You have faith, but even you know you gave up a life of adventure for that of the security in the Church. Assist the Priest in their daily tasks, maybe today will be the day something interesting happens. (Currently Astrata, Eora, Noc, Necra, and Pestra are supported.)"
@@ -21,7 +21,7 @@
 	name = "Acolyte"
 	jobtype = /datum/job/roguetown/monk
 
-	allowed_patrons = ALL_DIVINE_PATRONS
+	allowed_patrons = list(/datum/patron/divine/pestra, /datum/patron/divine/astrata, /datum/patron/divine/eora, /datum/patron/divine/noc, /datum/patron/divine/necra) //Eora content from Stonekeep
 
 
 /datum/outfit/job/roguetown/monk/pre_equip(mob/living/carbon/human/H)
@@ -67,10 +67,11 @@
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/eora
 		else
-			head = /obj/item/clothing/head/roguetown/roguehood
-			neck = /obj/item/clothing/neck/roguetown/psicross
+			head = /obj/item/clothing/head/roguetown/roguehood/astrata
+			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+			wrists = /obj/item/clothing/wrists/roguetown/wrappings
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
-			armor = /obj/item/clothing/suit/roguetown/shirt/robe
+			armor = /obj/item/clothing/suit/roguetown/shirt/robe/astrata
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)

--- a/modular_hearthstone/code/game/objects/items/clothes/neck.dm
+++ b/modular_hearthstone/code/game/objects/items/clothes/neck.dm
@@ -1,0 +1,9 @@
+// Activate the devotion prayer verb from MMB
+/obj/item/clothing/neck/roguetown/psicross/MiddleClick(mob/user)
+	if (.)
+		return
+	
+	user.changeNext_move(CLICK_CD_MELEE)
+	var/prayer = locate(/mob/living/carbon/human/proc/clericpray) in user.verbs
+	if (prayer)
+		call(user, prayer)()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3580,6 +3580,7 @@
 #include "modular_hearthstone\code\datums\skills\misc.dm"
 #include "modular_hearthstone\code\game\objects\effects\track.dm"
 #include "modular_hearthstone\code\game\objects\items\signal_horn.dm"
+#include "modular_hearthstone\code\game\objects\items\clothes\neck.dm"
 #include "modular_hearthstone\code\game\objects\items\clothes\stockings.dm"
 #include "modular_hearthstone\code\game\objects\items\clothes\strapless_dress.dm"
 #include "modular_hearthstone\code\game\objects\structures\canopy.dm"


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/Tree445/Hearthstone/pull/339 by @Ephemeralis

- "Using MMB on a worn psycross causes you to start doing a devotion prayer if you have the ability to, otherwise it does nothing new. Purely a convenience/QoL thing to make people need to look at the verb panel less.
- A new Adventurer subclass has been added for the Cleric: Cloistered Devout.
- Cloistered Devout is a spellcaster-focused variant of the cleric that foregoes all of the armor and weapon buffs it gets in exchange for gaining half the passive devotion gain that Priest gets (0.5) and access to T3 spells like an Acolyte. It does not gain Churn like ordinary clerics do to compensate for this.
- It gets a gambeson, some devotional robes (matched to your chosen patron where possible) and a wooden staff as starting gear instead of the halfplate+mace+shield that cleric ordinarily gets.
- The physical attribute bonuses cleric ordinarily gives are removed (STR, CON and END), and replaced with a -2 to STR, a +4 to INT, a +2 to PER and a +1 to SPD.
- It has a host of bookish skills pulled from the other cleric subclasses and improved slightly to compensate for the lack of starting combat strength. It also has level 5 holy magic, which gives a pretty sizable chunk to active devotion regain when praying, among other things."

Ontop of the port I've also:
* Adjusted Cloistered Devout skills.

What did not make it to the port:
*  The entire Divine Pantheon (to clarify, the Ten except Dendor, which the Druid role already covers) has been added to the Acolyte church role so that people can play clergy that aren't hardlocked to Pestra, Eora or Astrata.

## Why It's Good For The Game
"Adventurer clerics can now go for a spellcastery bent if they want to, with some slight flavoring of their chosen patron.

The MMB psycross devotional prayer thing is self-explanatory."

Compiled and tested, devout loads in & with patron-based loadout.
