### PR TITLE
Adds silverware to the keep

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -22,8 +22,8 @@
 /area/rogue/under/town/sewer)
 "aad" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/clothing/neck/roguetown/psicross/wood,
@@ -31,7 +31,6 @@
 /area/rogue/indoors/town/church)
 "aae" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -59,11 +58,9 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/chicken,
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -74,15 +71,12 @@
 	},
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -178,7 +172,6 @@
 "acF" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4;
 	pixel_x = 7
 	},
@@ -186,15 +179,14 @@
 /area/rogue/indoors/town/manor)
 "acV" = (
 /obj/structure/mineral_door/wood{
-	name = "stall i";
 	locked = 1;
-	lockid = "apartment1"
+	lockid = "apartment1";
+	name = "stall i"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
 "ada" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -211,8 +203,8 @@
 /area/rogue/indoors/town)
 "adM" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -232,7 +224,6 @@
 /area/rogue/under/town/basement)
 "adV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
@@ -265,8 +256,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "aeX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/natural/feather{
 	pixel_x = -17;
@@ -313,7 +304,6 @@
 "ahX" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -365,9 +355,9 @@
 /area/rogue/under/town/basement)
 "akh" = (
 /obj/structure/mineral_door/wood{
-	name = "veterans house";
 	locked = 1;
-	lockid = "garrison"
+	lockid = "garrison";
+	name = "veterans house"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -375,7 +365,6 @@
 /area/rogue/indoors/town)
 "akR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -407,8 +396,8 @@
 /area/rogue/outdoors/town)
 "alU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/structure/fluff/railing/border{
@@ -418,8 +407,8 @@
 /area/rogue/indoors/shelter/woods)
 "aml" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -432,8 +421,8 @@
 /area/rogue/outdoors/rtfield)
 "amw" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/walls,
 /obj/item/roguekey/manor,
@@ -448,9 +437,9 @@
 /area/rogue/indoors/town/garrison)
 "anc" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Dining Room";
 	locked = 1;
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Dining Room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -466,7 +455,6 @@
 /area/rogue/indoors/town)
 "aoe" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/hexstone,
@@ -484,11 +472,9 @@
 /area/rogue/indoors)
 "api" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -517,7 +503,6 @@
 /area/rogue/under/town/basement/keep)
 "arK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -550,14 +535,12 @@
 /area/rogue/indoors/town/manor)
 "asT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
 "atf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/psycross,
@@ -568,7 +551,6 @@
 /area/rogue/under/cave)
 "atE" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -593,7 +575,6 @@
 /area/rogue/outdoors/town)
 "auO" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -607,16 +588,14 @@
 /area/rogue/indoors/town/magician)
 "auX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/mirror{
 	pixel_y = 28
 	},
 /obj/item/natural/cloth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "avz" = (
 /obj/structure/toilet,
@@ -639,8 +618,8 @@
 	redstone_id = "armourer_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
@@ -660,8 +639,8 @@
 	pixel_x = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/burial_shroud{
 	pixel_x = 5;
@@ -685,7 +664,6 @@
 /area/rogue/outdoors/town)
 "ayo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -707,8 +685,8 @@
 "azs" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -723,8 +701,8 @@
 /area/rogue/indoors/town/garrison)
 "aAs" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/walldeco/psybanner{
 	pixel_y = 29
@@ -745,8 +723,8 @@
 /area/rogue/indoors/shelter/woods)
 "aCb" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/carpet/red,
@@ -782,15 +760,14 @@
 	},
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/pillory/reinforced,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "aDd" = (
 /obj/effect/landmark/start/servant{
-	icon_state = "arrow";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -819,7 +796,6 @@
 /area/rogue/indoors/town/bath)
 "aED" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
@@ -896,15 +872,14 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/roguekey/walls{
-	name = "farm key";
-	lockid = "farm"
+	lockid = "farm";
+	name = "farm key"
 	},
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "aIG" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -930,7 +905,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -975,7 +949,6 @@
 /area/rogue/indoors/town)
 "aNp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -1003,10 +976,10 @@
 /area/rogue/indoors/shelter/woods)
 "aOB" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Archivist's Office";
 	dir = 8;
 	locked = 1;
-	lockid = "archive"
+	lockid = "archive";
+	name = "Archivist's Office"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
@@ -1045,7 +1018,6 @@
 /area/rogue/indoors/town)
 "aPn" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -1055,9 +1027,7 @@
 	locked = 1;
 	lockid = "nightmaiden"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "aPK" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -1070,16 +1040,13 @@
 /area/rogue/indoors/town/manor)
 "aQs" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "aQA" = (
 /obj/structure/chair/bench/ultimacouch,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "aQJ" = (
 /obj/structure/closet/crate/chest,
@@ -1088,7 +1055,6 @@
 /area/rogue/indoors/town)
 "aRe" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -1129,7 +1095,6 @@
 /area/rogue/under/town/basement)
 "aTh" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -1174,7 +1139,6 @@
 /area/rogue/outdoors/rtfield)
 "aVh" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -1201,7 +1165,6 @@
 /area/rogue/indoors/town/church/chapel)
 "aVR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/closet/crate/chest,
@@ -1227,8 +1190,8 @@
 /area/rogue/indoors/town/tavern)
 "aXp" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -1243,8 +1206,8 @@
 /area/rogue/indoors/town/tavern)
 "aXO" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1296,11 +1259,9 @@
 /area/rogue/indoors/town/physician)
 "bbl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -1327,7 +1288,6 @@
 /area/rogue/outdoors/town/roofs)
 "bcj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
@@ -1347,8 +1307,8 @@
 /area/rogue/outdoors/town)
 "bcF" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -1380,8 +1340,8 @@
 /area/rogue/under/town/basement/keep)
 "bez" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -1400,8 +1360,8 @@
 /area/rogue/under/town/basement/keep)
 "bfW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -1431,8 +1391,8 @@
 /area/rogue/indoors/town/garrison)
 "bhU" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -1459,14 +1419,14 @@
 /area/rogue/under/town/basement)
 "biZ" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "bjc" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/herringbone,
@@ -1520,19 +1480,18 @@
 /area/rogue/outdoors/town)
 "blr" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "blC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town)
@@ -1550,8 +1509,8 @@
 /area/rogue/indoors/town)
 "bmI" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 1
+	dir = 1;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "bnE" = (
@@ -1609,8 +1568,8 @@
 	},
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "bqr" = (
@@ -1658,7 +1617,6 @@
 "bsT" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -1675,9 +1633,7 @@
 /area/rogue/indoors/town/church)
 "bup" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "buI" = (
 /obj/structure/bed/rogue/shit{
@@ -1718,8 +1674,8 @@
 /area/rogue/under/town/basement/keep)
 "bvN" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
@@ -1750,7 +1706,6 @@
 /area/rogue/outdoors/town/roofs)
 "bzx" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle{
@@ -1763,8 +1718,8 @@
 /area/rogue/outdoors/town)
 "bAa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 8
+	dir = 8;
+	icon_state = "longtable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -1790,7 +1745,6 @@
 /area/rogue/indoors/town/physician)
 "bAb" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -1845,20 +1799,17 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs/stone{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "bDS" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -1911,15 +1862,14 @@
 /area/rogue/outdoors/town/roofs)
 "bGd" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "bGJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -1935,9 +1885,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "bHo" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -2000,13 +1948,10 @@
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_y = 10
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bKz" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -2026,8 +1971,7 @@
 /area/rogue/indoors/town/physician)
 "bLo" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
@@ -2036,9 +1980,7 @@
 /turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
 "bLX" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bMi" = (
 /obj/machinery/light/rogue/hearth,
@@ -2059,7 +2001,6 @@
 "bNE" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -2070,7 +2011,6 @@
 /area/rogue/outdoors/town)
 "bOF" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/machinery/light/rogue/torchholder/c,
@@ -2081,7 +2021,6 @@
 /area/rogue/indoors/town/tavern)
 "bOH" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /obj/structure/chair/bench,
@@ -2114,8 +2053,8 @@
 /area/rogue/indoors/town)
 "bPY" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -2162,7 +2101,6 @@
 /area/rogue/outdoors/town)
 "bSI" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -2187,7 +2125,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2196,8 +2133,8 @@
 /area/rogue/indoors/town)
 "bUw" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
@@ -2209,7 +2146,6 @@
 /area/rogue/under/town/basement/keep)
 "bUV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -2243,19 +2179,11 @@
 /obj/item/book/rogue/bibble,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
-"bWt" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 5
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
 "bWU" = (
 /obj/structure/stairs{
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -2266,9 +2194,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "bXl" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "bXz" = (
@@ -2285,7 +2211,6 @@
 /area/rogue/indoors/town)
 "bXK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/structure/fluff/railing/border,
@@ -2305,9 +2230,7 @@
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "bYR" = (
 /obj/structure/fluff/walldeco/stone,
@@ -2320,7 +2243,6 @@
 /area/rogue/indoors/town/manor)
 "bZu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/church/smallbench,
@@ -2342,7 +2264,6 @@
 /area/rogue/indoors/town/tavern)
 "cba" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs{
@@ -2352,8 +2273,8 @@
 /area/rogue/indoors/town/garrison)
 "cbg" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2430,20 +2351,17 @@
 /area/rogue/outdoors/town)
 "cfd" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "cha" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "chq" = (
 /obj/structure/bookcase,
@@ -2453,8 +2371,8 @@
 /area/rogue/indoors/town/manor)
 "chQ" = (
 /obj/structure/mineral_door/wood/window{
-	name = "Library";
-	lockid = "archive"
+	lockid = "archive";
+	name = "Library"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -2472,7 +2390,6 @@
 /area/rogue/indoors/town/church/chapel)
 "cip" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -2489,8 +2406,7 @@
 /area/rogue/under/town/basement/keep)
 "cjg" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "cjh" = (
@@ -2510,11 +2426,9 @@
 /area/rogue/outdoors/town)
 "cjX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -2522,7 +2436,6 @@
 "ckM" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/fluff/walldeco/stone{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -2561,9 +2474,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "cmz" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "cmA" = (
 /obj/structure/table/wood{
@@ -2589,8 +2500,8 @@
 /area/rogue/indoors/town/manor)
 "cmZ" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
@@ -2618,8 +2529,8 @@
 /area/rogue/indoors/town)
 "coK" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/twig,
@@ -2652,7 +2563,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "cqB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/bookcase/random/religion,
@@ -2666,8 +2576,8 @@
 /area/rogue/indoors/town/manor)
 "csh" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -2695,7 +2605,6 @@
 /area/rogue/indoors/town)
 "cty" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -2720,7 +2629,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
@@ -2737,12 +2645,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
-"cvX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/outdoors/town/roofs)
 "cwq" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 1
@@ -2759,8 +2661,8 @@
 "cxD" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
@@ -2782,15 +2684,14 @@
 /area/rogue/outdoors/town)
 "cyB" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/reagent_containers/powder/ozium,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "cyD" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2801,13 +2702,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"czw" = (
-/obj/structure/stairs{
-	icon_state = "stairs";
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "czC" = (
 /obj/structure/stairs{
 	dir = 4
@@ -2842,7 +2736,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -2864,19 +2757,18 @@
 	dir = 8
 	},
 /obj/structure/lever/wall{
-	name = "inner passage lever";
-	icon_state = "leverwall1";
 	dir = 4;
+	icon_state = "leverwall1";
+	name = "inner passage lever";
 	pixel_x = 6;
 	pixel_y = -9;
-	toggled = 1;
-	redstone_id = "keepgate_inner"
+	redstone_id = "keepgate_inner";
+	toggled = 1
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cBU" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/grass,
@@ -2892,15 +2784,14 @@
 "cCz" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "cCO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/natural/stone{
@@ -2915,21 +2806,17 @@
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "cDJ" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "cDO" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -2939,8 +2826,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/neck/roguetown/psicross,
 /turf/open/floor/rogue/tile,
@@ -2950,15 +2837,14 @@
 /area/rogue/outdoors/town)
 "cEi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
 "cED" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fermenting_barrel/crafted,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -2977,9 +2863,9 @@
 /area/rogue/under/town/basement)
 "cGR" = (
 /obj/structure/mineral_door/wood{
-	name = "house i";
 	locked = 1;
-	lockid = "house1"
+	lockid = "house1";
+	name = "house i"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -2993,7 +2879,6 @@
 /area/rogue/under/town/basement/keep)
 "cHG" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -3006,8 +2891,8 @@
 /area/rogue/outdoors/town)
 "cHT" = (
 /turf/open/water/river{
-	icon_state = "rockwd";
-	dir = 4
+	dir = 4;
+	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/rtfield)
 "cIC" = (
@@ -3022,8 +2907,8 @@
 /area/rogue/indoors/town/church/chapel)
 "cJN" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull/lit{
 	pixel_x = -3;
@@ -3033,8 +2918,8 @@
 /area/rogue/under/town/basement)
 "cJT" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fermenting_barrel/crafted,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -3054,8 +2939,8 @@
 /area/rogue/indoors/town/physician)
 "cKp" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
@@ -3099,7 +2984,6 @@
 /area/rogue/outdoors/rtfield)
 "cPJ" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -3110,7 +2994,6 @@
 /area/rogue/under/town/basement)
 "cQy" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -3148,7 +3031,6 @@
 "cRY" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -3169,30 +3051,28 @@
 /area/rogue/indoors/town/magician)
 "cTj" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
 "cTw" = (
 /obj/structure/mineral_door/wood{
-	name = "stall i";
 	locked = 1;
-	lockid = "stall1"
+	lockid = "stall1";
+	name = "stall i"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "cTF" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "cTP" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -3202,8 +3082,8 @@
 /area/rogue/indoors/town)
 "cUn" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
@@ -3213,8 +3093,8 @@
 /area/rogue/indoors/town/bath)
 "cVf" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -3236,8 +3116,8 @@
 /area/rogue/under/town/sewer)
 "cVQ" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "bogrtout_cave";
-	aportalgoesto = "bogrtin_cave"
+	aportalgoesto = "bogrtin_cave";
+	aportalid = "bogrtout_cave"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
@@ -3291,17 +3171,14 @@
 /area/rogue/indoors/town/church)
 "cXV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "cXZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -3330,7 +3207,6 @@
 /area/rogue/indoors/town/physician)
 "cZf" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -3338,14 +3214,12 @@
 "cZX" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "dau" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -3358,7 +3232,6 @@
 /area/rogue/indoors/town)
 "daH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -3457,8 +3330,8 @@
 /area/rogue/indoors/town/magician)
 "ddu" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	name = "Dressing Room";
-	dir = 1
+	dir = 1;
+	name = "Dressing Room"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
@@ -3495,7 +3368,6 @@
 /area/rogue/indoors/town)
 "ddU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -3511,7 +3383,6 @@
 /area/rogue/indoors/town/physician)
 "det" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
@@ -3523,7 +3394,6 @@
 /area/rogue/indoors/town/manor)
 "dex" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -3618,15 +3488,14 @@
 /area/rogue/outdoors/mountains)
 "djT" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "forestout2";
+	aallmig = "rwfieldin1";
 	aportalgoesto = "forestin2";
-	aallmig = "rwfieldin1"
+	aportalid = "forestout2"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "djU" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/customflag{
@@ -3708,7 +3577,6 @@
 /area/rogue/under/town/basement)
 "dnp" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile{
@@ -3776,8 +3644,8 @@
 /area/rogue/indoors/town)
 "dpX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/sword/sabre,
 /turf/open/floor/rogue/ruinedwood{
@@ -3859,7 +3727,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/machinery/light/rogue/torchholder/l,
@@ -3867,8 +3734,8 @@
 /area/rogue/outdoors/town)
 "dvK" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/carpet,
@@ -3893,9 +3760,9 @@
 /area/rogue/indoors/town/shop)
 "dxs" = (
 /obj/structure/closet/crate/chest{
-	name = "spare house keys";
 	locked = 1;
-	lockid = "steward"
+	lockid = "steward";
+	name = "spare house keys"
 	},
 /obj/item/roguekey/houses/house1,
 /obj/item/roguekey/houses/house2,
@@ -3907,7 +3774,6 @@
 /area/rogue/indoors/town)
 "dxE" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -3921,8 +3787,8 @@
 /area/rogue/indoors/town)
 "dxQ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/skull{
 	pixel_x = 5;
@@ -3950,7 +3816,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -3970,14 +3835,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "dzt" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "dAb" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -3991,7 +3854,6 @@
 /area/rogue/under/town/basement/keep)
 "dAn" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -4015,8 +3877,8 @@
 /area/rogue/indoors/town/magician)
 "dAX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -4028,8 +3890,8 @@
 /area/rogue/indoors/town/physician)
 "dCo" = (
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/mountains)
 "dCX" = (
@@ -4041,11 +3903,9 @@
 /area/rogue/under/town/basement)
 "dDJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -4075,7 +3935,6 @@
 /area/rogue/indoors/town)
 "dEZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/carpet,
@@ -4088,15 +3947,15 @@
 /area/rogue/indoors/town/shop)
 "dFN" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "dGH" = (
@@ -4113,9 +3972,9 @@
 /area/rogue/indoors/town)
 "dHr" = (
 /obj/structure/closet/crate/chest{
-	name = "house keys";
 	locked = 1;
-	lockid = "steward"
+	lockid = "steward";
+	name = "house keys"
 	},
 /obj/item/roguekey/houses/house1,
 /obj/item/roguekey/houses/house2,
@@ -4146,8 +4005,8 @@
 /area/rogue/under/town/basement)
 "dIL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
@@ -4157,7 +4016,6 @@
 /area/rogue/outdoors/rtfield)
 "dJn" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -4195,7 +4053,6 @@
 /area/rogue/indoors/shelter/woods)
 "dMM" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -4281,11 +4138,9 @@
 /area/rogue/indoors/town)
 "dRa" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -4305,11 +4160,9 @@
 /area/rogue/indoors/town)
 "dRT" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -4354,7 +4207,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/twig,
@@ -4385,9 +4237,7 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/kitchen/rollingpin,
 /obj/item/rogueweapon/huntingknife/chefknife,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "dWj" = (
 /obj/structure/flora/roguegrass,
@@ -4397,7 +4247,6 @@
 "dWm" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -4412,8 +4261,8 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "dWx" = (
@@ -4424,17 +4273,13 @@
 	icon_state = "longtable"
 	},
 /obj/item/roguekey/manor,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "dXO" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/silver/pile,
 /obj/item/roguecoin/silver/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "dYe" = (
 /obj/structure/table/wood,
@@ -4463,22 +4308,14 @@
 /area/rogue/indoors/town/cell)
 "dYF" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
-"dYY" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/outdoors/town/roofs)
 "dZj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -4491,7 +4328,6 @@
 /area/rogue/indoors/town/garrison)
 "dZu" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -4531,12 +4367,12 @@
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "ecx" = (
@@ -4548,18 +4384,15 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "edu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -4572,8 +4405,8 @@
 /area/rogue/under/town/basement)
 "eev" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -4667,8 +4500,8 @@
 /area/rogue/indoors/town/physician)
 "ejk" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
@@ -4682,8 +4515,8 @@
 /area/rogue/indoors/town/shop)
 "ejT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -4692,7 +4525,6 @@
 /area/rogue/outdoors/town)
 "ekh" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -4762,7 +4594,6 @@
 /area/rogue/outdoors/rtfield)
 "eon" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -4773,7 +4604,6 @@
 /area/rogue/outdoors/beach)
 "eou" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -4786,7 +4616,6 @@
 /area/rogue/outdoors/town)
 "eoH" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -4811,7 +4640,6 @@
 /area/rogue/indoors/town/tavern)
 "epS" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood{
@@ -4849,8 +4677,8 @@
 /area/rogue/indoors/town/physician)
 "erC" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -4874,8 +4702,8 @@
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -4893,8 +4721,8 @@
 /area/rogue/under/cave)
 "euL" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -4938,8 +4766,8 @@
 /area/rogue/under/town/basement)
 "ewK" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -4960,10 +4788,10 @@
 /area/rogue/indoors/town/garrison)
 "eyi" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable i";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable1";
-	keylock = 1
+	name = "stable i"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -4997,11 +4825,9 @@
 /area/rogue/outdoors/town)
 "eAh" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9;
 	pixel_y = -22
 	},
@@ -5107,7 +4933,6 @@
 "eGP" = (
 /obj/structure/closet/dirthole/closed/loot,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/ambush,
@@ -5131,8 +4956,8 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -5146,9 +4971,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "eJJ" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -5183,7 +5006,6 @@
 /area/rogue/indoors/town/church/chapel)
 "eLf" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -5194,8 +5016,8 @@
 /area/rogue/indoors/town/church/chapel)
 "eLq" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/needle,
 /obj/item/needle{
@@ -5224,8 +5046,8 @@
 /area/rogue/indoors/town/physician)
 "eMA" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/cobble,
@@ -5255,8 +5077,8 @@
 /area/rogue/indoors/town/physician)
 "eNy" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Council Office";
-	lockid = "manor"
+	lockid = "manor";
+	name = "Council Office"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
@@ -5287,8 +5109,8 @@
 "eQs" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/natural/feather,
 /obj/item/candle/yellow/lit{
@@ -5304,9 +5126,7 @@
 /area/rogue/indoors/town/tavern)
 "eRV" = (
 /obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "eSe" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -5323,7 +5143,6 @@
 /area/rogue/indoors/town/dwarfin)
 "eTi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -5345,7 +5164,6 @@
 /area/rogue/under/town/basement)
 "eTw" = (
 /obj/structure/stairs/fancy/r{
-	icon_state = "fancy_stairs_r";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord{
@@ -5354,7 +5172,6 @@
 /area/rogue/indoors/town/manor)
 "eTM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/grass,
@@ -5413,16 +5230,16 @@
 	redstone_id = "weaponsmith_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "eWI" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "eWN" = (
@@ -5445,17 +5262,15 @@
 /area/rogue/indoors/town/manor)
 "eYT" = (
 /obj/structure/mineral_door/wood/violet{
-	name = "INNKEEP";
 	locked = 1;
-	lockid = "innkeep"
+	lockid = "innkeep";
+	name = "INNKEEP"
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "eZb" = (
 /obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "eZg" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -5496,7 +5311,6 @@
 /area/rogue/indoors/town)
 "fbj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -5521,9 +5335,9 @@
 /area/rogue/indoors/town/church/chapel)
 "fca" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM V";
 	locked = 1;
-	lockid = "roomv"
+	lockid = "roomv";
+	name = "ROOM V"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -5536,7 +5350,6 @@
 /area/rogue/indoors/shelter/woods)
 "fcv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -5564,7 +5377,6 @@
 /area/rogue/indoors/town)
 "fdk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -5573,15 +5385,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
-"fdT" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
-	},
-/area/rogue/outdoors/town/roofs/keep)
 "feH" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -5609,9 +5412,7 @@
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "ffs" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -5634,12 +5435,10 @@
 /area/rogue/indoors/town/manor)
 "fgW" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "fha" = (
@@ -5686,7 +5485,6 @@
 /area/rogue/indoors/town/manor)
 "fkD" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -5694,8 +5492,7 @@
 /area/rogue/indoors/town)
 "flo" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
@@ -5733,7 +5530,6 @@
 /area/rogue/indoors/town/dwarfin)
 "fmT" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 8
 	},
 /area/rogue/indoors/town/physician)
@@ -5748,12 +5544,10 @@
 /area/rogue/indoors/town)
 "fnS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "foe" = (
@@ -5775,7 +5569,6 @@
 "fpN" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/landmark/start/druid{
@@ -5823,9 +5616,9 @@
 /area/rogue/indoors/town/manor)
 "frH" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "examination room";
 	dir = 4;
-	lockid = "physician"
+	lockid = "physician";
+	name = "examination room"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
@@ -5844,8 +5637,8 @@
 /area/rogue/under/town/basement)
 "ftb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/idagger{
 	pixel_x = 2;
@@ -5856,20 +5649,12 @@
 "ftD" = (
 /obj/structure/roguemachine/atm,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"ftM" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
-	dir = 8
-	},
-/area/rogue/indoors/town)
 "fuY" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/green,
@@ -5905,15 +5690,15 @@
 /area/rogue/under/town/basement)
 "fwi" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "fwr" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/canopy/green,
 /obj/structure/mineral_door/wood/deadbolt/shutter{
@@ -5931,9 +5716,7 @@
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/gold/pile,
 /obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "fwW" = (
 /obj/structure/closet/crate/roguecloset,
@@ -5951,8 +5734,8 @@
 /area/rogue/indoors/town/bath)
 "fyl" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -5961,7 +5744,6 @@
 /area/rogue/under/town/basement/keep)
 "fyC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/closet/crate/roguecloset/inn,
@@ -5977,7 +5759,6 @@
 /area/rogue/outdoors/town)
 "fzy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -6120,12 +5901,10 @@
 /area/rogue/indoors/town/garrison)
 "fFj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "fFk" = (
@@ -6142,13 +5921,11 @@
 /area/rogue/under/town/basement/keep)
 "fFB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "fFJ" = (
 /obj/structure/fluff/railing/border{
@@ -6195,7 +5972,6 @@
 /area/rogue/indoors/town)
 "fHK" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -6216,20 +5992,14 @@
 /obj/item/rogueweapon/pick,
 /obj/item/rogueweapon/pick,
 /obj/item/rogueweapon/pick,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "fKS" = (
-/obj/effect/landmark/mapGenerator/rogue/roguetownfield{
-	endTurfX = 155;
-	endTurfY = 155
-	},
+/obj/effect/landmark/mapGenerator/rogue/roguetownfield,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "fKY" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -6263,15 +6033,14 @@
 /area/rogue/outdoors/town)
 "fNR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "fOh" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -6279,8 +6048,8 @@
 "fOu" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/grown/log/tree/small,
 /obj/item/flint,
@@ -6288,8 +6057,8 @@
 /area/rogue/indoors/town/dwarfin)
 "fOC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
@@ -6319,12 +6088,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
-"fQO" = (
-/turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
-	dir = 8
-	},
-/area/rogue/indoors/town/dwarfin)
 "fQW" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/dwarfin)
@@ -6341,7 +6104,6 @@
 "fRF" = (
 /obj/structure/roguemachine/scomm,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -6362,9 +6124,7 @@
 "fTX" = (
 /obj/structure/chair/bench/coucha,
 /obj/effect/landmark/start/nightmaiden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "fTZ" = (
 /obj/structure/roguewindow,
@@ -6386,19 +6146,17 @@
 /area/rogue/indoors/town/manor)
 "fUx" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Vault Door";
 	dir = 1;
 	locked = 1;
-	lockid = "vault"
+	lockid = "vault";
+	name = "Vault Door"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "fUG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/torchholder/l,
 /obj/item/rogueweapon/tongs,
@@ -6428,7 +6186,6 @@
 "fXj" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -6501,8 +6258,8 @@
 /area/rogue/indoors/town)
 "gcw" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
@@ -6543,8 +6300,8 @@
 /area/rogue/indoors/town)
 "geX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/mask/rogue/facemask,
 /obj/item/clothing/mask/rogue/lordmask,
@@ -6559,7 +6316,6 @@
 /area/rogue/outdoors/town)
 "gfq" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic,
@@ -6569,7 +6325,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -6585,7 +6340,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6594,7 +6348,6 @@
 /area/rogue/indoors/town)
 "ggH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -6616,7 +6369,6 @@
 /area/rogue/indoors/town/cell)
 "gii" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6625,9 +6377,7 @@
 /area/rogue/indoors/town/church/chapel)
 "giB" = (
 /obj/item/reagent_containers/glass/cup/golden,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "giG" = (
 /obj/structure/fermenting_barrel,
@@ -6635,7 +6385,6 @@
 /area/rogue/under/town/basement/keep)
 "giU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -6648,8 +6397,8 @@
 /area/rogue/outdoors/town)
 "gjj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -6668,7 +6417,6 @@
 /area/rogue/indoors/town/garrison)
 "gjH" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -6695,7 +6443,6 @@
 /area/rogue/outdoors/mountains)
 "glv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8;
 	pixel_y = 5
 	},
@@ -6731,8 +6478,8 @@
 /area/rogue/indoors/town/church/chapel)
 "gmc" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
@@ -6758,14 +6505,12 @@
 /area/rogue/indoors/town/shop)
 "gmz" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "gmX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/cobble,
@@ -6781,8 +6526,7 @@
 /area/rogue/indoors/town/cell)
 "goi" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -6815,21 +6559,18 @@
 /area/rogue/indoors/shelter/woods)
 "gpb" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "gpx" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/reagent_containers/glass/cup/skull,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
 "gqi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -6837,7 +6578,6 @@
 /area/rogue/under/town/basement/keep)
 "gqq" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -6854,8 +6594,8 @@
 /area/rogue/under/town/basement/keep)
 "gqW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/tongs{
 	pixel_x = 5;
@@ -6889,8 +6629,8 @@
 /area/rogue/indoors/town/dwarfin)
 "gtW" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -6918,8 +6658,8 @@
 /area/rogue/indoors/town/bath)
 "gvO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -6928,8 +6668,8 @@
 /area/rogue/indoors/town/shop)
 "gwy" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/bowl{
 	pixel_x = 4;
@@ -6942,7 +6682,6 @@
 /area/rogue/indoors/town)
 "gxc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -6972,16 +6711,14 @@
 /area/rogue/under/town/basement)
 "gxZ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
 "gyz" = (
 /obj/machinery/light/rogue/smelter,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "gyF" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -6998,34 +6735,25 @@
 /area/rogue/indoors/town/church/chapel)
 "gzG" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
-"gzW" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "gAj" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "gAA" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town)
 "gAE" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood{
@@ -7053,13 +6781,11 @@
 /area/rogue/indoors/town/dwarfin)
 "gCg" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town/physician)
 "gCw" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -7087,8 +6813,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/exposed/town/keep)
@@ -7119,15 +6845,14 @@
 /area/rogue/indoors/town/church/chapel)
 "gGR" = (
 /obj/structure/mineral_door/wood{
-	name = "physician's backdoor";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "physician's backdoor"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "gHf" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -7188,7 +6913,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -7234,15 +6958,14 @@
 "gMV" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "gNo" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
@@ -7255,8 +6978,8 @@
 /area/rogue/outdoors/town)
 "gNX" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/clothing/head/roguetown/menacing{
 	pixel_x = -3;
@@ -7303,7 +7026,6 @@
 /area/rogue/indoors/town/manor)
 "gPW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -7321,8 +7043,8 @@
 /area/rogue/indoors/town/manor)
 "gQJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -7347,12 +7069,12 @@
 /area/rogue/indoors/town/tavern)
 "gSg" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -7378,7 +7100,6 @@
 /area/rogue/outdoors/town)
 "gSu" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -7391,8 +7112,8 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "gTl" = (
@@ -7410,8 +7131,8 @@
 /area/rogue/indoors/shelter/woods)
 "gTY" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/book_crafting_kit,
 /obj/item/book_crafting_kit,
@@ -7420,8 +7141,8 @@
 /area/rogue/indoors/town)
 "gUU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/silver,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -7444,16 +7165,13 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "gWx" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "gXi" = (
 /obj/structure/well/fountain{
@@ -7469,14 +7187,12 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "gXL" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -7484,15 +7200,12 @@
 /area/rogue/indoors/town)
 "gXR" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -7507,7 +7220,6 @@
 /area/rogue/indoors/town/church/chapel)
 "gYJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -7546,8 +7258,8 @@
 /area/rogue/indoors/town/church/chapel)
 "hbq" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/herringbone,
@@ -7567,8 +7279,8 @@
 /area/rogue/indoors/town/church/chapel)
 "hbU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/apartments/apartment1{
 	name = "stall i key";
@@ -7589,9 +7301,7 @@
 	locked = 1;
 	lockid = "artificer"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "hdp" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -7610,8 +7320,8 @@
 /area/rogue/under/town/sewer)
 "heR" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
@@ -7638,8 +7348,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "hfu" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden{
 	pixel_x = 2;
@@ -7649,7 +7359,6 @@
 /area/rogue/indoors/town/dwarfin)
 "hgu" = (
 /obj/structure/stairs/fancy/r{
-	icon_state = "fancy_stairs_r";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/right,
@@ -7671,15 +7380,14 @@
 /area/rogue/indoors/shelter/woods)
 "hgV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "hhg" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -7764,19 +7472,11 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
-"hoH" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 1
-	},
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/town)
 "hoU" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
 "hpb" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge,
@@ -7787,7 +7487,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -7849,8 +7548,8 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -7876,8 +7575,8 @@
 "hsK" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
@@ -7892,7 +7591,6 @@
 /area/rogue/indoors/town/church/chapel)
 "htG" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -7902,7 +7600,6 @@
 /obj/item/rogueweapon/shield/wood/crafted,
 /obj/item/rogueweapon/shield/wood/crafted,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -7965,20 +7662,20 @@
 /area/rogue/indoors/town/shop)
 "hws" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
 "hwQ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	locked = 1
+	locked = 1;
+	lockid = "church"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
@@ -8016,8 +7713,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "hzT" = (
@@ -8035,13 +7731,10 @@
 /area/rogue/indoors/town)
 "hAM" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "hAS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ywflowers,
@@ -8056,21 +7749,17 @@
 /area/rogue/indoors/town/manor)
 "hCc" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hCr" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -8086,7 +7775,6 @@
 /area/rogue/indoors/town/church/chapel)
 "hDp" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -8124,8 +7812,8 @@
 /area/rogue/outdoors/town/roofs)
 "hFr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
@@ -8142,7 +7830,6 @@
 /area/rogue/under/town/basement/keep)
 "hGe" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -8165,18 +7852,15 @@
 /area/rogue/indoors/town/manor)
 "hGQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "hGV" = (
 /obj/structure/stairs/fancy/l{
-	icon_state = "fancy_stairs_l";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord/left,
@@ -8189,9 +7873,7 @@
 /area/rogue/outdoors/town)
 "hHp" = (
 /obj/structure/closet/crate/chest/gold,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hHv" = (
 /obj/machinery/light/rogue/hearth,
@@ -8201,9 +7883,7 @@
 /area/rogue/indoors/town)
 "hHw" = (
 /obj/structure/roguemachine/lottery_roguetown,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hHC" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -8213,7 +7893,6 @@
 /area/rogue/indoors/town/physician)
 "hHM" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -8221,19 +7900,17 @@
 "hHQ" = (
 /obj/structure/fluff/nest,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "hIg" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/paper,
@@ -8249,8 +7926,8 @@
 /area/rogue/indoors/town)
 "hIk" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 4
@@ -8262,11 +7939,9 @@
 /area/rogue/indoors/town/manor)
 "hIF" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -8312,9 +7987,7 @@
 /area/rogue/under/town/basement/keep)
 "hKl" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "hKO" = (
 /obj/structure/table/wood{
@@ -8325,7 +7998,6 @@
 /area/rogue/indoors/town)
 "hLv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/machinery/light/rogue/torchholder/l,
@@ -8334,7 +8006,6 @@
 "hLP" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -8351,7 +8022,6 @@
 /area/rogue/indoors/town/magician)
 "hNd" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -8401,7 +8071,6 @@
 /area/rogue/under/town/basement/keep)
 "hRf" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -8425,8 +8094,8 @@
 /area/rogue/indoors/town/dwarfin)
 "hSx" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -8445,7 +8114,6 @@
 /area/rogue/indoors/town/manor)
 "hTH" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood,
@@ -8463,7 +8131,6 @@
 /area/rogue/indoors/town)
 "hVE" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -8488,7 +8155,6 @@
 /area/rogue/indoors/town/garrison)
 "hWZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -8497,7 +8163,6 @@
 /area/rogue/indoors/town/manor)
 "hXc" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -8505,15 +8170,13 @@
 	},
 /area/rogue/indoors/town/physician)
 "hXf" = (
-/obj/effect/decal/cobbleedge{
-	dir = 2
-	},
+/obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "hXp" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /obj/effect/decal/cobbleedge{
@@ -8582,8 +8245,8 @@
 /area/rogue/under/town/basement)
 "hYJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -8624,7 +8287,6 @@
 /area/rogue/indoors/town/bath)
 "icQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
@@ -8658,8 +8320,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "ifx" = (
@@ -8676,8 +8338,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ifY" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
@@ -8709,7 +8370,6 @@
 /area/rogue/outdoors/town)
 "iiF" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -8732,8 +8392,8 @@
 /area/rogue/indoors/town/bath)
 "ijT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -8763,7 +8423,6 @@
 /area/rogue/indoors/town/church/chapel)
 "ikj" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -8772,13 +8431,6 @@
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/town/basement)
-"ikB" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/beach)
 "ilw" = (
 /obj/structure/table/wood{
 	icon_state = "map1"
@@ -8791,7 +8443,6 @@
 /area/rogue/outdoors/rtfield)
 "imh" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -8861,15 +8512,13 @@
 	locked = 1;
 	lockid = "nightman"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "iqf" = (
 /obj/structure/mineral_door/wood{
-	name = "alchemy room";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "alchemy room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -8877,9 +8526,9 @@
 /area/rogue/indoors/town/physician)
 "iql" = (
 /obj/structure/mineral_door/wood/window{
-	name = "captains room door";
 	locked = 1;
-	lockid = "sheriff"
+	lockid = "sheriff";
+	name = "captains room door"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -8895,9 +8544,7 @@
 /area/rogue/indoors/town/manor)
 "iqT" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "irh" = (
 /obj/structure/fluff/railing/border{
@@ -8958,9 +8605,7 @@
 /obj/effect/landmark/start/monk{
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "iuG" = (
 /obj/structure/roguemachine/scomm/r,
@@ -8977,7 +8622,6 @@
 /area/rogue/indoors/town/dwarfin)
 "ivW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/couchablack,
@@ -8985,8 +8629,8 @@
 /area/rogue/under/town/basement/keep)
 "iwd" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -9006,7 +8650,6 @@
 /area/rogue/indoors/town)
 "iwJ" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/indoors/town)
@@ -9047,8 +8690,8 @@
 /area/rogue/under/town/basement/keep)
 "iyW" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
@@ -9065,9 +8708,9 @@
 /area/rogue/indoors/town/manor)
 "izX" = (
 /obj/structure/mineral_door/wood{
-	name = "jesters chambers";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "jesters chambers"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -9077,7 +8720,6 @@
 /area/rogue/outdoors/town)
 "iAu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -9093,10 +8735,10 @@
 /area/rogue/outdoors/town/roofs)
 "iBL" = (
 /obj/structure/mineral_door/wood{
-	name = "royal guard quarters";
 	icon_state = "wcv";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "royal guard quarters"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement/keep)
@@ -9111,26 +8753,24 @@
 /area/rogue/indoors/town/garrison)
 "iCU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "iDm" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/book/rogue/cardgame,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "iDt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -9174,8 +8814,8 @@
 	dir = 9
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
@@ -9229,7 +8869,6 @@
 /area/rogue/indoors/town)
 "iHY" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -9239,11 +8878,9 @@
 /area/rogue/indoors/town/bath)
 "iIH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/transparent/openspace,
@@ -9257,17 +8894,14 @@
 /area/rogue/under/town/basement/keep)
 "iJx" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/indoors/town/physician)
 "iKC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -9302,8 +8936,8 @@
 /area/rogue/indoors/town/dwarfin)
 "iMm" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/rogue/tile{
@@ -9323,11 +8957,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "iNg" = (
-/obj/structure/roguethrone{
-	pixel_x = -32
-	},
+/obj/structure/roguethrone,
 /obj/structure/roguemachine/titan{
-	density = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/carpet/lord/center,
@@ -9342,7 +8973,6 @@
 /area/rogue/under/town/basement/keep)
 "iNt" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -9350,9 +8980,7 @@
 "iNE" = (
 /obj/machinery/light/rogue/oven/east,
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "iNM" = (
 /obj/structure/flora/newleaf,
@@ -9372,7 +9000,6 @@
 /area/rogue/indoors/town/physician)
 "iOF" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/stairs/stone{
@@ -9398,7 +9025,6 @@
 "iPP" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grassred,
@@ -9432,10 +9058,10 @@
 /area/rogue/indoors/town)
 "iSc" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable ii";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable2";
-	keylock = 1
+	name = "stable ii"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -9446,14 +9072,12 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/magician)
 "iSr" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -9465,7 +9089,6 @@
 /area/rogue/indoors/town/bath)
 "iSJ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -9512,7 +9135,6 @@
 /area/rogue/indoors/town)
 "iWT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
@@ -9541,9 +9163,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
 "iYk" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
 	},
@@ -9561,18 +9181,16 @@
 /area/rogue/outdoors/exposed/town/keep)
 "iZj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "iZw" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -9599,8 +9217,8 @@
 /area/rogue/indoors/town/manor)
 "jaS" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
@@ -9626,7 +9244,6 @@
 /area/rogue/indoors/town)
 "jbx" = (
 /obj/structure/stairs/fancy/l{
-	icon_state = "fancy_stairs_l";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord{
@@ -9642,19 +9259,17 @@
 /area/rogue/outdoors/exposed/town/keep)
 "jbY" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "jcB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -9712,22 +9327,20 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town)
 "jfy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "jfC" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = 3;
@@ -9765,7 +9378,6 @@
 /area/rogue/under/town/basement/keep)
 "jhc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9796,8 +9408,8 @@
 /area/rogue/indoors/town)
 "jiG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
@@ -9811,7 +9423,6 @@
 /area/rogue/under/town/basement)
 "jiM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -9851,8 +9462,8 @@
 /area/rogue/indoors/town/church/chapel)
 "jlc" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "bogrtout2";
-	aportalgoesto = "bogrtin2"
+	aportalgoesto = "bogrtin2";
+	aportalid = "bogrtout2"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
@@ -9888,7 +9499,6 @@
 /area/rogue/outdoors/town/roofs)
 "jnW" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -9917,14 +9527,12 @@
 /area/rogue/indoors/town/shop)
 "jpw" = (
 /obj/structure/roguemachine/withdraw,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "jpy" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /obj/item/natural/feather,
@@ -9936,15 +9544,14 @@
 /area/rogue/under/town/basement/keep)
 "jpM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs/keep)
 "jqw" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -9965,8 +9572,8 @@
 /area/rogue/indoors/town)
 "jrz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
@@ -9984,8 +9591,8 @@
 /area/rogue/indoors/town/manor)
 "jsm" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
@@ -9994,7 +9601,6 @@
 /area/rogue/indoors/town/garrison)
 "jsJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -10045,7 +9651,6 @@
 /area/rogue/indoors/town/manor)
 "jzA" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/church)
@@ -10057,8 +9662,8 @@
 /area/rogue/indoors/town)
 "jAw" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood{
@@ -10079,7 +9684,6 @@
 "jBv" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic/single,
@@ -10099,7 +9703,6 @@
 /area/rogue/indoors/town/tavern)
 "jBQ" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -10172,8 +9775,8 @@
 /area/rogue/indoors/town/physician)
 "jHu" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "jHz" = (
@@ -10204,8 +9807,8 @@
 /area/rogue/indoors/town)
 "jIY" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 1
@@ -10226,28 +9829,25 @@
 /obj/structure/roguemachine/atm{
 	mammonsiphoned = 250
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "jKz" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "jLc" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor)
 "jLj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
@@ -10275,7 +9875,6 @@
 /area/rogue/indoors/town)
 "jMa" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /obj/structure/fluff/railing/fence,
@@ -10346,7 +9945,6 @@
 "jPb" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -10358,8 +9956,8 @@
 "jPJ" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -10414,7 +10012,6 @@
 /area/rogue/indoors/town/dwarfin)
 "jRq" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/effect/decal/cobbleedge{
@@ -10436,7 +10033,6 @@
 /area/rogue/indoors/town/tavern)
 "jRL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -10448,8 +10044,8 @@
 /area/rogue/under/town/sewer)
 "jRY" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -10473,7 +10069,6 @@
 /area/rogue/indoors/town/manor)
 "jTo" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/stump,
@@ -10491,7 +10086,6 @@
 /area/rogue/indoors/town)
 "jVk" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -10505,10 +10099,10 @@
 /area/rogue/under/town/basement/keep)
 "jVM" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stable iii";
+	keylock = 1;
 	locked = 1;
 	lockid = "stable3";
-	keylock = 1
+	name = "stable iii"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -10519,9 +10113,9 @@
 /area/rogue/indoors/town/manor)
 "jWf" = (
 /obj/structure/mineral_door/wood{
-	name = "apothacary bunks";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "apothacary bunks"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10535,7 +10129,6 @@
 "jWu" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -10581,9 +10174,7 @@
 	icon_state = "ultimacochright"
 	},
 /obj/structure/fluff/walldeco/maidensigil,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "jYO" = (
 /turf/open/floor/rogue/woodturned,
@@ -10600,9 +10191,7 @@
 /area/rogue/indoors/town)
 "jZD" = (
 /obj/structure/bars,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kae" = (
 /turf/open/floor/rogue/dirt,
@@ -10612,15 +10201,13 @@
 /area/rogue/indoors/shelter/woods)
 "kbt" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kbK" = (
 /obj/structure/handcart{
@@ -10668,14 +10255,12 @@
 /area/rogue/indoors/town/manor)
 "kcZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "kdI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10779,12 +10364,9 @@
 /area/rogue/outdoors/mountains)
 "klb" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "kle" = (
 /obj/structure/closet/crate/roguecloset/crafted,
@@ -10807,12 +10389,10 @@
 "kmF" = (
 /obj/item/rogue/instrument/harp,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "kmO" = (
 /obj/structure/roguewindow,
@@ -10837,15 +10417,14 @@
 /area/rogue/outdoors/town)
 "kov" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "koL" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -10863,8 +10442,8 @@
 	mailtag = "Bathhouse"
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry,
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry,
@@ -10909,8 +10488,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -10919,7 +10498,6 @@
 /area/rogue/outdoors/mountains)
 "ksf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/hexstone,
@@ -10978,7 +10556,6 @@
 /area/rogue/indoors/town/bath)
 "kul" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/roguegrass,
@@ -11001,7 +10578,6 @@
 /area/rogue/indoors/town)
 "kuI" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -10
 	},
@@ -11015,7 +10591,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kuZ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -11026,8 +10601,8 @@
 /area/rogue/under/town/basement/keep)
 "kvv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/clothing/mask/rogue/wildguard,
 /obj/item/clothing/mask/rogue/wildguard,
@@ -11049,8 +10624,8 @@
 "kwu" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -11080,18 +10655,16 @@
 /area/rogue/indoors/town/manor)
 "kyM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "kyP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -11100,7 +10673,6 @@
 /area/rogue/indoors/town/manor)
 "kza" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/effect/decal/cobbleedge{
@@ -11125,8 +10697,8 @@
 /area/rogue/outdoors/town)
 "kzW" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "southgate_outer"
 	},
 /turf/open/floor/rogue/metal{
@@ -11177,8 +10749,8 @@
 /area/rogue/indoors/town/garrison)
 "kCr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
@@ -11217,22 +10789,20 @@
 /area/rogue/outdoors/town)
 "kEv" = (
 /obj/effect/landmark/start/barkeep{
-	name = "Innkeeper";
-	dir = 1
+	dir = 1;
+	name = "Innkeeper"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "kEG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "kEN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/cobble,
@@ -11262,9 +10832,7 @@
 /area/rogue/under/town/sewer)
 "kGq" = (
 /obj/machinery/light/rogue/hearth,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kGs" = (
 /obj/structure/closet/crate/roguecloset,
@@ -11328,8 +10896,8 @@
 /area/rogue/indoors/town)
 "kJD" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /obj/item/roguekey/velder,
@@ -11351,9 +10919,7 @@
 /area/rogue/indoors/town/bath)
 "kKI" = (
 /obj/machinery/light/rogue/oven/east,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "kKS" = (
 /obj/structure/flora/roguetree,
@@ -11374,7 +10940,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kLO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/chair/wood/rogue/chair3{
@@ -11393,8 +10958,8 @@
 /area/rogue/indoors/town/church/chapel)
 "kMr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
@@ -11413,8 +10978,8 @@
 /area/rogue/outdoors/town)
 "kNj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
@@ -11475,7 +11040,6 @@
 /area/rogue/indoors/town)
 "kNC" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/structure/fluff/clodpile,
@@ -11507,8 +11071,8 @@
 /area/rogue/indoors/town)
 "kOv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/carpet/red,
@@ -11537,7 +11101,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "kPo" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -11581,15 +11144,14 @@
 /area/rogue/indoors/town/manor)
 "kQC" = (
 /obj/structure/mineral_door/bars{
-	name = "royal crypt";
 	locked = 1;
-	lockid = "graveyard"
+	lockid = "graveyard";
+	name = "royal crypt"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "kQI" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -11606,7 +11168,6 @@
 /area/rogue/indoors/town/church/chapel)
 "kSm" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 8;
 	locked = 1;
 	lockid = "nightmaiden"
@@ -11615,8 +11176,8 @@
 /area/rogue/indoors/town/bath)
 "kSx" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/cobble,
@@ -11633,10 +11194,10 @@
 /area/rogue/indoors/town/church/chapel)
 "kTg" = (
 /obj/structure/mineral_door/wood{
-	name = "Seneschal's Quarters";
 	icon_state = "wcv";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Seneschal's Quarters"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11664,9 +11225,9 @@
 /area/rogue/outdoors/exposed/town/keep)
 "kTO" = (
 /obj/structure/mineral_door/wood{
-	name = "physician's office";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "physician's office"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -11677,8 +11238,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "kUe" = (
@@ -11697,8 +11257,8 @@
 /area/rogue/under/town/basement/keep)
 "kUP" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
@@ -11782,9 +11342,7 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "kZU" = (
 /obj/structure/fluff/clock,
@@ -11801,7 +11359,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -11818,21 +11375,18 @@
 "lay" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "laD" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "laX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/effect/decal/mossy{
@@ -11854,7 +11408,6 @@
 /area/rogue/indoors/town/manor)
 "lbI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/herringbone,
@@ -11865,8 +11418,8 @@
 /area/rogue/outdoors/town)
 "lck" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "shipside bunkhouse";
-	dir = 1
+	dir = 1;
+	name = "shipside bunkhouse"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
@@ -11908,8 +11461,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ldX" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -11934,7 +11487,6 @@
 /area/rogue/indoors/town/physician)
 "led" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -11997,7 +11549,6 @@
 "lgZ" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic/single,
@@ -12090,19 +11641,16 @@
 /area/rogue/outdoors/exposed/town/keep)
 "lmf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/dwarfin)
 "lmq" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -12134,8 +11682,8 @@
 /area/rogue/outdoors/town)
 "lnv" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -12167,7 +11715,6 @@
 /area/rogue/indoors/town/manor)
 "loB" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12182,7 +11729,6 @@
 /area/rogue/indoors/town)
 "loI" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -12224,9 +11770,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "lpX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
@@ -12242,8 +11786,8 @@
 /area/rogue/indoors/town/church)
 "lsi" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -12255,9 +11799,9 @@
 /area/rogue/indoors/town/manor)
 "lsG" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Guest Room";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Guest Room"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -12304,17 +11848,13 @@
 /area/rogue/indoors/town/shop)
 "lvi" = (
 /obj/structure/roguetent,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "lvo" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -12329,11 +11869,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -12365,8 +11903,8 @@
 /area/rogue/indoors/town/tavern)
 "lxe" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/powder/flour,
@@ -12392,8 +11930,8 @@
 /area/rogue/outdoors/town/roofs)
 "lxN" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/cup/steel{
 	pixel_x = -6;
@@ -12417,12 +11955,11 @@
 /area/rogue/outdoors/rtfield)
 "lAt" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -12430,7 +11967,6 @@
 /area/rogue/indoors/town)
 "lAL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
@@ -12478,7 +12014,6 @@
 /area/rogue/indoors/town/physician)
 "lDW" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -12486,8 +12021,8 @@
 "lEf" = (
 /obj/item/soap,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
@@ -12516,7 +12051,6 @@
 /area/rogue/indoors/town)
 "lFW" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -12528,7 +12062,6 @@
 /area/rogue/indoors/town/garrison)
 "lGO" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town/dwarfin)
@@ -12542,8 +12075,8 @@
 /area/rogue/indoors/town/garrison)
 "lHl" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
@@ -12567,7 +12100,6 @@
 /area/rogue/outdoors/town)
 "lIv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12576,8 +12108,7 @@
 /area/rogue/indoors/town/magician)
 "lIC" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 2
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -12598,7 +12129,6 @@
 /area/rogue/indoors/town/dwarfin)
 "lJa" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -12628,14 +12158,12 @@
 /area/rogue/under/town/basement/keep)
 "lLL" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
 "lMc" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -12655,7 +12183,6 @@
 "lMj" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -12690,8 +12217,8 @@
 /area/rogue/indoors/shelter/woods)
 "lOX" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -12699,11 +12226,9 @@
 "lPe" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5;
 	pixel_x = -24;
 	pixel_y = -23
@@ -12712,8 +12237,8 @@
 /area/rogue/indoors/town/tavern)
 "lPB" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/carpet/red,
@@ -12728,8 +12253,8 @@
 /area/rogue/indoors/town/bath)
 "lQS" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/herringbone,
@@ -12740,8 +12265,8 @@
 /area/rogue/outdoors/mountains)
 "lRa" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
@@ -12763,9 +12288,9 @@
 /area/rogue/outdoors/town)
 "lSf" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM II";
 	locked = 1;
-	lockid = "roomii"
+	lockid = "roomii";
+	name = "ROOM II"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -12839,7 +12364,6 @@
 /area/rogue/outdoors/mountains)
 "lVW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/stump,
@@ -12860,8 +12384,7 @@
 /area/rogue/outdoors/town)
 "lYJ" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road,
@@ -12883,15 +12406,15 @@
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "lZW" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
@@ -12905,9 +12428,9 @@
 /area/rogue/indoors/town/magician)
 "maj" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Apartment";
 	locked = 1;
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -12927,7 +12450,6 @@
 /area/rogue/indoors/town/physician)
 "mbO" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/carpet,
@@ -12980,16 +12502,6 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
-"meP" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town)
 "meT" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -12999,8 +12511,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "mfn" = (
@@ -13016,7 +12528,6 @@
 /area/rogue/indoors/town)
 "mfP" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
@@ -13030,7 +12541,6 @@
 /area/rogue/indoors/town/manor)
 "mgA" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -13051,7 +12561,6 @@
 /area/rogue/indoors/town/physician)
 "mgM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13095,9 +12604,7 @@
 /obj/effect/landmark/start/dungeoneer{
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "mjw" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -13116,15 +12623,15 @@
 "mkg" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
 "mkB" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -13155,9 +12662,9 @@
 /area/rogue/indoors/town/magician)
 "mlM" = (
 /obj/structure/mineral_door/wood{
-	name = "house iii";
 	locked = 1;
-	lockid = "house3"
+	lockid = "house3";
+	name = "house iii"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
@@ -13179,8 +12686,7 @@
 /area/rogue/outdoors/town)
 "mmh" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
@@ -13197,19 +12703,17 @@
 /area/rogue/outdoors/town)
 "mmT" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
 "mnl" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -13263,7 +12767,6 @@
 /area/rogue/under/town/basement/keep)
 "mrL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -13312,8 +12815,8 @@
 /area/rogue/under/town/sewer)
 "mva" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/cloth,
 /obj/item/natural/bundle/cloth{
@@ -13335,8 +12838,8 @@
 /area/rogue/outdoors/town/roofs/keep)
 "mvz" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
@@ -13345,8 +12848,8 @@
 /area/rogue/indoors/town/church)
 "mvF" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Heir's Apartment";
-	lockid = "heir"
+	lockid = "heir";
+	name = "Heir's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -13368,8 +12871,7 @@
 "mxw" = (
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "mxz" = (
@@ -13380,9 +12882,7 @@
 /area/rogue/indoors/town/garrison)
 "mxK" = (
 /obj/structure/bars,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "myb" = (
 /obj/structure/rack/rogue/shelf/big{
@@ -13395,15 +12895,12 @@
 /area/rogue/outdoors/town)
 "myj" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/item/roguebin/water,
@@ -13411,7 +12908,6 @@
 /area/rogue/outdoors/town)
 "myk" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
@@ -13434,8 +12930,8 @@
 "mzg" = (
 /obj/structure/winch{
 	dir = 4;
-	pixel_x = -7;
 	gid = "thronegate";
+	pixel_x = -7;
 	redstone_id = "thronegate"
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -13498,7 +12994,6 @@
 /area/rogue/indoors/town/garrison)
 "mDM" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
@@ -13525,11 +13020,9 @@
 /area/rogue/outdoors/town)
 "mEu" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9;
 	pixel_y = -25
 	},
@@ -13560,20 +13053,11 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
-"mGi" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/shelter/woods)
 "mGS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -13748,7 +13232,6 @@
 "mTX" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/effect/landmark/start/squire{
-	icon_state = "arrow";
 	dir = 4
 	},
 /obj/structure/bed/rogue,
@@ -13758,8 +13241,8 @@
 /area/rogue/indoors/town/garrison)
 "mUJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/storage/roguebag{
 	pixel_x = -7;
@@ -13770,8 +13253,8 @@
 /area/rogue/indoors/town/dwarfin)
 "mUR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter{
 	dir = 2
@@ -13896,8 +13379,8 @@
 /obj/item/kitchen/rollingpin,
 /obj/structure/rack/rogue/shelf,
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = 5;
@@ -13925,9 +13408,9 @@
 /area/rogue/indoors/town)
 "naO" = (
 /obj/structure/mineral_door/wood{
-	name = "nitemaiden chambers";
 	locked = 1;
-	lockid = "nightmaiden"
+	lockid = "nightmaiden";
+	name = "nitemaiden chambers"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
@@ -13951,8 +13434,8 @@
 "nbM" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
+	dir = 4;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
@@ -13964,7 +13447,6 @@
 "ncQ" = (
 /obj/structure/flora/roguegrass,
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble/mossy,
@@ -13986,7 +13468,6 @@
 /area/rogue/outdoors/town)
 "ndm" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -13995,8 +13476,8 @@
 /area/rogue/indoors/town/physician)
 "ndv" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine,
@@ -14024,7 +13505,6 @@
 /area/rogue/under/town/basement/keep)
 "neL" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -14032,7 +13512,6 @@
 "nfy" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -14052,18 +13531,16 @@
 /area/rogue/indoors/town/bath)
 "ngM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "ngZ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/candle/skull,
 /turf/open/floor/carpet/inn,
@@ -14076,7 +13553,6 @@
 /area/rogue/indoors/town/manor)
 "nho" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -14128,14 +13604,12 @@
 /area/rogue/outdoors/town)
 "nkZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "nlp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/water/bath,
@@ -14156,7 +13630,6 @@
 /area/rogue/indoors/town/garrison)
 "nlJ" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -14172,7 +13645,6 @@
 /area/rogue/under/town/basement)
 "nmj" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
@@ -14186,8 +13658,8 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "nna" = (
@@ -14200,7 +13672,6 @@
 /area/rogue/outdoors/rtfield)
 "nov" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -14208,8 +13679,8 @@
 "noF" = (
 /obj/structure/fluff/canopy,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -14223,8 +13694,8 @@
 /area/rogue/indoors/town/church/chapel)
 "npT" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -14249,12 +13720,10 @@
 /area/rogue/indoors/town/manor)
 "nqC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "nqQ" = (
@@ -14271,7 +13740,6 @@
 /area/rogue/outdoors/town)
 "nrp" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/hexstone,
@@ -14297,12 +13765,9 @@
 /area/rogue/indoors/town/magician)
 "nsb" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "nsf" = (
 /obj/structure/flora/roguegrass/bush,
@@ -14313,19 +13778,17 @@
 /area/rogue/outdoors/town)
 "nsg" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "nsk" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 4
+	dir = 4;
+	icon_state = "longtable"
 	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
@@ -14356,7 +13819,6 @@
 /area/rogue/indoors/town/bath)
 "nto" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -14414,7 +13876,6 @@
 /area/rogue/indoors/town/manor)
 "nwO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/fluff/railing/border,
@@ -14438,8 +13899,8 @@
 /area/rogue/under/town/sewer)
 "nyM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -14449,7 +13910,6 @@
 "nyR" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/grassyel,
@@ -14503,8 +13963,8 @@
 /area/rogue/indoors/town/bath)
 "nFb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/cobble,
@@ -14524,8 +13984,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "nGm" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "nGn" = (
@@ -14534,8 +13994,8 @@
 /area/rogue/indoors/town/manor)
 "nGr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/neck/roguetown/coif,
 /obj/item/clothing/mask/bandana/black,
@@ -14557,8 +14017,8 @@
 /area/rogue/indoors/town/dwarfin)
 "nHP" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
@@ -14584,7 +14044,6 @@
 /area/rogue/indoors/town/church)
 "nIN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/chair/bench/couchablack/r,
@@ -14642,8 +14101,8 @@
 /area/rogue/indoors/town/tavern)
 "nKp" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "northgate_outer"
 	},
 /turf/open/floor/rogue/metal{
@@ -14707,17 +14166,17 @@
 /area/rogue/outdoors/town)
 "nNw" = (
 /obj/structure/mineral_door/swing_door{
-	name = "stables";
+	keylock = 1;
 	locked = 1;
 	lockid = "manor";
-	keylock = 1
+	name = "stables"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
 "nNH" = (
 /obj/structure/toilet/greyscale{
-	name = "The Royal Shitter";
-	color = "#ffee00"
+	color = "#ffee00";
+	name = "The Royal Shitter"
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/hexstone,
@@ -14739,9 +14198,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
 "nOZ" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir"
-	},
+/obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "nPa" = (
@@ -14759,8 +14216,8 @@
 /area/rogue/indoors/town/tavern)
 "nPH" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -14772,8 +14229,8 @@
 /area/rogue/outdoors/rtfield)
 "nQa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/roguekey/lord,
 /turf/open/floor/rogue/ruinedwood{
@@ -14800,8 +14257,8 @@
 /area/rogue/outdoors/rtfield)
 "nQQ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -14838,18 +14295,15 @@
 /area/rogue/under/town/basement)
 "nRN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "nRX" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -14868,7 +14322,6 @@
 /area/rogue/indoors/town/tavern)
 "nSu" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -14894,7 +14347,6 @@
 /area/rogue/indoors/town/manor)
 "nTR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -14907,7 +14359,6 @@
 /area/rogue/indoors/town)
 "nUn" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -14918,7 +14369,6 @@
 /area/rogue/indoors/town/tavern)
 "nVd" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/structure/fluff/clodpile,
@@ -14944,15 +14394,14 @@
 /area/rogue/indoors/town)
 "nWw" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
 "nWK" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -15001,13 +14450,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
-"nZx" = (
-/obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/tavern)
 "nZW" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/globe,
@@ -15025,15 +14467,14 @@
 /area/rogue/indoors/town/manor)
 "oaL" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "oaV" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
@@ -15061,9 +14502,7 @@
 /area/rogue/indoors/town/church/chapel)
 "ocH" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "ocI" = (
 /obj/effect/decal/cobbleedge{
@@ -15098,12 +14537,10 @@
 /area/rogue/indoors/town/tavern)
 "oew" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "oeW" = (
@@ -15149,11 +14586,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/tile{
@@ -15183,7 +14618,6 @@
 /area/rogue/indoors/town/tavern)
 "ohE" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15192,7 +14626,6 @@
 /area/rogue/indoors/town/church/chapel)
 "ohF" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15205,15 +14638,14 @@
 /area/rogue/indoors/town/tavern)
 "oim" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "oiN" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_y = 12
@@ -15239,7 +14671,6 @@
 /area/rogue/indoors/town/magician)
 "okO" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -15294,8 +14725,8 @@
 /area/rogue/indoors/town/manor)
 "ooy" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/idagger/navaja,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -15368,19 +14799,16 @@
 /area/rogue/indoors/town/magician)
 "orK" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/manor)
 "orU" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "orW" = (
@@ -15399,7 +14827,6 @@
 	dir = 9
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -10
 	},
@@ -15417,11 +14844,9 @@
 /area/rogue/indoors/town/shop)
 "osM" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -15434,7 +14859,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -15458,11 +14882,9 @@
 /area/rogue/indoors/town)
 "otV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/effect/decal/cobbleedge{
@@ -15472,9 +14894,9 @@
 /area/rogue/outdoors/town)
 "otY" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Butchers House";
 	locked = 1;
-	lockid = "farm"
+	lockid = "farm";
+	name = "Butchers House"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -15482,8 +14904,8 @@
 /area/rogue/indoors/town)
 "ous" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/natural/feather,
 /obj/item/candle/skull/lit,
@@ -15491,8 +14913,7 @@
 /area/rogue/indoors/town/shop)
 "ouw" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "ouA" = (
@@ -15515,8 +14936,7 @@
 /area/rogue/outdoors/town)
 "ovs" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 2
+	icon_state = "longtable"
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
@@ -15564,8 +14984,8 @@
 /area/rogue/indoors/town/manor)
 "ozA" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/silk{
 	pixel_x = 5
@@ -15579,7 +14999,6 @@
 /area/rogue/indoors/town)
 "ozE" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15668,8 +15087,8 @@
 /area/rogue/outdoors/town)
 "oCI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper,
 /obj/item/natural/feather,
@@ -15688,14 +15107,12 @@
 /area/rogue/under/town/basement)
 "oDn" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "oDH" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/concrete,
@@ -15724,9 +15141,7 @@
 /obj/item/natural/stone,
 /obj/item/natural/stone,
 /obj/item/natural/stone,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "oEk" = (
 /obj/structure/fluff/walldeco/painting{
@@ -15775,8 +15190,8 @@
 /area/rogue/indoors/town/physician)
 "oGR" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = 3
@@ -15811,7 +15226,6 @@
 /area/rogue/indoors/town/church)
 "oIK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/transparent/openspace,
@@ -15892,7 +15306,6 @@
 /area/rogue/indoors/town/manor)
 "oNE" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -15920,8 +15333,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
@@ -15948,8 +15361,8 @@
 /area/rogue/indoors/town/manor)
 "oQn" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -15988,8 +15401,8 @@
 /area/rogue/indoors/town)
 "oRM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/natural/feather{
 	pixel_x = 8;
@@ -16008,9 +15421,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "oSV" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "oSX" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
@@ -16021,8 +15432,8 @@
 	dir = 10
 	},
 /obj/structure/lever/wall{
-	name = "outer passage lever";
 	dir = 4;
+	name = "outer passage lever";
 	pixel_x = 6;
 	redstone_id = "keepgate_outer"
 	},
@@ -16067,7 +15478,6 @@
 /area/rogue/outdoors/town)
 "oWN" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -16091,8 +15501,7 @@
 /area/rogue/indoors/town/tavern)
 "oXN" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
@@ -16126,15 +15535,14 @@
 /area/rogue/indoors/shelter/woods)
 "oZv" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
 "oZH" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -16151,7 +15559,6 @@
 /area/rogue/indoors/town/church/chapel)
 "pag" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 8
 	},
 /turf/open/floor/rogue/twig,
@@ -16180,8 +15587,8 @@
 /area/rogue/outdoors/town)
 "pbB" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/roguekey/garrison,
 /obj/item/storage/keyring,
@@ -16192,7 +15599,6 @@
 /area/rogue/indoors/town/garrison)
 "pcB" = (
 /obj/effect/decal/cobbleedge{
-	dir = 2;
 	pixel_y = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -16271,8 +15677,8 @@
 /area/rogue/indoors/town)
 "phI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -16314,9 +15720,7 @@
 "pjc" = (
 /obj/item/roguecoin/silver/pile,
 /obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "pjk" = (
 /obj/structure/flora/roguetree/burnt,
@@ -16338,7 +15742,6 @@
 /area/rogue/under/town/basement)
 "pjV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -16420,11 +15823,9 @@
 /area/rogue/indoors/town/church/chapel)
 "plY" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -16436,21 +15837,21 @@
 /area/rogue/indoors/town/manor)
 "pmA" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/under/town/sewer)
 "pmX" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/indoors/town/dwarfin)
 "pnh" = (
 /obj/structure/mineral_door/wood{
-	name = "stall ii";
 	locked = 1;
-	lockid = "stall2"
+	lockid = "stall2";
+	name = "stall ii"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -16467,8 +15868,8 @@
 "poj" = (
 /obj/item/cooking/pan,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -16501,9 +15902,7 @@
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "ppA" = (
 /obj/structure/bookcase/random/nonfiction,
@@ -16511,8 +15910,8 @@
 /area/rogue/indoors/town)
 "ppJ" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "prt" = (
@@ -16561,20 +15960,18 @@
 	pixel_x = -8
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "ptN" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 1
 	},
 /area/rogue/indoors/town)
 "ptQ" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -16673,7 +16070,6 @@
 /area/rogue/outdoors/town/roofs)
 "pzs" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -16686,7 +16082,6 @@
 /area/rogue/outdoors/town)
 "pAl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -16714,7 +16109,6 @@
 "pBF" = (
 /obj/structure/closet/dirthole/grave,
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -16730,14 +16124,12 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "pCC" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/woodturned,
@@ -16788,9 +16180,9 @@
 /area/rogue/outdoors/town)
 "pFo" = (
 /obj/structure/mineral_door/wood{
-	name = "house ii";
 	locked = 1;
-	lockid = "house2"
+	lockid = "house2";
+	name = "house ii"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -16822,7 +16214,6 @@
 /area/rogue/outdoors/town)
 "pGK" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/effect/decal/cobbleedge{
@@ -16840,7 +16231,6 @@
 "pGZ" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -16879,7 +16269,6 @@
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
 /obj/effect/landmark/start/servant{
-	icon_state = "arrow";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -16897,7 +16286,6 @@
 /area/rogue/indoors/town)
 "pIO" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -16931,8 +16319,8 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "pJQ" = (
@@ -16960,15 +16348,15 @@
 /area/rogue/indoors/town/manor)
 "pKz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "pKF" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -16992,7 +16380,6 @@
 /area/rogue/indoors/shelter/woods)
 "pLN" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -17032,11 +16419,9 @@
 /area/rogue/indoors/town)
 "pND" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -17058,9 +16443,9 @@
 /area/rogue/indoors/town/church/chapel)
 "pOd" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM I";
 	locked = 1;
-	lockid = "roomi"
+	lockid = "roomi";
+	name = "ROOM I"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -17068,18 +16453,11 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"pOo" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 6
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
 "pOp" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -17087,8 +16465,8 @@
 /area/rogue/under/town/basement/keep)
 "pOG" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/redwine,
 /turf/open/floor/rogue/ruinedwood{
@@ -17103,7 +16481,6 @@
 /area/rogue/indoors/town/shop)
 "pPu" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
@@ -17120,7 +16497,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt,
@@ -17133,12 +16509,10 @@
 /area/rogue/outdoors/rtfield)
 "pQT" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "pRj" = (
@@ -17147,16 +16521,16 @@
 /area/rogue/indoors/town)
 "pRx" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Marshal's Quarters";
 	locked = 1;
-	lockid = "sheriff"
+	lockid = "sheriff";
+	name = "Marshal's Quarters"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "pRI" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/item/storage/keyring,
 /obj/item/roguekey/merchant,
@@ -17180,7 +16554,6 @@
 /area/rogue/under/town/basement/keep)
 "pTw" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -17197,14 +16570,12 @@
 /area/rogue/outdoors/town)
 "pUo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach)
 "pUt" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 8;
 	locked = 1;
 	lockid = "steward"
@@ -17247,7 +16618,6 @@
 /area/rogue/indoors/town/tavern)
 "pWV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/carpet/royalblack,
@@ -17275,7 +16645,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "pYo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -17288,7 +16657,6 @@
 /area/rogue/outdoors/rtfield)
 "pYV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -17303,7 +16671,6 @@
 /area/rogue/under/town/basement)
 "pZI" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -17343,8 +16710,7 @@
 "qbF" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "qbL" = (
@@ -17357,7 +16723,6 @@
 /area/rogue/indoors/town)
 "qcS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -17368,7 +16733,6 @@
 /area/rogue/indoors/town/dwarfin)
 "qdX" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -17435,8 +16799,8 @@
 /area/rogue/outdoors/town/roofs)
 "qhq" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Apartment";
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -17506,6 +16870,18 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/clothing/head/roguetown/chef,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -17518,9 +16894,9 @@
 /area/rogue/outdoors/town/roofs/keep)
 "qly" = (
 /obj/structure/mineral_door/wood/violet{
-	name = "STAFF";
 	locked = 1;
-	lockid = "tavern"
+	lockid = "tavern";
+	name = "STAFF"
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
@@ -17542,8 +16918,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper,
 /turf/open/floor/rogue/herringbone,
@@ -17571,9 +16947,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
 "qqw" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "qqS" = (
 /obj/structure/roguemachine/scomm,
@@ -17597,18 +16971,16 @@
 /area/rogue/indoors/town/manor)
 "qsr" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
 "qsO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -17625,7 +16997,6 @@
 /area/rogue/outdoors/rtfield)
 "quo" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -17639,8 +17010,8 @@
 "qvo" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
@@ -17652,8 +17023,8 @@
 /area/rogue/indoors/town)
 "qvM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
@@ -17745,17 +17116,15 @@
 /area/rogue/indoors/town)
 "qzM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/rtfield)
 "qzO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -17805,8 +17174,8 @@
 /area/rogue/indoors/town/bath)
 "qAV" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
@@ -17815,10 +17184,10 @@
 	dir = 9
 	},
 /obj/structure/mineral_door/wood/donjon{
-	name = "keep entrance";
 	dir = 1;
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "keep entrance"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -17854,7 +17223,6 @@
 /area/rogue/indoors/town/tavern)
 "qBM" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -17868,7 +17236,6 @@
 /area/rogue/outdoors/town)
 "qDm" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -17882,12 +17249,9 @@
 /area/rogue/indoors/town/shop)
 "qDY" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "qEa" = (
 /obj/effect/decal/cobbleedge{
@@ -17901,8 +17265,8 @@
 /area/rogue/outdoors/rtfield)
 "qEs" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/stoneaxe/woodcut,
@@ -17928,19 +17292,17 @@
 /area/rogue/indoors/town/dwarfin)
 "qFO" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "qGh" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
@@ -17989,16 +17351,14 @@
 /area/rogue/indoors/town/shop)
 "qIz" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/bars{
 	icon_state = "barsbent";
 	layer = 2.81
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "qIK" = (
 /obj/structure/flora/roguegrass,
@@ -18018,7 +17378,6 @@
 /area/rogue/indoors/town/church/chapel)
 "qJJ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -18045,8 +17404,8 @@
 /area/rogue/indoors/town/magician)
 "qMb" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -18069,8 +17428,8 @@
 /area/rogue/outdoors/town)
 "qOg" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -18119,9 +17478,7 @@
 /area/rogue/indoors/town/church/chapel)
 "qPZ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "qQt" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -18166,16 +17523,16 @@
 /area/rogue/indoors/town/tavern)
 "qTJ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -18193,14 +17550,12 @@
 /area/rogue/indoors/town/tavern)
 "qVz" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /obj/structure/fluff/railing/border{
@@ -18229,10 +17584,10 @@
 /area/rogue/indoors/town)
 "qWI" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Throne Room";
 	dir = 1;
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Throne Room"
 	},
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
@@ -18267,20 +17622,17 @@
 /area/rogue/indoors/town/magician)
 "qXF" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "qXK" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "qYz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
@@ -18340,7 +17692,6 @@
 /area/rogue/indoors/town/garrison)
 "rab" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/walldeco/customflag{
@@ -18379,11 +17730,10 @@
 "raV" = (
 /obj/machinery/light/rogue/firebowl/church,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/churchmarble,
@@ -18396,7 +17746,6 @@
 	pixel_y = -32
 	},
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -18413,7 +17762,6 @@
 	pixel_y = 32
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/wood,
@@ -18426,8 +17774,8 @@
 /area/rogue/under/town/basement/keep)
 "rcJ" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
@@ -18469,7 +17817,6 @@
 /area/rogue/under/town/basement/keep)
 "reZ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -18519,7 +17866,6 @@
 	dir = 6
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -18536,8 +17882,8 @@
 /area/rogue/indoors/shelter/woods)
 "rho" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/elfred,
 /obj/item/reagent_containers/glass/cup/silver{
@@ -18550,7 +17896,6 @@
 /area/rogue/indoors/town/manor)
 "rhr" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -18587,15 +17932,14 @@
 /area/rogue/indoors)
 "rjw" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "rjG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/needle/thorn,
@@ -18607,7 +17951,6 @@
 	},
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/twig,
@@ -18618,8 +17961,8 @@
 /area/rogue/indoors/town/bath)
 "rkv" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
@@ -18629,8 +17972,8 @@
 /area/rogue/indoors/town/church)
 "rkL" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/head/peaceflower{
 	pixel_x = -13;
@@ -18639,19 +17982,10 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
-"rkX" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "rmy" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/item/roguegem/violet,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rou" = (
 /obj/item/roguebin/water/gross,
@@ -18661,30 +17995,26 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
 "roA" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
 "roU" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rpj" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "rpq" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "forestout";
+	aallmig = "rwfieldin1";
 	aportalgoesto = "forestin";
-	aallmig = "rwfieldin1"
+	aportalid = "forestout"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
@@ -18709,7 +18039,6 @@
 /area/rogue/indoors/town/bath)
 "rtf" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/structure/fluff/walldeco/psybanner{
@@ -18719,8 +18048,8 @@
 /area/rogue/indoors/town/church)
 "rtH" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogue/instrument/drum,
 /obj/structure/fluff/walldeco/customflag{
@@ -18734,9 +18063,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ruG" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "ruM" = (
 /obj/structure/rack/rogue,
@@ -18757,7 +18084,6 @@
 	dir = 10
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -18765,7 +18091,6 @@
 /area/rogue/indoors/town/garrison)
 "rvA" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -18785,8 +18110,8 @@
 /area/rogue/indoors/town/dwarfin)
 "rwd" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
@@ -18847,7 +18172,6 @@
 /area/rogue/indoors/town)
 "rAJ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/villager{
@@ -18860,8 +18184,8 @@
 /area/rogue/indoors/town/tavern)
 "rBd" = (
 /obj/structure/lever/wall{
-	name = "drawbridge lever";
 	dir = 4;
+	name = "drawbridge lever";
 	pixel_x = 6;
 	pixel_y = 9;
 	redstone_id = "gatelava"
@@ -18887,19 +18211,18 @@
 /area/rogue/outdoors/town)
 "rCZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "rDa" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
@@ -18909,8 +18232,8 @@
 /area/rogue/indoors/town/manor)
 "rDj" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/town/sewer)
 "rDz" = (
@@ -18926,7 +18249,6 @@
 /area/rogue/indoors/town/manor)
 "rDX" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 4
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -18965,8 +18287,8 @@
 /area/rogue/indoors/town)
 "rGy" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -19026,11 +18348,9 @@
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19041,7 +18361,6 @@
 /area/rogue/under/town/basement)
 "rKE" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -19068,8 +18387,8 @@
 "rLe" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
@@ -19113,11 +18432,9 @@
 /area/rogue/indoors/town)
 "rNp" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /turf/open/floor/rogue/grass,
@@ -19141,8 +18458,8 @@
 /area/rogue/outdoors/town)
 "rOJ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -19150,8 +18467,8 @@
 /area/rogue/indoors/town)
 "rOL" = (
 /obj/structure/mineral_door/bars{
-	lockid = "graveyard";
-	locked = 1
+	locked = 1;
+	lockid = "graveyard"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -19169,11 +18486,9 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -19197,16 +18512,16 @@
 /area/rogue/under/town/sewer)
 "rQG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "rQI" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/tile/masonic{
 	dir = 8
@@ -19215,7 +18530,6 @@
 "rQJ" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -19228,7 +18542,6 @@
 /area/rogue/indoors/town)
 "rRc" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -19236,7 +18549,6 @@
 /area/rogue/under/town/basement)
 "rRf" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -19271,8 +18583,8 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
@@ -19306,7 +18618,6 @@
 /area/rogue/indoors/town)
 "rSR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/closet/crate/chest/neu,
@@ -19338,8 +18649,8 @@
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/fluff/wallclock,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -19363,7 +18674,6 @@
 /area/rogue/under/town/basement)
 "rVC" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -19374,9 +18684,9 @@
 /area/rogue/outdoors/town)
 "rWN" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Hand's Chambers";
 	locked = 1;
-	lockid = "hand"
+	lockid = "hand";
+	name = "Hand's Chambers"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -19396,8 +18706,8 @@
 /area/rogue/outdoors/town)
 "rZc" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_x = 5;
@@ -19406,27 +18716,22 @@
 /obj/item/clothing/mask/cigarette/pipe/westman{
 	pixel_y = 10
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "rZv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "sac" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "saf" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/structure/fluff/wallclock,
@@ -19438,8 +18743,8 @@
 /area/rogue/outdoors/town)
 "saM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/flint{
 	pixel_x = -6;
@@ -19453,9 +18758,9 @@
 /area/rogue/under/town/basement)
 "saU" = (
 /obj/structure/mineral_door/wood{
-	name = "alchemy";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "alchemy"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -19490,7 +18795,6 @@
 /area/rogue/outdoors/rtfield)
 "scg" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/grass,
@@ -19565,9 +18869,9 @@
 /area/rogue/indoors/town)
 "sgY" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM VI";
 	locked = 1;
-	lockid = "roomvi"
+	lockid = "roomvi";
+	name = "ROOM VI"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -19594,15 +18898,15 @@
 /area/rogue/indoors/town)
 "sid" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "sif" = (
 /obj/structure/gate{
-	name = "The Throne";
 	gid = "thronegate";
+	name = "The Throne";
 	redstone_id = "thronegate"
 	},
 /turf/open/floor/rogue/carpet/lord/left,
@@ -19669,7 +18973,6 @@
 /area/rogue/indoors/town/bath)
 "skH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -19683,8 +18986,8 @@
 "sma" = (
 /obj/structure/fluff/canopy,
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -19705,16 +19008,16 @@
 "sns" = (
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "snM" = (
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
@@ -19730,8 +19033,8 @@
 	},
 /obj/effect/decal/cobbleedge,
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/structure/pillory/reinforced,
 /turf/open/floor/rogue/cobblerock,
@@ -19793,8 +19096,7 @@
 "ssO" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "ssW" = (
@@ -19806,8 +19108,8 @@
 /area/rogue/indoors/town)
 "ssZ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
@@ -19846,7 +19148,6 @@
 /area/rogue/indoors/town)
 "suw" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/closet/crate/chest/old_crate,
@@ -19855,7 +19156,6 @@
 /area/rogue/indoors/town)
 "sux" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -19868,7 +19168,6 @@
 "suz" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19907,7 +19206,6 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -19920,7 +19218,6 @@
 /area/rogue/outdoors/town)
 "syj" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -19970,7 +19267,6 @@
 /area/rogue/indoors/town/manor)
 "sAZ" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -19979,8 +19275,8 @@
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/flashlight/flare/torch/lantern,
 /turf/open/floor/rogue/cobble,
@@ -20010,7 +19306,6 @@
 /area/rogue/under/town/sewer)
 "sDO" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -20047,7 +19342,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -20060,9 +19354,7 @@
 /area/rogue/indoors/town)
 "sGb" = (
 /obj/structure/table/wood/crafted,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "sGz" = (
 /obj/effect/decal/cobbleedge,
@@ -20071,8 +19363,8 @@
 /area/rogue/outdoors/town)
 "sHe" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/ruinedwood{
@@ -20093,9 +19385,7 @@
 /area/rogue/indoors/town)
 "sHo" = (
 /obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "sHU" = (
 /obj/structure/chair/wood/rogue,
@@ -20119,8 +19409,8 @@
 /area/rogue/indoors/town/church)
 "sKe" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
 /obj/item/clothing/mask/cigarette/rollie/nicotine,
@@ -20129,9 +19419,7 @@
 /area/rogue/under/town/basement/keep)
 "sKi" = (
 /obj/structure/mineral_door/wood/donjon{
-	icon_state = "donjondir";
 	dir = 4;
-	locked = 0;
 	lockid = "nightmaiden"
 	},
 /turf/open/floor/rogue/hexstone,
@@ -20152,7 +19440,6 @@
 /area/rogue/outdoors/town/roofs)
 "sLb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -20162,7 +19449,6 @@
 /area/rogue/outdoors/town)
 "sLy" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/stairs/stone{
@@ -20172,14 +19458,12 @@
 /area/rogue/outdoors/town)
 "sLH" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "sLS" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/transparent/openspace,
@@ -20194,8 +19478,6 @@
 /obj/item/reagent_containers/glass/cup,
 /obj/item/reagent_containers/glass/cup/silver,
 /obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
 /obj/item/cooking/platter,
 /obj/item/cooking/platter,
 /obj/effect/decal/cobbleedge{
@@ -20203,6 +19485,17 @@
 	},
 /obj/item/cooking/platter,
 /obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -20213,15 +19506,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "sMD" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border"
-	},
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "sNg" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/toy/cards/deck{
 	pixel_x = 3;
@@ -20238,9 +19529,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/under/town/basement/keep)
 "sNI" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 2
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/shop)
 "sOm" = (
 /obj/structure/stairs{
@@ -20267,26 +19556,21 @@
 /area/rogue/indoors/town/tavern)
 "sQg" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "sQv" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "sRc" = (
 /obj/structure/mineral_door/wood/deadbolt{
-	icon_state = "wooddir";
 	dir = 4
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "sRz" = (
 /obj/structure/flora/roguegrass/bush,
@@ -20294,8 +19578,8 @@
 /area/rogue/outdoors/town)
 "sRP" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 8
+	dir = 8;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "sRU" = (
@@ -20344,7 +19628,6 @@
 /area/rogue/indoors/town/shop)
 "sUt" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle,
@@ -20359,12 +19642,10 @@
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "sVH" = (
@@ -20381,12 +19662,12 @@
 /area/rogue/outdoors/exposed/town/keep)
 "sWd" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "sWi" = (
@@ -20414,16 +19695,15 @@
 /area/rogue/under/town/basement)
 "sXv" = (
 /obj/structure/mineral_door/wood{
-	name = "house v";
 	locked = 1;
-	lockid = "house5"
+	lockid = "house5";
+	name = "house v"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "sXy" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -20442,7 +19722,6 @@
 /area/rogue/indoors/town)
 "sXQ" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /obj/effect/landmark/start/villager{
@@ -20457,7 +19736,6 @@
 /area/rogue/indoors/town/cell)
 "sZw" = (
 /obj/structure/stairs/fancy/c{
-	icon_state = "fancy_stairs_c";
 	dir = 1
 	},
 /turf/open/floor/rogue/carpet/lord,
@@ -20530,12 +19808,12 @@
 /area/rogue/under/town/basement/keep)
 "tdu" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Farm";
 	dir = 8;
+	lock_strength = 100;
 	locked = 1;
 	lockid = "farm";
-	lock_strength = 100;
-	max_integrity = 1000
+	max_integrity = 1000;
+	name = "Farm"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -20548,7 +19826,6 @@
 "tei" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -20574,7 +19851,6 @@
 "tfo" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/chair/bench{
-	icon_state = "bench";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -20586,8 +19862,8 @@
 	redstone_id = "armourer_shutter"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
@@ -20735,14 +20011,13 @@
 /area/rogue/under/town/basement/keep)
 "tjp" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Lord's Restroom";
-	lockid = "royal"
+	lockid = "royal";
+	name = "Lord's Restroom"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "tjy" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -20754,8 +20029,8 @@
 /area/rogue/indoors/town)
 "tkg" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/clothing/cloak/apron/waist,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -20849,13 +20124,6 @@
 /obj/structure/fermenting_barrel/crafted,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"toL" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/beach)
 "tqe" = (
 /obj/structure/far_travel,
 /turf/open/floor/rogue/dirt/road,
@@ -20867,8 +20135,8 @@
 /area/rogue/indoors/town/physician)
 "tqC" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 12
@@ -20946,15 +20214,14 @@
 /area/rogue/indoors/town/magician)
 "tuG" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "tvk" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20977,9 +20244,7 @@
 "tvU" = (
 /obj/structure/chair/bench/ultimacouch,
 /obj/structure/fluff/walldeco/maidensigil/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "tvX" = (
 /turf/closed/wall/mineral/rogue/decowood,
@@ -21043,11 +20308,9 @@
 /area/rogue/indoors/town/bath)
 "tyv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -21056,13 +20319,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"tyQ" = (
-/obj/structure/fluff/railing/border{
-	icon_state = "border";
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
 "tzi" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/guardsman,
@@ -21087,9 +20343,7 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "tAB" = (
 /obj/structure/table/wood{
@@ -21172,7 +20426,6 @@
 /area/rogue/indoors/shelter/woods)
 "tFb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/carpet/royalblack,
@@ -21201,8 +20454,8 @@
 /area/rogue/indoors/town/physician)
 "tGt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
@@ -21239,9 +20492,9 @@
 /area/rogue/indoors/town)
 "tHJ" = (
 /obj/structure/mineral_door/wood{
-	name = "stall iii";
 	locked = 1;
-	lockid = "stall3"
+	lockid = "stall3";
+	name = "stall iii"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -21262,11 +20515,9 @@
 /area/rogue/indoors/town/garrison)
 "tJs" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -21275,9 +20526,7 @@
 /obj/structure/closet/crate/chest/neu,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "tKw" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -21287,7 +20536,6 @@
 /area/rogue/indoors/town)
 "tKP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -21351,9 +20599,9 @@
 /area/rogue/outdoors/town/roofs/keep)
 "tPt" = (
 /obj/structure/mineral_door/wood{
-	name = "house iii";
 	locked = 1;
-	lockid = "house3"
+	lockid = "house3";
+	name = "house iii"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -21445,8 +20693,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "tUv" = (
@@ -21459,9 +20706,9 @@
 /area/rogue/indoors/town/bath)
 "tVc" = (
 /obj/structure/mineral_door/wood{
-	name = "house vi";
 	locked = 1;
-	lockid = "house6"
+	lockid = "house6";
+	name = "house vi"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -21476,7 +20723,6 @@
 /area/rogue/outdoors/town)
 "tVM" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -21495,8 +20741,8 @@
 /area/rogue/outdoors/town)
 "tWM" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge,
 /obj/structure/flora/roguegrass,
@@ -21504,29 +20750,26 @@
 /area/rogue/outdoors/town)
 "tXc" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "tXs" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "tXX" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/fluff/millstone{
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "tXZ" = (
 /turf/open/transparent/openspace,
@@ -21541,8 +20784,8 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/bars/passage/shutter{
 	redstone_id = "weaponsmith_shutter"
@@ -21551,8 +20794,7 @@
 /area/rogue/indoors/town/dwarfin)
 "tYX" = (
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs/keep)
 "tZa" = (
@@ -21611,8 +20853,8 @@
 	dir = 1
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/ruinedwood{
@@ -21739,7 +20981,6 @@
 /area/rogue/indoors/town)
 "ukZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -21752,7 +20993,6 @@
 /area/rogue/outdoors/rtfield)
 "ulo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 9
 	},
 /obj/effect/decal/cobbleedge{
@@ -21772,7 +21012,6 @@
 /area/rogue/outdoors/rtfield)
 "umV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border,
@@ -21780,7 +21019,6 @@
 /area/rogue/indoors/town)
 "umX" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -21853,7 +21091,6 @@
 	dir = 5
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -21883,8 +21120,8 @@
 /area/rogue/under/cave)
 "usq" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+	dir = 9;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
@@ -21902,7 +21139,6 @@
 /area/rogue/indoors/town/magician)
 "uto" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -21929,9 +21165,9 @@
 /area/rogue/indoors/town/dwarfin)
 "uut" = (
 /obj/structure/mineral_door/wood{
-	name = "house i";
 	locked = 1;
-	lockid = "house1"
+	lockid = "house1";
+	name = "house i"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -21948,7 +21184,6 @@
 /area/rogue/indoors/town/manor)
 "uuU" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 1
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -21965,8 +21200,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "uvq" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 8
+	dir = 8;
+	icon_state = "longtable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -22045,7 +21280,6 @@
 /area/rogue/indoors/town/tavern)
 "uyA" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -22063,7 +21297,6 @@
 /area/rogue/under/cave)
 "uzB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/blocks,
@@ -22071,9 +21304,7 @@
 "uzK" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "uAV" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
@@ -22115,15 +21346,14 @@
 /area/rogue/outdoors/town)
 "uDd" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
 "uDo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/effect/decal/cobbleedge{
@@ -22136,8 +21366,8 @@
 /area/rogue/indoors/town)
 "uDt" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = -4;
@@ -22162,13 +21392,10 @@
 /area/rogue/indoors/town/physician)
 "uDM" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "uDU" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22192,7 +21419,6 @@
 /area/rogue/indoors/town/bath)
 "uEl" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22263,8 +21489,8 @@
 /area/rogue/indoors/town)
 "uJa" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/mossy{
 	dir = 1
@@ -22273,12 +21499,10 @@
 /area/rogue/outdoors/town)
 "uJi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "uKb" = (
@@ -22304,8 +21528,8 @@
 /area/rogue/under/town/basement)
 "uMk" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church)
@@ -22323,8 +21547,8 @@
 /area/rogue/indoors/town)
 "uMM" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter,
 /obj/structure/fluff/canopy,
@@ -22349,8 +21573,8 @@
 /area/rogue/outdoors/town)
 "uON" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_line"
 	},
 /area/rogue/under/cave)
 "uOU" = (
@@ -22378,7 +21602,6 @@
 /area/rogue/under/town/basement)
 "uRK" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22387,18 +21610,17 @@
 /area/rogue/indoors/town/manor)
 "uRQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/outdoors/rtfield)
 "uRZ" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/paper,
 /obj/item/paper,
@@ -22435,7 +21657,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "uTW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -22455,7 +21676,6 @@
 /area/rogue/outdoors/town)
 "uVa" = (
 /obj/structure/fluff/walldeco/church/line{
-	icon_state = "churchslate";
 	dir = 4
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -22517,7 +21737,6 @@
 /area/rogue/outdoors/town/roofs/keep)
 "uZr" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 4
 	},
 /obj/structure/fluff/railing/wood{
@@ -22534,8 +21753,8 @@
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -22550,9 +21769,9 @@
 /area/rogue/outdoors/town)
 "uZR" = (
 /obj/structure/mineral_door/wood{
-	name = "HUNT ROOM";
 	locked = 1;
-	lockid = "roomhunt"
+	lockid = "roomhunt";
+	name = "HUNT ROOM"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
@@ -22584,7 +21803,6 @@
 "vcp" = (
 /obj/item/reagent_containers/food/snacks/cracker,
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/grassyel,
@@ -22640,7 +21858,6 @@
 /area/rogue/indoors/town/church)
 "vgA" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22649,7 +21866,6 @@
 /area/rogue/indoors/town)
 "vgF" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
@@ -22676,8 +21892,8 @@
 	dir = 9
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
@@ -22689,9 +21905,7 @@
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "viU" = (
 /obj/structure/flora/roguegrass,
@@ -22703,7 +21917,6 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -22735,14 +21948,13 @@
 /area/rogue/indoors/town)
 "vnC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church)
 "vnL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -22769,7 +21981,6 @@
 /area/rogue/outdoors/town/roofs)
 "vpm" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/effect/landmark/start/monk{
@@ -22781,12 +21992,12 @@
 /area/rogue/indoors/town/church/chapel)
 "vps" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "Farm";
 	dir = 4;
+	lock_strength = 100;
 	locked = 1;
 	lockid = "farm";
-	lock_strength = 100;
-	max_integrity = 1000
+	max_integrity = 1000;
+	name = "Farm"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -22840,7 +22051,6 @@
 /area/rogue/indoors/town/manor)
 "vtR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 5
 	},
 /turf/open/transparent/openspace,
@@ -22884,15 +22094,14 @@
 /area/rogue/indoors/town)
 "vvP" = (
 /obj/structure/mineral_door/wood{
-	name = "examination room";
 	locked = 1;
-	lockid = "physician"
+	lockid = "physician";
+	name = "examination room"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "vvV" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/hexstone,
@@ -22909,9 +22118,9 @@
 /area/rogue/under/town/basement)
 "vwW" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Servant's Entry";
 	locked = 1;
-	lockid = "manor"
+	lockid = "manor";
+	name = "Servant's Entry"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor)
@@ -22983,8 +22192,8 @@
 /area/rogue/indoors/town)
 "vCO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/flint{
 	pixel_x = -1
@@ -23004,9 +22213,9 @@
 /area/rogue/indoors/town/church/chapel)
 "vCS" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM IV";
 	locked = 1;
-	lockid = "roomiv"
+	lockid = "roomiv";
+	name = "ROOM IV"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -23109,7 +22318,6 @@
 /area/rogue/indoors/town/church)
 "vHV" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23128,7 +22336,6 @@
 /area/rogue/indoors/town/garrison)
 "vIQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/blocks,
@@ -23144,7 +22351,6 @@
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
@@ -23199,7 +22405,6 @@
 /area/rogue/under/town/basement/keep)
 "vMx" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 1
 	},
 /turf/open/floor/rogue/grassyel,
@@ -23260,7 +22465,6 @@
 /area/rogue/indoors/town/magician)
 "vRD" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /obj/structure/flora/roguegrass/bush/wall,
@@ -23273,7 +22477,6 @@
 /area/rogue/indoors/town/garrison)
 "vTk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23374,12 +22577,12 @@
 /area/rogue/indoors/town/garrison)
 "vYw" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
@@ -23430,7 +22633,6 @@
 /area/rogue/under/town/basement)
 "wdv" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -23438,11 +22640,9 @@
 "wdX" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/church,
@@ -23465,28 +22665,27 @@
 /area/rogue/indoors/town)
 "weU" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 4
+	dir = 4;
+	icon_state = "iron_corner"
 	},
 /area/rogue/under/cave)
 "weW" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "weZ" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "wfj" = (
@@ -23546,9 +22745,7 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /obj/item/kitchen/rollingpin,
 /obj/item/rogueweapon/huntingknife/chefknife,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "wiX" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -23593,7 +22790,6 @@
 /area/rogue/indoors/town)
 "wlk" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/wood,
@@ -23606,9 +22802,9 @@
 /area/rogue/indoors/town/tavern)
 "wms" = (
 /obj/structure/mineral_door/wood{
-	name = "house ii";
 	locked = 1;
-	lockid = "house2"
+	lockid = "house2";
+	name = "house ii"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -23623,9 +22819,7 @@
 "wmN" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /obj/structure/fluff/walldeco/maidensigil,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "wmR" = (
 /obj/structure/flora/newleaf{
@@ -23636,27 +22830,27 @@
 /area/rogue/indoors/shelter/woods)
 "wmW" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church)
 "wnd" = (
 /obj/structure/closet/crate/chest{
-	name = "Spare keys";
-	icon_state = "woodchestalt";
+	base_icon_state = "woodchestalt";
 	color = "#8f7f62";
-	base_icon_state = "woodchestalt"
+	icon_state = "woodchestalt";
+	name = "Spare keys"
 	},
 /obj/item/roguekey/roomhunt,
 /obj/item/roguekey/roomiv{
-	name = "room VI key";
-	lockid = "roomvi"
+	lockid = "roomvi";
+	name = "room VI key"
 	},
 /obj/item/roguekey/roomiv{
-	name = "room V key";
-	lockid = "roomv"
+	lockid = "roomv";
+	name = "room V key"
 	},
 /obj/item/roguekey/roomiv,
 /obj/item/roguekey/roomiii,
@@ -23673,12 +22867,12 @@
 /area/rogue/indoors/town/magician)
 "wof" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-e";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-e"
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -23700,7 +22894,6 @@
 /area/rogue/indoors/town/church/chapel)
 "wpL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /obj/structure/closet/crate/chest/neu,
@@ -23710,12 +22903,10 @@
 /area/rogue/indoors/town/church/chapel)
 "wpQ" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -23726,9 +22917,7 @@
 /area/rogue/indoors/town)
 "wqf" = (
 /obj/structure/fluff/psycross,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "wqm" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -23747,9 +22936,7 @@
 /obj/item/roguegem/green,
 /obj/item/roguegem/blue,
 /obj/structure/closet/crate/chest/neu_fancy,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "wqJ" = (
 /obj/structure/table/wood{
@@ -23760,8 +22947,8 @@
 /area/rogue/under/town/basement/keep)
 "wrk" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -23779,14 +22966,12 @@
 	pixel_y = 0
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/rogueweapon/sword/long/exe/cloth,
 /obj/item/natural/stone,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "wss" = (
 /obj/structure/closet/crate/roguecloset,
@@ -23829,8 +23014,8 @@
 /area/rogue/indoors/town/manor)
 "wul" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -23843,10 +23028,10 @@
 /area/rogue/outdoors/town/roofs)
 "wuw" = (
 /obj/structure/mineral_door/wood/donjon{
-	name = "squireroom door";
 	dir = 1;
 	locked = 1;
-	lockid = "garrison"
+	lockid = "garrison";
+	name = "squireroom door"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
@@ -23859,7 +23044,6 @@
 /area/rogue/indoors/town/garrison)
 "wvf" = (
 /obj/structure/handcart{
-	icon_state = "cart-empty";
 	dir = 8
 	},
 /turf/open/floor/rogue/dirt/road,
@@ -23881,15 +23065,14 @@
 /area/rogue/indoors/town)
 "wxB" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town)
 "wxH" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/effect/decal/wood/herringbone2,
 /obj/item/reagent_containers/glass/bowl,
@@ -23897,7 +23080,6 @@
 /area/rogue/indoors/town)
 "wxP" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/masonic{
@@ -23906,8 +23088,8 @@
 /area/rogue/indoors/town/manor)
 "wxS" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -23923,9 +23105,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "wyG" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "wyH" = (
 /obj/structure/closet/crate/roguecloset,
@@ -23953,15 +23133,15 @@
 /area/rogue/indoors/town)
 "wzd" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/paper{
 	pixel_x = 4;
@@ -24017,9 +23197,9 @@
 /area/rogue/outdoors/exposed/town/keep)
 "wAc" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "forestout_cave";
+	aallmig = "rwfieldin1";
 	aportalgoesto = "forestin_cave";
-	aallmig = "rwfieldin1"
+	aportalid = "forestout_cave"
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
@@ -24030,7 +23210,6 @@
 /area/rogue/indoors/town/dwarfin)
 "wBb" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -24125,8 +23304,7 @@
 /area/rogue/outdoors/town)
 "wHt" = (
 /obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
@@ -24149,7 +23327,6 @@
 /area/rogue/outdoors/town)
 "wIe" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -24171,9 +23348,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/shop)
 "wJb" = (
-/obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir"
-	},
+/obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "wJD" = (
@@ -24186,7 +23361,6 @@
 /area/rogue/indoors/town/manor)
 "wJI" = (
 /obj/machinery/light/rogue/torchholder{
-	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
@@ -24197,8 +23371,8 @@
 /area/rogue/indoors/town/church/chapel)
 "wKp" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/effect/landmark/events/testportal{
 	aportalloc = "manor"
@@ -24322,7 +23496,6 @@
 /area/rogue/outdoors/town/roofs)
 "wOa" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
@@ -24338,7 +23511,6 @@
 "wOE" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobblerock,
@@ -24346,8 +23518,8 @@
 "wOS" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -24405,8 +23577,8 @@
 /area/rogue/indoors/town/bath)
 "wQM" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
@@ -24445,11 +23617,9 @@
 /area/rogue/indoors/town/manor)
 "wSp" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
@@ -24466,13 +23636,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"wTk" = (
-/obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/tavern)
 "wTN" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -24501,7 +23664,6 @@
 /area/rogue/under/town/basement)
 "wUy" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
@@ -24537,9 +23699,9 @@
 /area/rogue/indoors/shelter/woods)
 "wVx" = (
 /obj/structure/mineral_door/wood/window{
-	name = "dungeoneer's room door";
 	locked = 1;
-	lockid = "dungeon"
+	lockid = "dungeon";
+	name = "dungeoneer's room door"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -24549,8 +23711,8 @@
 /area/rogue/indoors/town/garrison)
 "wVP" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -24570,8 +23732,8 @@
 /area/rogue/indoors/town/vault)
 "wWx" = (
 /obj/structure/roguemachine/mail/r{
-	pixel_x = -32;
-	mailtag = "Physician"
+	mailtag = "Physician";
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -24582,13 +23744,10 @@
 /area/rogue/under/town/basement/keep)
 "wXw" = (
 /obj/item/clothing/ring/silver,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "wXx" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/inn,
@@ -24608,30 +23767,27 @@
 /area/rogue/indoors/town/tavern)
 "wZC" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
-	icon_state = "endwooddark";
 	dir = 4
 	},
 /area/rogue/under/town/basement)
 "wZH" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /obj/structure/mineral_door/wood/deadbolt/shutter{
-	name = "counter hatch";
 	dir = 2;
-	lockdir = 1
+	lockdir = 1;
+	name = "counter hatch"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "wZK" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -24652,14 +23808,13 @@
 /area/rogue/under/town/basement/keep)
 "xac" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
-	icon_state = "decostone-l";
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
 "xaG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -24714,7 +23869,6 @@
 /area/rogue/indoors/town/magician)
 "xcM" = (
 /obj/effect/landmark/start/squire{
-	icon_state = "arrow";
 	dir = 4
 	},
 /obj/structure/bed/rogue,
@@ -24724,8 +23878,8 @@
 /area/rogue/indoors/town/garrison)
 "xcU" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/structure/mirror,
 /obj/item/candle/yellow/lit{
@@ -24744,7 +23898,6 @@
 /area/rogue/under/town/basement/keep)
 "xeN" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
@@ -24758,7 +23911,6 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -24782,8 +23934,8 @@
 /obj/item/natural/cloth,
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -24793,11 +23945,9 @@
 /area/rogue/outdoors/rtfield)
 "xfN" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -24816,19 +23966,17 @@
 /area/rogue/indoors)
 "xgI" = (
 /obj/item/reagent_containers/food/snacks/crow{
-	icon_state = "crow";
 	dir = 1
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 2
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/mountains)
 "xgU" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "Heir's Apartment";
 	locked = 1;
-	lockid = "heir"
+	lockid = "heir";
+	name = "Heir's Apartment"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -24836,15 +23984,15 @@
 /area/rogue/indoors/town/manor)
 "xhj" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
+	dir = 1;
+	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
 "xhp" = (
@@ -24855,8 +24003,8 @@
 	dir = 6
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -24887,8 +24035,8 @@
 /area/rogue/outdoors/town)
 "xif" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper/scroll,
 /turf/open/floor/carpet/royalblack,
@@ -24927,8 +24075,8 @@
 /area/rogue/indoors/town/church/chapel)
 "xlv" = (
 /turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+	dir = 1;
+	icon_state = "iron_corner"
 	},
 /area/rogue/indoors/town/dwarfin)
 "xlI" = (
@@ -24976,17 +24124,16 @@
 /area/rogue/outdoors/town/roofs/keep)
 "xmW" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "xnf" = (
 /obj/structure/mineral_door/wood/fancywood{
-	name = "bunkhouse";
 	dir = 1;
 	locked = 1;
-	lockid = "merc"
+	lockid = "merc";
+	name = "bunkhouse"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -25000,7 +24147,6 @@
 /area/rogue/indoors/town/manor)
 "xnB" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -25009,14 +24155,12 @@
 /obj/structure/fluff/railing/fence,
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 4
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "xnL" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/transparent/openspace,
@@ -25026,7 +24170,6 @@
 	pixel_y = 32
 	},
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -25052,10 +24195,7 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/tavern)
 "xpL" = (
-/obj/effect/landmark/events/haunts{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "xpP" = (
@@ -25069,14 +24209,12 @@
 /area/rogue/indoors/town/dwarfin)
 "xpR" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town/roofs)
 "xqi" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 1
 	},
 /turf/open/floor/carpet/inn,
@@ -25102,8 +24240,8 @@
 /area/rogue/indoors/town)
 "xrL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -25118,7 +24256,6 @@
 /area/rogue/indoors/town/garrison)
 "xrQ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/naturalstone,
@@ -25136,8 +24273,8 @@
 /area/rogue/under/town/sewer)
 "xtL" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -25147,12 +24284,11 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xux" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/floor/rogue/rooftop{
-	icon_state = "roofg";
-	dir = 4
+	dir = 4;
+	icon_state = "roofg"
 	},
 /area/rogue/outdoors/town/roofs)
 "xuG" = (
@@ -25179,7 +24315,6 @@
 /area/rogue/indoors/town/manor)
 "xvM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /turf/open/transparent/openspace,
@@ -25193,8 +24328,8 @@
 /area/rogue/indoors/shelter/woods)
 "xwb" = (
 /obj/structure/fluff/traveltile{
-	aportalid = "bogrtout";
-	aportalgoesto = "bogrtin"
+	aportalgoesto = "bogrtin";
+	aportalid = "bogrtout"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
@@ -25204,8 +24339,8 @@
 /area/rogue/indoors/town/cell)
 "xwr" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/effect/decal/wood/herringbone2,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -25242,7 +24377,6 @@
 /area/rogue/under/town/basement/keep)
 "xxW" = (
 /obj/structure/fluff/railing/fence{
-	icon_state = "fence";
 	dir = 8
 	},
 /obj/structure/fluff/railing/fence,
@@ -25303,7 +24437,6 @@
 /area/rogue/indoors/shelter/woods)
 "xBk" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 8
 	},
 /turf/open/floor/rogue/hexstone,
@@ -25330,13 +24463,10 @@
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
 "xCI" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 4
 	},
 /obj/effect/landmark/start/villager{
@@ -25382,8 +24512,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
@@ -25428,16 +24558,16 @@
 /area/rogue/indoors/town/manor)
 "xHd" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/candle/yellow,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement)
 "xIj" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /obj/item/kitchen/spoon,
 /turf/open/floor/rogue/ruinedwood{
@@ -25500,8 +24630,8 @@
 /area/rogue/indoors/town)
 "xKL" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/steel,
 /turf/open/floor/carpet/red,
@@ -25518,7 +24648,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xMo" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -25569,8 +24698,8 @@
 /area/rogue/indoors/town/church)
 "xOb" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/structure/rogue/trophy/deer,
 /obj/item/rogueweapon/sword/iron/short{
@@ -25587,9 +24716,7 @@
 "xOg" = (
 /obj/structure/toilet,
 /obj/effect/landmark/start/guardsman,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "xOq" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -25608,17 +24735,13 @@
 /area/rogue/outdoors/rtfield)
 "xOF" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "xOU" = (
 /obj/structure/stairs{
-	icon_state = "stairs";
 	dir = 4
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood,
@@ -25650,13 +24773,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"xQm" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	lockid = "church";
-	locked = 1
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/church/chapel)
 "xQs" = (
 /obj/structure/stairs{
 	dir = 8
@@ -25695,8 +24811,8 @@
 /area/rogue/indoors/shelter/woods)
 "xQF" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
@@ -25714,8 +24830,8 @@
 	mailtag = "Warehouse"
 	},
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 1
+	dir = 1;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -25732,19 +24848,17 @@
 /area/rogue/indoors/town/manor)
 "xRi" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 1
 	},
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "xRp" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -25756,9 +24870,7 @@
 	icon_state = "barsbent";
 	layer = 2.81
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xRJ" = (
 /obj/effect/decal/cobbleedge{
@@ -25775,7 +24887,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "xSg" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_x = -8
 	},
@@ -25818,14 +24929,12 @@
 /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "chess"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "xUa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
@@ -25870,8 +24979,8 @@
 /area/rogue/indoors/town/dwarfin)
 "xVQ" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /obj/item/kitchen/rollingpin,
@@ -25894,16 +25003,16 @@
 /area/rogue/indoors)
 "xXn" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "xXs" = (
 /obj/structure/bars/passage{
-	icon_state = "passage1";
 	density = 0;
+	icon_state = "passage1";
 	redstone_id = "keepgate_outer"
 	},
 /obj/effect/decal/cobbleedge{
@@ -25924,8 +25033,8 @@
 /area/rogue/indoors/town)
 "xYu" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -25977,8 +25086,8 @@
 /area/rogue/under/town/basement)
 "yaE" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-n";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
@@ -25998,8 +25107,8 @@
 /area/rogue/indoors/town/tavern)
 "ybp" = (
 /obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
@@ -26017,8 +25126,8 @@
 /area/rogue/indoors/town/church/chapel)
 "ycO" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-w";
-	dir = 10
+	dir = 10;
+	icon_state = "cobbleedge-w"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
@@ -26078,8 +25187,8 @@
 /area/rogue/indoors/town)
 "yeh" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
@@ -26110,14 +25219,12 @@
 /area/rogue/indoors/town/magician)
 "yev" = (
 /obj/structure/chair/wood/rogue{
-	icon_state = "chair2";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "yfg" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/blocks,
@@ -26150,7 +25257,6 @@
 /area/rogue/indoors/town/manor)
 "yge" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /obj/structure/fluff/railing/border{
@@ -26168,9 +25274,9 @@
 /area/rogue/indoors/town/shop)
 "ygy" = (
 /obj/structure/mineral_door/wood{
-	name = "ROOM III";
 	locked = 1;
-	lockid = "roomiii"
+	lockid = "roomiii";
+	name = "ROOM III"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
@@ -26181,14 +25287,12 @@
 "yhY" = (
 /obj/structure/chair/stool/rogue,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "yie" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/grass,
@@ -26204,15 +25308,14 @@
 /area/rogue/indoors/town/church/chapel)
 "yiq" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/manor)
 "yiO" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -26234,7 +25337,6 @@
 /area/rogue/outdoors/mountains)
 "yjo" = (
 /obj/structure/fluff/railing/wood{
-	icon_state = "woodrailing";
 	dir = 8;
 	pixel_y = -1
 	},
@@ -26242,8 +25344,8 @@
 /area/rogue/outdoors/town/roofs/keep)
 "yjt" = (
 /obj/structure/closet/crate/chest{
-	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	base_icon_state = "woodchestalt";
+	icon_state = "woodchestalt"
 	},
 /obj/item/natural/bundle/fibers/full{
 	pixel_x = -5
@@ -26260,7 +25362,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "ykc" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -26276,8 +25377,8 @@
 /area/rogue/indoors/town/manor)
 "ykz" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
+	dir = 5;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
@@ -26298,9 +25399,9 @@
 /area/rogue/under/town/basement/keep)
 "ykK" = (
 /obj/structure/closet/crate/chest{
-	name = "meat chest";
+	base_icon_state = "woodchestalt";
 	icon_state = "woodchestalt";
-	base_icon_state = "woodchestalt"
+	name = "meat chest"
 	},
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -26320,7 +25421,6 @@
 /area/rogue/outdoors/rtfield)
 "ymf" = (
 /obj/structure/roguewindow/openclose{
-	icon_state = "woodwindowdir";
 	dir = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -55042,7 +54142,7 @@ jfy
 ylN
 ylN
 ylN
-czw
+oAP
 xOC
 eUz
 eUz
@@ -55959,13 +55059,13 @@ ndg
 fBB
 hvn
 dRZ
-ftM
+igG
 aai
 xEW
 xDC
 hJn
 rou
-ftM
+igG
 jIk
 jIk
 ymg
@@ -59256,14 +58356,14 @@ waT
 hvn
 hvn
 rLi
-ftM
+igG
 loH
 aak
 ugU
 lMh
 loH
 aap
-ftM
+igG
 nko
 cxb
 cxb
@@ -60455,7 +59555,7 @@ fBB
 doE
 yjt
 eSe
-tyQ
+uyi
 pND
 eSe
 rRb
@@ -63501,7 +62601,7 @@ ctF
 cxb
 oyZ
 ugU
-hoH
+nNJ
 lNY
 qyk
 xSN
@@ -63519,9 +62619,9 @@ xOC
 xOC
 xOC
 xOC
-pOo
+btI
 low
-bWt
+wFC
 xOC
 xOC
 xOC
@@ -63658,7 +62758,7 @@ ctF
 cxb
 oyZ
 ugU
-hoH
+nNJ
 qyk
 qyk
 qyk
@@ -64774,7 +63874,7 @@ xOC
 iXP
 sRV
 sRV
-toL
+pwS
 cKj
 hmb
 cKj
@@ -65401,7 +64501,7 @@ mNh
 mNh
 mNh
 mNh
-ikB
+wSj
 sRV
 sRV
 sRV
@@ -68353,7 +67453,7 @@ fNg
 lyO
 tVC
 waT
-ftM
+igG
 fTZ
 fTZ
 iwJ
@@ -78548,10 +77648,10 @@ tXZ
 oKg
 tEM
 lAL
-mGi
-mGi
+jaW
+jaW
 yge
-mGi
+jaW
 mEa
 mgM
 jaW
@@ -81027,7 +80127,7 @@ haD
 kMl
 gKA
 gKA
-xQm
+pjY
 mXn
 pIq
 qhb
@@ -81372,7 +80472,7 @@ pov
 eVv
 qeJ
 jBO
-nZx
+hkC
 jBO
 eVv
 eVv
@@ -81978,7 +81078,7 @@ vEG
 vEG
 jnQ
 nRX
-gzW
+aUC
 qhb
 qhb
 qhb
@@ -82606,7 +81706,7 @@ qhb
 oKl
 tcy
 nRX
-gzW
+aUC
 qhb
 qhb
 qhb
@@ -82626,10 +81726,10 @@ gmc
 qsr
 pov
 sjq
-wTk
+kwG
 jBO
 sjq
-wTk
+kwG
 jBO
 sjq
 qhb
@@ -82757,12 +81857,12 @@ kuX
 ixQ
 ixQ
 det
-rkX
-gzW
+otC
+aUC
 qhb
 sLS
-rkX
-gzW
+otC
+aUC
 qhb
 qhb
 qhb
@@ -84791,7 +83891,7 @@ eSe
 eSe
 jMj
 hRf
-cvX
+wzR
 ouw
 ouw
 ouw
@@ -84948,7 +84048,7 @@ eSe
 ebf
 eSe
 mlJ
-cvX
+wzR
 ouw
 ouw
 ouw
@@ -85105,7 +84205,7 @@ oyt
 gKS
 fnb
 doE
-dYY
+wMV
 ouw
 ouw
 ouw
@@ -86529,7 +85629,7 @@ vAP
 oVP
 xVF
 cAt
-fQO
+syG
 ouw
 qhb
 qhb
@@ -87145,7 +86245,7 @@ qhb
 nkZ
 qhb
 tvX
-meP
+umV
 vpP
 czZ
 kuF
@@ -87942,7 +87042,7 @@ lIO
 wAU
 wMO
 cAt
-fQO
+syG
 fnS
 qhb
 qhb
@@ -110707,7 +109807,7 @@ cAt
 wKP
 dQx
 wKP
-fQO
+syG
 qhb
 qhb
 qhb
@@ -110865,7 +109965,7 @@ nLp
 gBZ
 ono
 cAt
-fQO
+syG
 qhb
 qhb
 qhb
@@ -111324,7 +110424,7 @@ qhb
 qhb
 qhb
 xmF
-meP
+umV
 vpP
 tvX
 eeB
@@ -112120,7 +111220,7 @@ cAt
 wKP
 dQx
 wKP
-fQO
+syG
 qhb
 qhb
 qhb
@@ -112278,7 +111378,7 @@ fmZ
 emP
 pBa
 cAt
-fQO
+syG
 qhb
 qhb
 qhb
@@ -116353,8 +115453,8 @@ tYX
 tYX
 tYX
 cXV
-fdT
-fdT
+oew
+oew
 ngM
 tYX
 tYX

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -16909,6 +16909,18 @@
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/clothing/head/roguetown/chef,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironspoon,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
+/obj/item/kitchen/ironfork,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -19534,6 +19546,13 @@
 /obj/item/cooking/platter,
 /obj/item/cooking/platter,
 /obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a set of six spoons, six forks, and a few extra platters and bowls to the keep's kitchens.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's kind of absurd for there to be plates and bowls in the manor but not so much as a single spoon or fork in the entire keep, especially now that silverware is a physiological need for nobles. Also, not only should servants not be expected to make cruddy wooden forks and knives for the richest people in Azure Peak, but if they can afford to have three separate private baths, they can probably afford to come pre-stocked with metal silverware.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
