### PR TITLE
Fixes Crown being summonable off of a head (maybe)

### DIFF
--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 						say("[HC.real_name] holds the crown!")
 						playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
 						return
-					if(H.head == I)
+					if(HC.head == I)
 						say("[HC.real_name] wears the crown!")
 						playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
 						return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This should prevent people from summoning the crown while it's being worn and creating that buggy double crown. 
Keyword: "Should"

## Why It's Good For The Game

Probably better to have people actually able to wear the crown rather than being forced to hold it in their hands to prevent summoning
