### PR TITLE
Archivist tweaks: gets a serfstone, consistent arcane skill

### DIFF
--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -53,7 +53,7 @@
 		H.grant_language(/datum/language/hellspeak)
 		H.grant_language(/datum/language/orcish)
 		H.grant_language(/datum/language/draconic) // All but beast, which is associated with werewolves.
-		ADD_TRAIT(H, TRAIT_SEEPRICES, "[type]")
+		ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
 		H.change_stat("strength", -1)
 		H.change_stat("constitution", -1)
 		H.change_stat("intelligence", 4)

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -34,7 +34,7 @@
 	beltl = /obj/item/storage/keyring/archivist
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
 	mask = /obj/item/clothing/mask/rogue/spectacles
-
+	id = /obj/item/scomstone/bad
 
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
@@ -45,7 +45,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/magic/arcane, rand(1,2), TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
 		H.mind.adjust_spellpoints(1)
 		H.grant_language(/datum/language/elvish)
 		H.grant_language(/datum/language/dwarvish)
@@ -53,7 +53,7 @@
 		H.grant_language(/datum/language/hellspeak)
 		H.grant_language(/datum/language/orcish)
 		H.grant_language(/datum/language/draconic) // All but beast, which is associated with werewolves.
-		ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
+		ADD_TRAIT(H, TRAIT_SEEPRICES, "[type]")
 		H.change_stat("strength", -1)
 		H.change_stat("constitution", -1)
 		H.change_stat("intelligence", 4)


### PR DESCRIPTION
## About The Pull Request

One of those "I Play This Job A Lot And These Things Annoy Me" PRs.

- Archivist gets a serfstone at roundstart (they can already afford one 95% of the time thanks to their starting mid pouch, but it's just an annoyance on no-merchant rounds)
- Archivist arcane skill is now hard-set at 2 so you consistently have the same spellpoints to play with each round
## Why It's Good For The Game

A gentle balancejak massage for a not-especially played or prominent keep-adjacent role.
