### PR TITLE
Templar Stat Tweaks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -163,10 +163,9 @@
 		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)	//May tone down to 2; seems OK.
-		H.change_stat("strength", 3)
+		H.change_stat("strength", 2)
 		H.change_stat("constitution", 2)
 		H.change_stat("endurance", 3)
-		H.change_stat("speed", -2)
 		
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Reduces templar's strength modifier from +3 to +2, but removes their -2 speed debuff.

## Why It's Good For The Game

Every other non-antag +3 strength heavy armor class has had their strength modifier reduced to +2, templar retaining their +3 strength mod was apparently an oversight. More than +2 strength is supposed to be reserved for antags and/or roles that do not have armor proficiencies like monk/barbarian.

![image](https://github.com/user-attachments/assets/6a4c0c88-f820-4001-9653-cc9810bf1bdb)

![image](https://github.com/user-attachments/assets/f508e3d8-4b75-47bb-af4c-3f55a56ab98c)
