### PR TITLE
Hoardmaster fixes/tweaks

### DIFF
--- a/code/modules/cargo/packsrogue/Brigand.dm
+++ b/code/modules/cargo/packsrogue/Brigand.dm
@@ -98,11 +98,6 @@
 	cost = 10
 	contains = list(/obj/item/rogueweapon/flail)
 
-/datum/supply_pack/rogue/Brigand/repentaen
-	name = "Loyalty's Reward"
-	cost = 50
-	contains = list(/obj/item/rogueweapon/whip/antique)
-
 /datum/supply_pack/rogue/Brigand/mace
 	name = "Iron Mace"
 	cost = 10

--- a/code/modules/cargo/packsrogue/Brigand.dm
+++ b/code/modules/cargo/packsrogue/Brigand.dm
@@ -59,7 +59,7 @@
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
 
-/datum/supply_pack/rogue/Brigand/steelcuirass
+/datum/supply_pack/rogue/Brigand/blksteelcuirass
 	name = "Blacksteel Cuirass"
 	cost = 60
 	contains = list(/obj/item/clothing/suit/roguetown/armor/blacksteel/cuirass)

--- a/code/modules/cargo/packsrogue/Knave.dm
+++ b/code/modules/cargo/packsrogue/Knave.dm
@@ -88,31 +88,6 @@
 	cost = 5
 	contains = list(/obj/item/quiver)
 
-/datum/supply_pack/rogue/Knave/arrow
-	name = "Arrows"
-	cost = 5
-	contains = list(
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-					/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-				)
 
 /datum/supply_pack/rogue/Knave/quivers/arrows
 	name = "Quiver of Arrows"
@@ -126,105 +101,21 @@
 
 
 
-
 /datum/supply_pack/rogue/Knave/Parrows
-	name = "Poisoned Arrows"
-	cost = 60
-	contains = list(/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison,
-					/obj/item/ammo_casing/caseless/rogue/arrow/poison)
+	name = "Poisoned Arrow"
+	cost = 3
+	contains = list(/obj/item/ammo_casing/caseless/rogue/arrow/poison)
 
 /datum/supply_pack/rogue/Knave/pyroarrows
-	name = "Pyroclastic Arrows"
-	cost = 60
-	contains = list(/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
-					/obj/item/ammo_casing/caseless/rogue/arrow/pyro,)
-
-/datum/supply_pack/rogue/Knave/bolt
-	name = "Bolts"
-	cost = 20
-	contains = list(
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-				)
+	name = "Pyroclastic Arrow"
+	cost = 8
+	contains = list(/obj/item/ammo_casing/caseless/rogue/arrow/pyro)
 
 
 /datum/supply_pack/rogue/Knave/pyrobolts
 	name = "Pyroclastic bolts"
-	cost = 60
-	contains = list(/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
-					/obj/item/ammo_casing/caseless/rogue/bolt/pyro,)
+	cost = 12
+	contains = list(/obj/item/ammo_casing/caseless/rogue/bolt/pyro)
 
 /datum/supply_pack/rogue/Knave/Mancatcher
 	name = "Mancatcher"

--- a/code/modules/cargo/packsrogue/Knave.dm
+++ b/code/modules/cargo/packsrogue/Knave.dm
@@ -113,7 +113,7 @@
 
 
 /datum/supply_pack/rogue/Knave/pyrobolts
-	name = "Pyroclastic bolts"
+	name = "Pyroclastic bolt"
 	cost = 12
 	contains = list(/obj/item/ammo_casing/caseless/rogue/bolt/pyro)
 

--- a/code/modules/cargo/packsrogue/Mage.dm
+++ b/code/modules/cargo/packsrogue/Mage.dm
@@ -36,12 +36,8 @@
 
 /datum/supply_pack/rogue/Mage/scrolls
 	name = "Scrolls"
-	cost = 10
-	contains = list(/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll,
-					/obj/item/paper/scroll)
+	cost = 2
+	contains = list(/obj/item/paper/scroll)
 
 /datum/supply_pack/rogue/Mage/unfinbook
 	name = "Unfinished Spellbook"

--- a/code/modules/cargo/packsrogue/Sawbones.dm
+++ b/code/modules/cargo/packsrogue/Sawbones.dm
@@ -54,10 +54,10 @@
 
 /datum/supply_pack/rogue/Sawbones/leather/botbomb
 	name = "Bottle bomb"
-	cost = 50
+	cost = 30
 	contains = list(/obj/item/bomb)
 
 /datum/supply_pack/rogue/Sawbones/leather/poison
 	name = "High-Potency poison"
-	cost = 50
+	cost = 100
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/poison)

--- a/code/modules/cargo/packsrogue/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/Sellsword.dm
@@ -4,31 +4,33 @@
 	crate_name = "Gifts of Coinspillers"
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
-/datum/supply_pack/rogue/Sellsword/drider
+
+/datum/supply_pack/rogue/Sellsword/dridersword
 	name = "Old Zybantine package..."
-	cost = 70
-	contains = list(/obj/item/clothing/head/roguetown/roguehood/shalal,
-					/obj/item/storage/belt/rogue/leather/shalal,
-					/obj/item/rogueweapon/sword/long/rider,
-					/obj/item/clothing/suit/roguetown/armor/plate/scale,
-					/obj/item/clothing/under/roguetown/chainlegs/iron,
-					/obj/item/clothing/neck/roguetown/shalal,
-					/obj/item/clothing/suit/roguetown/armor/plate/scale,
-					/obj/item/storage/backpack/rogue/satchel/black,
-					/obj/item/clothing/gloves/roguetown/angle)
+	cost = 10
+	contains = list(/obj/item/rogueweapon/sword/long/rider)
 
-/datum/supply_pack/rogue/Sellsword/Grenzel
-	name = "Old Grenzelhoft package..."
-	cost = 70
-	contains = list(/obj/item/clothing/suit/roguetown/shirt/grenzelhoft,
-					/obj/item/clothing/head/roguetown/grenzelhofthat,
-					/obj/item/clothing/suit/roguetown/armor/blacksteel/cuirass,
-					/obj/item/clothing/under/roguetown/grenzelpants,
-					/obj/item/clothing/shoes/roguetown/grenzelhoft,
-					/obj/item/clothing/gloves/roguetown/grenzelgloves,
-					/obj/item/storage/backpack/rogue/satchel/black,
-					/obj/item/rogueweapon/halberd)
 
+/datum/supply_pack/rogue/Sellsword/driderhead
+	name = "Desert Rider headdress"
+	cost = 5
+	contains = list(/obj/item/clothing/head/roguetown/roguehood/shalal)
+
+
+/datum/supply_pack/rogue/Sellsword/grenzelhofthat
+	name = "Grenzel Hat"
+	cost = 5
+	contains = list(/obj/item/clothing/head/roguetown/grenzelhofthat)
+
+/datum/supply_pack/rogue/Sellsword/Grenzelpants
+	name = "Grenzel Pants"
+	cost = 5
+	contains = list(/obj/item/clothing/under/roguetown/grenzelpants)
+
+/datum/supply_pack/rogue/Sellsword/Grenzelshoes
+	name = "Grenzel Shoes"
+	cost = 5
+	contains = list(/obj/item/clothing/shoes/roguetown/grenzelhoft)
 
 /datum/supply_pack/rogue/Sellsword/coif/steel
 	name = "Steel Coif"
@@ -163,32 +165,6 @@
 	name = "Quiver of Bolts"
 	cost = 20
 	contains = list(/obj/item/quiver/bolts)
-
-/datum/supply_pack/rogue/Sellsword/bolt
-	name = "Bolts"
-	cost = 15
-	contains = list(
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-					/obj/item/ammo_casing/caseless/rogue/bolt,
-				)
 
 
 /datum/supply_pack/rogue/Sellsword/crossbow

--- a/code/modules/cargo/packsrogue/Things.dm
+++ b/code/modules/cargo/packsrogue/Things.dm
@@ -25,6 +25,11 @@
 	cost = 5
 	contains = list(/obj/item/needle)
 
+/datum/supply_pack/rogue/Things/hknife
+	name = "Hunting Knife"
+	cost = 5
+	contains = list(/obj/item/rogueweapon/huntingknife)
+
 /datum/supply_pack/rogue/Things/cloth
 	name = "Cloth"
 	cost = 2

--- a/code/modules/cargo/packsrogue/Things.dm
+++ b/code/modules/cargo/packsrogue/Things.dm
@@ -27,15 +27,8 @@
 
 /datum/supply_pack/rogue/Things/cloth
 	name = "Cloth"
-	cost = 10
-	contains = list(/obj/item/natural/cloth,
-	/obj/item/natural/cloth,
-	/obj/item/natural/cloth,
-	/obj/item/natural/cloth,
-	/obj/item/natural/cloth,
-	/obj/item/natural/cloth,
-	/obj/item/natural/cloth,
-	/obj/item/natural/cloth)
+	cost = 2
+	contains = list(/obj/item/natural/cloth)
 
 /datum/supply_pack/rogue/Things/Waterskin
 	name = "Waterskin"
@@ -81,5 +74,5 @@
 
 /datum/supply_pack/rogue/Things/Dragonscale
 	name = "Dragonscale Necklace"
-	cost = 750
+	cost = 900
 	contains = list(/obj/item/clothing/neck/roguetown/blkknight)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
@@ -59,7 +59,6 @@
 			backr = /obj/item/storage/backpack/rogue/satchel
 			backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1, /obj/item/lockpickring/mundane = 1) //rogue gets lockpicks
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		if("Bow & Sword") //Poacher
 			backl= /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			beltl = /obj/item/rogueweapon/sword/short
@@ -68,4 +67,3 @@
 			backr = /obj/item/storage/backpack/rogue/satchel
 			backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1, /obj/item/restraints/legcuffs/beartrap = 2) //poacher gets mantraps
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -15,25 +15,28 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/belt/rogue/surgery_bag/full
-	beltr = /obj/item/rogueweapon/huntingknife/idagger/navaja /// now THIS is a knoife
+	beltr = /obj/item/rogueweapon/sword/rapier
 	pants = /obj/item/clothing/under/roguetown/trou
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/mattcoin
 	backpack_contents = list(		/obj/item/natural/worms/leech/cheele = 1, /obj/item/natural/cloth = 2,)
-	H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/labor/lumberjacking, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE) //needed for getting into hideout
 	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
-	H.change_stat("intelligence", 3)
+	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+	H.change_stat("speed", 3)
+	H.change_stat("intelligence", 4)
 	H.change_stat("fortune", 3)
 	if(H.age == AGE_OLD)
 		H.change_stat("speed", -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes some broken items in the HOARDMASTER. Arrows, steel cuirass, and any item that had multiples has been reduced to singles. The cost of Pyroclastic arrows and bolts has gone up TREMENDOUSLY. I didn't realize they were so good! Dragonscale necklace has gone from 750 base favor to 900, being the ultimate 'End Game' of the Favor list. Sellsword's 'old merc cosplay' buy lists have been fixed and cheapened. Bottle bombs down to 30 from 50 favor, the INSANELY lethal high-lethal poison up from 50->100. Sawbones' playstyle actually restored, they now have the proper spd, sword skill, and dodge bonus I intended for.

## Why It's Good For The Game

yeag jus' some fixes pretty much? Sawbones is balance but, It was mentioned in the og post and just got fucked up because merge stuff awawa. Little bit of balance stuff for FAVOR costs.
