### PR TITLE
Fixes intents not updating when putting a bolt/arrow into a quiver

### DIFF
--- a/code/modules/clothing/rogueclothes/quiver.dm
+++ b/code/modules/clothing/rogueclothes/quiver.dm
@@ -42,7 +42,11 @@
 /obj/item/quiver/attackby(obj/A, loc, params)
 	if(A.type in subtypesof(/obj/item/ammo_casing/caseless/rogue))
 		if(arrows.len < max_storage)
-			A.forceMove(src)
+			if(ismob(loc))
+				var/mob/M = loc
+				M.doUnEquip(A, TRUE, src, TRUE, silent = TRUE)
+			else
+				A.forceMove(src)
 			arrows += A
 			update_icon()
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Before, intents would not correctly update on a player when a bolt/arrow is loaded into a quiver, leading to some annoying inconveniences for bow/crossbow enjoyers. This fixes that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's nice when quivers work exactly as you expect them to!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
