### PR TITLE
Limit orison create water xp ticks and prevent orison from skilling above expert miracles

### DIFF
--- a/modular_azurepeak/code/modules/spells/orison.dm
+++ b/modular_azurepeak/code/modules/spells/orison.dm
@@ -46,7 +46,9 @@
 
 	var/obj/effect/proc_holder/spell/targeted/touch/orison/base_spell = attached_spell
 	if (user)
-		adjust_experience(user, base_spell.associated_skill, fatigue+attached_spell.devotion_cost)
+		var/skill_level = user.mind?.get_skill_level(attached_spell.associated_skill)
+		if (skill_level <= SKILL_LEVEL_EXPERT)
+			adjust_experience(user, base_spell.associated_skill, fatigue+attached_spell.devotion_cost)
 
 /obj/item/melee/touch_attack/orison/MiddleClick(mob/living/user, params)
 	. = ..()
@@ -323,7 +325,7 @@
 			if (prob(80))
 				playsound(user, 'sound/items/fillcup.ogg', 55, TRUE)
 		
-		return fatigue_spent
+		return min(50, fatigue_spent)
 	else if (istype(thing, /obj/item/natural/cloth))
 		// stupid little easter egg here: you can dampen a cloth to clean with it, because prestidigitation also lets you clean things. also a lot cheaper devotion-wise than filling a bucket
 		var/obj/item/natural/cloth/the_cloth = thing


### PR DESCRIPTION
## About The Pull Request

Apparently people are sitting inside the church spamming create water on barrels for 30-90 minutes instead of playing the game to max holy magic levels. Clearly not the intention when orison was added.

I've given orison the same expert skill ceiling cap as prestidigitation, and also limited it to a maximum of 50 xp per cast (which should roughly equate to about 10 ticks of water, which is what I'd consider the median use case). You can now spend 30-90 minutes doing the roguetown equivalent of tick manipulation if you want your fat XP gains.

Or you know, you could just go play the game. Or the administrators could beat people with hammers who are doing this kinda thing. I don't know.

## Why It's Good For The Game

It just is.
