### PR TITLE
Vaquero Flavour Pack woooooo!!

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -299,7 +299,7 @@
 /obj/item/rogueweapon/huntingknife/idagger/navaja
 	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut,  /datum/intent/dagger/thrust/pick)
 	name = "navaja"
-	desc = "A folding Zybantian knife used by merchants, mercenaries, and peasants out east. It's far rarer, here. The long hilt allows for a sizeable blade with good reach."
+	desc = "A folding Etruscan knife valued by merchants, mercenaries and peasants for its convenience. It possesses a long hilt, allowing for a sizeable blade with good reach."
 	force = 5
 	icon_state = "navaja_c"
 	item_state = "elfdag"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/vaquero.dm
@@ -24,7 +24,7 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/labor/fishing, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/vaquero.dm
@@ -49,7 +49,7 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltl = /obj/item/rogueweapon/sword/rapier
 	backr = /obj/item/rogue/instrument/guitar
-	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/lockpick = 1)
+	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/rogueweapon/huntingknife/idagger/navaja = 1, /obj/item/lockpick = 1)
 	H.change_stat("intelligence", 2)
 	H.change_stat("endurance", 2)
 	H.change_stat("speed", 2)


### PR DESCRIPTION
## About The Pull Request
This changes the description of the navaja knife, grants said knife to the vaquero and slightly buffs the vaquero's climbing stat, to better fill the swashbuckler archetype.

## Why It's Good For The Game
The navaja is a very iconic weapon originating in Iberia due to the conditions of its time. It has a very strong reason to be invented in the Iberian-Italian Etrusca, rather than the more middle-eastern inspired Zybantian. It would still find its way to the latter through large amounts of trade.

I think it is much more flavourful for the vaquero to receive this knife, rather than the current steel-dagger. It also directly ties the class to the other Etruscan class, the condottieri, who also uses the knife!

Finally, the slight buff to climbing allows the Vaquero to be the dexterous and dashing fencer of all of our dreams...
