### PR TITLE
Don't spawn rous from the SCOM at >200 chars

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -246,12 +246,12 @@
 				calling.repeat_message(raw_message, src, usedcolor, message_language)
 			return
 		if(length(raw_message) > 100) //When these people talk too much, put that shit in slow motion, yeah
-			if(length(raw_message) > 200)
+			/*if(length(raw_message) > 200)
 				if(!spawned_rat)
 					visible_message(span_warning("An angered rous emerges from the SCOMlines!"))
 					new /mob/living/simple_animal/hostile/retaliate/rogue/bigrat(get_turf(src))
 					spawned_rat = TRUE
-				return
+				return*/
 			raw_message = "<small>[raw_message]</small>"
 		for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
 			if(!S.calling)


### PR DESCRIPTION
## About The Pull Request

It's kind of incredible that this hasn't happened more often given the SCOM volume we've got in our current map. Messages over 200 characters used to spawn a pissed off rous once per SCOM, now they don't.

Roleplay server and all that.

## Why It's Good For The Game

I shouldn't really need to explain why spawning hostile mobs on people who are longform roleplaying is a bad thing. (Also, you could totally abuse this for free early mats and annoy everyone in the process if you wanted to.)