### PR TITLE
Bumps PQ requirements for a few guard/guard adjacent roles

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -17,7 +17,7 @@
 	advclass_cat_rolls = list(CTAG_MENATARMS = 20)
 
 	give_bank_account = 22
-	min_pq = 1
+	min_pq = 3
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -17,7 +17,7 @@
 
 	give_bank_account = 40
 	noble_income = 20
-	min_pq = 5
+	min_pq = 8
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_guard.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -18,7 +18,7 @@
 
 	give_bank_account = 26
 	noble_income = 16
-	min_pq = 5
+	min_pq = 9
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_knight.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -15,7 +15,7 @@
 	whitelist_req = TRUE
 	give_bank_account = 44
 	noble_income = 22
-	min_pq = 6 //The second most powerful person in the realm...is Mhelping where the keep is
+	min_pq = 9 //The second most powerful person in the realm...
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_fancy.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -16,7 +16,7 @@
 
 	give_bank_account = 22
 	noble_income = 10
-	min_pq = 4
+	min_pq = 8
 	max_pq = null
 	round_contrib_points = 2
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR increases PQ requirements for man at arms, royal guard, guard captain, marshal, and the hand.

## Why It's Good For The Game

We've had an influx of new players as of late and this should help prevent those new players from immediately rushing into roles that are often required to interact with antagonists and call for a good understanding of escalation rules, in-roleplay criminal sentencing, and general conflict resolution. 

@Lutowski suggested a PQ minimum increase for royal guards in the comments of another PR, so I thought I'd go ahead and increase the minimum PQ values for RG and a few other guard/guard-adjacent roles while I was at it. 

Exact PQ minimum values can be adjusted as needed if this is maybe too much.
