### PR TITLE
Arcyne Knight, the Eldritch Knight addition

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
@@ -1,6 +1,6 @@
 /datum/advclass/knighterrant
 	name = "Knight-errant"
-	tutorial = "You fashion yourself a knight from a distant land, a scion of a noble house. Whether or not that's true is irrelevant; manner maketh man, bandit. Carry yourself with dignity and remind the land that chivalry still exists, or give everyone a cruel reality check as they decry you as a blackguard under the weight of a steel boot. After selection you receive a choice between a shining knight or a black knight, which is entirely aesthetic."
+	tutorial = "You fashion yourself a knight from a distant land, a scion of a noble house. Whether or not that's true is irrelevant; manner maketh man, bandit. Carry yourself with dignity and remind the land that chivalry still exists, or give everyone a cruel reality check as they decry you as a blackguard under the weight of a steel boot. After selection you receive a choice between a shining, black or, arcyne knight, the latter trading martial skill for basic magic." //Azure Peak Updated for Arcyne Knight
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/adventurer/knighterrant
@@ -14,7 +14,7 @@
 /datum/outfit/job/roguetown/adventurer/knighterrant/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_blindness(-3)
-	var/classes = list("Normal Knight","Black Knight")
+	var/classes = list("Normal Knight","Black Knight","Arcyne Knight") //Azure peak updated for Arcyne Knight
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)
@@ -108,6 +108,56 @@
 					beltr = /obj/item/rogueweapon/flail/sflail
 				if("Spear")
 					r_hand = /obj/item/rogueweapon/spear
+
+		if("Arcyne Knight") //Azure Peak Addition
+			REMOVE_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+			head = /obj/item/clothing/head/roguetown/bardhat
+			gloves = /obj/item/clothing/gloves/roguetown/chain
+			pants = /obj/item/clothing/under/roguetown/chainlegs
+			cloak = /obj/item/clothing/cloak/black_cloak
+			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/half
+			wrists = /obj/item/clothing/wrists/roguetown/bracers
+			shoes = /obj/item/clothing/shoes/roguetown/shortboots
+			belt = /obj/item/storage/belt/rogue/leather
+			backr = /obj/item/storage/backpack/rogue/satchel
+			beltl = /obj/item/book/granter/spellbook/magician
+			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger = 1,/obj/item/storage/belt/rogue/pouch/coins/poor)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 1, TRUE)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+			H.mind.adjust_spellpoints(1) // total of 3
+			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
+			var/weapons = list("Rapier","Flail","Spear","Bastard Sword")
+			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			H.set_blindness(0)
+			switch(weapon_choice)
+				if("Bastard Sword")	
+					beltr = /obj/item/rogueweapon/sword/long
+				if("Rapier")	
+					beltr = /obj/item/rogueweapon/sword/rapier
+				if("Flail")
+					beltr = /obj/item/rogueweapon/flail/sflail
+				if("Spear")
+					r_hand = /obj/item/rogueweapon/spear
+			H.change_stat("strength", 1)
+			H.change_stat("intelligence", 1)
+			H.change_stat("endurance", 2) // 5 stat points total as a low-skill martial role with magic, comparable to Pally.
+			H.change_stat("constitution", 1) //Azure Peak addition End
 
 /obj/item/clothing/gloves/roguetown/chain/blk
 		color = CLOTHING_GREY

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
@@ -4,7 +4,6 @@
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/adventurer/knighterrant
-	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_NOBLE)
 	category_tags = list(CTAG_ADVENTURER)
 
 	noble_income = 5
@@ -20,6 +19,8 @@
 	switch(classchoice)
 
 		if("Normal Knight")
+			ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight
 			gloves = /obj/item/clothing/gloves/roguetown/chain
 			pants = /obj/item/clothing/under/roguetown/chainlegs
@@ -65,6 +66,8 @@
 					r_hand = /obj/item/rogueweapon/spear
 
 		if("Black Knight")
+			ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/black
 			gloves = /obj/item/clothing/gloves/roguetown/chain/blk
 			pants = /obj/item/clothing/under/roguetown/chainlegs/blk
@@ -110,7 +113,7 @@
 					r_hand = /obj/item/rogueweapon/spear
 
 		if("Arcyne Knight") //Azure Peak Addition
-			REMOVE_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 			head = /obj/item/clothing/head/roguetown/bardhat
 			gloves = /obj/item/clothing/gloves/roguetown/chain

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
@@ -128,7 +128,6 @@
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request

Adds a 'Eldritch Knight' or 'Red Mage'-esque class choice to Knight Errant, to allow for a hybrid spell-sword choice to match up with Paladin and Cleric.

Arcyne Knight, much like its similar hybrid the Arcanist, gets a lower level of arcyne talent than mages, while still retaining its class's main aesthetic, a knight of nobility. To compensate for their added magical ability, they take the following penalties:
 - Stats are nerfed from a total of 7 stat boosts to 5, with strength and constitution being lowered by 1.
 - Shield proficiency is removed
 - Weapon abilities lowered to apprentice
 - Heavy armor proficiency is removed and replaced with medium armor
 - Starting armor matched to new proficiency

## Why It's Good For The Game

I know it was said that we want more classes for in town, but if someone doesn't want to be in town, they won't be, and having more options won't really change that. Regardless, I felt there was a hole in the choices for adventurer, for both this and another PR. I know magic is hard to balance, so of course, open to discussion on how to balance it further. Sword and tome gaming!

Also I know this is not modular, I have no idea if this would have been better stuck as like a vagabond spec or something, let me know.