### PR TITLE
Gives the wardens their own tower key

### DIFF
--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -1265,7 +1265,11 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "kv" = (
-/obj/structure/closet/crate/roguecloset/dark,
+/obj/structure/closet/crate/roguecloset/dark{
+	locked = 1;
+	lockid = "warden";
+	keylock = 1
+	},
 /obj/item/clothing/cloak/raincloak/furcloak/woad,
 /obj/item/clothing/cloak/raincloak/furcloak/woad,
 /obj/item/clothing/mask/rogue/wildguard,

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -244,6 +244,12 @@
 	icon_state = "plating2"
 	},
 /area/rogue/under/cave/dungeon1/gethsmane)
+"bP" = (
+/obj/structure/fluff/railing/fence{
+	dir = 8
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "bR" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -1184,6 +1190,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"jY" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "jZ" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /obj/machinery/conveyor/auto{
@@ -2098,6 +2108,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
+"ro" = (
+/obj/structure/fluff/railing/fence,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "rr" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -2757,6 +2771,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "wE" = (
+/obj/structure/handcart,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/woods)
 "wH" = (
@@ -3265,6 +3280,10 @@
 "Bj" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
+	},
+/obj/structure/fluff/railing/fence{
+	dir = 4;
+	icon_state = "fence"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods)
@@ -4335,7 +4354,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/woods)
 "Ko" = (
-/obj/structure/handcart,
+/obj/structure/fluff/railing/fence{
+	dir = 4;
+	icon_state = "fence"
+	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
 "Kp" = (
@@ -5802,6 +5824,13 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/shelter/woods)
+"Xd" = (
+/obj/structure/fluff/railing/fence{
+	dir = 4;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/woods)
 "Xf" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/naturalstone,
@@ -5929,6 +5958,14 @@
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane)
+"Yl" = (
+/obj/structure/fluff/railing/fence,
+/obj/structure/fluff/railing/fence{
+	dir = 4;
+	icon_state = "fence"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/woods)
 "Yo" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4;
@@ -48101,12 +48138,12 @@ nt
 nt
 nt
 Ut
-nt
-nt
-nt
-nt
-nt
-nt
+bP
+bP
+bP
+bP
+bP
+bP
 Ut
 jW
 jW
@@ -48264,7 +48301,7 @@ Vh
 nt
 nt
 nt
-jW
+jY
 jW
 jW
 nt
@@ -48421,7 +48458,7 @@ jW
 MK
 Vh
 nt
-nt
+ro
 jW
 jW
 nt
@@ -48571,14 +48608,14 @@ Yi
 Yi
 jW
 jW
-nt
+rl
 jW
 MK
 Vh
 Vh
 ew
-ew
-BO
+Vh
+ro
 nt
 jW
 jW
@@ -48735,7 +48772,7 @@ ew
 ew
 ew
 Vh
-BO
+ro
 nt
 jW
 jW
@@ -48884,7 +48921,7 @@ jW
 jW
 Yi
 MK
-Vh
+jW
 TH
 Vh
 ew
@@ -48892,7 +48929,7 @@ ew
 ew
 Vh
 nt
-nt
+ro
 jW
 nt
 nt
@@ -49049,7 +49086,7 @@ Vh
 Vh
 jW
 Vh
-nt
+ro
 jW
 nt
 nt
@@ -49206,7 +49243,7 @@ jW
 uW
 jW
 nt
-nt
+ro
 jW
 nt
 nt
@@ -49676,9 +49713,9 @@ Yi
 qF
 ou
 ou
+ro
 jW
 jW
-dA
 nt
 nt
 nt
@@ -49833,10 +49870,10 @@ jW
 jW
 jW
 jW
-nt
+ro
 nt
 jW
-nt
+Vy
 nt
 nt
 nt
@@ -49981,16 +50018,16 @@ Kv
 NU
 NU
 Bj
-jW
+Xd
 Ko
 MK
 MK
 MK
 MK
-MK
-jW
-jW
-nt
+Ko
+Xd
+Xd
+Yl
 nt
 jW
 nt
@@ -50138,7 +50175,7 @@ RR
 RR
 nt
 nt
-By
+jW
 MK
 MK
 jW
@@ -50452,7 +50489,7 @@ jW
 MK
 jW
 MK
-MK
+LA
 MK
 nt
 nt

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -1269,8 +1269,8 @@
 /obj/item/clothing/cloak/raincloak/furcloak/woad,
 /obj/item/clothing/cloak/raincloak/furcloak/woad,
 /obj/item/clothing/mask/rogue/wildguard,
-/obj/item/storage/keyring/guard,
 /obj/item/clothing/mask/rogue/wildguard,
+/obj/item/roguekey/warden,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "vertw"
@@ -2590,7 +2590,7 @@
 "vi" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "garrison";
+	lockid = "warden";
 	name = "warden's watchtower"
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -2888,7 +2888,7 @@
 "yb" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "garrison";
+	lockid = "warden";
 	name = "warden's watchtower"
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -5214,7 +5214,7 @@
 "Sc" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "garrison";
+	lockid = "warden";
 	name = "warden's watchtower"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -237,7 +237,7 @@
 	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/guard
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/warden)
 
 /obj/item/storage/keyring/guardcastle
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -96,6 +96,12 @@
 	icon_state = "spikekey"
 	lockid = "garrison"
 
+/obj/item/roguekey/warden
+	name = "watchtower key"
+	desc = "This key belongs to the wardens."
+	icon_state = "spikekey"
+	lockid = "warden"
+
 /obj/item/roguekey/dungeon
 	name = "dungeon key"
 	desc = "This key should unlock the rusty bars and doors of the dungeon."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This gives the warden their own 'watchtower' key and removes the extra garrison keys from the watchtower, replacing them with spare watchtower keys. 

The warden watchtower is now opened with a watchtower key as opposed to a garrison key.

I also threw a few palisades around the watchtower as well because I think they look cute. They don't really add a whole lot of security, in truth - I just like them.

## Why It's Good For The Game

There aren't many people that play warden; and the watchtower is often rushed early into the round and looted for the free garrison keys inside - which sucks. This should hopefully give people less incentive to break in near round start just to rush the free set of keys inside.

Wardens are still a part of the garrison and still spawn with garrison keys in their key ring as well as a watchtower key, so if there are any actually in the round antagonists can still mug them for their keys - this just prevents people from getting armory keys essentially for free without even needing to interact with anyone.