### PR TITLE
NPCs now respect and interact with stealth/sneaking

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -43,6 +43,7 @@
 			if(!HAS_TRAIT(L, TRAIT_KNEESTINGER_IMMUNITY))
 				if(L.electrocute_act(30, src))
 					L.emote("painscream")
+					L.update_sneak_invis(TRUE)
 					L.consider_ambush()
 	. = ..()
 

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -280,6 +280,7 @@
 			BP.add_wound(/datum/wound/fracture)
 			BP.update_disabled()
 			C.apply_damage(trap_damage, BRUTE, def_zone)
+			C.update_sneak_invis(TRUE)
 			C.consider_ambush()
 			return FALSE
 		else
@@ -304,6 +305,7 @@
 				BP.add_wound(/datum/wound/fracture)
 				BP.update_disabled()
 				C.apply_damage(trap_damage, BRUTE, def_zone)
+				C.update_sneak_invis(TRUE)
 				C.consider_ambush()
 				return FALSE
 	..()
@@ -316,6 +318,7 @@
 		close_trap()
 		if(isliving(user))
 			var/mob/living/L = user
+			L.update_sneak_invis(TRUE)
 			L.consider_ambush()
 		return
 	..()

--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -56,6 +56,7 @@
 /mob/living/simple_animal
 	var/can_saddle = FALSE
 	var/obj/item/ssaddle
+	var/simple_detect_bonus = 0 // A flat percentage bonus to our ability to detect sneaking people only. Use in lieu of giving mobs huge STAPER bonuses if you want them to be observant.
 
 /obj/item/natural/bone
 	name = "bone"

--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -251,6 +251,8 @@
 		if(prob(prob2break))
 			playsound(src,'sound/items/seedextract.ogg', 100, FALSE)
 			qdel(src)
+			if (L.alpha == 0 && L.rogue_sneaking) // not anymore you're not
+				L.update_sneak_invis(TRUE)
 			L.consider_ambush()
 
 /obj/item/natural/bundle/fibers

--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -77,6 +77,8 @@
 		if(prob(prob2break))
 			playsound(src,'sound/items/seedextract.ogg', 100, FALSE)
 			qdel(src)
+			if (L.alpha == 0 && L.rogue_sneaking) // not anymore you're not
+				L.update_sneak_invis(TRUE)
 			L.consider_ambush()
 
 /obj/item/grown/log/tree/stick/Initialize()

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -21,6 +21,7 @@
 	var/next_idle = 0
 	var/next_seek = 0
 	var/next_stand = 0
+	var/next_passive_detect = 0
 	var/flee_in_pain = FALSE
 	var/stand_attempts = 0
 	var/ai_currently_active = FALSE
@@ -241,6 +242,9 @@
 	if(L == src)
 		return FALSE
 
+	if (L.alpha == 0 && L.rogue_sneaking)
+		return FALSE
+
 	if(!is_in_zweb(src.z,L.z))
 		return FALSE
 
@@ -269,12 +273,19 @@
 				for(var/mob/living/L in view(7, src)) // scan for enemies
 					if(should_target(L))
 						retaliate(L)
+					if (world.time >= next_passive_detect && L.alpha == 0 && L.rogue_sneaking && prob(STAPER / 2))
+						if (!npc_detect_sneak(L, -20)) // attempt a passive detect with 20% increased difficulty
+							next_passive_detect = world.time + STAPER SECONDS
 
 		if(AI_HUNT)		// hunting for attacker
 			if(target != null)
 				if(!should_target(target))
-					back_to_idle()
-					return TRUE
+					if (target.alpha == 0 && target.rogue_sneaking) // attempt one detect since we were just fighting them and have lost them
+						if (npc_detect_sneak(target))
+							retaliate(target)
+					else
+						back_to_idle()
+						return TRUE
 				m_intent = MOVE_INTENT_WALK
 				INVOKE_ASYNC(src, PROC_REF(walk2derpless), target)
 
@@ -414,6 +425,13 @@
 	if(L == src)
 		return
 	if(mode != AI_OFF)
+		if (L.alpha == 0 && L.rogue_sneaking)
+			// we just got hit by something hidden so try and find them
+			if (prob(5))
+				visible_message(span_notice("[src] begins searching around frantically..."))
+			var/extra_chance = (health <= maxHealth * 50) ? 30 : 0 // if we're below half health, we're way more alert
+			if (!npc_detect_sneak(L, extra_chance))
+				return
 		mode = AI_HUNT
 		last_aggro_loss = null
 		face_atom(L)
@@ -421,6 +439,38 @@
 			emote("aggro")
 		target = L
 		enemies |= L
+
+/mob/living/proc/npc_detect_sneak(mob/living/target, extra_prob = 0)
+	if (target.alpha > 0 || !target.rogue_sneaking)
+		return TRUE
+	var/probby = 4 * STAPER //this is 10 by default - npcs get an easier time to detect to slightly thwart cheese
+	probby += extra_prob
+	var/sneak_bonus = 0
+	if(target.mind)
+		if (world.time < target.mob_timers[MT_INVISIBILITY])
+			// we're invisible as per the spell effect, so use the highest of our arcane magic (or holy) skill instead of our sneaking
+			sneak_bonus = (max(target.mind?.get_skill_level(/datum/skill/magic/arcane), target.mind?.get_skill_level(/datum/skill/magic/holy)) * 10)
+			probby -= 20 // also just a fat lump of extra difficulty for the npc since spells are hard, you know?
+		else
+			sneak_bonus = (target.mind?.get_skill_level(/datum/skill/misc/sneaking) * 5)
+		probby -= sneak_bonus
+	if(!target.check_armor_skill())
+		probby += 85 //armor is loud as fuck
+		if (sneak_bonus)
+			probby += sneak_bonus // you don't get sneak bonus in heavy armor at all, on top of that
+	if (target.badluck(5))
+		probby += (10 - target.STALUC) * 5 // drop 5% chance for every bit of fortune we're missing
+	if (target.goodluck(5))
+		probby -= (10 - target.STALUC) * 5 // make it 5% harder for every bit of fortune over 10 that we do have
+
+	if (prob(probby))
+		// whoops it saw us
+		target.mob_timers[MT_FOUNDSNEAK] = world.time
+		to_chat(target, span_danger("[src] sees me! I'm found!"))
+		target.update_sneak_invis(TRUE)
+		return TRUE
+	else
+		return FALSE
 
 
 /mob/living/carbon/human/attackby(obj/item/W, mob/user, params)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -210,6 +210,10 @@
 
 
 /mob/living/simple_animal/hostile/proc/Found(atom/A)//This is here as a potential override to pick a specific target if available
+	if (isliving(A))
+		var/mob/living/living_target = A
+		if(living_target.alpha == 0 && living_target.rogue_sneaking) // is our target hidden? if they are, attempt to detect them once
+			return npc_detect_sneak(living_target, simple_detect_bonus)
 	return
 
 /mob/living/simple_animal/hostile/proc/PickTarget(list/Targets)//Step 3, pick amongst the possible, attackable targets

--- a/code/modules/mob/living/simple_animal/rogue/creacher/volf.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/volf.dm
@@ -33,6 +33,7 @@
 	STACON = 7
 	STASTR = 7
 	STASPD = 13
+	simple_detect_bonus = 20
 	deaggroprob = 0
 	defprob = 40
 	defdrain = 10


### PR DESCRIPTION
## About The Pull Request

Previously, NPCs did not give a solitary shit if you were sneaking or not - they just got up in your shit. Now, they do!

Based on a patented blend(tm) of the mob's perception, the manner of your sneakiness/invisibility, the equipment you're wearing and a good ol' dash of luck (both good and bad), NPCs will now interact meaningfully with your visibility or lack thereof, allowing you to potentially sneak past them, stab them violently in the back, or whatever it is you wish to do.

Naturally, magical invisibility is a little bit better at hiding you than mundane invisibility. Who would've thunk?

In addition, stepping on twigs and thorns also causes you to briefly leave your stealth, including if you're invisible. Tread carefully, wanderer!

## Why It's Good For The Game

Sneak around dungeons for loot and glory. Frustrate the beans out of martial adventurers forced to claw their way through hordes for their loot. Fail a roll and find yourself in hot water with 6 skeletons surrounding you, the way Xylix intended.
