### PR TITLE
[TESTMERGE ONLY] NPC stand-spam fix and idle mode health regeneration

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -20,6 +20,7 @@
 	var/ai_when_client = FALSE
 	var/next_idle = 0
 	var/next_seek = 0
+	var/next_stand = 0
 	var/flee_in_pain = FALSE
 	var/stand_attempts = 0
 	var/ai_currently_active = FALSE
@@ -55,11 +56,8 @@
 			resisting = FALSE
 		if(!resisting)
 			if(!(mobility_flags & MOBILITY_STAND) && (stand_attempts < 3))
-				resisting = TRUE
 				npc_stand()
-				resisting = FALSE
 			else
-				stand_attempts = 0
 				if(!handle_combat())
 					if(mode == AI_IDLE && !pickupTarget)
 						npc_idle()
@@ -71,10 +69,16 @@
 		return TRUE
 
 /mob/living/carbon/human/proc/npc_stand()
+	// the sane way to do this would be to try and check if we can even realistically stand 
+	resisting = TRUE
 	if(stand_up())
 		stand_attempts = 0
+		resisting = FALSE
+		return TRUE
 	else
 		stand_attempts += rand(1,3)
+		resisting = FALSE
+		return FALSE
 
 /mob/living/carbon/human/proc/npc_idle()
 	if(m_intent == MOVE_INTENT_SNEAK)
@@ -82,6 +86,10 @@
 	if(world.time < next_idle + rand(30,50))
 		return
 	next_idle = world.time + rand(30,50)
+	if ((world.time < next_stand + rand(50, 100)) && !npc_stand()) // attempt to stand up when idle, but only once every so often
+		next_stand = world.time + rand(50, 100)
+	if (getToxLoss() <= STACON) // if we have toxin damage less than our constitution, attempt to heal
+		heal_wounds(STACON / 4)
 	if((mobility_flags & MOBILITY_MOVE) && isturf(loc))
 		if(wander)
 			if(prob(50))

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -308,7 +308,8 @@
 					var/paine = get_complex_pain()
 					if(paine >= ((STAEND * 10)*0.9))
 //						mode = AI_FLEE
-						walk_away(src, target, 5, update_movespeed())
+						if (!restrained())
+							walk_away(src, target, 5, update_movespeed())
 				return TRUE
 			else								// not next to perp
 				frustration++

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -657,6 +657,7 @@
 				return TRUE
 		else
 			src.visible_message(span_warning("[src] tries to stand up."))
+			return FALSE
 
 /mob/living/proc/toggle_rest()
 	set name = "Rest/Stand"


### PR DESCRIPTION
## About The Pull Request

Addresses the 'stand spam for 700 years' thing we've had for a while. Downed NPCs will now try to fight back and flee where appropriate. I've marked this as testmerge only because it kind of makes a lot of encounters significantly more challenging now that things just don't let you kill them all the time.

Additionally, when idle, they will attempt to stand up every 5-20 seconds, and **will heal for 25% of their Constitution stat** every 6-10 seconds **UNLESS THEY HAVE MORE TOX DAMAGE THAN THEIR CONSTITUTION STAT.** You should be able to semi-effectively whittle down tougher NPCs with poison hit and run attacks now, to mirror poison's usefulness on simplemobs.

I've put the regeneration in to give mobs a bit of a chance to recuperate if they manage to get away from you and you don't push the advantage fast enough.

NPCs now should also properly respect being grabbed when trying to flee, so you can actually try to stop them that way.

## Why It's Good For The Game

Affects practically all of our human NPC combat. Big implications for it all, really.
