### PR TITLE
Update knighterrant stats -1 SPE.dm

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
@@ -51,7 +51,7 @@
 			H.change_stat("endurance", 1)
 			H.change_stat("constitution", 2)
 			H.change_stat("intelligence", 1)
-			H.change_stat("speed", 1)
+			H.change_stat("speed", -1)
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 			var/weapons = list("Bastard Sword","Flail","Spear")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
@@ -96,7 +96,7 @@
 			H.change_stat("endurance", 1)
 			H.change_stat("constitution", 2)
 			H.change_stat("intelligence", 1)
-			H.change_stat("speed", 1)
+			H.change_stat("speed", -1)
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 			var/weapons = list("Bastard Sword","Flail","Spear")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Reduces Errant Knight's SPE stat from 1 to -1.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Royal Guards stats are very similar to Errant Knights, except on SPE. It seems off that RGs have -2 while Errant Knight has 1. I think reducing the Errant Knight's speed by 2 will bring them closer to being balanced with RG, while still keeping a speed advantage.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
