### PR TITLE
Update swords Saber Clickcd.dm

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -487,7 +487,7 @@
 	wbalance = 1
 
 /datum/intent/sword/cut/sabre
-	clickcd = 10
+	clickcd = 8
 
 /obj/item/rogueweapon/sword/sabre/dec
 	icon_state = "decsaber"


### PR DESCRIPTION
Reduced Saber cut clickcd from 10 to 8

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Reduced Saber's cut clickcd from 10 to 8
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The saber is rarely used in large part because despite using the same materials as rapier, it's objectively worse. Less AP, defense and speed than the rapier. This update is an attempt to try and bring the saber to relevance and likely not the only change that needs to be made, but a starting point. To me it makes sense that making cuts with a saber should be a quick attack, like the rapier's thrust, which is why saber's cut was given the same ClickCD as the rapier's thrust.
The goal is that the saber won't be an objective downgrade from the rapier.
I'd welcome people's ideas on how else to make sabers an interesting and relevant weapon that people get not only for drip and aesthetics.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
