### PR TITLE
wood armz r cheaper, reflavors a couple knives

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -124,8 +124,9 @@
 
 /obj/item/rogueweapon/huntingknife/cleaver/combat
 	force = 16
-	name = "combat knife"
-	desc = "A combat knife. Swift and deadly if you hit."
+	name = "seax"
+	desc = "A fighting knife used amongst the Grenzels and Northerners for centuries, serving dual purpose as a \
+	tool of daily life and as a capable fighting knife."
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/chop/cleaver, )
 	icon_state = "combatknife"
 	icon = 'icons/roguetown/weapons/32.dmi'
@@ -291,8 +292,8 @@
 	is_silver = TRUE
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/elvish/drow
-	name = "nite elf dagger"
-	desc = "This ominous, dark handled silver dagger was crafted by the assassin race of nite elves."
+	name = "dark elvish dagger"
+	desc = "A vicious wave-bladed dagger from the Underdark."
 	force = 25
 	last_used = 0
 	is_silver = TRUE

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -650,16 +650,14 @@
 /datum/crafting_recipe/roguetown/prosthetic/woodleft
 	name = "wood arm (L)"
 	result = list(/obj/item/bodypart/l_arm/prosthetic/woodleft)
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-	/obj/item/roguegear = 1)
+	reqs = list(/obj/item/grown/log/tree/small = 1)
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/prosthetic/woodright
 	name = "wood arm (R)"
 	result = list(/obj/item/bodypart/r_arm/prosthetic/woodright)
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-	/obj/item/roguegear = 1)
+	reqs = list(/obj/item/grown/log/tree/small = 1)
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 3
 

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -651,14 +651,14 @@
 	name = "wood arm (L)"
 	result = list(/obj/item/bodypart/l_arm/prosthetic/woodleft)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
-	skillcraft = /datum/skill/craft/engineering
+	skillcraft = /datum/skill/craft/crafting
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/prosthetic/woodright
 	name = "wood arm (R)"
 	result = list(/obj/item/bodypart/r_arm/prosthetic/woodright)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
-	skillcraft = /datum/skill/craft/engineering
+	skillcraft = /datum/skill/craft/crafting
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/tarot_deck


### PR DESCRIPTION
## About The Pull Request

removes the cog requirement from prosthetic arm recipes because it doesn't make sense. also changes their skill to basic crafting because you don't need an engineer to whittle a bad prosthetic. reflavors the combat knife to a seax because the sprite pretty much fits and that name kind of annoyed me. reflavors the nite elf dagger to a dark elf dagger.

## Why It's Good For The Game

if you have cogs and an artificer you aren't going to make wood arms, you're going to make bronze ones. this allows wood arms, which suck, to serve as an ersatz solution for when you don't have an arty to make the good stuff. the knife changes are just because seeing the name 'combat knife' makes me think of some ww1 shit at the absolute earliest, so now it's medieval. and. what yon fucke are nite elves?
