### PR TITLE
Older miracles properly return devotion & reset cooldown on failed cast

### DIFF
--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -39,6 +39,7 @@
 		else
 			to_chat(user, span_warning("You point at [O], but it fails to catch fire."))
 			return FALSE
+	revert_cast()
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/revive
@@ -102,6 +103,7 @@
 				ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 			target.mind.remove_antag_datum(/datum/antagonist/zombie)
 		return TRUE
+	revert_cast()
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/revive/cast_check(skipcharge = 0,mob/user = usr)

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -23,6 +23,7 @@
 		new /obj/item/clothing/head/peaceflower(T)
 		return TRUE
 	to_chat(user, "<span class='warning'>The targeted location is blocked. The flowers of Eora refuse to grow.</span>")
+	revert_cast()
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/eoracurse
@@ -49,4 +50,5 @@
 		target.visible_message("<span class='info'>A purple haze shrouds [target]!</span>", "<span class='notice'>I feel much calmer.</span>")
 		target.blur_eyes(10)
 		return TRUE
+	revert_cast()
 	return FALSE

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -152,6 +152,7 @@
 			target.adjustBruteLoss(-healing*10)
 			target.adjustFireLoss(-healing*10)
 		return TRUE
+	revert_cast()
 	return FALSE
 
 // Miracle
@@ -192,4 +193,5 @@
 			target.adjustBruteLoss(-50)
 			target.adjustFireLoss(-50)
 		return TRUE
+	revert_cast()
 	return FALSE

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -24,7 +24,9 @@
 			return FALSE
 		target.visible_message(span_warning("[user] points at [target]'s eyes!"),span_warning("My eyes are covered in darkness!"))
 		target.blind_eyes(2)
-	return TRUE
+		return TRUE
+	revert_cast()
+	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/invisibility
 	name = "Invisibility"
@@ -54,4 +56,6 @@
 		target.mob_timers[MT_INVISIBILITY] = world.time + 15 SECONDS
 		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), 15 SECONDS)
 		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), 15 SECONDS)
-	return TRUE
+		return TRUE
+	revert_cast()
+	return FALSE

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -29,6 +29,7 @@
 			to_chat(user, span_warning("A slight yellowing indicates the barest presence of disrupted choleric humor."))
 		
 		return TRUE
+	revert_cast()
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/diagnose/secular
@@ -135,6 +136,7 @@
 				limb.skeletonized = FALSE
 		human_target.update_body()
 		return TRUE
+	revert_cast()
 	return FALSE
 
 // Cure rot
@@ -212,6 +214,7 @@
 		else
 			target.visible_message(span_warning("The rot fails to leave [target]'s body!"), span_warning("I feel no different..."))
 		return TRUE
+	revert_cast()
 	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/cure_rot/cast_check(skipcharge = 0,mob/user = usr)


### PR DESCRIPTION
## About The Pull Request

We don't really use the spell pipeline properly in a lot of cases for most currently coded spells, so we rely on `revert_cast()` being called manually inside spell blocks to refund resources and reset cooldowns if a given target isn't supplied correctly.

I've gone through a bunch of the older miracles still in play and applied this behavior where appropriate.

tl;dr: most miracles will refund devotion and not go on cooldown if you target the wrong thing with them now.

## Why It's Good For The Game

Just a straight up quality of life thing.