### PR TITLE
Infection & improvised surgery updates

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -20,6 +20,8 @@
 #define TOOL_SAW			"saw"
 #define TOOL_BONESETTER		"bonesetter"
 #define TOOL_SUTURE			"suture"
+#define TOOL_IMPROVISED_RETRACTOR "improvised_retractor"
+#define TOOL_IMPROVISED_HEMOSTAT "improvised_hemostat"
 
 // If delay between the start and the end of tool operation is less than MIN_TOOL_SOUND_DELAY,
 // tool sound is only played when op is started. If not, it's played twice.

--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -132,6 +132,7 @@
 	blade_dulling = 0
 	max_integrity = 20
 	static_debris = null
+	tool_behaviour = TOOL_IMPROVISED_RETRACTOR
 	obj_flags = null
 	w_class = WEIGHT_CLASS_SMALL
 	twohands_required = FALSE

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -159,3 +159,46 @@
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()
 	return ..()
+
+/datum/reagent/infection
+	name = "excess choleric humour"
+	description = "Red-yellow pustulence - the carrier of disease, the enemy of all Pestrans."
+	reagent_state = LIQUID
+	color = "#dfe36f"
+	metabolization_rate = 0.1
+	var/damage_tick = 0.3
+	var/lethal_fever = FALSE
+	var/fever_multiplier = 1
+
+/datum/reagent/infection/on_mob_life(mob/living/carbon/M)
+	var/heat = (BODYTEMP_AUTORECOVERY_MINIMUM + clamp(volume, 3, 15)) * fever_multiplier
+	M.adjustToxLoss(damage_tick, 0)
+	if (lethal_fever)
+		M.adjust_bodytemperature(heat, 0)
+		if (prob(5))
+			to_chat(M, span_warning("A wicked heat settles within me... I feel ill. Very ill."))
+	else
+		M.adjust_bodytemperature(heat, 0, BODYTEMP_HEAT_DAMAGE_LIMIT - 1)
+		if (prob(5))
+			to_chat(M, span_warning("I feel a horrible chill despite the sweat rolling from my brow..."))
+	return ..()
+
+/datum/reagent/infection/minor
+	name = "disrupted choleric humor"
+	description = "Symptomatic of disrupted humours."
+	damage_tick = 0.1
+	lethal_fever = FALSE
+
+/datum/reagent/infection/major
+	name = "excess melancholic humour"
+	description = "Kingsfield's Bane. Excess melancholic has killed thousands, and even Pestra's greatest struggle against its insidious advance."
+	damage_tick = 1
+	lethal_fever = TRUE
+	fever_multiplier = 3
+
+/datum/reagent/infection/major/on_mob_life(mob/living/carbon/M)
+	if (prob(2))
+		M.reagents.add_reagent(src, rand(1,3))
+		to_chat(M, span_small("I feel even worse..."))
+	return ..()
+	

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -197,7 +197,7 @@
 	fever_multiplier = 3
 
 /datum/reagent/infection/major/on_mob_life(mob/living/carbon/M)
-	if (prob(2))
+	if (M.badluck(1))
 		M.reagents.add_reagent(src, rand(1,3))
 		to_chat(M, span_small("I feel even worse..."))
 	return ..()

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -145,6 +145,7 @@
 	//dropshrink = 0.8
 	wlength = 10
 	slot_flags = ITEM_SLOT_HIP
+	tool_behaviour = TOOL_IMPROVISED_HEMOSTAT
 	associated_skill = null
 	var/obj/item/ingot/hingot = null
 	var/hott = FALSE

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -166,8 +166,13 @@
 					has_rot = TRUE
 					break
 		if(!has_rot)
-			to_chat(user, span_warning("Nothing happens."))
-			return FALSE
+			if (target.reagents.has_reagent(/datum/reagent/infection/major))
+				target.reagents.remove_reagent(/datum/reagent/infection/major, rand(5,10))
+				to_chat(user, span_notice("I settle some of [target]'s excess melancholic humour."))
+				return TRUE
+			else
+				to_chat(user, span_warning("Nothing happens."))
+				return FALSE
 		if(GLOB.tod == "night")
 			to_chat(user, span_warning("Let there be light."))
 		for(var/obj/structure/fluff/psycross/S in oview(5, user))

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -20,11 +20,11 @@
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/human_target = targets[1]
 		human_target.check_for_injuries(user)
-		
+
 		if (human_target.reagents.has_reagent(/datum/reagent/infection/major))
 			to_chat(user, span_boldwarning("Streaks of black and yellow doubtlessly indicate an excess of melancholic humour."))
 		else if (human_target.reagents.has_reagent(/datum/reagent/infection))
-			to_chat(user, span_warning("[user.p_Their()] flesh is reddened and inflamed, their brow flecked with sweat. Excess choleric, perhaps?"))
+			to_chat(user, span_warning("Reddened and inflamed flesh accompanied by a brow flecked with sweat. Excess choleric, perhaps?"))
 		else if (human_target.reagents.has_reagent(/datum/reagent/infection/minor))
 			to_chat(user, span_warning("A slight yellowing indicates the barest presence of disrupted choleric humor."))
 		

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -20,6 +20,14 @@
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/human_target = targets[1]
 		human_target.check_for_injuries(user)
+		
+		if (human_target.reagents.has_reagent(/datum/reagent/infection/major))
+			to_chat(user, span_boldwarning("Streaks of black and yellow doubtlessly indicate an excess of melancholic humour."))
+		else if (human_target.reagents.has_reagent(/datum/reagent/infection))
+			to_chat(user, span_warning("[user.p_Their()] flesh is reddened and inflamed, their brow flecked with sweat. Excess choleric, perhaps?"))
+		else if (human_target.reagents.has_reagent(/datum/reagent/infection/minor))
+			to_chat(user, span_warning("A slight yellowing indicates the barest presence of disrupted choleric humor."))
+		
 		return TRUE
 	return FALSE
 

--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -369,6 +369,13 @@
 	display_results(user, target, span_warning("I screw up!"),
 		span_warning("[user] screws up!"),
 		span_notice("[user] finishes."), TRUE) //By default the patient will notice if the wrong thing has been cut
+	switch (success_prob)
+		if (0 to 15)
+			target.reagents.add_reagent(/datum/reagent/infection/major, rand(2,5))
+		if (16 to 50)
+			target.reagents.add_reagent(/datum/reagent/infection, rand(1,3))
+		if (51 to 70)
+			target.reagents.add_reagent(/datum/reagent/infection/minor, rand(1,6))
 	return TRUE
 
 /datum/surgery_step/proc/play_failure_sound(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/surgeries/organic_steps.dm
+++ b/code/modules/surgery/surgeries/organic_steps.dm
@@ -36,6 +36,7 @@
 	implements = list(
 		TOOL_HEMOSTAT = 75,
 		TOOL_WIRECUTTER = 60,
+		TOOL_IMPROVISED_HEMOSTAT = 38,
 	)
 	time = 2.4 SECONDS
 	surgery_flags_blocked = SURGERY_CLAMPED
@@ -64,6 +65,7 @@
 		TOOL_RETRACTOR = 75,
 		TOOL_SCREWDRIVER = 50,
 		TOOL_WIRECUTTER = 35,
+		TOOL_IMPROVISED_RETRACTOR = 38,
 	)
 	time = 2.4 SECONDS
 	surgery_flags_blocked = SURGERY_RETRACTED


### PR DESCRIPTION
## About The Pull Request

Does a few things:
- Tongs (inc. stone) and stakes are usable as improvised retractors and improvised hemostats respectively, at a low success chance.
- Failing surgery steps adds a simulated infection reagent to your patient/victim that slowly poisons them over time, scaling depending on how bad your success chances are at that particular step.
- Infection causes slow ticks of toxin damage over time and raises your temperature relative to how much infection you have in you.
- Major infections can raise your body temperature to levels where it can kill you.
- Major infections can also potentially self-sustain themselves in you if you're very unlucky, so take care of your Fortune levels when you think you're super sick (indulge your vices, handle your stress, etc).
- The Cure Rot miracle for Pestran clerics/devotionists is the only thing that can cure major infections outside of time, and it ONLY cures major infections.
- Diagnosis miracles (secular and otherwise) show the presence of the worst form of infection present in a target. They can have multiple simultaneously, beware.

Remember, leeches are your friend. Infections don't kill especially fast (except major infections, which kill at about 1/3 the speed of berry poison). You can likely sleep most of them off.

## Why It's Good For The Game

Allows for bootleg field surgery to be undertaken more readily and adds appropriately themely consequences for doing so. Also adds a very basic form of infection that we can use for other stuff.
