### PR TITLE
Lowers the crafting cost of Moondust and Ozium

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -22,7 +22,7 @@
 	name = "3x Ozium"
 	result = list(/obj/item/reagent_containers/powder/ozium)
 	reqs = list(/obj/item/ash = 3, /datum/reagent/berrypoison = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 2)
-	craftdiff = 2
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/moon
 	name = "Moondust"
@@ -34,7 +34,7 @@
 	name = "3x Moondust"
 	result = list(/obj/item/reagent_containers/powder/moondust)
 	reqs = list(/obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 2, /datum/reagent/berrypoison = 3)
-	craftdiff = 2
+	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/alchemy/salt
 	name = "Salt Pile"

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -15,13 +15,25 @@
 /datum/crafting_recipe/roguetown/alchemy/ozium
 	name = "Ozium"
 	result = list(/obj/item/reagent_containers/powder/ozium)
-	reqs = list(/obj/item/ash = 2, /datum/reagent/berrypoison = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 2)
+	reqs = list(/obj/item/ash = 2, /datum/reagent/berrypoison = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 1)
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/alchemy/ozium
+	name = "3x Ozium"
+	result = list(/obj/item/reagent_containers/powder/ozium)
+	reqs = list(/obj/item/ash = 3, /datum/reagent/berrypoison = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry = 2)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/moon
 	name = "Moondust"
 	result = list(/obj/item/reagent_containers/powder/moondust)
-	reqs = list(/obj/item/ash = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 2, /datum/reagent/berrypoison = 2)
+	reqs = list(/obj/item/ash = 2, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 1, /datum/reagent/berrypoison = 2)
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/alchemy/moon
+	name = "3x Moondust"
+	result = list(/obj/item/reagent_containers/powder/moondust)
+	reqs = list(/obj/item/ash = 3, /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry = 2, /datum/reagent/berrypoison = 3)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/salt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Lowers the cost of crafting:
Ozium (From 2 ash, 0,66 Oz of Berry Poison, 2 swampweed to 2 ash, 0,66 Oz of Berry Poison, 1 swampweed)
Moondust (From 2 ash, 0,66 Oz of Berry Poison, 2 pipe leaf to 2 ash, 0,66 Oz of Berry Poison, 1 pipe leaf)

And adds bulk crafting recipes for them, with costs of:
3 ash, 1 Oz of berry poison, two swampweeds for Ozium
3 ash, 1 Oz of berry poison, two pipe leaves for Moondust.

## Why It's Good For The Game

Crafting drugs has not been done  a lot (If at all) due to the merchant selling them for VERY cheap. This hopefully will make it so that producing drugs by yourself is more enticing instead of a waste of time, also also makes it so that you don't need to have a garden as an alchemist to make drugs, foraging will give you all you need, baby!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
