### PR TITLE
Fetch no longer embeds things in catch mode

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -531,7 +531,7 @@
 				carbon_firer = firer
 				if (carbon_firer?.can_catch_item())
 					throw_target = get_turf(firer)
-			I.throw_at(throw_target, 200, 4)
+			I.throw_at(throw_target, 200, 3)
 
 /obj/projectile/magic/sickness
 	name = "Bolt of Sickness"


### PR DESCRIPTION
## About The Pull Request

Throw speed 4 is the magic number for getting things stuck in people, it seems. This changes it to be 3 in catch mode, which is a bit slower but also safer.

## Why It's Good For The Game

As funny as mages embedding goblets into random body parts was, it was ultimately stopping people from using arguably one of the mage's coolest spells.