### PR TITLE
Rituos completion removes hunger and need to breathe, skeletonized limbs no longer painful

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -222,7 +222,7 @@
 /mob/living/carbon/proc/get_complex_pain()
 	var/amt = 0
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
-		if(limb.status == BODYPART_ROBOTIC)
+		if(limb.status == BODYPART_ROBOTIC || limb.skeletonized)
 			continue
 		var/bodypart_pain = ((limb.brute_dam + limb.burn_dam) / limb.max_damage) * 100
 		for(var/datum/wound/wound as anything in limb.wounds)

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -211,6 +211,8 @@
 		user.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		user.mind?.adjust_spellpoints(3)
 		user.visible_message(span_boldwarning("[user]'s form swells with terrible power as they cast away almost all of the remnants of their mortal flesh, arcyne runes glowing upon their exposed bones..."), span_notice("I HAVE DONE IT! I HAVE COMPLETED HER LESSER WORK! I stand at the cusp of unspeakable power, but something is yet missing..."))
+		ADD_TRAIT(user, TRAIT_NOHUNGER, "[type]")
+		ADD_TRAIT(user, TRAIT_NOBREATH, "[type]")
 		if (prob(33))
 			to_chat(user, span_small("...what have I done?"))
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

The header pretty much covers this. Two quick changes:

- Rituos gives you NOHUNGER and NOBREATH upon completing it, since it sort of doesn't make sense to be worried about hunger when you're a head atop a ritually-empowered skeleton.
- Skeletonized limbs no longer count for complex pain calculations, meaning that in practice, if you're not hitting a Rituos user's head, they're not going to get painstunned.

Seen a few impressive people playing soft antagonists as Zizo clerics so far, and just wanted to tidy up a few consistent oddities I've noticed observing.

## Why It's Good For The Game

Sensical mechanics are generally good, and also incentivizes people to keep their skeleton limbs w/ Rituos so as to provide protection against pain strats.
