### PR TITLE
Moves Purity to bath house intake room.

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -28559,7 +28559,7 @@ cVp
 kAA
 kAA
 kAA
-soL
+kAA
 bLX
 pUC
 pUC
@@ -31238,7 +31238,7 @@ kAA
 kOC
 icN
 icN
-kAA
+soL
 kAA
 hHp
 bLX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Moves the Purity machine to a new location in the bath house to ensure public accessibility whilst still directing the population by the front desk. 
![image](https://github.com/user-attachments/assets/3e827785-6770-44b2-814e-f9791afb0d06)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In practice I've found that the bathhouse just remains locked, especially on lowpop, and the Purity (which has a purpose as a super expensive and antisocial alternative to drugs better purchased at merchant) is often inaccessible without a master key or similar. This puts it in a better position. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
