### PR TITLE
fuck torches

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -37,12 +37,6 @@
 
 	H.advjob = name
 
-	//sleep(1)
-	//testing("[H] spawn troch")
-	var/obj/item/flashlight/flare/torch/T = new()
-	T.spark_act()
-	H.put_in_hands(T, forced = TRUE)
-
 	var/turf/TU = get_turf(H)
 	if(TU)
 		if(horse)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/Iconoclast.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/Iconoclast.dm
@@ -31,7 +31,11 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1)
+	backpack_contents = list(
+					/obj/item/needle/thorn = 1,
+					/obj/item/natural/cloth = 1,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	head = /obj/item/clothing/head/roguetown/roguehood
 	armor = /obj/item/clothing/suit/roguetown/armor/plate
 	beltr = /obj/item/rogueweapon/katar

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
@@ -32,7 +32,11 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/random
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1)
+	backpack_contents = list(
+					/obj/item/needle/thorn = 1,
+					/obj/item/natural/cloth = 1,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
 	neck = /obj/item/clothing/neck/roguetown/coif
 	head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
@@ -24,7 +24,10 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backl = /obj/item/rogueweapon/shield/tower/metal
 	id = /obj/item/mattcoin
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger = 1)
+	backpack_contents = list(
+					/obj/item/rogueweapon/huntingknife/idagger = 1,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
@@ -57,7 +57,12 @@
 			cloak = /obj/item/clothing/cloak/raincloak/mortus //cool cloak
 			beltl = /obj/item/rogueweapon/huntingknife/idagger/steel
 			backr = /obj/item/storage/backpack/rogue/satchel
-			backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1, /obj/item/lockpickring/mundane = 1) //rogue gets lockpicks
+			backpack_contents = list(
+						/obj/item/needle/thorn = 1,
+						/obj/item/natural/cloth = 1,
+						/obj/item/lockpickring/mundane = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						) //rogue gets lockpicks
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
 		if("Bow & Sword") //Poacher
 			backl= /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
@@ -65,5 +70,10 @@
 			beltr = /obj/item/quiver/arrows
 			head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm //cool hat
 			backr = /obj/item/storage/backpack/rogue/satchel
-			backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1, /obj/item/restraints/legcuffs/beartrap = 2) //poacher gets mantraps
+			backpack_contents = list(
+						/obj/item/needle/thorn = 1,
+						/obj/item/natural/cloth = 1,
+						/obj/item/restraints/legcuffs/beartrap = 2,
+						/obj/item/flashlight/flare/torch = 1,
+						) //poacher gets mantraps
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
@@ -16,7 +16,11 @@
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltr = /obj/item/reagent_containers/glass/bottle/rogue/manapot
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1)
+	backpack_contents = list(
+					/obj/item/needle/thorn = 1,
+					/obj/item/natural/cloth = 1,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	mask = /obj/item/clothing/mask/rogue/facemask/steel //idk if this makes it so they cant cast but i want all of the bandits to have the same mask
 	neck = /obj/item/clothing/neck/roguetown/coif
 	head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -20,7 +20,11 @@
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/mattcoin
-	backpack_contents = list(		/obj/item/natural/worms/leech/cheele = 1, /obj/item/natural/cloth = 2,)
+	backpack_contents = list(
+					/obj/item/natural/worms/leech/cheele = 1,
+					/obj/item/natural/cloth = 2,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
@@ -32,7 +32,11 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/needle/thorn = 1, /obj/item/natural/cloth = 1)
+	backpack_contents = list(
+					/obj/item/needle/thorn = 1,
+					/obj/item/natural/cloth = 1,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/amazon.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/amazon.dm
@@ -28,6 +28,9 @@
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/bikini
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/barbarian.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/barbarian.dm
@@ -40,6 +40,9 @@
 			belt = /obj/item/storage/belt/rogue/leather
 			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 			backl = /obj/item/storage/backpack/rogue/satchel
+			backpack_contents = list(
+								/obj/item/flashlight/flare/torch = 1,
+								)
 			shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			head = /obj/item/clothing/head/roguetown/helmet/horned
@@ -97,6 +100,9 @@
 			shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			backr = /obj/item/storage/backpack/rogue/satchel
+			backpack_contents = list(
+								/obj/item/flashlight/flare/torch = 1,
+								)			
 			cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
 			H.change_stat("intelligence", -1) // The hunter is smarter, more skilled -- but not as tough.
@@ -129,6 +135,9 @@
 			beltl = /obj/item/rogueweapon/huntingknife
 			shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 			backr = /obj/item/storage/backpack/rogue/satchel
+			backpack_contents = list(
+								/obj/item/flashlight/flare/torch = 1,
+								)			
 			cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
@@ -57,7 +57,10 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger/steel
-			backpack_contents = list(/obj/item/lockpickring/one = 1)
+			backpack_contents = list(
+							/obj/item/lockpickring/one = 1,
+							/obj/item/flashlight/flare/torch = 1,
+							)
 			H.change_stat("intelligence", 1)
 			H.change_stat("perception", 2)
 			H.change_stat("endurance", 1)
@@ -99,7 +102,11 @@
 				cloak = /obj/item/clothing/cloak/raincloak/red
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/rogueweapon/sword/iron
-			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel, /obj/item/storage/belt/rogue/pouch/coins/mid)
+			backpack_contents = list(
+							/obj/item/rogueweapon/huntingknife/idagger/steel,
+							/obj/item/storage/belt/rogue/pouch/coins/mid,
+							/obj/item/flashlight/flare/torch = 1,
+							)
 			H.change_stat("constitution", 2)
 			H.change_stat("strength", 1)
 			H.change_stat("speed", 1)
@@ -136,6 +143,9 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/white
 			cloak = /obj/item/clothing/cloak/raincloak/purple
 			backl = /obj/item/storage/backpack/rogue/satchel
+			backpack_contents = list(
+								/obj/item/flashlight/flare/torch = 1,
+								)
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
 			backpack_contents = list(/obj/item/lockpickring/one = 1)
@@ -171,6 +181,9 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/white
 			cloak = /obj/item/clothing/cloak/raincloak
 			backl = /obj/item/storage/backpack/rogue/satchel
+			backpack_contents = list(
+								/obj/item/flashlight/flare/torch = 1,
+								)
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
 			switch(H.patron?.type)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -128,7 +128,10 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/shield/wood
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife)
+	backpack_contents = list(
+						/obj/item/rogueweapon/huntingknife,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	// everything about this sucks - we should really make a subclass datum or something
 
 	// HEARTHSTONE ADD: cloistered devout custom outfits

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dbomb.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dbomb.dm
@@ -15,6 +15,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/rogueweapon/huntingknife
+	beltr = /obj/item/flashlight/flare/torch
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	backl = /obj/item/storage/backpack/rogue/backpack

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/dwarfwarrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/dwarfwarrior.dm
@@ -15,6 +15,7 @@
 	pants = /obj/item/clothing/under/roguetown/trou
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/flashlight/flare/torch
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/paladin.dm
@@ -86,6 +86,9 @@
 			id = /obj/item/clothing/ring/silver
 			backr = /obj/item/rogueweapon/sword
 			backl = /obj/item/storage/backpack/rogue/satchel
+			backpack_contents = list(
+								/obj/item/flashlight/flare/torch = 1,
+								)
 		if("Battle Master")
 			H.set_blindness(0)
 			to_chat(H, span_warning("You are a battle-master."))
@@ -121,6 +124,9 @@
 			backr = /obj/item/rogueweapon/flail
 			l_hand = /obj/item/rogueweapon/shield/tower/metal
 			backl = /obj/item/storage/backpack/rogue/satchel
+			backpack_contents = list(
+								/obj/item/flashlight/flare/torch = 1,
+								)
 
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/donator/vaquero.dm
@@ -44,7 +44,12 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltl = /obj/item/rogueweapon/sword/rapier
 	backr = /obj/item/rogue/instrument/guitar
-	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/rogueweapon/huntingknife/idagger/navaja = 1, /obj/item/lockpick = 1)
+	backpack_contents = list(
+					/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+					/obj/item/rogueweapon/huntingknife/idagger/navaja = 1,
+					/obj/item/lockpick = 1,
+					/obj/item/flashlight/flare/torch = 1,,
+					)
 	H.change_stat("intelligence", 2)
 	H.change_stat("endurance", 2)
 	H.change_stat("speed", 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dwarfranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/dwarfranger.dm
@@ -23,7 +23,10 @@
 	beltl = /obj/item/quiver/bolts
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1)
+	backpack_contents = list(
+						/obj/item/rogueweapon/huntingknife = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	if(prob(23))
 		shoes = /obj/item/clothing/shoes/roguetown/boots
 	if(prob(23))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -18,6 +18,9 @@
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	r_hand = /obj/item/rogueweapon/woodstaff
 	if(H.mind)
 		to_chat(H, span_warning("Magic is often times refered to as an art. At times it is treated as a primordial beast, chaos incarnate. To more learned men it is a precise science, to be studied and examined. In the end, magic is all three of the above. It is Art, Chaos, and Science: a blessing, a curse, and progress. It all depends on who calls upon it, and for what purpose."))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/monk.dm
@@ -21,6 +21,9 @@
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/backpack
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	r_hand = /obj/item/rogueweapon/woodstaff
 	if(H.mind)
 		to_chat(src, span_warning("Monks are pilgrims of powerful belief who empart the teachings of their Temple or God by their interactions with the people of the world. A good monk would seek to help travellers on the road, feed the hungry and teach the weak to become strong. A bad one however..."))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -30,7 +30,11 @@
 			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltr = /obj/item/flashlight/flare/torch/lantern
-			backpack_contents = list(/obj/item/bait = 1, /obj/item/rogueweapon/huntingknife = 1)
+			backpack_contents = list(
+								/obj/item/bait = 1,
+								/obj/item/rogueweapon/huntingknife = 1,
+								/obj/item/flashlight/flare/torch = 1,
+								)
 			beltl = /obj/item/quiver/arrows
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
@@ -73,7 +77,10 @@
 			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltr = /obj/item/flashlight/flare/torch/lantern
-			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+			backpack_contents = list(
+								/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+								/obj/item/flashlight/flare/torch = 1,
+								)
 			beltl = /obj/item/quiver/arrows
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelt.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelt.dm
@@ -24,6 +24,9 @@
 	beltr = /obj/item/rogueweapon/huntingknife
 	gloves = /obj/item/clothing/gloves/roguetown/leather/black
 	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	id = /obj/item/scomstone
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelthand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/heartfelthand.dm
@@ -22,6 +22,9 @@
 	beltl = /obj/item/rogueweapon/sword/sabre/dec
 	beltr = /obj/item/rogueweapon/huntingknife
 	backr = /obj/item/storage/backpack/rogue/satchel/heartfelt
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	mask = /obj/item/clothing/mask/rogue/spectacles/golden
 	id = /obj/item/scomstone
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/knighterrant.dm
@@ -32,7 +32,11 @@
 			belt = /obj/item/storage/belt/rogue/leather
 			backr = /obj/item/storage/backpack/rogue/satchel/black
 			backl = /obj/item/rogueweapon/shield/tower/metal
-			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger = 1,/obj/item/storage/belt/rogue/pouch/coins/poor)
+			backpack_contents = list(
+							/obj/item/rogueweapon/huntingknife/idagger = 1,
+							/obj/item/storage/belt/rogue/pouch/coins/poor,
+							/obj/item/flashlight/flare/torch = 1,
+							)
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/necromancer.dm
@@ -17,6 +17,9 @@
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/necromancer
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	beltr = /obj/item/reagent_containers/glass/bottle/rogue/manapot
 	beltl = /obj/item/rogueweapon/huntingknife
 	r_hand = /obj/item/rogueweapon/woodstaff

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/sentinel.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/sentinel.dm
@@ -40,7 +40,11 @@
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltr = /obj/item/rogueweapon/sword/sabre
-	backpack_contents = list(/obj/item/bait = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/elvish = 1)
+	backpack_contents = list(
+				/obj/item/bait = 1,
+				/obj/item/rogueweapon/huntingknife/idagger/silver/elvish = 1,
+				/obj/item/flashlight/flare/torch = 1,
+				)
 	beltl = /obj/item/quiver/arrows
 	H.change_stat("perception", 5)
 	H.change_stat("endurance", 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/squireerrant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/squireerrant.dm
@@ -19,11 +19,11 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	beltr = /obj/item/rogueweapon/sword/iron
 	backpack_contents = list(
-		/obj/item/storage/belt/rogue/pouch/coins/poor,
-		/obj/item/rogueweapon/hammer,
-		/obj/item/rogueweapon/tongs
-
-	)
+					/obj/item/storage/belt/rogue/pouch/coins/poor,
+					/obj/item/rogueweapon/hammer,
+					/obj/item/rogueweapon/tongs,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/treasurehunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/treasurehunter.dm
@@ -15,7 +15,12 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 	backl = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather
-	backpack_contents = list(/obj/item/rogueweapon/pick = 1, /obj/item/lockpick, /obj/item/rogueweapon/huntingknife/idagger/navaja)
+	backpack_contents = list(
+					/obj/item/rogueweapon/pick = 1,
+					/obj/item/lockpick,
+					/obj/item/rogueweapon/huntingknife/idagger/navaja,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless
 	cloak = /obj/item/clothing/cloak/raincloak/mortus
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/witchhunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rare/witchhunter.dm
@@ -26,7 +26,10 @@
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	beltl = /obj/item/rogueweapon/sword/rapier
 	backl = /obj/item/storage/backpack/rogue/satchel/black
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver = 1)
+	backpack_contents = list(
+					/obj/item/rogueweapon/huntingknife/idagger/silver = 1,
+					/obj/item/flashlight/flare/torch = 1,
+					)
 
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -60,7 +60,9 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel
 	beltl = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
-	backpack_contents = list(/obj/item/lockpickring/mundane)
+	backpack_contents = list(
+						/obj/item/lockpickring/mundane,
+						/obj/item/flashlight/flare/torch = 1,)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
@@ -113,7 +115,11 @@
 	H.change_stat("intelligence", 2)
 	H.cmode_music = 'sound/music/combat_rogue.ogg'
 	to_chat(H, span_info("I honed my skills as a rogue through the years, and was skilled enough to become an assassin. Now it depends to me how I use my abilities."))
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel, /obj/item/lockpickring/mundane)
+	backpack_contents = list(
+						/obj/item/rogueweapon/huntingknife/idagger/steel,
+						/obj/item/lockpickring/mundane,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 
 /datum/outfit/job/roguetown/adventurer/rogue/proc/duelistarch(mob/living/carbon/human/H)
 	//less of other skills, more sword and knife combat skills.
@@ -149,7 +155,10 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltl = /obj/item/rogueweapon/sword/rapier
 	beltr = /obj/item/rogueweapon/shield/buckler
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/parrying)
+	backpack_contents = list(
+						/obj/item/rogueweapon/huntingknife/idagger/steel/parrying,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DECEIVING_MEEKNESS, TRAIT_GENERIC)
 	H.change_stat("strength", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/sorceress.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/sorceress.dm
@@ -14,6 +14,9 @@
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/mage
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	beltr = /obj/item/reagent_containers/glass/bottle/rogue/manapot
 	beltl = /obj/item/rogueweapon/huntingknife
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -117,6 +117,9 @@
 					H.mind.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)
 					backr = /obj/item/rogueweapon/stoneaxe/battle
 	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	beltl = /obj/item/rogueweapon/huntingknife
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	gloves = /obj/item/clothing/gloves/roguetown/leather

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
@@ -22,7 +22,12 @@
 	pants = /obj/item/clothing/under/roguetown/trou
 
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/flint = 1, /obj/item/rogueore/coal=1, /obj/item/rogueore/iron=1)
+	backpack_contents = list(
+						/obj/item/flint = 1,
+						/obj/item/rogueore/coal=1,
+						/obj/item/rogueore/iron=1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	ADD_TRAIT(H, TRAIT_TRAINED_SMITH, TRAIT_GENERIC)
 	if(H.pronouns == HE_HIM)
 		shoes = /obj/item/clothing/shoes/roguetown/boots/leather

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/carpenter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/carpenter.dm
@@ -39,7 +39,11 @@
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltl = /obj/item/rogueweapon/hammer/claw
 	backl = /obj/item/storage/backpack/rogue/backpack
-	backpack_contents = list(/obj/item/flint = 1, /obj/item/rogueweapon/huntingknife = 1)
+	backpack_contents = list(
+						/obj/item/flint = 1,
+						/obj/item/rogueweapon/huntingknife = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	H.change_stat("strength", 1)
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/cheesemaker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/cheesemaker.dm
@@ -43,6 +43,7 @@
 		/obj/item/natural/cloth = 2,
 		/obj/item/book/rogue/yeoldecookingmanual = 1,
 		)
+	r_hand = /obj/item/flashlight/flare/torch
 	H.change_stat("intelligence", 2)
 	H.change_stat("constitution", 2) // Cheese diet.
 	H.change_stat("endurance", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/drunkard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/drunkard.dm
@@ -19,7 +19,12 @@
 		belt = /obj/item/storage/belt/rogue/leather
 		beltr = /obj/item/clothing/mask/cigarette/rollie/cannabis
 		beltl = /obj/item/flint
-		backpack_contents = list(/obj/item/storage/pill_bottle/dice = 1, /obj/item/toy/cards/deck = 1, /obj/item/reagent_containers/glass/bottle/rogue/wine = 1)
+		backpack_contents = list(
+							/obj/item/storage/pill_bottle/dice = 1,
+							/obj/item/toy/cards/deck = 1,
+							/obj/item/reagent_containers/glass/bottle/rogue/wine = 1,
+							/obj/item/flashlight/flare/torch = 1,
+							)
 		H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
@@ -53,7 +53,11 @@
 		backr = /obj/item/fishingrod
 		beltr = /obj/item/cooking/pan
 		beltl = /obj/item/flint
-		backpack_contents = list(/obj/item/natural/worms = 2,/obj/item/rogueweapon/shovel/small=1)
+		backpack_contents = list(
+							/obj/item/natural/worms = 2,
+							/obj/item/rogueweapon/shovel/small = 1,
+							/obj/item/flashlight/flare/torch = 1,
+							)
 	else
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 		shoes = /obj/item/clothing/shoes/roguetown/boots/leather
@@ -65,4 +69,8 @@
 		backr = /obj/item/fishingrod
 		beltr = /obj/item/cooking/pan
 		beltl = /obj/item/flint
-		backpack_contents = list(/obj/item/natural/worms = 2,/obj/item/rogueweapon/shovel/small=1)
+		backpack_contents = list(
+							/obj/item/natural/worms = 2,
+							/obj/item/rogueweapon/shovel/small = 1,
+							/obj/item/flashlight/flare/torch = 1,
+							)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
@@ -20,7 +20,12 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/quiver/arrows
 	beltl = /obj/item/flashlight/flare/torch/lantern
-	backpack_contents = list(/obj/item/flint = 1, /obj/item/bait = 1, /obj/item/rogueweapon/huntingknife = 1)
+	backpack_contents = list(
+						/obj/item/flint = 1,
+						/obj/item/bait = 1,
+						/obj/item/rogueweapon/huntingknife = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -17,7 +17,10 @@
 	beltl = /obj/item/rogueweapon/pick
 	beltr = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/backpack
-	backpack_contents = list(/obj/item/flint = 1)
+	backpack_contents = list(
+						/obj/item/flint = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	if(H.gender == FEMALE)
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/brown

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/minstrel.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/minstrel.dm
@@ -25,7 +25,12 @@
 	belt = /obj/item/storage/belt/rogue/leather/cloth
 	beltr = /obj/item/rogueweapon/huntingknife/idagger
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/rogue/instrument/lute = 1, /obj/item/rogue/instrument/flute = 1, /obj/item/rogue/instrument/drum = 1)
+	backpack_contents = list(
+						/obj/item/rogue/instrument/lute = 1,
+						/obj/item/rogue/instrument/flute = 1,
+						/obj/item/rogue/instrument/drum = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	H.change_stat("speed", 1)  
 	H.change_stat("fortune", 1)
 	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/noble.dm
@@ -17,7 +17,10 @@
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel)
+	backpack_contents = list(
+						/obj/item/rogueweapon/huntingknife/idagger/steel,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	id = /obj/item/clothing/ring/silver
 	cloak = /obj/item/clothing/cloak/half/red

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/peasant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/peasant.dm
@@ -33,7 +33,12 @@
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		pants = null
-	backpack_contents = list(/obj/item/seeds/wheat=1,/obj/item/seeds/apple=1,/obj/item/ash=1)
+	backpack_contents = list(
+						/obj/item/seeds/wheat=1,
+						/obj/item/seeds/apple=1,
+						/obj/item/ash=1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	beltl = /obj/item/rogueweapon/sickle
 	backr = /obj/item/rogueweapon/hoe
 	H.change_stat("strength", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lcarp.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lcarp.dm
@@ -41,7 +41,11 @@
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltl = /obj/item/rogueweapon/hammer/claw
 	backl = /obj/item/storage/backpack/rogue/backpack
-	backpack_contents = list(/obj/item/flint = 1, /obj/item/rogueweapon/huntingknife = 1)
+	backpack_contents = list(
+						/obj/item/flint = 1,
+						/obj/item/rogueweapon/huntingknife = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	H.change_stat("strength", 2)
 	H.change_stat("endurance", 3)
 	H.change_stat("constitution", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lchef.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lchef.dm
@@ -35,6 +35,7 @@
 	beltr = /obj/item/cooking/pan
 	mouth = /obj/item/rogueweapon/huntingknife/cleaver
 	beltl = /obj/item/flint
+	r_hand = /obj/item/flashlight/flare/torch
 	H.change_stat("intelligence", 3)
 	H.change_stat("constitution", 2)
 	if(H.age == AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lfish.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lfish.dm
@@ -27,7 +27,11 @@
 		beltr = /obj/item/cooking/pan
 		mouth = /obj/item/rogueweapon/huntingknife
 		beltl = /obj/item/flint
-		backpack_contents = list(/obj/item/natural/worms = 2,/obj/item/rogueweapon/shovel/small=1)
+		backpack_contents = list(
+							/obj/item/natural/worms = 2,
+							/obj/item/rogueweapon/shovel/small=1,
+							/obj/item/flashlight/flare/torch = 1,
+							)
 		if(H.mind)
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lmason.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lmason.dm
@@ -42,6 +42,9 @@
 	beltl = /obj/item/rogueweapon/pick
 	backr = /obj/item/rogueweapon/stoneaxe/woodcut
 	backl = /obj/item/storage/backpack/rogue/backpack
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	H.change_stat("strength", 1)
 	H.change_stat("intelligence", 2)
 	H.change_stat("endurance", 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lminer.dm
@@ -23,6 +23,9 @@
 	neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltl = /obj/item/rogueweapon/pick
 	backl = /obj/item/storage/backpack/rogue/backpack
+	backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lpeasant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lpeasant.dm
@@ -37,7 +37,12 @@
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		pants = null
-	backpack_contents = list(/obj/item/seeds/wheat=1,/obj/item/seeds/apple=1,/obj/item/ash=1)
+	backpack_contents = list(
+						/obj/item/seeds/wheat=1,
+						/obj/item/seeds/apple=1,
+						/obj/item/ash=1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	beltl = /obj/item/rogueweapon/sickle
 	beltr = /obj/item/flint
 	backr = /obj/item/rogueweapon/hoe

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lsmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lsmith.dm
@@ -27,7 +27,13 @@
 	cloak = /obj/item/clothing/cloak/apron/blacksmith
 
 	backl = /obj/item/storage/backpack/rogue/backpack
-	backpack_contents = list(/obj/item/flint = 1, /obj/item/rogueore/coal=2, /obj/item/rogueore/iron=2, /obj/item/rogueore/silver=1)
+	backpack_contents = list(
+						/obj/item/flint = 1,
+						/obj/item/rogueore/coal=2,
+						/obj/item/rogueore/iron=2,
+						/obj/item/rogueore/silver=1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	ADD_TRAIT(H, TRAIT_TRAINED_SMITH, TRAIT_GENERIC)
 	if(H.pronouns == HE_HIM)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lwoodcut.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/rare/Lwoodcut.dm
@@ -41,7 +41,10 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black 
 	beltr = /obj/item/rogueweapon/stoneaxe/woodcut
 	beltl = /obj/item/rogueweapon/huntingknife
-	backpack_contents = list(/obj/item/flint = 1)
+	backpack_contents = list(
+						/obj/item/flint = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	H.change_stat("strength", 4)
 	H.change_stat("constitution", 1)
 	H.change_stat("perception", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/seamstress.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/seamstress.dm
@@ -27,7 +27,11 @@
 	beltl = /obj/item/needle
 	beltr = /obj/item/rogueweapon/huntingknife/idagger
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/natural/cloth = 2, /obj/item/natural/bundle/fibers/full = 1)
+	backpack_contents = list(
+						/obj/item/natural/cloth = 2,
+						/obj/item/natural/bundle/fibers/full = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	H.change_stat("intelligence", 2)
 	H.change_stat("speed", 2)
 	H.change_stat("perception", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/tbutcher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/tbutcher.dm
@@ -22,7 +22,11 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	backpack_contents = list(/obj/item/kitchen/spoon, /obj/item/reagent_containers/food/snacks/rogue/truffles)
+	backpack_contents = list(
+						/obj/item/kitchen/spoon,
+						/obj/item/reagent_containers/food/snacks/rogue/truffles,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 	else

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -30,7 +30,8 @@
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	armor = /obj/item/clothing/suit/roguetown/armor/workervest
-	beltr = /obj/item/rogueweapon/mace/cudgel // It claims to be a weapon for brigands but bandits don't actually use them...
+	beltr = /obj/item/rogueweapon/mace/cudgel
+	beltl = /obj/item/flashlight/flare/torch
 	H.change_stat("strength", 2)
 	H.change_stat("intelligence", -2)
 	H.change_stat("speed", -1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/towndoctor.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/towndoctor.dm
@@ -22,9 +22,10 @@
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
-		/obj/item/natural/worms/leech/cheele = 1,
-		/obj/item/natural/cloth = 2,
-	)
+						/obj/item/natural/worms/leech/cheele = 1,
+						/obj/item/natural/cloth = 2,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodcutter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodcutter.dm
@@ -36,7 +36,10 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	beltr = /obj/item/rogueweapon/stoneaxe/woodcut
 	beltl = /obj/item/rogueweapon/huntingknife
-	backpack_contents = list(/obj/item/flint = 1)
+	backpack_contents = list(
+						/obj/item/flint = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen
 	else

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
@@ -47,7 +47,10 @@
 	beltr = /obj/item/rogueweapon/sword/decorated
 	beltl = /obj/item/clothing/head/roguetown/helmet/heavy/crusader
 	neck = /obj/item/clothing/neck/roguetown/psicross/g
-	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/rich=1)
+	backpack_contents = list(
+						/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 2)
@@ -70,7 +73,11 @@
 		backr = /obj/item/storage/backpack/rogue/satchel
 		gloves = null
 		shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-		backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver = 1, /obj/item/storage/belt/rogue/pouch/coins/rich=1)
+		backpack_contents = list(
+							/obj/item/rogueweapon/huntingknife/idagger/silver = 1,
+							/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
+							/obj/item/flashlight/flare/torch = 1,
+							)
 		H.change_stat("strength", 1)
 
 


### PR DESCRIPTION
## About The Pull Request

advclasses no longer generate a torch on spawn. instead, adventurer classes get a torch somewhere in their inventory and everyone else gets nothing, because they don't spawn in a spooky forest and don't care. for some reason classes that spawn a weapon into their hand still drop it, but it's not clear why.

## Why It's Good For The Game

less clutter, probably more performant given the way that the forced torchification was implemented, kills potential runtimes.