### PR TITLE
Alters Psydon barbute FOV

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -2363,9 +2363,9 @@
 /area/rogue/outdoors/town)
 "bYJ" = (
 /obj/structure/fluff/statue/femalestatue/zizo{
-	pixel_y = 0;
+	desc = "An ancient statue depicting an elven woman.";
 	name = "Ancient Statue";
-	desc = "An ancient statue depicting an elven woman."
+	pixel_y = 0
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave)
@@ -2521,8 +2521,8 @@
 	pixel_y = 6
 	},
 /obj/item/staff/broom{
-	pixel_y = 7;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 7
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
@@ -3040,8 +3040,8 @@
 /area/rogue/indoors/town/church/chapel)
 "cGG" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
@@ -3341,8 +3341,8 @@
 /area/rogue/indoors/town)
 "cWu" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble/mossy,
@@ -3464,7 +3464,6 @@
 /area/rogue/indoors/town/garrison)
 "daX" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -4187,8 +4186,8 @@
 /area/rogue/outdoors/town/roofs)
 "dDX" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /obj/item/clothing/cloak/raincloak/mortus,
 /turf/open/floor/rogue/cobble,
@@ -4241,13 +4240,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
-"dGH" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "dGX" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -4628,7 +4620,7 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute,
+/obj/item/clothing/head/roguetown/helmet/psydonbarbute,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
 "dZh" = (
@@ -4988,8 +4980,8 @@
 	layer = 2.81
 	},
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
@@ -5218,8 +5210,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "eBA" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/book/rogue/robber,
 /turf/open/floor/rogue/cobble,
@@ -5269,8 +5261,8 @@
 /area/rogue/indoors/town)
 "eDH" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
+	dir = 8;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
@@ -5474,8 +5466,8 @@
 /area/rogue/under/town/basement)
 "ePC" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
@@ -6844,7 +6836,6 @@
 /area/rogue/outdoors/town)
 "gjh" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/concrete,
@@ -7001,7 +6992,6 @@
 /area/rogue/indoors/town/cell)
 "goy" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 10
 	},
 /turf/open/floor/rogue/cobble,
@@ -7059,8 +7049,8 @@
 /area/rogue/under/town/basement/keep)
 "gqL" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 6
+	dir = 6;
+	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/idagger/navaja,
 /turf/open/floor/rogue/cobble,
@@ -7557,8 +7547,8 @@
 	dir = 1
 	},
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
@@ -7574,7 +7564,6 @@
 "gRB" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/tile/bath,
@@ -7660,7 +7649,6 @@
 /area/rogue/indoors/town)
 "gTZ" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
@@ -8010,13 +7998,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"hoH" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/town/basement)
 "hoU" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
@@ -9223,7 +9204,6 @@
 /area/rogue/indoors/town/dwarfin)
 "ivS" = (
 /obj/structure/stairs/stone{
-	icon_state = "stonestairs";
 	dir = 1
 	},
 /turf/open/floor/rogue/hexstone,
@@ -10300,8 +10280,8 @@
 /area/rogue/indoors/town)
 "jvD" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
@@ -10323,9 +10303,9 @@
 /area/rogue/indoors/town/magician)
 "jyi" = (
 /obj/structure/mineral_door/wood/donjon/stone{
-	name = "Forgotten Chapel";
 	locked = 1;
-	lockid = "inhumen"
+	lockid = "inhumen";
+	name = "Forgotten Chapel"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave)
@@ -10374,7 +10354,7 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute,
+/obj/item/clothing/head/roguetown/helmet/psydonbarbute,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
 "jBv" = (
@@ -11066,8 +11046,8 @@
 /area/rogue/under/town/basement/keep)
 "kkF" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave)
@@ -12002,8 +11982,8 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
@@ -13613,7 +13593,6 @@
 /area/rogue/under/town/sewer)
 "muY" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
@@ -14127,8 +14106,8 @@
 /area/rogue/indoors/town/church/chapel)
 "mWa" = (
 /obj/structure/table/wood{
-	icon_state = "longtable_mid";
-	dir = 1
+	dir = 1;
+	icon_state = "longtable_mid"
 	},
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -14575,23 +14554,23 @@
 "npD" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/item/burial_shroud{
-	pixel_y = -8;
-	pixel_x = -8;
-	layer = 2.9
-	},
-/obj/item/burial_shroud{
-	pixel_y = -1;
-	pixel_x = -8
-	},
-/obj/item/burial_shroud{
-	pixel_y = -6;
-	pixel_x = -1;
-	layer = 2.8
-	},
-/obj/item/burial_shroud{
-	pixel_y = 1;
 	layer = 2.9;
-	pixel_x = -1
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/burial_shroud{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/obj/item/burial_shroud{
+	layer = 2.8;
+	pixel_x = -1;
+	pixel_y = -6
+	},
+/obj/item/burial_shroud{
+	layer = 2.9;
+	pixel_x = -1;
+	pixel_y = 1
 	},
 /obj/item/natural/bundle/stick{
 	pixel_x = -5
@@ -15754,8 +15733,8 @@
 /area/rogue/indoors/town)
 "orA" = (
 /obj/structure/bookcase{
-	name = "suspicious bookcase";
-	density = 0
+	density = 0;
+	name = "suspicious bookcase"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
@@ -15803,8 +15782,8 @@
 /area/rogue/outdoors/exposed/town/keep)
 "osh" = (
 /obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	dir = 1
+	dir = 1;
+	icon_state = "borderfall"
 	},
 /obj/machinery/light/rogue/firebowl/church{
 	light_color = "#b30202"
@@ -16230,8 +16209,8 @@
 /area/rogue/indoors/town/manor)
 "oJm" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 4
+	dir = 4;
+	icon_state = "largetable"
 	},
 /obj/item/clothing/cloak/raincloak/mortus,
 /turf/open/floor/rogue/cobble,
@@ -19028,7 +19007,6 @@
 /area/rogue/indoors/town/manor)
 "roM" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 8
 	},
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -21757,8 +21735,8 @@
 /area/rogue/indoors/town/shop)
 "tNw" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood2";
-	dir = 10
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/flint,
 /turf/open/floor/rogue/cobble,
@@ -23844,8 +23822,8 @@
 /area/rogue/indoors/town/garrison)
 "vYF" = (
 /obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 10
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
@@ -24890,7 +24868,6 @@
 /area/rogue/indoors/town/garrison)
 "wRt" = (
 /obj/structure/fluff/railing/border{
-	icon_state = "border";
 	dir = 4
 	},
 /turf/open/floor/rogue/concrete,
@@ -24937,7 +24914,6 @@
 /area/rogue/indoors/town/dwarfin)
 "wSt" = (
 /obj/structure/chair/wood/rogue/fancy{
-	icon_state = "chair1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
@@ -25566,8 +25542,8 @@
 /area/rogue/outdoors/town)
 "xpO" = (
 /obj/structure/table/wood{
-	icon_state = "tablewood1";
-	dir = 1
+	dir = 1;
+	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/cobble,
@@ -36107,7 +36083,7 @@ xpt
 xpt
 xpt
 xpt
-dGH
+rBh
 gdw
 heh
 cVE
@@ -36264,7 +36240,7 @@ pOg
 xpt
 xpt
 xpt
-dGH
+rBh
 gdw
 heh
 cVE
@@ -37363,7 +37339,7 @@ vFB
 eTu
 bBD
 bBD
-hoH
+bRT
 nze
 cVE
 heh

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -512,6 +512,16 @@
 	icon_state = "kettle"
 	body_parts_covered = HEAD|HAIR|EARS
 	armor = list("blunt" = 80, "slash" = 90, "stab" = 70, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	
+/obj/item/clothing/head/roguetown/helmet/psydonbarbute
+	name = "psydonian barbute"
+	desc = "A barbute styled with Psydonian Imagery."
+	icon_state = "psydonbarbute"
+	item_state = "psydonbarbute"
+	block2add = FOV_BEHIND
+	flags_inv = HIDEEARS|HIDEFACE
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	body_parts_covered = FULL_HEAD
 
 /obj/item/clothing/head/roguetown/helmet/kettle/attackby(obj/item/W, mob/living/user, params)
 	..()
@@ -689,12 +699,6 @@
 	block2add = FOV_RIGHT|FOV_LEFT
 	smeltresult = /obj/item/ingot/steel
 	max_integrity = 400
-
-/obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute
-	name = "psydonian barbute"
-	desc = "A barbute styled with Psydonian Imagery."
-	icon_state = "psydonbarbute"
-	item_state = "psydonbarbute"
 
 /obj/item/clothing/head/roguetown/helmet/heavy/guard
 	name = "savoyard"


### PR DESCRIPTION
At present, the Inquisition Templars have the choice of both an armet and the Psydonian barbute. Both are heavy helms with a 90 degree cone of FOV. However, this pretty severely limits visibility for a role that starts with some pretty weak armour and a shield- and visibility is necessary to use that shield to any decent effect.

After discussing with Ambrose and Onut, we agreed on the change of the barbute to have a 180 cone of vision, whilst losing its status as a heavy helm in recompense. This removes some of the crit protection of the helm. This also makes more sense given the larger viewslits shown on the sprite of the barbute, and offers the Otavan templars an option between less visibility for the more armoured warrior, and more visibility for those more light on their feet and shield-inclined.

Also makes a small edit to the Dun Manor map in the form of replacing the old barbutes in the Inquisition chambers with the new path.
