### PR TITLE
adds braziers along the southern road =)

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -57822,7 +57822,7 @@ jIk
 jIk
 jIk
 wDa
-nPK
+fsP
 fsP
 ylN
 ylN
@@ -57979,7 +57979,7 @@ jIk
 jIk
 pHC
 wDa
-wDa
+nPK
 fsP
 ylN
 ylN
@@ -58136,7 +58136,7 @@ jIk
 jIk
 wDa
 wDa
-wDa
+fsP
 fsP
 ylN
 ylN
@@ -58293,7 +58293,7 @@ jIk
 jIk
 wDa
 wDa
-jIk
+fsP
 ylN
 ylN
 ylN

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -1828,10 +1828,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
-"bPa" = (
-/obj/structure/flora/roguetree/burnt,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/rtfield)
 "bPh" = (
 /obj/structure/roguemachine/steward,
 /turf/open/floor/rogue/hexstone,
@@ -16274,6 +16270,7 @@
 /area/rogue/indoors/town/manor)
 "qjQ" = (
 /obj/structure/fluff/railing/border,
+/obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "qko" = (
@@ -52630,7 +52627,7 @@ jIk
 omo
 jIk
 jIk
-wDa
+qal
 jIk
 jIk
 dPz
@@ -54996,7 +54993,7 @@ fsP
 ylN
 ylN
 ylN
-fsP
+nPK
 fsP
 fsP
 jIk
@@ -56410,7 +56407,7 @@ jIk
 ylN
 ylN
 ylN
-bPa
+fsP
 fsP
 fsP
 jIk
@@ -56566,7 +56563,7 @@ wDa
 jIk
 ylN
 ylN
-fsP
+nPK
 fsP
 lyQ
 huO
@@ -57348,7 +57345,7 @@ jIk
 wDa
 wDa
 jIk
-oYo
+wDa
 ylN
 ylN
 fsP
@@ -57662,7 +57659,7 @@ omo
 wDa
 wDa
 wDa
-jIk
+fsP
 ylN
 ylN
 ylN
@@ -57819,7 +57816,7 @@ jIk
 jIk
 jIk
 wDa
-pHC
+nPK
 fsP
 ylN
 ylN
@@ -57974,7 +57971,7 @@ ymg
 ymg
 jIk
 jIk
-jIk
+pHC
 wDa
 wDa
 fsP
@@ -58133,7 +58130,7 @@ jIk
 jIk
 wDa
 wDa
-oYo
+wDa
 fsP
 ylN
 ylN
@@ -58604,7 +58601,7 @@ fsP
 jIk
 jIk
 wDa
-oYo
+wDa
 ylN
 ylN
 ylN
@@ -59232,7 +59229,7 @@ ymg
 fsP
 fsP
 fsP
-omo
+jIk
 ylN
 ylN
 ylN
@@ -59863,7 +59860,7 @@ ylN
 ylN
 ylN
 ylN
-omo
+jIk
 biI
 biI
 biI
@@ -60019,7 +60016,7 @@ ymg
 fsP
 ylN
 ylN
-fsP
+nPK
 biI
 biI
 biI
@@ -63618,7 +63615,7 @@ cxb
 cxb
 iPW
 rhJ
-fZj
+pJn
 pJn
 mKL
 mKL

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -4302,6 +4302,12 @@
 /obj/structure/roguetent,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"enF" = (
+/obj/structure/fluff/signage{
+	name = "AZURE PEAK - NORTH"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "eon" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1;
@@ -53421,7 +53427,7 @@ fsP
 dPz
 eUz
 mIn
-jMT
+ylN
 ylN
 ylN
 dPz
@@ -55473,7 +55479,7 @@ jIk
 omo
 jIk
 nPK
-fsP
+enF
 ylN
 ylN
 ylN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This adds a few extra braziers along the southern road leading into town from the forest.

https://github.com/user-attachments/assets/4c8f3a1c-6da6-4e2d-93ff-e824f0ebb0d0

## Why It's Good For The Game

The latejoin towner spawn location was recently moved further south. The road leading into the town from the latejoin spawn carriage is really dark and most towner roles do not spawn with a torch or lantern. While this isn't exactly a massive issue if you know where you're going, this should make it just a little bit easier for new players to navigate to town, especially if spawning at night.