### PR TITLE
Changes window descriptions

### DIFF
--- a/code/game/objects/structures/roguewindow.dm
+++ b/code/game/objects/structures/roguewindow.dm
@@ -1,7 +1,7 @@
 
 /obj/structure/roguewindow
 	name = "window"
-	desc = "A glass window. Glass is very rare nowadays."
+	desc = "A glass window."
 	icon = 'icons/roguetown/misc/structure.dmi'
 	icon_state = "window-solid"
 	layer = TABLE_LAYER
@@ -63,7 +63,7 @@
 	integrity_failure = 0.9
 
 /obj/structure/roguewindow/openclose/reinforced
-	desc = "A glass window. Glass is very rare nowadays. This one looks reinforced with a metal mesh."
+	desc = "A glass window. This one looks reinforced with a metal mesh."
 	icon_state = "reinforcedwindowdir"
 	base_state = "reinforcedwindow"
 	max_integrity = 800


### PR DESCRIPTION
## About The Pull Request
Changes the description of windows and reinforced windows to remove a reference to glass' rarity.

## Why It's Good For The Game
This is a holdover in the code from other server's lore. Glass is plentiful in our server and is not more expensive than you'd expect. Glass bottles do not cost a lord's ransom, so the reference is inaccurate to our lore. 