### PR TITLE
Thrown Weapon Strap

### DIFF
--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -58,6 +58,13 @@
 				/obj/item/rope = 1)
 	sellprice = 30
 
+/datum/crafting_recipe/roguetown/leather/twstrap
+	name = "Thrown Weapon Strap"
+	result = /obj/item/twstrap
+	reqs = list(/obj/item/natural/hide = 2,
+				/obj/item/rope = 1)
+	sellprice = 30
+
 /datum/crafting_recipe/roguetown/leather/belt
 	name = "leather belt"
 	result = /obj/item/storage/belt/rogue/leather


### PR DESCRIPTION
## About The Pull Request

Now that I have the code for the GWStrap down, I can easily extend that to another project I had in mind, the thrown weapon bandolier!

After compiling the different weapons in the code into my excel doc, I found that daggers actually did have an overall higher thrown weapon damage. I've never actually seen anyone use daggers to throw though. Why? Because we cannot open our bags/belts/pouches/whatever while moving. It's clunky to do in a setting, even if you really want to show off your Matthios rizz with some tossable blades. TO THAT END, I give to you the Thrown Weapon Strap.

### How it works:
- The TWS has a recipe akin to the GWS, making it equally time consuming to make.
- The TWS takes up your back slot and only your back slut, meaning you are sacrificing your back slot to use this item.
- The TWS takes 5 seconds to put on.
- The TWS takes 5 seconds to take off.
- You WILL NOT be able to properly use the TWS unless you have a knife-fighting skill of at least apprentice. If you do not, you will have a 2 second delay on drawing a dagger from it.
- Only children of huntingknife/throwing_star can be put into the TWS.
- The TWS has a maximum capacity of FIVE.
- The TWS DOES retain its daggers if removed from the person.
- The TWS sprite updates to show how many knives it has remaining.

## Why It's Good For The Game

This allows for another ranged fighting style to go alongside bows, though its limited capacity of 5 makes it more of a run-and-gun type fighting style. If you miss, you probably will not be getting those daggers back until the fight is over, but if you hit, well you are weakening your target a little before it closes the gap to you.

Knives are probably one of the lesser used weapons in the game, giving them more of a reason to exist will make more classes with knife-fighting viable, like the rogue.


https://github.com/user-attachments/assets/53a33bb2-5aa7-4e26-9938-dcae69b02478


