### PR TITLE
Bank Accounts Tied To The Treasury

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -119,26 +119,22 @@ SUBSYSTEM_DEF(treasury)
 		return
 	if(!target)
 		return
+	amt = min(amt, 10000) //No exponentials, please!
 	var/target_name = target
 	if(istype(target,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = target
 		target_name = H.real_name
 	var/found_account
-	if (amt > treasury_value)  // Check if the amount exceeds the treasury balance
-		send_ooc_note("<b>MEISTER:</b> Error: Insufficient funds in the treasury to complete the transaction.", name = target_name)
-		return FALSE  // Return early if the treasury balance is insufficient
 	for(var/X in bank_accounts)
 		if(X == target)
 			if(amt > 0)
-				bank_accounts[X] += amt  // Deposit the money into the player's account
-				treasury_value -= amt   // Deduct the given amount from the treasury
+				bank_accounts[X] += amt  // Add funds into the player's account
 			else
 				// Check if the amount to be fined exceeds the player's account balance
 				if(abs(amt) > bank_accounts[X])
 					send_ooc_note("<b>MEISTER:</b> Error: Insufficient funds in the account to complete the fine.", name = target_name)
 					return FALSE  // Return early if the player has insufficient funds
 				bank_accounts[X] -= abs(amt)  // Deduct the fine amount from the player's account
-				treasury_value += abs(amt)  // Add the fined amount to the treasury
 			found_account = TRUE
 			break
 	if(!found_account)
@@ -148,10 +144,10 @@ SUBSYSTEM_DEF(treasury)
 		// Player received money
 		if(source)
 			send_ooc_note("<b>MEISTER:</b> You received [amt]m. ([source])", name = target_name)
-			log_to_steward("+[amt] from treasury to [name] ([source])")
+			log_to_steward("+[amt] from treasury to [target_name] ([source])")
 		else
 			send_ooc_note("<b>MEISTER:</b> You received [amt]m.", name = target_name)
-			log_to_steward("+[amt] from treasury to [name]")
+			log_to_steward("+[amt] from treasury to [target_name]")
 	else
 		// Player was fined
 		if(source)
@@ -174,6 +170,7 @@ SUBSYSTEM_DEF(treasury)
 		return FALSE
 	var/taxed_amount = 0
 	var/original_amt = amt
+	treasury_value += amt
 	if(character in bank_accounts)
 		if(HAS_TRAIT(character, TRAIT_NOBLE))
 			bank_accounts[character] += amt
@@ -181,11 +178,10 @@ SUBSYSTEM_DEF(treasury)
 			taxed_amount = round(amt * tax_value)
 			amt -= taxed_amount
 			bank_accounts[character] += amt
-			treasury_value += taxed_amount
 	else
 		return FALSE
 
-	log_to_steward("+[original_amt] deposited by [character] of which taxed [taxed_amount]")
+	log_to_steward("+[original_amt] deposited by [character.real_name] of which taxed [taxed_amount]")
 
 	return TRUE
 
@@ -203,12 +199,16 @@ SUBSYSTEM_DEF(treasury)
 			if(bank_accounts[X] < amt)  // Check if the withdrawal amount exceeds the player's account balance
 				send_ooc_note("<b>MEISTER:</b> Error: Insufficient funds in the account to complete the withdrawal.", name = target_name)
 				return  // Return without processing the transaction
+			if(treasury_value < amt)  // Check if the amount exceeds the treasury balance
+				send_ooc_note("<b>MEISTER:</b> Error: Insufficient funds in the treasury to complete the transaction.", name = target_name)
+				return  // Return early if the treasury balance is insufficient
 			bank_accounts[X] -= amt //The account accounts accountingly. Shame on you if you copy this, apple.
+			treasury_value -= amt
 			found_account = TRUE
 			break
 	if(!found_account)
 		return
-	log_to_steward("-[amt] withdrawn by [name]")
+	log_to_steward("-[amt] withdrawn by [target_name]")
 	return TRUE
 
 

--- a/code/modules/roguetown/roguemachine/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward.dm
@@ -42,6 +42,11 @@
 				return
 		to_chat(user, span_warning("Wrong key."))
 		return
+	if(istype(P, /obj/item/roguecoin))
+		SStreasury.give_money_treasury(P.get_real_price(), "NERVE MASTER deposit")
+		qdel(P)
+		playsound(src, 'sound/misc/coininsert.ogg', 100, FALSE, -1)
+		return
 	return ..()
 
 


### PR DESCRIPTION
Your bank account is no longer independent from the treasury. Being paid or fined will affect your balance without affecting the treasury. Withdrawing will drain the funds from both your account and the treasury. Putting money in adds money to both, also.

So basically this means you can pay people with money you don't have. Like a bank! Wow!

You can now put coins directly into the NERVE MASTER to add funds to the treasury.

The treasury log will correctly mention the names of account owners.