### PR TITLE
fixes captain inventory, adds strap-ons to some classes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -50,6 +50,7 @@
 				if("Greatsword")
 					H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 					r_hand = /obj/item/rogueweapon/greatsword/zwei
+					backr = /obj/item/gwstrap
 				if("Mace & Shield")
 					H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
 					beltr =/obj/item/rogueweapon/mace/spiked
@@ -104,6 +105,7 @@
 				if("Greatsword")
 					H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 					r_hand = /obj/item/rogueweapon/greatsword/zwei
+					backr = /obj/item/gwstrap
 				if("Mace & Shield")
 					H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
 					beltr =/obj/item/rogueweapon/mace/spiked

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -34,11 +34,6 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
 	cloak = /obj/item/clothing/cloak/stabard/guardhood
-	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backpack_contents = list(
-		/obj/item/storage/keyring/sheriff = 1,
-		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
-		)
 
 /datum/job/roguetown/captain/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
@@ -78,6 +73,11 @@
 /datum/outfit/job/roguetown/captain/infantry/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface
+	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backpack_contents = list(
+		/obj/item/storage/keyring/sheriff = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
@@ -112,25 +112,31 @@
 		"Great Mace",
 		"Battle Axe",
 		"Estoc",
-		"Bastard Sword",
-		"Flail",
+		"Bastard Sword & Shield",
+		"Flail & Shield",
+		"Sabre & Shield",
 		)
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
 		if("Zweihander")
 			r_hand = /obj/item/rogueweapon/greatsword/zwei
+			backl = /obj/item/gwstrap
 		if("Great Mace")
 			r_hand = /obj/item/rogueweapon/mace/goden/steel
 		if("Battle Axe")
 			r_hand = /obj/item/rogueweapon/stoneaxe/battle
 		if("Estoc")
 			r_hand = /obj/item/rogueweapon/estoc
+			backl = /obj/item/gwstrap
 		if("Bastard Sword")
 			beltr = /obj/item/rogueweapon/sword/long
 			backl = /obj/item/rogueweapon/shield/tower/metal
 		if("Flail")
 			beltr = /obj/item/rogueweapon/flail/sflail
+			backl = /obj/item/rogueweapon/shield/tower/metal
+		if("Sabre")
+			beltr = /obj/item/rogueweapon/sword/sabre
 			backl = /obj/item/rogueweapon/shield/tower/metal
 
 /datum/advclass/captain/cavalry
@@ -144,6 +150,11 @@
 /datum/outfit/job/roguetown/captain/cavalry/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
+	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backpack_contents = list(
+		/obj/item/storage/keyring/sheriff = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 5, TRUE)
@@ -174,9 +185,10 @@
 	H.verbs |= /mob/proc/haltyell
 	H.adjust_blindness(-3)
 	var/weapons = list(
-		"Sword + Recurve Bow",
-		"Mace + Crossbow",
-		"Spear + Shield",
+		"Sword & Recurve Bow",
+		"Mace & Crossbow",
+		"Spear & Shield",
+		"Sabre & Shield",
 		)
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
@@ -191,6 +203,9 @@
 			beltr = /obj/item/quiver/bolts
 		if ("Spear + Shield")
 			r_hand = /obj/item/rogueweapon/spear
+			backl = /obj/item/rogueweapon/shield/tower/metal
+		if("Sabre")
+			beltr = /obj/item/rogueweapon/sword/sabre
 			backl = /obj/item/rogueweapon/shield/tower/metal
 
 /obj/effect/proc_holder/spell/self/convertrole

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -112,12 +112,14 @@
 	switch(weapon_choice)
 		if("Zweihander") 	// A two-handed sword, but not the strongest one
 			r_hand = /obj/item/rogueweapon/greatsword/zwei
+			backl = /obj/item/gwstrap
 		if("Great Mace")	// Great-mace, 2-handed
 			r_hand = /obj/item/rogueweapon/mace/goden/steel
 		if("Battle Axe")	// Why did heavy knights get a mace+shield combo if they're supposed to be the two-hander guys? Gives them a greataxe instead.
 			r_hand = /obj/item/rogueweapon/stoneaxe/battle
 		if("Estoc")
 			r_hand = /obj/item/rogueweapon/estoc
+			backl = /obj/item/gwstrap
 
 	neck = /obj/item/clothing/neck/roguetown/bevor
 	armor = /obj/item/clothing/suit/roguetown/armor/plate		//this is actually steel half-plate, full plate is plate/full. given because they are SLOW.


### PR DESCRIPTION
## About The Pull Request

captain's backpack doesn't come with extra prizes anymore. subclasses/loadouts of the knight, captain, and warrior that receive greatswords or their children know have a roundstart strap to wear. i specifically didn't give it to classes that had spears because they should be holding those at the ready so they can block the path of filthy peasants trying to make their wæ into the greathall.

in the future ill probably remember to give mounted knight and infantry captain some kind of polearm weapon because thats what cavalry use but looking over our polearm roster its just a spear, which sucks, and then a bunch of infantry style polearm weapons. we need a lance. that's for another pr tho

## Why It's Good For The Game

i fixed a bug :3c
