### PR TITLE
Ascendent/inhuman pantheon miracle fix + zizo miracle fix

### DIFF
--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -2,6 +2,7 @@
 	name = null
 	associated_faith = /datum/faith/inhumen
 	undead_hater = FALSE
+	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	confess_lines = list(
 		"PSYDON IS THE DEMIURGE!",
 		"THE TEN ARE WORTHLESS COWARDS!",

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -108,9 +108,10 @@
 				// set up a ritual pile of bones (or just cast near a stack of bones whatever) around us for massive bonuses, cap at 50 for 75 healing total (wowie)
 				situational_bonus = 0
 				for (var/obj/item/stack/sheet/bone/O in oview(5, user))
-					situational_bonus = min(situational_bonus + 5, 50)
+					situational_bonus += (O.amount * 5)
 				if (situational_bonus > 0)
 					conditional_buff = TRUE
+					situational_bonus = min(situational_bonus, 50)
 			if(/datum/patron/inhumen/graggar)
 				target.visible_message(span_info("Foul fumes billow outward as [target] is restored!"), span_notice("A noxious scent burns my nostrils, but I feel better!"))
 				// if you've got lingering toxin damage, you get healed more, but your bonus healing doesn't affect toxin


### PR DESCRIPTION
## About The Pull Request

Two quick fixes:

Inhumen pantheon never had a T0 set, so some roles that can spawn as inhumen devotionals (such as vagabond's Excommunicated subclass) weren't getting lesser miracle. This is fixed.

In addition, Zizo's miracle conditional bonus was treating an entire stack of bones as just 1 bone. It now handles this properly.

## Why It's Good For The Game

Inhumen devotionists should be able to heal when they're not churchlings! Definite oversight.