### PR TITLE
Sleeping on beds no longer requires you to be buckled

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -37,8 +37,14 @@
 
 		//Healing while sleeping in a bed
 		if(IsSleeping())
-			var/sleepy_mod = buckled?.sleepy || 0.5
+			var/sleepy_mod = 0.5
 			var/yess = HAS_TRAIT(src, TRAIT_NOHUNGER)
+			if(buckled?.sleepy)
+				sleepy_mod = buckled.sleepy
+			else if(isturf(loc)) //No illegal tech.
+				var/obj/structure/bed/rogue/bed = locate() in loc
+				if(bed)
+					sleepy_mod = bed.sleepy
 			if(nutrition > 0 || yess)
 				rogstam_add(sleepy_mod * 15)
 			if(hydration > 0 || yess)
@@ -59,7 +65,14 @@
 					Sleeping(300)
 		else if(!IsSleeping() && !HAS_TRAIT(src, TRAIT_NOSLEEP))
 			// Resting on a bed or something
+			var/sleepy_mod = 0
 			if(buckled?.sleepy)
+				sleepy_mod = buckled.sleepy
+			else if(isturf(loc) && !(mobility_flags & MOBILITY_STAND))
+				var/obj/structure/bed/rogue/bed = locate() in loc
+				if(bed)
+					sleepy_mod = bed.sleepy
+			if(sleepy_mod > 0)
 				if(eyesclosed)
 					var/armor_blocked
 					if(ishuman(src))
@@ -83,6 +96,7 @@
 							Sleeping(300)
 				else
 					rogstam_add(buckled.sleepy * 10)
+					rogstam_add(sleepy_mod * 10)
 			// Resting on the ground (not sleeping or with eyes closed and about to fall asleep)
 			else if(!(mobility_flags & MOBILITY_STAND))
 				if(eyesclosed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Ports https://github.com/Tree445/Hearthstone/pull/365 from Hearthstone.

You can now sleep comfortably so long as you are prone and on a tile with a bed; you no longer need to be buckled to the bed.

## Why It's Good For The Game

This allows multiple people to sleep in the same bed. Someone requested this in the suggestions channel on Discord and it seems fine.