### PR TITLE
Desert Rider Sub-Classes Tweak 2

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -42,6 +42,8 @@
 			backl = /obj/item/rogueweapon/shield/wood
 			r_hand = /obj/item/rogueweapon/mace/steel
 			neck = /obj/item/clothing/neck/roguetown/chaincoif/full
+			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
 		if("Blade Dancer")
 			H.set_blindness(0)
 			to_chat(H, span_warning("Zybantian 'Blade Dancers' are famed and feared the world over. Their expertise in blades both long and short is well known..."))
@@ -65,16 +67,16 @@
 			H.change_stat("intelligence", 1)
 			H.change_stat("speed", 3)
 			backl = /obj/item/rogueweapon/sword/long/rider
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
+			armor = /obj/item/clothing/suit/roguetown/armor/chainmail
 
 	shoes = /obj/item/clothing/shoes/roguetown/shalal
-	head = /obj/item/clothing/head/roguetown/roguehood/shalal
+	mask = /obj/item/clothing/head/roguetown/roguehood/shalal
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	belt = /obj/item/storage/belt/rogue/leather/shalal
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	beltl = /obj/item/flashlight/flare/torch
-	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 
 	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/clothing/neck/roguetown/shalal)


### PR DESCRIPTION
## About The Pull Request
Alters the two Desert Rider subclasses to be more distinct.

## Why It's Good For The Game
After monitoring the two subclasses since their addition, and receiving player feedback, it was clear that a bit more work was needed to differentiate the two classes. This update changes their look, whilst also enforcing more distinct fighting styles to match the flavour of each class.

Specifically, the Blade Dancer's scalemail is replaced by light chain, whereas the Janissary's scalemail is reinforced by a heavy gambeson. Both classes retain the same traits, as this was requested after the first pull request I made. 

![DRs](https://github.com/user-attachments/assets/1362e288-8475-48b4-9d1a-5fc211497922)
(The top is the new loadout for Blade Dancer, the lower is the Janissary)