### PR TITLE
Nymphomaniacs can sense each other's TENSION

### DIFF
--- a/code/datums/character_flaw/addiction.dm
+++ b/code/datums/character_flaw/addiction.dm
@@ -2,6 +2,14 @@
 /mob/living/carbon/human
 	var/datum/charflaw/charflaw
 
+/mob/proc/advance_addiction()
+	return
+
+/mob/living/carbon/human/advance_addiction(speedup)
+	if(istype(charflaw, /datum/charflaw/addiction))
+		var/datum/charflaw/addiction/A = charflaw
+		A.next_sate -= speedup SECONDS
+
 /mob/proc/sate_addiction()
 	return
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -457,6 +457,34 @@
 			if(-INFINITY to -5)
 				. += span_warning("<B>[t_He] look[p_s()] much weaker than I.</B>")
 
+		//The Nymphomaniac Underground
+		if((!appears_dead) && stat == CONSCIOUS && src.has_flaw(/datum/charflaw/addiction/lovefiend))
+			var/datum/charflaw/addiction/bonercheck = src.charflaw
+			if((bonercheck) && (bonercheck.sated == 0))
+				if(user.has_flaw(/datum/charflaw/addiction/lovefiend)) //Takes one to know one
+					switch(rand(1,5))
+						if(1)
+							. += span_love("I can sense [m2] <B>need</B> for a good time.")
+						if(2)
+							. += span_love("[m1] <B>aching</B> for a release.")
+						if(3)
+							. += span_love("A carnal hunger <B>stirs</B> within [m2] core.")
+						if(4)
+							. += span_love("I can practically hear the <B>thrum</B> of [m2] heartbeat.")
+						if(5)
+							. += span_love("Embers of desire <B>smolder</B> within [m2] eyes.")
+					user.advance_addiction(60) //Don't look now!
+				else if(Adjacent(user)) //No nympho, but close enough to notice.
+					switch(rand(1,4))
+						if(1)
+							. += span_love("[m1] blushing quite fiercely.")
+						if(2)
+							. += span_love("I can see [m2] face is flushed.")
+						if(3)
+							. += span_love("[m3] an odd way of breathing.")
+						if(4)
+							. += span_love("[m1] restless, for some reason.")
+
 	if(maniac)
 		var/obj/item/organ/heart/heart = getorganslot(ORGAN_SLOT_HEART)
 		if(heart?.inscryption && (heart.inscryption_key in maniac.key_nums))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

I thought it would be useful to let Nymphos sniff each other out. It happens IRL, or so I am told. Like a spider sense.

Adds a proc that will shorten next_sate, which makes addictions penalties arrive faster from stimuli.
People with Nympho can tell when another nympho is stressing through examine. It hastens their own stress's arrival by a minute.
Non-nymphos can also tell when adjacent, but their innocent minds can't quite spell it out for them.

I haven't touched BYOND code in close to a decade so this might be a runtime issue. Worked in my testing, but I can't even fathom the edge cases to think about for this. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

![image](https://github.com/user-attachments/assets/c933e2f9-bd13-4a42-a939-65a7b647de72)


## Why It's Good For The Game

Encourages spontaneous networking and content for nymphos. It's also pretty funny.

[https://www.youtube.com/watch?v=cW5BOWe3BQM](https://www.youtube.com/watch?v=cW5BOWe3BQM)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
