### PR TITLE
Update sentinel stats, +2 SPE.dm

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/sentinel.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/sentinel.dm
@@ -44,5 +44,5 @@
 	beltl = /obj/item/quiver/arrows
 	H.change_stat("perception", 5)
 	H.change_stat("endurance", 2)
-    H.change_stat("speed", 2)
+	H.change_stat("speed", 2)
 	H.ambushable = FALSE

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/sentinel.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/sentinel.dm
@@ -44,4 +44,5 @@
 	beltl = /obj/item/quiver/arrows
 	H.change_stat("perception", 5)
 	H.change_stat("endurance", 2)
+    H.change_stat("speed", 2)
 	H.ambushable = FALSE


### PR DESCRIPTION
adds 2 speed to sentinel stats

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds 2 speed to the Sentinel stats

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sentinels are supposed to be elite Elven rangers, hence why their numbers per round are limited, while rangers aren't. I think that while their 5 perception is a lot, a glaring flaw is their lack of speed, which is necessary for effective hit and run combat which ranged characters are forced into in the current system.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
