### PR TITLE
Allow tiefling tail color customization

### DIFF
--- a/code/modules/client/customizer/customizers/organ/tail.dm
+++ b/code/modules/client/customizer/customizers/organ/tail.dm
@@ -83,7 +83,7 @@
 		/datum/sprite_accessory/tail/tiefling,
 		/datum/sprite_accessory/tail/tiefling/heart,
 		)
-	allows_accessory_color_customization = FALSE
+	allows_accessory_color_customization = TRUE
 
 /datum/customizer/organ/tail/demihuman
 	customizer_choices = list(/datum/customizer_choice/organ/tail/demihuman)


### PR DESCRIPTION
## About The Pull Request

For reasons unknown to man, tiefling tail color customization was disabled and locked to your progenitor color. Can't really think of a solid reason why, and have confirmed that both tail sprite accessories color properly as intended.

## Why It's Good For The Game

Allows tiefling characters to be *slightly* more customizable, especially in circumstances where someone may want different colored tails.
