### PR TITLE
Expands the underground arena

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -8127,11 +8127,6 @@
 /obj/item/book/rogue/blackmountain,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
-"hTx" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/under/town/basement)
 "hTE" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/cobble,
@@ -34034,8 +34029,8 @@ gdw
 gdw
 nze
 gdw
-hdp
-hdp
+nze
+nze
 gdw
 gdw
 gdw
@@ -34970,7 +34965,7 @@ pNQ
 iMs
 heh
 cVE
-hTx
+hYd
 gdw
 idX
 bBD

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -22,8 +22,8 @@
 /area/rogue/under/town/sewer)
 "aad" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/clothing/neck/roguetown/psicross/wood,
@@ -31,7 +31,6 @@
 /area/rogue/indoors/town/church)
 "aae" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -59,11 +58,9 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -74,15 +71,12 @@
 	},
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -178,7 +172,6 @@
 "acF" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4;
 	pixel_x = 7
 	},
@@ -186,15 +179,14 @@
 /area/rogue/indoors/town/manor)
 "acV" = (
 /obj/structure/mineral_door/wood{
-	name = "stall i";
 	locked = 1;
-	lockid = "apartment1"
+	lockid = "apartment1";
+	name = "stall i"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
 "ada" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -211,8 +203,8 @@
 /area/rogue/indoors/town)
 "adM" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -232,7 +224,6 @@
 /area/rogue/under/town/basement)
 "adV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
@@ -265,8 +256,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "aeX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/natural/feather{
 	pixel_x = -17;
@@ -313,7 +304,6 @@
 "ahX" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -365,9 +355,9 @@
 /area/rogue/under/town/basement)
 "akh" = (
 /obj/structure/mineral_door/wood{
-	name = "veterans house";
 	locked = 1;
-	lockid = "garrison"
+	lockid = "garrison";
+	name = "veterans house"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -375,7 +365,6 @@
 /area/rogue/indoors/town)
 "akR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -407,8 +396,8 @@
 /area/rogue/outdoors/town)
 "alU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/fluff/railing/border{
@@ -418,8 +407,8 @@
 /area/rogue/indoors/shelter/woods)
 "aml" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -432,8 +421,8 @@
 /area/rogue/outdoors/rtfield)
 "amw" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/walls,
 /obj/item/roguekey/manor,
@@ -448,9 +437,9 @@
 /area/rogue/indoors/town/garrison)
 "anc" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Dining Room";
 	locked = 1;
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Dining Room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -466,7 +455,6 @@
 /area/rogue/indoors/town)
 "aoe" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/hexstone,
@@ -484,11 +472,9 @@
 /area/rogue/indoors)
 "api" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -517,7 +503,6 @@
 /area/rogue/under/town/basement/keep)
 "arK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -550,14 +535,12 @@
 /area/rogue/indoors/town/manor)
 "asT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
 "atf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/psycross,
@@ -568,7 +551,6 @@
 /area/rogue/under/cave)
 "atE" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -593,7 +575,6 @@
 /area/rogue/outdoors/town)
 "auO" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -607,16 +588,14 @@
 /area/rogue/indoors/town/magician)
 "auX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/mirror{
 	pixel_y = 28
 	},
 /obj/item/natural/cloth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "avz" = (
 /obj/structure/toilet,
@@ -639,8 +618,8 @@
 	redstone_id = "armourer_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
@@ -660,8 +639,8 @@
 	pixel_x = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/burial_shroud{
 	pixel_x = 5;
@@ -685,7 +664,6 @@
 /area/rogue/outdoors/town)
 "ayo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -707,8 +685,8 @@
 "azs" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -723,8 +701,8 @@
 /area/rogue/indoors/town/garrison)
 "aAs" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/walldeco/psybanner{
 	pixel_y = 29
@@ -745,8 +723,8 @@
 /area/rogue/indoors/shelter/woods)
 "aCb" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/carpet/red,
@@ -782,15 +760,14 @@
 	},
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/pillory/reinforced,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "aDd" = (
 /obj/effect/landmark/start/servant{
-	icon_state = "arrow";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -819,7 +796,6 @@
 /area/rogue/indoors/town/bath)
 "aED" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
@@ -896,15 +872,14 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/roguekey/walls{
-	name = "farm key";
-	lockid = "farm"
+	lockid = "farm";
+	name = "farm key"
 	},
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "aIG" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -930,7 +905,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -975,7 +949,6 @@
 /area/rogue/indoors/town)
 "aNp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -992,6 +965,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"aNV" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "aOh" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/hexstone,
@@ -1003,10 +982,10 @@
 /area/rogue/indoors/shelter/woods)
 "aOB" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Archivist's Office";
 	dir = 8;
 	locked = 1;
-	lockid = "archive"
+	lockid = "archive";
+	name = "Archivist's Office"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
@@ -1045,7 +1024,6 @@
 /area/rogue/indoors/town)
 "aPn" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -1055,9 +1033,7 @@
 	locked = 1;
 	lockid = "nightmaiden"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "aPK" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -1070,16 +1046,13 @@
 /area/rogue/indoors/town/manor)
 "aQs" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "aQA" = (
 /obj/structure/chair/bench/ultimacouch,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "aQJ" = (
 /obj/structure/closet/crate/chest,
@@ -1088,7 +1061,6 @@
 /area/rogue/indoors/town)
 "aRe" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -1129,7 +1101,6 @@
 /area/rogue/under/town/basement)
 "aTh" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -1174,7 +1145,6 @@
 /area/rogue/outdoors/rtfield)
 "aVh" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -1201,7 +1171,6 @@
 /area/rogue/indoors/town/church/chapel)
 "aVR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/closet/crate/chest,
@@ -1227,8 +1196,8 @@
 /area/rogue/indoors/town/tavern)
 "aXp" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -1243,8 +1212,8 @@
 /area/rogue/indoors/town/tavern)
 "aXO" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1296,11 +1265,9 @@
 /area/rogue/indoors/town/physician)
 "bbl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -1327,7 +1294,6 @@
 /area/rogue/outdoors/town/roofs)
 "bcj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
@@ -1345,10 +1311,16 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"bcE" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "bcF" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -1380,8 +1352,8 @@
 /area/rogue/under/town/basement/keep)
 "bez" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -1400,8 +1372,8 @@
 /area/rogue/under/town/basement/keep)
 "bfW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -1431,8 +1403,8 @@
 /area/rogue/indoors/town/garrison)
 "bhU" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -1459,14 +1431,14 @@
 /area/rogue/under/town/basement)
 "biZ" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "bjc" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/herringbone,
@@ -1520,19 +1492,18 @@
 /area/rogue/outdoors/town)
 "blr" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "blC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town)
@@ -1550,8 +1521,8 @@
 /area/rogue/indoors/town)
 "bmI" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 1
+	dir = 1;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "bnE" = (
@@ -1609,8 +1580,8 @@
 	},
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "bqr" = (
@@ -1658,7 +1629,6 @@
 "bsT" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -1675,9 +1645,7 @@
 /area/rogue/indoors/town/church)
 "bup" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "buI" = (
 /obj/structure/bed/rogue/shit{
@@ -1718,8 +1686,8 @@
 /area/rogue/under/town/basement/keep)
 "bvN" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
@@ -1750,7 +1718,6 @@
 /area/rogue/outdoors/town/roofs)
 "bzx" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle{
@@ -1763,8 +1730,8 @@
 /area/rogue/outdoors/town)
 "bAa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 8
+	dir = 8;
+	icon_state = "longtable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -1790,7 +1757,6 @@
 /area/rogue/indoors/town/physician)
 "bAb" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -1845,20 +1811,17 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs/stone{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "bDS" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -1911,15 +1874,14 @@
 /area/rogue/outdoors/town/roofs)
 "bGd" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "bGJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -1935,9 +1897,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "bHo" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -2000,13 +1960,10 @@
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_y = 10
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bKz" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -2026,8 +1983,7 @@
 /area/rogue/indoors/town/physician)
 "bLo" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
@@ -2036,9 +1992,7 @@
 /turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
 "bLX" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bMi" = (
 /obj/machinery/light/rogue/hearth,
@@ -2059,7 +2013,6 @@
 "bNE" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -2070,7 +2023,6 @@
 /area/rogue/outdoors/town)
 "bOF" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/machinery/light/rogue/torchholder/c,
@@ -2081,7 +2033,6 @@
 /area/rogue/indoors/town/tavern)
 "bOH" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /obj/structure/chair/bench,
@@ -2114,8 +2065,8 @@
 /area/rogue/indoors/town)
 "bPY" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -2127,6 +2078,13 @@
 "bRO" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"bRT" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "bSn" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -2162,7 +2120,6 @@
 /area/rogue/outdoors/town)
 "bSI" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -2187,7 +2144,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2196,8 +2152,8 @@
 /area/rogue/indoors/town)
 "bUw" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
@@ -2209,7 +2165,6 @@
 /area/rogue/under/town/basement/keep)
 "bUV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -2243,19 +2198,11 @@
 /obj/item/book/rogue/bibble,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
-"bWt" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 5
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
 "bWU" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -2266,9 +2213,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "bXl" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "bXz" = (
@@ -2285,7 +2230,6 @@
 /area/rogue/indoors/town)
 "bXK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/structure/fluff/railing/border,
@@ -2305,9 +2249,7 @@
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bYR" = (
 /obj/structure/fluff/walldeco/stone,
@@ -2320,7 +2262,6 @@
 /area/rogue/indoors/town/manor)
 "bZu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/church/smallbench,
@@ -2342,7 +2283,6 @@
 /area/rogue/indoors/town/tavern)
 "cba" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs{
@@ -2352,8 +2292,8 @@
 /area/rogue/indoors/town/garrison)
 "cbg" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2430,20 +2370,17 @@
 /area/rogue/outdoors/town)
 "cfd" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "cha" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "chq" = (
 /obj/structure/bookcase,
@@ -2453,8 +2390,8 @@
 /area/rogue/indoors/town/manor)
 "chQ" = (
 /obj/structure/mineral_door/wood/window{
-	name = "Library";
-	lockid = "archive"
+	lockid = "archive";
+	name = "Library"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -2472,7 +2409,6 @@
 /area/rogue/indoors/town/church/chapel)
 "cip" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -2489,8 +2425,7 @@
 /area/rogue/under/town/basement/keep)
 "cjg" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "cjh" = (
@@ -2510,11 +2445,9 @@
 /area/rogue/outdoors/town)
 "cjX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -2522,7 +2455,6 @@
 "ckM" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2553,17 +2485,8 @@
 "clT" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"clX" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "tourneybottom"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement)
 "cmz" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "cmA" = (
 /obj/structure/table/wood{
@@ -2589,8 +2512,8 @@
 /area/rogue/indoors/town/manor)
 "cmZ" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
@@ -2618,8 +2541,8 @@
 /area/rogue/indoors/town)
 "coK" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/twig,
@@ -2652,7 +2575,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "cqB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/bookcase/random/religion,
@@ -2666,8 +2588,8 @@
 /area/rogue/indoors/town/manor)
 "csh" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -2695,7 +2617,6 @@
 /area/rogue/indoors/town)
 "cty" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -2720,7 +2641,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
@@ -2737,12 +2657,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
-"cvX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/outdoors/town/roofs)
 "cwq" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -2759,8 +2673,8 @@
 "cxD" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
@@ -2782,15 +2696,14 @@
 /area/rogue/outdoors/town)
 "cyB" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/reagent_containers/powder/ozium,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "cyD" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2801,13 +2714,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"czw" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "czC" = (
 /obj/structure/stairs{
 	dir = 4
@@ -2842,7 +2748,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -2864,19 +2769,18 @@
 	dir = 8
 	},
 /obj/structure/lever/wall{
-	name = "inner passage lever";
-	icon_state = "leverwall1";
 	dir = 4;
+	icon_state = "leverwall1";
+	name = "inner passage lever";
 	pixel_x = 6;
 	pixel_y = -9;
-	toggled = 1;
-	redstone_id = "keepgate_inner"
+	redstone_id = "keepgate_inner";
+	toggled = 1
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cBU" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/grass,
@@ -2892,15 +2796,14 @@
 "cCz" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "cCO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/natural/stone{
@@ -2915,21 +2818,17 @@
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "cDJ" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "cDO" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2939,8 +2838,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/tile,
@@ -2950,15 +2849,14 @@
 /area/rogue/outdoors/town)
 "cEi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
 "cED" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fermenting_barrel/crafted,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -2971,15 +2869,11 @@
 "cGm" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
-"cGL" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/town/basement)
 "cGR" = (
 /obj/structure/mineral_door/wood{
-	name = "house i";
 	locked = 1;
-	lockid = "house1"
+	lockid = "house1";
+	name = "house i"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -2993,7 +2887,6 @@
 /area/rogue/under/town/basement/keep)
 "cHG" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -3006,8 +2899,8 @@
 /area/rogue/outdoors/town)
 "cHT" = (
 /turf/open/water/river{
-	icon_state = "rockwd";
-	dir = 4
+	dir = 4;
+	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/rtfield)
 "cIC" = (
@@ -3022,8 +2915,8 @@
 /area/rogue/indoors/town/church/chapel)
 "cJN" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull/lit{
 	pixel_x = -3;
@@ -3033,8 +2926,8 @@
 /area/rogue/under/town/basement)
 "cJT" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fermenting_barrel/crafted,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -3054,8 +2947,8 @@
 /area/rogue/indoors/town/physician)
 "cKp" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
@@ -3099,7 +2992,6 @@
 /area/rogue/outdoors/rtfield)
 "cPJ" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -3110,7 +3002,6 @@
 /area/rogue/under/town/basement)
 "cQy" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -3148,7 +3039,6 @@
 "cRY" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -3169,30 +3059,28 @@
 /area/rogue/indoors/town/magician)
 "cTj" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
 "cTw" = (
 /obj/structure/mineral_door/wood{
-	name = "stall i";
 	locked = 1;
-	lockid = "stall1"
+	lockid = "stall1";
+	name = "stall i"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "cTF" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "cTP" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -3202,8 +3090,8 @@
 /area/rogue/indoors/town)
 "cUn" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
@@ -3213,8 +3101,8 @@
 /area/rogue/indoors/town/bath)
 "cVf" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -3236,8 +3124,8 @@
 /area/rogue/under/town/sewer)
 "cVQ" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "bogrtout_cave";
-	aportalgoesto = "bogrtin_cave"
+	aportalgoesto = "bogrtin_cave";
+	aportalid = "bogrtout_cave"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
@@ -3291,17 +3179,14 @@
 /area/rogue/indoors/town/church)
 "cXV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "cXZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -3330,7 +3215,6 @@
 /area/rogue/indoors/town/physician)
 "cZf" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -3338,14 +3222,12 @@
 "cZX" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "dau" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -3358,7 +3240,6 @@
 /area/rogue/indoors/town)
 "daH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -3457,8 +3338,8 @@
 /area/rogue/indoors/town/magician)
 "ddu" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	name = "Dressing Room";
-	dir = 1
+	dir = 1;
+	name = "Dressing Room"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
@@ -3495,7 +3376,6 @@
 /area/rogue/indoors/town)
 "ddU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -3511,7 +3391,6 @@
 /area/rogue/indoors/town/physician)
 "det" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
@@ -3523,7 +3402,6 @@
 /area/rogue/indoors/town/manor)
 "dex" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -3618,15 +3496,14 @@
 /area/rogue/outdoors/mountains)
 "djT" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "forestout2";
+	aallmig = "rwfieldin1";
 	aportalgoesto = "forestin2";
-	aallmig = "rwfieldin1"
+	aportalid = "forestout2"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "djU" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/customflag{
@@ -3708,7 +3585,6 @@
 /area/rogue/under/town/basement)
 "dnp" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile{
@@ -3776,8 +3652,8 @@
 /area/rogue/indoors/town)
 "dpX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/sword/sabre,
 /turf/open/floor/rogue/ruinedwood{
@@ -3859,7 +3735,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/machinery/light/rogue/torchholder/l,
@@ -3867,8 +3742,8 @@
 /area/rogue/outdoors/town)
 "dvK" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
@@ -3893,9 +3768,9 @@
 /area/rogue/indoors/town/shop)
 "dxs" = (
 /obj/structure/closet/crate/chest{
-	name = "spare house keys";
 	locked = 1;
-	lockid = "steward"
+	lockid = "steward";
+	name = "spare house keys"
 	},
 /obj/item/roguekey/houses/house1,
 /obj/item/roguekey/houses/house2,
@@ -3907,7 +3782,6 @@
 /area/rogue/indoors/town)
 "dxE" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -3921,8 +3795,8 @@
 /area/rogue/indoors/town)
 "dxQ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/skull{
 	pixel_x = 5;
@@ -3950,7 +3824,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -3970,14 +3843,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "dzt" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "dAb" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -3991,7 +3862,6 @@
 /area/rogue/under/town/basement/keep)
 "dAn" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -4015,8 +3885,8 @@
 /area/rogue/indoors/town/magician)
 "dAX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -4028,8 +3898,8 @@
 /area/rogue/indoors/town/physician)
 "dCo" = (
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/mountains)
 "dCX" = (
@@ -4041,11 +3911,9 @@
 /area/rogue/under/town/basement)
 "dDJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -4075,7 +3943,6 @@
 /area/rogue/indoors/town)
 "dEZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/carpet,
@@ -4088,15 +3955,15 @@
 /area/rogue/indoors/town/shop)
 "dFN" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "dGH" = (
@@ -4113,9 +3980,9 @@
 /area/rogue/indoors/town)
 "dHr" = (
 /obj/structure/closet/crate/chest{
-	name = "house keys";
 	locked = 1;
-	lockid = "steward"
+	lockid = "steward";
+	name = "house keys"
 	},
 /obj/item/roguekey/houses/house1,
 /obj/item/roguekey/houses/house2,
@@ -4146,8 +4013,8 @@
 /area/rogue/under/town/basement)
 "dIL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
@@ -4157,7 +4024,6 @@
 /area/rogue/outdoors/rtfield)
 "dJn" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -4195,7 +4061,6 @@
 /area/rogue/indoors/shelter/woods)
 "dMM" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -4281,11 +4146,9 @@
 /area/rogue/indoors/town)
 "dRa" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -4305,11 +4168,9 @@
 /area/rogue/indoors/town)
 "dRT" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -4354,7 +4215,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/twig,
@@ -4385,9 +4245,7 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/kitchen/rollingpin,
 /obj/item/rogueweapon/huntingknife/chefknife,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "dWj" = (
 /obj/structure/flora/roguegrass,
@@ -4397,7 +4255,6 @@
 "dWm" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -4412,8 +4269,8 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "dWx" = (
@@ -4424,17 +4281,13 @@
 	icon_state = "longtable"
 	},
 /obj/item/roguekey/manor,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "dXO" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/silver/pile,
 /obj/item/roguecoin/silver/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "dYe" = (
 /obj/structure/table/wood,
@@ -4463,22 +4316,14 @@
 /area/rogue/indoors/town/cell)
 "dYF" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
-"dYY" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/outdoors/town/roofs)
 "dZj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -4491,7 +4336,6 @@
 /area/rogue/indoors/town/garrison)
 "dZu" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -4531,12 +4375,12 @@
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "ecx" = (
@@ -4548,18 +4392,15 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "edu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -4572,8 +4413,8 @@
 /area/rogue/under/town/basement)
 "eev" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -4667,8 +4508,8 @@
 /area/rogue/indoors/town/physician)
 "ejk" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
@@ -4682,8 +4523,8 @@
 /area/rogue/indoors/town/shop)
 "ejT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -4692,7 +4533,6 @@
 /area/rogue/outdoors/town)
 "ekh" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -4762,7 +4602,6 @@
 /area/rogue/outdoors/rtfield)
 "eon" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -4773,7 +4612,6 @@
 /area/rogue/outdoors/beach)
 "eou" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -4786,7 +4624,6 @@
 /area/rogue/outdoors/town)
 "eoH" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -4809,9 +4646,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"epL" = (
+/obj/machinery/light/rogue/torchholder/l,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "epS" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood{
@@ -4849,8 +4693,8 @@
 /area/rogue/indoors/town/physician)
 "erC" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -4874,8 +4718,8 @@
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -4893,8 +4737,8 @@
 /area/rogue/under/cave)
 "euL" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -4938,8 +4782,8 @@
 /area/rogue/under/town/basement)
 "ewK" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -4960,10 +4804,10 @@
 /area/rogue/indoors/town/garrison)
 "eyi" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable i";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable1";
-	keylock = 1
+	name = "stable i"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -4997,11 +4841,9 @@
 /area/rogue/outdoors/town)
 "eAh" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9;
 	pixel_y = -22
 	},
@@ -5107,7 +4949,6 @@
 "eGP" = (
 /obj/structure/closet/dirthole/closed/loot,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/ambush,
@@ -5131,8 +4972,8 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -5146,9 +4987,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "eJJ" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -5183,7 +5022,6 @@
 /area/rogue/indoors/town/church/chapel)
 "eLf" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -5194,8 +5032,8 @@
 /area/rogue/indoors/town/church/chapel)
 "eLq" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/needle,
 /obj/item/needle{
@@ -5224,8 +5062,8 @@
 /area/rogue/indoors/town/physician)
 "eMA" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/cobble,
@@ -5255,8 +5093,8 @@
 /area/rogue/indoors/town/physician)
 "eNy" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Council Office";
-	lockid = "manor"
+	lockid = "manor";
+	name = "Council Office"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
@@ -5269,10 +5107,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
-"eOz" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/town/basement)
 "ePO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/fluff/wallclock,
@@ -5287,8 +5121,8 @@
 "eQs" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/natural/feather,
 /obj/item/candle/yellow/lit{
@@ -5304,9 +5138,7 @@
 /area/rogue/indoors/town/tavern)
 "eRV" = (
 /obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "eSe" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -5323,7 +5155,6 @@
 /area/rogue/indoors/town/dwarfin)
 "eTi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -5345,7 +5176,6 @@
 /area/rogue/under/town/basement)
 "eTw" = (
 /obj/structure/stairs/fancy/r{
-	icon_state = "fancy_stairs_r";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord{
@@ -5354,7 +5184,6 @@
 /area/rogue/indoors/town/manor)
 "eTM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/grass,
@@ -5413,16 +5242,16 @@
 	redstone_id = "weaponsmith_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "eWI" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "eWN" = (
@@ -5445,17 +5274,15 @@
 /area/rogue/indoors/town/manor)
 "eYT" = (
 /obj/structure/mineral_door/wood/violet{
-	name = "INNKEEP";
 	locked = 1;
-	lockid = "innkeep"
+	lockid = "innkeep";
+	name = "INNKEEP"
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "eZb" = (
 /obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "eZg" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -5496,7 +5323,6 @@
 /area/rogue/indoors/town)
 "fbj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -5521,9 +5347,9 @@
 /area/rogue/indoors/town/church/chapel)
 "fca" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM V";
 	locked = 1;
-	lockid = "roomv"
+	lockid = "roomv";
+	name = "ROOM V"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -5536,7 +5362,6 @@
 /area/rogue/indoors/shelter/woods)
 "fcv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -5564,7 +5389,6 @@
 /area/rogue/indoors/town)
 "fdk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -5573,15 +5397,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
-"fdT" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
-	},
-/area/rogue/outdoors/town/roofs/keep)
 "feH" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -5609,9 +5424,7 @@
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "ffs" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -5634,12 +5447,10 @@
 /area/rogue/indoors/town/manor)
 "fgW" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "fha" = (
@@ -5686,7 +5497,6 @@
 /area/rogue/indoors/town/manor)
 "fkD" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -5694,8 +5504,7 @@
 /area/rogue/indoors/town)
 "flo" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -5733,7 +5542,6 @@
 /area/rogue/indoors/town/dwarfin)
 "fmT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 8
 	},
 /area/rogue/indoors/town/physician)
@@ -5748,12 +5556,10 @@
 /area/rogue/indoors/town)
 "fnS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "foe" = (
@@ -5775,7 +5581,6 @@
 "fpN" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/landmark/start/druid{
@@ -5823,9 +5628,9 @@
 /area/rogue/indoors/town/manor)
 "frH" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "examination room";
 	dir = 4;
-	lockid = "physician"
+	lockid = "physician";
+	name = "examination room"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
@@ -5844,8 +5649,8 @@
 /area/rogue/under/town/basement)
 "ftb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/idagger{
 	pixel_x = 2;
@@ -5856,20 +5661,12 @@
 "ftD" = (
 /obj/structure/roguemachine/atm,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"ftM" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
-	dir = 8
-	},
-/area/rogue/indoors/town)
 "fuY" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/green,
@@ -5905,15 +5702,15 @@
 /area/rogue/under/town/basement)
 "fwi" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "fwr" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/canopy/green,
 /obj/structure/mineral_door/wood/deadbolt/shutter{
@@ -5931,9 +5728,7 @@
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/gold/pile,
 /obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "fwW" = (
 /obj/structure/closet/crate/roguecloset,
@@ -5951,8 +5746,8 @@
 /area/rogue/indoors/town/bath)
 "fyl" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -5961,7 +5756,6 @@
 /area/rogue/under/town/basement/keep)
 "fyC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/closet/crate/roguecloset/inn,
@@ -5977,7 +5771,6 @@
 /area/rogue/outdoors/town)
 "fzy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -6120,12 +5913,10 @@
 /area/rogue/indoors/town/garrison)
 "fFj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "fFk" = (
@@ -6142,13 +5933,11 @@
 /area/rogue/under/town/basement/keep)
 "fFB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "fFJ" = (
 /obj/structure/fluff/railing/border{
@@ -6195,7 +5984,6 @@
 /area/rogue/indoors/town)
 "fHK" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -6216,20 +6004,14 @@
 /obj/item/rogueweapon/pick,
 /obj/item/rogueweapon/pick,
 /obj/item/rogueweapon/pick,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "fKS" = (
-/obj/effect/landmark/mapGenerator/rogue/roguetownfield{
-	endTurfX = 155;
-	endTurfY = 155
-	},
+/obj/effect/landmark/mapGenerator/rogue/roguetownfield,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "fKY" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -6263,15 +6045,14 @@
 /area/rogue/outdoors/town)
 "fNR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "fOh" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -6279,8 +6060,8 @@
 "fOu" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/grown/log/tree/small,
 /obj/item/flint,
@@ -6288,8 +6069,8 @@
 /area/rogue/indoors/town/dwarfin)
 "fOC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
@@ -6319,12 +6100,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"fQO" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
-	dir = 8
-	},
-/area/rogue/indoors/town/dwarfin)
 "fQW" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/dwarfin)
@@ -6341,7 +6116,6 @@
 "fRF" = (
 /obj/structure/roguemachine/scomm,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -6362,9 +6136,7 @@
 "fTX" = (
 /obj/structure/chair/bench/coucha,
 /obj/effect/landmark/start/nightmaiden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "fTZ" = (
 /obj/structure/roguewindow,
@@ -6386,19 +6158,17 @@
 /area/rogue/indoors/town/manor)
 "fUx" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Vault Door";
 	dir = 1;
 	locked = 1;
-	lockid = "vault"
+	lockid = "vault";
+	name = "Vault Door"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "fUG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/torchholder/l,
 /obj/item/rogueweapon/tongs,
@@ -6428,7 +6198,6 @@
 "fXj" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -6501,8 +6270,8 @@
 /area/rogue/indoors/town)
 "gcw" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
@@ -6543,8 +6312,8 @@
 /area/rogue/indoors/town)
 "geX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/mask/rogue/facemask,
 /obj/item/clothing/mask/rogue/lordmask,
@@ -6559,7 +6328,6 @@
 /area/rogue/outdoors/town)
 "gfq" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic,
@@ -6569,7 +6337,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -6585,7 +6352,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6594,7 +6360,6 @@
 /area/rogue/indoors/town)
 "ggH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -6616,7 +6381,6 @@
 /area/rogue/indoors/town/cell)
 "gii" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6625,9 +6389,7 @@
 /area/rogue/indoors/town/church/chapel)
 "giB" = (
 /obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "giG" = (
 /obj/structure/fermenting_barrel,
@@ -6635,7 +6397,6 @@
 /area/rogue/under/town/basement/keep)
 "giU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -6648,8 +6409,8 @@
 /area/rogue/outdoors/town)
 "gjj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -6668,7 +6429,6 @@
 /area/rogue/indoors/town/garrison)
 "gjH" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -6695,7 +6455,6 @@
 /area/rogue/outdoors/mountains)
 "glv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8;
 	pixel_y = 5
 	},
@@ -6731,8 +6490,8 @@
 /area/rogue/indoors/town/church/chapel)
 "gmc" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -6758,14 +6517,12 @@
 /area/rogue/indoors/town/shop)
 "gmz" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "gmX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/cobble,
@@ -6781,8 +6538,7 @@
 /area/rogue/indoors/town/cell)
 "goi" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -6815,21 +6571,18 @@
 /area/rogue/indoors/shelter/woods)
 "gpb" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "gpx" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/reagent_containers/glass/cup/skull,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
 "gqi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -6837,7 +6590,6 @@
 /area/rogue/under/town/basement/keep)
 "gqq" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -6854,8 +6606,8 @@
 /area/rogue/under/town/basement/keep)
 "gqW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/tongs{
 	pixel_x = 5;
@@ -6889,8 +6641,8 @@
 /area/rogue/indoors/town/dwarfin)
 "gtW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -6918,8 +6670,8 @@
 /area/rogue/indoors/town/bath)
 "gvO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -6928,8 +6680,8 @@
 /area/rogue/indoors/town/shop)
 "gwy" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/bowl{
 	pixel_x = 4;
@@ -6942,7 +6694,6 @@
 /area/rogue/indoors/town)
 "gxc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -6972,16 +6723,14 @@
 /area/rogue/under/town/basement)
 "gxZ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
 "gyz" = (
 /obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "gyF" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -6998,34 +6747,25 @@
 /area/rogue/indoors/town/church/chapel)
 "gzG" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"gzW" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "gAj" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "gAA" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town)
 "gAE" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood{
@@ -7053,13 +6793,11 @@
 /area/rogue/indoors/town/dwarfin)
 "gCg" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town/physician)
 "gCw" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -7087,8 +6825,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/exposed/town/keep)
@@ -7119,15 +6857,14 @@
 /area/rogue/indoors/town/church/chapel)
 "gGR" = (
 /obj/structure/mineral_door/wood{
-	name = "physician's backdoor";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "physician's backdoor"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "gHf" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -7188,7 +6925,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -7234,15 +6970,14 @@
 "gMV" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "gNo" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
@@ -7255,8 +6990,8 @@
 /area/rogue/outdoors/town)
 "gNX" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/clothing/head/roguetown/menacing{
 	pixel_x = -3;
@@ -7303,7 +7038,6 @@
 /area/rogue/indoors/town/manor)
 "gPW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -7321,8 +7055,8 @@
 /area/rogue/indoors/town/manor)
 "gQJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -7347,12 +7081,12 @@
 /area/rogue/indoors/town/tavern)
 "gSg" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -7378,7 +7112,6 @@
 /area/rogue/outdoors/town)
 "gSu" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -7391,8 +7124,8 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "gTl" = (
@@ -7410,8 +7143,8 @@
 /area/rogue/indoors/shelter/woods)
 "gTY" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/book_crafting_kit,
 /obj/item/book_crafting_kit,
@@ -7420,8 +7153,8 @@
 /area/rogue/indoors/town)
 "gUU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/silver,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -7444,16 +7177,13 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "gWx" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "gXi" = (
 /obj/structure/well/fountain{
@@ -7469,14 +7199,12 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "gXL" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -7484,15 +7212,12 @@
 /area/rogue/indoors/town)
 "gXR" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -7507,7 +7232,6 @@
 /area/rogue/indoors/town/church/chapel)
 "gYJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -7546,8 +7270,8 @@
 /area/rogue/indoors/town/church/chapel)
 "hbq" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/herringbone,
@@ -7567,8 +7291,8 @@
 /area/rogue/indoors/town/church/chapel)
 "hbU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/apartments/apartment1{
 	name = "stall i key";
@@ -7589,9 +7313,7 @@
 	locked = 1;
 	lockid = "artificer"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "hdp" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -7610,8 +7332,8 @@
 /area/rogue/under/town/sewer)
 "heR" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -7638,8 +7360,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "hfu" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden{
 	pixel_x = 2;
@@ -7649,7 +7371,6 @@
 /area/rogue/indoors/town/dwarfin)
 "hgu" = (
 /obj/structure/stairs/fancy/r{
-	icon_state = "fancy_stairs_r";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/right,
@@ -7671,15 +7392,14 @@
 /area/rogue/indoors/shelter/woods)
 "hgV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "hhg" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -7764,19 +7484,11 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"hoH" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/town)
 "hoU" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "hpb" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge,
@@ -7787,7 +7499,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -7849,8 +7560,8 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -7876,8 +7587,8 @@
 "hsK" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
@@ -7892,7 +7603,6 @@
 /area/rogue/indoors/town/church/chapel)
 "htG" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -7902,7 +7612,6 @@
 /obj/item/rogueweapon/shield/wood/crafted,
 /obj/item/rogueweapon/shield/wood/crafted,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -7965,20 +7674,20 @@
 /area/rogue/indoors/town/shop)
 "hws" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "hwQ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	locked = 1
+	locked = 1;
+	lockid = "church"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
@@ -8016,8 +7725,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "hzT" = (
@@ -8035,13 +7743,10 @@
 /area/rogue/indoors/town)
 "hAM" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "hAS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ywflowers,
@@ -8056,21 +7761,17 @@
 /area/rogue/indoors/town/manor)
 "hCc" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hCr" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -8086,11 +7787,17 @@
 /area/rogue/indoors/town/church/chapel)
 "hDp" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"hDI" = (
+/obj/structure/lever/wall{
+	pixel_x = 32;
+	redstone_id = "tourneybottom"
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "hEo" = (
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -8124,8 +7831,8 @@
 /area/rogue/outdoors/town/roofs)
 "hFr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
@@ -8142,7 +7849,6 @@
 /area/rogue/under/town/basement/keep)
 "hGe" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -8165,18 +7871,15 @@
 /area/rogue/indoors/town/manor)
 "hGQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "hGV" = (
 /obj/structure/stairs/fancy/l{
-	icon_state = "fancy_stairs_l";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/left,
@@ -8189,9 +7892,7 @@
 /area/rogue/outdoors/town)
 "hHp" = (
 /obj/structure/closet/crate/chest/gold,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hHv" = (
 /obj/machinery/light/rogue/hearth,
@@ -8201,9 +7902,7 @@
 /area/rogue/indoors/town)
 "hHw" = (
 /obj/structure/roguemachine/lottery_roguetown,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hHC" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -8213,7 +7912,6 @@
 /area/rogue/indoors/town/physician)
 "hHM" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -8221,19 +7919,17 @@
 "hHQ" = (
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "hIg" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/paper,
@@ -8249,8 +7945,8 @@
 /area/rogue/indoors/town)
 "hIk" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 4
@@ -8262,11 +7958,9 @@
 /area/rogue/indoors/town/manor)
 "hIF" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -8312,9 +8006,7 @@
 /area/rogue/under/town/basement/keep)
 "hKl" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hKO" = (
 /obj/structure/table/wood{
@@ -8325,7 +8017,6 @@
 /area/rogue/indoors/town)
 "hLv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/machinery/light/rogue/torchholder/l,
@@ -8334,7 +8025,6 @@
 "hLP" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -8351,7 +8041,6 @@
 /area/rogue/indoors/town/magician)
 "hNd" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -8401,7 +8090,6 @@
 /area/rogue/under/town/basement/keep)
 "hRf" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -8425,8 +8113,8 @@
 /area/rogue/indoors/town/dwarfin)
 "hSx" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -8439,13 +8127,17 @@
 /obj/item/book/rogue/blackmountain,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"hTx" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/basement)
 "hTE" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "hTH" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood,
@@ -8463,7 +8155,6 @@
 /area/rogue/indoors/town)
 "hVE" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8488,7 +8179,6 @@
 /area/rogue/indoors/town/garrison)
 "hWZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -8497,7 +8187,6 @@
 /area/rogue/indoors/town/manor)
 "hXc" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -8505,15 +8194,13 @@
 	},
 /area/rogue/indoors/town/physician)
 "hXf" = (
-/obj/effect/decal/cobbleedge{
-	dir = 2
-	},
+/obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "hXp" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /obj/effect/decal/cobbleedge{
@@ -8582,8 +8269,8 @@
 /area/rogue/under/town/basement)
 "hYJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -8624,7 +8311,6 @@
 /area/rogue/indoors/town/bath)
 "icQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
@@ -8637,6 +8323,10 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"idX" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "iee" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
@@ -8658,8 +8348,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "ifx" = (
@@ -8676,8 +8366,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ifY" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
@@ -8709,7 +8398,6 @@
 /area/rogue/outdoors/town)
 "iiF" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -8732,8 +8420,8 @@
 /area/rogue/indoors/town/bath)
 "ijT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -8763,7 +8451,6 @@
 /area/rogue/indoors/town/church/chapel)
 "ikj" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -8772,13 +8459,6 @@
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/town/basement)
-"ikB" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/beach)
 "ilw" = (
 /obj/structure/table/wood{
 	icon_state = "map1"
@@ -8791,7 +8471,6 @@
 /area/rogue/outdoors/rtfield)
 "imh" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -8861,15 +8540,13 @@
 	locked = 1;
 	lockid = "nightman"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "iqf" = (
 /obj/structure/mineral_door/wood{
-	name = "alchemy room";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "alchemy room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -8877,9 +8554,9 @@
 /area/rogue/indoors/town/physician)
 "iql" = (
 /obj/structure/mineral_door/wood/window{
-	name = "captains room door";
 	locked = 1;
-	lockid = "sheriff"
+	lockid = "sheriff";
+	name = "captains room door"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -8895,9 +8572,7 @@
 /area/rogue/indoors/town/manor)
 "iqT" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "irh" = (
 /obj/structure/fluff/railing/border{
@@ -8958,9 +8633,7 @@
 /obj/effect/landmark/start/monk{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "iuG" = (
 /obj/structure/roguemachine/scomm/r,
@@ -8977,7 +8650,6 @@
 /area/rogue/indoors/town/dwarfin)
 "ivW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/couchablack,
@@ -8985,8 +8657,8 @@
 /area/rogue/under/town/basement/keep)
 "iwd" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -9006,7 +8678,6 @@
 /area/rogue/indoors/town)
 "iwJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/indoors/town)
@@ -9047,8 +8718,8 @@
 /area/rogue/under/town/basement/keep)
 "iyW" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
@@ -9065,9 +8736,9 @@
 /area/rogue/indoors/town/manor)
 "izX" = (
 /obj/structure/mineral_door/wood{
-	name = "jesters chambers";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "jesters chambers"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -9077,7 +8748,6 @@
 /area/rogue/outdoors/town)
 "iAu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -9093,10 +8763,10 @@
 /area/rogue/outdoors/town/roofs)
 "iBL" = (
 /obj/structure/mineral_door/wood{
-	name = "royal guard quarters";
 	icon_state = "wcv";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "royal guard quarters"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement/keep)
@@ -9111,26 +8781,24 @@
 /area/rogue/indoors/town/garrison)
 "iCU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "iDm" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/book/rogue/cardgame,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "iDt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -9174,8 +8842,8 @@
 	dir = 9
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
@@ -9229,7 +8897,6 @@
 /area/rogue/indoors/town)
 "iHY" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -9239,11 +8906,9 @@
 /area/rogue/indoors/town/bath)
 "iIH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/transparent/openspace,
@@ -9257,17 +8922,14 @@
 /area/rogue/under/town/basement/keep)
 "iJx" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/indoors/town/physician)
 "iKC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -9302,8 +8964,8 @@
 /area/rogue/indoors/town/dwarfin)
 "iMm" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/rogue/tile{
@@ -9323,11 +8985,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "iNg" = (
-/obj/structure/roguethrone{
-	pixel_x = -32
-	},
+/obj/structure/roguethrone,
 /obj/structure/roguemachine/titan{
-	density = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/carpet/lord/center,
@@ -9342,7 +9001,6 @@
 /area/rogue/under/town/basement/keep)
 "iNt" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -9350,9 +9008,7 @@
 "iNE" = (
 /obj/machinery/light/rogue/oven/east,
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "iNM" = (
 /obj/structure/flora/newleaf,
@@ -9372,7 +9028,6 @@
 /area/rogue/indoors/town/physician)
 "iOF" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/stairs/stone{
@@ -9398,7 +9053,6 @@
 "iPP" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
@@ -9432,10 +9086,10 @@
 /area/rogue/indoors/town)
 "iSc" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable ii";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable2";
-	keylock = 1
+	name = "stable ii"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -9446,14 +9100,12 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/magician)
 "iSr" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -9465,7 +9117,6 @@
 /area/rogue/indoors/town/bath)
 "iSJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -9512,7 +9163,6 @@
 /area/rogue/indoors/town)
 "iWT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
@@ -9541,9 +9191,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
 "iYk" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
 	},
@@ -9561,18 +9209,16 @@
 /area/rogue/outdoors/exposed/town/keep)
 "iZj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "iZw" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -9599,8 +9245,8 @@
 /area/rogue/indoors/town/manor)
 "jaS" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
@@ -9626,7 +9272,6 @@
 /area/rogue/indoors/town)
 "jbx" = (
 /obj/structure/stairs/fancy/l{
-	icon_state = "fancy_stairs_l";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord{
@@ -9642,19 +9287,17 @@
 /area/rogue/outdoors/exposed/town/keep)
 "jbY" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "jcB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -9712,22 +9355,20 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "jfy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "jfC" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = 3;
@@ -9765,7 +9406,6 @@
 /area/rogue/under/town/basement/keep)
 "jhc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9796,8 +9436,8 @@
 /area/rogue/indoors/town)
 "jiG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
@@ -9811,7 +9451,6 @@
 /area/rogue/under/town/basement)
 "jiM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9851,8 +9490,8 @@
 /area/rogue/indoors/town/church/chapel)
 "jlc" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "bogrtout2";
-	aportalgoesto = "bogrtin2"
+	aportalgoesto = "bogrtin2";
+	aportalid = "bogrtout2"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
@@ -9888,7 +9527,6 @@
 /area/rogue/outdoors/town/roofs)
 "jnW" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9917,14 +9555,12 @@
 /area/rogue/indoors/town/shop)
 "jpw" = (
 /obj/structure/roguemachine/withdraw,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "jpy" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /obj/item/natural/feather,
@@ -9936,15 +9572,14 @@
 /area/rogue/under/town/basement/keep)
 "jpM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs/keep)
 "jqw" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -9965,8 +9600,8 @@
 /area/rogue/indoors/town)
 "jrz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
@@ -9984,8 +9619,8 @@
 /area/rogue/indoors/town/manor)
 "jsm" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
@@ -9994,7 +9629,6 @@
 /area/rogue/indoors/town/garrison)
 "jsJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -10045,7 +9679,6 @@
 /area/rogue/indoors/town/manor)
 "jzA" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/church)
@@ -10057,8 +9690,8 @@
 /area/rogue/indoors/town)
 "jAw" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood{
@@ -10079,7 +9712,6 @@
 "jBv" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic/single,
@@ -10099,7 +9731,6 @@
 /area/rogue/indoors/town/tavern)
 "jBQ" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -10172,8 +9803,8 @@
 /area/rogue/indoors/town/physician)
 "jHu" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "jHz" = (
@@ -10204,13 +9835,20 @@
 /area/rogue/indoors/town)
 "jIY" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"jJc" = (
+/obj/structure/lever/wall{
+	pixel_x = 32;
+	redstone_id = "tourneytop"
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "jJz" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/hexstone,
@@ -10226,28 +9864,25 @@
 /obj/structure/roguemachine/atm{
 	mammonsiphoned = 250
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "jKz" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "jLc" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
 "jLj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
@@ -10275,7 +9910,6 @@
 /area/rogue/indoors/town)
 "jMa" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /obj/structure/fluff/railing/fence,
@@ -10346,7 +9980,6 @@
 "jPb" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -10358,8 +9991,8 @@
 "jPJ" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -10414,7 +10047,6 @@
 /area/rogue/indoors/town/dwarfin)
 "jRq" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/effect/decal/cobbleedge{
@@ -10436,7 +10068,6 @@
 /area/rogue/indoors/town/tavern)
 "jRL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -10448,14 +10079,21 @@
 /area/rogue/under/town/sewer)
 "jRY" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "jSi" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
+"jSK" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "jSY" = (
 /obj/structure/mineral_door/wood/fancywood{
@@ -10473,7 +10111,6 @@
 /area/rogue/indoors/town/manor)
 "jTo" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/stump,
@@ -10491,7 +10128,6 @@
 /area/rogue/indoors/town)
 "jVk" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10505,10 +10141,10 @@
 /area/rogue/under/town/basement/keep)
 "jVM" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable iii";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable3";
-	keylock = 1
+	name = "stable iii"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -10519,9 +10155,9 @@
 /area/rogue/indoors/town/manor)
 "jWf" = (
 /obj/structure/mineral_door/wood{
-	name = "apothacary bunks";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "apothacary bunks"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10535,11 +10171,20 @@
 "jWu" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
+"jWw" = (
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "jWD" = (
 /obj/structure/closet/crate/drawer/random,
 /obj/item/roguekey/tower,
@@ -10581,9 +10226,7 @@
 	icon_state = "ultimacochright"
 	},
 /obj/structure/fluff/walldeco/maidensigil,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "jYO" = (
 /turf/open/floor/rogue/woodturned,
@@ -10600,9 +10243,7 @@
 /area/rogue/indoors/town)
 "jZD" = (
 /obj/structure/bars,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kae" = (
 /turf/open/floor/rogue/dirt,
@@ -10612,15 +10253,13 @@
 /area/rogue/indoors/shelter/woods)
 "kbt" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kbK" = (
 /obj/structure/handcart{
@@ -10668,14 +10307,12 @@
 /area/rogue/indoors/town/manor)
 "kcZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "kdI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10779,12 +10416,9 @@
 /area/rogue/outdoors/mountains)
 "klb" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "kle" = (
 /obj/structure/closet/crate/roguecloset/crafted,
@@ -10807,12 +10441,10 @@
 "kmF" = (
 /obj/item/rogue/instrument/harp,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "kmO" = (
 /obj/structure/roguewindow,
@@ -10837,15 +10469,14 @@
 /area/rogue/outdoors/town)
 "kov" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "koL" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -10863,8 +10494,8 @@
 	mailtag = "Bathhouse"
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry,
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry,
@@ -10909,8 +10540,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -10919,7 +10550,6 @@
 /area/rogue/outdoors/mountains)
 "ksf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/hexstone,
@@ -10978,7 +10608,6 @@
 /area/rogue/indoors/town/bath)
 "kul" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/roguegrass,
@@ -11001,7 +10630,6 @@
 /area/rogue/indoors/town)
 "kuI" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -10
 	},
@@ -11015,7 +10643,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kuZ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -11026,8 +10653,8 @@
 /area/rogue/under/town/basement/keep)
 "kvv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/clothing/mask/rogue/wildguard,
 /obj/item/clothing/mask/rogue/wildguard,
@@ -11049,8 +10676,8 @@
 "kwu" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -11080,18 +10707,16 @@
 /area/rogue/indoors/town/manor)
 "kyM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "kyP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -11100,7 +10725,6 @@
 /area/rogue/indoors/town/manor)
 "kza" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/effect/decal/cobbleedge{
@@ -11125,8 +10749,8 @@
 /area/rogue/outdoors/town)
 "kzW" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "southgate_outer"
 	},
 /turf/open/floor/rogue/metal{
@@ -11177,8 +10801,8 @@
 /area/rogue/indoors/town/garrison)
 "kCr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
@@ -11211,28 +10835,37 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/dwarfin)
+"kDT" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/item/reagent_containers/glass/bucket/wooden{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "kEs" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "kEv" = (
 /obj/effect/landmark/start/barkeep{
-	name = "Innkeeper";
-	dir = 1
+	dir = 1;
+	name = "Innkeeper"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "kEG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "kEN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/cobble,
@@ -11262,9 +10895,7 @@
 /area/rogue/under/town/sewer)
 "kGq" = (
 /obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kGs" = (
 /obj/structure/closet/crate/roguecloset,
@@ -11328,8 +10959,8 @@
 /area/rogue/indoors/town)
 "kJD" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /obj/item/roguekey/velder,
@@ -11351,9 +10982,7 @@
 /area/rogue/indoors/town/bath)
 "kKI" = (
 /obj/machinery/light/rogue/oven/east,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kKS" = (
 /obj/structure/flora/roguetree,
@@ -11374,7 +11003,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kLO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/chair/wood/rogue/chair3{
@@ -11393,8 +11021,8 @@
 /area/rogue/indoors/town/church/chapel)
 "kMr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
@@ -11413,8 +11041,8 @@
 /area/rogue/outdoors/town)
 "kNj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
@@ -11475,7 +11103,6 @@
 /area/rogue/indoors/town)
 "kNC" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/structure/fluff/clodpile,
@@ -11507,8 +11134,8 @@
 /area/rogue/indoors/town)
 "kOv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/carpet/red,
@@ -11537,7 +11164,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "kPo" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -11581,15 +11207,14 @@
 /area/rogue/indoors/town/manor)
 "kQC" = (
 /obj/structure/mineral_door/bars{
-	name = "royal crypt";
 	locked = 1;
-	lockid = "graveyard"
+	lockid = "graveyard";
+	name = "royal crypt"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "kQI" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -11606,7 +11231,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kSm" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 8;
 	locked = 1;
 	lockid = "nightmaiden"
@@ -11615,8 +11239,8 @@
 /area/rogue/indoors/town/bath)
 "kSx" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/cobble,
@@ -11633,10 +11257,10 @@
 /area/rogue/indoors/town/church/chapel)
 "kTg" = (
 /obj/structure/mineral_door/wood{
-	name = "Seneschal's Quarters";
 	icon_state = "wcv";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Seneschal's Quarters"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11664,9 +11288,9 @@
 /area/rogue/outdoors/exposed/town/keep)
 "kTO" = (
 /obj/structure/mineral_door/wood{
-	name = "physician's office";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "physician's office"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11677,8 +11301,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "kUe" = (
@@ -11697,8 +11320,8 @@
 /area/rogue/under/town/basement/keep)
 "kUP" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
@@ -11782,9 +11405,7 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kZU" = (
 /obj/structure/fluff/clock,
@@ -11801,7 +11422,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -11818,21 +11438,18 @@
 "lay" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "laD" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "laX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/effect/decal/mossy{
@@ -11854,7 +11471,6 @@
 /area/rogue/indoors/town/manor)
 "lbI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/herringbone,
@@ -11865,8 +11481,8 @@
 /area/rogue/outdoors/town)
 "lck" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "shipside bunkhouse";
-	dir = 1
+	dir = 1;
+	name = "shipside bunkhouse"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
@@ -11908,8 +11524,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ldX" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -11934,7 +11550,6 @@
 /area/rogue/indoors/town/physician)
 "led" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -11997,7 +11612,6 @@
 "lgZ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic/single,
@@ -12090,19 +11704,16 @@
 /area/rogue/outdoors/exposed/town/keep)
 "lmf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/dwarfin)
 "lmq" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -12134,8 +11745,8 @@
 /area/rogue/outdoors/town)
 "lnv" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -12167,7 +11778,6 @@
 /area/rogue/indoors/town/manor)
 "loB" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12182,7 +11792,6 @@
 /area/rogue/indoors/town)
 "loI" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -12224,9 +11833,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "lpX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
@@ -12242,8 +11849,8 @@
 /area/rogue/indoors/town/church)
 "lsi" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -12255,9 +11862,9 @@
 /area/rogue/indoors/town/manor)
 "lsG" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Guest Room";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Guest Room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -12304,17 +11911,13 @@
 /area/rogue/indoors/town/shop)
 "lvi" = (
 /obj/structure/roguetent,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "lvo" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -12329,11 +11932,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -12365,8 +11966,8 @@
 /area/rogue/indoors/town/tavern)
 "lxe" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/powder/flour,
@@ -12392,8 +11993,8 @@
 /area/rogue/outdoors/town/roofs)
 "lxN" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/cup/steel{
 	pixel_x = -6;
@@ -12417,12 +12018,11 @@
 /area/rogue/outdoors/rtfield)
 "lAt" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -12430,7 +12030,6 @@
 /area/rogue/indoors/town)
 "lAL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
@@ -12478,7 +12077,6 @@
 /area/rogue/indoors/town/physician)
 "lDW" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -12486,8 +12084,8 @@
 "lEf" = (
 /obj/item/soap,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
@@ -12516,7 +12114,6 @@
 /area/rogue/indoors/town)
 "lFW" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -12528,7 +12125,6 @@
 /area/rogue/indoors/town/garrison)
 "lGO" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town/dwarfin)
@@ -12542,8 +12138,8 @@
 /area/rogue/indoors/town/garrison)
 "lHl" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
@@ -12567,7 +12163,6 @@
 /area/rogue/outdoors/town)
 "lIv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12576,8 +12171,7 @@
 /area/rogue/indoors/town/magician)
 "lIC" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 2
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -12598,7 +12192,6 @@
 /area/rogue/indoors/town/dwarfin)
 "lJa" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -12628,14 +12221,12 @@
 /area/rogue/under/town/basement/keep)
 "lLL" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
 "lMc" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -12655,7 +12246,6 @@
 "lMj" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -12690,8 +12280,8 @@
 /area/rogue/indoors/shelter/woods)
 "lOX" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -12699,11 +12289,9 @@
 "lPe" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5;
 	pixel_x = -24;
 	pixel_y = -23
@@ -12712,8 +12300,8 @@
 /area/rogue/indoors/town/tavern)
 "lPB" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/carpet/red,
@@ -12728,8 +12316,8 @@
 /area/rogue/indoors/town/bath)
 "lQS" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/herringbone,
@@ -12740,8 +12328,8 @@
 /area/rogue/outdoors/mountains)
 "lRa" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
@@ -12763,9 +12351,9 @@
 /area/rogue/outdoors/town)
 "lSf" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM II";
 	locked = 1;
-	lockid = "roomii"
+	lockid = "roomii";
+	name = "ROOM II"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -12839,7 +12427,6 @@
 /area/rogue/outdoors/mountains)
 "lVW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/stump,
@@ -12858,14 +12445,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
-"lYJ" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/under/town/basement)
 "lYS" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/carpet/inn,
@@ -12883,15 +12462,15 @@
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "lZW" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
@@ -12905,9 +12484,9 @@
 /area/rogue/indoors/town/magician)
 "maj" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Apartment";
 	locked = 1;
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -12927,7 +12506,6 @@
 /area/rogue/indoors/town/physician)
 "mbO" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/carpet,
@@ -12980,16 +12558,6 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
-"meP" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town)
 "meT" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -12999,8 +12567,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "mfn" = (
@@ -13016,7 +12584,6 @@
 /area/rogue/indoors/town)
 "mfP" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -13030,7 +12597,6 @@
 /area/rogue/indoors/town/manor)
 "mgA" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -13051,7 +12617,6 @@
 /area/rogue/indoors/town/physician)
 "mgM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13095,9 +12660,7 @@
 /obj/effect/landmark/start/dungeoneer{
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "mjw" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -13116,15 +12679,15 @@
 "mkg" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "mkB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -13155,9 +12718,9 @@
 /area/rogue/indoors/town/magician)
 "mlM" = (
 /obj/structure/mineral_door/wood{
-	name = "house iii";
 	locked = 1;
-	lockid = "house3"
+	lockid = "house3";
+	name = "house iii"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -13179,8 +12742,7 @@
 /area/rogue/outdoors/town)
 "mmh" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
@@ -13197,19 +12759,17 @@
 /area/rogue/outdoors/town)
 "mmT" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "mnl" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -13263,7 +12823,6 @@
 /area/rogue/under/town/basement/keep)
 "mrL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -13312,8 +12871,8 @@
 /area/rogue/under/town/sewer)
 "mva" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/cloth,
 /obj/item/natural/bundle/cloth{
@@ -13335,8 +12894,8 @@
 /area/rogue/outdoors/town/roofs/keep)
 "mvz" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
@@ -13345,8 +12904,8 @@
 /area/rogue/indoors/town/church)
 "mvF" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Heir's Apartment";
-	lockid = "heir"
+	lockid = "heir";
+	name = "Heir's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -13368,8 +12927,7 @@
 "mxw" = (
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "mxz" = (
@@ -13380,9 +12938,7 @@
 /area/rogue/indoors/town/garrison)
 "mxK" = (
 /obj/structure/bars,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "myb" = (
 /obj/structure/rack/rogue/shelf/big{
@@ -13395,15 +12951,12 @@
 /area/rogue/outdoors/town)
 "myj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/item/roguebin/water,
@@ -13411,7 +12964,6 @@
 /area/rogue/outdoors/town)
 "myk" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
@@ -13434,8 +12986,8 @@
 "mzg" = (
 /obj/structure/winch{
 	dir = 4;
-	pixel_x = -7;
 	gid = "thronegate";
+	pixel_x = -7;
 	redstone_id = "thronegate"
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -13476,11 +13028,6 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"mBU" = (
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave)
 "mCu" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -13498,7 +13045,6 @@
 /area/rogue/indoors/town/garrison)
 "mDM" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
@@ -13525,11 +13071,9 @@
 /area/rogue/outdoors/town)
 "mEu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9;
 	pixel_y = -25
 	},
@@ -13560,20 +13104,11 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
-"mGi" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "mGS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -13748,7 +13283,6 @@
 "mTX" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/effect/landmark/start/squire{
-	icon_state = "arrow";
 	dir = 4
 	},
 /obj/structure/bed/rogue,
@@ -13758,8 +13292,8 @@
 /area/rogue/indoors/town/garrison)
 "mUJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/storage/roguebag{
 	pixel_x = -7;
@@ -13770,8 +13304,8 @@
 /area/rogue/indoors/town/dwarfin)
 "mUR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter{
 	dir = 2
@@ -13896,8 +13430,8 @@
 /obj/item/kitchen/rollingpin,
 /obj/structure/rack/rogue/shelf,
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = 5;
@@ -13925,9 +13459,9 @@
 /area/rogue/indoors/town)
 "naO" = (
 /obj/structure/mineral_door/wood{
-	name = "nitemaiden chambers";
 	locked = 1;
-	lockid = "nightmaiden"
+	lockid = "nightmaiden";
+	name = "nitemaiden chambers"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
@@ -13951,8 +13485,8 @@
 "nbM" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
+	dir = 4;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
@@ -13964,7 +13498,6 @@
 "ncQ" = (
 /obj/structure/flora/roguegrass,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble/mossy,
@@ -13986,7 +13519,6 @@
 /area/rogue/outdoors/town)
 "ndm" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -13995,8 +13527,8 @@
 /area/rogue/indoors/town/physician)
 "ndv" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
@@ -14024,7 +13556,6 @@
 /area/rogue/under/town/basement/keep)
 "neL" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -14032,7 +13563,6 @@
 "nfy" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -14052,18 +13582,16 @@
 /area/rogue/indoors/town/bath)
 "ngM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "ngZ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/carpet/inn,
@@ -14076,7 +13604,6 @@
 /area/rogue/indoors/town/manor)
 "nho" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -14128,14 +13655,12 @@
 /area/rogue/outdoors/town)
 "nkZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "nlp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/water/bath,
@@ -14156,7 +13681,6 @@
 /area/rogue/indoors/town/garrison)
 "nlJ" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -14172,7 +13696,6 @@
 /area/rogue/under/town/basement)
 "nmj" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
@@ -14186,8 +13709,8 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "nna" = (
@@ -14200,7 +13723,6 @@
 /area/rogue/outdoors/rtfield)
 "nov" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -14208,8 +13730,8 @@
 "noF" = (
 /obj/structure/fluff/canopy,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -14223,8 +13745,8 @@
 /area/rogue/indoors/town/church/chapel)
 "npT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -14249,12 +13771,10 @@
 /area/rogue/indoors/town/manor)
 "nqC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "nqQ" = (
@@ -14271,7 +13791,6 @@
 /area/rogue/outdoors/town)
 "nrp" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/hexstone,
@@ -14297,12 +13816,9 @@
 /area/rogue/indoors/town/magician)
 "nsb" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "nsf" = (
 /obj/structure/flora/roguegrass/bush,
@@ -14313,19 +13829,17 @@
 /area/rogue/outdoors/town)
 "nsg" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "nsk" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
+	dir = 4;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
@@ -14356,7 +13870,6 @@
 /area/rogue/indoors/town/bath)
 "nto" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -14414,7 +13927,6 @@
 /area/rogue/indoors/town/manor)
 "nwO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/fluff/railing/border,
@@ -14438,8 +13950,8 @@
 /area/rogue/under/town/sewer)
 "nyM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -14449,7 +13961,6 @@
 "nyR" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/grassyel,
@@ -14466,13 +13977,6 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
-"nAP" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "tourneytop"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement)
 "nBk" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
@@ -14503,8 +14007,8 @@
 /area/rogue/indoors/town/bath)
 "nFb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/cobble,
@@ -14524,8 +14028,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "nGm" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "nGn" = (
@@ -14534,8 +14038,8 @@
 /area/rogue/indoors/town/manor)
 "nGr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/neck/roguetown/coif,
 /obj/item/clothing/mask/bandana/black,
@@ -14557,8 +14061,8 @@
 /area/rogue/indoors/town/dwarfin)
 "nHP" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
@@ -14584,7 +14088,6 @@
 /area/rogue/indoors/town/church)
 "nIN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/couchablack/r,
@@ -14642,8 +14145,8 @@
 /area/rogue/indoors/town/tavern)
 "nKp" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "northgate_outer"
 	},
 /turf/open/floor/rogue/metal{
@@ -14707,17 +14210,17 @@
 /area/rogue/outdoors/town)
 "nNw" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stables";
+	keylock = 1;
 	locked = 1;
 	lockid = "manor";
-	keylock = 1
+	name = "stables"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "nNH" = (
 /obj/structure/toilet/greyscale{
-	name = "The Royal Shitter";
-	color = "#ffee00"
+	color = "#ffee00";
+	name = "The Royal Shitter"
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/hexstone,
@@ -14735,13 +14238,17 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"nOU" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "nOY" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
 "nOZ" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir"
-	},
+/obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "nPa" = (
@@ -14759,8 +14266,8 @@
 /area/rogue/indoors/town/tavern)
 "nPH" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -14772,8 +14279,8 @@
 /area/rogue/outdoors/rtfield)
 "nQa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/roguekey/lord,
 /turf/open/floor/rogue/ruinedwood{
@@ -14800,8 +14307,8 @@
 /area/rogue/outdoors/rtfield)
 "nQQ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -14838,18 +14345,15 @@
 /area/rogue/under/town/basement)
 "nRN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "nRX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -14868,7 +14372,6 @@
 /area/rogue/indoors/town/tavern)
 "nSu" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -14894,7 +14397,6 @@
 /area/rogue/indoors/town/manor)
 "nTR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -14907,7 +14409,6 @@
 /area/rogue/indoors/town)
 "nUn" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -14918,7 +14419,6 @@
 /area/rogue/indoors/town/tavern)
 "nVd" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/structure/fluff/clodpile,
@@ -14944,15 +14444,14 @@
 /area/rogue/indoors/town)
 "nWw" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
 "nWK" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -15001,13 +14500,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
-"nZx" = (
-/obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/tavern)
 "nZW" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/globe,
@@ -15025,18 +14517,11 @@
 /area/rogue/indoors/town/manor)
 "oaL" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"oaV" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/town/basement)
 "obx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
@@ -15061,9 +14546,7 @@
 /area/rogue/indoors/town/church/chapel)
 "ocH" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "ocI" = (
 /obj/effect/decal/cobbleedge{
@@ -15098,12 +14581,10 @@
 /area/rogue/indoors/town/tavern)
 "oew" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "oeW" = (
@@ -15149,11 +14630,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/tile{
@@ -15183,7 +14662,6 @@
 /area/rogue/indoors/town/tavern)
 "ohE" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15192,7 +14670,6 @@
 /area/rogue/indoors/town/church/chapel)
 "ohF" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15205,15 +14682,14 @@
 /area/rogue/indoors/town/tavern)
 "oim" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "oiN" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_y = 12
@@ -15239,7 +14715,6 @@
 /area/rogue/indoors/town/magician)
 "okO" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -15273,10 +14748,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
-"onk" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "ono" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15294,8 +14765,8 @@
 /area/rogue/indoors/town/manor)
 "ooy" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/idagger/navaja,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -15368,19 +14839,16 @@
 /area/rogue/indoors/town/magician)
 "orK" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "orU" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "orW" = (
@@ -15399,7 +14867,6 @@
 	dir = 9
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -10
 	},
@@ -15417,11 +14884,9 @@
 /area/rogue/indoors/town/shop)
 "osM" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -15434,7 +14899,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -15458,11 +14922,9 @@
 /area/rogue/indoors/town)
 "otV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
@@ -15472,9 +14934,9 @@
 /area/rogue/outdoors/town)
 "otY" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Butchers House";
 	locked = 1;
-	lockid = "farm"
+	lockid = "farm";
+	name = "Butchers House"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -15482,8 +14944,8 @@
 /area/rogue/indoors/town)
 "ous" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/natural/feather,
 /obj/item/candle/skull/lit,
@@ -15491,8 +14953,7 @@
 /area/rogue/indoors/town/shop)
 "ouw" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "ouA" = (
@@ -15515,8 +14976,7 @@
 /area/rogue/outdoors/town)
 "ovs" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 2
+	icon_state = "longtable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
@@ -15564,8 +15024,8 @@
 /area/rogue/indoors/town/manor)
 "ozA" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/silk{
 	pixel_x = 5
@@ -15579,7 +15039,6 @@
 /area/rogue/indoors/town)
 "ozE" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15668,8 +15127,8 @@
 /area/rogue/outdoors/town)
 "oCI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -15688,14 +15147,12 @@
 /area/rogue/under/town/basement)
 "oDn" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "oDH" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/concrete,
@@ -15724,9 +15181,7 @@
 /obj/item/natural/stone,
 /obj/item/natural/stone,
 /obj/item/natural/stone,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "oEk" = (
 /obj/structure/fluff/walldeco/painting{
@@ -15775,8 +15230,8 @@
 /area/rogue/indoors/town/physician)
 "oGR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = 3
@@ -15811,7 +15266,6 @@
 /area/rogue/indoors/town/church)
 "oIK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -15892,7 +15346,6 @@
 /area/rogue/indoors/town/manor)
 "oNE" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15920,8 +15373,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
@@ -15948,8 +15401,8 @@
 /area/rogue/indoors/town/manor)
 "oQn" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -15988,8 +15441,8 @@
 /area/rogue/indoors/town)
 "oRM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/natural/feather{
 	pixel_x = 8;
@@ -16008,9 +15461,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "oSV" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "oSX" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
@@ -16021,8 +15472,8 @@
 	dir = 10
 	},
 /obj/structure/lever/wall{
-	name = "outer passage lever";
 	dir = 4;
+	name = "outer passage lever";
 	pixel_x = 6;
 	redstone_id = "keepgate_outer"
 	},
@@ -16067,7 +15518,6 @@
 /area/rogue/outdoors/town)
 "oWN" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -16091,8 +15541,7 @@
 /area/rogue/indoors/town/tavern)
 "oXN" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
@@ -16126,15 +15575,14 @@
 /area/rogue/indoors/shelter/woods)
 "oZv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "oZH" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -16151,7 +15599,6 @@
 /area/rogue/indoors/town/church/chapel)
 "pag" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
@@ -16180,8 +15627,8 @@
 /area/rogue/outdoors/town)
 "pbB" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/garrison,
 /obj/item/storage/keyring,
@@ -16192,7 +15639,6 @@
 /area/rogue/indoors/town/garrison)
 "pcB" = (
 /obj/effect/decal/cobbleedge{
-	dir = 2;
 	pixel_y = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -16271,8 +15717,8 @@
 /area/rogue/indoors/town)
 "phI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -16314,9 +15760,7 @@
 "pjc" = (
 /obj/item/roguecoin/silver/pile,
 /obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "pjk" = (
 /obj/structure/flora/roguetree/burnt,
@@ -16338,7 +15782,6 @@
 /area/rogue/under/town/basement)
 "pjV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -16420,11 +15863,9 @@
 /area/rogue/indoors/town/church/chapel)
 "plY" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -16436,21 +15877,21 @@
 /area/rogue/indoors/town/manor)
 "pmA" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/under/town/sewer)
 "pmX" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/indoors/town/dwarfin)
 "pnh" = (
 /obj/structure/mineral_door/wood{
-	name = "stall ii";
 	locked = 1;
-	lockid = "stall2"
+	lockid = "stall2";
+	name = "stall ii"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -16467,8 +15908,8 @@
 "poj" = (
 /obj/item/cooking/pan,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -16501,9 +15942,7 @@
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "ppA" = (
 /obj/structure/bookcase/random/nonfiction,
@@ -16511,8 +15950,8 @@
 /area/rogue/indoors/town)
 "ppJ" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "prt" = (
@@ -16552,6 +15991,10 @@
 /obj/item/book/rogue/bibble,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
+"ptA" = (
+/obj/structure/roguetent,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "ptM" = (
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = 6;
@@ -16561,20 +16004,18 @@
 	pixel_x = -8
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "ptN" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town)
 "ptQ" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -16673,7 +16114,6 @@
 /area/rogue/outdoors/town/roofs)
 "pzs" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -16686,7 +16126,6 @@
 /area/rogue/outdoors/town)
 "pAl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -16714,7 +16153,6 @@
 "pBF" = (
 /obj/structure/closet/dirthole/grave,
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -16730,14 +16168,12 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "pCC" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -16788,9 +16224,9 @@
 /area/rogue/outdoors/town)
 "pFo" = (
 /obj/structure/mineral_door/wood{
-	name = "house ii";
 	locked = 1;
-	lockid = "house2"
+	lockid = "house2";
+	name = "house ii"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -16822,7 +16258,6 @@
 /area/rogue/outdoors/town)
 "pGK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/effect/decal/cobbleedge{
@@ -16840,7 +16275,6 @@
 "pGZ" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -16879,7 +16313,6 @@
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
 /obj/effect/landmark/start/servant{
-	icon_state = "arrow";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -16897,7 +16330,6 @@
 /area/rogue/indoors/town)
 "pIO" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -16931,8 +16363,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "pJQ" = (
@@ -16960,15 +16392,15 @@
 /area/rogue/indoors/town/manor)
 "pKz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "pKF" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -16992,7 +16424,6 @@
 /area/rogue/indoors/shelter/woods)
 "pLN" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -17032,11 +16463,9 @@
 /area/rogue/indoors/town)
 "pND" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -17058,9 +16487,9 @@
 /area/rogue/indoors/town/church/chapel)
 "pOd" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM I";
 	locked = 1;
-	lockid = "roomi"
+	lockid = "roomi";
+	name = "ROOM I"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -17068,18 +16497,11 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"pOo" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 6
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
 "pOp" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -17087,8 +16509,8 @@
 /area/rogue/under/town/basement/keep)
 "pOG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/redwine,
 /turf/open/floor/rogue/ruinedwood{
@@ -17103,7 +16525,6 @@
 /area/rogue/indoors/town/shop)
 "pPu" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -17120,7 +16541,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
@@ -17133,12 +16553,10 @@
 /area/rogue/outdoors/rtfield)
 "pQT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "pRj" = (
@@ -17147,16 +16565,16 @@
 /area/rogue/indoors/town)
 "pRx" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Marshal's Quarters";
 	locked = 1;
-	lockid = "sheriff"
+	lockid = "sheriff";
+	name = "Marshal's Quarters"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "pRI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/storage/keyring,
 /obj/item/roguekey/merchant,
@@ -17180,7 +16598,6 @@
 /area/rogue/under/town/basement/keep)
 "pTw" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -17197,14 +16614,12 @@
 /area/rogue/outdoors/town)
 "pUo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "pUt" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 8;
 	locked = 1;
 	lockid = "steward"
@@ -17247,7 +16662,6 @@
 /area/rogue/indoors/town/tavern)
 "pWV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/carpet/royalblack,
@@ -17275,7 +16689,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "pYo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -17288,7 +16701,6 @@
 /area/rogue/outdoors/rtfield)
 "pYV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -17303,7 +16715,6 @@
 /area/rogue/under/town/basement)
 "pZI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -17343,8 +16754,7 @@
 "qbF" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "qbL" = (
@@ -17357,7 +16767,6 @@
 /area/rogue/indoors/town)
 "qcS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -17368,7 +16777,6 @@
 /area/rogue/indoors/town/dwarfin)
 "qdX" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -17435,8 +16843,8 @@
 /area/rogue/outdoors/town/roofs)
 "qhq" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Apartment";
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -17518,9 +16926,9 @@
 /area/rogue/outdoors/town/roofs/keep)
 "qly" = (
 /obj/structure/mineral_door/wood/violet{
-	name = "STAFF";
 	locked = 1;
-	lockid = "tavern"
+	lockid = "tavern";
+	name = "STAFF"
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
@@ -17542,8 +16950,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper,
 /turf/open/floor/rogue/herringbone,
@@ -17571,9 +16979,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
 "qqw" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "qqS" = (
 /obj/structure/roguemachine/scomm,
@@ -17597,18 +17003,16 @@
 /area/rogue/indoors/town/manor)
 "qsr" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
 "qsO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -17625,7 +17029,6 @@
 /area/rogue/outdoors/rtfield)
 "quo" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -17639,8 +17042,8 @@
 "qvo" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
@@ -17650,13 +17053,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
-"qvM" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/town/basement)
 "qwm" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = 16;
@@ -17745,17 +17141,15 @@
 /area/rogue/indoors/town)
 "qzM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/rtfield)
 "qzO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -17805,8 +17199,8 @@
 /area/rogue/indoors/town/bath)
 "qAV" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
@@ -17815,10 +17209,10 @@
 	dir = 9
 	},
 /obj/structure/mineral_door/wood/donjon{
-	name = "keep entrance";
 	dir = 1;
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "keep entrance"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -17854,7 +17248,6 @@
 /area/rogue/indoors/town/tavern)
 "qBM" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -17868,7 +17261,6 @@
 /area/rogue/outdoors/town)
 "qDm" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -17882,12 +17274,9 @@
 /area/rogue/indoors/town/shop)
 "qDY" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "qEa" = (
 /obj/effect/decal/cobbleedge{
@@ -17901,8 +17290,8 @@
 /area/rogue/outdoors/rtfield)
 "qEs" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -17928,19 +17317,17 @@
 /area/rogue/indoors/town/dwarfin)
 "qFO" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "qGh" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
@@ -17989,16 +17376,14 @@
 /area/rogue/indoors/town/shop)
 "qIz" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/bars{
 	icon_state = "barsbent";
 	layer = 2.81
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "qIK" = (
 /obj/structure/flora/roguegrass,
@@ -18018,7 +17403,6 @@
 /area/rogue/indoors/town/church/chapel)
 "qJJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -18045,8 +17429,8 @@
 /area/rogue/indoors/town/magician)
 "qMb" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -18069,8 +17453,8 @@
 /area/rogue/outdoors/town)
 "qOg" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -18119,9 +17503,7 @@
 /area/rogue/indoors/town/church/chapel)
 "qPZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "qQt" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -18166,16 +17548,16 @@
 /area/rogue/indoors/town/tavern)
 "qTJ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -18193,14 +17575,12 @@
 /area/rogue/indoors/town/tavern)
 "qVz" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/fluff/railing/border{
@@ -18229,10 +17609,10 @@
 /area/rogue/indoors/town)
 "qWI" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Throne Room";
 	dir = 1;
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Throne Room"
 	},
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
@@ -18267,20 +17647,17 @@
 /area/rogue/indoors/town/magician)
 "qXF" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "qXK" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "qYz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -18340,7 +17717,6 @@
 /area/rogue/indoors/town/garrison)
 "rab" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/customflag{
@@ -18379,11 +17755,10 @@
 "raV" = (
 /obj/machinery/light/rogue/firebowl/church,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -18396,7 +17771,6 @@
 	pixel_y = -32
 	},
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -18413,7 +17787,6 @@
 	pixel_y = 32
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -18426,8 +17799,8 @@
 /area/rogue/under/town/basement/keep)
 "rcJ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -18469,7 +17842,6 @@
 /area/rogue/under/town/basement/keep)
 "reZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -18519,7 +17891,6 @@
 	dir = 6
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -18536,8 +17907,8 @@
 /area/rogue/indoors/shelter/woods)
 "rho" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/elfred,
 /obj/item/reagent_containers/glass/cup/silver{
@@ -18550,7 +17921,6 @@
 /area/rogue/indoors/town/manor)
 "rhr" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -18587,15 +17957,14 @@
 /area/rogue/indoors)
 "rjw" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "rjG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/needle/thorn,
@@ -18607,7 +17976,6 @@
 	},
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/twig,
@@ -18618,8 +17986,8 @@
 /area/rogue/indoors/town/bath)
 "rkv" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
@@ -18629,8 +17997,8 @@
 /area/rogue/indoors/town/church)
 "rkL" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = -13;
@@ -18639,19 +18007,10 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
-"rkX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "rmy" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/item/roguegem/violet,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rou" = (
 /obj/item/roguebin/water/gross,
@@ -18661,30 +18020,26 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "roA" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
 "roU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rpj" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "rpq" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "forestout";
+	aallmig = "rwfieldin1";
 	aportalgoesto = "forestin";
-	aallmig = "rwfieldin1"
+	aportalid = "forestout"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
@@ -18707,9 +18062,16 @@
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"rsm" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "rtf" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -18719,8 +18081,8 @@
 /area/rogue/indoors/town/church)
 "rtH" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogue/instrument/drum,
 /obj/structure/fluff/walldeco/customflag{
@@ -18734,9 +18096,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ruG" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "ruM" = (
 /obj/structure/rack/rogue,
@@ -18757,7 +18117,6 @@
 	dir = 10
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -18765,7 +18124,6 @@
 /area/rogue/indoors/town/garrison)
 "rvA" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -18785,8 +18143,8 @@
 /area/rogue/indoors/town/dwarfin)
 "rwd" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
@@ -18847,7 +18205,6 @@
 /area/rogue/indoors/town)
 "rAJ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/villager{
@@ -18860,14 +18217,21 @@
 /area/rogue/indoors/town/tavern)
 "rBd" = (
 /obj/structure/lever/wall{
-	name = "drawbridge lever";
 	dir = 4;
+	name = "drawbridge lever";
 	pixel_x = 6;
 	pixel_y = 9;
 	redstone_id = "gatelava"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"rBh" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement)
 "rCx" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobble/mossy,
@@ -18887,19 +18251,18 @@
 /area/rogue/outdoors/town)
 "rCZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "rDa" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
@@ -18909,8 +18272,8 @@
 /area/rogue/indoors/town/manor)
 "rDj" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "rDz" = (
@@ -18926,7 +18289,6 @@
 /area/rogue/indoors/town/manor)
 "rDX" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -18965,8 +18327,8 @@
 /area/rogue/indoors/town)
 "rGy" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -19026,11 +18388,9 @@
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19041,7 +18401,6 @@
 /area/rogue/under/town/basement)
 "rKE" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -19068,8 +18427,8 @@
 "rLe" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
@@ -19113,11 +18472,9 @@
 /area/rogue/indoors/town)
 "rNp" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -19141,8 +18498,8 @@
 /area/rogue/outdoors/town)
 "rOJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -19150,8 +18507,8 @@
 /area/rogue/indoors/town)
 "rOL" = (
 /obj/structure/mineral_door/bars{
-	lockid = "graveyard";
-	locked = 1
+	locked = 1;
+	lockid = "graveyard"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -19169,11 +18526,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -19197,16 +18552,16 @@
 /area/rogue/under/town/sewer)
 "rQG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "rQI" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 8
@@ -19215,7 +18570,6 @@
 "rQJ" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -19228,7 +18582,6 @@
 /area/rogue/indoors/town)
 "rRc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -19236,7 +18589,6 @@
 /area/rogue/under/town/basement)
 "rRf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -19271,8 +18623,8 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -19306,7 +18658,6 @@
 /area/rogue/indoors/town)
 "rSR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/closet/crate/chest/neu,
@@ -19338,8 +18689,8 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/wallclock,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -19363,7 +18714,6 @@
 /area/rogue/under/town/basement)
 "rVC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -19374,9 +18724,9 @@
 /area/rogue/outdoors/town)
 "rWN" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Hand's Chambers";
 	locked = 1;
-	lockid = "hand"
+	lockid = "hand";
+	name = "Hand's Chambers"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -19396,8 +18746,8 @@
 /area/rogue/outdoors/town)
 "rZc" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_x = 5;
@@ -19406,27 +18756,22 @@
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_y = 10
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rZv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "sac" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "saf" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/structure/fluff/wallclock,
@@ -19438,8 +18783,8 @@
 /area/rogue/outdoors/town)
 "saM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/flint{
 	pixel_x = -6;
@@ -19453,9 +18798,9 @@
 /area/rogue/under/town/basement)
 "saU" = (
 /obj/structure/mineral_door/wood{
-	name = "alchemy";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "alchemy"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -19490,7 +18835,6 @@
 /area/rogue/outdoors/rtfield)
 "scg" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/grass,
@@ -19565,9 +18909,9 @@
 /area/rogue/indoors/town)
 "sgY" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM VI";
 	locked = 1;
-	lockid = "roomvi"
+	lockid = "roomvi";
+	name = "ROOM VI"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -19594,15 +18938,15 @@
 /area/rogue/indoors/town)
 "sid" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "sif" = (
 /obj/structure/gate{
-	name = "The Throne";
 	gid = "thronegate";
+	name = "The Throne";
 	redstone_id = "thronegate"
 	},
 /turf/open/floor/rogue/carpet/lord/left,
@@ -19669,7 +19013,6 @@
 /area/rogue/indoors/town/bath)
 "skH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -19683,8 +19026,8 @@
 "sma" = (
 /obj/structure/fluff/canopy,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -19705,16 +19048,16 @@
 "sns" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "snM" = (
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -19730,8 +19073,8 @@
 	},
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/pillory/reinforced,
 /turf/open/floor/rogue/cobblerock,
@@ -19780,6 +19123,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"srr" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "srJ" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/mountains)
@@ -19793,8 +19141,7 @@
 "ssO" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "ssW" = (
@@ -19806,8 +19153,8 @@
 /area/rogue/indoors/town)
 "ssZ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
@@ -19844,9 +19191,14 @@
 	},
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town)
+"suv" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "suw" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/closet/crate/chest/old_crate,
@@ -19855,7 +19207,6 @@
 /area/rogue/indoors/town)
 "sux" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -19868,7 +19219,6 @@
 "suz" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19907,7 +19257,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19920,7 +19269,6 @@
 /area/rogue/outdoors/town)
 "syj" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -19970,7 +19318,6 @@
 /area/rogue/indoors/town/manor)
 "sAZ" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -19979,8 +19326,8 @@
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/cobble,
@@ -20010,7 +19357,6 @@
 /area/rogue/under/town/sewer)
 "sDO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -20047,7 +19393,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -20060,9 +19405,7 @@
 /area/rogue/indoors/town)
 "sGb" = (
 /obj/structure/table/wood/crafted,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "sGz" = (
 /obj/effect/decal/cobbleedge,
@@ -20071,8 +19414,8 @@
 /area/rogue/outdoors/town)
 "sHe" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/ruinedwood{
@@ -20093,9 +19436,7 @@
 /area/rogue/indoors/town)
 "sHo" = (
 /obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "sHU" = (
 /obj/structure/chair/wood/rogue,
@@ -20119,8 +19460,8 @@
 /area/rogue/indoors/town/church)
 "sKe" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -20129,9 +19470,7 @@
 /area/rogue/under/town/basement/keep)
 "sKi" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 4;
-	locked = 0;
 	lockid = "nightmaiden"
 	},
 /turf/open/floor/rogue/hexstone,
@@ -20152,7 +19491,6 @@
 /area/rogue/outdoors/town/roofs)
 "sLb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -20162,7 +19500,6 @@
 /area/rogue/outdoors/town)
 "sLy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/stairs/stone{
@@ -20172,14 +19509,12 @@
 /area/rogue/outdoors/town)
 "sLH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "sLS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -20213,15 +19548,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "sMD" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "sNg" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/toy/cards/deck{
 	pixel_x = 3;
@@ -20238,9 +19571,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement/keep)
 "sNI" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 2
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/shop)
 "sOm" = (
 /obj/structure/stairs{
@@ -20267,26 +19598,21 @@
 /area/rogue/indoors/town/tavern)
 "sQg" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "sQv" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "sRc" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "sRz" = (
 /obj/structure/flora/roguegrass/bush,
@@ -20294,8 +19620,8 @@
 /area/rogue/outdoors/town)
 "sRP" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "sRU" = (
@@ -20344,7 +19670,6 @@
 /area/rogue/indoors/town/shop)
 "sUt" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -20359,12 +19684,10 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "sVH" = (
@@ -20381,12 +19704,12 @@
 /area/rogue/outdoors/exposed/town/keep)
 "sWd" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "sWi" = (
@@ -20414,16 +19737,15 @@
 /area/rogue/under/town/basement)
 "sXv" = (
 /obj/structure/mineral_door/wood{
-	name = "house v";
 	locked = 1;
-	lockid = "house5"
+	lockid = "house5";
+	name = "house v"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "sXy" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -20442,7 +19764,6 @@
 /area/rogue/indoors/town)
 "sXQ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/villager{
@@ -20457,7 +19778,6 @@
 /area/rogue/indoors/town/cell)
 "sZw" = (
 /obj/structure/stairs/fancy/c{
-	icon_state = "fancy_stairs_c";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord,
@@ -20530,12 +19850,12 @@
 /area/rogue/under/town/basement/keep)
 "tdu" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Farm";
 	dir = 8;
+	lock_strength = 100;
 	locked = 1;
 	lockid = "farm";
-	lock_strength = 100;
-	max_integrity = 1000
+	max_integrity = 1000;
+	name = "Farm"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -20548,7 +19868,6 @@
 "tei" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -20574,7 +19893,6 @@
 "tfo" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/chair/bench{
-	icon_state = "bench";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -20586,8 +19904,8 @@
 	redstone_id = "armourer_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -20735,14 +20053,13 @@
 /area/rogue/under/town/basement/keep)
 "tjp" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Restroom";
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Restroom"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "tjy" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -20754,8 +20071,8 @@
 /area/rogue/indoors/town)
 "tkg" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/clothing/cloak/apron/waist,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -20849,13 +20166,6 @@
 /obj/structure/fermenting_barrel/crafted,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"toL" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/beach)
 "tqe" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/dirt/road,
@@ -20867,8 +20177,8 @@
 /area/rogue/indoors/town/physician)
 "tqC" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 12
@@ -20946,15 +20256,14 @@
 /area/rogue/indoors/town/magician)
 "tuG" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "tvk" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20977,9 +20286,7 @@
 "tvU" = (
 /obj/structure/chair/bench/ultimacouch,
 /obj/structure/fluff/walldeco/maidensigil/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "tvX" = (
 /turf/closed/wall/mineral/rogue/decowood,
@@ -21043,11 +20350,9 @@
 /area/rogue/indoors/town/bath)
 "tyv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -21056,13 +20361,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"tyQ" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
 "tzi" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/guardsman,
@@ -21087,9 +20385,7 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "tAB" = (
 /obj/structure/table/wood{
@@ -21172,7 +20468,6 @@
 /area/rogue/indoors/shelter/woods)
 "tFb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/carpet/royalblack,
@@ -21201,8 +20496,8 @@
 /area/rogue/indoors/town/physician)
 "tGt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
@@ -21214,6 +20509,13 @@
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
+"tHg" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "tHr" = (
 /obj/structure/roguemachine/stockpile,
 /obj/structure/roguemachine/scomm/l,
@@ -21239,9 +20541,9 @@
 /area/rogue/indoors/town)
 "tHJ" = (
 /obj/structure/mineral_door/wood{
-	name = "stall iii";
 	locked = 1;
-	lockid = "stall3"
+	lockid = "stall3";
+	name = "stall iii"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -21262,11 +20564,9 @@
 /area/rogue/indoors/town/garrison)
 "tJs" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -21275,9 +20575,7 @@
 /obj/structure/closet/crate/chest/neu,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "tKw" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -21287,7 +20585,6 @@
 /area/rogue/indoors/town)
 "tKP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -21351,9 +20648,9 @@
 /area/rogue/outdoors/town/roofs/keep)
 "tPt" = (
 /obj/structure/mineral_door/wood{
-	name = "house iii";
 	locked = 1;
-	lockid = "house3"
+	lockid = "house3";
+	name = "house iii"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -21445,8 +20742,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "tUv" = (
@@ -21459,9 +20755,9 @@
 /area/rogue/indoors/town/bath)
 "tVc" = (
 /obj/structure/mineral_door/wood{
-	name = "house vi";
 	locked = 1;
-	lockid = "house6"
+	lockid = "house6";
+	name = "house vi"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -21476,7 +20772,6 @@
 /area/rogue/outdoors/town)
 "tVM" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -21495,8 +20790,8 @@
 /area/rogue/outdoors/town)
 "tWM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge,
 /obj/structure/flora/roguegrass,
@@ -21504,29 +20799,26 @@
 /area/rogue/outdoors/town)
 "tXc" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "tXs" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "tXX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "tXZ" = (
 /turf/open/transparent/openspace,
@@ -21541,8 +20833,8 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/bars/passage/shutter{
 	redstone_id = "weaponsmith_shutter"
@@ -21551,8 +20843,7 @@
 /area/rogue/indoors/town/dwarfin)
 "tYX" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "tZa" = (
@@ -21611,8 +20902,8 @@
 	dir = 1
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/ruinedwood{
@@ -21739,7 +21030,6 @@
 /area/rogue/indoors/town)
 "ukZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -21752,7 +21042,6 @@
 /area/rogue/outdoors/rtfield)
 "ulo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/effect/decal/cobbleedge{
@@ -21772,7 +21061,6 @@
 /area/rogue/outdoors/rtfield)
 "umV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -21780,7 +21068,6 @@
 /area/rogue/indoors/town)
 "umX" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -21853,7 +21140,6 @@
 	dir = 5
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -21883,8 +21169,8 @@
 /area/rogue/under/cave)
 "usq" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -21902,7 +21188,6 @@
 /area/rogue/indoors/town/magician)
 "uto" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -21929,9 +21214,9 @@
 /area/rogue/indoors/town/dwarfin)
 "uut" = (
 /obj/structure/mineral_door/wood{
-	name = "house i";
 	locked = 1;
-	lockid = "house1"
+	lockid = "house1";
+	name = "house i"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -21948,7 +21233,6 @@
 /area/rogue/indoors/town/manor)
 "uuU" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -21965,8 +21249,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "uvq" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 8
+	dir = 8;
+	icon_state = "longtable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -22045,7 +21329,6 @@
 /area/rogue/indoors/town/tavern)
 "uyA" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -22063,7 +21346,6 @@
 /area/rogue/under/cave)
 "uzB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/blocks,
@@ -22071,9 +21353,7 @@
 "uzK" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "uAV" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
@@ -22115,15 +21395,14 @@
 /area/rogue/outdoors/town)
 "uDd" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
 "uDo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -22136,8 +21415,8 @@
 /area/rogue/indoors/town)
 "uDt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -22162,13 +21441,10 @@
 /area/rogue/indoors/town/physician)
 "uDM" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "uDU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22192,7 +21468,6 @@
 /area/rogue/indoors/town/bath)
 "uEl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22235,6 +21510,9 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"uHG" = (
+/turf/closed/wall/mineral/rogue/tent,
+/area/rogue/under/town/basement)
 "uIf" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/dirt/road,
@@ -22263,8 +21541,8 @@
 /area/rogue/indoors/town)
 "uJa" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/mossy{
 	dir = 1
@@ -22273,12 +21551,10 @@
 /area/rogue/outdoors/town)
 "uJi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "uKb" = (
@@ -22304,8 +21580,8 @@
 /area/rogue/under/town/basement)
 "uMk" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church)
@@ -22323,8 +21599,8 @@
 /area/rogue/indoors/town)
 "uMM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /obj/structure/fluff/canopy,
@@ -22349,8 +21625,8 @@
 /area/rogue/outdoors/town)
 "uON" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/under/cave)
 "uOU" = (
@@ -22378,7 +21654,6 @@
 /area/rogue/under/town/basement)
 "uRK" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22387,18 +21662,17 @@
 /area/rogue/indoors/town/manor)
 "uRQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/rtfield)
 "uRZ" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/paper,
 /obj/item/paper,
@@ -22435,7 +21709,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "uTW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -22455,7 +21728,6 @@
 /area/rogue/outdoors/town)
 "uVa" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -22517,7 +21789,6 @@
 /area/rogue/outdoors/town/roofs/keep)
 "uZr" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood{
@@ -22534,8 +21805,8 @@
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -22550,9 +21821,9 @@
 /area/rogue/outdoors/town)
 "uZR" = (
 /obj/structure/mineral_door/wood{
-	name = "HUNT ROOM";
 	locked = 1;
-	lockid = "roomhunt"
+	lockid = "roomhunt";
+	name = "HUNT ROOM"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
@@ -22584,7 +21855,6 @@
 "vcp" = (
 /obj/item/reagent_containers/food/snacks/cracker,
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/grassyel,
@@ -22640,7 +21910,6 @@
 /area/rogue/indoors/town/church)
 "vgA" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22649,7 +21918,6 @@
 /area/rogue/indoors/town)
 "vgF" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -22676,8 +21944,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -22689,9 +21957,7 @@
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "viU" = (
 /obj/structure/flora/roguegrass,
@@ -22703,7 +21969,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -22735,14 +22000,13 @@
 /area/rogue/indoors/town)
 "vnC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church)
 "vnL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22769,7 +22033,6 @@
 /area/rogue/outdoors/town/roofs)
 "vpm" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/effect/landmark/start/monk{
@@ -22781,12 +22044,12 @@
 /area/rogue/indoors/town/church/chapel)
 "vps" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Farm";
 	dir = 4;
+	lock_strength = 100;
 	locked = 1;
 	lockid = "farm";
-	lock_strength = 100;
-	max_integrity = 1000
+	max_integrity = 1000;
+	name = "Farm"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -22840,7 +22103,6 @@
 /area/rogue/indoors/town/manor)
 "vtR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -22884,15 +22146,14 @@
 /area/rogue/indoors/town)
 "vvP" = (
 /obj/structure/mineral_door/wood{
-	name = "examination room";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "examination room"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "vvV" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22903,15 +22164,11 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
-"vwK" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "vwW" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Servant's Entry";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Servant's Entry"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
@@ -22983,8 +22240,8 @@
 /area/rogue/indoors/town)
 "vCO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/flint{
 	pixel_x = -1
@@ -23004,9 +22261,9 @@
 /area/rogue/indoors/town/church/chapel)
 "vCS" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM IV";
 	locked = 1;
-	lockid = "roomiv"
+	lockid = "roomiv";
+	name = "ROOM IV"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -23109,7 +22366,6 @@
 /area/rogue/indoors/town/church)
 "vHV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23128,7 +22384,6 @@
 /area/rogue/indoors/town/garrison)
 "vIQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -23144,7 +22399,6 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -23199,7 +22453,6 @@
 /area/rogue/under/town/basement/keep)
 "vMx" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/grassyel,
@@ -23260,7 +22513,6 @@
 /area/rogue/indoors/town/magician)
 "vRD" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /obj/structure/flora/roguegrass/bush/wall,
@@ -23273,7 +22525,6 @@
 /area/rogue/indoors/town/garrison)
 "vTk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23374,12 +22625,12 @@
 /area/rogue/indoors/town/garrison)
 "vYw" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
@@ -23400,6 +22651,11 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
+"waf" = (
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "wam" = (
 /obj/structure/chair/bench/church/r,
 /obj/effect/decal/cobbleedge{
@@ -23430,7 +22686,6 @@
 /area/rogue/under/town/basement)
 "wdv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -23438,11 +22693,9 @@
 "wdX" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/church,
@@ -23465,28 +22718,27 @@
 /area/rogue/indoors/town)
 "weU" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "weW" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "weZ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "wfj" = (
@@ -23546,9 +22798,7 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /obj/item/kitchen/rollingpin,
 /obj/item/rogueweapon/huntingknife/chefknife,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "wiX" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -23593,7 +22843,6 @@
 /area/rogue/indoors/town)
 "wlk" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -23606,9 +22855,9 @@
 /area/rogue/indoors/town/tavern)
 "wms" = (
 /obj/structure/mineral_door/wood{
-	name = "house ii";
 	locked = 1;
-	lockid = "house2"
+	lockid = "house2";
+	name = "house ii"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -23623,9 +22872,7 @@
 "wmN" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /obj/structure/fluff/walldeco/maidensigil,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "wmR" = (
 /obj/structure/flora/newleaf{
@@ -23636,27 +22883,27 @@
 /area/rogue/indoors/shelter/woods)
 "wmW" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "wnd" = (
 /obj/structure/closet/crate/chest{
-	name = "Spare keys";
-	icon_state = "woodchestalt";
+	base_icon_state = "woodchestalt";
 	color = "#8f7f62";
-	base_icon_state = "woodchestalt"
+	icon_state = "woodchestalt";
+	name = "Spare keys"
 	},
 /obj/item/roguekey/roomhunt,
 /obj/item/roguekey/roomiv{
-	name = "room VI key";
-	lockid = "roomvi"
+	lockid = "roomvi";
+	name = "room VI key"
 	},
 /obj/item/roguekey/roomiv{
-	name = "room V key";
-	lockid = "roomv"
+	lockid = "roomv";
+	name = "room V key"
 	},
 /obj/item/roguekey/roomiv,
 /obj/item/roguekey/roomiii,
@@ -23673,12 +22920,12 @@
 /area/rogue/indoors/town/magician)
 "wof" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -23700,7 +22947,6 @@
 /area/rogue/indoors/town/church/chapel)
 "wpL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/closet/crate/chest/neu,
@@ -23710,12 +22956,10 @@
 /area/rogue/indoors/town/church/chapel)
 "wpQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -23726,9 +22970,7 @@
 /area/rogue/indoors/town)
 "wqf" = (
 /obj/structure/fluff/psycross,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "wqm" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -23747,9 +22989,7 @@
 /obj/item/roguegem/green,
 /obj/item/roguegem/blue,
 /obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "wqJ" = (
 /obj/structure/table/wood{
@@ -23760,8 +23000,8 @@
 /area/rogue/under/town/basement/keep)
 "wrk" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -23779,14 +23019,12 @@
 	pixel_y = 0
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/rogueweapon/sword/long/exe/cloth,
 /obj/item/natural/stone,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "wss" = (
 /obj/structure/closet/crate/roguecloset,
@@ -23829,8 +23067,8 @@
 /area/rogue/indoors/town/manor)
 "wul" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -23843,10 +23081,10 @@
 /area/rogue/outdoors/town/roofs)
 "wuw" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "squireroom door";
 	dir = 1;
 	locked = 1;
-	lockid = "garrison"
+	lockid = "garrison";
+	name = "squireroom door"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -23859,7 +23097,6 @@
 /area/rogue/indoors/town/garrison)
 "wvf" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -23881,15 +23118,14 @@
 /area/rogue/indoors/town)
 "wxB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "wxH" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/effect/decal/wood/herringbone2,
 /obj/item/reagent_containers/glass/bowl,
@@ -23897,7 +23133,6 @@
 /area/rogue/indoors/town)
 "wxP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -23906,8 +23141,8 @@
 /area/rogue/indoors/town/manor)
 "wxS" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -23923,9 +23158,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "wyG" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "wyH" = (
 /obj/structure/closet/crate/roguecloset,
@@ -23953,15 +23186,15 @@
 /area/rogue/indoors/town)
 "wzd" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = 4;
@@ -24017,9 +23250,9 @@
 /area/rogue/outdoors/exposed/town/keep)
 "wAc" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "forestout_cave";
+	aallmig = "rwfieldin1";
 	aportalgoesto = "forestin_cave";
-	aallmig = "rwfieldin1"
+	aportalid = "forestout_cave"
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
@@ -24030,7 +23263,6 @@
 /area/rogue/indoors/town/dwarfin)
 "wBb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -24125,8 +23357,7 @@
 /area/rogue/outdoors/town)
 "wHt" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
@@ -24149,7 +23380,6 @@
 /area/rogue/outdoors/town)
 "wIe" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -24171,9 +23401,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
 "wJb" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "wJD" = (
@@ -24186,7 +23414,6 @@
 /area/rogue/indoors/town/manor)
 "wJI" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -24197,8 +23424,8 @@
 /area/rogue/indoors/town/church/chapel)
 "wKp" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/effect/landmark/events/testportal{
 	aportalloc = "manor"
@@ -24322,7 +23549,6 @@
 /area/rogue/outdoors/town/roofs)
 "wOa" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -24338,7 +23564,6 @@
 "wOE" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -24346,8 +23571,8 @@
 "wOS" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -24405,8 +23630,8 @@
 /area/rogue/indoors/town/bath)
 "wQM" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
@@ -24445,11 +23670,9 @@
 /area/rogue/indoors/town/manor)
 "wSp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -24466,13 +23689,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"wTk" = (
-/obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/tavern)
 "wTN" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -24501,7 +23717,6 @@
 /area/rogue/under/town/basement)
 "wUy" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -24537,9 +23752,9 @@
 /area/rogue/indoors/shelter/woods)
 "wVx" = (
 /obj/structure/mineral_door/wood/window{
-	name = "dungeoneer's room door";
 	locked = 1;
-	lockid = "dungeon"
+	lockid = "dungeon";
+	name = "dungeoneer's room door"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -24549,8 +23764,8 @@
 /area/rogue/indoors/town/garrison)
 "wVP" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -24570,8 +23785,8 @@
 /area/rogue/indoors/town/vault)
 "wWx" = (
 /obj/structure/roguemachine/mail/r{
-	pixel_x = -32;
-	mailtag = "Physician"
+	mailtag = "Physician";
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -24582,13 +23797,10 @@
 /area/rogue/under/town/basement/keep)
 "wXw" = (
 /obj/item/clothing/ring/silver,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "wXx" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/inn,
@@ -24608,30 +23820,27 @@
 /area/rogue/indoors/town/tavern)
 "wZC" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/under/town/basement)
 "wZH" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter{
-	name = "counter hatch";
 	dir = 2;
-	lockdir = 1
+	lockdir = 1;
+	name = "counter hatch"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "wZK" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -24652,14 +23861,13 @@
 /area/rogue/under/town/basement/keep)
 "xac" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
 "xaG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -24714,7 +23922,6 @@
 /area/rogue/indoors/town/magician)
 "xcM" = (
 /obj/effect/landmark/start/squire{
-	icon_state = "arrow";
 	dir = 4
 	},
 /obj/structure/bed/rogue,
@@ -24724,8 +23931,8 @@
 /area/rogue/indoors/town/garrison)
 "xcU" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/mirror,
 /obj/item/candle/yellow/lit{
@@ -24744,7 +23951,6 @@
 /area/rogue/under/town/basement/keep)
 "xeN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -24758,7 +23964,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -24782,8 +23987,8 @@
 /obj/item/natural/cloth,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -24793,11 +23998,9 @@
 /area/rogue/outdoors/rtfield)
 "xfN" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -24816,19 +24019,17 @@
 /area/rogue/indoors)
 "xgI" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "xgU" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Heir's Apartment";
 	locked = 1;
-	lockid = "heir"
+	lockid = "heir";
+	name = "Heir's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -24836,15 +24037,15 @@
 /area/rogue/indoors/town/manor)
 "xhj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "xhp" = (
@@ -24855,8 +24056,8 @@
 	dir = 6
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -24887,8 +24088,8 @@
 /area/rogue/outdoors/town)
 "xif" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper/scroll,
 /turf/open/floor/carpet/royalblack,
@@ -24927,8 +24128,8 @@
 /area/rogue/indoors/town/church/chapel)
 "xlv" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/indoors/town/dwarfin)
 "xlI" = (
@@ -24976,17 +24177,16 @@
 /area/rogue/outdoors/town/roofs/keep)
 "xmW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "xnf" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "bunkhouse";
 	dir = 1;
 	locked = 1;
-	lockid = "merc"
+	lockid = "merc";
+	name = "bunkhouse"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -25000,7 +24200,6 @@
 /area/rogue/indoors/town/manor)
 "xnB" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -25009,14 +24208,12 @@
 /obj/structure/fluff/railing/fence,
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "xnL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -25026,7 +24223,6 @@
 	pixel_y = 32
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -25052,10 +24248,7 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
 "xpL" = (
-/obj/effect/landmark/events/haunts{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "xpP" = (
@@ -25069,14 +24262,12 @@
 /area/rogue/indoors/town/dwarfin)
 "xpR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town/roofs)
 "xqi" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/inn,
@@ -25102,8 +24293,8 @@
 /area/rogue/indoors/town)
 "xrL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -25118,7 +24309,6 @@
 /area/rogue/indoors/town/garrison)
 "xrQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -25136,8 +24326,8 @@
 /area/rogue/under/town/sewer)
 "xtL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -25147,12 +24337,11 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xux" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "xuG" = (
@@ -25179,7 +24368,6 @@
 /area/rogue/indoors/town/manor)
 "xvM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -25193,8 +24381,8 @@
 /area/rogue/indoors/shelter/woods)
 "xwb" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "bogrtout";
-	aportalgoesto = "bogrtin"
+	aportalgoesto = "bogrtin";
+	aportalid = "bogrtout"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
@@ -25204,8 +24392,8 @@
 /area/rogue/indoors/town/cell)
 "xwr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/effect/decal/wood/herringbone2,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -25242,7 +24430,6 @@
 /area/rogue/under/town/basement/keep)
 "xxW" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/railing/fence,
@@ -25303,7 +24490,6 @@
 /area/rogue/indoors/shelter/woods)
 "xBk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -25330,13 +24516,10 @@
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "xCI" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/effect/landmark/start/villager{
@@ -25382,8 +24565,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -25428,16 +24611,16 @@
 /area/rogue/indoors/town/manor)
 "xHd" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement)
 "xIj" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/kitchen/spoon,
 /turf/open/floor/rogue/ruinedwood{
@@ -25500,8 +24683,8 @@
 /area/rogue/indoors/town)
 "xKL" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/carpet/red,
@@ -25518,7 +24701,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xMo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -25569,8 +24751,8 @@
 /area/rogue/indoors/town/church)
 "xOb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/rogue/trophy/deer,
 /obj/item/rogueweapon/sword/iron/short{
@@ -25587,9 +24769,7 @@
 "xOg" = (
 /obj/structure/toilet,
 /obj/effect/landmark/start/guardsman,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "xOq" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -25608,17 +24788,13 @@
 /area/rogue/outdoors/rtfield)
 "xOF" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "xOU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -25650,13 +24826,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"xQm" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	locked = 1
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "xQs" = (
 /obj/structure/stairs{
 	dir = 8
@@ -25695,8 +24864,8 @@
 /area/rogue/indoors/shelter/woods)
 "xQF" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
@@ -25714,8 +24883,8 @@
 	mailtag = "Warehouse"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -25732,19 +24901,17 @@
 /area/rogue/indoors/town/manor)
 "xRi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "xRp" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -25756,9 +24923,7 @@
 	icon_state = "barsbent";
 	layer = 2.81
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xRJ" = (
 /obj/effect/decal/cobbleedge{
@@ -25775,7 +24940,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xSg" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -25818,14 +24982,12 @@
 /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xUa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
@@ -25870,8 +25032,8 @@
 /area/rogue/indoors/town/dwarfin)
 "xVQ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /obj/item/kitchen/rollingpin,
@@ -25894,16 +25056,16 @@
 /area/rogue/indoors)
 "xXn" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "xXs" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /obj/effect/decal/cobbleedge{
@@ -25924,8 +25086,8 @@
 /area/rogue/indoors/town)
 "xYu" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -25977,8 +25139,8 @@
 /area/rogue/under/town/basement)
 "yaE" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
@@ -25998,8 +25160,8 @@
 /area/rogue/indoors/town/tavern)
 "ybp" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -26017,8 +25179,8 @@
 /area/rogue/indoors/town/church/chapel)
 "ycO" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
@@ -26078,8 +25240,8 @@
 /area/rogue/indoors/town)
 "yeh" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -26110,14 +25272,12 @@
 /area/rogue/indoors/town/magician)
 "yev" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "yfg" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -26150,7 +25310,6 @@
 /area/rogue/indoors/town/manor)
 "yge" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
@@ -26168,9 +25327,9 @@
 /area/rogue/indoors/town/shop)
 "ygy" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM III";
 	locked = 1;
-	lockid = "roomiii"
+	lockid = "roomiii";
+	name = "ROOM III"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -26181,14 +25340,12 @@
 "yhY" = (
 /obj/structure/chair/stool/rogue,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "yie" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/grass,
@@ -26204,15 +25361,14 @@
 /area/rogue/indoors/town/church/chapel)
 "yiq" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
 "yiO" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -26234,7 +25390,6 @@
 /area/rogue/outdoors/mountains)
 "yjo" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -26242,8 +25397,8 @@
 /area/rogue/outdoors/town/roofs/keep)
 "yjt" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/fibers/full{
 	pixel_x = -5
@@ -26260,7 +25415,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ykc" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -26276,8 +25430,8 @@
 /area/rogue/indoors/town/manor)
 "ykz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -26298,9 +25452,9 @@
 /area/rogue/under/town/basement/keep)
 "ykK" = (
 /obj/structure/closet/crate/chest{
-	name = "meat chest";
+	base_icon_state = "woodchestalt";
 	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	name = "meat chest"
 	},
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -26320,7 +25474,6 @@
 /area/rogue/outdoors/rtfield)
 "ymf" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -34420,8 +33573,8 @@ oGK
 oGK
 oGK
 oGK
+oGK
 vrR
-pNQ
 pNQ
 pNQ
 pNQ
@@ -34577,12 +33730,12 @@ heh
 heh
 heh
 heh
+heh
 pmA
 pNQ
 pNQ
-pNQ
+mhu
 mjw
-qOY
 qOY
 lKl
 lKl
@@ -34720,7 +33873,7 @@ gdw
 pmA
 heh
 heh
-cVE
+tGy
 cVE
 cVE
 cVE
@@ -34733,13 +33886,13 @@ cVE
 cVE
 cVE
 cVE
+cVE
 heh
 pmA
 pNQ
 pNQ
 pNQ
-mBU
-qOY
+waf
 qOY
 lKl
 lKl
@@ -34876,27 +34029,27 @@ gdw
 gdw
 pmA
 heh
-heh
-cVE
+gdw
+gdw
 gdw
 nze
 gdw
+hdp
+hdp
+gdw
+gdw
+gdw
+gdw
+nze
+nze
 xsI
 cVE
-gdw
-gdw
-gdw
-gdw
-nze
-nze
-xsI
 heh
 ppJ
 oGK
+oGK
 qGI
-pNQ
-pNQ
-qOY
+mhu
 qOY
 lKl
 lKl
@@ -35033,11 +34186,11 @@ gdw
 jHu
 rDj
 heh
-heh
-cVE
 nze
-nze
-gdw
+kDT
+suv
+nOU
+nOU
 gdw
 gdw
 gdw
@@ -35046,15 +34199,15 @@ gZb
 xRp
 nFb
 nze
+xsI
 cVE
+heh
 heh
 heh
 heh
 xfP
 exi
 exi
-exi
-qOY
 pNQ
 pNQ
 pNQ
@@ -35190,28 +34343,28 @@ jHu
 rDj
 heh
 heh
-heh
-tGy
-gdw
+iSP
+bRT
+vFB
 bBD
-bBD
+bcE
 gdw
 gdw
 gdw
 xpt
 xpt
 vFB
-qvM
+bRT
 gdw
-kkj
+tHg
+cVE
+cVE
 cVE
 cVE
 heh
 gVe
 exi
-exi
-qOY
-pNQ
+dSI
 pNQ
 pNQ
 pNQ
@@ -35346,27 +34499,27 @@ pNQ
 pmA
 heh
 heh
-heh
 cVE
-xsI
-gdw
-biU
+iSP
+bRT
 bBD
+xpt
+xpt
 gdw
 bPk
 gdw
 xpt
-vwK
+xpt
 xpt
 qRc
+gdw
+gdw
 gdw
 gdw
 gdw
 cVE
 heh
 xfP
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -35500,18 +34653,20 @@ pfh
 gdw
 pNQ
 pNQ
-pmA
-heh
+qGI
 heh
 cVE
 xsI
-hYd
 gdw
-bBD
-bBD
-bBD
+uHG
+ptA
+ptA
+uHG
+gdw
 xpt
 lpm
+xpt
+xpt
 pOg
 pOg
 pOg
@@ -35522,8 +34677,6 @@ gdw
 cVE
 heh
 qGI
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -35660,27 +34813,27 @@ pNQ
 pNQ
 heh
 cVE
-xsI
-nze
+hYd
 gdw
-gdw
-dGH
-ngp
-iSP
-iSP
-ewt
-eTu
-eTu
-ngp
+srr
+bBD
+bBD
+bBD
 xpt
 xpt
 xpt
+xpt
+xpt
+xpt
+xpt
+xpt
+xpt
+xpt
+rBh
 gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -35817,27 +34970,27 @@ pNQ
 iMs
 heh
 cVE
-nze
-nze
-aSP
+hTx
+gdw
+idX
 bBD
 bBD
-eTu
 bBD
-pZE
-pZE
-rCx
 xpt
-eTu
+xpt
+pOg
+pOg
+xpt
+pOg
 pOg
 xpt
 xpt
+xpt
+rBh
 gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -35974,27 +35127,27 @@ iMs
 iMs
 heh
 cVE
-nze
-eOz
-cGL
-bBD
-xpt
+gdw
+gdw
 eTu
-pZE
-pZE
-vFB
-bBD
-xpt
+iSP
+dGH
+iSP
 eTu
-pOg
+ngp
+iSP
+iSP
+ewt
+eTu
+eTu
+ngp
+xpt
 xpt
 xpt
 gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36131,27 +35284,27 @@ qOY
 qOY
 heh
 cVE
-gdw
-vFB
-ahZ
+nze
+nze
+aSP
 bBD
-lZp
+bBD
+biU
+xRp
 eTu
-vFB
-bBD
 bBD
 pZE
+pZE
+rCx
 xpt
 eTu
+pOg
 xpt
 xpt
-bBD
-iSP
+gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36285,30 +35438,30 @@ gdw
 gdw
 pNQ
 qOY
-pmA
+qGI
 heh
 cVE
-gdw
+nze
+epL
+vFB
 bBD
 ahZ
-xpt
-oDh
-eTu
-vFB
-psG
 bBD
+xpt
+eTu
 pZE
+pZE
+vFB
+bBD
 xpt
 eTu
 pOg
-bBD
-bBD
-mBm
+xpt
+xpt
+gdw
 xsI
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36444,28 +35597,28 @@ pNQ
 qOY
 pmA
 heh
-cVE
+tGy
 gdw
+vFB
+ahZ
 bBD
 mrD
-xpt
+bBD
 lZp
 eTu
-bBD
 vFB
 bBD
 bBD
+pZE
 xpt
 eTu
-pOg
+xpt
+xpt
 bBD
-vFB
 iSP
 xsI
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36603,26 +35756,26 @@ pmA
 heh
 cVE
 gdw
+bBD
+ahZ
 xpt
 mrD
 xpt
-bBD
+oDh
 eTu
-pZE
-bBD
-bBD
 vFB
+psG
+bBD
+pZE
 xpt
 eTu
+pOg
 bBD
 bBD
-qvM
-nze
+mBm
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36761,25 +35914,25 @@ heh
 cVE
 gdw
 bBD
-onk
-nAP
-clX
-eTu
-lYJ
-pZE
-vFB
-oaV
+mrD
 xpt
-hYC
+mrD
 bBD
-qvM
-qvM
-gdw
+lZp
+eTu
+bBD
+vFB
+bBD
+bBD
+xpt
+eTu
+pOg
+bBD
+vFB
+iSP
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36917,26 +36070,26 @@ pmA
 heh
 cVE
 gdw
-gdw
-gdw
-gdw
-gdw
-gdw
-gdw
+xpt
+mrD
+xpt
+mrD
+bBD
+bBD
 eTu
+pZE
+bBD
+bBD
+vFB
+xpt
 eTu
-gdw
-gdw
+bBD
+bBD
+bRT
 nze
-nze
-gdw
-gdw
-gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37073,27 +36226,27 @@ pNQ
 pmA
 heh
 cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-tGy
+gdw
+jWw
+xpt
+bBD
+bBD
+jJc
+hDI
+eTu
+jSK
+pZE
+vFB
+aNV
+xpt
+hYC
+bBD
+bRT
+rsm
+gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37229,28 +36382,28 @@ pNQ
 pNQ
 pmA
 heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
+cVE
+gdw
+gdw
+gdw
+gdw
+gdw
+gdw
+gdw
+gdw
+gdw
+eTu
+eTu
+gdw
+gdw
+nze
+nze
+gdw
+gdw
+gdw
+tGy
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37384,30 +36537,30 @@ iMs
 pNQ
 pNQ
 pNQ
-ppJ
-vrR
-xsI
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
+pmA
 heh
-cVE
-cVE
-cVE
-cVE
-cVE
-xsI
-xsI
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37541,30 +36694,30 @@ pNQ
 pNQ
 pNQ
 pNQ
-pNQ
-ppJ
-oGK
-oGK
-oGK
-oGK
-oGK
-oGK
-oGK
-oGK
-vrR
+uON
+xsI
+xsI
+cVE
+cVE
+cVE
+cVE
+xsI
+cVE
+cVE
+cVE
 cVE
 heh
-jHu
-oGK
-oGK
-oGK
-oGK
-vrR
+cVE
+cVE
+cVE
+cVE
+cVE
+xsI
+xsI
+cVE
 xsI
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37698,30 +36851,30 @@ uxb
 uxb
 uxb
 uxb
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pmA
+sRP
+lcS
+lcS
+lcS
+lcS
+lcS
+lcS
+lcS
+lcS
+lcS
+vrR
+cVE
+heh
+jHu
+lcS
+lcS
+lcS
+lcS
+oGK
+oGK
+vrR
 cVE
 heh
 pmA
-pNQ
-pNQ
-pNQ
-pNQ
-pmA
-cVE
-heh
-pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37873,12 +37026,12 @@ pNQ
 pNQ
 pNQ
 pNQ
+mhu
+mhu
 pmA
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -38023,19 +37176,19 @@ pNQ
 pNQ
 pNQ
 pmA
-xsI
-heh
-pmA
-pNQ
-pNQ
-pNQ
-pNQ
-pmA
 cVE
 heh
 pmA
 pNQ
 pNQ
+pNQ
+pNQ
+mhu
+mhu
+pmA
+cVE
+heh
+pmA
 pNQ
 pNQ
 pNQ
@@ -38187,12 +37340,12 @@ pNQ
 pNQ
 pNQ
 pNQ
+mhu
+mhu
 pmA
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -38344,12 +37497,12 @@ pNQ
 pNQ
 pNQ
 pNQ
+mhu
+mhu
 pmA
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -38501,12 +37654,12 @@ pNQ
 pNQ
 pNQ
 pNQ
-pmA
-xsI
+jHu
+oGK
+rDj
+cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -38660,10 +37813,10 @@ pNQ
 pNQ
 pmA
 xsI
+cVE
+xsI
 heh
 ppJ
-oGK
-oGK
 oGK
 oGK
 oGK
@@ -38817,9 +37970,9 @@ pNQ
 pNQ
 pmA
 cVE
+cVE
+cVE
 heh
-cVE
-cVE
 xsI
 cVE
 bOK
@@ -55042,7 +54195,7 @@ jfy
 ylN
 ylN
 ylN
-czw
+oAP
 xOC
 eUz
 eUz
@@ -55959,13 +55112,13 @@ ndg
 fBB
 hvn
 dRZ
-ftM
+igG
 aai
 xEW
 xDC
 hJn
 rou
-ftM
+igG
 jIk
 jIk
 ymg
@@ -59256,14 +58409,14 @@ waT
 hvn
 hvn
 rLi
-ftM
+igG
 loH
 aak
 ugU
 lMh
 loH
 aap
-ftM
+igG
 nko
 cxb
 cxb
@@ -60455,7 +59608,7 @@ fBB
 doE
 yjt
 eSe
-tyQ
+uyi
 pND
 eSe
 rRb
@@ -63501,7 +62654,7 @@ ctF
 cxb
 oyZ
 ugU
-hoH
+nNJ
 lNY
 qyk
 xSN
@@ -63519,9 +62672,9 @@ xOC
 xOC
 xOC
 xOC
-pOo
+btI
 low
-bWt
+wFC
 xOC
 xOC
 xOC
@@ -63658,7 +62811,7 @@ ctF
 cxb
 oyZ
 ugU
-hoH
+nNJ
 qyk
 qyk
 qyk
@@ -64774,7 +63927,7 @@ xOC
 iXP
 sRV
 sRV
-toL
+pwS
 cKj
 hmb
 cKj
@@ -65401,7 +64554,7 @@ mNh
 mNh
 mNh
 mNh
-ikB
+wSj
 sRV
 sRV
 sRV
@@ -68353,7 +67506,7 @@ fNg
 lyO
 tVC
 waT
-ftM
+igG
 fTZ
 fTZ
 iwJ
@@ -78548,10 +77701,10 @@ tXZ
 oKg
 tEM
 lAL
-mGi
-mGi
+jaW
+jaW
 yge
-mGi
+jaW
 mEa
 mgM
 jaW
@@ -81027,7 +80180,7 @@ haD
 kMl
 gKA
 gKA
-xQm
+pjY
 mXn
 pIq
 qhb
@@ -81372,7 +80525,7 @@ pov
 eVv
 qeJ
 jBO
-nZx
+hkC
 jBO
 eVv
 eVv
@@ -81978,7 +81131,7 @@ vEG
 vEG
 jnQ
 nRX
-gzW
+aUC
 qhb
 qhb
 qhb
@@ -82606,7 +81759,7 @@ qhb
 oKl
 tcy
 nRX
-gzW
+aUC
 qhb
 qhb
 qhb
@@ -82626,10 +81779,10 @@ gmc
 qsr
 pov
 sjq
-wTk
+kwG
 jBO
 sjq
-wTk
+kwG
 jBO
 sjq
 qhb
@@ -82757,12 +81910,12 @@ kuX
 ixQ
 ixQ
 det
-rkX
-gzW
+otC
+aUC
 qhb
 sLS
-rkX
-gzW
+otC
+aUC
 qhb
 qhb
 qhb
@@ -84791,7 +83944,7 @@ eSe
 eSe
 jMj
 hRf
-cvX
+wzR
 ouw
 ouw
 ouw
@@ -84948,7 +84101,7 @@ eSe
 ebf
 eSe
 mlJ
-cvX
+wzR
 ouw
 ouw
 ouw
@@ -85105,7 +84258,7 @@ oyt
 gKS
 fnb
 doE
-dYY
+wMV
 ouw
 ouw
 ouw
@@ -86529,7 +85682,7 @@ vAP
 oVP
 xVF
 cAt
-fQO
+syG
 ouw
 qhb
 qhb
@@ -87145,7 +86298,7 @@ qhb
 nkZ
 qhb
 tvX
-meP
+umV
 vpP
 czZ
 kuF
@@ -87942,7 +87095,7 @@ lIO
 wAU
 wMO
 cAt
-fQO
+syG
 fnS
 qhb
 qhb
@@ -110707,7 +109860,7 @@ cAt
 wKP
 dQx
 wKP
-fQO
+syG
 qhb
 qhb
 qhb
@@ -110865,7 +110018,7 @@ nLp
 gBZ
 ono
 cAt
-fQO
+syG
 qhb
 qhb
 qhb
@@ -111324,7 +110477,7 @@ qhb
 qhb
 qhb
 xmF
-meP
+umV
 vpP
 tvX
 eeB
@@ -112120,7 +111273,7 @@ cAt
 wKP
 dQx
 wKP
-fQO
+syG
 qhb
 qhb
 qhb
@@ -112278,7 +111431,7 @@ fmZ
 emP
 pBa
 cAt
-fQO
+syG
 qhb
 qhb
 qhb
@@ -116353,8 +115506,8 @@ tYX
 tYX
 tYX
 cXV
-fdT
-fdT
+oew
+oew
 ngM
 tYX
 tYX

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -22,8 +22,8 @@
 /area/rogue/under/town/sewer)
 "aad" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/clothing/neck/roguetown/psicross/wood,
@@ -31,7 +31,6 @@
 /area/rogue/indoors/town/church)
 "aae" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -59,11 +58,9 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -74,15 +71,12 @@
 	},
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -178,7 +172,6 @@
 "acF" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4;
 	pixel_x = 7
 	},
@@ -186,15 +179,14 @@
 /area/rogue/indoors/town/manor)
 "acV" = (
 /obj/structure/mineral_door/wood{
-	name = "stall i";
 	locked = 1;
-	lockid = "apartment1"
+	lockid = "apartment1";
+	name = "stall i"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
 "ada" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -211,8 +203,8 @@
 /area/rogue/indoors/town)
 "adM" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -232,7 +224,6 @@
 /area/rogue/under/town/basement)
 "adV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
@@ -265,8 +256,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "aeX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/natural/feather{
 	pixel_x = -17;
@@ -313,14 +304,13 @@
 "ahX" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "ahZ" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/cobble,
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
 "aiD" = (
 /obj/structure/fluff/canopy/booth/booth02,
@@ -365,9 +355,9 @@
 /area/rogue/under/town/basement)
 "akh" = (
 /obj/structure/mineral_door/wood{
-	name = "veterans house";
 	locked = 1;
-	lockid = "garrison"
+	lockid = "garrison";
+	name = "veterans house"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -375,7 +365,6 @@
 /area/rogue/indoors/town)
 "akR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -407,8 +396,8 @@
 /area/rogue/outdoors/town)
 "alU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/fluff/railing/border{
@@ -418,8 +407,8 @@
 /area/rogue/indoors/shelter/woods)
 "aml" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -432,8 +421,8 @@
 /area/rogue/outdoors/rtfield)
 "amw" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/walls,
 /obj/item/roguekey/manor,
@@ -448,9 +437,9 @@
 /area/rogue/indoors/town/garrison)
 "anc" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Dining Room";
 	locked = 1;
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Dining Room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -466,7 +455,6 @@
 /area/rogue/indoors/town)
 "aoe" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/hexstone,
@@ -484,11 +472,9 @@
 /area/rogue/indoors)
 "api" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -517,7 +503,6 @@
 /area/rogue/under/town/basement/keep)
 "arK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -550,14 +535,12 @@
 /area/rogue/indoors/town/manor)
 "asT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
 "atf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/psycross,
@@ -568,7 +551,6 @@
 /area/rogue/under/cave)
 "atE" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -593,7 +575,6 @@
 /area/rogue/outdoors/town)
 "auO" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -607,16 +588,14 @@
 /area/rogue/indoors/town/magician)
 "auX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/mirror{
 	pixel_y = 28
 	},
 /obj/item/natural/cloth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "avz" = (
 /obj/structure/toilet,
@@ -639,8 +618,8 @@
 	redstone_id = "armourer_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
@@ -660,8 +639,8 @@
 	pixel_x = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/burial_shroud{
 	pixel_x = 5;
@@ -685,7 +664,6 @@
 /area/rogue/outdoors/town)
 "ayo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -707,8 +685,8 @@
 "azs" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -723,8 +701,8 @@
 /area/rogue/indoors/town/garrison)
 "aAs" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/walldeco/psybanner{
 	pixel_y = 29
@@ -745,8 +723,8 @@
 /area/rogue/indoors/shelter/woods)
 "aCb" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/carpet/red,
@@ -782,15 +760,14 @@
 	},
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/pillory/reinforced,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "aDd" = (
 /obj/effect/landmark/start/servant{
-	icon_state = "arrow";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -819,7 +796,6 @@
 /area/rogue/indoors/town/bath)
 "aED" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
@@ -896,15 +872,14 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/roguekey/walls{
-	name = "farm key";
-	lockid = "farm"
+	lockid = "farm";
+	name = "farm key"
 	},
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "aIG" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -930,7 +905,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -975,7 +949,6 @@
 /area/rogue/indoors/town)
 "aNp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -1003,10 +976,10 @@
 /area/rogue/indoors/shelter/woods)
 "aOB" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Archivist's Office";
 	dir = 8;
 	locked = 1;
-	lockid = "archive"
+	lockid = "archive";
+	name = "Archivist's Office"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
@@ -1045,7 +1018,6 @@
 /area/rogue/indoors/town)
 "aPn" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -1055,9 +1027,7 @@
 	locked = 1;
 	lockid = "nightmaiden"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "aPK" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -1070,16 +1040,13 @@
 /area/rogue/indoors/town/manor)
 "aQs" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "aQA" = (
 /obj/structure/chair/bench/ultimacouch,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "aQJ" = (
 /obj/structure/closet/crate/chest,
@@ -1088,7 +1055,6 @@
 /area/rogue/indoors/town)
 "aRe" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -1124,12 +1090,11 @@
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/mountains)
 "aSP" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "aTh" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -1165,7 +1130,6 @@
 /area/rogue/under/town/basement)
 "aVh" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -1192,7 +1156,6 @@
 /area/rogue/indoors/town/church/chapel)
 "aVR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/closet/crate/chest,
@@ -1218,8 +1181,8 @@
 /area/rogue/indoors/town/tavern)
 "aXp" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -1234,8 +1197,8 @@
 /area/rogue/indoors/town/tavern)
 "aXO" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1287,11 +1250,9 @@
 /area/rogue/indoors/town/physician)
 "bbl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -1318,7 +1279,6 @@
 /area/rogue/outdoors/town/roofs)
 "bcj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
@@ -1338,8 +1298,8 @@
 /area/rogue/outdoors/town)
 "bcF" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -1371,8 +1331,8 @@
 /area/rogue/under/town/basement/keep)
 "bez" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -1391,8 +1351,8 @@
 /area/rogue/under/town/basement/keep)
 "bfW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -1422,8 +1382,8 @@
 /area/rogue/indoors/town/garrison)
 "bhU" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -1445,19 +1405,23 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "biU" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/cobble,
+/obj/machinery/light/rogue/torchholder/l,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
 "biZ" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "bjc" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/herringbone,
@@ -1511,19 +1475,18 @@
 /area/rogue/outdoors/town)
 "blr" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "blC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town)
@@ -1541,8 +1504,8 @@
 /area/rogue/indoors/town)
 "bmI" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 1
+	dir = 1;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "bnE" = (
@@ -1600,8 +1563,8 @@
 	},
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "bqr" = (
@@ -1643,7 +1606,6 @@
 "bsT" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -1660,9 +1622,7 @@
 /area/rogue/indoors/town/church)
 "bup" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "buI" = (
 /obj/structure/bed/rogue/shit{
@@ -1703,8 +1663,8 @@
 /area/rogue/under/town/basement/keep)
 "bvN" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
@@ -1735,7 +1695,6 @@
 /area/rogue/outdoors/town/roofs)
 "bzx" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle{
@@ -1748,8 +1707,8 @@
 /area/rogue/outdoors/town)
 "bAa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 8
+	dir = 8;
+	icon_state = "longtable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -1775,7 +1734,6 @@
 /area/rogue/indoors/town/physician)
 "bAb" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -1830,20 +1788,17 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs/stone{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "bDS" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -1896,15 +1851,14 @@
 /area/rogue/outdoors/town/roofs)
 "bGd" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "bGJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -1920,9 +1874,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "bHo" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -1985,13 +1937,10 @@
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_y = 10
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bKz" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -2011,8 +1960,7 @@
 /area/rogue/indoors/town/physician)
 "bLo" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
@@ -2021,9 +1969,7 @@
 /turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
 "bLX" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bMi" = (
 /obj/machinery/light/rogue/hearth,
@@ -2044,7 +1990,6 @@
 "bNE" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -2055,7 +2000,6 @@
 /area/rogue/outdoors/town)
 "bOF" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/machinery/light/rogue/torchholder/c,
@@ -2066,7 +2010,6 @@
 /area/rogue/indoors/town/tavern)
 "bOH" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /obj/structure/chair/bench,
@@ -2099,8 +2042,8 @@
 /area/rogue/indoors/town)
 "bPY" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -2147,7 +2090,6 @@
 /area/rogue/outdoors/town)
 "bSI" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -2172,7 +2114,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2181,8 +2122,8 @@
 /area/rogue/indoors/town)
 "bUw" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
@@ -2194,7 +2135,6 @@
 /area/rogue/under/town/basement/keep)
 "bUV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -2229,18 +2169,20 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
 "bWt" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 5
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "bWU" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -2251,9 +2193,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "bXl" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "bXz" = (
@@ -2270,7 +2210,6 @@
 /area/rogue/indoors/town)
 "bXK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/structure/fluff/railing/border,
@@ -2290,9 +2229,7 @@
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bYR" = (
 /obj/structure/fluff/walldeco/stone,
@@ -2305,7 +2242,6 @@
 /area/rogue/indoors/town/manor)
 "bZu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/church/smallbench,
@@ -2327,7 +2263,6 @@
 /area/rogue/indoors/town/tavern)
 "cba" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs{
@@ -2337,8 +2272,8 @@
 /area/rogue/indoors/town/garrison)
 "cbg" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2415,20 +2350,17 @@
 /area/rogue/outdoors/town)
 "cfd" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "cha" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "chq" = (
 /obj/structure/bookcase,
@@ -2438,8 +2370,8 @@
 /area/rogue/indoors/town/manor)
 "chQ" = (
 /obj/structure/mineral_door/wood/window{
-	name = "Library";
-	lockid = "archive"
+	lockid = "archive";
+	name = "Library"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -2457,7 +2389,6 @@
 /area/rogue/indoors/town/church/chapel)
 "cip" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -2474,8 +2405,7 @@
 /area/rogue/under/town/basement/keep)
 "cjg" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "cjh" = (
@@ -2495,11 +2425,9 @@
 /area/rogue/outdoors/town)
 "cjX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -2507,7 +2435,6 @@
 "ckM" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2538,17 +2465,8 @@
 "clT" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"clX" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "tourneybottom"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement)
 "cmz" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "cmA" = (
 /obj/structure/table/wood{
@@ -2574,8 +2492,8 @@
 /area/rogue/indoors/town/manor)
 "cmZ" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
@@ -2603,8 +2521,8 @@
 /area/rogue/indoors/town)
 "coK" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/twig,
@@ -2637,7 +2555,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "cqB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/bookcase/random/religion,
@@ -2651,8 +2568,8 @@
 /area/rogue/indoors/town/manor)
 "csh" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -2680,7 +2597,6 @@
 /area/rogue/indoors/town)
 "cty" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -2705,7 +2621,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
@@ -2723,11 +2638,16 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "cvX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/outdoors/town/roofs)
+/obj/item/reagent_containers/glass/bucket/wooden{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "cwq" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -2744,8 +2664,8 @@
 "cxD" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
@@ -2767,15 +2687,14 @@
 /area/rogue/outdoors/town)
 "cyB" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/reagent_containers/powder/ozium,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "cyD" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2820,7 +2739,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -2842,19 +2760,18 @@
 	dir = 8
 	},
 /obj/structure/lever/wall{
-	name = "inner passage lever";
-	icon_state = "leverwall1";
 	dir = 4;
+	icon_state = "leverwall1";
+	name = "inner passage lever";
 	pixel_x = 6;
 	pixel_y = -9;
-	toggled = 1;
-	redstone_id = "keepgate_inner"
+	redstone_id = "keepgate_inner";
+	toggled = 1
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cBU" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/grass,
@@ -2870,15 +2787,14 @@
 "cCz" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "cCO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/natural/stone{
@@ -2893,21 +2809,17 @@
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "cDJ" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "cDO" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2917,8 +2829,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/tile,
@@ -2928,15 +2840,14 @@
 /area/rogue/outdoors/town)
 "cEi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
 "cED" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fermenting_barrel/crafted,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -2950,14 +2861,13 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "cGL" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/cobble/mossy,
+/turf/closed/wall/mineral/rogue/tent,
 /area/rogue/under/town/basement)
 "cGR" = (
 /obj/structure/mineral_door/wood{
-	name = "house i";
 	locked = 1;
-	lockid = "house1"
+	lockid = "house1";
+	name = "house i"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -2971,7 +2881,6 @@
 /area/rogue/under/town/basement/keep)
 "cHG" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -2984,8 +2893,8 @@
 /area/rogue/outdoors/town)
 "cHT" = (
 /turf/open/water/river{
-	icon_state = "rockwd";
-	dir = 4
+	dir = 4;
+	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/rtfield)
 "cIC" = (
@@ -3000,8 +2909,8 @@
 /area/rogue/indoors/town/church/chapel)
 "cJN" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull/lit{
 	pixel_x = -3;
@@ -3011,8 +2920,8 @@
 /area/rogue/under/town/basement)
 "cJT" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fermenting_barrel/crafted,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -3032,8 +2941,8 @@
 /area/rogue/indoors/town/physician)
 "cKp" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
@@ -3077,7 +2986,6 @@
 /area/rogue/outdoors/rtfield)
 "cPJ" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -3088,7 +2996,6 @@
 /area/rogue/under/town/basement)
 "cQy" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -3126,7 +3033,6 @@
 "cRY" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -3147,30 +3053,28 @@
 /area/rogue/indoors/town/magician)
 "cTj" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
 "cTw" = (
 /obj/structure/mineral_door/wood{
-	name = "stall i";
 	locked = 1;
-	lockid = "stall1"
+	lockid = "stall1";
+	name = "stall i"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "cTF" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "cTP" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -3180,8 +3084,8 @@
 /area/rogue/indoors/town)
 "cUn" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
@@ -3191,8 +3095,8 @@
 /area/rogue/indoors/town/bath)
 "cVf" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -3214,8 +3118,8 @@
 /area/rogue/under/town/sewer)
 "cVQ" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "bogrtout_cave";
-	aportalgoesto = "bogrtin_cave"
+	aportalgoesto = "bogrtin_cave";
+	aportalid = "bogrtout_cave"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
@@ -3269,17 +3173,14 @@
 /area/rogue/indoors/town/church)
 "cXV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "cXZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -3308,7 +3209,6 @@
 /area/rogue/indoors/town/physician)
 "cZf" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -3316,14 +3216,12 @@
 "cZX" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "dau" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -3336,7 +3234,6 @@
 /area/rogue/indoors/town)
 "daH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -3435,8 +3332,8 @@
 /area/rogue/indoors/town/magician)
 "ddu" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	name = "Dressing Room";
-	dir = 1
+	dir = 1;
+	name = "Dressing Room"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
@@ -3473,7 +3370,6 @@
 /area/rogue/indoors/town)
 "ddU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -3489,7 +3385,6 @@
 /area/rogue/indoors/town/physician)
 "det" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
@@ -3501,7 +3396,6 @@
 /area/rogue/indoors/town/manor)
 "dex" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -3595,7 +3489,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
@@ -3605,7 +3498,6 @@
 /area/rogue/outdoors/rtfield)
 "djU" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/customflag{
@@ -3687,7 +3579,6 @@
 /area/rogue/under/town/basement)
 "dnp" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile{
@@ -3755,8 +3646,8 @@
 /area/rogue/indoors/town)
 "dpX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/sword/sabre,
 /turf/open/floor/rogue/ruinedwood{
@@ -3838,7 +3729,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/machinery/light/rogue/torchholder/l,
@@ -3846,8 +3736,8 @@
 /area/rogue/outdoors/town)
 "dvK" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
@@ -3872,9 +3762,9 @@
 /area/rogue/indoors/town/shop)
 "dxs" = (
 /obj/structure/closet/crate/chest{
-	name = "spare house keys";
 	locked = 1;
-	lockid = "steward"
+	lockid = "steward";
+	name = "spare house keys"
 	},
 /obj/item/roguekey/houses/house1,
 /obj/item/roguekey/houses/house2,
@@ -3886,7 +3776,6 @@
 /area/rogue/indoors/town)
 "dxE" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -3900,8 +3789,8 @@
 /area/rogue/indoors/town)
 "dxQ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/skull{
 	pixel_x = 5;
@@ -3929,7 +3818,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -3949,14 +3837,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "dzt" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "dAb" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -3970,7 +3856,6 @@
 /area/rogue/under/town/basement/keep)
 "dAn" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -3994,8 +3879,8 @@
 /area/rogue/indoors/town/magician)
 "dAX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -4007,8 +3892,8 @@
 /area/rogue/indoors/town/physician)
 "dCo" = (
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/mountains)
 "dCX" = (
@@ -4020,11 +3905,9 @@
 /area/rogue/under/town/basement)
 "dDJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -4054,7 +3937,6 @@
 /area/rogue/indoors/town)
 "dEZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/carpet,
@@ -4067,21 +3949,20 @@
 /area/rogue/indoors/town/shop)
 "dFN" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "dGH" = (
-/obj/structure/mineral_door/bars{
-	lockid = "manor"
-	},
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "dGX" = (
@@ -4092,9 +3973,9 @@
 /area/rogue/indoors/town)
 "dHr" = (
 /obj/structure/closet/crate/chest{
-	name = "house keys";
 	locked = 1;
-	lockid = "steward"
+	lockid = "steward";
+	name = "house keys"
 	},
 /obj/item/roguekey/houses/house1,
 /obj/item/roguekey/houses/house2,
@@ -4125,8 +4006,8 @@
 /area/rogue/under/town/basement)
 "dIL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
@@ -4136,7 +4017,6 @@
 /area/rogue/outdoors/rtfield)
 "dJn" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -4174,7 +4054,6 @@
 /area/rogue/indoors/shelter/woods)
 "dMM" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -4260,11 +4139,9 @@
 /area/rogue/indoors/town)
 "dRa" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -4284,11 +4161,9 @@
 /area/rogue/indoors/town)
 "dRT" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -4333,7 +4208,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/twig,
@@ -4364,9 +4238,7 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/kitchen/rollingpin,
 /obj/item/rogueweapon/huntingknife/chefknife,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "dWj" = (
 /obj/structure/flora/roguegrass,
@@ -4376,7 +4248,6 @@
 "dWm" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -4391,8 +4262,8 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "dWx" = (
@@ -4403,17 +4274,13 @@
 	icon_state = "longtable"
 	},
 /obj/item/roguekey/manor,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "dXO" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/silver/pile,
 /obj/item/roguecoin/silver/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "dYe" = (
 /obj/structure/table/wood,
@@ -4442,22 +4309,20 @@
 /area/rogue/indoors/town/cell)
 "dYF" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
 "dYY" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
 	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "dZj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -4470,7 +4335,6 @@
 /area/rogue/indoors/town/garrison)
 "dZu" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -4510,12 +4374,12 @@
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "ecx" = (
@@ -4527,18 +4391,15 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "edu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -4551,8 +4412,8 @@
 /area/rogue/under/town/basement)
 "eev" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -4642,8 +4503,8 @@
 /area/rogue/indoors/town/physician)
 "ejk" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
@@ -4657,8 +4518,8 @@
 /area/rogue/indoors/town/shop)
 "ejT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -4667,7 +4528,6 @@
 /area/rogue/outdoors/town)
 "ekh" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -4737,7 +4597,6 @@
 /area/rogue/outdoors/rtfield)
 "eon" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -4748,7 +4607,6 @@
 /area/rogue/outdoors/beach)
 "eou" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -4761,7 +4619,6 @@
 /area/rogue/outdoors/town)
 "eoH" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -4786,7 +4643,6 @@
 /area/rogue/indoors/town/tavern)
 "epS" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood{
@@ -4824,8 +4680,8 @@
 /area/rogue/indoors/town/physician)
 "erC" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -4849,8 +4705,8 @@
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -4868,8 +4724,8 @@
 /area/rogue/under/cave)
 "euL" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -4906,15 +4762,13 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "ewt" = (
-/obj/structure/bars/passage{
-	redstone_id = "tourneytop"
-	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/roguetent,
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ewK" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -4935,10 +4789,10 @@
 /area/rogue/indoors/town/garrison)
 "eyi" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable i";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable1";
-	keylock = 1
+	name = "stable i"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -4972,11 +4826,9 @@
 /area/rogue/outdoors/town)
 "eAh" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9;
 	pixel_y = -22
 	},
@@ -5082,7 +4934,6 @@
 "eGP" = (
 /obj/structure/closet/dirthole/closed/loot,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/ambush,
@@ -5106,8 +4957,8 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -5121,9 +4972,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "eJJ" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -5162,8 +5011,8 @@
 /area/rogue/indoors/town/church/chapel)
 "eLq" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/needle,
 /obj/item/needle{
@@ -5192,8 +5041,8 @@
 /area/rogue/indoors/town/physician)
 "eMA" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/cobble,
@@ -5223,8 +5072,8 @@
 /area/rogue/indoors/town/physician)
 "eNy" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Council Office";
-	lockid = "manor"
+	lockid = "manor";
+	name = "Council Office"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
@@ -5238,8 +5087,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "eOz" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "ePO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -5255,8 +5106,8 @@
 "eQs" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/natural/feather,
 /obj/item/candle/yellow/lit{
@@ -5272,9 +5123,7 @@
 /area/rogue/indoors/town/tavern)
 "eRV" = (
 /obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "eSe" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -5291,7 +5140,6 @@
 /area/rogue/indoors/town/dwarfin)
 "eTi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -5313,7 +5161,6 @@
 /area/rogue/under/town/basement)
 "eTw" = (
 /obj/structure/stairs/fancy/r{
-	icon_state = "fancy_stairs_r";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord{
@@ -5322,7 +5169,6 @@
 /area/rogue/indoors/town/manor)
 "eTM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/grass,
@@ -5381,16 +5227,16 @@
 	redstone_id = "weaponsmith_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "eWI" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "eWN" = (
@@ -5413,17 +5259,15 @@
 /area/rogue/indoors/town/manor)
 "eYT" = (
 /obj/structure/mineral_door/wood/violet{
-	name = "INNKEEP";
 	locked = 1;
-	lockid = "innkeep"
+	lockid = "innkeep";
+	name = "INNKEEP"
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "eZb" = (
 /obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "eZg" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -5464,7 +5308,6 @@
 /area/rogue/indoors/town)
 "fbj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -5489,9 +5332,9 @@
 /area/rogue/indoors/town/church/chapel)
 "fca" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM V";
 	locked = 1;
-	lockid = "roomv"
+	lockid = "roomv";
+	name = "ROOM V"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -5504,7 +5347,6 @@
 /area/rogue/indoors/shelter/woods)
 "fcv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -5532,7 +5374,6 @@
 /area/rogue/indoors/town)
 "fdk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -5541,15 +5382,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
-"fdT" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
-	},
-/area/rogue/outdoors/town/roofs/keep)
 "feH" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -5577,9 +5409,7 @@
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "ffs" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -5602,12 +5432,10 @@
 /area/rogue/indoors/town/manor)
 "fgW" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "fha" = (
@@ -5654,7 +5482,6 @@
 /area/rogue/indoors/town/manor)
 "fkD" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -5662,8 +5489,7 @@
 /area/rogue/indoors/town)
 "flo" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -5701,7 +5527,6 @@
 /area/rogue/indoors/town/dwarfin)
 "fmT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 8
 	},
 /area/rogue/indoors/town/physician)
@@ -5716,12 +5541,10 @@
 /area/rogue/indoors/town)
 "fnS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "foe" = (
@@ -5743,7 +5566,6 @@
 "fpN" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/landmark/start/druid{
@@ -5791,9 +5613,9 @@
 /area/rogue/indoors/town/manor)
 "frH" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "examination room";
 	dir = 4;
-	lockid = "physician"
+	lockid = "physician";
+	name = "examination room"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
@@ -5812,8 +5634,8 @@
 /area/rogue/under/town/basement)
 "ftb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/idagger{
 	pixel_x = 2;
@@ -5824,20 +5646,18 @@
 "ftD" = (
 /obj/structure/roguemachine/atm,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "ftM" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
-	dir = 8
+/obj/structure/mineral_door/bars{
+	lockid = "manor"
 	},
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "fuY" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/green,
@@ -5873,15 +5693,15 @@
 /area/rogue/under/town/basement)
 "fwi" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "fwr" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/canopy/green,
 /obj/structure/mineral_door/wood/deadbolt/shutter{
@@ -5899,9 +5719,7 @@
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/gold/pile,
 /obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "fwW" = (
 /obj/structure/closet/crate/roguecloset,
@@ -5919,8 +5737,8 @@
 /area/rogue/indoors/town/bath)
 "fyl" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -5929,7 +5747,6 @@
 /area/rogue/under/town/basement/keep)
 "fyC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/closet/crate/roguecloset/inn,
@@ -5945,7 +5762,6 @@
 /area/rogue/outdoors/town)
 "fzy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -6088,12 +5904,10 @@
 /area/rogue/indoors/town/garrison)
 "fFj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "fFk" = (
@@ -6110,13 +5924,11 @@
 /area/rogue/under/town/basement/keep)
 "fFB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "fFJ" = (
 /obj/structure/fluff/railing/border{
@@ -6163,7 +5975,6 @@
 /area/rogue/indoors/town)
 "fHK" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -6184,20 +5995,14 @@
 /obj/item/rogueweapon/pick,
 /obj/item/rogueweapon/pick,
 /obj/item/rogueweapon/pick,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "fKS" = (
-/obj/effect/landmark/mapGenerator/rogue/roguetownfield{
-	endTurfX = 155;
-	endTurfY = 155
-	},
+/obj/effect/landmark/mapGenerator/rogue/roguetownfield,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "fKY" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -6231,15 +6036,14 @@
 /area/rogue/outdoors/town)
 "fNR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "fOh" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -6247,8 +6051,8 @@
 "fOu" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/grown/log/tree/small,
 /obj/item/flint,
@@ -6256,8 +6060,8 @@
 /area/rogue/indoors/town/dwarfin)
 "fOC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
@@ -6288,11 +6092,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "fQO" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
-	dir = 8
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 1
 	},
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "fQW" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/dwarfin)
@@ -6309,7 +6113,6 @@
 "fRF" = (
 /obj/structure/roguemachine/scomm,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -6330,9 +6133,7 @@
 "fTX" = (
 /obj/structure/chair/bench/coucha,
 /obj/effect/landmark/start/nightmaiden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "fTZ" = (
 /obj/structure/roguewindow,
@@ -6354,19 +6155,17 @@
 /area/rogue/indoors/town/manor)
 "fUx" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Vault Door";
 	dir = 1;
 	locked = 1;
-	lockid = "vault"
+	lockid = "vault";
+	name = "Vault Door"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "fUG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/torchholder/l,
 /obj/item/rogueweapon/tongs,
@@ -6396,7 +6195,6 @@
 "fXj" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -6463,8 +6261,8 @@
 /area/rogue/indoors/town)
 "gcw" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
@@ -6478,7 +6276,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -6511,8 +6308,8 @@
 /area/rogue/indoors/town)
 "geX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/mask/rogue/facemask,
 /obj/item/clothing/mask/rogue/lordmask,
@@ -6527,7 +6324,6 @@
 /area/rogue/outdoors/town)
 "gfq" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic,
@@ -6537,7 +6333,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -6553,7 +6348,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6562,7 +6356,6 @@
 /area/rogue/indoors/town)
 "ggH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -6584,7 +6377,6 @@
 /area/rogue/indoors/town/cell)
 "gii" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6593,9 +6385,7 @@
 /area/rogue/indoors/town/church/chapel)
 "giB" = (
 /obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "giG" = (
 /obj/structure/fermenting_barrel,
@@ -6603,7 +6393,6 @@
 /area/rogue/under/town/basement/keep)
 "giU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -6616,8 +6405,8 @@
 /area/rogue/outdoors/town)
 "gjj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -6636,7 +6425,6 @@
 /area/rogue/indoors/town/garrison)
 "gjH" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -6659,7 +6447,6 @@
 /area/rogue/indoors/town)
 "glv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8;
 	pixel_y = 5
 	},
@@ -6695,8 +6482,8 @@
 /area/rogue/indoors/town/church/chapel)
 "gmc" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -6722,14 +6509,12 @@
 /area/rogue/indoors/town/shop)
 "gmz" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "gmX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/cobble,
@@ -6745,8 +6530,7 @@
 /area/rogue/indoors/town/cell)
 "goi" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -6779,21 +6563,18 @@
 /area/rogue/indoors/shelter/woods)
 "gpb" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "gpx" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/reagent_containers/glass/cup/skull,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
 "gqi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -6801,7 +6582,6 @@
 /area/rogue/under/town/basement/keep)
 "gqq" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -6818,8 +6598,8 @@
 /area/rogue/under/town/basement/keep)
 "gqW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/tongs{
 	pixel_x = 5;
@@ -6853,8 +6633,8 @@
 /area/rogue/indoors/town/dwarfin)
 "gtW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -6882,8 +6662,8 @@
 /area/rogue/indoors/town/bath)
 "gvO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -6892,8 +6672,8 @@
 /area/rogue/indoors/town/shop)
 "gwy" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/bowl{
 	pixel_x = 4;
@@ -6906,7 +6686,6 @@
 /area/rogue/indoors/town)
 "gxc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -6936,16 +6715,14 @@
 /area/rogue/under/town/basement)
 "gxZ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
 "gyz" = (
 /obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "gyF" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -6962,7 +6739,6 @@
 /area/rogue/indoors/town/church/chapel)
 "gzG" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/flora/ausbushes/ywflowers,
@@ -6970,26 +6746,22 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "gzW" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "gAj" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "gAA" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town)
 "gAE" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood{
@@ -7017,13 +6789,11 @@
 /area/rogue/indoors/town/dwarfin)
 "gCg" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town/physician)
 "gCw" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -7051,8 +6821,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/exposed/town/keep)
@@ -7083,15 +6853,14 @@
 /area/rogue/indoors/town/church/chapel)
 "gGR" = (
 /obj/structure/mineral_door/wood{
-	name = "physician's backdoor";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "physician's backdoor"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "gHf" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -7152,7 +6921,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -7198,15 +6966,14 @@
 "gMV" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "gNo" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
@@ -7219,8 +6986,8 @@
 /area/rogue/outdoors/town)
 "gNX" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/clothing/head/roguetown/menacing{
 	pixel_x = -3;
@@ -7267,7 +7034,6 @@
 /area/rogue/indoors/town/manor)
 "gPW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -7285,8 +7051,8 @@
 /area/rogue/indoors/town/manor)
 "gQJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -7311,12 +7077,12 @@
 /area/rogue/indoors/town/tavern)
 "gSg" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -7342,7 +7108,6 @@
 /area/rogue/outdoors/town)
 "gSu" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -7355,8 +7120,8 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "gTl" = (
@@ -7374,8 +7139,8 @@
 /area/rogue/indoors/shelter/woods)
 "gTY" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/book_crafting_kit,
 /obj/item/book_crafting_kit,
@@ -7384,8 +7149,8 @@
 /area/rogue/indoors/town)
 "gUU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/silver,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -7408,16 +7173,13 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "gWx" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "gXi" = (
 /obj/structure/well/fountain{
@@ -7433,14 +7195,12 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "gXL" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -7448,15 +7208,12 @@
 /area/rogue/indoors/town)
 "gXR" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -7503,8 +7260,8 @@
 /area/rogue/indoors/town/church/chapel)
 "hbq" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/herringbone,
@@ -7524,8 +7281,8 @@
 /area/rogue/indoors/town/church/chapel)
 "hbU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/apartments/apartment1{
 	name = "stall i key";
@@ -7546,9 +7303,7 @@
 	locked = 1;
 	lockid = "artificer"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "hdp" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -7567,8 +7322,8 @@
 /area/rogue/under/town/sewer)
 "heR" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -7595,8 +7350,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "hfu" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden{
 	pixel_x = 2;
@@ -7606,7 +7361,6 @@
 /area/rogue/indoors/town/dwarfin)
 "hgu" = (
 /obj/structure/stairs/fancy/r{
-	icon_state = "fancy_stairs_r";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/right,
@@ -7628,15 +7382,14 @@
 /area/rogue/indoors/shelter/woods)
 "hgV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "hhg" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -7722,18 +7475,17 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "hoH" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 1
+/obj/structure/lever/wall{
+	pixel_x = 32;
+	redstone_id = "tourneytop"
 	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "hoU" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "hpb" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge,
@@ -7744,7 +7496,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -7806,8 +7557,8 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -7833,8 +7584,8 @@
 "hsK" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
@@ -7849,7 +7600,6 @@
 /area/rogue/indoors/town/church/chapel)
 "htG" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -7859,7 +7609,6 @@
 /obj/item/rogueweapon/shield/wood/crafted,
 /obj/item/rogueweapon/shield/wood/crafted,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -7922,20 +7671,20 @@
 /area/rogue/indoors/town/shop)
 "hws" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "hwQ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	locked = 1
+	locked = 1;
+	lockid = "church"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
@@ -7973,8 +7722,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "hzT" = (
@@ -7992,13 +7740,10 @@
 /area/rogue/indoors/town)
 "hAM" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "hAS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ywflowers,
@@ -8013,21 +7758,17 @@
 /area/rogue/indoors/town/manor)
 "hCc" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hCr" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -8043,7 +7784,6 @@
 /area/rogue/indoors/town/church/chapel)
 "hDp" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -8081,8 +7821,8 @@
 /area/rogue/outdoors/town/roofs)
 "hFr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
@@ -8099,7 +7839,6 @@
 /area/rogue/under/town/basement/keep)
 "hGe" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -8122,18 +7861,15 @@
 /area/rogue/indoors/town/manor)
 "hGQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "hGV" = (
 /obj/structure/stairs/fancy/l{
-	icon_state = "fancy_stairs_l";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/left,
@@ -8146,9 +7882,7 @@
 /area/rogue/outdoors/town)
 "hHp" = (
 /obj/structure/closet/crate/chest/gold,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hHv" = (
 /obj/machinery/light/rogue/hearth,
@@ -8158,9 +7892,7 @@
 /area/rogue/indoors/town)
 "hHw" = (
 /obj/structure/roguemachine/lottery_roguetown,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hHC" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -8170,7 +7902,6 @@
 /area/rogue/indoors/town/physician)
 "hHM" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -8178,19 +7909,17 @@
 "hHQ" = (
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "hIg" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/paper,
@@ -8206,8 +7935,8 @@
 /area/rogue/indoors/town)
 "hIk" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 4
@@ -8219,11 +7948,9 @@
 /area/rogue/indoors/town/manor)
 "hIF" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -8269,9 +7996,7 @@
 /area/rogue/under/town/basement/keep)
 "hKl" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hKO" = (
 /obj/structure/table/wood{
@@ -8282,7 +8007,6 @@
 /area/rogue/indoors/town)
 "hLv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/machinery/light/rogue/torchholder/l,
@@ -8291,7 +8015,6 @@
 "hLP" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -8308,7 +8031,6 @@
 /area/rogue/indoors/town/magician)
 "hNd" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -8358,7 +8080,6 @@
 /area/rogue/under/town/basement/keep)
 "hRf" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -8382,8 +8103,8 @@
 /area/rogue/indoors/town/dwarfin)
 "hSx" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -8402,7 +8123,6 @@
 /area/rogue/indoors/town/manor)
 "hTH" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood,
@@ -8420,7 +8140,6 @@
 /area/rogue/indoors/town)
 "hVE" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8445,7 +8164,6 @@
 /area/rogue/indoors/town/garrison)
 "hWZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -8454,7 +8172,6 @@
 /area/rogue/indoors/town/manor)
 "hXc" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -8462,15 +8179,13 @@
 	},
 /area/rogue/indoors/town/physician)
 "hXf" = (
-/obj/effect/decal/cobbleedge{
-	dir = 2
-	},
+/obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "hXp" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /obj/effect/decal/cobbleedge{
@@ -8532,15 +8247,13 @@
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
 "hYC" = (
-/obj/structure/bars/passage{
-	redstone_id = "tourneybottom"
-	},
+/obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "hYJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -8581,7 +8294,6 @@
 /area/rogue/indoors/town/bath)
 "icQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
@@ -8615,8 +8327,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "ifx" = (
@@ -8633,8 +8345,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ifY" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
@@ -8666,7 +8377,6 @@
 /area/rogue/outdoors/town)
 "iiF" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -8689,8 +8399,8 @@
 /area/rogue/indoors/town/bath)
 "ijT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -8720,7 +8430,6 @@
 /area/rogue/indoors/town/church/chapel)
 "ikj" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -8730,12 +8439,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/town/basement)
 "ikB" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
+/obj/structure/lever/wall{
+	pixel_x = 32;
+	redstone_id = "tourneybottom"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/beach)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "ilw" = (
 /obj/structure/table/wood{
 	icon_state = "map1"
@@ -8748,7 +8457,6 @@
 /area/rogue/outdoors/rtfield)
 "imh" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -8814,15 +8522,13 @@
 	locked = 1;
 	lockid = "nightman"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "iqf" = (
 /obj/structure/mineral_door/wood{
-	name = "alchemy room";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "alchemy room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -8830,9 +8536,9 @@
 /area/rogue/indoors/town/physician)
 "iql" = (
 /obj/structure/mineral_door/wood/window{
-	name = "captains room door";
 	locked = 1;
-	lockid = "sheriff"
+	lockid = "sheriff";
+	name = "captains room door"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -8848,9 +8554,7 @@
 /area/rogue/indoors/town/manor)
 "iqT" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "irh" = (
 /obj/structure/fluff/railing/border{
@@ -8911,9 +8615,7 @@
 /obj/effect/landmark/start/monk{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "iuG" = (
 /obj/structure/roguemachine/scomm/r,
@@ -8930,7 +8632,6 @@
 /area/rogue/indoors/town/dwarfin)
 "ivW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/couchablack,
@@ -8938,8 +8639,8 @@
 /area/rogue/under/town/basement/keep)
 "iwd" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -8959,7 +8660,6 @@
 /area/rogue/indoors/town)
 "iwJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/indoors/town)
@@ -9000,8 +8700,8 @@
 /area/rogue/under/town/basement/keep)
 "iyW" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
@@ -9018,9 +8718,9 @@
 /area/rogue/indoors/town/manor)
 "izX" = (
 /obj/structure/mineral_door/wood{
-	name = "jesters chambers";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "jesters chambers"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -9030,7 +8730,6 @@
 /area/rogue/outdoors/town)
 "iAu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -9046,10 +8745,10 @@
 /area/rogue/outdoors/town/roofs)
 "iBL" = (
 /obj/structure/mineral_door/wood{
-	name = "royal guard quarters";
 	icon_state = "wcv";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "royal guard quarters"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement/keep)
@@ -9064,26 +8763,24 @@
 /area/rogue/indoors/town/garrison)
 "iCU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "iDm" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/book/rogue/cardgame,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "iDt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -9123,8 +8820,8 @@
 	dir = 9
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
@@ -9178,7 +8875,6 @@
 /area/rogue/indoors/town)
 "iHY" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -9188,11 +8884,9 @@
 /area/rogue/indoors/town/bath)
 "iIH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/transparent/openspace,
@@ -9206,17 +8900,14 @@
 /area/rogue/under/town/basement/keep)
 "iJx" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/indoors/town/physician)
 "iKC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -9251,8 +8942,8 @@
 /area/rogue/indoors/town/dwarfin)
 "iMm" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/rogue/tile{
@@ -9272,11 +8963,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "iNg" = (
-/obj/structure/roguethrone{
-	pixel_x = -32
-	},
+/obj/structure/roguethrone,
 /obj/structure/roguemachine/titan{
-	density = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/carpet/lord/center,
@@ -9291,7 +8979,6 @@
 /area/rogue/under/town/basement/keep)
 "iNt" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -9299,9 +8986,7 @@
 "iNE" = (
 /obj/machinery/light/rogue/oven/east,
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "iNM" = (
 /obj/structure/flora/newleaf,
@@ -9321,7 +9006,6 @@
 /area/rogue/indoors/town/physician)
 "iOF" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/stairs/stone{
@@ -9347,7 +9031,6 @@
 "iPP" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
@@ -9381,10 +9064,10 @@
 /area/rogue/indoors/town)
 "iSc" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable ii";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable2";
-	keylock = 1
+	name = "stable ii"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -9395,14 +9078,12 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/magician)
 "iSr" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -9414,7 +9095,6 @@
 /area/rogue/indoors/town/bath)
 "iSJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -9461,7 +9141,6 @@
 /area/rogue/indoors/town)
 "iWT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
@@ -9490,9 +9169,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
 "iYk" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
 	},
@@ -9510,18 +9187,16 @@
 /area/rogue/outdoors/exposed/town/keep)
 "iZj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "iZw" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -9548,8 +9223,8 @@
 /area/rogue/indoors/town/manor)
 "jaS" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
@@ -9575,7 +9250,6 @@
 /area/rogue/indoors/town)
 "jbx" = (
 /obj/structure/stairs/fancy/l{
-	icon_state = "fancy_stairs_l";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord{
@@ -9591,19 +9265,17 @@
 /area/rogue/outdoors/exposed/town/keep)
 "jbY" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "jcB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -9661,22 +9333,20 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "jfy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "jfC" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = 3;
@@ -9714,7 +9384,6 @@
 /area/rogue/under/town/basement/keep)
 "jhc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9745,8 +9414,8 @@
 /area/rogue/indoors/town)
 "jiG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
@@ -9760,7 +9429,6 @@
 /area/rogue/under/town/basement)
 "jiM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9830,7 +9498,6 @@
 /area/rogue/outdoors/town/roofs)
 "jnW" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9859,14 +9526,12 @@
 /area/rogue/indoors/town/shop)
 "jpw" = (
 /obj/structure/roguemachine/withdraw,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "jpy" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /obj/item/natural/feather,
@@ -9878,15 +9543,14 @@
 /area/rogue/under/town/basement/keep)
 "jpM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs/keep)
 "jqw" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -9907,8 +9571,8 @@
 /area/rogue/indoors/town)
 "jrz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
@@ -9926,8 +9590,8 @@
 /area/rogue/indoors/town/manor)
 "jsm" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
@@ -9936,7 +9600,6 @@
 /area/rogue/indoors/town/garrison)
 "jsJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -9987,7 +9650,6 @@
 /area/rogue/indoors/town/manor)
 "jzA" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/church)
@@ -9999,8 +9661,8 @@
 /area/rogue/indoors/town)
 "jAw" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood{
@@ -10021,7 +9683,6 @@
 "jBv" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic/single,
@@ -10041,7 +9702,6 @@
 /area/rogue/indoors/town/tavern)
 "jBQ" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -10114,8 +9774,8 @@
 /area/rogue/indoors/town/physician)
 "jHu" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "jHz" = (
@@ -10146,8 +9806,8 @@
 /area/rogue/indoors/town)
 "jIY" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -10168,28 +9828,25 @@
 /obj/structure/roguemachine/atm{
 	mammonsiphoned = 250
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "jKz" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "jLc" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
 "jLj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
@@ -10217,7 +9874,6 @@
 /area/rogue/indoors/town)
 "jMa" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /obj/structure/fluff/railing/fence,
@@ -10288,7 +9944,6 @@
 "jPb" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -10300,8 +9955,8 @@
 "jPJ" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -10356,7 +10011,6 @@
 /area/rogue/indoors/town/dwarfin)
 "jRq" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/effect/decal/cobbleedge{
@@ -10378,7 +10032,6 @@
 /area/rogue/indoors/town/tavern)
 "jRL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -10390,8 +10043,8 @@
 /area/rogue/under/town/sewer)
 "jRY" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -10415,7 +10068,6 @@
 /area/rogue/indoors/town/manor)
 "jTo" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/stump,
@@ -10433,7 +10085,6 @@
 /area/rogue/indoors/town)
 "jVk" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10447,10 +10098,10 @@
 /area/rogue/under/town/basement/keep)
 "jVM" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable iii";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable3";
-	keylock = 1
+	name = "stable iii"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -10461,9 +10112,9 @@
 /area/rogue/indoors/town/manor)
 "jWf" = (
 /obj/structure/mineral_door/wood{
-	name = "apothacary bunks";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "apothacary bunks"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10477,7 +10128,6 @@
 "jWu" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -10520,9 +10170,7 @@
 	icon_state = "ultimacochright"
 	},
 /obj/structure/fluff/walldeco/maidensigil,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "jYO" = (
 /turf/open/floor/rogue/woodturned,
@@ -10539,9 +10187,7 @@
 /area/rogue/indoors/town)
 "jZD" = (
 /obj/structure/bars,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kae" = (
 /turf/open/floor/rogue/dirt,
@@ -10551,15 +10197,13 @@
 /area/rogue/indoors/shelter/woods)
 "kbt" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kbK" = (
 /obj/structure/handcart{
@@ -10607,14 +10251,12 @@
 /area/rogue/indoors/town/manor)
 "kcZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "kdI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10718,12 +10360,9 @@
 /area/rogue/outdoors/mountains)
 "klb" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "kle" = (
 /obj/structure/closet/crate/roguecloset/crafted,
@@ -10746,12 +10385,10 @@
 "kmF" = (
 /obj/item/rogue/instrument/harp,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "kmO" = (
 /obj/structure/roguewindow,
@@ -10776,15 +10413,14 @@
 /area/rogue/outdoors/town)
 "kov" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "koL" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -10802,8 +10438,8 @@
 	mailtag = "Bathhouse"
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry,
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry,
@@ -10848,8 +10484,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -10858,7 +10494,6 @@
 /area/rogue/outdoors/mountains)
 "ksf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/hexstone,
@@ -10917,7 +10552,6 @@
 /area/rogue/indoors/town/bath)
 "kul" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/roguegrass,
@@ -10940,7 +10574,6 @@
 /area/rogue/indoors/town)
 "kuI" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -10
 	},
@@ -10954,7 +10587,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kuZ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -10965,8 +10597,8 @@
 /area/rogue/under/town/basement/keep)
 "kvv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/clothing/mask/rogue/wildguard,
 /obj/item/clothing/mask/rogue/wildguard,
@@ -10988,8 +10620,8 @@
 "kwu" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -11019,18 +10651,16 @@
 /area/rogue/indoors/town/manor)
 "kyM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "kyP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -11039,7 +10669,6 @@
 /area/rogue/indoors/town/manor)
 "kza" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/effect/decal/cobbleedge{
@@ -11064,8 +10693,8 @@
 /area/rogue/outdoors/town)
 "kzW" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "southgate_outer"
 	},
 /turf/open/floor/rogue/metal{
@@ -11116,8 +10745,8 @@
 /area/rogue/indoors/town/garrison)
 "kCr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
@@ -11156,22 +10785,20 @@
 /area/rogue/outdoors/town)
 "kEv" = (
 /obj/effect/landmark/start/barkeep{
-	name = "Innkeeper";
-	dir = 1
+	dir = 1;
+	name = "Innkeeper"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "kEG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "kEN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/cobble,
@@ -11195,7 +10822,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
@@ -11210,9 +10836,7 @@
 /area/rogue/under/town/sewer)
 "kGq" = (
 /obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kGs" = (
 /obj/structure/closet/crate/roguecloset,
@@ -11276,8 +10900,8 @@
 /area/rogue/indoors/town)
 "kJD" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /obj/item/roguekey/velder,
@@ -11299,9 +10923,7 @@
 /area/rogue/indoors/town/bath)
 "kKI" = (
 /obj/machinery/light/rogue/oven/east,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kKS" = (
 /obj/structure/flora/roguetree,
@@ -11322,7 +10944,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kLO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/chair/wood/rogue/chair3{
@@ -11341,8 +10962,8 @@
 /area/rogue/indoors/town/church/chapel)
 "kMr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
@@ -11361,8 +10982,8 @@
 /area/rogue/outdoors/town)
 "kNj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
@@ -11423,7 +11044,6 @@
 /area/rogue/indoors/town)
 "kNC" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/structure/fluff/clodpile,
@@ -11455,8 +11075,8 @@
 /area/rogue/indoors/town)
 "kOv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/carpet/red,
@@ -11485,7 +11105,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "kPo" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -11529,15 +11148,14 @@
 /area/rogue/indoors/town/manor)
 "kQC" = (
 /obj/structure/mineral_door/bars{
-	name = "royal crypt";
 	locked = 1;
-	lockid = "graveyard"
+	lockid = "graveyard";
+	name = "royal crypt"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "kQI" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -11554,7 +11172,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kSm" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 8;
 	locked = 1;
 	lockid = "nightmaiden"
@@ -11563,8 +11180,8 @@
 /area/rogue/indoors/town/bath)
 "kSx" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/cobble,
@@ -11581,10 +11198,10 @@
 /area/rogue/indoors/town/church/chapel)
 "kTg" = (
 /obj/structure/mineral_door/wood{
-	name = "Seneschal's Quarters";
 	icon_state = "wcv";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Seneschal's Quarters"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11612,9 +11229,9 @@
 /area/rogue/outdoors/exposed/town/keep)
 "kTO" = (
 /obj/structure/mineral_door/wood{
-	name = "physician's office";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "physician's office"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11625,8 +11242,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "kUe" = (
@@ -11645,8 +11261,8 @@
 /area/rogue/under/town/basement/keep)
 "kUP" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
@@ -11730,9 +11346,7 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kZU" = (
 /obj/structure/fluff/clock,
@@ -11749,7 +11363,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -11766,21 +11379,18 @@
 "lay" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "laD" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "laX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/effect/decal/mossy{
@@ -11802,7 +11412,6 @@
 /area/rogue/indoors/town/manor)
 "lbI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/herringbone,
@@ -11813,8 +11422,8 @@
 /area/rogue/outdoors/town)
 "lck" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "shipside bunkhouse";
-	dir = 1
+	dir = 1;
+	name = "shipside bunkhouse"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
@@ -11856,8 +11465,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ldX" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -11882,7 +11491,6 @@
 /area/rogue/indoors/town/physician)
 "led" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -11945,7 +11553,6 @@
 "lgZ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic/single,
@@ -12038,19 +11645,16 @@
 /area/rogue/outdoors/exposed/town/keep)
 "lmf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/dwarfin)
 "lmq" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -12082,8 +11686,8 @@
 /area/rogue/outdoors/town)
 "lnv" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -12115,7 +11719,6 @@
 /area/rogue/indoors/town/manor)
 "loB" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12130,7 +11733,6 @@
 /area/rogue/indoors/town)
 "loI" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -12172,9 +11774,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "lpX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
@@ -12190,8 +11790,8 @@
 /area/rogue/indoors/town/church)
 "lsi" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -12203,9 +11803,9 @@
 /area/rogue/indoors/town/manor)
 "lsG" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Guest Room";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Guest Room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -12252,9 +11852,7 @@
 /area/rogue/indoors/town/shop)
 "lvi" = (
 /obj/structure/roguetent,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "lvu" = (
 /obj/structure/fluff/statue/knight/r,
@@ -12266,11 +11864,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -12302,8 +11898,8 @@
 /area/rogue/indoors/town/tavern)
 "lxe" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/powder/flour,
@@ -12329,8 +11925,8 @@
 /area/rogue/outdoors/town/roofs)
 "lxN" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/cup/steel{
 	pixel_x = -6;
@@ -12354,12 +11950,11 @@
 /area/rogue/outdoors/rtfield)
 "lAt" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -12367,7 +11962,6 @@
 /area/rogue/indoors/town)
 "lAL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
@@ -12415,7 +12009,6 @@
 /area/rogue/indoors/town/physician)
 "lDW" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -12423,8 +12016,8 @@
 "lEf" = (
 /obj/item/soap,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
@@ -12453,7 +12046,6 @@
 /area/rogue/indoors/town)
 "lFW" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -12465,7 +12057,6 @@
 /area/rogue/indoors/town/garrison)
 "lGO" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town/dwarfin)
@@ -12479,8 +12070,8 @@
 /area/rogue/indoors/town/garrison)
 "lHl" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
@@ -12504,7 +12095,6 @@
 /area/rogue/outdoors/town)
 "lIv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12513,8 +12103,7 @@
 /area/rogue/indoors/town/magician)
 "lIC" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 2
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -12535,7 +12124,6 @@
 /area/rogue/indoors/town/dwarfin)
 "lJa" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -12565,14 +12153,12 @@
 /area/rogue/under/town/basement/keep)
 "lLL" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
 "lMc" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -12592,7 +12178,6 @@
 "lMj" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -12627,8 +12212,8 @@
 /area/rogue/indoors/shelter/woods)
 "lOX" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -12636,11 +12221,9 @@
 "lPe" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5;
 	pixel_x = -24;
 	pixel_y = -23
@@ -12649,8 +12232,8 @@
 /area/rogue/indoors/town/tavern)
 "lPB" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/carpet/red,
@@ -12665,8 +12248,8 @@
 /area/rogue/indoors/town/bath)
 "lQS" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/herringbone,
@@ -12677,8 +12260,8 @@
 /area/rogue/outdoors/mountains)
 "lRa" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
@@ -12700,9 +12283,9 @@
 /area/rogue/outdoors/town)
 "lSf" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM II";
 	locked = 1;
-	lockid = "roomii"
+	lockid = "roomii";
+	name = "ROOM II"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -12776,7 +12359,6 @@
 /area/rogue/outdoors/mountains)
 "lVW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/stump,
@@ -12796,21 +12378,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "lYJ" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/dirt/road,
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "lYS" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
-"lZp" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "lZE" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/effect/decal/cobbleedge{
@@ -12820,15 +12394,15 @@
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "lZW" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
@@ -12842,9 +12416,9 @@
 /area/rogue/indoors/town/magician)
 "maj" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Apartment";
 	locked = 1;
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -12864,7 +12438,6 @@
 /area/rogue/indoors/town/physician)
 "mbO" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/carpet,
@@ -12917,16 +12490,6 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
-"meP" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town)
 "meT" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -12936,8 +12499,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "mfn" = (
@@ -12953,7 +12516,6 @@
 /area/rogue/indoors/town)
 "mfP" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -12967,7 +12529,6 @@
 /area/rogue/indoors/town/manor)
 "mgA" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12988,7 +12549,6 @@
 /area/rogue/indoors/town/physician)
 "mgM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13032,9 +12592,7 @@
 /obj/effect/landmark/start/dungeoneer{
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "mjw" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -13053,15 +12611,15 @@
 "mkg" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "mkB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -13092,9 +12650,9 @@
 /area/rogue/indoors/town/magician)
 "mlM" = (
 /obj/structure/mineral_door/wood{
-	name = "house iii";
 	locked = 1;
-	lockid = "house3"
+	lockid = "house3";
+	name = "house iii"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -13116,8 +12674,7 @@
 /area/rogue/outdoors/town)
 "mmh" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
@@ -13134,19 +12691,17 @@
 /area/rogue/outdoors/town)
 "mmT" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "mnl" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -13188,10 +12743,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"mrD" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "mrG" = (
 /obj/structure/fermenting_barrel/zagul,
 /turf/open/floor/rogue/tile{
@@ -13200,7 +12751,6 @@
 /area/rogue/under/town/basement/keep)
 "mrL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -13249,8 +12799,8 @@
 /area/rogue/under/town/sewer)
 "mva" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/cloth,
 /obj/item/natural/bundle/cloth{
@@ -13272,8 +12822,8 @@
 /area/rogue/outdoors/town/roofs/keep)
 "mvz" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
@@ -13282,8 +12832,8 @@
 /area/rogue/indoors/town/church)
 "mvF" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Heir's Apartment";
-	lockid = "heir"
+	lockid = "heir";
+	name = "Heir's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -13305,8 +12855,7 @@
 "mxw" = (
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "mxz" = (
@@ -13317,9 +12866,7 @@
 /area/rogue/indoors/town/garrison)
 "mxK" = (
 /obj/structure/bars,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "myb" = (
 /obj/structure/rack/rogue/shelf/big{
@@ -13332,15 +12879,12 @@
 /area/rogue/outdoors/town)
 "myj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/item/roguebin/water,
@@ -13348,7 +12892,6 @@
 /area/rogue/outdoors/town)
 "myk" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
@@ -13371,8 +12914,8 @@
 "mzg" = (
 /obj/structure/winch{
 	dir = 4;
-	pixel_x = -7;
 	gid = "thronegate";
+	pixel_x = -7;
 	redstone_id = "thronegate"
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -13410,14 +12953,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "mBm" = (
-/obj/structure/mineral_door/bars,
-/turf/open/floor/rogue/cobble,
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement)
 "mBU" = (
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave)
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
+	},
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/basement)
 "mCu" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -13435,7 +12980,6 @@
 /area/rogue/indoors/town/garrison)
 "mDM" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
@@ -13462,11 +13006,9 @@
 /area/rogue/outdoors/town)
 "mEu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9;
 	pixel_y = -25
 	},
@@ -13498,19 +13040,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "mGi" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
+/obj/effect/landmark/events/haunts,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "mGS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -13685,7 +13222,6 @@
 "mTX" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/effect/landmark/start/squire{
-	icon_state = "arrow";
 	dir = 4
 	},
 /obj/structure/bed/rogue,
@@ -13695,8 +13231,8 @@
 /area/rogue/indoors/town/garrison)
 "mUJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/storage/roguebag{
 	pixel_x = -7;
@@ -13707,8 +13243,8 @@
 /area/rogue/indoors/town/dwarfin)
 "mUR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter{
 	dir = 2
@@ -13833,8 +13369,8 @@
 /obj/item/kitchen/rollingpin,
 /obj/structure/rack/rogue/shelf,
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = 5;
@@ -13862,9 +13398,9 @@
 /area/rogue/indoors/town)
 "naO" = (
 /obj/structure/mineral_door/wood{
-	name = "nitemaiden chambers";
 	locked = 1;
-	lockid = "nightmaiden"
+	lockid = "nightmaiden";
+	name = "nitemaiden chambers"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
@@ -13888,8 +13424,8 @@
 "nbM" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
+	dir = 4;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
@@ -13901,7 +13437,6 @@
 "ncQ" = (
 /obj/structure/flora/roguegrass,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble/mossy,
@@ -13923,7 +13458,6 @@
 /area/rogue/outdoors/town)
 "ndm" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -13932,8 +13466,8 @@
 /area/rogue/indoors/town/physician)
 "ndv" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
@@ -13961,7 +13495,6 @@
 /area/rogue/under/town/basement/keep)
 "neL" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -13969,7 +13502,6 @@
 "nfy" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -13977,8 +13509,10 @@
 	},
 /area/rogue/indoors/town)
 "ngp" = (
-/obj/structure/fluff/walldeco/customflag,
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/structure/bars/passage{
+	redstone_id = "tourneytop"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "ngx" = (
 /obj/machinery/light/rogue/firebowl/standing,
@@ -13989,18 +13523,16 @@
 /area/rogue/indoors/town/bath)
 "ngM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "ngZ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/carpet/inn,
@@ -14013,7 +13545,6 @@
 /area/rogue/indoors/town/manor)
 "nho" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -14065,14 +13596,12 @@
 /area/rogue/outdoors/town)
 "nkZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "nlp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/water/bath,
@@ -14093,7 +13622,6 @@
 /area/rogue/indoors/town/garrison)
 "nlJ" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -14109,7 +13637,6 @@
 /area/rogue/under/town/basement)
 "nmj" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
@@ -14123,8 +13650,8 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "nna" = (
@@ -14137,7 +13664,6 @@
 /area/rogue/outdoors/rtfield)
 "nov" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -14145,8 +13671,8 @@
 "noF" = (
 /obj/structure/fluff/canopy,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -14160,8 +13686,8 @@
 /area/rogue/indoors/town/church/chapel)
 "npT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -14186,12 +13712,10 @@
 /area/rogue/indoors/town/manor)
 "nqC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "nqQ" = (
@@ -14208,7 +13732,6 @@
 /area/rogue/outdoors/town)
 "nrp" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/hexstone,
@@ -14234,12 +13757,9 @@
 /area/rogue/indoors/town/magician)
 "nsb" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "nsf" = (
 /obj/structure/flora/roguegrass/bush,
@@ -14250,19 +13770,17 @@
 /area/rogue/outdoors/town)
 "nsg" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "nsk" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
+	dir = 4;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
@@ -14293,7 +13811,6 @@
 /area/rogue/indoors/town/bath)
 "nto" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -14351,7 +13868,6 @@
 /area/rogue/indoors/town/manor)
 "nwO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/fluff/railing/border,
@@ -14375,8 +13891,8 @@
 /area/rogue/under/town/sewer)
 "nyM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -14386,7 +13902,6 @@
 "nyR" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/grassyel,
@@ -14404,11 +13919,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
 "nAP" = (
-/obj/structure/lever/wall{
-	pixel_x = 32;
-	redstone_id = "tourneytop"
-	},
-/turf/open/floor/rogue/cobble,
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
 "nBk" = (
 /obj/structure/fermenting_barrel/water,
@@ -14440,8 +13952,8 @@
 /area/rogue/indoors/town/bath)
 "nFb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/cobble,
@@ -14461,8 +13973,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "nGm" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "nGn" = (
@@ -14471,8 +13983,8 @@
 /area/rogue/indoors/town/manor)
 "nGr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/neck/roguetown/coif,
 /obj/item/clothing/mask/bandana/black,
@@ -14494,8 +14006,8 @@
 /area/rogue/indoors/town/dwarfin)
 "nHP" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
@@ -14521,7 +14033,6 @@
 /area/rogue/indoors/town/church)
 "nIN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/couchablack/r,
@@ -14579,8 +14090,8 @@
 /area/rogue/indoors/town/tavern)
 "nKp" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "northgate_outer"
 	},
 /turf/open/floor/rogue/metal{
@@ -14623,8 +14134,7 @@
 /area/rogue/indoors/town/shop)
 "nMp" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
@@ -14650,17 +14160,17 @@
 /area/rogue/outdoors/town)
 "nNw" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stables";
+	keylock = 1;
 	locked = 1;
 	lockid = "manor";
-	keylock = 1
+	name = "stables"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "nNH" = (
 /obj/structure/toilet/greyscale{
-	name = "The Royal Shitter";
-	color = "#ffee00"
+	color = "#ffee00";
+	name = "The Royal Shitter"
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/hexstone,
@@ -14682,9 +14192,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
 "nOZ" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir"
-	},
+/obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "nPa" = (
@@ -14702,8 +14210,8 @@
 /area/rogue/indoors/town/tavern)
 "nPH" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -14715,8 +14223,8 @@
 /area/rogue/outdoors/rtfield)
 "nQa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/roguekey/lord,
 /turf/open/floor/rogue/ruinedwood{
@@ -14743,8 +14251,8 @@
 /area/rogue/outdoors/rtfield)
 "nQQ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -14781,18 +14289,15 @@
 /area/rogue/under/town/basement)
 "nRN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "nRX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -14811,7 +14316,6 @@
 /area/rogue/indoors/town/tavern)
 "nSu" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -14837,7 +14341,6 @@
 /area/rogue/indoors/town/manor)
 "nTR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -14850,7 +14353,6 @@
 /area/rogue/indoors/town)
 "nUn" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -14861,7 +14363,6 @@
 /area/rogue/indoors/town/tavern)
 "nVd" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/structure/fluff/clodpile,
@@ -14887,15 +14388,14 @@
 /area/rogue/indoors/town)
 "nWw" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
 "nWK" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -14945,12 +14445,11 @@
 	},
 /area/rogue/indoors/town/magician)
 "nZx" = (
-/obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
-	dir = 4
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = 32
 	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/tavern)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "nZW" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/globe,
@@ -14968,17 +14467,16 @@
 /area/rogue/indoors/town/manor)
 "oaL" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "oaV" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/structure/bars/passage{
+	redstone_id = "tourneybottom"
 	},
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "obx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -15004,9 +14502,7 @@
 /area/rogue/indoors/town/church/chapel)
 "ocH" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "ocI" = (
 /obj/effect/decal/cobbleedge{
@@ -15041,12 +14537,10 @@
 /area/rogue/indoors/town/tavern)
 "oew" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "oeW" = (
@@ -15092,11 +14586,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/tile{
@@ -15126,7 +14618,6 @@
 /area/rogue/indoors/town/tavern)
 "ohE" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15135,7 +14626,6 @@
 /area/rogue/indoors/town/church/chapel)
 "ohF" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15148,15 +14638,14 @@
 /area/rogue/indoors/town/tavern)
 "oim" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "oiN" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_y = 12
@@ -15182,7 +14671,6 @@
 /area/rogue/indoors/town/magician)
 "okO" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -15211,7 +14699,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "onk" = (
-/obj/machinery/light/rogue/torchholder/r,
+/obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "ono" = (
@@ -15231,8 +14719,8 @@
 /area/rogue/indoors/town/manor)
 "ooy" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/idagger/navaja,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -15305,19 +14793,16 @@
 /area/rogue/indoors/town/magician)
 "orK" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "orU" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "orW" = (
@@ -15336,7 +14821,6 @@
 	dir = 9
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -10
 	},
@@ -15354,11 +14838,9 @@
 /area/rogue/indoors/town/shop)
 "osM" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -15371,7 +14853,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -15395,11 +14876,9 @@
 /area/rogue/indoors/town)
 "otV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
@@ -15409,9 +14888,9 @@
 /area/rogue/outdoors/town)
 "otY" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Butchers House";
 	locked = 1;
-	lockid = "farm"
+	lockid = "farm";
+	name = "Butchers House"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -15419,8 +14898,8 @@
 /area/rogue/indoors/town)
 "ous" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/natural/feather,
 /obj/item/candle/skull/lit,
@@ -15428,8 +14907,7 @@
 /area/rogue/indoors/town/shop)
 "ouw" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "ouA" = (
@@ -15452,8 +14930,7 @@
 /area/rogue/outdoors/town)
 "ovs" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 2
+	icon_state = "longtable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
@@ -15501,8 +14978,8 @@
 /area/rogue/indoors/town/manor)
 "ozA" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/silk{
 	pixel_x = 5
@@ -15516,7 +14993,6 @@
 /area/rogue/indoors/town)
 "ozE" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15539,7 +15015,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -15609,8 +15084,8 @@
 /area/rogue/outdoors/town)
 "oCI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -15624,19 +15099,17 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "oDh" = (
-/obj/structure/chair/wood/rogue/fancy,
-/turf/open/floor/rogue/blocks,
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "oDn" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "oDH" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/concrete,
@@ -15665,9 +15138,7 @@
 /obj/item/natural/stone,
 /obj/item/natural/stone,
 /obj/item/natural/stone,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "oEk" = (
 /obj/structure/fluff/walldeco/painting{
@@ -15716,8 +15187,8 @@
 /area/rogue/indoors/town/physician)
 "oGR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = 3
@@ -15742,7 +15213,6 @@
 /area/rogue/indoors/town/garrison)
 "oIK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -15823,7 +15293,6 @@
 /area/rogue/indoors/town/manor)
 "oNE" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15851,8 +15320,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
@@ -15879,8 +15348,8 @@
 /area/rogue/indoors/town/manor)
 "oQn" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -15910,8 +15379,8 @@
 /area/rogue/indoors/town)
 "oRM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/natural/feather{
 	pixel_x = 8;
@@ -15930,9 +15399,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "oSV" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "oSX" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
@@ -15943,8 +15410,8 @@
 	dir = 10
 	},
 /obj/structure/lever/wall{
-	name = "outer passage lever";
 	dir = 4;
+	name = "outer passage lever";
 	pixel_x = 6;
 	redstone_id = "keepgate_outer"
 	},
@@ -15989,7 +15456,6 @@
 /area/rogue/outdoors/town)
 "oWN" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -16013,8 +15479,7 @@
 /area/rogue/indoors/town/tavern)
 "oXN" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
@@ -16048,15 +15513,14 @@
 /area/rogue/indoors/shelter/woods)
 "oZv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "oZH" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -16073,7 +15537,6 @@
 /area/rogue/indoors/town/church/chapel)
 "pag" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
@@ -16102,8 +15565,8 @@
 /area/rogue/outdoors/town)
 "pbB" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/garrison,
 /obj/item/storage/keyring,
@@ -16114,7 +15577,6 @@
 /area/rogue/indoors/town/garrison)
 "pcB" = (
 /obj/effect/decal/cobbleedge{
-	dir = 2;
 	pixel_y = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -16193,8 +15655,8 @@
 /area/rogue/indoors/town)
 "phI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -16236,9 +15698,7 @@
 "pjc" = (
 /obj/item/roguecoin/silver/pile,
 /obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "pjk" = (
 /obj/structure/flora/roguetree/burnt,
@@ -16260,7 +15720,6 @@
 /area/rogue/under/town/basement)
 "pjV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -16268,12 +15727,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
 "pjY" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "church"
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "pkc" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/cudgel,
@@ -16342,11 +15801,9 @@
 /area/rogue/indoors/town/church/chapel)
 "plY" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -16358,21 +15815,21 @@
 /area/rogue/indoors/town/manor)
 "pmA" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/under/town/sewer)
 "pmX" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/indoors/town/dwarfin)
 "pnh" = (
 /obj/structure/mineral_door/wood{
-	name = "stall ii";
 	locked = 1;
-	lockid = "stall2"
+	lockid = "stall2";
+	name = "stall ii"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -16389,8 +15846,8 @@
 "poj" = (
 /obj/item/cooking/pan,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -16423,9 +15880,7 @@
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "ppA" = (
 /obj/structure/bookcase/random/nonfiction,
@@ -16433,8 +15888,8 @@
 /area/rogue/indoors/town)
 "ppJ" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "prt" = (
@@ -16466,8 +15921,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "psG" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "ptr" = (
 /obj/structure/table/wood/fancy/royalblack,
@@ -16483,20 +15938,18 @@
 	pixel_x = -8
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "ptN" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town)
 "ptQ" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -16595,7 +16048,6 @@
 /area/rogue/outdoors/town/roofs)
 "pzs" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -16608,7 +16060,6 @@
 /area/rogue/outdoors/town)
 "pAl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -16636,7 +16087,6 @@
 "pBF" = (
 /obj/structure/closet/dirthole/grave,
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -16652,14 +16102,12 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "pCC" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -16710,9 +16158,9 @@
 /area/rogue/outdoors/town)
 "pFo" = (
 /obj/structure/mineral_door/wood{
-	name = "house ii";
 	locked = 1;
-	lockid = "house2"
+	lockid = "house2";
+	name = "house ii"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -16744,7 +16192,6 @@
 /area/rogue/outdoors/town)
 "pGK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/effect/decal/cobbleedge{
@@ -16762,7 +16209,6 @@
 "pGZ" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -16801,7 +16247,6 @@
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
 /obj/effect/landmark/start/servant{
-	icon_state = "arrow";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -16819,7 +16264,6 @@
 /area/rogue/indoors/town)
 "pIO" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -16853,8 +16297,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "pJQ" = (
@@ -16882,15 +16326,15 @@
 /area/rogue/indoors/town/manor)
 "pKz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "pKF" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -16914,7 +16358,6 @@
 /area/rogue/indoors/shelter/woods)
 "pLN" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -16954,11 +16397,9 @@
 /area/rogue/indoors/town)
 "pND" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -16980,9 +16421,9 @@
 /area/rogue/indoors/town/church/chapel)
 "pOd" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM I";
 	locked = 1;
-	lockid = "roomi"
+	lockid = "roomi";
+	name = "ROOM I"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -16991,17 +16432,17 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "pOo" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 6
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement)
 "pOp" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -17009,8 +16450,8 @@
 /area/rogue/under/town/basement/keep)
 "pOG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/redwine,
 /turf/open/floor/rogue/ruinedwood{
@@ -17025,7 +16466,6 @@
 /area/rogue/indoors/town/shop)
 "pPu" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -17042,7 +16482,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
@@ -17053,12 +16492,10 @@
 /area/rogue/outdoors/rtfield)
 "pQT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "pRj" = (
@@ -17067,16 +16504,16 @@
 /area/rogue/indoors/town)
 "pRx" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Marshal's Quarters";
 	locked = 1;
-	lockid = "sheriff"
+	lockid = "sheriff";
+	name = "Marshal's Quarters"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "pRI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/storage/keyring,
 /obj/item/roguekey/merchant,
@@ -17100,7 +16537,6 @@
 /area/rogue/under/town/basement/keep)
 "pTw" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -17117,14 +16553,12 @@
 /area/rogue/outdoors/town)
 "pUo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "pUt" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 8;
 	locked = 1;
 	lockid = "steward"
@@ -17167,7 +16601,6 @@
 /area/rogue/indoors/town/tavern)
 "pWV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/carpet/royalblack,
@@ -17195,7 +16628,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "pYo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -17208,7 +16640,6 @@
 /area/rogue/outdoors/rtfield)
 "pYV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -17223,7 +16654,6 @@
 /area/rogue/under/town/basement)
 "pZI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -17263,8 +16693,7 @@
 "qbF" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "qbL" = (
@@ -17277,7 +16706,6 @@
 /area/rogue/indoors/town)
 "qcS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -17288,7 +16716,6 @@
 /area/rogue/indoors/town/dwarfin)
 "qdX" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -17355,8 +16782,8 @@
 /area/rogue/outdoors/town/roofs)
 "qhq" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Apartment";
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -17438,9 +16865,9 @@
 /area/rogue/outdoors/town/roofs/keep)
 "qly" = (
 /obj/structure/mineral_door/wood/violet{
-	name = "STAFF";
 	locked = 1;
-	lockid = "tavern"
+	lockid = "tavern";
+	name = "STAFF"
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
@@ -17462,8 +16889,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper,
 /turf/open/floor/rogue/herringbone,
@@ -17491,9 +16918,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
 "qqw" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "qqS" = (
 /obj/structure/roguemachine/scomm,
@@ -17517,18 +16942,16 @@
 /area/rogue/indoors/town/manor)
 "qsr" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
 "qsO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -17545,7 +16968,6 @@
 /area/rogue/outdoors/rtfield)
 "quo" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -17559,8 +16981,8 @@
 "qvo" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
@@ -17572,8 +16994,8 @@
 /area/rogue/indoors/town)
 "qvM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
@@ -17665,17 +17087,15 @@
 /area/rogue/indoors/town)
 "qzM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/rtfield)
 "qzO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -17725,8 +17145,8 @@
 /area/rogue/indoors/town/bath)
 "qAV" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
@@ -17735,10 +17155,10 @@
 	dir = 9
 	},
 /obj/structure/mineral_door/wood/donjon{
-	name = "keep entrance";
 	dir = 1;
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "keep entrance"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -17774,7 +17194,6 @@
 /area/rogue/indoors/town/tavern)
 "qBM" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -17788,7 +17207,6 @@
 /area/rogue/outdoors/town)
 "qDm" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -17802,12 +17220,9 @@
 /area/rogue/indoors/town/shop)
 "qDY" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "qEa" = (
 /obj/effect/decal/cobbleedge{
@@ -17821,8 +17236,8 @@
 /area/rogue/outdoors/rtfield)
 "qEs" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -17848,19 +17263,17 @@
 /area/rogue/indoors/town/dwarfin)
 "qFO" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "qGh" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
@@ -17909,16 +17322,14 @@
 /area/rogue/indoors/town/shop)
 "qIz" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/bars{
 	icon_state = "barsbent";
 	layer = 2.81
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "qIK" = (
 /obj/structure/flora/roguegrass,
@@ -17938,7 +17349,6 @@
 /area/rogue/indoors/town/church/chapel)
 "qJJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -17965,8 +17375,8 @@
 /area/rogue/indoors/town/magician)
 "qMb" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -17989,8 +17399,8 @@
 /area/rogue/outdoors/town)
 "qOg" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -18039,9 +17449,7 @@
 /area/rogue/indoors/town/church/chapel)
 "qPZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "qQt" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -18086,16 +17494,16 @@
 /area/rogue/indoors/town/tavern)
 "qTJ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -18113,14 +17521,12 @@
 /area/rogue/indoors/town/tavern)
 "qVz" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/fluff/railing/border{
@@ -18149,10 +17555,10 @@
 /area/rogue/indoors/town)
 "qWI" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Throne Room";
 	dir = 1;
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Throne Room"
 	},
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
@@ -18187,20 +17593,17 @@
 /area/rogue/indoors/town/magician)
 "qXF" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "qXK" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "qYz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -18260,7 +17663,6 @@
 /area/rogue/indoors/town/garrison)
 "rab" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/customflag{
@@ -18299,11 +17701,10 @@
 "raV" = (
 /obj/machinery/light/rogue/firebowl/church,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -18316,7 +17717,6 @@
 	pixel_y = -32
 	},
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -18333,7 +17733,6 @@
 	pixel_y = 32
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -18346,8 +17745,8 @@
 /area/rogue/under/town/basement/keep)
 "rcJ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -18389,7 +17788,6 @@
 /area/rogue/under/town/basement/keep)
 "reZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -18435,7 +17833,6 @@
 	dir = 6
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -18452,8 +17849,8 @@
 /area/rogue/indoors/shelter/woods)
 "rho" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/elfred,
 /obj/item/reagent_containers/glass/cup/silver{
@@ -18466,7 +17863,6 @@
 /area/rogue/indoors/town/manor)
 "rhr" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -18503,15 +17899,14 @@
 /area/rogue/indoors)
 "rjw" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "rjG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/needle/thorn,
@@ -18523,7 +17918,6 @@
 	},
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/twig,
@@ -18534,8 +17928,8 @@
 /area/rogue/indoors/town/bath)
 "rkv" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
@@ -18545,8 +17939,8 @@
 /area/rogue/indoors/town/church)
 "rkL" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = -13;
@@ -18556,18 +17950,17 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "rkX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/basement)
 "rmy" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/item/roguegem/violet,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rou" = (
 /obj/item/roguebin/water/gross,
@@ -18577,30 +17970,26 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "roA" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
 "roU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rpj" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "rpq" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "forestout";
+	aallmig = "rwfieldin1";
 	aportalgoesto = "forestin";
-	aallmig = "rwfieldin1"
+	aportalid = "forestout"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
@@ -18625,7 +18014,6 @@
 /area/rogue/indoors/town/bath)
 "rtf" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -18635,8 +18023,8 @@
 /area/rogue/indoors/town/church)
 "rtH" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogue/instrument/drum,
 /obj/structure/fluff/walldeco/customflag{
@@ -18650,9 +18038,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ruG" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "ruM" = (
 /obj/structure/rack/rogue,
@@ -18673,7 +18059,6 @@
 	dir = 10
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -18681,7 +18066,6 @@
 /area/rogue/indoors/town/garrison)
 "rvA" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -18701,8 +18085,8 @@
 /area/rogue/indoors/town/dwarfin)
 "rwd" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
@@ -18763,7 +18147,6 @@
 /area/rogue/indoors/town)
 "rAJ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/villager{
@@ -18776,8 +18159,8 @@
 /area/rogue/indoors/town/tavern)
 "rBd" = (
 /obj/structure/lever/wall{
-	name = "drawbridge lever";
 	dir = 4;
+	name = "drawbridge lever";
 	pixel_x = 6;
 	pixel_y = 9;
 	redstone_id = "gatelava"
@@ -18785,8 +18168,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "rCx" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "rCz" = (
 /obj/structure/flora/roguegrass/bush,
@@ -18803,19 +18186,18 @@
 /area/rogue/outdoors/town)
 "rCZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "rDa" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
@@ -18825,8 +18207,8 @@
 /area/rogue/indoors/town/manor)
 "rDj" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "rDz" = (
@@ -18842,7 +18224,6 @@
 /area/rogue/indoors/town/manor)
 "rDX" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -18881,8 +18262,8 @@
 /area/rogue/indoors/town)
 "rGy" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -18942,11 +18323,9 @@
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -18957,7 +18336,6 @@
 /area/rogue/under/town/basement)
 "rKE" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -18984,8 +18362,8 @@
 "rLe" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
@@ -19029,11 +18407,9 @@
 /area/rogue/indoors/town)
 "rNp" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -19057,8 +18433,8 @@
 /area/rogue/outdoors/town)
 "rOJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -19066,8 +18442,8 @@
 /area/rogue/indoors/town)
 "rOL" = (
 /obj/structure/mineral_door/bars{
-	lockid = "graveyard";
-	locked = 1
+	locked = 1;
+	lockid = "graveyard"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -19085,11 +18461,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -19113,16 +18487,16 @@
 /area/rogue/under/town/sewer)
 "rQG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "rQI" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 8
@@ -19131,7 +18505,6 @@
 "rQJ" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -19144,7 +18517,6 @@
 /area/rogue/indoors/town)
 "rRc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -19152,7 +18524,6 @@
 /area/rogue/under/town/basement)
 "rRf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -19187,8 +18558,8 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -19222,7 +18593,6 @@
 /area/rogue/indoors/town)
 "rSR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/closet/crate/chest/neu,
@@ -19254,8 +18624,8 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/wallclock,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -19279,7 +18649,6 @@
 /area/rogue/under/town/basement)
 "rVC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -19290,9 +18659,9 @@
 /area/rogue/outdoors/town)
 "rWN" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Hand's Chambers";
 	locked = 1;
-	lockid = "hand"
+	lockid = "hand";
+	name = "Hand's Chambers"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -19312,8 +18681,8 @@
 /area/rogue/outdoors/town)
 "rZc" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_x = 5;
@@ -19322,27 +18691,22 @@
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_y = 10
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rZv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "sac" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "saf" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/structure/fluff/wallclock,
@@ -19354,8 +18718,8 @@
 /area/rogue/outdoors/town)
 "saM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/flint{
 	pixel_x = -6;
@@ -19369,9 +18733,9 @@
 /area/rogue/under/town/basement)
 "saU" = (
 /obj/structure/mineral_door/wood{
-	name = "alchemy";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "alchemy"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -19406,7 +18770,6 @@
 /area/rogue/outdoors/rtfield)
 "scg" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/grass,
@@ -19481,9 +18844,9 @@
 /area/rogue/indoors/town)
 "sgY" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM VI";
 	locked = 1;
-	lockid = "roomvi"
+	lockid = "roomvi";
+	name = "ROOM VI"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -19510,15 +18873,15 @@
 /area/rogue/indoors/town)
 "sid" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "sif" = (
 /obj/structure/gate{
-	name = "The Throne";
 	gid = "thronegate";
+	name = "The Throne";
 	redstone_id = "thronegate"
 	},
 /turf/open/floor/rogue/carpet/lord/left,
@@ -19585,7 +18948,6 @@
 /area/rogue/indoors/town/bath)
 "skH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -19599,8 +18961,8 @@
 "sma" = (
 /obj/structure/fluff/canopy,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -19621,16 +18983,16 @@
 "sns" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "snM" = (
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -19646,8 +19008,8 @@
 	},
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/pillory/reinforced,
 /turf/open/floor/rogue/cobblerock,
@@ -19709,8 +19071,7 @@
 "ssO" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "ssW" = (
@@ -19722,8 +19083,8 @@
 /area/rogue/indoors/town)
 "ssZ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
@@ -19762,7 +19123,6 @@
 /area/rogue/indoors/town)
 "suw" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/closet/crate/chest/old_crate,
@@ -19771,7 +19131,6 @@
 /area/rogue/indoors/town)
 "sux" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -19784,7 +19143,6 @@
 "suz" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19823,7 +19181,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19836,7 +19193,6 @@
 /area/rogue/outdoors/town)
 "syj" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -19886,7 +19242,6 @@
 /area/rogue/indoors/town/manor)
 "sAZ" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -19895,8 +19250,8 @@
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/cobble,
@@ -19926,7 +19281,6 @@
 /area/rogue/under/town/sewer)
 "sDO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -19963,7 +19317,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -19976,9 +19329,7 @@
 /area/rogue/indoors/town)
 "sGb" = (
 /obj/structure/table/wood/crafted,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "sGz" = (
 /obj/effect/decal/cobbleedge,
@@ -19987,8 +19338,8 @@
 /area/rogue/outdoors/town)
 "sHe" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/ruinedwood{
@@ -20009,9 +19360,7 @@
 /area/rogue/indoors/town)
 "sHo" = (
 /obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "sHU" = (
 /obj/structure/chair/wood/rogue,
@@ -20035,8 +19384,8 @@
 /area/rogue/indoors/town/church)
 "sKe" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -20045,9 +19394,7 @@
 /area/rogue/under/town/basement/keep)
 "sKi" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 4;
-	locked = 0;
 	lockid = "nightmaiden"
 	},
 /turf/open/floor/rogue/hexstone,
@@ -20068,7 +19415,6 @@
 /area/rogue/outdoors/town/roofs)
 "sLb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -20078,7 +19424,6 @@
 /area/rogue/outdoors/town)
 "sLy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/stairs/stone{
@@ -20088,14 +19433,12 @@
 /area/rogue/outdoors/town)
 "sLH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "sLS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -20129,15 +19472,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "sMD" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "sNg" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/toy/cards/deck{
 	pixel_x = 3;
@@ -20154,9 +19495,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement/keep)
 "sNI" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 2
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/shop)
 "sOm" = (
 /obj/structure/stairs{
@@ -20183,26 +19522,21 @@
 /area/rogue/indoors/town/tavern)
 "sQg" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "sQv" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "sRc" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "sRz" = (
 /obj/structure/flora/roguegrass/bush,
@@ -20210,8 +19544,8 @@
 /area/rogue/outdoors/town)
 "sRP" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "sRU" = (
@@ -20260,7 +19594,6 @@
 /area/rogue/indoors/town/shop)
 "sUt" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -20275,12 +19608,10 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "sVH" = (
@@ -20297,12 +19628,12 @@
 /area/rogue/outdoors/exposed/town/keep)
 "sWd" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "sWi" = (
@@ -20330,16 +19661,15 @@
 /area/rogue/under/town/basement)
 "sXv" = (
 /obj/structure/mineral_door/wood{
-	name = "house v";
 	locked = 1;
-	lockid = "house5"
+	lockid = "house5";
+	name = "house v"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "sXy" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -20358,7 +19688,6 @@
 /area/rogue/indoors/town)
 "sXQ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/villager{
@@ -20373,7 +19702,6 @@
 /area/rogue/indoors/town/cell)
 "sZw" = (
 /obj/structure/stairs/fancy/c{
-	icon_state = "fancy_stairs_c";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord,
@@ -20446,12 +19774,12 @@
 /area/rogue/under/town/basement/keep)
 "tdu" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Farm";
 	dir = 8;
+	lock_strength = 100;
 	locked = 1;
 	lockid = "farm";
-	lock_strength = 100;
-	max_integrity = 1000
+	max_integrity = 1000;
+	name = "Farm"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -20464,7 +19792,6 @@
 "tei" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -20490,7 +19817,6 @@
 "tfo" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/chair/bench{
-	icon_state = "bench";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -20502,8 +19828,8 @@
 	redstone_id = "armourer_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -20651,14 +19977,13 @@
 /area/rogue/under/town/basement/keep)
 "tjp" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Restroom";
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Restroom"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "tjy" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -20670,8 +19995,8 @@
 /area/rogue/indoors/town)
 "tkg" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/clothing/cloak/apron/waist,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -20766,12 +20091,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "toL" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/beach)
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/under/town/sewer)
 "tqe" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/dirt/road,
@@ -20783,8 +20104,8 @@
 /area/rogue/indoors/town/physician)
 "tqC" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 12
@@ -20862,15 +20183,14 @@
 /area/rogue/indoors/town/magician)
 "tuG" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "tvk" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20893,9 +20213,7 @@
 "tvU" = (
 /obj/structure/chair/bench/ultimacouch,
 /obj/structure/fluff/walldeco/maidensigil/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "tvX" = (
 /turf/closed/wall/mineral/rogue/decowood,
@@ -20959,22 +20277,18 @@
 /area/rogue/indoors/town/bath)
 "tyv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
 "tyQ" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "tzi" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/guardsman,
@@ -20999,9 +20313,7 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "tAB" = (
 /obj/structure/table/wood{
@@ -21084,7 +20396,6 @@
 /area/rogue/indoors/shelter/woods)
 "tFb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/carpet/royalblack,
@@ -21113,8 +20424,8 @@
 /area/rogue/indoors/town/physician)
 "tGt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
@@ -21151,9 +20462,9 @@
 /area/rogue/indoors/town)
 "tHJ" = (
 /obj/structure/mineral_door/wood{
-	name = "stall iii";
 	locked = 1;
-	lockid = "stall3"
+	lockid = "stall3";
+	name = "stall iii"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -21174,11 +20485,9 @@
 /area/rogue/indoors/town/garrison)
 "tJs" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -21187,9 +20496,7 @@
 /obj/structure/closet/crate/chest/neu,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "tKw" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -21199,7 +20506,6 @@
 /area/rogue/indoors/town)
 "tKP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -21263,9 +20569,9 @@
 /area/rogue/outdoors/town/roofs/keep)
 "tPt" = (
 /obj/structure/mineral_door/wood{
-	name = "house iii";
 	locked = 1;
-	lockid = "house3"
+	lockid = "house3";
+	name = "house iii"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -21357,8 +20663,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "tUv" = (
@@ -21371,9 +20676,9 @@
 /area/rogue/indoors/town/bath)
 "tVc" = (
 /obj/structure/mineral_door/wood{
-	name = "house vi";
 	locked = 1;
-	lockid = "house6"
+	lockid = "house6";
+	name = "house vi"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -21388,7 +20693,6 @@
 /area/rogue/outdoors/town)
 "tVM" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -21407,8 +20711,8 @@
 /area/rogue/outdoors/town)
 "tWM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge,
 /obj/structure/flora/roguegrass,
@@ -21416,29 +20720,26 @@
 /area/rogue/outdoors/town)
 "tXc" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "tXs" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "tXX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "tXZ" = (
 /turf/open/transparent/openspace,
@@ -21453,8 +20754,8 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/bars/passage/shutter{
 	redstone_id = "weaponsmith_shutter"
@@ -21463,8 +20764,7 @@
 /area/rogue/indoors/town/dwarfin)
 "tYX" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "tZa" = (
@@ -21523,8 +20823,8 @@
 	dir = 1
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/ruinedwood{
@@ -21651,7 +20951,6 @@
 /area/rogue/indoors/town)
 "ukZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -21664,7 +20963,6 @@
 /area/rogue/outdoors/rtfield)
 "ulo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/effect/decal/cobbleedge{
@@ -21684,7 +20982,6 @@
 /area/rogue/outdoors/rtfield)
 "umV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -21692,7 +20989,6 @@
 /area/rogue/indoors/town)
 "umX" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -21765,7 +21061,6 @@
 	dir = 5
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -21795,8 +21090,8 @@
 /area/rogue/under/cave)
 "usq" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -21814,7 +21109,6 @@
 /area/rogue/indoors/town/magician)
 "uto" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -21841,9 +21135,9 @@
 /area/rogue/indoors/town/dwarfin)
 "uut" = (
 /obj/structure/mineral_door/wood{
-	name = "house i";
 	locked = 1;
-	lockid = "house1"
+	lockid = "house1";
+	name = "house i"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -21860,7 +21154,6 @@
 /area/rogue/indoors/town/manor)
 "uuU" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -21877,8 +21170,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "uvq" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 8
+	dir = 8;
+	icon_state = "longtable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -21957,7 +21250,6 @@
 /area/rogue/indoors/town/tavern)
 "uyA" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -21975,7 +21267,6 @@
 /area/rogue/under/cave)
 "uzB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/blocks,
@@ -21983,9 +21274,7 @@
 "uzK" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "uAV" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
@@ -22027,15 +21316,14 @@
 /area/rogue/outdoors/town)
 "uDd" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
 "uDo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -22048,8 +21336,8 @@
 /area/rogue/indoors/town)
 "uDt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -22074,13 +21362,10 @@
 /area/rogue/indoors/town/physician)
 "uDM" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "uDU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22104,7 +21389,6 @@
 /area/rogue/indoors/town/bath)
 "uEl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22175,8 +21459,8 @@
 /area/rogue/indoors/town)
 "uJa" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/mossy{
 	dir = 1
@@ -22185,12 +21469,10 @@
 /area/rogue/outdoors/town)
 "uJi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "uKb" = (
@@ -22216,8 +21498,8 @@
 /area/rogue/under/town/basement)
 "uMk" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church)
@@ -22235,8 +21517,8 @@
 /area/rogue/indoors/town)
 "uMM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /obj/structure/fluff/canopy,
@@ -22261,8 +21543,8 @@
 /area/rogue/outdoors/town)
 "uON" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/under/cave)
 "uOU" = (
@@ -22290,7 +21572,6 @@
 /area/rogue/under/town/basement)
 "uRK" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22299,18 +21580,17 @@
 /area/rogue/indoors/town/manor)
 "uRQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/rtfield)
 "uRZ" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/paper,
 /obj/item/paper,
@@ -22347,7 +21627,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "uTW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -22367,7 +21646,6 @@
 /area/rogue/outdoors/town)
 "uVa" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -22429,7 +21707,6 @@
 /area/rogue/outdoors/town/roofs/keep)
 "uZr" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood{
@@ -22446,8 +21723,8 @@
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -22462,9 +21739,9 @@
 /area/rogue/outdoors/town)
 "uZR" = (
 /obj/structure/mineral_door/wood{
-	name = "HUNT ROOM";
 	locked = 1;
-	lockid = "roomhunt"
+	lockid = "roomhunt";
+	name = "HUNT ROOM"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
@@ -22496,7 +21773,6 @@
 "vcp" = (
 /obj/item/reagent_containers/food/snacks/cracker,
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/grassyel,
@@ -22552,7 +21828,6 @@
 /area/rogue/indoors/town/church)
 "vgA" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22561,7 +21836,6 @@
 /area/rogue/indoors/town)
 "vgF" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -22588,8 +21862,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -22601,9 +21875,7 @@
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "viU" = (
 /obj/structure/flora/roguegrass,
@@ -22615,7 +21887,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -22647,14 +21918,13 @@
 /area/rogue/indoors/town)
 "vnC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church)
 "vnL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22681,7 +21951,6 @@
 /area/rogue/outdoors/town/roofs)
 "vpm" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/effect/landmark/start/monk{
@@ -22693,12 +21962,12 @@
 /area/rogue/indoors/town/church/chapel)
 "vps" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Farm";
 	dir = 4;
+	lock_strength = 100;
 	locked = 1;
 	lockid = "farm";
-	lock_strength = 100;
-	max_integrity = 1000
+	max_integrity = 1000;
+	name = "Farm"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -22752,7 +22021,6 @@
 /area/rogue/indoors/town/manor)
 "vtR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -22796,15 +22064,14 @@
 /area/rogue/indoors/town)
 "vvP" = (
 /obj/structure/mineral_door/wood{
-	name = "examination room";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "examination room"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "vvV" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22815,15 +22082,11 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
-"vwK" = (
-/obj/effect/landmark/events/haunts,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "vwW" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Servant's Entry";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Servant's Entry"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
@@ -22895,8 +22158,8 @@
 /area/rogue/indoors/town)
 "vCO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/flint{
 	pixel_x = -1
@@ -22916,9 +22179,9 @@
 /area/rogue/indoors/town/church/chapel)
 "vCS" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM IV";
 	locked = 1;
-	lockid = "roomiv"
+	lockid = "roomiv";
+	name = "ROOM IV"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -23021,7 +22284,6 @@
 /area/rogue/indoors/town/church)
 "vHV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23040,7 +22302,6 @@
 /area/rogue/indoors/town/garrison)
 "vIQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -23056,7 +22317,6 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -23111,7 +22371,6 @@
 /area/rogue/under/town/basement/keep)
 "vMx" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/grassyel,
@@ -23166,7 +22425,6 @@
 /area/rogue/indoors/town/magician)
 "vRD" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /obj/structure/flora/roguegrass/bush/wall,
@@ -23179,7 +22437,6 @@
 /area/rogue/indoors/town/garrison)
 "vTk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23280,12 +22537,12 @@
 /area/rogue/indoors/town/garrison)
 "vYw" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
@@ -23336,7 +22593,6 @@
 /area/rogue/under/town/basement)
 "wdv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -23344,11 +22600,9 @@
 "wdX" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/church,
@@ -23371,28 +22625,27 @@
 /area/rogue/indoors/town)
 "weU" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "weW" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "weZ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "wfp" = (
@@ -23446,9 +22699,7 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /obj/item/kitchen/rollingpin,
 /obj/item/rogueweapon/huntingknife/chefknife,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "wiX" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -23493,7 +22744,6 @@
 /area/rogue/indoors/town)
 "wlk" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -23506,9 +22756,9 @@
 /area/rogue/indoors/town/tavern)
 "wms" = (
 /obj/structure/mineral_door/wood{
-	name = "house ii";
 	locked = 1;
-	lockid = "house2"
+	lockid = "house2";
+	name = "house ii"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -23523,9 +22773,7 @@
 "wmN" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /obj/structure/fluff/walldeco/maidensigil,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "wmR" = (
 /obj/structure/flora/newleaf{
@@ -23536,27 +22784,27 @@
 /area/rogue/indoors/shelter/woods)
 "wmW" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "wnd" = (
 /obj/structure/closet/crate/chest{
-	name = "Spare keys";
-	icon_state = "woodchestalt";
+	base_icon_state = "woodchestalt";
 	color = "#8f7f62";
-	base_icon_state = "woodchestalt"
+	icon_state = "woodchestalt";
+	name = "Spare keys"
 	},
 /obj/item/roguekey/roomhunt,
 /obj/item/roguekey/roomiv{
-	name = "room VI key";
-	lockid = "roomvi"
+	lockid = "roomvi";
+	name = "room VI key"
 	},
 /obj/item/roguekey/roomiv{
-	name = "room V key";
-	lockid = "roomv"
+	lockid = "roomv";
+	name = "room V key"
 	},
 /obj/item/roguekey/roomiv,
 /obj/item/roguekey/roomiii,
@@ -23573,12 +22821,12 @@
 /area/rogue/indoors/town/magician)
 "wof" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -23600,7 +22848,6 @@
 /area/rogue/indoors/town/church/chapel)
 "wpL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/closet/crate/chest/neu,
@@ -23610,12 +22857,10 @@
 /area/rogue/indoors/town/church/chapel)
 "wpQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -23626,9 +22871,7 @@
 /area/rogue/indoors/town)
 "wqf" = (
 /obj/structure/fluff/psycross,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "wqm" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -23647,9 +22890,7 @@
 /obj/item/roguegem/green,
 /obj/item/roguegem/blue,
 /obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "wqJ" = (
 /obj/structure/table/wood{
@@ -23660,8 +22901,8 @@
 /area/rogue/under/town/basement/keep)
 "wrk" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -23679,14 +22920,12 @@
 	pixel_y = 0
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/rogueweapon/sword/long/exe/cloth,
 /obj/item/natural/stone,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "wss" = (
 /obj/structure/closet/crate/roguecloset,
@@ -23729,8 +22968,8 @@
 /area/rogue/indoors/town/manor)
 "wul" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -23743,10 +22982,10 @@
 /area/rogue/outdoors/town/roofs)
 "wuw" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "squireroom door";
 	dir = 1;
 	locked = 1;
-	lockid = "garrison"
+	lockid = "garrison";
+	name = "squireroom door"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -23759,7 +22998,6 @@
 /area/rogue/indoors/town/garrison)
 "wvf" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -23781,15 +23019,14 @@
 /area/rogue/indoors/town)
 "wxB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "wxH" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/effect/decal/wood/herringbone2,
 /obj/item/reagent_containers/glass/bowl,
@@ -23797,7 +23034,6 @@
 /area/rogue/indoors/town)
 "wxP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -23806,8 +23042,8 @@
 /area/rogue/indoors/town/manor)
 "wxS" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -23823,9 +23059,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "wyG" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "wyH" = (
 /obj/structure/closet/crate/roguecloset,
@@ -23853,15 +23087,15 @@
 /area/rogue/indoors/town)
 "wzd" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = 4;
@@ -23917,9 +23151,9 @@
 /area/rogue/outdoors/exposed/town/keep)
 "wAc" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "forestout_cave";
+	aallmig = "rwfieldin1";
 	aportalgoesto = "forestin_cave";
-	aallmig = "rwfieldin1"
+	aportalid = "forestout_cave"
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
@@ -23930,7 +23164,6 @@
 /area/rogue/indoors/town/dwarfin)
 "wBb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -24025,8 +23258,7 @@
 /area/rogue/outdoors/town)
 "wHt" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
@@ -24049,7 +23281,6 @@
 /area/rogue/outdoors/town)
 "wIe" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -24071,9 +23302,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
 "wJb" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "wJD" = (
@@ -24086,7 +23315,6 @@
 /area/rogue/indoors/town/manor)
 "wJI" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -24097,8 +23325,8 @@
 /area/rogue/indoors/town/church/chapel)
 "wKp" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/effect/landmark/events/testportal{
 	aportalloc = "manor"
@@ -24222,7 +23450,6 @@
 /area/rogue/outdoors/town/roofs)
 "wOa" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -24238,7 +23465,6 @@
 "wOE" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -24246,8 +23472,8 @@
 "wOS" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -24305,8 +23531,8 @@
 /area/rogue/indoors/town/bath)
 "wQM" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
@@ -24345,11 +23571,9 @@
 /area/rogue/indoors/town/manor)
 "wSp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -24366,13 +23590,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"wTk" = (
-/obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/tavern)
 "wTN" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -24401,7 +23618,6 @@
 /area/rogue/under/town/basement)
 "wUy" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -24437,9 +23653,9 @@
 /area/rogue/indoors/shelter/woods)
 "wVx" = (
 /obj/structure/mineral_door/wood/window{
-	name = "dungeoneer's room door";
 	locked = 1;
-	lockid = "dungeon"
+	lockid = "dungeon";
+	name = "dungeoneer's room door"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -24449,8 +23665,8 @@
 /area/rogue/indoors/town/garrison)
 "wVP" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -24470,8 +23686,8 @@
 /area/rogue/indoors/town/vault)
 "wWx" = (
 /obj/structure/roguemachine/mail/r{
-	pixel_x = -32;
-	mailtag = "Physician"
+	mailtag = "Physician";
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -24482,13 +23698,10 @@
 /area/rogue/under/town/basement/keep)
 "wXw" = (
 /obj/item/clothing/ring/silver,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "wXx" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/inn,
@@ -24508,30 +23721,27 @@
 /area/rogue/indoors/town/tavern)
 "wZC" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/under/town/basement)
 "wZH" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter{
-	name = "counter hatch";
 	dir = 2;
-	lockdir = 1
+	lockdir = 1;
+	name = "counter hatch"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "wZK" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -24552,14 +23762,13 @@
 /area/rogue/under/town/basement/keep)
 "xac" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
 "xaG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -24614,7 +23823,6 @@
 /area/rogue/indoors/town/magician)
 "xcM" = (
 /obj/effect/landmark/start/squire{
-	icon_state = "arrow";
 	dir = 4
 	},
 /obj/structure/bed/rogue,
@@ -24624,8 +23832,8 @@
 /area/rogue/indoors/town/garrison)
 "xcU" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/mirror,
 /obj/item/candle/yellow/lit{
@@ -24644,7 +23852,6 @@
 /area/rogue/under/town/basement/keep)
 "xeN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -24658,7 +23865,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -24682,8 +23888,8 @@
 /obj/item/natural/cloth,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -24693,18 +23899,13 @@
 /area/rogue/outdoors/rtfield)
 "xfN" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
-"xfP" = (
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/under/town/sewer)
 "xfU" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
@@ -24716,19 +23917,17 @@
 /area/rogue/indoors)
 "xgI" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "xgU" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Heir's Apartment";
 	locked = 1;
-	lockid = "heir"
+	lockid = "heir";
+	name = "Heir's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -24736,15 +23935,15 @@
 /area/rogue/indoors/town/manor)
 "xhj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "xhp" = (
@@ -24755,8 +23954,8 @@
 	dir = 6
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -24787,8 +23986,8 @@
 /area/rogue/outdoors/town)
 "xif" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper/scroll,
 /turf/open/floor/carpet/royalblack,
@@ -24827,8 +24026,8 @@
 /area/rogue/indoors/town/church/chapel)
 "xlv" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/indoors/town/dwarfin)
 "xlI" = (
@@ -24876,17 +24075,16 @@
 /area/rogue/outdoors/town/roofs/keep)
 "xmW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "xnf" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "bunkhouse";
 	dir = 1;
 	locked = 1;
-	lockid = "merc"
+	lockid = "merc";
+	name = "bunkhouse"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -24900,7 +24098,6 @@
 /area/rogue/indoors/town/manor)
 "xnB" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -24909,14 +24106,12 @@
 /obj/structure/fluff/railing/fence,
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "xnL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -24926,7 +24121,6 @@
 	pixel_y = 32
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -24952,10 +24146,7 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
 "xpL" = (
-/obj/effect/landmark/events/haunts{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "xpP" = (
@@ -24969,14 +24160,12 @@
 /area/rogue/indoors/town/dwarfin)
 "xpR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town/roofs)
 "xqi" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/inn,
@@ -25002,8 +24191,8 @@
 /area/rogue/indoors/town)
 "xrL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -25018,7 +24207,6 @@
 /area/rogue/indoors/town/garrison)
 "xrQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -25036,8 +24224,8 @@
 /area/rogue/under/town/sewer)
 "xtL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -25047,12 +24235,11 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xux" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "xuG" = (
@@ -25079,7 +24266,6 @@
 /area/rogue/indoors/town/manor)
 "xvM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -25093,8 +24279,8 @@
 /area/rogue/indoors/shelter/woods)
 "xwb" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "bogrtout";
-	aportalgoesto = "bogrtin"
+	aportalgoesto = "bogrtin";
+	aportalid = "bogrtout"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
@@ -25104,8 +24290,8 @@
 /area/rogue/indoors/town/cell)
 "xwr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/effect/decal/wood/herringbone2,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -25142,7 +24328,6 @@
 /area/rogue/under/town/basement/keep)
 "xxW" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/railing/fence,
@@ -25203,7 +24388,6 @@
 /area/rogue/indoors/shelter/woods)
 "xBk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -25230,13 +24414,10 @@
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "xCI" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/effect/landmark/start/villager{
@@ -25282,8 +24463,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -25328,16 +24509,16 @@
 /area/rogue/indoors/town/manor)
 "xHd" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement)
 "xIj" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/kitchen/spoon,
 /turf/open/floor/rogue/ruinedwood{
@@ -25400,8 +24581,8 @@
 /area/rogue/indoors/town)
 "xKL" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/carpet/red,
@@ -25418,7 +24599,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xMo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -25469,8 +24649,8 @@
 /area/rogue/indoors/town/church)
 "xOb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/rogue/trophy/deer,
 /obj/item/rogueweapon/sword/iron/short{
@@ -25487,9 +24667,7 @@
 "xOg" = (
 /obj/structure/toilet,
 /obj/effect/landmark/start/guardsman,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "xOq" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -25508,17 +24686,13 @@
 /area/rogue/outdoors/rtfield)
 "xOF" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "xOU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -25552,8 +24726,8 @@
 /area/rogue/outdoors/town)
 "xQm" = (
 /obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	locked = 1
+	locked = 1;
+	lockid = "church"
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
@@ -25595,8 +24769,8 @@
 /area/rogue/indoors/shelter/woods)
 "xQF" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
@@ -25614,8 +24788,8 @@
 	mailtag = "Warehouse"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -25632,19 +24806,17 @@
 /area/rogue/indoors/town/manor)
 "xRi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "xRp" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -25656,9 +24828,7 @@
 	icon_state = "barsbent";
 	layer = 2.81
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xRJ" = (
 /obj/effect/decal/cobbleedge{
@@ -25675,7 +24845,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xSg" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -25718,14 +24887,12 @@
 /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xUa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
@@ -25770,8 +24937,8 @@
 /area/rogue/indoors/town/dwarfin)
 "xVQ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /obj/item/kitchen/rollingpin,
@@ -25794,16 +24961,16 @@
 /area/rogue/indoors)
 "xXn" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "xXs" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /obj/effect/decal/cobbleedge{
@@ -25824,8 +24991,8 @@
 /area/rogue/indoors/town)
 "xYu" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -25871,14 +25038,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"yaa" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "yaE" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
@@ -25898,8 +25061,8 @@
 /area/rogue/indoors/town/tavern)
 "ybp" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -25917,8 +25080,8 @@
 /area/rogue/indoors/town/church/chapel)
 "ycO" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
@@ -25978,8 +25141,8 @@
 /area/rogue/indoors/town)
 "yeh" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -26010,14 +25173,12 @@
 /area/rogue/indoors/town/magician)
 "yev" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "yfg" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -26050,7 +25211,6 @@
 /area/rogue/indoors/town/manor)
 "yge" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
@@ -26068,9 +25228,9 @@
 /area/rogue/indoors/town/shop)
 "ygy" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM III";
 	locked = 1;
-	lockid = "roomiii"
+	lockid = "roomiii";
+	name = "ROOM III"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -26081,14 +25241,12 @@
 "yhY" = (
 /obj/structure/chair/stool/rogue,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "yie" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/grass,
@@ -26104,15 +25262,14 @@
 /area/rogue/indoors/town/church/chapel)
 "yiq" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
 "yiO" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -26134,7 +25291,6 @@
 /area/rogue/outdoors/mountains)
 "yjo" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -26142,8 +25298,8 @@
 /area/rogue/outdoors/town/roofs/keep)
 "yjt" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/fibers/full{
 	pixel_x = -5
@@ -26160,7 +25316,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ykc" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -26176,8 +25331,8 @@
 /area/rogue/indoors/town/manor)
 "ykz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -26198,9 +25353,9 @@
 /area/rogue/under/town/basement/keep)
 "ykK" = (
 /obj/structure/closet/crate/chest{
-	name = "meat chest";
+	base_icon_state = "woodchestalt";
 	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	name = "meat chest"
 	},
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -26220,7 +25375,6 @@
 /area/rogue/outdoors/rtfield)
 "ymf" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -34320,8 +33474,8 @@ oGK
 oGK
 oGK
 oGK
+oGK
 vrR
-pNQ
 pNQ
 pNQ
 pNQ
@@ -34477,12 +33631,12 @@ heh
 heh
 heh
 heh
+heh
 pmA
 pNQ
 pNQ
 pNQ
 mjw
-qOY
 qOY
 lKl
 lKl
@@ -34620,7 +33774,7 @@ gdw
 pmA
 heh
 heh
-cVE
+tGy
 cVE
 cVE
 cVE
@@ -34633,13 +33787,13 @@ cVE
 cVE
 cVE
 cVE
+cVE
 heh
 pmA
 pNQ
 pNQ
 pNQ
-mBU
-qOY
+tyQ
 qOY
 lKl
 lKl
@@ -34776,27 +33930,27 @@ gdw
 gdw
 pmA
 heh
-heh
-cVE
+gdw
+gdw
 gdw
 nze
 gdw
+nze
+nze
+gdw
+gdw
+gdw
+gdw
+nze
+nze
 xsI
 cVE
-gdw
-gdw
-gdw
-gdw
-nze
-nze
-xsI
 heh
 ppJ
 oGK
+oGK
 qGI
 pNQ
-pNQ
-qOY
 qOY
 lKl
 lKl
@@ -34933,11 +34087,11 @@ gdw
 jHu
 rDj
 heh
-heh
-cVE
 nze
-nze
-gdw
+cvX
+dYY
+eOz
+eOz
 gdw
 gdw
 gdw
@@ -34946,15 +34100,15 @@ gZb
 xRp
 nFb
 nze
+xsI
 cVE
 heh
 heh
 heh
-xfP
+heh
+toL
 exi
 exi
-exi
-qOY
 pNQ
 pNQ
 pNQ
@@ -35090,11 +34244,11 @@ jHu
 rDj
 heh
 heh
-heh
-tGy
-gdw
+iSP
+qvM
+vFB
 bBD
-bBD
+fQO
 gdw
 gdw
 gdw
@@ -35103,15 +34257,15 @@ xpt
 vFB
 qvM
 gdw
-kkj
+pjY
+cVE
+cVE
 cVE
 cVE
 heh
 gVe
 exi
-exi
 qOY
-pNQ
 pNQ
 pNQ
 pNQ
@@ -35246,27 +34400,27 @@ pNQ
 pmA
 heh
 heh
-heh
 cVE
-xsI
-gdw
-biU
+iSP
+qvM
 bBD
+xpt
+xpt
 gdw
 bPk
 gdw
 xpt
-vwK
+xpt
 xpt
 qRc
 gdw
 gdw
 gdw
+gdw
+gdw
 cVE
 heh
-xfP
-pNQ
-pNQ
+toL
 pNQ
 pNQ
 pNQ
@@ -35400,30 +34554,30 @@ pfh
 gdw
 pNQ
 pNQ
-pmA
-heh
+qGI
 heh
 cVE
 xsI
-hYd
 gdw
-bBD
-bBD
-bBD
+cGL
+ewt
+ewt
+cGL
+gdw
 xpt
 lpm
+xpt
+xpt
 pOg
 pOg
 pOg
 xpt
 grm
-yaa
+psG
 gdw
 cVE
 heh
 qGI
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -35560,27 +34714,27 @@ pNQ
 pNQ
 heh
 cVE
-xsI
-nze
-gdw
+hYd
 gdw
 dGH
-ngp
-iSP
-iSP
-ewt
-eTu
-eTu
-ngp
+bBD
+bBD
+bBD
 xpt
 xpt
 xpt
+xpt
+xpt
+xpt
+xpt
+xpt
+xpt
+xpt
+pOo
 gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -35717,27 +34871,27 @@ pNQ
 iMs
 heh
 cVE
-nze
-nze
+hYd
+gdw
 aSP
 bBD
 bBD
-eTu
 bBD
-pZE
-pZE
-rCx
 xpt
-eTu
+xpt
+pOg
+pOg
+xpt
+pOg
 pOg
 xpt
 xpt
+xpt
+pOo
 gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -35874,27 +35028,27 @@ iMs
 iMs
 heh
 cVE
-nze
-eOz
-cGL
-bBD
-xpt
+gdw
+gdw
 eTu
-pZE
-pZE
-vFB
-bBD
-xpt
+iSP
+ftM
+iSP
 eTu
-pOg
+mBm
+iSP
+iSP
+ngp
+eTu
+eTu
+mBm
+xpt
 xpt
 xpt
 gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36031,27 +35185,27 @@ qOY
 qOY
 heh
 cVE
-gdw
-vFB
+nze
+nze
 ahZ
 bBD
-lZp
-eTu
-vFB
 bBD
+gzW
+xRp
+eTu
 bBD
 pZE
+pZE
+nAP
 xpt
 eTu
+pOg
 xpt
 xpt
-bBD
-iSP
+gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36185,30 +35339,30 @@ gdw
 gdw
 pNQ
 qOY
-pmA
+qGI
 heh
 cVE
-gdw
-bBD
-ahZ
-xpt
-oDh
-eTu
+nze
+biU
 vFB
-psG
 bBD
+oDh
+bBD
+xpt
+eTu
 pZE
+pZE
+vFB
+bBD
 xpt
 eTu
 pOg
-bBD
-bBD
-mBm
+xpt
+xpt
+gdw
 xsI
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36344,28 +35498,28 @@ pNQ
 qOY
 pmA
 heh
-cVE
+tGy
 gdw
+vFB
+oDh
 bBD
-mrD
-xpt
-lZp
+onk
+bBD
+lYJ
 eTu
-bBD
 vFB
 bBD
 bBD
+pZE
 xpt
 eTu
-pOg
+xpt
+xpt
 bBD
-vFB
 iSP
 xsI
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36503,26 +35657,26 @@ pmA
 heh
 cVE
 gdw
-xpt
-mrD
-xpt
 bBD
+oDh
+xpt
+onk
+xpt
+hYC
 eTu
-pZE
-bBD
-bBD
 vFB
+mGi
+bBD
+pZE
 xpt
 eTu
+pOg
 bBD
 bBD
-qvM
-nze
+rCx
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36662,24 +35816,24 @@ cVE
 gdw
 bBD
 onk
-nAP
-clX
-eTu
-lYJ
-pZE
-vFB
-oaV
 xpt
-hYC
+onk
 bBD
-qvM
-qvM
-gdw
+lYJ
+eTu
+bBD
+vFB
+bBD
+bBD
+xpt
+eTu
+pOg
+bBD
+vFB
+iSP
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36817,26 +35971,26 @@ pmA
 heh
 cVE
 gdw
-gdw
-gdw
-gdw
-gdw
-gdw
-gdw
+xpt
+onk
+xpt
+onk
+bBD
+bBD
 eTu
+pZE
+bBD
+bBD
+vFB
+xpt
 eTu
-gdw
-gdw
+bBD
+bBD
+qvM
 nze
-nze
-gdw
-gdw
-gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -36973,27 +36127,27 @@ pNQ
 pmA
 heh
 cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-tGy
+gdw
+bWt
+xpt
+bBD
+bBD
+hoH
+ikB
+eTu
+mBU
+pZE
+vFB
+nZx
+xpt
+oaV
+bBD
+qvM
+rkX
+gdw
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37129,28 +36283,28 @@ pNQ
 pNQ
 pmA
 heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
-heh
+cVE
+gdw
+gdw
+gdw
+gdw
+gdw
+gdw
+gdw
+gdw
+gdw
+eTu
+eTu
+gdw
+gdw
+nze
+nze
+gdw
+gdw
+gdw
+tGy
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37284,30 +36438,30 @@ iMs
 pNQ
 pNQ
 pNQ
-ppJ
-vrR
-xsI
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
-cVE
+pmA
 heh
-cVE
-cVE
-cVE
-cVE
-cVE
-xsI
-xsI
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
+heh
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37441,30 +36595,30 @@ pNQ
 pNQ
 pNQ
 pNQ
-pNQ
-ppJ
-oGK
-oGK
-oGK
-oGK
-oGK
-oGK
-oGK
-oGK
-vrR
+pmA
+xsI
+xsI
+cVE
+cVE
+cVE
+cVE
+xsI
+cVE
+cVE
+cVE
 cVE
 heh
-jHu
-oGK
-oGK
-oGK
-oGK
-vrR
+cVE
+cVE
+cVE
+cVE
+cVE
+xsI
+xsI
+cVE
 xsI
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37598,30 +36752,30 @@ uxb
 uxb
 uxb
 uxb
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pNQ
-pmA
+ppJ
+oGK
+oGK
+oGK
+oGK
+oGK
+oGK
+oGK
+oGK
+oGK
+vrR
+cVE
+heh
+jHu
+oGK
+oGK
+oGK
+oGK
+oGK
+oGK
+vrR
 cVE
 heh
 pmA
-pNQ
-pNQ
-pNQ
-pNQ
-pmA
-cVE
-heh
-pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37773,12 +36927,12 @@ pNQ
 pNQ
 pNQ
 pNQ
+pNQ
+pNQ
 pmA
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -37923,9 +37077,11 @@ pNQ
 pNQ
 pNQ
 pmA
-xsI
+cVE
 heh
 pmA
+pNQ
+pNQ
 pNQ
 pNQ
 pNQ
@@ -37934,8 +37090,6 @@ pmA
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -38087,12 +37241,12 @@ pNQ
 pNQ
 pNQ
 pNQ
+pNQ
+pNQ
 pmA
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -38244,12 +37398,12 @@ pNQ
 pNQ
 pNQ
 pNQ
+pNQ
+pNQ
 pmA
 cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -38401,12 +37555,12 @@ pNQ
 pNQ
 pNQ
 pNQ
-pmA
-xsI
+biZ
+lcS
+rDj
+cVE
 heh
 pmA
-pNQ
-pNQ
 pNQ
 pNQ
 pNQ
@@ -38560,10 +37714,10 @@ pNQ
 pNQ
 pmA
 xsI
+cVE
+xsI
 heh
 ppJ
-oGK
-oGK
 oGK
 oGK
 oGK
@@ -38717,9 +37871,9 @@ pNQ
 pNQ
 pmA
 cVE
+cVE
+cVE
 heh
-cVE
-cVE
 xsI
 cVE
 bOK
@@ -55859,13 +55013,13 @@ ndg
 fBB
 hvn
 dRZ
-ftM
+igG
 aai
 xEW
 xDC
 hJn
 rou
-ftM
+igG
 jIk
 jIk
 ymg
@@ -59156,14 +58310,14 @@ waT
 hvn
 hvn
 rLi
-ftM
+igG
 loH
 aak
 ugU
 lMh
 loH
 aap
-ftM
+igG
 nko
 cxb
 cxb
@@ -60355,7 +59509,7 @@ fBB
 doE
 yjt
 eSe
-tyQ
+uyi
 pND
 eSe
 rRb
@@ -63401,7 +62555,7 @@ ctF
 cxb
 oyZ
 ugU
-hoH
+nNJ
 lNY
 qyk
 xSN
@@ -63419,9 +62573,9 @@ xOC
 xOC
 xOC
 xOC
-pOo
+btI
 low
-bWt
+wFC
 xOC
 xOC
 xOC
@@ -63558,7 +62712,7 @@ ctF
 cxb
 oyZ
 ugU
-hoH
+nNJ
 qyk
 qyk
 qyk
@@ -64674,7 +63828,7 @@ xOC
 iXP
 sRV
 sRV
-toL
+pwS
 cKj
 hmb
 cKj
@@ -65301,7 +64455,7 @@ mNh
 mNh
 mNh
 mNh
-ikB
+wSj
 sRV
 sRV
 sRV
@@ -68253,7 +67407,7 @@ fNg
 lyO
 tVC
 waT
-ftM
+igG
 fTZ
 fTZ
 iwJ
@@ -78448,10 +77602,10 @@ tXZ
 oKg
 tEM
 lAL
-mGi
-mGi
+jaW
+jaW
 yge
-mGi
+jaW
 mEa
 mgM
 jaW
@@ -81272,7 +80426,7 @@ pov
 eVv
 qeJ
 jBO
-nZx
+hkC
 jBO
 eVv
 eVv
@@ -81878,7 +81032,7 @@ vEG
 vEG
 jnQ
 nRX
-gzW
+aUC
 qhb
 qhb
 qhb
@@ -82506,7 +81660,7 @@ qhb
 oKl
 tcy
 nRX
-gzW
+aUC
 qhb
 qhb
 qhb
@@ -82526,10 +81680,10 @@ gmc
 qsr
 pov
 sjq
-wTk
+kwG
 jBO
 sjq
-wTk
+kwG
 jBO
 sjq
 qhb
@@ -82644,7 +81798,7 @@ ktP
 ktP
 qhb
 det
-pjY
+xQm
 qVf
 qVf
 qzq
@@ -82657,12 +81811,12 @@ kuX
 ixQ
 ixQ
 det
-rkX
-gzW
+otC
+aUC
 qhb
 sLS
-rkX
-gzW
+otC
+aUC
 qhb
 qhb
 qhb
@@ -84691,7 +83845,7 @@ eSe
 eSe
 jMj
 hRf
-cvX
+wzR
 ouw
 ouw
 ouw
@@ -84848,7 +84002,7 @@ eSe
 ebf
 eSe
 mlJ
-cvX
+wzR
 ouw
 ouw
 ouw
@@ -85005,7 +84159,7 @@ oyt
 gKS
 fnb
 doE
-dYY
+wMV
 ouw
 ouw
 ouw
@@ -86429,7 +85583,7 @@ vAP
 oVP
 xVF
 cAt
-fQO
+syG
 ouw
 qhb
 qhb
@@ -87045,7 +86199,7 @@ qhb
 nkZ
 qhb
 tvX
-meP
+umV
 vpP
 czZ
 kuF
@@ -87842,7 +86996,7 @@ lIO
 wAU
 wMO
 cAt
-fQO
+syG
 fnS
 qhb
 qhb
@@ -110607,7 +109761,7 @@ cAt
 wKP
 dQx
 wKP
-fQO
+syG
 qhb
 qhb
 qhb
@@ -110765,7 +109919,7 @@ nLp
 gBZ
 ono
 cAt
-fQO
+syG
 qhb
 qhb
 qhb
@@ -111224,7 +110378,7 @@ qhb
 qhb
 qhb
 xmF
-meP
+umV
 vpP
 tvX
 eeB
@@ -112020,7 +111174,7 @@ cAt
 wKP
 dQx
 wKP
-fQO
+syG
 qhb
 qhb
 qhb
@@ -112178,7 +111332,7 @@ fmZ
 emP
 pBa
 cAt
-fQO
+syG
 qhb
 qhb
 qhb
@@ -116253,8 +115407,8 @@ tYX
 tYX
 tYX
 cXV
-fdT
-fdT
+oew
+oew
 ngM
 tYX
 tYX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This makes the underground arena more spacious and roomy, and adds a small room to tend to wounded combatants.
![arena](https://github.com/user-attachments/assets/35e12ed3-0e60-4cff-aa35-a48fb84944a8)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

During highpop, tournaments hosted in this arena get downright claustrophobic. Spectators barely have any wiggle room to move about, and it leads to a look of awkwardly standing around each other, occasionally breaking the flow of tournaments. Furthermore, people always opt to build a space to tend to wounded fighters in her. This provides a more isolated and dedicated space for the wounded to be treated that also keeps them away from where the crowds are more likely to be, making it a bit easier for healers to tend to them in peace. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
