### PR TITLE
Mount Decapitation Dragon Adjustments

### DIFF
--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -564,7 +564,6 @@
 "vC" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/dragon{
 	faction = list("wolfs");
-	health = 1000;
 	retreat_health = 0.1
 	},
 /turf/open/floor/rogue/naturalstone,

--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -564,7 +564,8 @@
 "vC" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/dragon{
 	faction = list("wolfs");
-	health = 400
+	health = 1000;
+	retreat_health = 0.1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
@@ -915,10 +916,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
 "Hb" = (
-/mob/living/simple_animal/hostile/megafauna/dragon{
-	health = 1500;
-	faction = list("wolfs");
-	name = "dragon broodmother"
+/mob/living/simple_animal/hostile/retaliate/rogue/dragon/broodmother{
+	retreat_health = 0.1;
+	faction = list("wolfs")
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -197,4 +197,4 @@
 	projectilesound = 'sound/blank.ogg'
 	ranged = 1
 	ranged_message = "breathes fire"
-	ranged_cooldown_time = 15 SECONDS
+	ranged_cooldown_time = 20 SECONDS

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -20,8 +20,8 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 20,
 						/obj/item/natural/hide = 10, /obj/item/natural/bundle/bone/full = 4)
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
-	health = 1000
-	maxHealth = 1000
+	health = 800
+	maxHealth = 800
 	melee_damage_lower = 45
 	melee_damage_upper = 70
 	vision_range = 7
@@ -190,8 +190,8 @@
         M.throw_at(throw_target, exp_light, EXPLOSION_THROW_SPEED)
     
 /mob/living/simple_animal/hostile/retaliate/rogue/dragon/broodmother
-	health = 3000
-	maxHealth = 3000
+	health = 1600
+	maxHealth = 1600
 	name = "dragon broodmother"
 	projectiletype = /obj/projectile/magic/aoe/dragon_breath
 	projectilesound = 'sound/blank.ogg'

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -20,8 +20,8 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 20,
 						/obj/item/natural/hide = 10, /obj/item/natural/bundle/bone/full = 4)
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
-	health = 2500
-	maxHealth = 2500
+	health = 1000
+	maxHealth = 1000
 	melee_damage_lower = 45
 	melee_damage_upper = 70
 	vision_range = 7
@@ -152,3 +152,49 @@
 			return "foreleg"
 	return ..()
 
+/obj/projectile/magic/aoe/dragon_breath
+    name = "fire hairball"
+    icon_state = "fireball"
+    damage = 10
+    damage_type = BRUTE
+    nodamage = FALSE
+    light_color = "#f8af07"
+    light_range = 2
+    damage = 40
+    flag = "magic"
+    hitsound = 'sound/blank.ogg'
+
+    //explosion values
+    var/exp_heavy = 0
+    var/exp_light = 2
+    var/exp_flash = 3
+    var/exp_fire = 3
+
+
+
+/obj/projectile/magic/aoe/dragon_breath/on_hit(target)
+    . = ..()
+    if(ismob(target))
+        var/mob/living/M = target
+        if(exp_fire)
+            M.adjust_fire_stacks(exp_fire*3)
+    var/turf/T
+    if(isturf(target))
+        T = target
+    else
+        T = get_turf(target)
+    explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, soundin = explode_sound)
+    if(ismob(target))
+        var/mob/living/M = target
+        var/atom/throw_target = get_edge_target_turf(M, angle2dir(Angle))
+        M.throw_at(throw_target, exp_light, EXPLOSION_THROW_SPEED)
+    
+/mob/living/simple_animal/hostile/retaliate/rogue/dragon/broodmother
+	health = 3000
+	maxHealth = 3000
+	name = "dragon broodmother"
+	projectiletype = /obj/projectile/magic/aoe/dragon_breath
+	projectilesound = 'sound/blank.ogg'
+	ranged = 1
+	ranged_message = "breathes fire"
+	ranged_cooldown_time = 15 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR replaces the ash drake on Mount Decap with a new variant of dragon known as the "dragon broodmother" - which is simply a beef up simplemob dragon capable of casting a buffed version of greater fireball known as dragon's breath.

The three smaller dragons have had their health increased a bit to compensate for the fact that the boss fight is now a fair bit easier.

## Why It's Good For The Game

After watching players attempt to clear the dragon arena for the past week, I've come to the conclusion that a whole ass ash drake is probably too much. 

The ash drake would repeatedly get aggro'd by players, immediately kill whoever aggro'd it, and then wander around Mount Decap for the next 2 hours killing pretty much anyone it came in contact with. 

This PR should hopefully make it a challenging, but possible fight - and probably also a lot less lethal if someone manages to lure it outside of its arena.
