### PR TITLE
Preventing a null reference lookup in crafting for liquid contents access

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -329,6 +329,11 @@
 				var/datum/reagent/RGNT
 				while(amt > 0)
 					var/obj/item/reagent_containers/RC = locate() in surroundings
+					if(!RC)
+						break
+					if(!RC.reagents)
+						surroundings -= RC
+						continue
 					RG = RC.reagents.get_reagent(A)
 					if(RG)
 						if(!locate(RG.type) in Deletion)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Here is a runtime that happens when you try to make water to wine with only a single bottle filled with water.
![image](https://github.com/user-attachments/assets/450841b6-5f52-4419-839c-456bdefeb2a0)

Some liquid reagent crafting recipes trigger a runtime, like water to wine. I guess because it consumes the container that the reagent is in, and then makes another loop trying to look inside the consumed bottle? I'm not sure. In testing this seems to fix it, though it might be a little redundant. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Very obscure runtime fix. Feels like this fixes what is causing issue #736. Tested with this solution and didn't find the same issue (it consumed a bottle as expected).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
