### PR TITLE
fix for infinite cooking experience by adding onion

### DIFF
--- a/modular/Neu_Food/code/cooked/NeuFood_snacks.dm
+++ b/modular/Neu_Food/code/cooked/NeuFood_snacks.dm
@@ -46,10 +46,10 @@
 
 	if(istype(I, /obj/item/reagent_containers/food/snacks/rogue/preserved/onion_fried))
 		playsound(get_turf(user), 'sound/foley/dropsound/food_drop.ogg', 40, TRUE, -1)
-		add_sleep_experience(user, /datum/skill/craft/cooking, user.STAINT)
 		to_chat(user, span_notice("Adding onions..."))
 		if(do_after(user,short_cooktime, target = src))
 			new /obj/item/reagent_containers/food/snacks/rogue/onionsteak(loc)
+			add_sleep_experience(user, /datum/skill/craft/cooking, user.STAINT)
 			qdel(I)
 			qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

![image](https://github.com/user-attachments/assets/33614e7f-b958-4a36-acc1-e7d855e83bfd)

I went and checked all other instances of add_sleep_experience, all the rest of them seem to be nested in a do_after or in an appropriate proccall. This one recipe was just outside of the do_after, an anomaly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Just a tiny one liner bug fix.
