### PR TITLE
Minor Zizo fixes + Zizo-summoned skeletons are friendly to the Cabal

### DIFF
--- a/code/datums/gods/_patron.dm
+++ b/code/datums/gods/_patron.dm
@@ -40,9 +40,13 @@ GLOBAL_LIST_EMPTY(preference_patrons)
 		ADD_TRAIT(pious, trait, "[type]")
 	if(HAS_TRAIT(pious, TRAIT_XYLIX))
 		pious.grant_language(/datum/language/thievescant)
+	if (HAS_TRAIT(pious, TRAIT_CABAL))
+		pious.faction |= "cabal"
 
 /datum/patron/proc/on_loss(mob/living/pious)
-	for(var/trait in mob_traits)
-		REMOVE_TRAIT(pious, trait, "[type]")
+	if (HAS_TRAIT(pious, TRAIT_CABAL))
+		pious.faction -= "cabal"
 	if(HAS_TRAIT(pious, TRAIT_XYLIX))
 		pious.remove_language(/datum/language/thievescant)
+	for(var/trait in mob_traits)
+		REMOVE_TRAIT(pious, trait, "[type]")

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -101,10 +101,12 @@
 			return pick('sound/vo/mobs/skel/skeleton_idle (1).ogg','sound/vo/mobs/skel/skeleton_idle (2).ogg','sound/vo/mobs/skel/skeleton_idle (3).ogg')
 
 
-/mob/living/simple_animal/hostile/rogue/skeleton/Initialize(mapload, mob/user)
+/mob/living/simple_animal/hostile/rogue/skeleton/Initialize(mapload, mob/user, cabal_affine = FALSE)
 	. = ..()
 	if(user)
 		friends += user.name
+		if (cabal_affine)
+			faction |= "cabal"
 
 /mob/living/simple_animal/hostile/rogue/skeleton/Life()
 	. = ..()
@@ -117,25 +119,27 @@
 	GiveTarget(user)
 	return
 
+/mob/living/simple_animal/hostile/rogue/skeleton/proc/can_control(mob/user)
+	if(!(user.mind?.has_antag_datum(/datum/antagonist/lich)))
+		return FALSE
+	if (!(user.name in friends))
+		return FALSE
+	
+	return TRUE
+
 /mob/living/simple_animal/hostile/rogue/skeleton/beckoned(mob/user)
-	if(!user.mind)
+	if (can_control(user))
+		for(var/mob/living/simple_animal/hostile/rogue/skeleton/target in viewers(user))
+			target.LoseTarget()
+			target.search_objects = 2
+			target.add_overlay("peace_overlay")
 		return
-	if(!(user.mind.has_antag_datum(/datum/antagonist/lich)))
-		return
-	for(var/mob/living/simple_animal/hostile/rogue/skeleton/target in viewers(user))
-		target.LoseTarget()
-		target.search_objects = 2
-		target.add_overlay("peace_overlay")
-	return
 
 /mob/living/simple_animal/hostile/rogue/skeleton/shood(mob/user)
-	if(!user.mind)
+	if (can_control(user))
+		for(var/mob/living/simple_animal/hostile/rogue/skeleton/target in viewers(user))
+			target.RegainSearchObjects()
 		return
-	if(!(user.mind.has_antag_datum(/datum/antagonist/lich)))
-		return
-	for(var/mob/living/simple_animal/hostile/rogue/skeleton/target in viewers(user))
-		target.RegainSearchObjects()
-	return
 
 /mob/living/simple_animal/hostile/rogue/skeleton/RegainSearchObjects(value)
 	cut_overlay("peace_overlay")

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -104,16 +104,13 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/Initialize(mapload, mob/user)
 	. = ..()
 	if(user)
-		friends += user
+		friends += user.name
 
 /mob/living/simple_animal/hostile/rogue/skeleton/Life()
 	. = ..()
 	if(!target)
 		if(prob(60))
 			emote(pick("idle"), TRUE)
-
-
-
 
 /mob/living/simple_animal/hostile/rogue/skeleton/taunted(mob/user)
 	emote("aggro")

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -116,6 +116,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	charge_max = 60 SECONDS
+	var/cabal_affine = FALSE
 
 /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/cast(list/targets, mob/living/user)
 	. = ..()
@@ -124,15 +125,15 @@
 	if(isopenturf(T))
 		switch(skeleton_roll)
 			if(1 to 20)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T, user)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T, user, cabal_affine)
 			if(21 to 40)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T, user)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T, user, cabal_affine)
 			if(41 to 60)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T, user)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T, user, cabal_affine)
 			if(61 to 80)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T, user)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T, user, cabal_affine)
 			if(81 to 100)
-				new /mob/living/simple_animal/hostile/rogue/skeleton(T, user)
+				new /mob/living/simple_animal/hostile/rogue/skeleton(T, user, cabal_affine)
 		return TRUE
 	else
 		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -90,6 +90,7 @@
 /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/miracle
 	miracle = TRUE
 	devotion_cost = 75
+	cabal_affine = TRUE
 
 // T3: Rituos (usable once per sleep cycle, allows you to choose any 1 arcane spell to use for the duration w/ an associated devotion cost. each time you change it, 1 of your limbs is skeletonized, if all of your limbs are skeletonized, you gain access to arcane magic. continuing to use rituos after being fully skeletonized gives you additional spellpoints). Gives you the MOB_UNDEAD flag (needed for skeletonize to work) on first use.
 

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -206,6 +206,7 @@
 	if (post_rituos)
 		//everything but our head is skeletonized now, so grant them journeyman rank and 3 extra spellpoints to grief people with
 		user.mind?.adjust_skillrank(/datum/skill/magic/arcane, 3, TRUE)
+		user.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		user.mind?.adjust_spellpoints(3)
 		user.visible_message(span_boldwarning("[user]'s form swells with terrible power as they cast away almost all of the remnants of their mortal flesh, arcyne runes glowing upon their exposed bones..."), span_notice("I HAVE DONE IT! I HAVE COMPLETED HER LESSER WORK! I stand at the cusp of unspeakable power, but something is yet missing..."))
 		if (prob(33))

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -191,6 +191,7 @@
 		to_chat(user, span_smallred("I have forsaken the living. I am now closer to a deadite than a mortal... but I still yet draw breath and bleed."))
 	
 	part_to_bonify.skeletonize(FALSE)
+	user.update_body_parts()
 	user.visible_message(span_warning("Faint runes flare beneath [user]'s skin before [user.p_their()] flesh suddenly slides away from [user.p_their()] [part_to_bonify.name]!"), span_notice("I feel arcyne power surge throughout my frail mortal form, as the Rituos takes its terrible price from my [part_to_bonify.name]."))
 
 	if (user.mind?.rituos_spell)


### PR DESCRIPTION
## About The Pull Request

Fixes Rituos not updating body parts after the skeletonization process (visually, the underlying logic was fine).

Also fixes summoned skeletons not considering their summoners as friends. This has been broken in roguecode for possibly years before now.

In addition, skeletons summoned via Raise Lesser Undead will not be hostile to all Zizoites if their summoner is also of Zizo. This does not affect existing map-spawned skeletons in any way.

Rituos completion also grants access to Prestidigitation as well.

## Why It's Good For The Game

Zizo work good. Skeleton changes let the Cabal form creepy... well, cabals, allowing them to make spontaneous dungeons to endanger other wayward souls for fun and profit.
