### PR TITLE
Autopunctuation

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
@@ -58,6 +58,8 @@
 
 	message = treat_message_accent(message, strings("accent_universal.json", "universal"), REGEX_FULLWORD)
 
+	message = autopunct_bare(message)
+
 	speech_args[SPEECH_MESSAGE] = trim(message)
 
 

--- a/modular_azurepeak/code/datums/autopunctuation.dm
+++ b/modular_azurepeak/code/datums/autopunctuation.dm
@@ -1,0 +1,15 @@
+//Does the line end in any EOL char that isn't appropriate punctuation OR does it end in a chat-formatted markdown sequence (+bold+, etc) without a period?
+GLOBAL_DATUM_INIT(needs_eol_autopunctuation, /regex, regex(@"([a-zA-Z\d]|[^.?!~-][+|_])$"))
+
+//All non-capitalized 'i' surrounded with whitespace (aka, 'hello >i< am a cat')
+GLOBAL_DATUM_INIT(noncapital_i, /regex, regex(@"\b[i]\b", "g"))
+
+/// Ensures sentences end in appropriate punctuation (a period if none exist) and that all whitespace-bounded 'i' characters are capitalized.
+/// If the sentence ends in chat-flavored markdown for bolds, italics or underscores and does not have a preceding period, exclamation mark or other flavored sentence terminator, add a period.
+/// (e.g: 'Borgs are rogue' becomes 'Borgs are rogue.', '+BORGS ARE ROGUE+ becomes '+BORGS ARE ROGUE+.', '+Borgs are rogue~+' is untouched.)
+/proc/autopunct_bare(input_text)
+	if (findtext(input_text, GLOB.needs_eol_autopunctuation))
+		input_text += "."
+
+	input_text = replacetext(input_text, GLOB.noncapital_i, "I")
+	return input_text

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3571,6 +3571,7 @@
 #include "modular\Neu_Food\code\raw\NeuFood_veggies.dm"
 #include "modular\ze_genesis_call\genesis_call.dm"
 #include "modular_azurepeak\_statpacks.dm"
+#include "modular_azurepeak\code\datums\autopunctuation.dm"
 #include "modular_azurepeak\code\datums\loadout.dm"
 #include "modular_azurepeak\code\datums\mind.dm"
 #include "modular_azurepeak\code\game\area\areas.dm"


### PR DESCRIPTION
## About The Pull Request

Enforces periods at the end of sentences except where another marker (~ or + or -, etc) is present. Identical implementation to my work on other SS13 servers.

Also capitalizes lowercase i's in the middle of sentences.

## Why It's Good For The Game

Objective readability improvements, practically no performance hit.
