### PR TITLE
Bear PR Improvement Blast!!

### DIFF
--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -27,6 +27,9 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods)
+"ap" = (
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cavewet/bogcaves)
 "as" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobblerock,
@@ -40,7 +43,7 @@
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "aw" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/machinery/light/rogue/torchholder/r,
@@ -57,7 +60,16 @@
 /obj/structure/spacevine,
 /obj/structure/spacevine,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"az" = (
+/obj/machinery/light/small{
+	mouse_opacity = 0;
+	dir = 1;
+	color = "#b51d12";
+	light_color = "#b51d12"
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "aA" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
@@ -77,13 +89,13 @@
 	pixel_y = 9
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "aH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "aI" = (
 /obj/structure/spacevine,
 /turf/open/water/swamp,
@@ -116,6 +128,9 @@
 	dir = 1
 	},
 /area/rogue/outdoors/woods)
+"ba" = (
+/turf/closed/mineral/random/rogue,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "bb" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt,
@@ -132,10 +147,20 @@
 /obj/structure/fluff/walldeco/innsign,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
+"bo" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "bp" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"bq" = (
+/obj/machinery/door/airlock/grunge{
+	color = "#755f48"
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "br" = (
 /obj/item/natural/stone{
 	pixel_y = -14
@@ -195,13 +220,13 @@
 	max_integrity = 500
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "bI" = (
 /obj/machinery/door/airlock/grunge{
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "bJ" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -218,7 +243,7 @@
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
 	},
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "bR" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -253,7 +278,7 @@
 	pixel_y = -8
 	},
 /turf/open/lava/acid,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "cg" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood,
@@ -281,7 +306,7 @@
 	pixel_x = 8
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "co" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/grass,
@@ -323,7 +348,7 @@
 	},
 /obj/structure/glowshroom,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "cy" = (
 /obj/structure/chair/stool/rogue,
 /mob/living/carbon/human/species/goblin/npc/ambush/cave,
@@ -347,14 +372,14 @@
 	max_integrity = 20000
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "cD" = (
 /obj/item/wallframe/firealarm{
 	color = "#755f48";
 	pixel_x = -30
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "cN" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -400,14 +425,17 @@
 "dc" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
+"de" = (
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "di" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves)
 "dl" = (
-/turf/closed/mineral/random/rogue/med,
-/area/rogue/under/town/sewer)
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "dm" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/blocks,
@@ -418,7 +446,7 @@
 	},
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "dr" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
@@ -444,7 +472,7 @@
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
 	},
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "dE" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/river{
@@ -468,14 +496,14 @@
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "dP" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
 "dT" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "dV" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -513,7 +541,7 @@
 /area/rogue/under/cavewet/bogcaves)
 "ep" = (
 /turf/open/floor/rogue/metal,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "er" = (
 /obj/structure/fermenting_barrel/random/water,
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -537,7 +565,7 @@
 "eC" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "eD" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/dirt/road,
@@ -578,7 +606,7 @@
 "eW" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fa" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -611,7 +639,7 @@
 	light_color = "#b51d12"
 	},
 /turf/open/floor/rogue/metal,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fo" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
@@ -625,7 +653,7 @@
 /area/rogue/under/town/basement)
 "fr" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fs" = (
 /obj/item/natural/stone{
 	pixel_y = -9;
@@ -644,13 +672,13 @@
 "fu" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fv" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs)
 "fw" = (
 /turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fx" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -668,7 +696,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fD" = (
 /obj/structure/fluff/railing/border{
 	dir = 1;
@@ -715,14 +743,14 @@
 	color = "#755f48"
 	},
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fW" = (
 /obj/item/natural/stone{
 	pixel_y = -14
 	},
 /obj/item/rogueweapon/hammer/claw,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "fX" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4;
@@ -750,14 +778,14 @@
 	},
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "gb" = (
 /obj/machinery/conveyor/auto{
 	color = "#755f48"
 	},
 /obj/item/natural/stone,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "gc" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/shelter/woods)
@@ -793,7 +821,7 @@
 "gs" = (
 /obj/structure/bars/steel,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "gu" = (
 /obj/structure/stairs/stone{
 	dir = 1;
@@ -835,7 +863,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "gG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -857,7 +885,7 @@
 	dir = 8
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "gT" = (
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
@@ -872,7 +900,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hg" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/blocks,
@@ -886,7 +914,7 @@
 "hk" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hl" = (
 /obj/machinery/light/rogue/smelter/great{
 	name = "ancyent engine";
@@ -894,7 +922,7 @@
 	desc = ""
 	},
 /turf/open/floor/rogue/metal/barograte/open,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "hp" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -917,7 +945,7 @@
 "hu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "hw" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -934,7 +962,7 @@
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "hB" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter/mountains)
@@ -1055,7 +1083,11 @@
 /area/rogue/outdoors/mountains)
 "jj" = (
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"jk" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jm" = (
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1081,7 +1113,7 @@
 /obj/structure/closet/dirthole/closed/loot,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "jy" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
@@ -1092,7 +1124,7 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "jD" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood{
@@ -1138,7 +1170,7 @@
 	dir = 4
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "jT" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/dirt/road,
@@ -1159,7 +1191,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ke" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -1231,7 +1263,7 @@
 "ku" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "kv" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/item/clothing/cloak/raincloak/furcloak/woad,
@@ -1246,7 +1278,14 @@
 /area/rogue/indoors)
 "kz" = (
 /turf/open/water/cleanshallow,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
+"kC" = (
+/obj/machinery/light/small{
+	mouse_opacity = 0;
+	dir = 8
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "kF" = (
 /obj/structure/bars/pipe,
 /obj/machinery/light/small{
@@ -1256,7 +1295,7 @@
 	light_color = "#b51d12"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "kH" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -1290,7 +1329,7 @@
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
 	},
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "kT" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
@@ -1310,7 +1349,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "le" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -1320,7 +1359,7 @@
 "lf" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lg" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
@@ -1335,7 +1374,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "lm" = (
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/woods)
@@ -1362,8 +1401,11 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/basement)
 "lw" = (
-/turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/under/town/sewer)
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_line";
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon1/gethsmane)
 "lz" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -1371,11 +1413,14 @@
 	dir = 4
 	},
 /area/rogue/outdoors/woods)
+"lA" = (
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "lB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "lD" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/naturalstone,
@@ -1395,7 +1440,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lM" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
 /turf/open/floor/rogue/dirt/road,
@@ -1414,7 +1459,7 @@
 "lP" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "lS" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -1422,6 +1467,9 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
+"lU" = (
+/turf/open/water/swamp,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "lV" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "golgothaone"
@@ -1430,12 +1478,12 @@
 	redstone_id = "golgothaone"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lW" = (
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
 	},
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lY" = (
 /obj/machinery/conveyor/auto{
 	dir = 8;
@@ -1443,18 +1491,18 @@
 	},
 /obj/item/natural/stone,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lZ" = (
 /obj/structure/bars,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "mb" = (
 /obj/structure/bars/pipe{
 	dir = 8;
 	pixel_x = 8
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "mc" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -1556,17 +1604,17 @@
 	name = "\improper ancient signage"
 	},
 /turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "mQ" = (
 /obj/item/natural/cloth,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "mW" = (
 /obj/structure/spacevine,
 /obj/structure/flora/roguegrass/maneater/real,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "na" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/dirt,
@@ -1682,7 +1730,7 @@
 /obj/structure/bars/pipe,
 /obj/effect/turf_decal/trimline/yellow/filled,
 /turf/open/floor/rogue/metal,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "ot" = (
 /mob/living/carbon/human/species/skeleton/npc/ambush,
 /obj/structure/fluff/walldeco/church/line{
@@ -1704,7 +1752,7 @@
 	pixel_x = 25
 	},
 /turf/open/lava/acid,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ox" = (
 /obj/item/rope/chain,
 /obj/item/rope/chain,
@@ -1744,7 +1792,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "oO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/water/sewer,
@@ -1770,7 +1818,7 @@
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/metal,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "pj" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -1855,6 +1903,12 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
+"pV" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_corner";
+	dir = 1
+	},
+/area/rogue/under/cave/dungeon1/gethsmane)
 "pX" = (
 /obj/item/natural/stone{
 	pixel_y = -9;
@@ -1862,6 +1916,9 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"pY" = (
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "qa" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -1924,14 +1981,14 @@
 	light_color = "#b51d12"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "qB" = (
 /obj/structure/table/wood{
 	dir = 10;
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "qF" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -1985,13 +2042,17 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors)
+"qX" = (
+/obj/structure/glowshroom,
+/turf/open/water/sewer,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "qZ" = (
 /obj/machinery/conveyor/auto{
 	dir = 1;
 	color = "#755f48"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ra" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/basement)
@@ -2050,7 +2111,7 @@
 	light_color = "#b51d12"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "rv" = (
 /turf/closed/wall/mineral/rogue/decowood,
 /area/rogue/outdoors/beach/forest)
@@ -2116,7 +2177,7 @@
 	pixel_x = -11
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "rT" = (
 /obj/structure/table/wood,
 /obj/item/book/rogue/law{
@@ -2136,7 +2197,7 @@
 	color = "#675340"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "sa" = (
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/ruinedwood{
@@ -2156,7 +2217,7 @@
 	pixel_x = -11
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "si" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 1
@@ -2179,24 +2240,24 @@
 	},
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "sq" = (
 /obj/machinery/light/small{
 	mouse_opacity = 0;
 	dir = 8
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "ss" = (
 /obj/structure/bars,
 /turf/open/water/swamp,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "st" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "sw" = (
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "sy" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -2276,7 +2337,7 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "ti" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/naturalstone,
@@ -2296,10 +2357,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/woods)
 "to" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
-/turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "tu" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -2313,7 +2372,14 @@
 	},
 /obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
+"tL" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1";
+	dir = 1
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "tM" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -2322,7 +2388,7 @@
 /area/rogue/under/town/basement)
 "tN" = (
 /turf/open/lava/acid,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "tP" = (
 /obj/machinery/light/rogue/torchholder/c{
 	pixel_y = -32
@@ -2342,7 +2408,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "tT" = (
 /obj/structure/bed/rogue/inn/hay,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
@@ -2351,7 +2417,7 @@
 "tU" = (
 /obj/structure/spacevine,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "tW" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/tools,
@@ -2374,6 +2440,10 @@
 	},
 /turf/open/water/pond,
 /area/rogue/outdoors/woods)
+"ue" = (
+/obj/item/natural/stone,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "uf" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/grass,
@@ -2388,7 +2458,7 @@
 /area/rogue/under/town/basement)
 "um" = (
 /turf/open/water/swamp,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "uo" = (
 /obj/item/natural/stone{
 	pixel_y = 16;
@@ -2406,18 +2476,22 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter/woods)
+"uq" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "ur" = (
 /obj/structure/bars/pipe{
 	dir = 1;
 	pixel_x = 25
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ut" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "uu" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/churchrough,
@@ -2528,14 +2602,14 @@
 	},
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "vk" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest)
 "vl" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "vm" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
@@ -2560,7 +2634,7 @@
 	max_integrity = 20000
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "vt" = (
 /obj/machinery/light/rogue/oven/east,
 /turf/open/floor/rogue/cobble,
@@ -2613,14 +2687,14 @@
 "vX" = (
 /obj/structure/spacevine,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "vZ" = (
 /obj/machinery/conveyor/auto{
 	dir = 8;
 	color = "#755f48"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "wa" = (
 /obj/machinery/conveyor/auto{
 	dir = 1;
@@ -2628,7 +2702,7 @@
 	},
 /obj/structure/bars,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "we" = (
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves)
@@ -2673,7 +2747,7 @@
 	},
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "wD" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt/road,
@@ -2745,7 +2819,7 @@
 "xv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "xx" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -2803,14 +2877,14 @@
 	pixel_y = 9
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "ya" = (
 /obj/machinery/conveyor/auto{
 	color = "#755f48"
 	},
 /obj/structure/spacevine,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "yb" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -2822,12 +2896,17 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors)
+"yi" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_line"
+	},
+/area/rogue/under/cavewet/bogcaves)
 "yj" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "golgothaone"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ym" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -2864,7 +2943,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "yK" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2886,16 +2965,16 @@
 "yR" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/metal,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "yV" = (
 /obj/machinery/conveyor/auto{
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "yY" = (
 /turf/closed/mineral/rogue,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "za" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/blocks,
@@ -3003,7 +3082,13 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
+"zZ" = (
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon1/gethsmane)
+"Aa" = (
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cavewet/bogcaves)
 "Ac" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/bodypart/head/goblin,
@@ -3022,7 +3107,7 @@
 /area/rogue/outdoors/beach/forest)
 "Ai" = (
 /turf/closed/mineral/rogue/bedrock,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Aj" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1
@@ -3036,7 +3121,7 @@
 "Al" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ar" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
 /obj/structure/closet/crate/chest/wicker,
@@ -3047,7 +3132,7 @@
 "As" = (
 /obj/machinery/light/small{
 	mouse_opacity = 0;
-	dir = 4;
+	dir = 8;
 	color = "#b51d12";
 	light_color = "#b51d12"
 	},
@@ -3064,6 +3149,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woods)
+"Az" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_joint";
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon1/gethsmane)
 "AC" = (
 /obj/structure/rack/rogue{
 	density = 0;
@@ -3078,7 +3169,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "AE" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1;
@@ -3124,13 +3215,13 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "AS" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
 	},
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "AV" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/transparent/openspace,
@@ -3230,6 +3321,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement)
+"BG" = (
+/turf/open/lava/acid,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "BI" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -3295,7 +3389,7 @@
 /obj/structure/spacevine,
 /obj/structure/bars/pipe,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Cg" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/naturalstone,
@@ -3364,6 +3458,10 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"CI" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "CL" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/hexstone,
@@ -3384,7 +3482,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "CQ" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -3443,7 +3541,7 @@
 	dir = 8
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "DG" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -3462,6 +3560,14 @@
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
+"DP" = (
+/obj/structure/bars/pipe,
+/turf/open/water/sewer,
+/area/rogue/under/cave/dungeon1/gethsmane)
+"DR" = (
+/obj/structure/spacevine,
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "DU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -3469,14 +3575,14 @@
 	},
 /obj/structure/spacevine,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "DX" = (
 /obj/structure/lever/wall{
 	pixel_x = 17;
 	redstone_id = "golgothaone"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "DY" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/head/roguetown/helmet,
@@ -3521,7 +3627,7 @@
 	},
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Eo" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
@@ -3608,7 +3714,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Fi" = (
 /obj/structure/spacevine,
 /turf/open/water/swamp/deep,
@@ -3671,7 +3777,7 @@
 "Fz" = (
 /obj/structure/bars/steel,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "FE" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -3702,7 +3808,7 @@
 "FQ" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "FS" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
@@ -3714,7 +3820,7 @@
 "FZ" = (
 /obj/structure/spacevine,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ge" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -3733,7 +3839,7 @@
 	},
 /obj/structure/bars,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Gp" = (
 /turf/open/water/swamp,
 /area/rogue/under/town/basement)
@@ -3757,7 +3863,7 @@
 	dir = 4
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Gz" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt,
@@ -3769,7 +3875,7 @@
 "GF" = (
 /obj/item/rogueweapon/hammer,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "GH" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
@@ -3809,7 +3915,7 @@
 "GZ" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Hb" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = -16
@@ -3822,6 +3928,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
+"He" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_corner";
+	dir = 8
+	},
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Hf" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
@@ -3862,7 +3974,7 @@
 "Hs" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ht" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /mob/living/carbon/human/species/skeleton/npc/ambush,
@@ -3874,7 +3986,7 @@
 	pixel_x = 8
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Hw" = (
 /obj/structure/bars,
 /turf/open/water/swamp/deep,
@@ -3955,7 +4067,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "HY" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -3972,7 +4084,7 @@
 "Ii" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Io" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
@@ -3997,7 +4109,7 @@
 	},
 /obj/item/natural/bone,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Iu" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet/bogcaves)
@@ -4016,7 +4128,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "IH" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -4048,7 +4160,7 @@
 /turf/open/floor/rogue/metal{
 	icon_state = "plating2"
 	},
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "IP" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -4063,6 +4175,9 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"IW" = (
+/turf/open/water/swamp/deep,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "IX" = (
 /mob/living/carbon/human/species/goblin/npc/ambush,
 /turf/open/floor/rogue/twig,
@@ -4078,7 +4193,7 @@
 "Ja" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Jd" = (
 /obj/structure/closet/dirthole,
 /turf/open/floor/rogue/dirt/road,
@@ -4089,7 +4204,7 @@
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Jg" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -4170,7 +4285,7 @@
 /obj/structure/bars/pipe,
 /obj/effect/turf_decal/trimline/yellow/filled,
 /turf/open/floor/rogue/metal,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "JM" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/beach/forest)
@@ -4182,6 +4297,12 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"JQ" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_corner";
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon1/gethsmane)
 "JS" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -4238,7 +4359,7 @@
 	},
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Kv" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/shelter/woods)
@@ -4248,10 +4369,17 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/beach/forest)
+"Kz" = (
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	color = "#755f48"
+	},
+/turf/open/water/sewer,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "KB" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "KD" = (
 /obj/effect/decal/mossy{
 	dir = 4
@@ -4270,7 +4398,7 @@
 "KL" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "KM" = (
 /obj/item/chair/stool/bar/rogue/crafted,
 /turf/open/floor/rogue/ruinedwood,
@@ -4278,7 +4406,7 @@
 "KO" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "KP" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
@@ -4297,7 +4425,7 @@
 	},
 /obj/structure/bars,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "La" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/naturalstone,
@@ -4310,6 +4438,10 @@
 	dir = 4
 	},
 /area/rogue/indoors/shelter/woods)
+"Le" = (
+/obj/structure/bars/steel,
+/turf/open/water/sewer,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Lf" = (
 /obj/item/chair/stool/bar/rogue/crafted,
 /turf/open/floor/rogue/grass,
@@ -4357,14 +4489,14 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "LH" = (
 /obj/machinery/conveyor/auto{
 	dir = 4;
 	color = "#755f48"
 	},
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "LI" = (
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
@@ -4406,7 +4538,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "LW" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/ruinedwood,
@@ -4421,7 +4553,7 @@
 "LY" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ma" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -4445,15 +4577,15 @@
 "Md" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Mf" = (
 /obj/structure/flora/roguegrass/water,
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Mg" = (
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Ml" = (
 /obj/structure/lever/wall{
 	redstone_id = "puzzle3"
@@ -4531,7 +4663,7 @@
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "MT" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -4580,7 +4712,7 @@
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Nu" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/naturalstone,
@@ -4631,7 +4763,7 @@
 "NK" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "NL" = (
 /obj/structure/bars/steel,
 /turf/open/water/swamp/deep,
@@ -4662,7 +4794,7 @@
 "NX" = (
 /obj/structure/bars/pipe,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Oa" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town/roofs)
@@ -4713,13 +4845,17 @@
 "OV" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "OX" = (
 /obj/structure/fluff/signage{
 	name = "AZURE PEAK - EAST"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
+"OY" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "OZ" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 8
@@ -4732,7 +4868,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Pf" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
@@ -4742,7 +4878,7 @@
 	},
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Pi" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -4781,11 +4917,10 @@
 	max_integrity = 20000
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Pz" = (
-/obj/structure/spacevine,
-/turf/closed/wall/mineral/rogue/stone/moss,
-/area/rogue/under/cavewet/bogcaves)
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "PA" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -4813,7 +4948,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "PS" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/hexstone,
@@ -4828,6 +4963,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement)
+"PX" = (
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Qf" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt/road,
@@ -4854,6 +4992,9 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/basement)
+"Qp" = (
+/turf/open/water/sewer,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Qr" = (
 /obj/structure/mineral_door/wood/donjon{
 	pixel_x = 0;
@@ -4889,7 +5030,7 @@
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Qy" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/hexstone,
@@ -4909,7 +5050,7 @@
 "QJ" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "QO" = (
 /obj/effect/landmark/start/bogguardlate,
 /turf/open/floor/rogue/dirt,
@@ -4923,7 +5064,7 @@
 "QS" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "QW" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1;
@@ -4936,21 +5077,21 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "QY" = (
 /obj/structure/spacevine,
 /obj/structure/bars/pipe{
 	dir = 4
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ra" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
 	dir = 1
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Rf" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/grass,
@@ -4967,7 +5108,7 @@
 /area/rogue/indoors)
 "Rt" = (
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ru" = (
 /turf/open/transparent/openspace,
 /area/rogue/under/cave)
@@ -5033,11 +5174,11 @@
 	color = "#755f48"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "RQ" = (
 /obj/structure/bars/pipe/left,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "RR" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/indoors/shelter/woods)
@@ -5056,7 +5197,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "RX" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -5081,6 +5222,14 @@
 "Se" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains)
+"Sg" = (
+/obj/machinery/door/airlock/grunge{
+	color = "#755f48"
+	},
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Sh" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -5103,7 +5252,7 @@
 "Sr" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ss" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -5127,7 +5276,7 @@
 "SF" = (
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "SG" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
@@ -5136,7 +5285,7 @@
 "SI" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "SK" = (
 /obj/structure/fluff/walldeco/innsign{
 	pixel_x = -32
@@ -5147,6 +5296,13 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp,
 /area/rogue/outdoors/woods)
+"SV" = (
+/obj/item/natural/stone{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "SX" = (
 /obj/structure/stairs/stone{
 	dir = 1;
@@ -5165,7 +5321,7 @@
 	},
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/metal,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Tf" = (
 /mob/living/carbon/human/species/goblin/npc/ambush/cave,
 /turf/open/floor/rogue/naturalstone,
@@ -5206,7 +5362,7 @@
 	},
 /obj/structure/spacevine,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Tt" = (
 /obj/structure/flora/roguegrass,
 /obj/machinery/light/small{
@@ -5216,14 +5372,14 @@
 	light_color = "#b51d12"
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Tu" = (
 /obj/machinery/conveyor/auto{
 	dir = 4;
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/metal,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Tv" = (
 /obj/structure/fluff/railing/border{
 	dir = 6;
@@ -5270,7 +5426,7 @@
 "TI" = (
 /obj/structure/glowshroom,
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "TL" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -5300,11 +5456,11 @@
 	light_color = "#b51d12"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Ub" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Ug" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
@@ -5343,7 +5499,11 @@
 "UE" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/metal/barograte,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
+"UF" = (
+/obj/structure/spacevine,
+/turf/open/water/sewer,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "UG" = (
 /obj/item/natural/stone{
 	pixel_x = -5;
@@ -5384,7 +5544,7 @@
 "UR" = (
 /obj/structure/spacevine,
 /turf/open/water/swamp,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "UT" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -5408,7 +5568,7 @@
 	dir = 6
 	},
 /turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Vh" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods)
@@ -5455,7 +5615,7 @@
 	},
 /obj/item/bath/soap,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Vx" = (
 /turf/open/water/river{
 	icon_state = "rockwd";
@@ -5472,7 +5632,7 @@
 	color = "#755f48"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "VA" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/natural/feather,
@@ -5485,10 +5645,10 @@
 	},
 /obj/item/natural/rock,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "VF" = (
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "VG" = (
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/structure/rack/rogue,
@@ -5525,7 +5685,7 @@
 	},
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "VZ" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
@@ -5575,6 +5735,11 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves)
+"Wx" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_corner"
+	},
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Wz" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/goat,
 /turf/open/floor/rogue/grass,
@@ -5591,6 +5756,10 @@
 /obj/item/flashlight/flare/torch/metal,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
+"WJ" = (
+/obj/structure/spacevine,
+/turf/open/water/swamp/deep,
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "WL" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood,
@@ -5599,7 +5768,7 @@
 "WN" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "WT" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -5611,7 +5780,10 @@
 /area/rogue/under/town/basement)
 "WU" = (
 /turf/open/floor/rogue/dirt/road,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
+"WV" = (
+/turf/closed/wall/mineral/rogue/stone/moss,
+/area/rogue/under/cave/dungeon1/gethsmane)
 "WX" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5650,7 +5822,7 @@
 	color = "#755f48"
 	},
 /turf/open/water/swamp/deep,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Xq" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/indoors/shelter/woods)
@@ -5748,11 +5920,11 @@
 /obj/item/natural/rock,
 /obj/item/natural/rock,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Yk" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "Yo" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4;
@@ -5763,7 +5935,7 @@
 "Yp" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "Yr" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 8
@@ -5792,7 +5964,7 @@
 	max_integrity = 20000
 	},
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "YG" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -5802,6 +5974,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/woods)
+"YH" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_line"
+	},
+/area/rogue/under/cave/dungeon1/gethsmane)
 "YQ" = (
 /obj/structure/boatbell/fluff,
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -5812,7 +5989,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane/inner)
 "YT" = (
 /obj/item/rogueweapon/huntingknife/chefknife,
 /obj/structure/table/wood/bar{
@@ -5900,7 +6077,7 @@
 /obj/item/flint,
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/area/rogue/under/cave/dungeon1/gethsmane)
 "ZK" = (
 /obj/structure/ladder,
 /obj/machinery/light/rogue/torchholder/l,
@@ -5932,6 +6109,12 @@
 /obj/item/flashlight/flare/torch/metal,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"ZW" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_joint";
+	dir = 4
+	},
+/area/rogue/under/cave/dungeon1/gethsmane)
 "ZY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1
@@ -15254,7 +15437,7 @@ VO
 VO
 VO
 VO
-lw
+Pz
 Mg
 ZH
 Mg
@@ -15411,7 +15594,7 @@ vp
 vp
 VO
 lw
-lw
+Pz
 Mg
 Mg
 Mg
@@ -15421,7 +15604,7 @@ Mg
 Mg
 GZ
 Mg
-VO
+to
 VO
 Iu
 Iu
@@ -15564,7 +15747,7 @@ we
 we
 VO
 vp
-VF
+IW
 vp
 VO
 lw
@@ -15575,10 +15758,10 @@ Mg
 Mg
 Mg
 Mg
-Rt
+dl
 Mg
 Mg
-VO
+to
 VO
 VO
 Iu
@@ -15720,12 +15903,12 @@ we
 we
 VO
 VO
-fr
-VF
-fr
+WV
+IW
+WV
 we
 lw
-Rt
+dl
 Mg
 Mg
 Mg
@@ -15734,8 +15917,8 @@ GZ
 Mg
 Mg
 Mg
-lw
-Hr
+Pz
+Pz
 VO
 VO
 Iu
@@ -15877,21 +16060,21 @@ we
 VO
 VO
 vp
-fr
-VF
-VF
-VF
-lw
-lw
+WV
+IW
+IW
+IW
+He
+YH
 bL
-lw
-lw
-lw
-lw
-lw
-lw
+YH
+pV
+YH
+YH
+YH
+Wx
 Mg
-lw
+Pz
 Mg
 VO
 VO
@@ -16035,16 +16218,16 @@ ad
 vp
 vp
 tU
-um
-um
-VF
-VF
-jj
-jj
-jj
+lU
+lU
+IW
+IW
+Qp
+Qp
+Qp
 lw
 Vw
-Rt
+dl
 mQ
 lw
 Mg
@@ -16194,16 +16377,16 @@ As
 lP
 sw
 UR
-Rt
-Rt
-Rt
-jj
-TI
-lw
-lw
+dl
+dl
+dl
+Qp
+qX
+Az
+YH
 bL
-lw
-lw
+YH
+JQ
 Mg
 Mg
 Mg
@@ -16351,21 +16534,21 @@ sw
 WU
 sw
 sw
-Rt
-lw
-Rt
+dl
+Pz
+dl
 ep
-jj
+Qp
 lw
-Rt
-Rt
+dl
+dl
 Mg
 Mg
 Mg
 GZ
 Mg
 Mg
-lw
+Pz
 hq
 en
 Hw
@@ -16506,22 +16689,22 @@ gT
 we
 gs
 sw
-FZ
-jj
-jj
+UF
+Qp
+Qp
 lw
-Rt
+dl
 ep
-jj
+Qp
 lw
-hk
-Rt
+uq
+dl
 jA
 qB
 Mg
 Mg
-um
-um
+lU
+lU
 ss
 we
 we
@@ -16662,23 +16845,23 @@ ad
 ad
 aM
 NL
-FZ
-jj
-jj
-jj
-lw
-lw
+UF
+Qp
+Qp
+Qp
+Az
+Wx
 bL
-lw
-lw
-Rt
-Rt
+YH
+ZW
+dl
+dl
 th
 zY
 Mg
 Mg
 Mg
-um
+lU
 lZ
 we
 we
@@ -16820,22 +17003,22 @@ ad
 VO
 VO
 VO
-Fz
-Fz
-Fz
-lw
-lw
-Rt
+Le
+Le
+Le
+He
+ZW
+dl
 sq
 lw
-Rt
-Rt
+dl
+dl
 ty
 AN
 Mg
 xv
 Mg
-um
+lU
 Hr
 VO
 VO
@@ -16982,11 +17165,11 @@ mb
 mb
 Hu
 lw
-Rt
-hk
+dl
+uq
 lw
-Rt
-Rt
+dl
+dl
 Mg
 Mg
 Mg
@@ -17134,16 +17317,16 @@ VO
 VO
 VO
 VO
-Rt
-jj
-jj
-NX
+dl
+Qp
+Qp
+DP
 lw
-Rt
-Rt
+dl
+dl
 bL
-Rt
-Rt
+dl
+dl
 Mg
 Mg
 Mg
@@ -17291,16 +17474,16 @@ cp
 cp
 VO
 VO
-Rt
+dl
 Mg
-jj
-NX
+Qp
+DP
 os
-jj
-Rt
+Qp
+dl
 lw
-Rt
-hk
+dl
+uq
 Mg
 Mg
 Mg
@@ -17453,16 +17636,16 @@ NK
 Mg
 cl
 JL
-jj
-jj
+Qp
+Qp
 lw
-Rt
-Rt
+dl
+dl
 Mg
 Mg
 Mg
 Mg
-Ai
+to
 VO
 VO
 cp
@@ -17610,17 +17793,17 @@ tN
 tN
 Yk
 lw
-hk
-jj
+uq
+Qp
 lw
-Rt
-Rt
+dl
+dl
 Mg
 Mg
 GZ
 Mg
-Rt
-Rt
+dl
+dl
 VO
 cp
 cp
@@ -17767,17 +17950,17 @@ cd
 Mg
 Ja
 lw
-Rt
-jj
-lw
-lw
-lw
-lw
-lw
-lw
-lw
+dl
+Qp
+Az
+YH
+YH
+YH
+Pz
+YH
+YH
 bI
-Hr
+yi
 VO
 cp
 cp
@@ -17919,22 +18102,22 @@ cp
 cp
 VO
 VO
-eC
+bo
 tN
 tN
-Rt
+dl
 lw
-Rt
-Rt
+dl
+dl
 lw
-Rt
+dl
 hu
 dc
 lw
 Mg
-Rt
-Rt
-Rt
+dl
+dl
+dl
 VO
 cp
 cp
@@ -18076,22 +18259,22 @@ cp
 cp
 cp
 VO
-VO
-VO
-VO
-VO
+to
+to
+to
+to
 lw
-Rt
-Rt
+dl
+dl
 bL
-hk
+dl
 lj
 hl
 lw
-Rt
+dl
 rY
 Ra
-Rt
+dl
 VO
 cp
 cp
@@ -18238,16 +18421,16 @@ VO
 VO
 VO
 lw
-Rt
-Rt
+dl
+dl
 lw
-Rt
-to
+dl
+hu
 NK
 NK
-VO
-Rt
-Rt
+Mg
+dl
+dl
 VO
 VO
 cp
@@ -18380,25 +18563,25 @@ Iu
 VO
 VO
 VO
-Mg
+pY
 VO
 VO
 VO
 VO
 VO
 VO
-VO
-VO
-VO
-VO
-VO
-VO
-VO
+to
+to
+to
+to
+to
+to
+to
 lw
-Rt
-Rt
+dl
+dl
 lw
-Rt
+dl
 hu
 UE
 lw
@@ -18535,30 +18718,30 @@ cp
 VO
 VO
 VO
-Mg
-Mg
-Mg
-GZ
-Mg
+pY
+pY
+pY
+CI
+pY
 fr
 VO
 VO
 VO
-fr
-fr
-fr
-VO
-fr
-fr
-fr
+WV
+WV
+WV
+to
+WV
+WV
+WV
 lw
-Rt
-Rt
-lw
-lw
-lw
-lw
-lw
+dl
+dl
+Az
+YH
+YH
+YH
+Pz
 VO
 VO
 VO
@@ -18691,30 +18874,30 @@ cp
 cp
 VO
 VO
-Mg
+pY
 Hs
 eC
-GZ
-Mg
+CI
+pY
 fr
 fr
 VO
 VO
 VO
-fr
-yI
-fr
-fr
-fr
+WV
+Kz
+WV
+WV
+WV
 vl
 Mg
 lw
-Ua
-Rt
+az
+dl
 lw
 ku
 hu
-fw
+lA
 lw
 VO
 VO
@@ -18849,7 +19032,7 @@ VO
 VO
 um
 VF
-Mg
+pY
 VF
 VF
 VF
@@ -18858,18 +19041,18 @@ VO
 VO
 VO
 VO
-fr
-yI
-fr
+WV
+Kz
+WV
 vl
 Yj
 GZ
 xZ
 bI
-Rt
-Rt
+dl
+dl
 bL
-Rt
+dl
 hu
 hl
 lw
@@ -19002,31 +19185,31 @@ Iu
 cp
 cp
 cp
-VO
+Ai
 um
 VF
 VF
 um
 um
 um
-Mg
+pY
 fr
 VO
 VO
 VO
 VO
-fr
-yI
-fr
+WV
+Kz
+WV
 tS
 aF
 vl
 Mg
 lw
-Rt
-Rt
+dl
+dl
 lw
-Rt
+dl
 hu
 hl
 lw
@@ -19159,7 +19342,7 @@ cp
 cp
 cp
 VO
-VO
+Ai
 fu
 VF
 VF
@@ -19177,15 +19360,15 @@ cC
 fr
 fr
 fr
-vl
-fr
+ue
+WV
 lw
-eW
-Rt
+OY
+dl
 lw
-hk
+uq
 lB
-fw
+lA
 lw
 VO
 VO
@@ -19316,7 +19499,7 @@ cp
 cp
 VO
 VO
-VO
+Ai
 um
 VF
 VF
@@ -19335,15 +19518,15 @@ qZ
 qZ
 fr
 fr
-fr
-lw
+WV
+Pz
 dC
 dC
-lw
-lw
-lw
-lw
-lw
+Pz
+Pz
+Pz
+Pz
+Pz
 VO
 VO
 cp
@@ -19492,11 +19675,11 @@ qZ
 ga
 Ai
 fr
-lw
-lw
+de
+de
 au
 Rt
-sq
+kC
 cD
 HU
 hk
@@ -19621,15 +19804,15 @@ Iu
 Iu
 cp
 cp
-VO
-VO
-vp
-vp
-vp
-vp
-vp
-VO
-VO
+Ai
+Ai
+fr
+fr
+fr
+fr
+fr
+Ai
+Ai
 um
 VF
 Al
@@ -19652,7 +19835,7 @@ fr
 LY
 mK
 AD
-xZ
+SV
 Rt
 Rt
 Rt
@@ -19775,14 +19958,14 @@ HT
 en
 Iu
 cp
-dl
-Ai
+cp
+VO
 Ai
 Ai
 fr
 fr
 Rt
-sq
+kC
 Sr
 Rt
 um
@@ -19932,8 +20115,8 @@ Iu
 cp
 cp
 cp
-Ai
-Ai
+VO
+VO
 Ai
 Ai
 fr
@@ -19971,7 +20154,7 @@ Rt
 Rt
 Rt
 hk
-Ra
+tL
 fr
 VO
 Iu
@@ -20089,8 +20272,8 @@ cp
 cp
 VO
 VO
-Ai
-Ai
+VO
+VO
 Ai
 Ai
 fr
@@ -20106,7 +20289,7 @@ VF
 VF
 um
 fr
-ku
+jk
 jj
 Fh
 Yp
@@ -20243,8 +20426,8 @@ en
 Iu
 cp
 cp
-VO
-VO
+Ai
+Ai
 fr
 fr
 fr
@@ -20258,10 +20441,10 @@ kz
 LG
 Rt
 Rt
-Mg
-Mg
-Mg
-Mg
+pY
+pY
+pY
+pY
 yY
 Rt
 Rt
@@ -20399,11 +20582,11 @@ Iu
 Iu
 Iu
 cp
-VO
-VO
-VO
+Ai
+Ai
+Ai
 fr
-Mg
+pY
 um
 um
 jj
@@ -20416,7 +20599,7 @@ Rt
 Rt
 Rt
 Rt
-Mg
+pY
 Rt
 yY
 yY
@@ -20556,7 +20739,7 @@ Iu
 Iu
 Iu
 VO
-VO
+Ai
 Ai
 VF
 um
@@ -20889,7 +21072,7 @@ kz
 kz
 LG
 Rt
-tN
+BG
 fr
 jj
 jj
@@ -21190,7 +21373,7 @@ fr
 fr
 jj
 jj
-Mg
+pY
 AD
 AD
 Rt
@@ -21347,7 +21530,7 @@ fr
 jj
 jj
 jj
-Mg
+pY
 kz
 kz
 Qx
@@ -21356,8 +21539,8 @@ kz
 kz
 LG
 Rt
-lw
-lw
+de
+de
 Rt
 Rt
 fr
@@ -21381,8 +21564,8 @@ jj
 fr
 fr
 fr
-Mg
-Mg
+pY
+pY
 VO
 VO
 HT
@@ -21504,7 +21687,7 @@ fr
 jj
 jj
 jj
-Mg
+pY
 kz
 kz
 LG
@@ -21514,7 +21697,7 @@ kz
 LG
 Ai
 Ai
-lw
+de
 fw
 fw
 fr
@@ -21535,11 +21718,11 @@ Fz
 jj
 jj
 FZ
-Pz
-VO
-VO
-VO
-VO
+Md
+Ai
+Ai
+Ai
+Ai
 VO
 HT
 HT
@@ -21671,10 +21854,10 @@ aH
 Rt
 Ai
 Ai
-lw
+de
 Nt
 fw
-lw
+de
 fr
 fr
 fr
@@ -21688,11 +21871,11 @@ fr
 jj
 jj
 jj
-Fz
+Le
 FQ
-Md
-vp
-vp
+DR
+WV
+WV
 VO
 VO
 VO
@@ -21828,7 +22011,7 @@ AD
 Rt
 Ai
 Ai
-lw
+de
 Nt
 fw
 fw
@@ -21845,9 +22028,9 @@ fr
 IO
 IO
 IO
-fr
-fr
-fr
+WV
+WV
+WV
 VO
 VO
 en
@@ -21985,20 +22168,20 @@ kz
 LG
 Ai
 Ai
-lw
+de
 MS
 yV
 yV
 Nt
 yR
-lw
-lw
-lw
-lw
-lw
-lw
-lw
-lw
+de
+de
+de
+de
+de
+de
+de
+de
 VF
 VF
 Rt
@@ -22142,10 +22325,10 @@ kz
 LG
 Ai
 Ai
-lw
-lw
-lw
-lw
+de
+de
+de
+de
 Nt
 lW
 kR
@@ -22155,11 +22338,11 @@ lW
 lW
 lW
 lW
-lw
+de
 Rt
 Rt
 Rt
-VO
+Ai
 VO
 VO
 en
@@ -22285,9 +22468,9 @@ VO
 um
 um
 um
-Mg
-Mg
-Mg
+pY
+pY
+pY
 fr
 Rt
 aH
@@ -22302,7 +22485,7 @@ Ai
 Ai
 Ai
 Ai
-lw
+de
 MS
 yV
 yV
@@ -22312,11 +22495,11 @@ yV
 yV
 yV
 fw
-bI
+bq
 Rt
 Rt
 Rt
-VO
+Ai
 VO
 VO
 en
@@ -22443,7 +22626,7 @@ um
 um
 um
 um
-Mg
+pY
 eC
 fr
 fr
@@ -22459,21 +22642,21 @@ Ai
 Ai
 Ai
 Ai
-lw
-lw
-lw
+de
+de
+de
 OV
 fw
-lw
-lw
-lw
-lw
-lw
-lw
+de
+de
+de
+de
+de
+de
 Rt
 Rt
-Mg
-Mg
+pY
+pY
 VO
 VO
 en
@@ -22601,7 +22784,7 @@ um
 um
 um
 um
-Mg
+pY
 Ai
 Ai
 Ai
@@ -22618,19 +22801,19 @@ Ai
 Ai
 Ai
 Ai
-lw
+de
 OV
 OV
-lw
-VO
-VO
+de
 Ai
 Ai
 Ai
-Mg
-Mg
-Mg
-VO
+Ai
+Ai
+pY
+pY
+pY
+Ai
 VO
 Iu
 en
@@ -22775,16 +22958,16 @@ Ai
 Ai
 Ai
 Ai
-lw
-lw
-lw
-lw
-VO
-VO
-Mg
-Mg
-Mg
-Mg
+de
+de
+de
+de
+Ai
+Ai
+pY
+pY
+pY
+pY
 VO
 VO
 VO
@@ -22920,8 +23103,8 @@ Ai
 fr
 fr
 fr
-bL
-bL
+Sg
+Sg
 fr
 fr
 fr
@@ -23557,16 +23740,16 @@ wa
 lc
 RW
 VF
-Mg
+pY
 VO
 VO
-Iu
-Iu
-cp
-cp
-cp
-cp
-cp
+VO
+VO
+VO
+VO
+VO
+VO
+VO
 Iu
 Iu
 Iu
@@ -23701,7 +23884,7 @@ LH
 fr
 fr
 fr
-Mg
+pY
 Cf
 vX
 vX
@@ -23713,19 +23896,19 @@ FZ
 Ai
 Ai
 lY
-Mg
-Mg
+pY
+pY
+ap
+ap
 VO
 VO
-Iu
-cp
-cp
+HT
+HT
 mh
 mh
-mh
-cp
-cp
-Iu
+VO
+VO
+VO
 Iu
 Iu
 Iu
@@ -23857,7 +24040,7 @@ Ai
 LH
 fr
 VF
-tU
+WJ
 dT
 Cf
 FZ
@@ -23870,20 +24053,20 @@ FZ
 Ai
 VF
 lI
-Mg
-Ai
+pY
+PX
+ap
+HT
+VO
+HT
+HT
+mh
+HT
+HT
+mh
+cp
 VO
 VO
-Iu
-cp
-cp
-mh
-mh
-mh
-mh
-cp
-cp
-Iu
 Iu
 Iu
 Iu
@@ -24014,7 +24197,7 @@ Ai
 LH
 fr
 VF
-tU
+WJ
 Ts
 YS
 PN
@@ -24024,23 +24207,23 @@ QY
 PN
 PN
 QY
-Ai
-VF
+Rt
+Rt
 VX
-Mg
-Ai
+Rt
+Rt
+ap
+HT
 VO
-Iu
-Iu
-cp
-cp
-mh
-mh
-mh
-mh
-mh
-cp
-cp
+HT
+HT
+ap
+ap
+HT
+HT
+ap
+ap
+VO
 Iu
 Iu
 Iu
@@ -24181,23 +24364,23 @@ FZ
 jj
 jj
 FZ
-Ai
-VF
-lI
-Mg
-Ai
+Rt
+Rt
+Vz
+Rt
+zZ
+Aa
 VO
-Iu
-Iu
-cp
-mh
-mh
-mh
-mh
-mh
-mh
-cp
-cp
+VO
+HT
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+VO
 cp
 Iu
 Iu
@@ -24344,17 +24527,17 @@ lI
 Ai
 Ai
 VO
-Iu
-cp
-cp
+VO
+VO
+VO
+VO
+VO
+VO
 mh
 mh
 mh
-mh
-mh
-mh
-mh
-cp
+VO
+VO
 cp
 Iu
 Iu
@@ -24484,7 +24667,7 @@ VO
 Ai
 LH
 fr
-Mg
+pY
 VF
 VF
 fr
@@ -24502,15 +24685,15 @@ Ai
 Ai
 Iu
 Iu
-cp
-cp
+Aa
+Aa
+Aa
 mh
 mh
-mh
-mh
-mh
-mh
-mh
+VO
+VO
+VO
+VO
 mh
 cp
 cp
@@ -24642,7 +24825,7 @@ Ai
 It
 fr
 VF
-Mg
+pY
 VF
 VF
 eW
@@ -24659,9 +24842,9 @@ Ai
 Ai
 Iu
 Iu
-cp
-mh
-mh
+Aa
+Aa
+Aa
 mh
 mh
 mh
@@ -24813,7 +24996,7 @@ Xk
 Xk
 wB
 Ai
-VO
+Ai
 Iu
 cp
 mh
@@ -25120,13 +25303,13 @@ Ai
 Ai
 Ai
 Ai
-VO
-VO
-VO
-VO
-VO
-VO
-Iu
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+ba
 Iu
 Iu
 mh

--- a/code/modules/antagonists/roguetown/villain/vampire.dm
+++ b/code/modules/antagonists/roguetown/villain/vampire.dm
@@ -209,13 +209,13 @@
 	if(VD.disguised)
 		to_chat(src, span_warning("My curse is hidden."))
 		return
-	if(VD.vitae < 500)
+	if(VD.vitae < 100)
 		to_chat(src, span_warning("Not enough vitae."))
 		return
 	if(has_status_effect(/datum/status_effect/buff/bloodstrength))
 		to_chat(src, span_warning("Already active."))
 		return
-	VD.handle_vitae(-500)
+	VD.handle_vitae(-100)
 	apply_status_effect(/datum/status_effect/buff/bloodstrength)
 	to_chat(src, span_greentext("! NIGHT MUSCLES !"))
 	src.playsound_local(get_turf(src), 'sound/misc/vampirespell.ogg', 100, FALSE, pressure_affected = FALSE)
@@ -241,13 +241,13 @@
 	if(VD.disguised)
 		to_chat(src, span_warning("My curse is hidden."))
 		return
-	if(VD.vitae < 500)
+	if(VD.vitae < 100)
 		to_chat(src, span_warning("Not enough vitae."))
 		return
 	if(has_status_effect(/datum/status_effect/buff/celerity))
 		to_chat(src, span_warning("Already active."))
 		return
-	VD.handle_vitae(-500)
+	VD.handle_vitae(-100)
 	rogstam_add(2000)
 	apply_status_effect(/datum/status_effect/buff/celerity)
 	to_chat(src, span_greentext("! QUICKENING !"))
@@ -277,13 +277,13 @@
 	if(VD.disguised)
 		to_chat(src, span_warning("My curse is hidden."))
 		return
-	if(VD.vitae < 200)
+	if(VD.vitae < 100)
 		to_chat(src, span_warning("Not enough vitae blood."))
 		return
 	if(has_status_effect(/datum/status_effect/buff/fortitude))
 		to_chat(src, span_warning("Already active."))
 		return
-	VD.vitae -= 200
+	VD.vitae -= 100
 	rogstam_add(2000)
 	apply_status_effect(/datum/status_effect/buff/fortitude)
 	to_chat(src, span_greentext("! ARMOR OF DARKNESS !"))
@@ -344,12 +344,12 @@
 	if(silver_curse_status)
 		to_chat(src, span_warning("My BANE is not letting me REGEN!."))
 		return
-	if(VD.vitae < 500)
+	if(VD.vitae < 200)
 		to_chat(src, span_warning("Not enough vitae."))
 		return
 	to_chat(src, span_greentext("! REGENERATE !"))
 	src.playsound_local(get_turf(src), 'sound/misc/vampirespell.ogg', 100, FALSE, pressure_affected = FALSE)
-	VD.handle_vitae(-500)
+	VD.handle_vitae(-200)
 	fully_heal()
 
 /mob/living/carbon/human/proc/vampire_infect()

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -25,8 +25,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	var/starved = FALSE
 	var/sired = FALSE
 	var/vamplevel = 0
-	var/vitae = 1000
-	var/vmax = 2000
+	var/vitae = 2000
+	var/vmax = 2500
 	var/obj/structure/vampire/bloodpool/mypool
 	var/last_transform
 	var/cache_skin
@@ -58,7 +58,6 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	C.vampires |= owner
 	. = ..()
 	owner.special_role = name
-	ADD_TRAIT(owner.current, TRAIT_CRITICAL_WEAKNESS, "[type]") //half assed but necessary otherwise these guys be invincible
 	ADD_TRAIT(owner.current, TRAIT_STRONGBITE, "[type]")
 	ADD_TRAIT(owner.current, TRAIT_NOHUNGER, "[type]")
 	ADD_TRAIT(owner.current, TRAIT_NOBREATH, "[type]")
@@ -68,6 +67,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	ADD_TRAIT(owner.current, TRAIT_NOSLEEP, "[type]")
 	ADD_TRAIT(owner.current, TRAIT_VAMPMANSION, "[type]")
 	ADD_TRAIT(owner.current, TRAIT_VAMP_DREAMS, "[type]")
+	ADD_TRAIT(owner.current, TRAIT_NOROGSTAM, "[type]")
 	owner.current.cmode_music = 'sound/music/combat_vamp.ogg'
 	var/obj/item/organ/eyes/eyes = owner.current.getorganslot(ORGAN_SLOT_EYES)
 	if(eyes)
@@ -157,11 +157,11 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	..()
 	H.mind.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 6, TRUE) //he has been alive for 2 thousand years, bro why
+	H.mind.adjust_skillrank(/datum/skill/combat/maces, 6, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 6, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 6, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 5, TRUE)
 	pants = /obj/item/clothing/under/roguetown/tights/black
@@ -1333,7 +1333,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 					var/holyskill = L.mind.get_skill_level(/datum/skill/magic/holy)
 					var/arcaneskill = L.mind.get_skill_level(/datum/skill/magic/arcane)
 					if(holyskill + arcaneskill >= 1)
-						to_chat(L, "I feel like the unholy magic came from [user]. I should use my magic or miracles on them.")
+						to_chat(L, "I feel like the unholy magic came from [user].")
 
 /obj/effect/proc_holder/spell/targeted/transfix/master
 	name = "Subjugate"

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -125,12 +125,12 @@
 	desc = ""
 	icon_state = null
 	body_parts_covered = FULL_BODY
-	armor = list("blunt" = 100, "slash" = 90, "stab" = 80, "bullet" = 70, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	armor = list("blunt" = 100, "slash" = 90, "stab" = 80, "bullet" = 70, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 0)
 	prevent_crits = list(BCLASS_CUT, BCLASS_CHOP, BCLASS_STAB, BCLASS_BLUNT, BCLASS_TWIST)
 	blocksound = SOFTHIT
 	blade_dulling = DULLING_BASHCHOP
 	sewrepair = FALSE
-	max_integrity = 250
+	max_integrity = 550
 	item_flags = DROPDEL
 
 /datum/intent/simple/werewolf

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
@@ -64,4 +64,3 @@
 		user.put_in_hands(r, TRUE, FALSE, TRUE)
 		//user.visible_message("Your claws extend.", "You feel your claws extending.", "You hear a sound of claws extending.")
 		extended = TRUE
-

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -118,7 +118,7 @@
 	W.mind.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
 	W.mind.adjust_skillrank(/datum/skill/misc/climbing, 6, TRUE)
 
-	W.STASTR = 17
+	W.STASTR = 20
 	W.STACON = 20
 	W.STAEND = 20
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
@@ -5,7 +5,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/bandit/brigand
 	category_tags = list(CTAG_BANDIT)
-	cmode_music = 'sound/music/combat_bandit_brigand.ogg'	
+	cmode_music = 'sound/music/combat_bandit_brigand.ogg'
 
 /datum/outfit/job/roguetown/bandit/brigand/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -38,10 +38,12 @@
 	head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
 	id = /obj/item/mattcoin
-	H.change_stat("strength", 3)
+	H.change_stat("strength", 4) //have you seen this idiot's starting gear and skill spread??
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 2)
-	H.change_stat("intelligence", -3)
+	H.change_stat("intelligence", -1)
+	H.change_stat("speed", 1)
+	H.change_stat("fortune", 1)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	H.adjust_blindness(-3)
 	var/weapons = list("Battleaxe & Cudgel","Flail & Shield")
@@ -49,8 +51,8 @@
 	H.set_blindness(0)
 	switch(weapon_choice)
 		if("Battleaxe & Cudgel") //one weapon to hurt people one weapon to kill people
-			backl= /obj/item/rogueweapon/stoneaxe/battle		
+			backl= /obj/item/rogueweapon/stoneaxe/battle
 			beltr = /obj/item/rogueweapon/mace/cudgel
 		if("Flail & Shield") //plate users beware, you're in for a scare!
-			backl= /obj/item/rogueweapon/shield/wood	
-			beltr = /obj/item/rogueweapon/flail	
+			backl= /obj/item/rogueweapon/shield/wood
+			beltr = /obj/item/rogueweapon/flail

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
@@ -6,7 +6,7 @@
 	outfit = /datum/outfit/job/roguetown/bandit/hedgeknight
 	category_tags = list(CTAG_BANDIT)
 	maximum_possible_slots = 2 //Too many plate armoured fellas is scawy ...
-	cmode_music = 'sound/music/combat_bandit.ogg'	
+	cmode_music = 'sound/music/combat_bandit.ogg'
 
 /datum/outfit/job/roguetown/bandit/hedgeknight/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -31,7 +31,7 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
@@ -39,10 +39,11 @@
 	H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
 	H.change_stat("strength", 2)
-	H.change_stat("endurance", 1)
-	H.change_stat("constitution", 2)
+	H.change_stat("endurance", 2)
+	H.change_stat("constitution", 3) //dark souls 3 dual greatshield moment
 	H.change_stat("intelligence", 1)
 	H.change_stat("speed", 1)
+	H.change_stat("fortune", 2)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC) //hey buddy you hear about roleplaying

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
@@ -14,9 +14,9 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
@@ -39,9 +39,12 @@
 	neck = /obj/item/clothing/neck/roguetown/coif
 	armor = /obj/item/clothing/suit/roguetown/armor/leather
 	id = /obj/item/mattcoin
-	H.change_stat("endurance", 1) 
+	H.change_stat("strength", 1)
+	H.change_stat("constitution", 1)
+	H.change_stat("endurance", 1)
 	H.change_stat("perception", 2)
 	H.change_stat("speed", 3) //It's all about speed and perception
+	H.change_stat("fortune", 2)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC) //gets dodge expert but no medium armor training - gotta stay light
 	H.adjust_blindness(-3)
 	var/weapons = list("Crossbow & Dagger", "Bow & Sword")
@@ -60,7 +63,7 @@
 		if("Bow & Sword") //Poacher
 			backl= /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			beltl = /obj/item/rogueweapon/sword/short
-			beltr = /obj/item/quiver/arrows 
+			beltr = /obj/item/quiver/arrows
 			head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm //cool hat
 			backr = /obj/item/storage/backpack/rogue/satchel
 			backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1, /obj/item/restraints/legcuffs/beartrap = 2) //poacher gets mantraps

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
@@ -5,7 +5,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/bandit/roguemage
 	category_tags = list(CTAG_BANDIT)
-	cmode_music = 'sound/music/combat_bandit_mage.ogg'	
+	cmode_music = 'sound/music/combat_bandit_mage.ogg'
 
 /datum/outfit/job/roguetown/bandit/roguemage/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -38,18 +38,18 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 4, TRUE)
 		if(H.age == AGE_OLD)
 			head = /obj/item/clothing/head/roguetown/wizhat/gen
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe
 			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
-			H.change_stat("speed", -1)
 			H.change_stat("intelligence", 1)
 			H.change_stat("perception", 1)
 			H.mind.adjust_spellpoints(1)
-		H.change_stat("strength", -1)
 		H.change_stat("intelligence", 3)
 		H.change_stat("constitution", 1)
 		H.change_stat("endurance", -1)
+		H.change_stat("fortune", 2)
+		H.change_stat("speed", 1) //ohhh sweetie this is NOT gonna help
 		H.mind.adjust_spellpoints(1)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -15,16 +15,16 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/belt/rogue/surgery_bag/full
-	beltr = /obj/item/rogueweapon/huntingknife/cleaver /// proper self defense an tree aquiring
+	beltr = /obj/item/rogueweapon/huntingknife/idagger/navaja /// now THIS is a knoife
 	pants = /obj/item/clothing/under/roguetown/trou
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/mattcoin
 	backpack_contents = list(		/obj/item/natural/worms/leech/cheele = 1, /obj/item/natural/cloth = 2,)
-	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/labor/lumberjacking, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
@@ -32,7 +32,7 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
 	H.change_stat("intelligence", 3)
 	H.change_stat("fortune", 3)
 	if(H.age == AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -5,7 +5,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/bandit/sawbones
 	category_tags = list(CTAG_BANDIT)
-	cmode_music = 'sound/music/combat_physician.ogg'	
+	cmode_music = 'sound/music/combat_physician.ogg'
 
 /datum/outfit/job/roguetown/bandit/sawbones/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -34,7 +34,7 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
 	H.change_stat("intelligence", 3)
-	H.change_stat("fortune", 1)
+	H.change_stat("fortune", 3)
 	if(H.age == AGE_OLD)
 		H.change_stat("speed", -1)
 		H.change_stat("intelligence", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
@@ -5,7 +5,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/bandit/sellsword
 	category_tags = list(CTAG_BANDIT)
-	cmode_music = 'sound/music/combat_bandit2.ogg'	
+	cmode_music = 'sound/music/combat_bandit2.ogg'
 
 /datum/outfit/job/roguetown/bandit/sellsword/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -35,11 +35,12 @@
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
-	id = /obj/item/mattcoin	
-	H.change_stat("strength", 2) //less buffs than brigand but no int debuff 
+	id = /obj/item/mattcoin
+	H.change_stat("strength", 2)
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 1)
-	H.change_stat("speed", 1)
+	H.change_stat("speed", 2)
+	H.change_stat("fortune", 1)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	H.adjust_blindness(-3)
 	var/weapons = list("Spear & Crossbow","Sword & Buckler")

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -129,7 +129,7 @@
 	name = "Bat Form"
 	desc = ""
 	invocation = ""
-	vitaedrain = 2500
+	vitaedrain = 1000
 	charge_max = 60
 	cooldown_min = 50
 	die_with_shapeshifted_form =  FALSE
@@ -139,7 +139,7 @@
 	name = "Mist Form"
 	desc = ""
 	invocation = ""
-	vitaedrain = 2500
+	vitaedrain = 1500
 	charge_max = 60
 	cooldown_min = 50
 	die_with_shapeshifted_form =  FALSE

--- a/code/modules/roguetown/roguemachine/lottery.dm
+++ b/code/modules/roguetown/roguemachine/lottery.dm
@@ -90,21 +90,23 @@
 			src.say(pick("Well-maneuvered, aristocrat! Your peasant's tithe is now [src.gamblingprice] mammons. Play again?", "A bountiful harvest, this year- the peasant's tithe rises to [src.gamblingprice] mammons. Spin me again?",))
 
 			playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
-			src.stopgambling = 0
 			src.gamblingprob = src.gamblingbaseprob
 			src.oldtithe = src.gamblingprice //this is redundant but i feel like bad things will happen if i don't do this :T
+			sleep(15)
+			src.stopgambling = 0
 			return
 
 		else
 			src.say(pick("TEN, WHEEL OF FORTUNE - inversed.", "The Castle. O, Omen!", "A harvest of locusts...!", "Look into my eyes and whisper your woes.", "Aw, dangit.", "Fool. Poor fool.", "Your eyes leak out of your skull, drool falling from your lips.", "Divine idiocy.", "You stand just as I did; loser and a freek."))
 			playsound(src, 'sound/misc/bug.ogg', 100, FALSE, -1)
 			sleep(20) //really make them THINK about their life choices up to this point
-			src.stopgambling = 0
 			src.say(pick("King of fools, your land is barren. Play again?", "Divine comedy. Play again?", "Next time, surely. Play again?", "Haha-...ah-ha-ha! Again! Play again, jester!", "Poor beggar! Spin me again?"))
 			playsound(src, 'sound/misc/bug.ogg', 100, FALSE, -1)
 			src.gamblingprob = src.gamblingbaseprob
 			src.gamblingprice = 0
 			src.oldtithe = 0
+			sleep(15)
+			src.stopgambling = 0
 			return
 
 
@@ -163,7 +165,7 @@
 
 	if(src.checkchatter == 1)
 		return
-	if(src.gamblingprice < 1000)
+	if(src.gamblingprice < 140)
 		return
 
 	chatterbox = rand(1,4)
@@ -188,7 +190,7 @@
 			src.say("...especially for a lowly fool who thinks himself a king.")
 			playsound(src, 'sound/misc/bug.ogg', 100, FALSE, -1)
 		else
-			src.say("Me? Oh, no.")
+			src.say("Me? Am I anybody important...? Oh, no.")
 			playsound(src, 'sound/misc/machineyes.ogg', 100, FALSE, -1)
 			sleep(25)
 			src.say("I am nothing but a lowly jester, just like you! Ha-ha-ha!")


### PR DESCRIPTION
## About The Pull Request

a few things:
- antag balance pass so they're actual threats
- map fixes
- let's go gambling!! fixes/changes

Antags overall had generally worse stats than their townie counterparts.

The most egregious example of this was the bandit subclasses, which were all objectively worse than their merc counterparts in both gear and skills. Their skills probably need another poke, but their stats are now better, and generally on-par with the captain's. (Bandits will almost always be outnumbered; giving them extra stats as a cushion is fine.) They also get some extra fortune to offset the stress that they will inevitably accumulate, and because...hey, you kind of have to be a bit lucky to make it out there, right?

Only subclass im super concerned abt is hedge knight, but I don't rly foresee it being super crazy. again, these are ppl that are almost always immediately heavily outnumbered and outgeared

Vampyre skill costs reduced. Nobody was using them. Why the fuck would I blow half my vitae for 30 seconds of +6 STR when I can literally go up z-levels? Increased max vitae on VL. **Made VL not use stamina.** Vamp spawn and converted still do.

WW's armor increased in durability - was objectively worse than plate after the integ pass iirc, either way, needed buffs

Also fixes some mapping errors in the azure forest - my dungeon didn't have its proper areas set, and the walls were also broken. No idea who or what did this- assume it happened with TGS.

Xylix gambling machine fixes, and you get to hear the lore more.

## Why It's Good For The Game

Antags being able to kill ppl is good, actually
