### PR TITLE
Changes the Desert Rider sword's name

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -292,8 +292,8 @@
 	item_state = "tabi"
 	lefthand_file = 'icons/mob/inhands/weapons/roguebig_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/roguebig_righthand.dmi'
-	name = "kilij scimitar"
-	desc = "A scimitar with elegant curves and deadly sharpness."
+	name = "shamshir"
+	desc = "A one-handed sword with elegant curves and deadly sharpness."
 	parrysound = "bladedmedium"
 	swingsound = BLADEWOOSH_LARGE
 	pickup_sound = 'sound/foley/equip/swordlarge2.ogg'

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -1,6 +1,6 @@
 /datum/advclass/mercenary/desert_rider
 	name = "Desert Rider Mercenary"
-	tutorial = "Blood, like the desert sand, stains your hands, a crimson testament to the gold you covet. A desert rider, renowned mercenary of the far east, your scimitar whispers tales of centuries-old tradition. Your loyalty, a fleeting mirage in the shifting sands, will yield to the allure of fortune."
+	tutorial = "Blood, like the desert sand, stains your hands, a crimson testament to the gold you covet. A desert rider, renowned mercenary of the far east, your shamshir whispers tales of centuries-old tradition. Your loyalty, a fleeting mirage in the shifting sands, will yield to the allure of fortune."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/desert_rider


### PR DESCRIPTION
## About The Pull Request
Changes the desert rider's sword's name from 'kilij scimitar' to the more appropriate 'shamshir'. Also slightly tweaks the class' description to reflect this.

## Why It's Good For The Game
"Kilij scimitar" is an anachronistic name. A kilij is a similar yet different sword to a shamshir, and a 'scimitar' is a european spelling of 'shamshir' which would not be used by the native wielders of the weapon. Simply renaming the sword to 'shamshir' is more reflective of the weapon type, and more appropriate for the culture it emerges from in-game.

