### PR TITLE
Makes a silent type of sea raider that doesn't spam chat logs (as much)

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/searaider.dm
+++ b/code/modules/mob/living/carbon/human/npc/searaider.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 	dodgetime = 30
 	flee_in_pain = TRUE
 	possible_rmb_intents = list()
+	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 
 
 /mob/living/carbon/human/species/human/northern/searaider/ambush
@@ -22,7 +23,7 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 	if(target)
 		aggressive=1
 		wander = TRUE
-		if(target != newtarg)
+		if(!is_silent && target != newtarg)
 			say(pick(GLOB.searaider_aggro))
 			linepoint(target)
 
@@ -67,16 +68,20 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 			face_atom(get_step(src,pick(GLOB.cardinals)))
 	if(!wander && prob(10))
 		face_atom(get_step(src,pick(GLOB.cardinals)))
-	if(prob(12))
+	if(!is_silent && prob(12))
 		say(pick(GLOB.searaider_quotes))
-	if(prob(12))
+	if(!is_silent && prob(12))
 		emote(pick("laugh","burp","yawn","grumble","mumble","blink_r","clap"))
 
 /mob/living/carbon/human/species/human/northern/searaider/handle_combat()
 	if(mode == AI_HUNT)
-		if(prob(50))
+		if(prob(50)) // ignores is_silent because they should at least still be able to scream at people!
 			emote("rage")
 	. = ..()
+
+/// This version of sea raider actually stays quiet and doesn't yell. Great for admin spawn events if you don't want to destroy your players' chat logs!
+/mob/living/carbon/human/species/human/northern/searaider/silent
+	is_silent = TRUE
 
 /datum/outfit/job/roguetown/human/species/human/northern/searaider/pre_equip(mob/living/carbon/human/H)
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds an admin-spawn-only subtype of sea raider that doesn't say any of its voice lines OR point at people.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Great for graggarite-heavy events where the chat (and server) isn't spammed with ungodly amounts of graggarite screaming! Probably great for server performance, too!

... They do still do the *rage emote because I think they should at least still do that.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
