### PR TITLE
Add Borrowed Time spell to Necra (replaces Burial Rites)

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -75,7 +75,7 @@
 	desc = "Veiled Lady of the underworld, equally feared and respected by mortals. She taught mortals the inevitability of death and cares for them as they reach the afterlife.."
 	worshippers = "The Dead, Mourners, Gravekeepers"
 	mob_traits = list(TRAIT_SOUL_EXAMINE)
-	t1 = /obj/effect/proc_holder/spell/targeted/burialrite
+	t1 = /obj/effect/proc_holder/spell/invoked/avert
 	t2 = /obj/effect/proc_holder/spell/targeted/churn
 	t3 = /obj/effect/proc_holder/spell/targeted/soulspeak
 	confess_lines = list(

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -184,6 +184,13 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/devotion_cost = 0
 	var/ignore_cockblock = FALSE //whether or not to ignore TRAIT_SPELLCOCKBLOCK
 
+	//AZURE EDIT: spell charging notifications
+	var/cast_start_msg // What we show when we start channeling (or don't)
+	var/cast_start_msg_self
+	var/cast_full_msg // What we show when we're fully charged
+	var/cast_full_msg_self
+	//AZURE EDIT END
+
 	action_icon_state = "spell0"
 	action_icon = 'icons/mob/actions/roguespells.dmi'
 	action_background_icon_state = ""
@@ -399,6 +406,10 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 /obj/effect/proc_holder/spell/proc/start_recharge()
 	recharging = TRUE
+	//AZURE ADDITION: recharge/casting messages
+	if (cast_start_msg && cast_start_msg_self)
+		ranged_ability_user.visible_message(span_warning(cast_start_msg), span_notice(cast_start_msg_self))
+	//AZURE ADDITION END
 
 /obj/effect/proc_holder/spell/process()
 	if(recharging && charge_type == "recharge" && (charge_counter < charge_max))
@@ -407,6 +418,10 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			action.UpdateButtonIcon()
 			charge_counter = charge_max
 			recharging = FALSE
+			//AZURE ADDITION: recharge/casting messages
+			if (cast_full_msg && cast_full_msg_self)
+				ranged_ability_user.visible_message(span_warning(cast_full_msg), span_notice(cast_full_msg_self))
+			//AZURE ADDITION END
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = TRUE, mob/user = usr) //if recharge is started is important for the trigger spells
 	before_cast(targets, user = user)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -184,13 +184,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/devotion_cost = 0
 	var/ignore_cockblock = FALSE //whether or not to ignore TRAIT_SPELLCOCKBLOCK
 
-	//AZURE EDIT: spell charging notifications
-	var/cast_start_msg // What we show when we start channeling (or don't)
-	var/cast_start_msg_self
-	var/cast_full_msg // What we show when we're fully charged
-	var/cast_full_msg_self
-	//AZURE EDIT END
-
 	action_icon_state = "spell0"
 	action_icon = 'icons/mob/actions/roguespells.dmi'
 	action_background_icon_state = ""
@@ -406,10 +399,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 /obj/effect/proc_holder/spell/proc/start_recharge()
 	recharging = TRUE
-	//AZURE ADDITION: recharge/casting messages
-	if (cast_start_msg && cast_start_msg_self)
-		ranged_ability_user.visible_message(span_warning(cast_start_msg), span_notice(cast_start_msg_self))
-	//AZURE ADDITION END
 
 /obj/effect/proc_holder/spell/process()
 	if(recharging && charge_type == "recharge" && (charge_counter < charge_max))
@@ -418,10 +407,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			action.UpdateButtonIcon()
 			charge_counter = charge_max
 			recharging = FALSE
-			//AZURE ADDITION: recharge/casting messages
-			if (cast_full_msg && cast_full_msg_self)
-				ranged_ability_user.visible_message(span_warning(cast_full_msg), span_notice(cast_full_msg_self))
-			//AZURE ADDITION END
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = TRUE, mob/user = usr) //if recharge is started is important for the trigger spells
 	before_cast(targets, user = user)

--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -52,8 +52,6 @@
 		else
 			to_chat(span_warning("My devotion runs dry - the Intercession fades from my lips!"))
 			break
-		
-		health_adjust = get_health_bonus(living_target.health, living_target.maxHealth)
 	
 	REMOVE_TRAIT(living_target, TRAIT_NODEATH, "avert_spell")
 

--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -1,0 +1,60 @@
+// T1: Avert End (channel on an adjacent target to slowly spend devotion to grant them NODEATH and ticks of oxyloss healing)
+
+/obj/effect/proc_holder/spell/invoked/avert
+	name = "Borrowed Time"
+	desc = "Shield your fellow man from the Undermaiden's gaze, preventing them from slipping into death for as long as your faith and fatigue may muster."
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	associated_skill = /datum/skill/magic/holy
+	miracle = TRUE
+	devotion_cost = 10
+	var/list/near_death_lines = list(
+		"A haze begins to envelop me, but then suddenly recedes, as if warded back by some great light...",
+		"A terrible weight bears down upon me, as if the wyrld itself were crushing me with its heft...",
+		"The sound of a placid river drifts into hearing, followed by the ominous toll of a ferryman's bell...",
+		"Some vast, immeasurably distant figure looms beyond my perception - I feel it, more than I see. It waits. It watches.",
+	)
+
+/obj/effect/proc_holder/spell/invoked/avert/cast(list/targets, mob/living/carbon/human/user)
+	. = ..()
+	var/atom/target = targets[1]
+	if (!isliving(target))
+		revert_cast()
+		return FALSE
+
+	var/mob/living/living_target = target
+	if (!user.Adjacent(target))
+		to_chat(user, span_warning("I must be beside [living_target] to avert Her gaze from [living_target.p_them()]!"))
+		revert_cast()
+		return FALSE
+	
+	// add the no-death trait to them....
+	user.visible_message(span_notice("Whispering motes gently bead from [user]'s fingers as [user.p_they()] place a hand near [living_target], scriptures of the Undermaiden spilling from their lips..."), span_notice("I stand beside [living_target] and utter the hallowed words of Aeon's Intercession, staying Her grasp for just a little while longer..."))
+	to_chat(user, span_small("I must remain still and at [living_target]'s side..."))
+	to_chat(living_target, span_warning("An odd sensation blossoms in my chest, cold and unknown..."))
+
+	ADD_TRAIT(living_target, TRAIT_NODEATH, "avert_spell")
+
+	var/our_holy_skill = user.mind?.get_skill_level(associated_skill)
+	var/tickspeed = 30 + (5 * our_holy_skill)
+
+	while (do_after(user, tickspeed, target = living_target))
+		user.rogfat_add(2.5)
+
+		living_target.adjustOxyLoss(-10)
+		living_target.blood_volume = max((BLOOD_VOLUME_SURVIVE * 1.5), living_target.blood_volume)
+
+		if (living_target.health <= 5)
+			if (prob(5))
+				to_chat(living_target, span_small(pick(near_death_lines)))
+
+		if (user.devotion?.check_devotion(src))
+			user.devotion?.update_devotion(-10)
+		else
+			to_chat(span_warning("My devotion runs dry - the Intercession fades from my lips!"))
+			break
+		
+		health_adjust = get_health_bonus(living_target.health, living_target.maxHealth)
+	
+	REMOVE_TRAIT(living_target, TRAIT_NODEATH, "avert_spell")
+
+	user.visible_message(span_danger("[user]'s concentration breaks, the motes receding from [living_target] and into [user.p_their()] hand once more."), span_danger("My concentration breaks, and the Intercession falls silent."))

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3592,6 +3592,7 @@
 #include "modular_azurepeak\code\modules\mob\living\simple_animal\rogue\creacher\gethsmane.dm"
 #include "modular_azurepeak\code\modules\mob\living\simple_animal\rogue\creacher\newminotaur.dm"
 #include "modular_azurepeak\code\modules\spells\orison.dm"
+#include "modular_azurepeak\code\modules\spells\pantheon\divine\necra.dm"
 #include "modular_azurepeak\statpacks\agile.dm"
 #include "modular_azurepeak\statpacks\mental.dm"
 #include "modular_azurepeak\statpacks\physical.dm"


### PR DESCRIPTION
## About The Pull Request

I felt a little bad with Zizo getting all of the cool shit and Necra's still out here with like, two broken spells, so. I'm mulling over changes to Churn and a suitable t3 replacement for Necra still, but this'll do as a stopgap.

Replaces Burial Rites with a new Borrowed Time spell.

Borrowed Time allows you to channel a steady flow of fatigue and devotion into an adjacent target, during which time, they physically cannot die. They gain the NODEATH trait and have their blood set to a minimum-survivable level every tick, alongside a big wad of oxyloss healing. You can use this on people who are very alive too, for whatever reason - and this is entirely intentional. I'm sure some of you will find interesting (and horrible) ways to exploit selective invulnerability for your amusement and the detriment of others.

Note: being immune to death does not make you immune to being horribly maimed.

Your skill in miracles makes each tick last longer, which reduces the overall fatigue and devotion consumption.

## Why It's Good For The Game

Necra's had two busted spells for like a solid year at this point. Now she only has one!
