### PR TITLE
LET ME PLAY MAGE APPRENTICE AGAIN

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -4931,6 +4931,12 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
+"eLF" = (
+/obj/structure/mirror,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/magician)
 "eLM" = (
 /obj/structure/underworld/barrier,
 /turf/open/floor/rogue/dirt,
@@ -5138,18 +5144,8 @@
 	},
 /area/rogue/indoors/town)
 "eWN" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/obj/item/clothing/suit/roguetown/shirt/robe/mage,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/random,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/random,
-/obj/item/clothing/head/roguetown/roguehood/random,
-/obj/item/clothing/head/roguetown/wizhat/black,
-/obj/item/clothing/head/roguetown/wizhat/random,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/magician)
 "eXt" = (
 /obj/structure/flora/newleaf,
@@ -5672,6 +5668,12 @@
 	icon_state = "chess"
 	},
 /area/rogue/indoors/town/church)
+"fwW" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/magician)
 "fxv" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/structure/lever/wall{
@@ -7551,6 +7553,9 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors)
+"hrG" = (
+/turf/open/water/bath,
+/area/rogue/indoors/town/magician)
 "hrK" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -18796,6 +18801,18 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"scD" = (
+/obj/structure/rack/rogue,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/obj/item/clothing/suit/roguetown/shirt/tunic/white,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/magician)
 "scM" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -20502,6 +20519,12 @@
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/dwarfin)
+"tLg" = (
+/obj/machinery/gear_painter,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/magician)
 "tLJ" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church)
@@ -23558,6 +23581,9 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/physician)
+"wWO" = (
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/magician)
 "wXw" = (
 /obj/item/clothing/ring/silver,
 /turf/open/floor/rogue/tile{
@@ -30693,7 +30719,7 @@ hCc
 pUC
 pUC
 pUC
-bUa
+fpz
 fpz
 fpz
 fpz
@@ -44659,8 +44685,8 @@ ixc
 mag
 mag
 mag
-pNQ
-pNQ
+ixc
+ixc
 pNQ
 pNQ
 pNQ
@@ -44814,11 +44840,11 @@ mag
 cej
 sde
 mag
-cej
+eLF
 eWN
-mag
-pNQ
-pNQ
+hrG
+hrG
+ixc
 pNQ
 pNQ
 pNQ
@@ -44972,10 +44998,10 @@ eUm
 fEa
 mag
 eUm
-fEa
+wWO
+wWO
+wWO
 ixc
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -45129,10 +45155,10 @@ eUm
 fEQ
 mag
 eUm
-fEQ
-ixc
-pNQ
-pNQ
+tLg
+fwW
+scD
+mag
 pNQ
 pNQ
 pNQ

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -2217,6 +2217,7 @@
 	dir = 1
 	},
 /obj/structure/bed/rogue/inn/wool,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -2751,8 +2752,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "cHt" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
+/obj/structure/closet/crate/roguecloset/dark,
+/obj/item/clothing/suit/roguetown/shirt/robe/mage,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/random,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/random,
+/obj/item/clothing/head/roguetown/roguehood/random,
+/obj/item/clothing/head/roguetown/wizhat/black,
+/obj/item/clothing/head/roguetown/wizhat/random,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
 "cHG" = (
@@ -3451,7 +3461,7 @@
 /area/rogue/under/town/sewer)
 "dnp" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	dir = 1;
+	dir = 4;
 	icon_state = "wooddir"
 	},
 /turf/open/floor/rogue/tile{
@@ -5139,13 +5149,7 @@
 	},
 /area/rogue/indoors/town)
 "eWN" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/magician)
 "eXt" = (
 /obj/structure/flora/newleaf,
@@ -5811,13 +5815,6 @@
 	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/dwarfin)
-"fEa" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/magician)
 "fEo" = (
 /obj/structure/stairs{
 	dir = 8
@@ -5827,10 +5824,13 @@
 	},
 /area/rogue/under/town/basement)
 "fEQ" = (
-/obj/structure/toilet,
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
 "fEX" = (
@@ -9386,9 +9386,8 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
 "jgQ" = (
-/obj/structure/roguetent,
-/obj/effect/decal/cobbleedge{
-	dir = 9
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10103,20 +10102,18 @@
 	},
 /area/rogue/indoors/town)
 "jVk" = (
-/obj/structure/roguetent,
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4;
+	icon_state = "wooddir"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
 "jVE" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir"
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
 "jVM" = (
@@ -11683,11 +11680,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "lms" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town/magician)
 "lmE" = (
 /obj/structure/table/wood/bar,
@@ -16213,11 +16206,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "pFQ" = (
-/obj/structure/toilet,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "greenstone"
-	},
+/obj/structure/mineral_door/wood/deadbolt,
+/turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/magician)
 "pGb" = (
 /obj/effect/decal/cobbleedge{
@@ -18827,9 +18817,9 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/random,
 /obj/item/clothing/suit/roguetown/shirt/undershirt/random,
 /obj/item/clothing/suit/roguetown/shirt/undershirt/random,
-/obj/item/clothing/head/roguetown/wizhat,
 /obj/item/clothing/head/roguetown/wizhat/black,
 /obj/item/clothing/head/roguetown/roguehood/random,
+/obj/item/clothing/head/roguetown/wizhat/random,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -19539,7 +19529,7 @@
 /area/rogue/indoors)
 "sRc" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	dir = 1;
+	dir = 4;
 	icon_state = "wooddir"
 	},
 /turf/open/floor/rogue/tile{
@@ -22100,6 +22090,7 @@
 	dir = 1
 	},
 /obj/item/bedsheet/rogue/fabric,
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -23197,13 +23188,8 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors)
 "wKL" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/paper/scroll,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/toilet,
+/turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/magician)
 "wKP" = (
 /turf/closed/wall/mineral/rogue/decowood,
@@ -44665,8 +44651,8 @@ mag
 mag
 ixc
 mag
-pNQ
-pNQ
+mag
+mag
 pNQ
 pNQ
 pNQ
@@ -44822,9 +44808,9 @@ mag
 cej
 sde
 mag
-ixc
+cej
+cHt
 mag
-pNQ
 pNQ
 pNQ
 pNQ
@@ -44977,10 +44963,10 @@ ixc
 mag
 ixc
 eUm
-eUm
-fEa
-wKL
+jVE
 mag
+eUm
+jVE
 ixc
 pNQ
 pNQ
@@ -45134,10 +45120,10 @@ nov
 gqi
 mag
 eUm
-eUm
-eUm
-eWN
+fEQ
 mag
+eUm
+fEQ
 ixc
 pNQ
 pNQ
@@ -45293,11 +45279,11 @@ mag
 jgQ
 mag
 mag
+jgQ
+mag
 ixc
-mag
-mag
-oGK
-oGK
+ixc
+lms
 oGK
 oGK
 oGK
@@ -45449,12 +45435,12 @@ wUy
 iuO
 iuO
 teH
-jVE
-cHt
-fEQ
+iuO
+iuO
+pFQ
+eWN
+wKL
 kkp
-cVE
-cVE
 xsI
 cVE
 cVE
@@ -45606,12 +45592,12 @@ arz
 iuO
 iuO
 iuO
-oOv
-gbo
-gbo
-mag
-cVE
-heh
+iuO
+iuO
+ixc
+ixc
+ixc
+lms
 heh
 heh
 heh
@@ -45763,12 +45749,12 @@ arz
 iuO
 iuO
 uno
-jVE
-cHt
+iuO
+iuO
 pFQ
+eWN
+wKL
 kkp
-cVE
-cVE
 cVE
 heh
 xsI
@@ -45921,11 +45907,11 @@ mag
 jVk
 mag
 mag
+jVk
 mag
 mag
 ixc
-oGK
-qGI
+lms
 rxQ
 gVe
 nyq
@@ -46076,10 +46062,10 @@ kvm
 bUB
 ixc
 eUm
-eUm
-eUm
-eWN
+fEQ
 mag
+eUm
+fEQ
 mag
 pNQ
 pmA
@@ -46233,11 +46219,11 @@ ixc
 ixc
 mag
 eUm
+jVE
+mag
 eUm
-lms
-wKL
-mag
-mag
+jVE
+ixc
 pNQ
 pmA
 xsI
@@ -46391,10 +46377,10 @@ ixc
 mag
 vEL
 sde
+mag
+vEL
+sde
 ixc
-mag
-mag
-pNQ
 pNQ
 pmA
 cVE
@@ -46549,8 +46535,8 @@ mag
 ixc
 mag
 mag
-pNQ
-pNQ
+mag
+ixc
 pNQ
 pNQ
 pmA

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -2752,18 +2752,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "cHt" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/obj/item/clothing/suit/roguetown/shirt/robe/mage,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/suit/roguetown/shirt/tunic/random,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/random,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/random,
-/obj/item/clothing/head/roguetown/roguehood/random,
-/obj/item/clothing/head/roguetown/wizhat/black,
-/obj/item/clothing/head/roguetown/wizhat/random,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/magician)
 "cHG" = (
 /obj/structure/fluff/railing/border{
@@ -5149,7 +5138,18 @@
 	},
 /area/rogue/indoors/town)
 "eWN" = (
-/turf/open/floor/rogue/blocks/green,
+/obj/structure/closet/crate/roguecloset/dark,
+/obj/item/clothing/suit/roguetown/shirt/robe/mage,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/suit/roguetown/shirt/tunic/random,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/random,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/random,
+/obj/item/clothing/head/roguetown/roguehood/random,
+/obj/item/clothing/head/roguetown/wizhat/black,
+/obj/item/clothing/head/roguetown/wizhat/random,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/magician)
 "eXt" = (
 /obj/structure/flora/newleaf,
@@ -5815,6 +5815,12 @@
 	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/dwarfin)
+"fEa" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/magician)
 "fEo" = (
 /obj/structure/stairs{
 	dir = 8
@@ -10111,10 +10117,9 @@
 	},
 /area/rogue/indoors/town/magician)
 "jVE" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/toilet,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/magician)
 "jVM" = (
 /obj/structure/mineral_door/swing_door{
@@ -11680,7 +11685,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
 "lms" = (
-/turf/closed/wall/mineral/rogue/pipe,
+/turf/closed/wall/mineral/rogue/wooddark/slitted,
 /area/rogue/indoors/town/magician)
 "lmE" = (
 /obj/structure/table/wood/bar,
@@ -23189,6 +23194,7 @@
 /area/rogue/indoors)
 "wKL" = (
 /obj/structure/toilet,
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/magician)
 "wKP" = (
@@ -44809,7 +44815,7 @@ cej
 sde
 mag
 cej
-cHt
+eWN
 mag
 pNQ
 pNQ
@@ -44963,10 +44969,10 @@ ixc
 mag
 ixc
 eUm
-jVE
+fEa
 mag
 eUm
-jVE
+fEa
 ixc
 pNQ
 pNQ
@@ -45281,9 +45287,9 @@ mag
 mag
 jgQ
 mag
-ixc
-ixc
-lms
+mag
+mag
+mag
 oGK
 oGK
 oGK
@@ -45438,8 +45444,8 @@ teH
 iuO
 iuO
 pFQ
-eWN
-wKL
+cHt
+jVE
 kkp
 xsI
 cVE
@@ -45594,10 +45600,10 @@ iuO
 iuO
 iuO
 iuO
-ixc
-ixc
-ixc
 lms
+gbo
+gbo
+mag
 heh
 heh
 heh
@@ -45752,7 +45758,7 @@ uno
 iuO
 iuO
 pFQ
-eWN
+cHt
 wKL
 kkp
 cVE
@@ -45911,7 +45917,7 @@ jVk
 mag
 mag
 ixc
-lms
+ixc
 rxQ
 gVe
 nyq
@@ -46219,10 +46225,10 @@ ixc
 ixc
 mag
 eUm
-jVE
+fEa
 mag
 eUm
-jVE
+fEa
 ixc
 pNQ
 pmA

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1041,6 +1041,12 @@
 		wise.change_stat("intelligence", -2, "wisehat")
 		to_chat(wise, span_red("I lose wisdom."))
 
+// azure addition - random wizard hats
+
+/obj/item/clothing/head/roguetown/wizhat/random/Initialize()
+	icon_state = pick("wizardhatred", "wizardhatyellow", "wizardhatgreen", "wizardhat")
+	..()
+
 /obj/item/clothing/head/roguetown/witchhat
 	name = "witch hat"
 	desc = ""

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -3,7 +3,7 @@
 	flag = MAGEAPPRENTICE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 4
+	total_positions = 3
 	spawn_positions = 4
 
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -3,8 +3,8 @@
 	flag = MAGEAPPRENTICE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 4
+	spawn_positions = 4
 
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = list(AGE_ADULT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
changes mage apprentice to have 3 slots, and edits the mage tower to have 4 rooms for apprentices
Also Gives Apprentices Random Wizard Hats :]

<image src=https://github.com/user-attachments/assets/57825350-8424-4057-a41b-c4daebbce891 width=600>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
i regularly now see up to 4 players rolling for the two slots, making it questionably competitive to even play mage apprentice despite how relatively low stakes it is as a role. more people should be able to play it; it's a good role for new players.
i dont think this interrupts game balance that much, as mage apprentice is a relatively low stakes role.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
