### PR TITLE
Ruby band metaknowledge fixes

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -450,7 +450,7 @@
 // MATTHIAN SCOMCOIN
 
 /obj/item/mattcoin
-	name = "Ruby Band"
+	name = "rontz ring"
 	icon_state = "mattcoin"
 	desc = "A faded coin, a ruby laid into its center."
 	gripped_intents = null
@@ -467,6 +467,10 @@
 	var/listening = TRUE
 	var/speaking = TRUE
 	sellprice = 0
+
+/obj/item/mattcoin/New(loc, ...)
+	. = ..()
+	name = pick("rontz ring", "gold ring")
 
 /obj/item/mattcoin/pickup(mob/living/user)
 	if(!HAS_TRAIT(user, TRAIT_COMMIE))


### PR DESCRIPTION
## About The Pull Request

Renames the "Ruby Band" to a "rontz ring" by default and gives it a 50/50 chance upon spawn of also being named after an ordinary "gold ring". Sprite and everything else unchanged.

## Why It's Good For The Game

Hard for people to meta if they're not beaten in the head with something being flagrantly different! Now only close inspection will reveal if it is unusual or not (because the sprite is different).
