### PR TITLE
Stealing position and XP updates

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -398,7 +398,7 @@
 							to_chat(src, span_warning("What am I going to steal from there?"))
 							return
 						mobsbehind |= cone(V, list(turn(V.dir, 180)), list(src))
-						if(mobsbehind.Find(src))
+						if(mobsbehind.Find(src) || V.IsUnconscious() || V.eyesclosed || V.eye_blind || V.eye_blurry)
 							switch(U.zone_selected)
 								if("chest")
 									if (V.get_item_by_slot(SLOT_BACK_L))
@@ -418,11 +418,13 @@
 										stealpos.Add(V.get_item_by_slot(SLOT_RING))
 							if (length(stealpos) > 0)
 								var/obj/item/picked = pick(stealpos)
-								V.dropItemToGround(picked)
-								put_in_active_hand(picked)
+								V.dropItemToGround(picked, FALSE, TRUE)
+								put_in_active_hand(picked, FALSE, TRUE)
 								to_chat(src, span_green("I stole [picked]!"))
 								V.log_message("has had \the [picked] stolen by [key_name(U)]", LOG_ATTACK, color="black")
 								U.log_message("has stolen \the [picked] from [key_name(V)]", LOG_ATTACK, color="black")
+								if (picked.sellprice)
+									exp_to_gain += floor(picked.sellprice / 2)
 							else
 								exp_to_gain /= 2 // these can be removed or changed on reviewer's discretion
 								to_chat(src, span_warning("I didn't find anything there. Perhaps I should look elsewhere."))

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -398,7 +398,7 @@
 							to_chat(src, span_warning("What am I going to steal from there?"))
 							return
 						mobsbehind |= cone(V, list(turn(V.dir, 180)), list(src))
-						if(mobsbehind.Find(src) || V.IsUnconscious() || V.eyesclosed || V.eye_blind || V.eye_blurry)
+						if(mobsbehind.Find(src) || V.IsUnconscious() || V.eyesclosed || V.eye_blind || V.eye_blurry || !(V.mobility_flags & MOBILITY_STAND))
 							switch(U.zone_selected)
 								if("chest")
 									if (V.get_item_by_slot(SLOT_BACK_L))

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -425,6 +425,11 @@
 								U.log_message("has stolen \the [picked] from [key_name(V)]", LOG_ATTACK, color="black")
 								if (picked.sellprice)
 									exp_to_gain += floor(picked.sellprice / 2)
+								if (picked.contents)
+									exp_to_gain += floor(get_mammons_in_atom(picked) / 2)
+									for(var/atom/movable/thing in picked.contents)
+										if (thing.sellprice)
+											exp_to_gain += floor(thing.sellprice / 2)
 							else
 								exp_to_gain /= 2 // these can be removed or changed on reviewer's discretion
 								to_chat(src, span_warning("I didn't find anything there. Perhaps I should look elsewhere."))


### PR DESCRIPTION
## About The Pull Request

Theft is pretty spartan. The way it currently works is that the game checks to see if you're in the standard sight exclusion cone drawn behind someone, and if you are, it lets you try to steal.

This PR makes the following changes:

- Stealing can now be attempted if:
  - ...you are within the standard sight exclusion cone (as before)
  - ...your victim is not standing (from any direction)
  - ...your victim is unconscious (from any direction)
  - ...your victim's eyes are closed (from any direction)
  - ...your victim is blind (from any direction)
  - ...your victim's eyes are blurry (from any direction)
- Stealing should now no longer play a pickup sound & animation when successfully stealing something for nearby observers.
  - This always irked me since a *huge* number of people often immediately acted upon the pickup animation to assume that someone had been stolen from. Nuh-uh.
  - If this gets added back in any way, it needs to be a STAPER skillcheck for onlookers to realize someone's been stolen from. No free lunches for the statistically unobservant.

**Important note:** just because you can *attempt* theft does not mean you will succeed it. Theft still *always* rolls against the target's perception, even when any of the above categories are satisfied. That hasn't changed.

I've made these changes primarily because stealing was *extremely* binary before. You could only really do it when behind someone, and that was it. It didn't interact with any other mechanics other than "can I get behind someone". Now things like the Noc blindness spell and any other source of eye-blurriness or blindness imposition can potentially be used for theft. Someone can add pocket sand functionality at a later date to clods of dirt or something if they want to and it'll work with this.

In addition, if your theft is successful, you now gain **half** the item's sellprice value as extra xp. If you steal a container holding mammons or any other item with a sellprice, you also get half of the total value of all these things too.. It was basically impossible to skill up stealing before under any circumstances, but it should be fairly viable now.

## Why It's Good For The Game

Soft antagonism adds a lot of spice to a round, and this encourages people to try stealing things more.
