### PR TITLE
Pyroclastic arrow crafting fix

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -429,7 +429,7 @@
 /datum/crafting_recipe/roguetown/pyroarrow
 	name = "pyroclastic arrow"
 	result = /obj/item/ammo_casing/caseless/rogue/arrow/pyro
-	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow = 1,
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow/iron = 1,
 				/obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 1)
 	req_table = TRUE
 	craftdiff = 1
@@ -444,7 +444,7 @@
 				/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
 				/obj/item/ammo_casing/caseless/rogue/arrow/pyro
 				)
-	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow = 5,
+	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow/iron = 5,
 				/obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 5)
 	req_table = TRUE
 	craftdiff = 1


### PR DESCRIPTION
## About The Pull Request

fixes crafting pyro arrows

arrows are `/obj/item/ammo_casing/caseless/rogue/arrow/iron` not `/obj/item/ammo_casing/caseless/rogue/arrow` 

oops :(

## Why It's Good For The Game

pyro arrow crafting wasn't working...