### PR TITLE
Relevant mercenaries get a GW strap

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
@@ -24,6 +24,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
+	backr = /obj/item/gwstrap
 	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -75,6 +75,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
 	gloves = /obj/item/clothing/gloves/roguetown/grenzelgloves
 	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backl = /obj/item/gwstrap
 
 	backpack_contents = list(/obj/item/roguekey/mercenary)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This was originally suggested as a quality of life improvement for them, and the crafting recipe isn't _so_ bad that they can't manage it themselves. So, our elfy-polearm and pretzel mercenary friends both spawn with a strap, so they may carry freely. The other great weapon classes, like warrior MAA and knight, all have to source one themselves, still.

![image](https://github.com/user-attachments/assets/0bc0f7bc-3c06-4543-9ca0-01e4fc54104f)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It removes a round chore from a pair who'd want to do it, and are already otherwise equipped.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
