### PR TITLE
Reduce healing potion nutrition loss

### DIFF
--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -29,7 +29,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!istype(H.dna.species, /datum/species/werewolf))
-			M.adjust_nutrition(-5*REM)
+			M.adjust_nutrition(-2.5*REM)
 	..()
 	. = 1
 
@@ -81,7 +81,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!istype(H.dna.species, /datum/species/werewolf))
-			M.adjust_nutrition(-2.5*REM)
+			M.adjust_nutrition(-0.5*REM)
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request

Feast & Famine added nutrition drain to red healing potions. After reviewing some feedback from the recent dev surveys and tracing back people with a negative opinion to mostly guard mains, I've identified that one of the biggest contributors is probably red elixir use.

This tones down dated red's nutrition drain from -5 to -2.5, and player-crafted red's nutrition drain from -2.5 to -0.5.

## Why It's Good For The Game

In practice, this should make red use a little less punishing than before, and player-crafted red's drain is almost negligible overall, which gives it a lot more value for those willing to spend the time to make it.
