### PR TITLE
Removes access to torture verbs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/witchhunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/witchhunter.dm
@@ -54,8 +54,8 @@
 		H.change_stat("speed", 1)
 		H.change_stat("constitution", 1)
 		H.change_stat("perception", 2)
-	H.verbs |= /mob/living/carbon/human/proc/torture_victim
-	H.verbs |= /mob/living/carbon/human/proc/faith_test
+	//H.verbs |= /mob/living/carbon/human/proc/torture_victim
+	//H.verbs |= /mob/living/carbon/human/proc/faith_test
 
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/church/puritan.dm
@@ -69,8 +69,8 @@
 		H.change_stat("perception", 3)
 		H.change_stat("speed", 1)
 		H.change_stat("intelligence", 3)
-	H.verbs |= /mob/living/carbon/human/proc/faith_test
-	H.verbs |= /mob/living/carbon/human/proc/torture_victim
+	//H.verbs |= /mob/living/carbon/human/proc/faith_test
+	//H.verbs |= /mob/living/carbon/human/proc/torture_victim
 	ADD_TRAIT(H, TRAIT_NOSEGRAB, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -59,6 +59,6 @@
 	H.change_stat("endurance", 1)
 	H.change_stat("constituion", 2)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
-	H.verbs |= /mob/living/carbon/human/proc/torture_victim
+	//H.verbs |= /mob/living/carbon/human/proc/torture_victim
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

Inquisitor sucks.

It adds functionally nothing to the game in its present state outside of enabling people that probably shouldn't be in the community to begin with to indulge in one-sided torture scenes and keeping other players in paincrit for an hour and a half stretches at a time.

I was originally going to remove inquisitor as a role altogether, but another contributor apparently has plans for them so you get this instead: **no subclass has access to the faith test or torture verbs anymore.** This clips Dungeoneer and the Witch Hunter subclass as well.

## Why It's Good For The Game

See above.
