### PR TITLE
Silly little Village Elder skills change

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -6,14 +6,14 @@
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_sexes = list(MALE, FEMALE) //same as bog guard
+	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = list(AGE_OLD)
-	tutorial = "You are as venerable and ancient as the trees themselves, wise even for your years spent in the bog guard. The King may lead officially, but people look to you as Ealdorman to solve lesser issues. Remember the old ways of the law, not everything must end in bloodshed: no matter how much the retinue wish it were the case."
+	tutorial = "You are as venerable and ancient as the trees themselves, wise even for your years spent with the first Wardens. The people look up to you both as a teacher and a guide to solve lesser issues before violence is involved. Not everything must end in bloodshed, no matter how much the retinue wish it were the case."
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/woodsman
 	display_order = JDO_CHIEF
-	min_pq = 0
+	min_pq = 5
 	max_pq = null
 	give_bank_account = 16
 
@@ -23,7 +23,7 @@
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(istype(H.cloak, /obj/item/clothing/cloak/raincloak/furcloak))
+		if(istype(H.cloak, /obj/item/clothing/cloak/raincloak/furcloak/woad))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")
 			if(index)
@@ -38,32 +38,31 @@
 
 /datum/outfit/job/roguetown/woodsman/pre_equip(mob/living/carbon/human/H)
 	..()
-	cloak = /obj/item/clothing/cloak/raincloak/furcloak
+	cloak = /obj/item/clothing/cloak/raincloak/furcloak/woad
 	armor = /obj/item/clothing/suit/roguetown/armor/gambeson
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-	pants = /obj/item/clothing/under/roguetown/tights/random
+	pants = /obj/item/clothing/under/roguetown/tights
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/rogueweapon/mace/cudgel
+	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	r_hand = /obj/item/rogueweapon/woodstaff
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/storage/keyring/velder  = 1, /obj/item/storage/belt/rogue/pouch/coins/rich = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+	backpack_contents = list(/obj/item/storage/keyring/velder  = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/masonry, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/engineering, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/tanning, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
@@ -74,6 +73,5 @@
 		H.change_stat("endurance", 2)
 		H.change_stat("speed", -3)
 		H.change_stat("intelligence", 5)
-	H.verbs |= /mob/proc/haltyell
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
+	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -13,7 +13,7 @@
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/woodsman
 	display_order = JDO_CHIEF
-	min_pq = 5
+	min_pq = 2 //mentor role, not a high PQ requirement but not zero
 	max_pq = null
 	give_bank_account = 16
 
@@ -69,9 +69,10 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 3, TRUE)
-		H.change_stat("perception", 4)
+		H.change_stat("perception", 2)
 		H.change_stat("endurance", 2)
-		H.change_stat("speed", -3)
-		H.change_stat("intelligence", 5)
+		H.change_stat("speed", -1)
+		H.change_stat("constitution", 1)
+		H.change_stat("intelligence", 3)
 	ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
 	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

Changes up many of the Village Elder's skills to be the counterpart of the Veteran rather than a duplicate of them. The Elder is knowledge of trades over combat, after all.
The PR removes references to the Bog Guard and replaced it with the Wardens, giving her a Warden furcoat rather than the default white one. A little PQ restriction is added too, since the whole job slot revolves around conflict de-escalation, which is not something everyone is well aware of.

![Screen Shot 2024-10-20 at 2 19 37 PM](https://github.com/user-attachments/assets/979997d6-26e1-447d-bb67-b79b443fe1c8)

## Why It's Good For The Game

We have the Veteran to act as a mentor to the combat-oriented roles, but if anyone wants aid in a specific crafting skill? Good luck!
The Elder's ability to wear both medium and heavy armor has also been removed, replace instead with the Empathy and (poor) Price-Seeing traits.
As such, everything combat-oriented save for the Elder's sword, knife and unarmed skills have been removed, replaced instead with civilian skills. She's also lost her cudgel, as the Elder has access to an Old Blade in their quarters and still has their silver knife if they do lose their sword somehow.