### PR TITLE
Improv surgery fixes & excommunicated adjustment

### DIFF
--- a/code/modules/surgery/surgeries/organ_manipulation.dm
+++ b/code/modules/surgery/surgeries/organ_manipulation.dm
@@ -164,7 +164,8 @@ GLOBAL_LIST_INIT(moldable_organs, list(BODY_ZONE_PRECISE_GROIN=list(ORGAN_SLOT_P
 	accept_hand = TRUE
 	implements = list(
 		TOOL_HEMOSTAT = 80,
-		TOOL_CROWBAR = 65
+		TOOL_CROWBAR = 65,
+		TOOL_IMPROVISED_HEMOSTAT = 40,
 	)
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	surgery_flags = SURGERY_INCISED | SURGERY_RETRACTED

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/excommunicado.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/excommunicado.dm
@@ -26,7 +26,8 @@
 
 	if (H.mind)
 		H.mind.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.change_stat("perception", 2)


### PR DESCRIPTION
## About The Pull Request

Just a quick fix to allow for organ manipulation with improvised hemostats, and gives Excommunicated vagabond acolyte-level medical skill for them to do things with.

## Why It's Good For The Game

Fixes and very basic rebalancing. Kind of weird that a cleric role had no medicine.