### PR TITLE
Fukc Mine Sisyphean Serf Lyfe: Buffs Servant

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -28,7 +28,10 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
-		H.change_stat("constitution", -1)
+		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.change_stat("strength", -1)
+		H.change_stat("speed", 1)
 		H.change_stat("intelligence", 2)
 		H.change_stat("perception", 1)
 

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -28,6 +28,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.change_stat("strength", -1)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -21,19 +21,22 @@
 /datum/outfit/job/roguetown/servant/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.change_stat("strength", -1)
-		H.change_stat("constitution", -1)
+		H.change_stat("speed", 1)
 		H.change_stat("intelligence", 1)
 		H.change_stat("perception", 1)
 
 	if(H.pronouns == SHE_HER)
+		head = /obj/item/clothing/head/roguetown/armingcap
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
 		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 		cloak = /obj/item/clothing/cloak/apron/waist

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -29,6 +29,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.change_stat("strength", -1)
 		H.change_stat("speed", 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
SERVANT
* Mildly buffs knives, sneaking, sewing. Adds climbing, crafting, and lockpicking.
* Adds small speed buff.
* Adds peasant cap to servant loadout.
* Removes constitution debuff.

BUTLER
* Removes constitution debuff, replaced with strength debuff.
* Adds small speed buff.
* Adds climbing, lockpicking and stealing.

## Why It's Good For The Game
Steers the servant class into a more lithe direction, while also empowering their crafting capabilities. They'll be in a position to work against the keep as ears for outside sources, or prove themselves a household asset against the keeps' enemies. Should also incentivize royals not to be heavy handed with abuse larp now that a good servant is equipped with the means to really ruin their day.

This also really sucks.

![image](https://github.com/user-attachments/assets/5eee8221-bd9d-45dd-9f97-a2a8c3f59d40)

