### PR TITLE
Add create water, thaumaturgy and light orison for all divine casters

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -103,7 +103,7 @@
 	if(!H || !H.mind || !patron)
 		return
 
-	var/list/spelllist = list(patron.t0, patron.t1)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
@@ -117,7 +117,7 @@
 	if(!H || !H.mind || !patron)
 		return
 
-	var/list/spelllist = list(patron.t0)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0)
 	if(istype(patron,/datum/patron/divine))
 		spelllist += /obj/effect/proc_holder/spell/targeted/churn
 	for(var/spell_type in spelllist)
@@ -134,7 +134,7 @@
 	if(!H || !H.mind || !patron)
 		return
 
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/invoked/lesser_heal, /obj/effect/proc_holder/spell/invoked/diagnose) //This would have caused jank.
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, /obj/effect/proc_holder/spell/invoked/lesser_heal, /obj/effect/proc_holder/spell/invoked/diagnose) //This would have caused jank.
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
@@ -150,7 +150,7 @@
 		return
 
 	granted_spells = list()
-	var/list/spelllist = list(patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
@@ -167,7 +167,7 @@
 		return
 
 	granted_spells = list()
-	var/list/spelllist = list(patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -290,6 +290,22 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		if(say_test(message) == "2")	//CIT CHANGE - ditto
 			message_range += 10
 			Zs_too = TRUE
+	// AZURE EDIT: thaumaturgical loudness (from orisons)
+	if (has_status_effect(/datum/status_effect/thaumaturgy))
+		spans |= SPAN_REALLYBIG
+		var/datum/status_effect/thaumaturgy/buff = locate() in status_effects
+		message_range += (5 + buff.potency) // maximum 12 tiles extra, which is a lot!
+		for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
+			if (prob(buff.potency * 3) && S.speaking) // 3% chance per holy level, per SCOM for it to shriek your message in town wherever you are
+				S.verb_say = "shrieks in terror"
+				S.verb_exclaim = "shrieks in terror"
+				S.verb_yell = "shrieks in terror"
+				S.say(message, spans = list("info", "reallybig"))
+				S.verb_say = initial(S.verb_say)
+				S.verb_exclaim = initial(S.verb_exclaim)
+				S.verb_yell = initial(S.verb_yell)
+		remove_status_effect(/datum/status_effect/thaumaturgy)
+	// AZURE EDIT END
 	var/list/listening = get_hearers_in_view(message_range+eavesdrop_range, source)
 	var/list/the_dead = list()
 //	var/list/yellareas	//CIT CHANGE - adds the ability for yelling to penetrate walls and echo throughout areas

--- a/modular_azurepeak/code/modules/spells/orison.dm
+++ b/modular_azurepeak/code/modules/spells/orison.dm
@@ -109,9 +109,13 @@
 	owner.light_flags = initial(owner.light_flags)
 	owner.update_light()
 
-/obj/item/melee/touch_attack/orison/proc/cast_light(thing, mob/living/carbon/human/user)
+/obj/item/melee/touch_attack/orison/proc/cast_light(atom/thing, mob/living/carbon/human/user)
 	var/holy_skill = user.mind?.get_skill_level(attached_spell.associated_skill)
 	var/cast_time = 35 - (holy_skill * 3)
+	if (!thing.Adjacent(user))
+		to_chat(user, span_info("I need to be next to [thing] to channel a blessing of light!"))
+		return
+
 	if (isliving(thing))
 
 		if (thing != user)
@@ -213,6 +217,10 @@
 
 /obj/item/melee/touch_attack/orison/proc/create_water(atom/thing, mob/living/carbon/human/user)
 	// normally we wouldn't use fatigue here to keep in line w/ other holy magic, but we have to since water is a persistent resource
+	if (!thing.Adjacent(user))
+		to_chat(user, span_info("I need to be closer to [thing] in order to try filling it with water."))
+		return
+
 	if (thing.is_refillable())
 		if (thing.reagents.holder_full())
 			to_chat(user, span_warning("[thing] is full."))
@@ -250,3 +258,5 @@
 			the_cloth.wet += holy_skill * 5
 			user.visible_message(span_info("[user] closes [user.p_their()] eyes in prayer, beads of moisture coalescing in [user.p_their()] hands to moisten [the_cloth]."), span_notice("I utter forth a plea to [user.patron.name] for succour, and will moisture into [the_cloth]. I should be able to clean with it properly now."))
 			return water_moisten
+	else
+		to_chat(user, span_info("I'll need to find a container that can hold water."))

--- a/modular_azurepeak/code/modules/spells/orison.dm
+++ b/modular_azurepeak/code/modules/spells/orison.dm
@@ -29,8 +29,8 @@
 	var/xp_interval = 150
 	var/xp_cooldown = 0
 	var/right_click = FALSE
-	var/thaumaturgy_devotion = 15
-	var/light_devotion = 15
+	var/thaumaturgy_devotion = 10
+	var/light_devotion = 5
 	var/water_moisten = 2
 
 /obj/item/melee/touch_attack/orison/attack_self()

--- a/modular_azurepeak/code/modules/spells/orison.dm
+++ b/modular_azurepeak/code/modules/spells/orison.dm
@@ -1,0 +1,252 @@
+/obj/effect/proc_holder/spell/targeted/touch/orison
+	name = "Orison"
+	desc = "The basic precept of holy magic orients around the power of prayer and soliciting a Divine Patron for a tiny sliver of Their might."
+	clothes_req = FALSE
+	drawmessage = "I calm my mind and prepare to draw upon an orison."
+	dropmessage = "I return my mind to the now."
+	school = "transmutation"
+	chargedrain = 0
+	chargetime = 0
+	releasedrain = 5
+	miracle = TRUE
+	devotion_cost = 5
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/holy
+	hand_path = /obj/item/melee/touch_attack/orison
+
+/obj/item/melee/touch_attack/orison
+	name = "\improper lesser prayer"
+	desc = "The fundamental teachings of theology return to you:\n \
+		<b>Fill</b>: Beseech your Divine to create a small quantity of water in a container that you touch for some devotion.\n \
+		<b>Touch</b>: Direct a sliver of divine thaumaturgy into your being, causing your voice to become LOUD when you next speak. Known to sometimes scare the rats inside the SCOMlines. Can be used on light sources at range, and it will cause them flicker.\n \
+		<b>Use</b>: Issue a prayer for illumination, causing you or another living creature to begin glowing with light for five minutes - this stacks each time you cast it, with no upper limit. Using thaumaturgy on a person will remove this blessing from them, and MMB on your praying hand will remove any light blessings from yourself."
+	catchphrase = null
+	possible_item_intents = list(/datum/intent/fill, INTENT_HELP, /datum/intent/use)
+	icon = 'icons/mob/roguehudgrabs.dmi'
+	icon_state = "pulling"
+	icon_state = "grabbing_greyscale"
+	color = "#FFFFFF"
+	var/xp_interval = 150
+	var/xp_cooldown = 0
+	var/right_click = FALSE
+	var/thaumaturgy_devotion = 15
+	var/light_devotion = 15
+	var/water_moisten = 2
+
+/obj/item/melee/touch_attack/orison/attack_self()
+	qdel(src)
+
+/obj/item/melee/touch_attack/orison/proc/handle_xp(mob/living/carbon/human/user, fatigue, ignore_cooldown = FALSE)
+	if (!ignore_cooldown)
+		if (world.time < xp_cooldown + xp_interval)
+			return
+
+	xp_cooldown = world.time
+
+	var/obj/effect/proc_holder/spell/targeted/touch/orison/base_spell = attached_spell
+	if (user)
+		adjust_experience(user, base_spell.associated_skill, fatigue+attached_spell.devotion_cost)
+
+/obj/item/melee/touch_attack/orison/MiddleClick(mob/living/user, params)
+	. = ..()
+	if (user.has_status_effect(/datum/status_effect/light_buff))
+		user.remove_status_effect(/datum/status_effect/light_buff)
+		user.visible_message(span_notice("[user] closes [user.p_their()] eyes, and the holy light surrounding them retreats into their chest and disappears."), span_notice("I relinquish the gift of [user.patron.name]'s light."))
+		return
+
+/obj/item/melee/touch_attack/orison/afterattack(atom/target, mob/living/carbon/human/user, proximity)
+	var/fatigue_used
+	switch (user.used_intent.type)
+		if (/datum/intent/fill)
+			fatigue_used = create_water(target, user)
+			if (fatigue_used)
+				handle_xp(user, fatigue_used)
+				qdel(src)
+		if (INTENT_HELP)
+			fatigue_used = thaumaturgy(target, user)
+			if (fatigue_used)
+				handle_xp(user, fatigue_used)
+				user.devotion?.update_devotion(-fatigue_used)
+				qdel(src)
+		if (/datum/intent/use)
+			fatigue_used = cast_light(target, user)
+			if (fatigue_used)
+				handle_xp(user, fatigue_used)
+				user.devotion?.update_devotion(-fatigue_used)
+				qdel(src)
+
+/atom/movable/screen/alert/status_effect/light_buff
+	name = "Miraculous Light"
+	desc = "A blessing of light wards off the darkness surrounding me."
+	icon_state = "stressvg"
+
+/datum/status_effect/light_buff
+	id = "orison_light_buff"
+	alert_type = /atom/movable/screen/alert/status_effect/light_buff
+	duration = 5 MINUTES
+	status_type = STATUS_EFFECT_REFRESH
+	examine_text = "SUBJECTPRONOUN is surrounded by an aura of gentle light."
+	var/potency = 1
+
+/datum/status_effect/light_buff/on_creation(mob/living/new_owner, light_power)
+	potency = light_power
+	return ..()
+
+/datum/status_effect/light_buff/refresh()
+	// stack this up as much as we can be bothered to cast it
+	duration += initial(duration)
+
+/datum/status_effect/light_buff/on_apply()
+	to_chat(owner, span_notice("Light blossoms into being around me!"))
+	owner.light_range = potency
+	owner.light_flags = NONE
+	owner.update_light()
+	return TRUE
+
+/datum/status_effect/light_buff/on_remove()
+	to_chat(owner, span_notice("The miraculous light surrounding me has fled..."))
+	owner.light_range = initial(owner.light_range)
+	owner.light_flags = initial(owner.light_flags)
+	owner.update_light()
+
+/obj/item/melee/touch_attack/orison/proc/cast_light(thing, mob/living/carbon/human/user)
+	var/holy_skill = user.mind?.get_skill_level(attached_spell.associated_skill)
+	var/cast_time = 35 - (holy_skill * 3)
+	if (isliving(thing))
+
+		if (thing != user)
+			user.visible_message(span_notice("[user] reaches gently towards [thing], beads of light glimmering at [user.p_their()] fingertips..."), span_notice("Blessed [user.patron.name], I ask but for a light to guide the way..."))
+		else
+			user.visible_message(span_notice("[user] closes [user.p_their()] eyes and places a glowing hand upon [user.p_their()] chest..."), span_notice("Blessed [user.patron.name], I ask but for a light to guide the way..."))
+		
+		if (do_after(user, cast_time, target = thing))
+			var/mob/living/living_thing = thing
+			var/light_power = clamp(4 + (holy_skill - 3), 4, 7)
+
+			if (living_thing.has_status_effect(/datum/status_effect/light_buff))
+				user.visible_message(span_notice("The holy light emanating from [living_thing] becomes brighter!"), span_notice("I feed further devotion into [living_thing]'s blessing of light."))
+			else
+				user.visible_message(span_notice("A gentle illumination suddenly blossoms into being around [living_thing]!"), span_notice("I grant [living_thing] a blessing of light."))
+
+			living_thing.apply_status_effect(/datum/status_effect/light_buff, light_power)
+
+			return light_devotion
+	else
+		to_chat(user, span_notice("Only living creachers can bear the blessing of [user.patron.name]'s light."))
+		return
+
+/atom/movable/screen/alert/status_effect/thaumaturgy
+	name = "Thaumaturgical Voice"
+	desc = "The power of my god will make the next thing I say carry much further!"
+	icon_state = "stressvg"
+
+/datum/status_effect/thaumaturgy
+	id = "thaumaturgy"
+	alert_type = /atom/movable/screen/alert/status_effect/thaumaturgy
+	duration = 30 SECONDS
+	var/potency = 1
+
+/datum/status_effect/thaumaturgy/on_creation(mob/living/new_owner, skill_power)
+	potency = skill_power
+	return ..()
+
+/obj/item/melee/touch_attack/orison/proc/thaumaturgy(thing, mob/living/carbon/human/user)
+	var/holy_skill = user.mind?.get_skill_level(attached_spell.associated_skill)
+	if (thing == user)
+		// give us a buff that makes our next spoken thing really loud and also cause any linked, un-muted scom to shriek out the phrase at a 15% chance
+		var/cast_time = 50 - (holy_skill * 5)
+		user.visible_message(span_notice("[user] lowers [user.p_their()] head solemnly, whispered prayers spilling from [user.p_their()] lips..."), span_notice("O holy [user.patron.name], share unto me a sliver of your power..."))
+		
+		if (!user.has_status_effect(/datum/status_effect/thaumaturgy))
+			if (do_after(user, cast_time, target = user))
+				user.apply_status_effect(/datum/status_effect/thaumaturgy, holy_skill)
+				user.visible_message(span_notice("[user] throws open [user.p_their()] eyes, suddenly emboldened!"), span_notice("A feeling of power wells up in my throat: speak, and many will hear!"))
+				return thaumaturgy_devotion
+		else
+			to_chat(user, span_notice("I'm already empowered with divine thaumaturgy!"))
+			return
+	else
+		// make a light source flicker, and others around it within a radius	
+		if (istype(thing, /obj/machinery/light) || istype(thing, /obj/item/flashlight))
+			for (var/obj/maybe_light in view(3 + holy_skill, thing))
+				if (istype(maybe_light, /obj/machinery/light))
+					var/obj/machinery/light/other_light = maybe_light
+					other_light.flicker(holy_skill * 5)
+					user.devotion?.update_devotion(-1)
+				else if (istype(maybe_light, /obj/item/flashlight/flare))
+					var/obj/item/flashlight/flare/mobile_light = maybe_light
+					if (mobile_light.on)
+						mobile_light.turn_off()
+						user.devotion?.update_devotion(-1)
+
+			to_chat(user, span_notice("I direct the weight of my faith towards nearby flames, causing them to flicker!"))
+			
+			return thaumaturgy_devotion
+		else if (isturf(thing))
+
+			var/did_flicker = FALSE
+			for (var/obj/machinery/light/other_lights in view(3 + holy_skill, thing))
+				other_lights.flicker(holy_skill * 5)
+				user.devotion?.update_devotion(-1)
+				did_flicker = TRUE
+
+			if (did_flicker)
+				to_chat(user, span_notice("I direct the weight of my faith towards nearby flames, causing them to flicker!"))
+
+				return thaumaturgy_devotion
+			else
+				to_chat(user, span_notice("My faith finds no flames to show its passage..."))
+				qdel(src)
+		else if (isliving(thing))
+
+			var/mob/living/living_thing = thing
+			if (living_thing.has_status_effect(/datum/status_effect/light_buff))
+				living_thing.remove_status_effect(/datum/status_effect/light_buff)
+				user.visible_message(span_notice("[user] issues a reserved gesture towards [living_thing], and the holy light leaves [living_thing.p_them()]."), span_notice("I gesture towards [living_thing], and [living_thing.p_their()] blessing of light recedes."))
+				return
+			else
+				to_chat(user, span_notice("My divine thaumaturgy can only augment my own voice, or dismiss the blessing of light on others."))
+				return
+		else
+			to_chat(user, span_warning("I can only direct thaumaturgical prayers towards myself, the ground, and any nearby light sources."))
+			return
+
+/obj/item/melee/touch_attack/orison/proc/create_water(atom/thing, mob/living/carbon/human/user)
+	// normally we wouldn't use fatigue here to keep in line w/ other holy magic, but we have to since water is a persistent resource
+	if (thing.is_refillable())
+		if (thing.reagents.holder_full())
+			to_chat(user, span_warning("[thing] is full."))
+			return
+		
+		user.visible_message(span_info("[user] closes [user.p_their()] eyes in prayer and extends a hand over [thing] as water begins to stream from [user.p_their()] fingertips..."), span_notice("I utter forth a plea to [user.patron.name] for succour, and hold my hand out above [thing]..."))
+
+		var/holy_skill = user.mind?.get_skill_level(attached_spell.associated_skill)
+		var/drip_speed = 56 - (holy_skill * 8)
+		var/fatigue_spent = 0
+		var/fatigue_used = max(3, holy_skill)
+		while (do_after(user, drip_speed, target = thing))
+			if (thing.reagents.holder_full() || (user.devotion.devotion - fatigue_used <= 0))
+				break
+
+			var/water_qty = max(1, holy_skill / 2)
+			var/list/water_contents = list(/datum/reagent/water = water_qty)
+			var/datum/reagents/reagents_to_add = new()
+			reagents_to_add.add_reagent_list(water_contents)
+			reagents_to_add.trans_to(thing, reagents_to_add.total_volume, transfered_by = user, method = INGEST)
+
+			fatigue_spent += fatigue_used
+			user.rogfat_add(fatigue_used)
+			user.devotion?.update_devotion(-0.5)
+
+			if (prob(80))
+				playsound(user, 'sound/items/fillcup.ogg', 55, TRUE)
+		
+		return fatigue_spent
+	else if (istype(thing, /obj/item/natural/cloth))
+		// stupid little easter egg here: you can dampen a cloth to clean with it, because prestidigitation also lets you clean things. also a lot cheaper devotion-wise than filling a bucket
+		var/obj/item/natural/cloth/the_cloth = thing
+		if (!the_cloth.wet)
+			var/holy_skill = user.mind?.get_skill_level(attached_spell.associated_skill)
+			the_cloth.wet += holy_skill * 5
+			user.visible_message(span_info("[user] closes [user.p_their()] eyes in prayer, beads of moisture coalescing in [user.p_their()] hands to moisten [the_cloth]."), span_notice("I utter forth a plea to [user.patron.name] for succour, and will moisture into [the_cloth]. I should be able to clean with it properly now."))
+			return water_moisten

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3566,6 +3566,7 @@
 #include "modular_azurepeak\code\modules\mob\living\simple_animal\rogue\creacher\dragon.dm"
 #include "modular_azurepeak\code\modules\mob\living\simple_animal\rogue\creacher\gethsmane.dm"
 #include "modular_azurepeak\code\modules\mob\living\simple_animal\rogue\creacher\newminotaur.dm"
+#include "modular_azurepeak\code\modules\spells\orison.dm"
 #include "modular_azurepeak\statpacks\agile.dm"
 #include "modular_azurepeak\statpacks\mental.dm"
 #include "modular_azurepeak\statpacks\physical.dm"


### PR DESCRIPTION
## About The Pull Request

As mages have cantrips (prestidigitation), so too shall divine casters have orisons.

This adds a multi-functional hand touch spell to *all* divine casters (including churchlings) that has the following functionality:

- FILL intent creates water inside any container that can normally hold water, consuming a little bit of devotion and fatigue each time. It will continue to cycle of its own accord until you either stop it, the container is full, or you run out of devotion. Higher levels of holy magic skill increase the amount of water you make per devotion, and also decrease the fatigue component - accomplished holy casters will find this effortless.
   - You can also use the hand touch on a cloth to wet it, with higher holy levels increasing how much. This is significantly cheaper in all circumstances than making the water and then wetting the cloth normally - the intent is to make an easy way for church chars to clean stuff up (similar to prestidigitation) with less inventory requirement.
- TOUCH intent imbues you (or something else) with divine thaumaturgy.
   - Using thaumaturgy on yourself gives you a buff for 30 seconds that makes the next thing you say **LOUD**, causing it to travel an extra 5 tiles (plus 3 for every level of holy magic you have). At a small chance per SCOM (3x your holy magic skill level), whatever you say LOUDLY in this manner may be shrieked by the startled ratlings in the SCOMlines, **no matter where you are on the map.**
      - Yes, this means you can potentially send warnings to the town at a low chance and in a very unreliable way, because the chance is rolled *per SCOM*, meaning you might end up having your message sent to one that nobody is close enough to hear.
      - This also stacks with shouting, meaning that you can be heard from over 30 tiles away with high holy magic and thaumaturgy.
   - Using thaumaturgy on the ground causes any nearby light sources to flicker ominously with no reason given to anyone else as to why. Be spooky. You can also use this on any light source left unattended on the ground or on the walls.
- USE intent allows you to place a blessing of light on another living creature for 5 minutes per cast, with the potency of its light starting at 4 tiles and increasing up to 7 depending on your holy magic level.
   - You can use thaumaturgy people with this blessing from any distance to dismiss it from them, even blessings that come from other people.
   - You can also MMB the prayer hand to remove your own light buff, should you ever want to.

As prestidigitation, all of this functionality provides trickle amounts of experience for holy magic casting up to Expert, and then no further. Spamming this spell to gain experience is not advised as it only actually awards any experience once every 15 seconds, regardless of what you use.

## Why It's Good For The Game

Divine characters have like, no spells or features outside of a few thing. It kind of sucks, even if the one or two things they do have (lesser miracle and churn) are pretty good. Orisons are flavorful, generic, and let people do a variety of neat utility things.

I eagerly await people hosting sermons entirely in thaumaturgy loud mode and getting violently murdered for doing so.