### PR TITLE
Adds "rank up available" indicator in skills list printout

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -410,8 +410,11 @@
 		return
 	var/msg = ""
 	msg += span_info("*---------*\n")
-	for(var/i in shown_skills)
-		msg += "[i] - [SSskills.level_names[known_skills[i]]]\n"
+	for(var/datum/i in shown_skills)
+		var/can_advance_post = sleep_adv.enough_sleep_xp_to_advance(i.type, 1)
+		var/capped_post = sleep_adv.enough_sleep_xp_to_advance(i.type, 2)
+		var/rankup_postfix = capped_post ? span_nicegreen(" <b>(!!)</b>") : can_advance_post ? span_nicegreen(" <b>(!)</b>") : ""
+		msg += "[i] - [SSskills.level_names[known_skills[i]]][rankup_postfix]\n"
 	msg += "</span>"
 	to_chat(user, msg)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

See title.
Skills that are able to be ranked up in the skill menu will now have a simple indicator next to them in the character skills list.
One rank up being available is denoted by a **`(!)`**, Two rank ups are indicated with a **`(!!)`**

![dreamseeker_2024-11-27_15-17-53](https://github.com/user-attachments/assets/3771d5b3-21b1-47ae-bb9a-626b651e025c)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

A nice QoL feature that makes it more obvious when we can rank up a skill. Now for example squires will no longer have to guess if they actually learned something from a sparring session after the rank up message is immediately drowned by combat messages!
