### PR TITLE
Makes Merchants Nobles Again!!!

### DIFF
--- a/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
@@ -38,6 +38,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
 		backpack_contents = /obj/item/rogueweapon/huntingknife/idagger/navaja
+	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, type)
 	neck = /obj/item/clothing/neck/roguetown/horus
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/merchant


### PR DESCRIPTION
## About The Pull Request

Gives the Merchant role the Noble trait by default again. 

## Why It's Good For The Game

Merchants were originally nobles in original Roguetown, and every other Roguetown server except for Azure for a reason that nobody has clearly defined to me. Making them nobles again adds social convention to prevent Keep Players from steamrolling them to sidestep roleplay and use their facilities with little to no regard for other players. 

Merchants are described in their flavor text as "You were born into wealth, learning from before you could talk about the basics of mathematics. Counting coins is a simple pleasure for any person, but you've made it an artform. These people are addicted to your wares and you are the literal beating heart of this economy: Dont let these filthy-covered troglodytes ever forget that." This is much more conducive to them being nobles than being non-nobles and open to flagrant stomping by Keep Players. 

(Further PRs fixing these grammatical errors in the flavor text soon, maybe an entire rewrite)

Merchants already barely if ever put money into the Shylock, and now if they do they won't be automatically taxed. This now adds some possible friction between the keep and Merchant when it comes to taxes, and facilitates more roleplay as a result. The Keep should be interacting with the merchant through things like taxes to recoup some of the losses they incur from purchasing from him, instead of just ignoring him entirely. 
