### PR TITLE
Hymnist, the Gospel-Toting Bard

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
@@ -5,7 +5,7 @@
 	registered adventurers in Enigma, mostly because they are \
 	the last ones in a party to die. Their wish is to experience \
 	the greatest adventures of the age and write amazing songs about them. \
-	The class has the option between the jack of all trades Bard, the martial-focused Skald, magic-equip arcanist."
+	The class has the option between the jack of all trades Bard, the martial-focused Skald, magic-equip arcanist, and the gospel Hymnist." //Azure peak updated for Hymnist
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/bard
@@ -15,7 +15,7 @@
 /datum/outfit/job/roguetown/adventurer/bard/pre_equip(mob/living/carbon/human/H)
 	..() // The entertaining jack of all trades, uniquely handy with crossbows and swords. They're incredibly well travelled, can sneak, steal and survive on their own.
 	H.adjust_blindness(-3)
-	var/classes = list("Bard","Skald","Arcanist")
+	var/classes = list("Bard","Skald","Arcanist","Hymnist") //Azure Peak Edit for Hymnist
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)
@@ -140,6 +140,62 @@
 			H.change_stat("intelligence", 2)
 			H.change_stat("perception", 2)
 			H.change_stat("speed", 2)
+		if("Hymnist") //Azure Peak Update, Miracles and some utility skills, less combat prowess
+			to_chat(H, span_warning("The tales of the gods are mighty indeed, though your skill in their retelling through song has granted you a touch of their favor as thanks."))
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/stealing, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/music, 5, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 3, TRUE)
+			head = /obj/item/clothing/head/roguetown/bardhat
+			shoes = /obj/item/clothing/shoes/roguetown/boots
+			pants = /obj/item/clothing/under/roguetown/tights/black
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/puritan
+			gloves = /obj/item/clothing/gloves/roguetown/fingerless
+			belt = /obj/item/storage/belt/rogue/leather
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/white
+			cloak = /obj/item/clothing/cloak/raincloak
+			backl = /obj/item/storage/backpack/rogue/satchel
+			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+			beltr = /obj/item/rogueweapon/huntingknife/idagger
+			switch(H.patron?.type)
+				if(/datum/patron/divine/astrata)
+					neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+				if(/datum/patron/divine/noc)
+					neck = /obj/item/clothing/neck/roguetown/psicross/noc
+				if(/datum/patron/divine/dendor)
+					neck = /obj/item/clothing/neck/roguetown/psicross/dendor
+				if(/datum/patron/divine/necra)
+					neck = /obj/item/clothing/neck/roguetown/psicross/necra
+				if(/datum/patron/divine/pestra)
+					neck = /obj/item/clothing/neck/roguetown/psicross/pestra
+				if(/datum/patron/divine/ravox)
+					neck = /obj/item/clothing/neck/roguetown/psicross/ravox
+				if(/datum/patron/divine/malum)
+					neck = /obj/item/clothing/neck/roguetown/psicross/malum
+				if(/datum/patron/divine/eora) //Eora content from Stonekeep
+					neck = /obj/item/clothing/neck/roguetown/psicross/eora
+			backpack_contents = list(/obj/item/lockpickring/one = 1)
+			H.change_stat("strength", 1)
+			H.change_stat("intelligence", 2)
+			H.change_stat("perception", 1)
+			H.change_stat("speed", 1)
+			var/datum/devotion/C = new /datum/devotion(H, H.patron)
+			C.grant_spells_templar(H)
+			H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+			H.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/churn)//End of Azure Peak Update
 
 	var/weapons = list("Harp","Lute","Accordion","Guitar")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons


### PR DESCRIPTION
## About The Pull Request

The bard's taken a liking to singing about their favorite god.. someone tell the Necran Hymnist that heavy metal is still unacceptable on church grounds.

Adds a 'miracle' alternative to the arcanist, giving the bard a paladin-level of miracles, sans churn undead. Their stats are similar to arcanist, with a bit of stat shuffling.

## Why It's Good For The Game

Filling out holes in the adventurer's roster is always a good thing in my eyes! Much like my Arcyne Knight update, I will always think more is customization and options is better. I'll try to make some town alternatives in the future as well if these make it through at all, who knows. First stabs at making prs for roguetown stuff so I probably mucked it up for not being modular or something.
