### PR TITLE
Allow all char age ranges for Vagabond

### DIFF
--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/vagabond.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/vagabond.dm
@@ -2,6 +2,7 @@
 	tutorial = "The world is not a kind place, and many have lost everything in the pursuit of even a meagre existence. Vagabonds are such individuals, and start with next to nothing but their skills and wits."
 	outfit = null
 	outfit_female = null
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 
 	advclass_cat_rolls = list(CTAG_VAGABOND = 20)
 	wanderer_examine = TRUE


### PR DESCRIPTION
## About The Pull Request

The orphan job Vagabond is derived from was previously only accessible for adult chars - it's now accessible for all of the older age ranges, too.

## Why It's Good For The Game

Self explanatory.