### PR TITLE
Adds indicators for fellow ascendant worshippers in "people I know" menu

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -144,6 +144,11 @@
 				referred_gender = "Androgynous"
 		known_people[H.real_name]["FGENDER"] = referred_gender
 		known_people[H.real_name]["FAGE"] = H.age
+		if (ishuman(current))
+			var/mob/living/carbon/human/C = current
+			var/heretic_text = H.get_heretic_symbol(C)
+			if (heretic_text)
+				known_people[H.real_name]["FHERESY"] = heretic_text
 
 /datum/mind/proc/person_knows_me(person) //we are added to their lists
 	if(!person)
@@ -175,6 +180,12 @@
 						referred_gender = "Androgynous"
 				M.known_people[H.real_name]["FGENDER"] = referred_gender
 				M.known_people[H.real_name]["FAGE"] = H.age
+				if(ishuman(M.current))
+					var/mob/living/carbon/human/C = M.current
+					var/heretic_text = C.get_heretic_symbol(H)
+					if (heretic_text)
+						M.known_people[H.real_name]["FHERESY"] = heretic_text
+				
 
 /datum/mind/proc/do_i_know(datum/mind/person, name)
 	if(!person && !name)
@@ -219,7 +230,10 @@
 		var/fjob = known_people[P]["FJOB"]
 		var/fgender = known_people[P]["FGENDER"]
 		var/fage = known_people[P]["FAGE"]
+		var/fheresy = known_people[P]["FHERESY"]
 		if(fcolor && fjob)
+			if (fheresy)
+				contents +="<B><font color=#f1d669>[fheresy]</font></B> "
 			contents += "<B><font color=#[fcolor];text-shadow:0 0 10px #8d5958, 0 0 20px #8d5958, 0 0 30px #8d5958, 0 0 40px #8d5958, 0 0 50px #e60073, 0 0 60px #8d5958, 0 0 70px #8d5958;>[P]</font></B><BR>[fjob], [capitalize(fgender)], [fage]"
 			contents += "<BR>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -92,31 +92,12 @@
 			. += span_userdanger("OUTLAW!")
 
 
-		var/commie_text
-		if(mind)
-			if(mind.special_role == "Bandit")
-				if(HAS_TRAIT(user, TRAIT_COMMIE))
-					commie_text = span_notice("Free man!")
-				/*else
-					commie_text = span_userdanger("BANDIT!")*/
-			if(mind.special_role == "Vampire Lord")
-				. += span_userdanger("A MONSTER!")
-			if(mind.assigned_role == "Lunatic")
-				. += span_userdanger("LUNATIC!")
-
-		if(HAS_TRAIT(src, TRAIT_MANIAC_AWOKEN))
-			. += span_userdanger("MANIAC!")
-
-		if(commie_text)
-			. += commie_text
-		else if(HAS_TRAIT(src, TRAIT_COMMIE) && HAS_TRAIT(user, TRAIT_COMMIE))
-			. += span_notice("Comrade!")
-		else if(HAS_TRAIT(src, TRAIT_CABAL) && HAS_TRAIT(user, TRAIT_CABAL))
-			. += span_notice("Another of the Cabal!")
-		else if(HAS_TRAIT(src, TRAIT_HORDE) && HAS_TRAIT(user, TRAIT_HORDE))
-			. += span_notice("Anointed!")
-		else if(HAS_TRAIT(src, TRAIT_DEPRAVED) && HAS_TRAIT(user, TRAIT_DEPRAVED))
-			. += span_notice("Debased!")
+		var/villain_text = get_villain_text()
+		if(villain_text)
+			. += villain_text
+		var/heretic_text = get_heretic_text(user)
+		if(heretic_text)
+			. += span_notice(heretic_text)
 
 	if(leprosy == 1)
 		. += span_necrosis("A LEPER...")
@@ -568,3 +549,47 @@
 			dat += "[new_text]\n" //dat.Join("\n") doesn't work here, for some reason
 	if(dat.len)
 		return dat.Join()
+
+/// Returns patron-related examine text for the mob, if any. Can return null.
+/mob/living/proc/get_heretic_text(mob/examiner)
+	var/heretic_text
+	if(HAS_TRAIT(src, TRAIT_COMMIE) && HAS_TRAIT(examiner, TRAIT_COMMIE))
+		heretic_text += "Comrade!"
+	else if(HAS_TRAIT(src, TRAIT_CABAL) && HAS_TRAIT(examiner, TRAIT_CABAL))
+		heretic_text += "Another of the Cabal!"
+	else if(HAS_TRAIT(src, TRAIT_HORDE) && HAS_TRAIT(examiner, TRAIT_HORDE))
+		heretic_text += "Anointed!"
+	else if(HAS_TRAIT(src, TRAIT_DEPRAVED) && HAS_TRAIT(examiner, TRAIT_DEPRAVED))
+		heretic_text += "Debased!"
+	
+	return heretic_text
+
+/// Same as get_heretic_text, but returns a simple symbol depending on the type of heretic!
+/mob/living/proc/get_heretic_symbol(mob/examiner)
+	var/heretic_text
+	if(HAS_TRAIT(src, TRAIT_COMMIE) && HAS_TRAIT(examiner, TRAIT_COMMIE))
+		heretic_text += "♠"
+	else if(HAS_TRAIT(src, TRAIT_CABAL) && HAS_TRAIT(examiner, TRAIT_CABAL))
+		heretic_text += "♦"
+	else if(HAS_TRAIT(src, TRAIT_HORDE) && HAS_TRAIT(examiner, TRAIT_HORDE))
+		heretic_text += "♠"
+	else if(HAS_TRAIT(src, TRAIT_DEPRAVED) && HAS_TRAIT(examiner, TRAIT_DEPRAVED))
+		heretic_text += "♥"
+	
+	return heretic_text
+
+/// Returns antagonist-related examine text for the mob, if any. Can return null.
+/mob/living/proc/get_villain_text(mob/examiner)
+	var/villain_text
+	if(mind)
+		if(mind.special_role == "Bandit")
+			if(HAS_TRAIT(examiner, TRAIT_COMMIE))
+				villain_text = span_notice("Free man!")
+			/*else
+				villain_text = span_userdanger("BANDIT!")*/
+		if(mind.special_role == "Vampire Lord")
+			villain_text += span_userdanger("A MONSTER!")
+		if(mind.assigned_role == "Lunatic")
+			villain_text += span_userdanger("LUNATIC!")
+
+	return villain_text


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This adds a feature where, in the "People I Know" menu, Ascendant worshippers can see an indicator of fellow Ascendant worshippers, denoted by a bright yellow unicode symbol that depends on which ascendant they worship.
People who do not follow the same Ascendant patron cannot see this.
![2024-11-26_19-11-04](https://github.com/user-attachments/assets/db42e75e-a13c-4d29-b442-8cbfd78180d7)

## Why It's Good For The Game

This will make it much easier for fellow heretics to organize themselves and plan Big Schemes!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
