### PR TITLE
magick-jakking. (+2!!! new spell)

### DIFF
--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -219,7 +219,8 @@
 		/obj/effect/proc_holder/spell/invoked/projectile/acidsplash5e,
 		/obj/effect/proc_holder/spell/invoked/frostbite5e,
 		/obj/effect/proc_holder/spell/invoked/guidance,
-		/obj/effect/proc_holder/spell/invoked/fortitude
+		/obj/effect/proc_holder/spell/invoked/fortitude,
+		/obj/effect/proc_holder/spell/invoked/snap_freeze
 	)
 	for(var/i = 1, i <= spell_choices.len, i++)
 		choices["[spell_choices[i].name]: [spell_choices[i].cost]"] = spell_choices[i]
@@ -265,7 +266,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	var/wall_type = /obj/structure/forcefield_weak/caster
 	xp_gain = TRUE
-	cost = 2
+	cost = 1 
 
 //adapted from forcefields.dm, this needs to be destructible
 /obj/structure/forcefield_weak
@@ -277,7 +278,7 @@
 	attacked_sound = list('sound/combat/hits/onstone/wallhit.ogg', 'sound/combat/hits/onstone/wallhit2.ogg', 'sound/combat/hits/onstone/wallhit3.ogg')
 	opacity = 0
 	density = TRUE
-	max_integrity = 80
+	max_integrity = 100
 	CanAtmosPass = ATMOS_PASS_DENSITY
 	var/timeleft = 20 SECONDS
 
@@ -333,7 +334,7 @@
 	range = 6
 	overlay_state = "ensnare"
 	var/area_of_effect = 1
-	var/duration = 2.5 SECONDS
+	var/duration = 5 SECONDS
 	var/delay = 0.8 SECONDS
 
 /obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe/cast(list/targets, mob/user = usr)
@@ -487,7 +488,7 @@
 	releasedrain = 30
 	chargedrain = 1
 	chargetime = 20
-	charge_max = 10 SECONDS
+	charge_max = 15 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
@@ -495,15 +496,15 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "blade_burst"
-	var/delay = 7
-	var/damage = 120 //trust me, this is still way worse than you think it is
+	var/delay = 18
+	var/damage = 100 //trust me, this is still way worse than you think it is
 	var/area_of_effect = 1
 
 /obj/effect/temp_visual/trap
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "trap"
 	light_range = 2
-	duration = 7
+	duration = 18
 	layer = MASSIVE_OBJ_LAYER
 
 /obj/effect/temp_visual/blade_burst
@@ -987,6 +988,74 @@
 		user.visible_message("[user] mutters an incantation and they briefly shine orange.")
 
 	return TRUE
+
+/obj/effect/proc_holder/spell/invoked/snap_freeze
+	name = "Snap Freeze"
+	desc = "Freeze the air in a small area in an instant, slowing and mildly damaging those affected."
+	cost = 2
+	xp_gain = TRUE
+	releasedrain = 30
+	chargedrain = 1
+	chargetime = 15
+	charge_max = 15 SECONDS
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	movement_interrupt = FALSE
+	charging_slowdown = 2
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+	var/delay = 6
+	var/damage = 40 // less then fireball, more then lighting bolt
+	var/area_of_effect = 1
+
+/obj/effect/temp_visual/trapice
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "blueshatter"
+	light_range = 2
+	light_color = "#4cadee"
+	duration = 6
+	layer = MASSIVE_OBJ_LAYER
+
+/obj/effect/temp_visual/snap_freeze
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "shieldsparkles"
+	name = "rippeling arcyne ice"
+	desc = "Get out of the way!"
+	randomdir = FALSE
+	duration = 1 SECONDS
+	layer = MASSIVE_OBJ_LAYER
+
+
+/obj/effect/proc_holder/spell/invoked/snap_freeze/cast(list/targets, mob/user)
+	var/turf/T = get_turf(targets[1])
+
+	for(var/turf/affected_turf in view(area_of_effect, T))
+		if(affected_turf.density)
+			continue
+		new /obj/effect/temp_visual/trapice(affected_turf)
+	playsound(T, 'sound/combat/wooshes/blunt/wooshhuge (2).ogg', 80, TRUE, soundping = TRUE) // it kinda sounds like cold wind idk 
+
+	sleep(delay)
+	var/play_cleave = FALSE
+
+	for(var/turf/affected_turf in view(area_of_effect, T))
+		new /obj/effect/temp_visual/snap_freeze(affected_turf)
+		for(var/mob/living/L in affected_turf.contents)
+			play_cleave = TRUE
+			L.adjustFireLoss(damage)
+			L.apply_status_effect(/datum/status_effect/buff/frostbite5e/)
+			playsound(affected_turf, "genslash", 80, TRUE)
+			to_chat(L, "<span class='userdanger'>The air chills your bones!</span>")
+
+	if(play_cleave)
+		playsound(T, 'sound/combat/newstuck.ogg', 80, TRUE, soundping = TRUE) // this also kinda sounds like ice ngl
+
+	return TRUE
+
+
+
+
+
 
 #undef PRESTI_CLEAN
 #undef PRESTI_SPARK


### PR DESCRIPTION
i'm doing the equivalent of buying bubblegum (new spell!!!) with other embarrassing gas-station purchases (balance-jakking)

let's go over the boring stuff first.
--- **WARNING, BALANCE-JAKKING AHEAD**---

Big one: blade burst, lost 20 damage (negligible), more importantly, it now follows its spell description about having a delay before the swords cut you to bits. It's more than double what it is on live, from 7 to 18. I'm not **certain** on how this'll do with lag. But on live it's more or less impossible to react to blade bursts, and my attempt here is to make it hit you if you are 
a. slowed (foreshadowing)
b. not paying attention
c. got read like a book

If this doesn't make bladeburst not free damage on people at least it lost twenty of its damage. 

Other small stuff, Entangle: got it's duration doubled +.5 seconds. Once again, with lag no one could do anything with this spell, its paralyze ending before you could even react. This should give it a use, but not nearly enough to guarantee other spells hitting you . (sorry if it does lol)

also forcewall costs 1 now, and got like 20 more hp on it's walls. It's not that good for something that has 100 integ. (3ish hits?)
---**BALANCE-JAKKING OVER**---

---New spell!! **Snap-freeze**---

With blade burst losing it's almost free damage, safely from range. I realized there's an open niche for a spell, something that's very low risk/easy to hit with a medium reward. This is what snapfreeze is. 

It's **two points** for a blade-burst like aoe (with icey effects!) that goes off more or less as you cast it and applies the frostbite debuff (-2 SPD) in it's aoe, dealing a solid 40 damage to everyone affected. 

Comparing it to it's other two mainstay 2pt spells,  it's cd is more then fireball, and with less damage, allowing fireball to be your go to frontline melter, and faster cd then lighting bolt with a far softer cc, but in an aoe!

This should give mages who want to play safer a solid, easily useable spell that helps there allies, and also could combo into other—slower, higher damaging spells. (oh hey there's that foreshadowing) Of course, this all comes at the cost of losing the sheer stopping power something like a lighting bolt gives you, or the raw damage of a fireball. 

The only thing missing with this spell is we don't have any kind of ice icons for the scroll. (Neither does frostbite so lol) and I'm using some of the more generic sfx for it. (woosh for the cold winds, a lash for the sound of you freezing) 

also frostbite turned into frostbolt