### PR TITLE
Show embedded items larger than tiny on human examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -439,6 +439,13 @@
 	if(length(msg))
 		. += span_warning("[msg.Join("\n")]")
 
+	// Show especially large embedded objects at a glance
+	for(var/obj/item/bodypart/part in bodyparts)
+		if (LAZYLEN(part.embedded_objects))
+			for(var/obj/item/stuck_thing in part.embedded_objects)
+				if (stuck_thing.w_class >= WEIGHT_CLASS_SMALL)
+					. += span_bloody("<b>[m3] \a [stuck_thing] stuck in [m2] [part.name]!</b>")
+
 	if((user != src) && isliving(user))
 		var/mob/living/L = user
 		var/final_str = STASTR


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin: shift-clicking someone will now show if they have any especially large (*) items lodged in their body somewhere.

Especially large in this case means "larger than tiny w_class", so really small things like darts, splinters, throwing stars etc should remain hidden. Arrows, swords, knives and all that should be pretty obviously stuck in you.

## Why It's Good For The Game

It was needlessly obtuse before to find out if someone say, had a sword sticking out of their chest. You'd notice that normally. Now you do.