### PR TITLE
Pendantic tabard description change + chudcode removal + warrior class tweak

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -413,11 +413,6 @@
 	desc = ""
 	icon_state = "kippah"
 
-/obj/item/clothing/head/medievaljewhat
-	name = "medieval Jew hat"
-	desc = ""
-	icon_state = "medievaljewhat"
-
 /obj/item/clothing/head/taqiyahwhite
 	name = "white taqiyah"
 	desc = ""

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -297,7 +297,7 @@
 
 /obj/item/clothing/cloak/stabard
 	name = "surcoat"
-	desc = "A medieval overcoat meant to be used over the armor."
+	desc = "An outer garment commonly worn by soldiers."
 	icon_state = "stabard"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1059,7 +1059,7 @@
 
 /obj/item/clothing/cloak/templar/psydon
 	name = "psydon tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Psydon on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Psydon on it."
 	icon_state = "tabard_weeping"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1073,7 +1073,7 @@
 
 /obj/item/clothing/cloak/templar/astrata
 	name = "astratan tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Astrata on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Astrata on it."
 	icon_state = "tabard_astrata_alt"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1087,7 +1087,7 @@
 
 /obj/item/clothing/cloak/templar/noc
 	name = "noc tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Noc on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Noc on it."
 	icon_state = "tabard_noc"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1101,7 +1101,7 @@
 
 /obj/item/clothing/cloak/templar/dendor
 	name = "dendor tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Dendor on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Dendor on it."
 	icon_state = "tabard_dendor"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1115,7 +1115,7 @@
 
 /obj/item/clothing/cloak/templar/necra
 	name = "necra tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Necra on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Necra on it."
 	icon_state = "tabard_necra"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1129,7 +1129,7 @@
 
 /obj/item/clothing/cloak/templar/abyssor
 	name = "abyssor tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Abyssor on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Abyssor on it."
 	icon_state = "tabard_abyssor"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1143,7 +1143,7 @@
 
 /obj/item/clothing/cloak/templar/malum
 	name = "malum tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Malum on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Malum on it."
 	icon_state = "tabard_malum"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1157,7 +1157,7 @@
 
 /obj/item/clothing/cloak/templar/eora
 	name = "eora tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Eora on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Eora on it."
 	icon_state = "tabard_eora"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1171,7 +1171,7 @@
 
 /obj/item/clothing/cloak/templar/pestra
 	name = "pestra tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Pestra on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Pestra on it."
 	icon_state = "tabard_pestra"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1185,7 +1185,7 @@
 
 /obj/item/clothing/cloak/templar/ravox
 	name = "ravox tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Ravox on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Ravox on it."
 	icon_state = "tabard_ravox"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN
@@ -1199,7 +1199,7 @@
 
 /obj/item/clothing/cloak/templar/xylix
 	name = "xylix tabard"
-	desc = "A medieval overcoat meant to be used over the armor. This one has the symbol of Xylix on it."
+	desc = "An outer garment commonly worn by soldiers. This one has the symbol of Xylix on it."
 	icon_state = "tabard_xylix"
 	alternate_worn_layer = TABARD_LAYER
 	body_parts_covered = CHEST|GROIN

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -25,6 +25,7 @@
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
@@ -37,6 +38,7 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 			var/weapons = list("Bastard Sword","Mace","Billhook","Battle Axe")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			H.set_blindness(0)
@@ -68,6 +70,7 @@
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
@@ -79,6 +82,7 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 			H.change_stat("strength", 2)
 			H.change_stat("endurance", 1) // Weaker endurance compared to a traditional warrior/soldier. Smarter due to study of rare magical beasts.

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -356,7 +356,6 @@
 					/obj/item/clothing/head/beanie/rasta = 1)
 	contraband = list(/obj/item/toy/plush/plushvar = 1,
 					/obj/item/toy/plush/narplush = 1,
-					/obj/item/clothing/head/medievaljewhat = 3,
 					/obj/item/clothing/suit/chaplainsuit/clownpriest = 1,
 					/obj/item/clothing/head/clownmitre = 1)
 	premium = list(/obj/item/clothing/suit/chaplainsuit/bishoprobe = 1,

--- a/tools/UpdatePaths/Scripts/70060_hats_repath.txt
+++ b/tools/UpdatePaths/Scripts/70060_hats_repath.txt
@@ -106,7 +106,6 @@
 /obj/item/clothing/head/bandana/armored : /obj/item/clothing/head/costume/pirate/bandana/armored {@OLD}
 /obj/item/clothing/head/clownmitre : /obj/item/clothing/head/chaplain/clownmitre {@OLD}
 /obj/item/clothing/head/kippah : /obj/item/clothing/head/chaplain/kippah {@OLD}
-/obj/item/clothing/head/medievaljewhat : /obj/item/clothing/head/chaplain/medievaljewhat {@OLD}
 /obj/item/clothing/head/taqiyahwhite : /obj/item/clothing/head/chaplain/taqiyah/white {@OLD}
 /obj/item/clothing/head/taqiyahred : /obj/item/clothing/head/chaplain/taqiyah/red {@OLD}
 /obj/item/clothing/head/sombrero : /obj/item/clothing/head/costume/sombrero {@OLD}


### PR DESCRIPTION
## About The Pull Request
Changes the descriptions of several tabards + surcoats and removes some buried chudcode for good measure.

## Why It's Good For The Game
The previous description of these items mentioned that they were 'medieval garments', which sounds like a historian writing about a period in the past rather than someone living within that period. Tabards are not historical artifacts, to our characters, they are things they see commonly in every day life being worn. 

The item which references to have been removed was not in game, so served no purpose and had a nasty name. It will not be missed.

ALSO gives the warrior class for adventurer some reading skill and flail proficiency, as requested.