### PR TITLE
Greedy no longer gives skilled appraiser

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -293,7 +293,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 /datum/charflaw/greedy/on_mob_creation(mob/user)
 	next_mammon_increase = world.time + rand(15 MINUTES, 25 MINUTES)
 	last_passed_check = world.time
-	ADD_TRAIT(user, TRAIT_SEEPRICES, "[type]")
+	ADD_TRAIT(user, TRAIT_SEEPRICES_SHITTY, "[type]")
 
 /datum/charflaw/greedy/flaw_on_life(mob/user)
 	if(!first_tick)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The 'greedy' flaw no longer gives you the 'skilled appraiser' trait. Instead, you get the normal 'appraiser' trait.

## Why It's Good For The Game

The 'greedy' flaw currently gives you skilled appraiser for free - which is a pretty rare trait that only a handful of jobs actually spawn with. (Steward, merchant, court mage, consort, and treasure hunter are the only non-antag jobs that normally get it.)

Flaws probably shouldn't give you rare skills for free - this swaps out the 'skilled appraiser' trait with the significantly more common 'appraiser' trait - which still lets you estimate item value - but with much less accuracy.
