### PR TITLE
Saddle Up: Working storage inside saddles & goat saddling (plus goatherd tweaks)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -219,6 +219,12 @@
 		resolveAdjacentClick(A,W,params)
 		return
 
+	if (A.loc && ismob(A.loc.loc))
+		// we're inside a container inside a mob, so we're almost certainly a saddle, a box, or someone's organs. check if we're adjacent
+		if (src.Adjacent(A.loc.loc))
+			resolveAdjacentClick(A,W,params)
+			return
+
 	if(W)
 		if(ismob(A))
 			if(CanReach(A,W))

--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -35,6 +35,15 @@
 	force = 0
 	throwforce = 0
 	sellprice = 10
+	var/storage_type = /datum/component/storage/concrete
+
+/obj/item/natural/saddle/ComponentInitialize()
+	. = ..()
+	AddComponent(storage_type)
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 16
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_items = 12
 
 /obj/item/natural/saddle/attack(mob/living/target, mob/living/carbon/human/user)
 	if(istype(target, /mob/living/simple_animal))

--- a/code/modules/mob/living/simple_animal/rogue/farm/goat.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/goat.dm
@@ -21,7 +21,7 @@
 	if(can_buckle)
 		var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(-2, 6), TEXT_WEST = list(2, 6)))
-		D.set_vehicle_dir_layer(SOUTH, OBJ_LAYER)
+		D.set_vehicle_dir_layer(SOUTH, MOB_LAYER+0.1)
 		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 		D.set_vehicle_dir_layer(EAST, OBJ_LAYER)
 		D.set_vehicle_dir_layer(WEST, OBJ_LAYER)
@@ -231,6 +231,9 @@
 	bonus_tame_chance = 15
 	remains_type = /obj/effect/decal/remains/cow
 
+/mob/living/simple_animal/hostile/retaliate/rogue/goatmale/tame
+	tame = TRUE
+
 /mob/living/simple_animal/hostile/retaliate/rogue/goatmale/update_icon()
 	cut_overlays()
 	..()
@@ -250,7 +253,7 @@
 	if(can_buckle)
 		var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(-2, 6), TEXT_WEST = list(2, 6)))
-		D.set_vehicle_dir_layer(SOUTH, OBJ_LAYER)
+		D.set_vehicle_dir_layer(SOUTH, MOB_LAYER+0.1)
 		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 		D.set_vehicle_dir_layer(EAST, OBJ_LAYER)
 		D.set_vehicle_dir_layer(WEST, OBJ_LAYER)

--- a/code/modules/mob/living/simple_animal/rogue/farm/goat.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/goat.dm
@@ -98,7 +98,7 @@
 	childtype = list(/mob/living/simple_animal/hostile/retaliate/rogue/goat/goatlet = 90, /mob/living/simple_animal/hostile/retaliate/rogue/goat/goatletboy = 10)
 	can_buckle = TRUE
 	buckle_lying = 0
-	can_saddle = FALSE
+	can_saddle = TRUE
 	remains_type = /obj/effect/decal/remains/cow
 
 /mob/living/simple_animal/hostile/retaliate/rogue/goat/get_sound(input)
@@ -226,7 +226,7 @@
 	STASPD = 2
 	can_buckle = TRUE
 	buckle_lying = 0
-	can_saddle = FALSE
+	can_saddle = TRUE
 	tame_chance = 25
 	bonus_tame_chance = 15
 	remains_type = /obj/effect/decal/remains/cow

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -422,6 +422,11 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 					gib()
 					if(user.mind)
 						user.mind.add_sleep_experience(/datum/skill/labor/butchering, user.STAINT * 4)
+	else if (stat != DEAD && istype(ssaddle, /obj/item/natural/saddle))
+		var/datum/component/storage/saddle_storage = ssaddle.GetComponent(/datum/component/storage)
+		var/access_time = (user in buckled_mobs) ? 10 : 30
+		if (do_after(user, access_time, target = src))
+			saddle_storage.show_to(user)
 	..()
 
 /mob/living/simple_animal/gib()

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/goatherd.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/goatherd.dm
@@ -5,7 +5,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/vagabond/goatherd
 	category_tags = list(CTAG_VAGABOND)
-	horse = /mob/living/simple_animal/hostile/retaliate/rogue/goat/tame
+	horse = /mob/living/simple_animal/hostile/retaliate/rogue/goatmale/tame
 
 /datum/outfit/job/roguetown/vagabond/goatherd/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request

Few changes:

- Saddles are now containers. Not especially big ones, but they are containers. You could totally wear one on your left back slot if you wanted to. Not sure why you'd want to, but you can!
- You can access a saddle's inventory by middle-clicking on a mob that has a saddle attached to it.
   - If you're riding the mob at the time of doing this, it is three times faster to access.
- Goats are now saddleable and ridable, complete with sprites that they've always had but were never actually used for whatever reason.
- I've adjusted the south dir layering on goats to look far more realistic than it previously did.
- Goatherd vagabonds now spawn with a tame male goat so they can actually begin creating a herd of goats. You know, the thing that goatherds should be doing.

Maintainer note: this includes some low-level additions to the mob onclick proc, so it should be **testmerged** first, preferably during lowpop, to make sure shit does not break in unexpected ways. It shouldn't, but there's always the risk that it might.

## Why It's Good For The Game

Finishing what some very early Roguetown devs started long ago.
