### PR TITLE
Remove visible messages on look/examine (looks at X, looks up, looks down, looks into the distance)

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1926,8 +1926,8 @@
 	if(!can_look_up())
 		return
 	changeNext_move(CLICK_CD_MELEE)
-	if(m_intent != MOVE_INTENT_SNEAK)
-		visible_message(span_info("[src] looks up."))
+	/*if(m_intent != MOVE_INTENT_SNEAK)
+		visible_message(span_info("[src] looks up."))*/
 	var/turf/ceiling = get_step_multiz(src, UP)
 	var/turf/T = get_turf(src)
 	if(!ceiling) //We are at the highest z-level.
@@ -1992,8 +1992,8 @@
 		ttime = 10 - (STAPER - 5)
 		if(ttime < 0)
 			ttime = 0
-	if(m_intent != MOVE_INTENT_SNEAK)
-		visible_message(span_info("[src] looks into the distance."))
+	/*if(m_intent != MOVE_INTENT_SNEAK)
+		visible_message(span_info("[src] looks into the distance."))*/
 	animate(client, pixel_x = world.icon_size*_x, pixel_y = world.icon_size*_y, ttime)
 //	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(stop_looking))
 	update_cone_show()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -440,7 +440,7 @@ GLOBAL_VAR_INIT(mobids, 1)
 		to_chat(src, span_warning("Something is there but I can't see it!"))
 		return
 
-	if(isliving(src))
+	/*if(isliving(src))
 		var/message = "[src] looks at"
 		var/target = "\the [A]"
 		if(!isturf(A))
@@ -458,7 +458,7 @@ GLOBAL_VAR_INIT(mobids, 1)
 					target = "\the [T.name]'s [T.simple_limb_hit(zone_selected)]"
 				if(iscarbon(T) && T != src)
 					target = "[T]'s [parse_zone(zone_selected)]"
-			visible_message(span_emote("[message] [target]."))
+			visible_message(span_emote("[message] [target]."))*/
 
 	var/list/result = A.examine(src)
 	if(result)


### PR DESCRIPTION
## About The Pull Request

Nothing especially complicated here, just removes the visible_messages that get thrown when you look at someone/anything.

## Why It's Good For The Game

This is a bit of a game design discussion, so bear with me a bit.

Looking at someone essentially broadcasts to all visible observers in the scene that you're proximally interested in the other party, and this is often not the case. In prior Roguetown rife with paranoia and murder, knowing when someone was sizing you up had value, but in our slower, more roleplay-centric environment, the notification is more of an annoyance than a gear check.

Some players habitually examine others or themselves to re-read flavor text and appearances to "build" a scene in their head. That kind of behavior is discouraged here because you spam the beans out of the chat if you do it. Players involved in medical need to examine frequently in many circumstances as well and it can be a nuisance for Church or physician-related roles.

It is important to note that this does remove some telegraphing for shenanigans - thieves will now be able to tell where your visible valuables are without giving you a handy meta-ping in the process, and you'll only have do_after progress bars to suggest whether someone is looking up or down, among other things.
