### PR TITLE
Undead & NPC goblin eyes slowly poison player recipients

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -219,7 +219,7 @@
 	if(eyes)
 		eyes.Remove(src,1)
 		QDEL_NULL(eyes)
-	eyes = new /obj/item/organ/eyes/night_vision/nightmare
+	eyes = new /obj/item/organ/eyes/night_vision/wild_goblin
 	eyes.Insert(src)
 	if(src.charflaw)
 		QDEL_NULL(src.charflaw)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -151,6 +151,12 @@
 	name = "undead eyes"
 	desc = ""
 
+/obj/item/organ/eyes/night_vision/zombie/on_life()
+	. = ..()
+	if (!(owner.mob_biotypes & MOB_UNDEAD))
+		if (prob(10))
+			owner.adjustToxLoss(0.2)
+
 /obj/item/organ/eyes/night_vision/werewolf
 	name = "moonlight eyes"
 	desc = ""

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -166,6 +166,17 @@
 	desc = ""
 	icon_state = "burning_eyes"
 
+/obj/item/organ/eyes/night_vision/wild_goblin
+	name = "wild goblin eyes"
+	desc = "What manner of madness have these reddened orbs espied in the darker places of the realm?"
+	icon_state = "burning_eyes"
+
+/obj/item/organ/eyes/night_vision/wild_goblin/on_life()
+	. = ..()
+	if (!istype(owner, /mob/living/carbon/human/species/goblin))
+		if (prob(10))
+			owner.adjustToxLoss(0.2)
+
 /obj/item/organ/eyes/night_vision/mushroom
 	name = "fung-eye"
 	desc = ""


### PR DESCRIPTION
## About The Pull Request

Barber doctors making a business out of putting undead eyes on people is wonderfully thematic, but full night vision is a pretty strong thing to have with no downsides.

So, I've added one.

Non-undead creatures with undead eyes will suffer a very slow poisoning effect that should make them need to manage it over the course of a round with leech use, slow, ongoing healing potion consumption, or periodically visiting a nearby priest.

It will not kill you immediately or even quickly - I don't want to discourage people from doing this still, I just want them to have to engage with other game mechanics to support it.

## Why It's Good For The Game

More mechanical interactions are a good thing!