### PR TITLE
Changes dragon ring recipe

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
@@ -153,7 +153,7 @@
 
 /datum/anvil_recipe/valuables/dragon
 	name = "Dragon Ring (+ Secrets)"
-	req_bar =  /obj/item/ingot/steel
-	additional_items = list(/obj/item/ingot/gold, /obj/item/ingot/steel, /obj/item/roguegem/blue, /obj/item/roguegem/violet, /obj/item/clothing/neck/roguetown/psicross)
+	req_bar =  /obj/item/ingot/blacksteel
+	additional_items = list(/obj/item/ingot/gold, /obj/item/roguegem/blue, /obj/item/roguegem/violet, /obj/item/clothing/neck/roguetown/psicross/silver)
 	created_item = /obj/item/clothing/ring/dragon_ring
 	craftdiff = 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The dragon ring recipe now requires a single blacksteel bar instead of 2 regular steel bars, as well as specifically a silver psycross as opposed to *any* psycross. No longer can you simply use wooden psycrosses for a dragon ring.

## Why It's Good For The Game

Due to the amount of dungeons here that spawn with random gems, gems are a lot easier to acquire here than on other RT servers. This means dragon rings are currently fairly easy to make and give you a ridiculously strong stat buff for how easy they are to acquire. 

This should make dragon rings still plausible to make in-round if you put a good deal of effort into acquiring one; but they should be a fair bit rarer and harder to acquire.
