### PR TITLE
Something In The Air Tonight: Werewolf howl adjustments and Dendor T4 spell

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -40,6 +40,7 @@
 	t1 = /obj/effect/proc_holder/spell/targeted/blesscrop
 	t2 = /obj/effect/proc_holder/spell/targeted/beasttame
 	t3 = /obj/effect/proc_holder/spell/targeted/conjure_glowshroom
+	t4 = /obj/effect/proc_holder/spell/self/howl/call_of_the_moon
 	confess_lines = list(
 		"DENDOR PROVIDES!",
 		"THE TREEFATHER BRINGS BOUNTY!",

--- a/code/datums/special_traits/traits/traits.dm
+++ b/code/datums/special_traits/traits/traits.dm
@@ -216,7 +216,7 @@
 
 /datum/special_trait/languagesavant
 	name = "Polyglot"
-	greet_text = span_notice("I have always picked up on languages easily, even those that are forbidden to mortals.")
+	greet_text = span_notice("I have always picked up on languages easily, even those that are forbidden to mortals... except that accursed beastial chatter. What even is that nonsense?")
 	weight = 100
 
 /datum/special_trait/languagesavant/on_apply(mob/living/carbon/human/character, silent)
@@ -225,7 +225,6 @@
 	character.grant_language(/datum/language/hellspeak)
 	character.grant_language(/datum/language/celestial)
 	character.grant_language(/datum/language/orcish)
-	character.grant_language(/datum/language/beast)
 	character.grant_language(/datum/language/draconic)
 
 /datum/special_trait/civilizedbarbarian

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
@@ -5,16 +5,17 @@
 	antimagic_allowed = TRUE
 	charge_max = 600 //1 minute
 	ignore_cockblock = TRUE
+	var/use_language = FALSE
 
 /obj/effect/proc_holder/spell/self/howl/cast(mob/user = usr)
 	..()
-	var/message = input("Howl at the hidden moon", "WEREWOLF") as text|null
+	var/message = input("Howl at the hidden moon...", "MOONCURSED") as text|null
 	if(!message) return
 
 	var/datum/antagonist/werewolf/werewolf_player = user.mind.has_antag_datum(/datum/antagonist/werewolf)
 
 	// sound played for owner
-	playsound(src, pick('sound/vo/mobs/wwolf/howl (1).ogg','sound/vo/mobs/wwolf/howl (2).ogg'), 100, TRUE)
+	playsound(src, pick('sound/vo/mobs/wwolf/howl (1).ogg','sound/vo/mobs/wwolf/howl (2).ogg'), 75, TRUE)
 
 	for(var/mob/player in GLOB.player_list)
 
@@ -22,14 +23,14 @@
 		if(player.stat == DEAD) continue
 		if(isbrain(player)) continue
 
-		// Announcement to other werewolves
-		if(player.mind.has_antag_datum(/datum/antagonist/werewolf))
-			to_chat(player, span_boldannounce("[werewolf_player.wolfname] howls: [message]"))
+		// Announcement to other werewolves (and anyone else who has beast language somehow)
+		if(player.mind.has_antag_datum(/datum/antagonist/werewolf) || (use_language && player.has_language(/datum/language/beast)))
+			to_chat(player, span_boldannounce("[werewolf_player ? werewolf_player.wolfname : user.real_name] howls to the hidden moon: [message]"))
 
 		//sound played for other players
 		if(player == src) continue
 		if(get_dist(player, src) > 7)
-			player.playsound_local(get_turf(player), pick('sound/vo/mobs/wwolf/howldist (1).ogg','sound/vo/mobs/wwolf/howldist (2).ogg'), 100, FALSE, pressure_affected = FALSE)
+			player.playsound_local(get_turf(player), pick('sound/vo/mobs/wwolf/howldist (1).ogg','sound/vo/mobs/wwolf/howldist (2).ogg'), 50, FALSE, pressure_affected = FALSE)
 
 	user.log_message("howls: [message] (WEREWOLF)")
 

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -89,6 +89,7 @@
 	charge_max = 600
 	ignore_cockblock = TRUE
 	use_language = TRUE
+	var/first_cast = FALSE
 
 /obj/effect/proc_holder/spell/self/howl/call_of_the_moon/cast(mob/living/carbon/human/user)
 	// only usable at night
@@ -101,5 +102,9 @@
 		user.grant_language(/datum/language/beast)
 		to_chat(user, span_boldnotice("The vestige of the hidden moon high above reveals His truth: the knowledge of beast-tongue was in me all along."))
 	
+	if (!first_cast)
+		to_chat(user, span_boldwarning("So it is murmured in the Earth and Air: the Call of the Moon is sacred, and to share knowledge gleaned from it with those not of Him is a SIN."))
+		to_chat(user, span_boldwarning("Ware thee well, child of Dendor."))
+		first_cast = TRUE
 	. = ..()
 	

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -80,3 +80,26 @@
 		if(!isclosedturf(TT) && !locate(/obj/structure/glowshroom) in TT)
 			new /obj/structure/glowshroom(TT)
 	return TRUE
+
+/obj/effect/proc_holder/spell/self/howl/call_of_the_moon
+	name = "Call of the Moon"
+	desc = "Draw upon the the secrets of the hidden firmament to converse with the mooncursed."
+	overlay_state = "howl"
+	antimagic_allowed = FALSE
+	charge_max = 600
+	ignore_cockblock = TRUE
+	use_language = TRUE
+
+/obj/effect/proc_holder/spell/self/howl/call_of_the_moon/cast(mob/living/carbon/human/user)
+	// only usable at night
+	if (!GLOB.tod == "night")
+		to_chat(user, span_warning("I must wait for the hidden moon to rise before I may call upon it."))
+		revert_cast()
+		return
+	// if they don't have beast language somehow, give it to them
+	if (!user.has_language(/datum/language/beast))
+		user.grant_language(/datum/language/beast)
+		to_chat(user, span_boldnotice("The vestige of the hidden moon high above reveals His truth: the knowledge of beast-tongue was in me all along."))
+	
+	. = ..()
+	


### PR DESCRIPTION
## About The Pull Request

Spitballing in general chat on Discord revealed the funny idea of giving Dendor access to the werewolf howl via their missing T4 spell. So, I've gone ahead and done the following:

- The werewolf howl SFX is now **half** the volume that it was. That shit was loud as hell because it spawns directly on the turf underneath you, and it was also 100 volume before.
- Anyone with the Beast language can now understand werewolf howls.
- The Polyglot special no longer awards the Beast language.
- Dendor devotionists/druids get access to a modified version of the werewolf howl spell titled as Call of the Moon as their T4 spell.
   - It is only usable at night.
   - The first time you use it, you'll gain understanding of the Beast language if you don't already have it.

This also has the neat side effect of reducing metaknowledge of werewolf presence by making it plausible to think that druids or other Dendor clerics might be responsible for the midnight howling.

It also essentially grants Dendor t4 users a 1-per-minute global comms (only at night) to use for whatever they want.

This is probably just a stopgap for now until we think of a real t4 for Dendor, but it was easy to make so I figured why not try it out?

## Why It's Good For The Game

Antagonist-follower collusion *rules*. Dendor already kind of has a bit of this going on with the werewolves already, but making Dendor's T4 basically a form of global communications with them opens the opportunities right up for deranged wildpeople to help or hurt those dealing with one of Dendor's greatest blessings.