### PR TITLE
[TESTMERGE] Grain Toggle & Ready Logging

### DIFF
--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -97,8 +97,10 @@
 	static_inventory += using
 
 	using = new /atom/movable/screen/grain
-	using.hud = src
-	static_inventory += using
+	grain.hud = src
+	static_inventory += grain
+	if(owner.client?.prefs?.grain == TRUE)
+		grain.alpha = 55
 
 	scannies = new /atom/movable/screen/scannies
 	scannies.hud = src
@@ -162,8 +164,10 @@
 	static_inventory += using
 
 	using = new /atom/movable/screen/grain
-	using.hud = src
-	static_inventory += using
+	grain.hud = src
+	static_inventory += grain
+	if(owner.client?.prefs?.grain == TRUE)
+		grain.alpha = 55
 
 	scannies = new /atom/movable/screen/scannies
 	scannies.hud = src
@@ -196,8 +200,10 @@
 	static_inventory += using
 
 	using = new /atom/movable/screen/grain
-	using.hud = src
-	static_inventory += using
+	grain.hud = src
+	static_inventory += grain
+	if(owner.client?.prefs?.grain == TRUE)
+		grain.alpha = 55
 
 	scannies = new /atom/movable/screen/scannies
 	scannies.hud = src

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -96,7 +96,7 @@
 	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/grain
+	grain = new /atom/movable/screen/grain
 	grain.hud = src
 	static_inventory += grain
 	if(owner.client?.prefs?.grain == TRUE)
@@ -163,7 +163,7 @@
 	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/grain
+	grain = new /atom/movable/screen/grain
 	grain.hud = src
 	static_inventory += grain
 	if(owner.client?.prefs?.grain == TRUE)
@@ -199,7 +199,7 @@
 	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/grain
+	grain = new /atom/movable/screen/grain
 	grain.hud = src
 	static_inventory += grain
 	if(owner.client?.prefs?.grain == TRUE)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -109,6 +109,14 @@ GLOBAL_LIST_INIT(available_ui_styles, sortList(list(
 	if(owner.client?.prefs?.crt == TRUE)
 		scannies.alpha = 70
 
+/datum/hud/new_player/New(mob/owner)
+	..()
+	grain = new /atom/movable/screen/grain
+	grain.hud = src
+	static_inventory += grain
+	if(owner.client?.prefs?.grain == TRUE)
+		grain.alpha = 55
+
 /datum/hud/Destroy()
 	if(mymob.hud_used == src)
 		mymob.hud_used = null

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -99,7 +99,8 @@
 	grain = new /atom/movable/screen/grain
 	grain.hud = src
 	static_inventory += grain
-
+	if(owner.client?.prefs?.grain == TRUE)
+		grain.alpha = 55
 
 	reads = new /atom/movable/screen/read
 	reads.hud = src

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -1930,9 +1930,7 @@
 	name = ""
 	screen_loc = "1,1"
 	mouse_opacity = 0
-	alpha = 55 // I DO SEE NOTHING WITH 70 ALPHA
-//	layer = 20.5
-//	plane = 20
+	alpha = 0
 	layer = 13
 	plane = 0
 	blend_mode = 4

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -145,6 +145,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/family = FAMILY_NONE
 
 	var/crt = FALSE
+	var/grain = TRUE
 
 	var/list/customizer_entries = list()
 	var/list/list/body_markings = list()
@@ -683,6 +684,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 					dat += "<b>UNREADY</b> <a href='byond://?src=[REF(N)];ready=[PLAYER_READY_TO_PLAY]'>READY</a>"
 				if(PLAYER_READY_TO_PLAY)
 					dat += "<a href='byond://?src=[REF(N)];ready=[PLAYER_NOT_READY]'>UNREADY</a> <b>READY</b>"
+					log_game("([user || "NO KEY"]) readied as ([real_name])")
 		else
 			if(!is_active_migrant())
 				dat += "<a href='byond://?src=[REF(N)];late_join=1'>JOINLATE</a>"

--- a/code/modules/client/verbs/ghost.dm
+++ b/code/modules/client/verbs/ghost.dm
@@ -1,6 +1,7 @@
 GLOBAL_LIST_INIT(ghost_verbs, list(
 	/client/proc/ghost_up,
 	/client/proc/ghost_down,
+	/client/proc/descend,
 	/client/proc/reenter_corpse
 	))
 
@@ -15,6 +16,33 @@ GLOBAL_LIST_INIT(ghost_verbs, list(
 	set name = "GhostDown"
 	if(isobserver(mob))
 		mob.ghost_down()
+
+/client/proc/descend()
+	set name = "Journey to the Underworld"
+	set category = "Spirit"
+
+	switch(alert("Descend to the Underworld?",,"Yes","No"))
+		if("Yes")
+			if(istype(mob, /mob/living/carbon/spirit))
+				return
+
+			if(istype(mob, /mob/living/carbon/human))
+				var/mob/living/carbon/human/D = mob
+				if(D.buried && D.funeral)
+					D.returntolobby()
+					return
+
+				var/datum/job/target_job = SSjob.GetJob(D.mind.assigned_role)
+				if(target_job)
+					if(target_job.job_reopens_slots_on_death)
+						target_job.current_positions = max(0, target_job.current_positions - 1)
+					if(target_job.same_job_respawn_delay)
+						// Store the current time for the player
+						GLOB.job_respawn_delays[src.ckey] = world.time + target_job.same_job_respawn_delay
+			verbs -= GLOB.ghost_verbs
+			mob.returntolobby()
+		if("No")
+			usr << "You have second thoughts."
 
 /client/proc/reenter_corpse()
 	set category = "Spirit"

--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -124,8 +124,8 @@
 	if(!client)
 		return
 	/// Update grain alpha
-	var/atom/movable/screen/grain_obj = hud_used.grain
-	grain_obj.alpha = 55 + (new_stress * 1.5)
+	//var/atom/movable/screen/grain_obj = hud_used.grain
+	//grain_obj.alpha = 55 + (new_stress * 1.5)
 
 	var/fade_progress = 0
 	if(new_stress < 5)

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -208,13 +208,13 @@ Hotkey-Mode: (hotkey-mode must be on)
 	if(prefs.grain == TRUE)
 		prefs.grain = FALSE
 		prefs.save_preferences()
-		to_chat(src, "Grain is <font color='red'>OFF.</font>")
+		to_chat(src, "Grain is <font color='gray'>OFF.</font>")
 		for(var/atom/movable/screen/grain/S in screen)
 			S.alpha = 0
 	else
 		prefs.grain = TRUE
 		prefs.save_preferences()
-		to_chat(src, "Grain is <font color='green'>ON.</font>")
+		to_chat(src, "Grain is <font color='#007fff'>ON.</font>")
 		for(var/atom/movable/screen/grain/S in screen)
 			S.alpha = 55
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -208,13 +208,13 @@ Hotkey-Mode: (hotkey-mode must be on)
 	if(prefs.grain == TRUE)
 		prefs.grain = FALSE
 		prefs.save_preferences()
-		to_chat(src, "Grain is OFF.")
+		to_chat(src, "Grain is <font color='red'>OFF.</font>")
 		for(var/atom/movable/screen/grain/S in screen)
 			S.alpha = 0
 	else
 		prefs.grain = TRUE
 		prefs.save_preferences()
-		to_chat(src, "Grain is ON.")
+		to_chat(src, "Grain is <font color='green'>ON.</font>")
 		for(var/atom/movable/screen/grain/S in screen)
 			S.alpha = 55
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -200,6 +200,24 @@ Hotkey-Mode: (hotkey-mode must be on)
 		for(var/atom/movable/screen/scannies/S in screen)
 			S.alpha = 70
 
+/client/verb/grainfilter()
+	set category = "Options"
+	set name = "ToggleGrain"
+	if(!prefs)
+		return
+	if(prefs.grain == TRUE)
+		prefs.grain = FALSE
+		prefs.save_preferences()
+		to_chat(src, "Grain is OFF.")
+		for(var/atom/movable/screen/grain/S in screen)
+			S.alpha = 0
+	else
+		prefs.grain = TRUE
+		prefs.save_preferences()
+		to_chat(src, "Grain is ON.")
+		for(var/atom/movable/screen/grain/S in screen)
+			S.alpha = 55
+
 /client/verb/triggercommend()
 	set category = "OOC"
 	set name = "Commend Someone"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
* Grain filter is now a toggle under Options.
* Adds back respawn verb for when skull HUD breaks.
* Ready-ups are logged, credit to https://github.com/Darkrp-community/OpenKeep/pull/980. Would appreciate admins test this live because I've never been an admin and don't actually know where logs are kept.

## Why It's Good For The Game
grimshart is a choice

![image](https://github.com/user-attachments/assets/2b3c5c3b-80cd-4dad-a17c-09bba149c481)
