### PR TITLE
The Beggarocalypse: squash beggar into a vagabond advclass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
@@ -3,8 +3,8 @@
 	flag = BEGGAR
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = -1
-	spawn_positions = -1
+	total_positions = 0
+	spawn_positions = 0
 
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = ALL_AGES_LIST

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/beggar.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/beggar.dm
@@ -1,0 +1,58 @@
+/datum/advclass/vagabond_beggar
+	name = "Beggar"
+	tutorial = "You are without coin and without worth. The pity of others is your bread, and their mercy is your butter. Having sat by waystones and watched many a traveller pass in the hopes for alms, you've nursed a surprising talent for thievery, and have even cajoled knowledge of lockpicking out of an especially sentimental rogue."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/vagabond/beggar
+	category_tags = list(CTAG_VAGABOND)
+
+/datum/outfit/job/roguetown/vagabond/beggar/pre_equip(mob/living/carbon/human/H)
+	..()
+	if(prob(20))
+		head = /obj/item/clothing/head/roguetown/knitcap
+
+	if(prob(5))
+		beltr = /obj/item/reagent_containers/powder/moondust
+
+	if(prob(10))
+		beltl = /obj/item/clothing/mask/cigarette/rollie/cannabis
+
+	if(prob(10))
+		cloak = /obj/item/clothing/cloak/raincloak/brown
+
+	if(H.gender == FEMALE)
+		armor = /obj/item/clothing/suit/roguetown/shirt/rags
+	else
+		armor = null
+		pants = /obj/item/clothing/under/roguetown/tights/vagrant
+
+		if(prob(50))
+			pants = /obj/item/clothing/under/roguetown/tights/vagrant/l
+
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
+
+		if(prob(50))
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant/l
+
+	if(prob(5))
+		r_hand = /obj/item/rogueweapon/mace/woodclub
+	else
+		r_hand = null
+
+	if(prob(5))
+		l_hand = /obj/item/rogueweapon/mace/woodclub
+	else
+		l_hand = null
+
+	if (H.mind)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, rand(1,5), TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, rand(1,5), TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, pick (1,2,3,4,5), TRUE)
+		H.STALUC = rand(5, 15)
+		H.change_stat("strength", -1)
+		H.change_stat("intelligence", -4)
+		H.change_stat("constitution", -3)
+		H.change_stat("endurance", -3)
+		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_NASTY_EATER, TRAIT_GENERIC)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3579,6 +3579,7 @@
 #include "modular_azurepeak\code\game\objects\structures\fartravel.dm"
 #include "modular_azurepeak\code\modules\clothing\rogueclothes\cloaks.dm"
 #include "modular_azurepeak\code\modules\clothing\rogueclothes\hats.dm"
+#include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\beggar.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\courier.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\destitute_scholar.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\excommunicado.dm"


### PR DESCRIPTION
## About The Pull Request

Translates the Beggar job into a Vagabond subclass and makes the actual Beggar job not selectable at roundstart anymore.

I didn't bother porting the wise beggar thing since I don't think a single soul will miss it. Applied STALUC clamping to 5-15 instead of 1-20 as per the original vagabond rework, everything else is unchanged.

## Why It's Good For The Game

This is more or less an organizational refactor thing. Little functional change outside of making the job selection screen slightly less cluttered.