### PR TITLE
RCP Gives Up To 10 PQ

### DIFF
--- a/code/modules/admin/playerquality.dm
+++ b/code/modules/admin/playerquality.dm
@@ -248,7 +248,7 @@
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(json))
 
-	if(get_playerquality(key) > 10)
+	if(curcomm < 100 || get_playerquality(key) < 10)
 		adjust_playerquality(round(amt/10,0.1), ckey(key))
 
 /proc/get_roundpoints(key)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
@@ -16,6 +16,7 @@
 	show_in_credits = FALSE
 	min_pq = -30
 	max_pq = null
+	round_contrib_points = 2
 
 	cmode_music = 'sound/music/combat_bum.ogg'
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -754,7 +754,7 @@ GLOBAL_VAR_INIT(mobids, 1)
 				stat("Round End: [DisplayTimeText(time_left)]")
 			stat("TimeOfDay: [GLOB.tod]")
 
-	if(client && client.holder && check_rights(R_ADMIN,0))
+	if(client && client.holder && check_rights(R_DEBUG,0))
 		if(statpanel("MC"))
 			var/turf/T = get_turf(client.eye)
 			stat("Location:", COORD(T))

--- a/strings/changelog.txt
+++ b/strings/changelog.txt
@@ -1,4 +1,4 @@
 Roleplay ads can be set in the OOC tabs. Toggle Roleplay Ads on to be notified of new postings.
 Critical hits have minimum damage thresholds.
 Loadout items can be selected in the character creation menu.
-Round Contribution Points (RCP) added to all roles apart from Adventurer. You will gain a tenth of that amount as PQ, up to 10 PQ, as long as you gain at least one triumph from sleeping and have joined at least 45 minutes before the end of the round.
+Round Contribution Points (RCP) added to all roles apart from Adventurer. You will gain a tenth of that amount as PQ up to a maximum of 10 in total, as long as you gain at least one triumph from sleeping and have joined at least 45 minutes before the end of the round.


### PR DESCRIPTION
okay so umm im a silly goober and RCP used to give you PQ only if you had *more* than 10 PQ. haha

ANYWAYS.

RCP will give you PQ if either of the conditions are valid:
- You have less than 10 PQ.
- You have less than 100 RCP.

Also gives vagabond 2 RCP.

And because I'm the worst person ever I'm making the MC tab accessible to coders through the debug flag instead of admin.