### PR TITLE
library fixes

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -3463,7 +3463,6 @@
 /area/rogue/indoors/town/church)
 "dnd" = (
 /obj/structure/bookcase/random/archive{
-	density = 0;
 	opacity = 0
 	},
 /turf/open/floor/rogue/hexstone,
@@ -4131,7 +4130,6 @@
 /area/rogue/indoors)
 "dVM" = (
 /obj/structure/bookcase/random/archive{
-	density = 0;
 	opacity = 0
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -16187,11 +16185,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors)
 "pwl" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/bookcase/random/archive{
-	density = 0;
 	opacity = 0
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -39904,7 +39901,7 @@ gdw
 gdw
 dnd
 adU
-adU
+dnd
 dnd
 gdw
 gdw

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -9840,7 +9840,7 @@
 /area/rogue/outdoors/town)
 "jFz" = (
 /obj/structure/roguewindow,
-/turf/closed,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
 "jGs" = (
 /obj/structure/closet/crate/chest,
@@ -11413,6 +11413,10 @@
 "kWL" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town/shop)
+"kWP" = (
+/obj/structure/roguemachine/scomm/l,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement)
 "kWX" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/item/storage/roguebag,
@@ -38644,7 +38648,7 @@ gdw
 gdw
 gdw
 gdw
-gdw
+pNQ
 pNQ
 pNQ
 pNQ
@@ -38800,7 +38804,7 @@ dnd
 dnd
 dnd
 dnd
-dnd
+gdw
 gdw
 gdw
 gdw
@@ -38957,7 +38961,7 @@ dDy
 nFd
 nFd
 nFd
-nFd
+kWP
 tcC
 jis
 rRc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

the bookshelves actually have density flags now so you can't walk through them

also these two windows had no floors underneath them, i fixed them

![image](https://github.com/user-attachments/assets/04bcd377-38a5-4a19-8fbd-9b1f48e16cf2)

## Why It's Good For The Game

This PR makes meaningful improvements to the game’s environment by addressing both functional and aesthetic issues. The addition of density flags to bookshelves introduces a level of physical realism; bookshelves are now physical barriers that players cannot simply walk through. This aligns player movement with intuitive expectations, reinforcing the idea that objects in the game world have real mass and presence. As a result, the game environment becomes more engaging and consistent for players, deepening the sense of immersion.

In addition to the bookshelf density changes, this PR fixes an issue where two windows had no floors underneath them. This visual oversight, while small, can detract from the player's sense of realism and consistency within the environment. Floor tiles under windows not only maintain the visual flow of the map but also reinforce the structural integrity of the game’s design. By addressing this, the game now provides a more visually coherent experience for players, where environmental details match expected norms in a constructed space.

Overall, these updates contribute to a higher standard of quality and polish across the game’s environments. Removing these small but noticeable flaws reduces potential distractions that could pull players out of the experience. While they may seem minor individually, these improvements collectively enhance the player’s interaction with the environment, providing a smoother, more seamless gameplay experience.
