### PR TITLE
Peddlers prevent spoilage because ofc they should

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -117,7 +117,7 @@ All foods are distributed among various categories. Use common sense.
 /obj/item/reagent_containers/food/snacks/process()
 	..()
 	if(rotprocess)
-		if(!istype(loc, /obj/structure/closet/crate/chest))
+		if(!istype(loc, /obj/structure/closet/crate/chest) && !istype(loc, /obj/structure/roguemachine/vendor))
 			if(!locate(/obj/structure/table) in loc)
 				warming -= 20 //ssobj processing has a wait of 20
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
A tiny little line of code and now Peddlers will prevent spoilage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now food producers can sell their food without being constantly around to pull it from a chest. Allows cooks/innkeeps/farmers to provide their products while also making more products instead of leaving their food on the hearth to go serve the rush before their food burns. This feels like common sense--especially since Peddlers have a fairly limited capacity and can't completely replace a human vendor--rather, it helps fill the gaps when they get busy or serve up drinks while people self-serve food. Vendors still can't just fill it full and check out for the round, since they can only sell a handful of meals. 

Will benefit those in a hurry who would otherwise yell angrily for the innkeep, wait five seconds, then go and buy a bunch of apples and litter the cores in front of the stockpile. This won't hurt RP, because somebody who is just coming in for a quick bite won't usually stick around RP anything more than "How much for food?" and plonking down their coins, munching, and dipping.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
