### PR TITLE
Lord Rapier Fix

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -593,7 +593,6 @@
 	sellprice = 140
 
 /obj/item/rogueweapon/sword/rapier/lord
-	force = 20
 	name = "sword of the Mad Duke"
 	desc = "A royal heirloom whose spiraling basket hilt is inlaid with fine cut gems. It bears the burnish of \
 	time, where once sharply defined features have been worn down by so many hands. An old rumor ties this implement \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The lord rapier previously had 2 more damage than the average rapier. Since swords have been buffed... it ended up being 2 damage weaker than a normal rapier.

Oops my bad.
Making it identical to normal rapiers at the very least.
## Why It's Good For The Game

The fancy gem-encrusted one-of-a-kind rapier probably shouldn't be the weakest rapier in the game.
