### PR TITLE
[TESTMERGE] Feast And Famine 2: PSYDON above those numbers were high

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -382,7 +382,7 @@
 	sec_hud_set_security_status()
 	..()
 
-/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE, host_job)
+/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE)
 	var/datum/outfit/O = null
 
 	if(ispath(outfit))

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -26,6 +26,7 @@
 	M.adjustOxyLoss(-0.7, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.7*REM)
 	M.adjustCloneLoss(-0.7*REM, 0)
+	M.adjust_nutrition(-5*REM)
 	..()
 	. = 1
 
@@ -74,6 +75,7 @@
 	M.adjustOxyLoss(-1.4, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1.4*REM)
 	M.adjustCloneLoss(-1.4*REM, 0)
+	M.adjust_nutrition(-2.5*REM)
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request

It appears my prior testing methodology of "spawn in as vagabond and whack five trees with a stone knife" is not an especially great thing for ballparking something that affects every corner of the game. Who would've thought?

Anyway, fatigue consumes nutrition, as before, with the following changes:
- Baseline nutrition consumption compared to the **forbidden rounds** has been reduced by 85%.
- Athletics skill now factors in quite significantly to nutrition loss.
   - If your athletics skill plus 2 is greater than the amount **base** fatigue you lose in a single action, you have a 16% chance per athletics rank to just not consume any nutrition at all.
   - Athletics skill now applies a 5% reduction per rank to all nutrition loss from physical actions.
- When running, you have a 5% chance per point of CON to not consume any extra nutrition at all. At 10 CON, this is 50%.

Overall, you should see an increase in overall hunger compared baseline rounds to the tune of needing to eat maybe six or seven times IF you're highly physical. If you're a sedentary role, you shouldn't need to eat much more than before.

**Testmerge this first, please.**

## Why It's Good For The Game

More reason for food is good but the old numbers were kind of whackshit and not really balanced very well, sorry.