### PR TITLE
Add new vagabond busker subclass & flute to bard instrument options

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
@@ -141,7 +141,7 @@
 			H.change_stat("perception", 2)
 			H.change_stat("speed", 2)
 
-	var/weapons = list("Harp","Lute","Accordion","Guitar")
+	var/weapons = list("Harp","Lute","Accordion","Guitar", "Flute")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
@@ -153,6 +153,8 @@
 			backr = /obj/item/rogue/instrument/accord
 		if("Guitar")
 			backr = /obj/item/rogue/instrument/guitar
+		if("Flute")
+			backr = /obj/item/rogue/instrument/flute
 
 	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/busker.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/busker.dm
@@ -1,0 +1,47 @@
+/datum/advclass/vagabond_busker
+	name = "Songlost"
+	tutorial = "A melody beyond your reach haunts you in your dreams, and you've given up everything in the pursuit of artistry to try and find it."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/vagabond/busker
+	category_tags = list(CTAG_VAGABOND)
+
+/datum/outfit/job/roguetown/vagabond/busker/pre_equip(mob/living/carbon/human/H)
+	..()
+	if(H.gender == FEMALE)
+		armor = /obj/item/clothing/suit/roguetown/shirt/rags
+	else
+		pants = /obj/item/clothing/under/roguetown/tights/vagrant
+		if(prob(50))
+			pants = /obj/item/clothing/under/roguetown/tights/vagrant/l
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
+		if(prob(50))
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant/l
+
+	if(prob(33))
+		cloak = /obj/item/clothing/cloak/half/brown
+		gloves = /obj/item/clothing/gloves/roguetown/fingerless
+	
+	if (H.mind)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/music, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE)
+		H.change_stat("perception", 2)
+		H.change_stat("intelligence", 2)
+		H.change_stat("constitution", -1)
+		H.change_stat("endurance", -1)
+		H.change_stat("strength", -1)
+		var/instruments = list("Harp", "Lute", "Accordion", "Guitar", "Flute")
+		var/instrument_choice = input("Choose your musical medium.", "The Lost Song") as anything in instruments
+		switch(instrument_choice)
+			if("Harp")
+				backr = /obj/item/rogue/instrument/harp
+			if("Lute")
+				backr = /obj/item/rogue/instrument/lute
+			if("Accordion")
+				backr = /obj/item/rogue/instrument/accord
+			if("Guitar")
+				backr = /obj/item/rogue/instrument/guitar
+			if("Flute")
+				backr = /obj/item/rogue/instrument/flute
+		ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

Really simple: adds a new Songlost (busker) subclass for vagabond, and allows flutes as a spawn option for adventurer bards.

Songlost are spiritually inspired by a Certain Rodential Musician and have music 4, sneaking 4, climbing 4, +2 PER, +2 INT, -1 CON, END and STR, plus the Empath trait (which allows them to see pain levels).

## Why It's Good For The Game

Starving artists are a fun archetype to play, and while the Bard adventurer subclass isn't especially cracked, it can be better for certain concepts to start with less.
