### PR TITLE
Ascendent Pantheon followers recognize others of the same religion

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -59,10 +59,15 @@
 #define TRAIT_KNEESTINGER_IMMUNITY "Blessing of Dendor"
 #define TRAIT_SOUL_EXAMINE "Blessing of Necra" //can check bodies to see if they have departed
 #define TRAIT_CRACKHEAD "Blessing of Baotha" //will never overdose
-#define TRAIT_COMMIE "Blessing of Matthios" //recognized by bandits as an ally
 #define TRAIT_CHOSEN "Astrata's Chosen"
 #define TRAIT_ABYSSOR_SWIM "Blessing of Abyssor" //less base fatigue drain when swimming
 #define TRAIT_XYLIX "Blessing of Xylix" //secret thieves cant language
+
+// ASCENDANT CULTIST TRAITS (all of them recognize each other)
+#define TRAIT_COMMIE "Blessing of Matthios" //recognized by bandits as an ally
+#define TRAIT_CABAL "Of the Cabal" //Zizo cultists recognize each other too
+#define TRAIT_HORDE "Anointed" //Graggarites also recognize each other
+#define TRAIT_DEPRAVED "Fallen" //Baothans also recognize each other
 
 #define TRAIT_BASHDOORS "bashdoors"
 #define TRAIT_NOMOOD "no_mood"
@@ -149,7 +154,10 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_ABYSSOR_SWIM = "I get far less tired when swimming than my peers.",
 	TRAIT_LONGSTRIDER = "Each of my steps finds it's footing no matter how treacherous the terrain is.",
 	TRAIT_TRAINED_SMITH = span_info("I've spent long training, and with some more, I will be able to smith legendary items."),
-	TRAIT_XYLIX = span_info("I know how to speak in code that only fellow tricksters can understand.")
+	TRAIT_XYLIX = span_info("I know how to speak in code that only fellow tricksters can understand."),
+	TRAIT_CABAL = span_info("In secret, I have studied the ways of Her ascension, and know of others of the Cabal."),
+	TRAIT_HORDE = span_info("BY BLOOD AND BONE, I AM OF GRAGGAR'S ANOINTED! I FEEL THE STRENGTH IN OTHERS WHO ARE THE SAME."),
+	TRAIT_DEPRAVED = span_info("The languid scent of Her debauchery is known to me, and I can detect its sordid presence upon others.")
 ))
 
 // trait accessor defines

--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -13,6 +13,7 @@
 	domain = "Advancement, Hubris, Left Hand Magicks"
 	desc = "Snow Elf turned God, who in her endless pursuit of greatness sacrificed her kin for ascension. Zizo revolutionized many a science and magick and taught mortals to bend the natural world to their will."
 	worshippers = "Necromancers, Warlocks, and the Undead"
+	mob_traits = list(TRAIT_CABAL)
 	confess_lines = list(
 		"PRAISE ZIZO!",
 		"LONG LIVE ZIZO!",
@@ -24,7 +25,7 @@
 	domain = "God of Conquest, Murder and Pillaging"
 	desc = "Orc turned deity, said by the Holy Ecclesial to have been blessed by Ravox himself to fight the Archdevil Vheslyn. Instead of joining the Stalwart Warrior's army, he took his blessings to rampage and tear down the Old Ten. Bless the Blooded One."
 	worshippers = "Prisoners, Murderers and the Cruel"
-	mob_traits = list(TRAIT_ORGAN_EATER)
+	mob_traits = list(TRAIT_HORDE, TRAIT_ORGAN_EATER)
 	confess_lines = list(
 		"GRAGGAR IS THE BEAST I WORSHIP!",
 		"THROUGH VIOLENCE, DIVINITY!",
@@ -48,7 +49,7 @@
 	domain = "Goddess of Degeneracy, Debauchery and Addiction"
 	desc = "Eora's crueler half, made be from her one true love having been unfaithful. Filled with bitterness, she separated from Eora in spirit and spiraled into a dark hole of crippling hedonism. She teaches her ilk to place their trust in no one, and do only as they please."
 	worshippers = "Perverts, Gamblers, Drunkards, and Bards"
-	mob_traits = list(TRAIT_CRACKHEAD)
+	mob_traits = list(TRAIT_DEPRAVED, TRAIT_CRACKHEAD)
 	confess_lines = list(
 		"BAOTHA DEMANDS PLEASURE!",
 		"LIVE, LAUGH, LOVE!",

--- a/code/modules/antagonists/roguetown/villain/lich/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich/lich.dm
@@ -55,6 +55,7 @@
 	ADD_TRAIT(L, TRAIT_SEEPRICES, "[type]")
 	ADD_TRAIT(L, TRAIT_CRITICAL_RESISTANCE, "[type]")
 	ADD_TRAIT(L, TRAIT_HEAVYARMOR, "[type]")
+	ADD_TRAIT(L, TRAIT_CABAL, "[type]")
 	L.cmode_music = 'sound/music/combat_cult.ogg'
 	L.faction = list("undead")
 	if(L.charflaw)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -111,6 +111,12 @@
 			. += commie_text
 		else if(HAS_TRAIT(src, TRAIT_COMMIE) && HAS_TRAIT(user, TRAIT_COMMIE))
 			. += span_notice("Comrade!")
+		else if(HAS_TRAIT(src, TRAIT_CABAL) && HAS_TRAIT(user, TRAIT_CABAL))
+			. += span_notice("Another of the Cabal!")
+		else if(HAS_TRAIT(src, TRAIT_HORDE) && HAS_TRAIT(user, TRAIT_HORDE))
+			. += span_notice("Anointed!")
+		else if(HAS_TRAIT(src, TRAIT_DEPRAVED) && HAS_TRAIT(user, TRAIT_DEPRAVED))
+			. += span_notice("Debased!")
 
 	if(leprosy == 1)
 		. += span_necrosis("A LEPER...")


### PR DESCRIPTION
## About The Pull Request

Basically takes how Matthios' followers work and applies the same thing to Zizo, Baotha and Graggar. Members of that same faith will see each other on examines.

Additionally, the Lich is flagged as a Zizo cabalist, potentially prompting cross-cultist shenanigans with town Zizo followers.

## Why It's Good For The Game

The Matthios identification mechanic has produced *many* excellent interactions and has widely shaped their place as "soft antagonists", something the other Ascendent desperately need.

With Matthios in particular getting a lot of interplay between recent additions and forthcoming epic PRs like #659, I think it is time to open this up to the rest of the Ascendent and see how things emerge naturally.