### PR TITLE
Spells N' Runtimes

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -282,6 +282,10 @@
 	var/healing_on_tick = 1
 	var/outline_colour = "#c42424"
 
+/datum/status_effect/buff/healing/on_creation(mob/living/new_owner, new_healing_on_tick)
+	healing_on_tick = new_healing_on_tick
+	return ..()
+
 /datum/status_effect/buff/healing/on_apply()
 	var/filter = owner.get_filter(MIRACLE_HEALING_FILTER)
 	if (!filter)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -95,7 +95,6 @@
 						if(fallingas > 15)
 							Sleeping(300)
 				else
-					rogstam_add(buckled.sleepy * 10)
 					rogstam_add(sleepy_mod * 10)
 			// Resting on the ground (not sleeping or with eyes closed and about to fall asleep)
 			else if(!(mobility_flags & MOBILITY_STAND))

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -149,13 +149,7 @@
 			to_chat(user, "Channeling my patron's power is easier in these conditions!")
 			healing += situational_bonus
 
-		if(iscarbon(target))
-			var/mob/living/carbon/C = target
-			var/datum/status_effect/buff/healing/heal_effect = C.apply_status_effect(/datum/status_effect/buff/healing)
-			heal_effect.healing_on_tick = healing
-		else
-			target.adjustBruteLoss(-healing*10)
-			target.adjustFireLoss(-healing*10)
+		target.apply_status_effect(/datum/status_effect/buff/healing, healing)
 		return TRUE
 	revert_cast()
 	return FALSE

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -32,7 +32,7 @@
 		if(target.anti_magic_check(TRUE, TRUE))
 			return FALSE
 		target.visible_message(span_warning("[user] points at [target]'s eyes!"),span_warning("My eyes are covered in darkness!"))
-		target.blind_eyes(6)
+		target.blind_eyes(5)
 		return TRUE
 	revert_cast()
 	return FALSE

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -115,7 +115,7 @@
 	charging_slowdown = 1
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	charge_max = 60 SECONDS
+	charge_max = 30 SECONDS
 	var/cabal_affine = FALSE
 
 /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/cast(list/targets, mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
* Lowers Blindness spell effect from 6 to 5 seconds.
* Lowers cooldown to Raise Lesser Undead from 60 to 30 seconds.
* Fixes a runtime associated with Miracle healing.
* Fixes a runtime associated with buckle sleeping.

Big thanks to @noelle-lavenza for assistance with runtime fixes.

## Why It's Good For The Game
Undead are too easy to kill to be worth the cooldown.
Blindness is a bit too good in PVP. Will try five seconds but never lower than four, otherwise there's no point buffing it in the first place.
