### PR TITLE
Craftable volf helmets

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -934,7 +934,7 @@
 /obj/item/clothing/head/roguetown/helmet/leather/volfhelm
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_HIP
 	name = "volf helmet"
-	desc = "Bandit initiation rites involve the slaying of a volf."
+	desc = "A leather helmet fashioned from a volf's pelt."
 	body_parts_covered = HEAD|HAIR|EARS
 	icon_state = "volfhead"
 	item_state = "volfhead"

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -109,6 +109,12 @@
 	reqs = list(/obj/item/natural/hide = 1)
 	sellprice = 10
 
+/datum/crafting_recipe/roguetown/leather/volfhelm
+	name = "volf helm"
+	result = list(/obj/item/clothing/head/roguetown/helmet/leather/volfhelm)
+	reqs = list(/obj/item/natural/hide = 3, /obj/item/natural/fur = 2,)
+	sellprice = 20
+
 /datum/crafting_recipe/roguetown/leather/heavy_leather_pants
 	name = "heavy leather pants"
 	result = list(/obj/item/clothing/under/roguetown/heavy_leather_pants)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Allows you to craft volf helmets with 3 hide and 2 fur. Also changes the item's description to no longer mention volf helmets being associated with bandits.

## Why It's Good For The Game

These aren't actually very strong and don't offer much protection - but they're currently only available to bandits and serve as essentially a dead giveaway that someone is a bandit. Making these helmets craftable should help bandits be less immediately-recognizable and should hopefully make it just a little harder to metagame bandits.