### PR TITLE
Fetch improvements: caster can catch items

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -526,6 +526,11 @@
 	else
 		if(isitem(target))
 			var/obj/item/I = target
+			var/mob/living/carbon/human/carbon_firer
+			if (ishuman(firer))
+				carbon_firer = firer
+				if (carbon_firer?.can_catch_item())
+					throw_target = get_turf(firer)
 			I.throw_at(throw_target, 200, 4)
 
 /obj/projectile/magic/sickness


### PR DESCRIPTION
## About The Pull Request

Really simple: if you have CATCH mode enabled while casting Fetch at an item, you will attempt to catch whatever you're trying to fetch. Note: throw_at is not perfect, especially on diagonals. 

If you cannot catch it, it will be thrown at you directly instead. Be smart.

## Why It's Good For The Game

Sick wizard parkour. Makes fetch 100% more cool.
