### PR TITLE
Orison blessings & miracle healing show special outlines

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -255,11 +255,21 @@
 	desc = "Divine intervention relieves me of my ailments."
 	icon_state = "buff"
 
+#define MIRACLE_HEALING_FILTER "miracle_heal_glow"
+
 /datum/status_effect/buff/healing
 	id = "healing"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/healing
 	duration = 10 SECONDS
+	examine_text = "SUBJECTPRONOUN is bathed in a restorative aura!"
 	var/healing_on_tick = 1
+	var/outline_colour = "#c42424"
+
+/datum/status_effect/buff/healing/on_apply()
+	var/filter = owner.get_filter(MIRACLE_HEALING_FILTER)
+	if (!filter)
+		owner.add_filter(MIRACLE_HEALING_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 60, "size" = 1))
+	return TRUE
 
 /datum/status_effect/buff/healing/tick()
 	var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(owner))
@@ -277,6 +287,9 @@
 	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, -healing_on_tick)
 	owner.adjustCloneLoss(-healing_on_tick, 0)
 
+/datum/status_effect/buff/healing/on_remove()
+	owner.remove_filter(MIRACLE_HEALING_FILTER)
+	
 /atom/movable/screen/alert/status_effect/buff/fortify
 	name = "Fortifying Miracle"
 	desc = "Divine intervention bolsters me and aids my recovery."
@@ -287,3 +300,4 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/fortify
 	duration = 1 MINUTES
 
+#undef MIRACLE_HEALING_FILTER

--- a/modular_azurepeak/code/modules/spells/orison.dm
+++ b/modular_azurepeak/code/modules/spells/orison.dm
@@ -1,3 +1,5 @@
+#define BLESSINGOFLIGHT_FILTER "bol_glow"
+
 /obj/effect/proc_holder/spell/targeted/touch/orison
 	name = "Orison"
 	overlay_state = "thaumaturgy"
@@ -88,6 +90,7 @@
 	status_type = STATUS_EFFECT_REFRESH
 	examine_text = "SUBJECTPRONOUN is surrounded by an aura of gentle light."
 	var/potency = 1
+	var/outline_colour = "#f5edda"
 	var/list/mobs_affected
 
 /datum/status_effect/light_buff/on_creation(mob/living/new_owner, light_power)
@@ -100,6 +103,9 @@
 
 /datum/status_effect/light_buff/on_apply()
 	to_chat(owner, span_notice("Light blossoms into being around me!"))
+	var/filter = owner.get_filter(BLESSINGOFLIGHT_FILTER)
+	if (!filter)
+		owner.add_filter(BLESSINGOFLIGHT_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 60, "size" = 1))
 	add_light(owner)
 	return TRUE
 
@@ -120,6 +126,7 @@
 
 /datum/status_effect/light_buff/on_remove()
 	to_chat(owner, span_notice("The miraculous light surrounding me has fled..."))
+	owner.remove_filter(BLESSINGOFLIGHT_FILTER)
 	remove_light(owner)
 
 /obj/item/melee/touch_attack/orison/proc/cast_light(atom/thing, mob/living/carbon/human/user)
@@ -334,3 +341,5 @@
 			return water_moisten
 	else
 		to_chat(user, span_info("I'll need to find a container that can hold water."))
+
+#undef BLESSINGOFLIGHT_FILTER


### PR DESCRIPTION
## About The Pull Request

At the request of dongwaiver from Discord, both blessings of light and healing miracles now show a slight outline around their target to indicate that they're active. In addition, healing miracles now also have a show line on examine.

Healing miracle:
![](https://puu.sh/KhPfF/12b356d1a7.png)

Light blessing:
![](https://puu.sh/KhPgE/033070ac2f.png)

## Why It's Good For The Game

Knowing what's happening to people on your screen at a glance is always a good thing.