### PR TITLE
Feast & Famine: Nutrition changes

### DIFF
--- a/code/modules/mob/living/carbon/rogfatstam.dm
+++ b/code/modules/mob/living/carbon/rogfatstam.dm
@@ -58,12 +58,15 @@
 
 	if (rogfat >= (maxrogfat * 0.7)) // if you've spent 70% of your max fatigue, the base amount you lose is doubled
 		nutrition_amount *= 2
-	if (STAEND <= 9) // 10% extra nutrition loss for every END below 9
-		var/low_end_malus = (10 - STAEND) * 0.1
+	if (STACON <= 9) // 10% extra nutrition loss for every CON below 9
+		var/low_end_malus = (10 - STACON) * 0.1
 		nutrition_amount *= (1 + low_end_malus)
-	if (STAEND >= 11) // 5% less nutrition loss for every END above 11
-		var/high_end_buff = (STAEND - 10) * 0.05
+	if (STACON >= 11) // 5% less nutrition loss for every CON above 11
+		var/high_end_buff = (STACON - 10) * 0.05
 		nutrition_amount *= (1 - high_end_buff)
+	if (STASTR >= 11) // 7.5% increased nutrition loss for every STR above 11. the gainz don't come cheap
+		var/swole_malus = (10 - STASTR) * 0.075
+		nutrition_amount *= (1 + swole_malus)
 	
 	if (nutrition >= NUTRITION_LEVEL_WELL_FED) // we've only just eaten recently so just flat out reduce the total loss by half
 		nutrition_amount *= 0.5

--- a/code/modules/mob/living/carbon/rogfatstam.dm
+++ b/code/modules/mob/living/carbon/rogfatstam.dm
@@ -48,12 +48,38 @@
 /mob/proc/rogfat_add(added as num)
 	return TRUE
 
+/mob/living/proc/rogfat_nutrition_mod(amt)
+	// to simulate exertion, we deduct a mob's nutrition whenever it takes an action that would give us fatigue.
+	var/nutrition_amount = amt // nutrition goes up to 1k at max (but constantly ticks down) so we need to work at a slightly bigger scale
+
+	var/tox_damage = getToxLoss()
+	if (tox_damage >= (maxHealth * 0.2)) // if we have over 20% of our health as toxin damage, add 10% of our toxin damage as base loss
+		nutrition_amount += (tox_damage * 0.1)
+
+	if (rogfat >= (maxrogfat * 0.7)) // if you've spent 70% of your max fatigue, the base amount you lose is doubled
+		nutrition_amount *= 2
+	if (STAEND <= 9) // 10% extra nutrition loss for every END below 9
+		var/low_end_malus = (10 - STAEND) * 0.1
+		nutrition_amount *= (1 + low_end_malus)
+	if (STAEND >= 11) // 5% less nutrition loss for every END above 11
+		var/high_end_buff = (STAEND - 10) * 0.05
+		nutrition_amount *= (1 - high_end_buff)
+	
+	if (nutrition >= NUTRITION_LEVEL_WELL_FED) // we've only just eaten recently so just flat out reduce the total loss by half
+		nutrition_amount *= 0.5
+
+	if (reagents.has_reagent(/datum/reagent/consumable/nutriment)) // we're still digesting so knock off a tiny bit
+		nutrition_amount *= 0.9
+
+	return nutrition_amount
+
 /mob/living/rogfat_add(added as num, emote_override, force_emote = TRUE) //call update_rogfat here and set last_fatigued, return false when not enough fatigue left
 	if(HAS_TRAIT(src, TRAIT_NOROGSTAM))
 		return TRUE
 	rogfat = CLAMP(rogfat+added, 0, maxrogfat)
 	if(added > 0)
 		rogstam_add(added * -1)
+		adjust_nutrition(-rogfat_nutrition_mod(added))
 	if(added >= 5)
 		if(rogstam <= 0)
 			if(iscarbon(src))

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -26,6 +26,7 @@
 	M.adjustOxyLoss(-0.7, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.7*REM)
 	M.adjustCloneLoss(-0.7*REM, 0)
+	M.adjust_nutrition(-5*REM)
 	..()
 	. = 1
 
@@ -74,6 +75,7 @@
 	M.adjustOxyLoss(-1.4, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1.4*REM)
 	M.adjustCloneLoss(-1.4*REM, 0)
+	M.adjust_nutrition(-2.5*REM)
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request

Nutrition is a bit of a squandered gameplay mechanic in this codebase.

Not a whole lot of stuff interacts with it like you'd expect, so I've gone ahead and taken the liberty of putting in some very basic mechanical interactions that make hunger deplete slightly/significantly faster depending on your character's stats and level of physical activity.

To help explain this, max nutrition (full) is 1000 nutrition.

Anything that causes you to gain fatigue also causes you to lose nutrition/hunger. A 10 fatigue strike causes you to lose 10 nutrition, adjusted by the following values below:

- If you have any toxin damage above 20% of your max health, 10% of that damage is added on to the base nutrition you lose.
- If you have less than 30% fatigue remaining, the amount of nutrition consumed is doubled. (You're tired, working over time!)
- If your CON is below 10, you take an extra 10% increase to the amount of nutrition lost for every point below 10. 7 END equals a 30% increase.
- If your CON is above 10, the amount of nutrition you lose is reduced by 5% per point.
- If your STR is above 10, the amount of nutrition you consume is increased by 7.5% per point. Added by popular request. Strengthmaxxers beware.
- If you've recently eaten (are well fed), the total amount of nutrition you lose is reduced by half. (The well fed nutrition threshold is 700, so this essentially gives you an extra 600 effective nutrition to lose if you keep yourself well fed.)
- If you're still digesting food, the amount of nutrition you lose is reduced by 10%. Rest and digest!

In addition, red healing potions now also cause a considerable loss of nutrition (they're causing you to regenerate rapidly, basically). Dated reds cause the most loss, while fresh red have half as much loss. Miracles and other forms of healing are unchanged.

## Why It's Good For The Game

Food is very much an afterthought at the moment. Most people don't interact with the thought of consuming food more than a few times a round as it stands, even if they're doing highly physical activities.

The intent behind these changes is to give people more realistic opportunities to do things like adventurer campfire cooking moments. Carrying cooking kits with you should become a lot more valuable. A frypan is definitely way more of a nice thing to have now, and END has a bit more value for helping you get a lot more out of the food you do eat.

It is my hope that this'll get people interacting with food producers and cooking more, and make it a bit more of a thing for people to consider in a round.