### PR TITLE
Fixes desert rider's pants (oops)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -80,7 +80,7 @@
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	beltl = /obj/item/flashlight/flare/torch
-	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+	pants = /obj/item/clothing/under/roguetown/chainlegs
 
 	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/clothing/neck/roguetown/shalal)
 


### PR DESCRIPTION
## About The Pull Request
Gives the desert rider steel chain pants, rather than iron.
## Why It's Good For The Game
As demonstrated by the image below, with the new loadout for the Blade Dancer particularly, the shades of metal between the torso and legs on the Desert Rider was mismatched. And UGLY.
![men](https://github.com/user-attachments/assets/7846ca0b-acc2-4a62-8400-185e5a4feb9d)

My poor screenshotting skills mean you may have to squint, but it's very visible in-game. Left is before, right is after.

Unplayable!!!!!!!!!