### PR TITLE
Adds a surgery to use a saw to remove a prosthetic limb

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -221,6 +221,11 @@
 	to_chat(user, span_warning("I twist [C]'s [parse_zone(sublimb_grabbed)].[C.next_attack_msg.Join()]"))
 	C.next_attack_msg.Cut()
 	log_combat(user, C, "limbtwisted [sublimb_grabbed] ")
+	if(limb_grabbed.status == BODYPART_ROBOTIC && armor_block == 0) //Twisting off prosthetics.
+		C.visible_message(span_danger("[C]'s prosthetic [parse_zone(sublimb_grabbed)] twists off![C.next_attack_msg.Join()]"), \
+					span_userdanger("My prosthetic [parse_zone(sublimb_grabbed)] was twisted off of me![C.next_attack_msg.Join()]"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE, user)
+		to_chat(user, span_warning("I twisted [C]'s prosthetic [parse_zone(sublimb_grabbed)] off.[C.next_attack_msg.Join()]"))
+		limb_grabbed.drop_limb(TRUE)
 
 /obj/item/grabbing/proc/twistitemlimb(mob/living/user) //implies limb_grabbed and sublimb are things
 	var/mob/living/M = grabbed

--- a/code/modules/surgery/surgeries/prosthetic_replacement.dm
+++ b/code/modules/surgery/surgeries/prosthetic_replacement.dm
@@ -79,3 +79,50 @@
 		span_notice("[user] successfully transplants [target]'s [parse_zone(target_zone)] with [tool]!"),
 		span_notice("[user] successfully transplants [target]'s [parse_zone(target_zone)]!"))
 	return TRUE
+
+/datum/surgery/prosthetic_removal
+	name = "Prosthetic removal"
+	steps = list(
+		/datum/surgery_step/remove_prosthetic
+	)
+	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	possible_locs = list(
+		BODY_ZONE_R_ARM,
+		BODY_ZONE_L_ARM
+	)
+	requires_bodypart = TRUE
+	requires_bodypart_type = BODYPART_ROBOTIC
+
+/datum/surgery_step/remove_prosthetic
+	name = "Remove prosthetic"
+	implements = list(
+		TOOL_SAW = 90,
+	)
+	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	possible_locs = list(
+		BODY_ZONE_R_ARM,
+		BODY_ZONE_L_ARM
+	)
+	time = 10 SECONDS
+	requires_bodypart = TRUE
+	requires_bodypart_type = BODYPART_ROBOTIC
+	skill_min = SKILL_LEVEL_JOURNEYMAN
+	skill_median = SKILL_LEVEL_EXPERT
+	surgery_flags = NONE
+	preop_sound = 'sound/foley/sewflesh.ogg'
+	success_sound = 'sound/items/wood_sharpen.ogg'
+
+
+/datum/surgery_step/remove_prosthetic/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
+	display_results(user, target, span_notice("I begin to saw through the base of [target]'s [parse_zone(target_zone)]..."),
+		span_notice("[user] begins to saw through [target]'s [parse_zone(target_zone)]!"),
+		span_notice("[user] begins to saw through [target]'s [parse_zone(target_zone)]!"))
+	return TRUE
+
+/datum/surgery_step/remove_prosthetic/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
+	display_results(user, target, span_notice("I saw through the base of [target]'s [parse_zone(target_zone)]."),
+		span_notice("[user] saws through the base of [target]'s [parse_zone(target_zone)]!"),
+		span_notice("[user] saws through the base of [target]'s [parse_zone(target_zone)]!"))
+	var/obj/item/bodypart/target_limb = target.get_bodypart(check_zone(target_zone))
+	target_limb?.drop_limb(TRUE)
+	return TRUE

--- a/code/modules/surgery/surgeries/prosthetic_replacement.dm
+++ b/code/modules/surgery/surgeries/prosthetic_replacement.dm
@@ -114,15 +114,15 @@
 
 
 /datum/surgery_step/remove_prosthetic/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	display_results(user, target, span_notice("I begin to saw through the base of [target]'s [parse_zone(target_zone)]..."),
-		span_notice("[user] begins to saw through [target]'s [parse_zone(target_zone)]!"),
-		span_notice("[user] begins to saw through [target]'s [parse_zone(target_zone)]!"))
+	display_results(user, target, span_notice("I begin to saw through the base of [target]'s [parse_zone(target_zone)] prosthetic..."),
+		span_notice("[user] begins to saw through the base of [target]'s prosthetic [parse_zone(target_zone)]."),
+		span_notice("[user] begins to saw through the base of [target]'s prosthetic [parse_zone(target_zone)]."))
 	return TRUE
 
 /datum/surgery_step/remove_prosthetic/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	display_results(user, target, span_notice("I saw through the base of [target]'s [parse_zone(target_zone)]."),
-		span_notice("[user] saws through the base of [target]'s [parse_zone(target_zone)]!"),
-		span_notice("[user] saws through the base of [target]'s [parse_zone(target_zone)]!"))
+	display_results(user, target, span_notice("I saw through the base of [target]'s prosthetic [parse_zone(target_zone)]."),
+		span_notice("[user] saws through the base of [target]'s prosthetic [parse_zone(target_zone)]!"),
+		span_notice("[user] saws through the base of [target]'s prosthetic [parse_zone(target_zone)]!"))
 	var/obj/item/bodypart/target_limb = target.get_bodypart(check_zone(target_zone))
 	target_limb?.drop_limb(TRUE)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

![image](https://github.com/user-attachments/assets/a5ab0a2a-6c60-4643-a3a1-28e1839fc12c)

A copy of limb amputation surgery step that targets RT prosthetics to remove them without medical damage to the mob. The saw felt like the right tool for the job, and it does not collide with any other surgical steps. Just 1 step because non-organic limbs don't play nice with incision / clamping bleeders and so on.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Right now, people have to hit prosthetic limbs until they sever like a normal limb. Doing so triggers the normal limb severing damage, like profuse bleeding in the chest, which would not be the medically responsible method for removing a prosthetic from a stump. This gives a surgical step to remove (saw off) the base of the prosthetic, dropping the limb without damage to it or the patient.


https://github.com/user-attachments/assets/298d1a1b-c0a1-48a6-bb2c-192c2df1bb61


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
