### PR TITLE
Roundstart Bandit Slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -3,8 +3,8 @@
 	flag = BANDIT
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 5
+	spawn_positions = 5
 	antag_job = TRUE
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Long ago you did a crime worthy of your bounty being hung on the wall outside of the local inn. You now live with your fellow freemen in the bog, and generally get up to no good."

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -6,6 +6,7 @@
 	total_positions = 5
 	spawn_positions = 5
 	antag_job = TRUE
+	display_order = JDO_BANDIT
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Long ago you did a crime worthy of your bounty being hung on the wall outside of the local inn. You now live with your fellow freemen in the bog, and generally get up to no good."
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This ups the roundstart slots for bandits up to 5, (as well as capping them at 5.)

## Why It's Good For The Game

Some small amount of controlled, free form chaos is good, especially when it gives the keep a gameplay loop of "holy fucking shit, there's bandits." upon which they can give out bounties, hire adventurers, post guards in spaces that are vital, etc. This also gives guards a reason to exist outside the occasional soft-antaging adventurer player, or petty crime.