### PR TITLE
Sensual Seneschals; the servitude dlc

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -401,10 +401,9 @@
 /obj/item/candle/yellow,
 /obj/item/candle/yellow,
 /obj/item/flint,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/backpack/rogue/satchel,
-/obj/item/storage/backpack/rogue/satchel,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "asT" = (
@@ -635,6 +634,12 @@
 	},
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
+"aDr" = (
+/obj/structure/fermenting_barrel/water,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "aDy" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -2322,6 +2327,16 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"ckM" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/fluff/walldeco/stone{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "clq" = (
 /obj/structure/table/wood{
 	icon_state = "map3"
@@ -6926,6 +6941,9 @@
 "gJj" = (
 /obj/structure/closet/crate/drawer/random,
 /obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/wallfire{
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -11331,7 +11349,7 @@
 	icon_state = "wcv";
 	locked = 1;
 	lockid = "manor";
-	name = "Head Butler's Quarters"
+	name = "Senescal's Quarters"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11641,13 +11659,6 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"lfR" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/manor)
 "lfT" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -12884,6 +12895,10 @@
 	icon_state = "plating2"
 	},
 /area/rogue/indoors/town/dwarfin)
+"mnF" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/manor)
 "mnG" = (
 /obj/structure/closet/crate/chest/wicker{
 	opened = 1
@@ -13246,7 +13261,6 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
 "mJl" = (
-/obj/structure/roguemachine/scomm,
 /obj/structure/chair/bench/couch,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -14570,6 +14584,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
+"nWE" = (
+/obj/structure/fermenting_barrel/beer,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/manor)
 "nWK" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -15543,7 +15561,11 @@
 	dir = 10;
 	icon_state = "tablewood2"
 	},
-/obj/item/book/rogue/cardgame,
+/obj/item/natural/feather{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/paper,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "oRQ" = (
@@ -15856,6 +15878,16 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"piC" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "pja" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -17040,8 +17072,6 @@
 	pixel_x = -6;
 	pixel_y = 12
 	},
-/obj/item/roguekey/manor,
-/obj/item/roguekey/manor,
 /obj/item/rogueweapon/huntingknife/chefknife,
 /obj/item/book/rogue/yeoldecookingmanual{
 	pixel_x = 10
@@ -17067,6 +17097,18 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"qlk" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/structure/closet/crate/roguecloset,
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/clothing/head/roguetown/chef,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "qlw" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -17677,7 +17719,6 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
 "qRB" = (
-/obj/structure/roguemachine/scomm/r,
 /obj/effect/landmark/start/butler,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -18377,15 +18418,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"rCW" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
-/obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "rCZ" = (
 /obj/structure/fluff/railing/border{
 	dir = 8;
@@ -19227,7 +19259,6 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/butter,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
@@ -19238,9 +19269,11 @@
 /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
 /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
 /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
+/obj/item/reagent_containers/food/snacks/butter,
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -19653,10 +19686,11 @@
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/cooking/platter,
 /obj/item/cooking/platter,
-/obj/item/reagent_containers/peppermill,
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -20040,6 +20074,7 @@
 /area/rogue/indoors/town/dwarfin)
 "tfJ" = (
 /obj/structure/chair/bench/couchablack,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
 "tfW" = (
@@ -22098,6 +22133,7 @@
 /area/rogue/indoors/town/manor)
 "vsU" = (
 /obj/structure/table/wood,
+/obj/item/book/rogue/cardgame,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "vtR" = (
@@ -22450,7 +22486,6 @@
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/obj/machinery/light/rogue/torchholder/l,
 /obj/structure/closet/crate/chest,
 /obj/item/soap,
 /obj/item/soap,
@@ -23641,14 +23676,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"wRH" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/manor)
 "wSa" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -24105,21 +24132,6 @@
 /obj/item/reagent_containers/food/snacks/rogue/cheese,
 /obj/item/reagent_containers/food/snacks/rogue/honey,
 /obj/item/reagent_containers/food/snacks/rogue/honey,
-/obj/item/rogueweapon/huntingknife/cleaver{
-	pixel_y = 36;
-	pixel_x = -4;
-	name = "fish cleaver"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver{
-	pixel_y = 36;
-	pixel_x = 4;
-	name = "meat cleaver"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver{
-	pixel_y = 36;
-	pixel_x = 12;
-	name = "cheese cleaver"
-	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -69540,7 +69552,7 @@ vcT
 ycP
 flt
 dPO
-trF
+aDr
 vcT
 hvn
 hvn
@@ -70166,7 +70178,7 @@ vcT
 vcT
 vcT
 qiV
-kXB
+nWE
 uDU
 cap
 vcT
@@ -70632,9 +70644,9 @@ kuB
 cSR
 dEj
 vcT
-mFr
+qlk
 sqp
-rCW
+mFr
 xhJ
 vcT
 geE
@@ -91049,7 +91061,7 @@ hGV
 jvd
 vcT
 mJl
-sHf
+ckM
 vcT
 vcT
 vcT
@@ -91352,7 +91364,7 @@ qhb
 vcT
 vcT
 gJj
-wRH
+gTl
 ygb
 oRM
 vcT
@@ -91362,7 +91374,7 @@ fAW
 vcT
 vcT
 vcT
-lfR
+xDh
 fjC
 fjC
 dPO
@@ -91512,7 +91524,7 @@ qRB
 raP
 dPO
 fjC
-khn
+piC
 vcT
 fAW
 fAW
@@ -94341,8 +94353,8 @@ fjC
 dWm
 vcT
 tfJ
-oYc
 qsa
+mnF
 vcT
 mMX
 dPO

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -23308,6 +23308,10 @@
 "wCd" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
+"wCB" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "wDa" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
@@ -68478,7 +68482,7 @@ hvn
 rjw
 hIP
 pJn
-pJn
+sas
 pIO
 pJn
 pJn
@@ -69247,7 +69251,7 @@ wze
 cxb
 cxb
 cxb
-cxb
+wCB
 cxb
 cxb
 cxb

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -19691,6 +19691,7 @@
 	},
 /obj/item/cooking/platter,
 /obj/item/cooking/platter,
+/obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -224,6 +224,8 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_HEIR			"CAT_HEIR"			// Prince(cess) class - Handles Heir class selector
 #define CTAG_SQUIRE			"CAT_SQUIRE"		// Squire class - Handles Squire class selector
 #define CTAG_MARSHAL		"CAT_MARSHAL"		// Marshal class
+#define CTAG_SENESCHAL		"CAT_SENSCHAL"		// Seneschal's aesthetic choices. 
+#define CTAG_SERVANT		"CAT_SERVANT"		// Servant's aesthetic choices. 
 
 /*
 	Defines for the triumph buy datum categories

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -224,7 +224,7 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_HEIR			"CAT_HEIR"			// Prince(cess) class - Handles Heir class selector
 #define CTAG_SQUIRE			"CAT_SQUIRE"		// Squire class - Handles Squire class selector
 #define CTAG_MARSHAL		"CAT_MARSHAL"		// Marshal class
-#define CTAG_SENESCHAL		"CAT_SENSCHAL"		// Seneschal's aesthetic choices. 
+#define CTAG_SENESCHAL		"CAT_SENESCHAL"		// Seneschal's aesthetic choices. 
 #define CTAG_SERVANT		"CAT_SERVANT"		// Servant's aesthetic choices. 
 
 /*

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -376,7 +376,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/butler
-	name = "Head Butler"
+	name = "Seneschal"
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/barkeeper

--- a/code/modules/clothing/rogueclothes/gloves.dm
+++ b/code/modules/clothing/rogueclothes/gloves.dm
@@ -28,7 +28,7 @@
 
 /obj/item/clothing/gloves/roguetown/fingerless
 	name = "fingerless gloves"
-	desc = ""
+	desc = "Cloth gloves to absorb palm sweat while leaving the fingers free for fine manipulation."
 	icon_state = "fingerless_gloves"
 	resistance_flags = FIRE_PROOF
 	blocksound = SOFTHIT

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -1,6 +1,5 @@
-/datum/job/roguetown/butler
-	title = "Head Butler"
-	f_title = "Head Maid"
+/datum/job/roguetown/butler // really need to re-name all these when the codebase isn't a fork and search will update for the peasants...
+	title = "Seneschal"
 	flag = BUTLER
 	department_flag = COURTIERS
 	faction = "Station"
@@ -8,18 +7,25 @@
 	spawn_positions = 1
 
 	allowed_races = RACES_ALL_KINDS
-	//allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)
 
-	tutorial = "Servitude unto death; That is your motto. Having nurtured royalty for years, you are nothing short of the Duke's majordomo, commanding over the rest of the house staff."
-
+	tutorial = "Servitude unto death; that is your motto. You are the manor's major-domo, commanding over the house servants and seeing to the administrative affairs, day to day of the estate. This role has style options for chief butlers and head maids."
 	outfit = /datum/outfit/job/roguetown/butler
+	advclass_cat_rolls = list(CTAG_SENESCHAL = 20)
 	display_order = JDO_BUTLER
 	give_bank_account = 30
-	min_pq = 1 //Head Butler needs to actually give head at least once before getting the position
+	min_pq = 3
 	max_pq = null
-	round_contrib_points = 2
+	round_contrib_points = 3
 
-/datum/outfit/job/roguetown/butler/pre_equip(mob/living/carbon/human/H)
+/datum/job/roguetown/butler/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.advsetup = 1
+		H.invisibility = INVISIBILITY_MAXIMUM
+		H.become_blind("advsetup")
+
+/datum/outfit/job/roguetown/butler/pre_equip(mob/living/carbon/human/H) // Shared skills; the classes are for style.
 	..()
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
@@ -27,7 +33,7 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
@@ -41,31 +47,70 @@
 			H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
-		H.change_stat("strength", -1)
 		H.change_stat("speed", 1)
 		H.change_stat("intelligence", 2)
-		H.change_stat("perception", 1)
+		H.change_stat("perception", 2)
+		H.change_stat("fortune", 1) // Usually leadership carrot.
 
-	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
-	//	switch(H.patron?.type)
-	//		if(/datum/patron/divine/eora) //Eoran loadouts
-	//			armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy/black
-	//			pants = pick(/obj/item/clothing/under/roguetown/tights/stockings/silk/black, /obj/item/clothing/under/roguetown/tights/stockings/fishnet/black)
-	//			head  = /obj/item/clothing/head/peaceflower
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen
-		pants = pick(/obj/item/clothing/under/roguetown/tights/stockings/black, /obj/item/clothing/under/roguetown/tights/stockings/white) //Added stockings for the maids
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
-		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
-		cloak = /obj/item/clothing/cloak/apron/waist
-		belt = /obj/item/storage/belt/rogue/leather
-		beltr = /obj/item/storage/keyring/servant
-		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-	else
-		pants = /obj/item/clothing/under/roguetown/tights
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-		shoes = /obj/item/clothing/shoes/roguetown/shortboots
-		belt = /obj/item/storage/belt/rogue/leather
-		beltr = /obj/item/storage/keyring/servant
-		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
-		head = /obj/item/clothing/head/roguetown/fancyhat
+//	pants = /obj/item/clothing/under/roguetown/tights
+//	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+//	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+//	belt = /obj/item/storage/belt/rogue/leather
+//	beltr = /obj/item/storage/keyring/servant
+
+/datum/advclass/seneschal/seneschal
+	name = "Seneschal"
+	tutorial = "While still expected to fill in for the duties of the household servantry as needed, you have styled yourself as a figure beyond them."
+	outfit = /datum/outfit/job/roguetown/seneschal/seneschal
+	category_tags = list(CTAG_SENESCHAL)
+
+/datum/outfit/job/roguetown/seneschal/seneschal/pre_equip(mob/living/carbon/human/H)
+	..()
+	pants = /obj/item/clothing/under/roguetown/tights
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
+	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	backl = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/storage/keyring/servant
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
+	id = /obj/item/scomstone/bad
+	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F) 
+		armor = /obj/item/clothing/suit/roguetown/armor/silkcoat
+
+/datum/advclass/seneschal/headmaid
+	name = "Head Maid"
+	tutorial = "Whether you were promoted from one or just like the frills, you stylize yourself as a head maid. Your duties and talents remain the same, though."
+	outfit = /datum/outfit/job/roguetown/seneschal/headmaid
+	category_tags = list(CTAG_SENESCHAL)
+
+/datum/outfit/job/roguetown/seneschal/headmaid/pre_equip(mob/living/carbon/human/H)
+	..()
+	armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen
+	pants = pick(/obj/item/clothing/under/roguetown/tights/stockings/silk/white, /obj/item/clothing/under/roguetown/tights/stockings/silk/black) 
+	armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
+	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+	cloak = /obj/item/clothing/cloak/apron/waist
+	backl = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/storage/keyring/servant
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
+	id = /obj/item/scomstone/bad
+
+/datum/advclass/seneschal/chiefbutler
+	name = "Chief Butler"
+	tutorial = "You are the ruling class of butler and your ability to clear your throat and murmur 'I say' is without peer. Your duties and talents as seneschal remain the same, though."
+	outfit = /datum/outfit/job/roguetown/seneschal/chiefbutler
+	category_tags = list(CTAG_SENESCHAL)
+
+/datum/outfit/job/roguetown/seneschal/chiefbutler/pre_equip(mob/living/carbon/human/H)
+	..() // They need a monocle.
+	pants = /obj/item/clothing/under/roguetown/tights/black
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	backl = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/storage/keyring/servant
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
+	id = /obj/item/scomstone/bad
+

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -1,6 +1,6 @@
 /datum/job/roguetown/servant
 	title = "Servant"
-	f_title = "Maid"
+//	f_title = "Maid"
 	flag = SERVANT
 	department_flag = YOUNGFOLK
 	faction = "Station"
@@ -10,14 +10,23 @@
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = ALL_AGES_LIST
 
-	tutorial = "Granted a life of comfortable servitude in the Duke's manor, you follow the Head Butler/Maid's commands and spend your day performing necessary but menial tasks."
+	tutorial = "Granted a life of comfortable servitude in the Duke's manor, you follow the Seneschal's commands and spend your day performing necessary but menial tasks. This role offers an aesthetic choice between labor-servant, maid, and butler."
 
 	outfit = /datum/outfit/job/roguetown/servant
+	advclass_cat_rolls = list(CTAG_SERVANT = 20)
 	display_order = JDO_SERVANT
 	give_bank_account = TRUE
 	min_pq = -10
 	max_pq = null
 	round_contrib_points = 2
+
+/datum/job/roguetown/servant/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.advsetup = 1
+		H.invisibility = INVISIBILITY_MAXIMUM
+		H.become_blind("advsetup")
 
 /datum/outfit/job/roguetown/servant/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -32,24 +41,80 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.change_stat("strength", -1)
+		if(H.age == AGE_MIDDLEAGED)
+			H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
+		if(H.age == AGE_OLD)
+			H.mind.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/labor/farming, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.change_stat("speed", 1)
 		H.change_stat("intelligence", 1)
-		H.change_stat("perception", 1)
+		H.change_stat("perception", 2)
 
-	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
-		head = /obj/item/clothing/head/roguetown/armingcap
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
-		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
-		cloak = /obj/item/clothing/cloak/apron/waist
-		belt = /obj/item/storage/belt/rogue/leather
-		beltr = /obj/item/storage/keyring/servant
-		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-	else
-		pants = /obj/item/clothing/under/roguetown/tights
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-		shoes = /obj/item/clothing/shoes/roguetown/shortboots
-		belt = /obj/item/storage/belt/rogue/leather
-		beltr = /obj/item/storage/keyring/servant
-		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
+//	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
+//		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
+//		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+//		belt = /obj/item/storage/belt/rogue/leather
+//		beltr = /obj/item/storage/keyring/servant
+//	else
+//		pants = /obj/item/clothing/under/roguetown/tights
+//		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+//		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+//		belt = /obj/item/storage/belt/rogue/leather
+//		beltr = /obj/item/storage/keyring/servant
+
+/datum/advclass/servant/servant
+	name = "Servant"
+	tutorial = "You are a humdrum servant, dressed the part; lowly and best out of sight."
+	outfit = /datum/outfit/job/roguetown/servant/servant
+	category_tags = list(CTAG_SERVANT)
+
+/datum/outfit/job/roguetown/servant/servant/pre_equip(mob/living/carbon/human/H)
+	..()
+	pants = /obj/item/clothing/under/roguetown/trou
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
+	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	backl = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/storage/keyring/servant
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+	armor = /obj/item/clothing/suit/roguetown/armor/workervest
+	gloves = /obj/item/clothing/gloves/roguetown/fingerless
+
+/datum/advclass/servant/maid
+	name = "Maid"
+	tutorial = "Not one really mentions how hard it is to do yardwork in a dress and stockings, but at least you still look really good."
+	outfit = /datum/outfit/job/roguetown/servant/maid
+	category_tags = list(CTAG_SERVANT)
+
+/datum/outfit/job/roguetown/servant/maid/pre_equip(mob/living/carbon/human/H)
+	..()
+	head = /obj/item/clothing/head/roguetown/armingcap
+	armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
+	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+	pants = pick(/obj/item/clothing/under/roguetown/tights/stockings/black, /obj/item/clothing/under/roguetown/tights/stockings/white) 
+	cloak = /obj/item/clothing/cloak/apron/waist
+	backl = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/storage/keyring/servant
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+
+/datum/advclass/servant/butler
+	name = "Butler"
+	tutorial = "An impeccable appearance if your core being. You still dig through the mud, though, you just do the laundry more."
+	outfit = /datum/outfit/job/roguetown/servant/butler
+	category_tags = list(CTAG_SERVANT)
+
+/datum/outfit/job/roguetown/servant/butler/pre_equip(mob/living/carbon/human/H)
+	..()
+	pants = /obj/item/clothing/under/roguetown/tights/black
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	backl = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/storage/keyring/servant
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -19,6 +19,7 @@
 	min_pq = -10
 	max_pq = null
 	round_contrib_points = 2
+	advjob_examine = TRUE
 
 /datum/job/roguetown/servant/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -68,7 +68,7 @@
 
 /datum/advclass/servant/servant
 	name = "Servant"
-	tutorial = "You are a humdrum servant, dressed the part; lowly and best out of sight."
+	tutorial = "You are a humdrum servant, dressed the part; lowly and best out of sight. It's practical, however."
 	outfit = /datum/outfit/job/roguetown/servant/servant
 	category_tags = list(CTAG_SERVANT)
 
@@ -104,7 +104,7 @@
 
 /datum/advclass/servant/butler
 	name = "Butler"
-	tutorial = "An impeccable appearance if your core being. You still dig through the mud, though, you just do the laundry more."
+	tutorial = "An impeccable appearance is your core being. You still dig through the mud, though, you just do the laundry more."
 	outfit = /datum/outfit/job/roguetown/servant/butler
 	category_tags = list(CTAG_SERVANT)
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -75,7 +75,7 @@ GLOBAL_LIST_INIT(courtier_positions, list(
 	"Court Magician",
 	"Court Physician",
 	"Jester",
-	"Head Butler",
+	"Seneschal",
 ))
 
 GLOBAL_LIST_INIT(garrison_positions, list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Unfortunately the DLC is smothered a bit by sprite works, but oh well.

This changes the Head Butler/Maid to the more gender neutral Seneschal! Which, by the end of this, very much does not seem like a word anymore! The Seneschal is the administrator and steward of a noble estate, overseeing everything. Another, if more 16th century, title for it is major-domo, but I hate that word. The Seneschal picks up classes, allowing them to look like an admittedly somewhat flabby noble administrator, or their head butler/maid trappings of the past. They also picked up a serfring along the way. As they are officially a leadership character of the ever popular newbie-bait servant role (and to a lesser extent all keep roles by adjacency) they get a RCP bonus as well as the usual fortune carrot. 

Servants also get a change. Unfortunately at this time, this eats up the title of maid, but hopefully our top scientists get on the case - in the meantime, they'll all be marked as the still accurate servant. They also gain benefits for being older like their boss. Now servants have a similar class choice, letting them opt into a day-laborer servant, maid, or butler... irregardless of someone's sex.

In both cases the only differences in classes are aesthetics.

Unfortunately, the classes are wildly different in drip so it'll be another case of nude on the lobby screen. Advclass doesn't _replace_ gear already on someone.

I have also touched up on the map a little bit; the seneschal's office got an appropriately named door, as well as some writing material. I have adjusted SCOMs here and there to be out of the way of someone who'd actively be in that tile for irrelevant roleplaying, like on the Hand's couch. The kitchen area had its satchels removed, as servants just spawn with them now, and instead there are some bolts of cloth to save enterprising cleaners the trip downstairs. The spooky floating cleavers were finally fixed, and some extra cutlery was added. I may be refurbishing the storeroom at a later date. The keys that were once in the servants' room also got tossed up into the seneschal's, as that is their domain and it was really easy to steal them from careless servants. Most important of all; a chefs hat.

![image](https://github.com/user-attachments/assets/29db4cfa-432a-4faf-9efa-007a5ce1eebf)


Usual meagre proof of testing; 

![image](https://github.com/user-attachments/assets/9b0fd77f-e934-4945-a917-b0aec7e259c7)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game


![image](https://github.com/user-attachments/assets/039eb950-314c-4b1a-8a75-c962b9b78cf8)


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
