### PR TITLE
Prosthetics, anvil repair and smelting to bars

### DIFF
--- a/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
+++ b/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
@@ -15,6 +15,7 @@
 	max_integrity = 300
 	sellprice = 30
 	fingers = FALSE //can't swing weapons but can pick stuff up and punch
+	anvilrepair = /datum/skill/craft/carpentry
 
 /obj/item/bodypart/l_arm/prosthetic/bronzeleft
 	name = "bronze left arm"
@@ -31,6 +32,8 @@
 	max_integrity = 350
 	sellprice = 30
 	fingers = TRUE // it acts like a normal arm
+	anvilrepair = /datum/skill/craft/engineering
+	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/bodypart/l_arm/prosthetic/attack(mob/living/M, mob/user)
 	if(!ishuman(M))
@@ -62,6 +65,7 @@
 	max_integrity = 300
 	sellprice = 30
 	fingers = FALSE //can't swing weapons but can pick stuff up and punch
+	anvilrepair = /datum/skill/craft/carpentry
 
 /obj/item/bodypart/r_arm/prosthetic/bronzeright
 	name = "bronze right arm"
@@ -78,6 +82,8 @@
 	max_integrity = 350
 	sellprice = 30
 	fingers = TRUE // it acts like a normal arm
+	anvilrepair = /datum/skill/craft/engineering
+	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/bodypart/r_arm/prosthetic/attack(mob/living/M, mob/user)
 	if(!ishuman(M))
@@ -110,6 +116,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
 	sellprice = 30
+	anvilrepair = /datum/skill/craft/carpentry
 
 /obj/item/bodypart/l_leg/prosthetic/bronzeleft
 	name = "bronze left leg"
@@ -125,6 +132,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30
+	anvilrepair = /datum/skill/craft/engineering
+	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/bodypart/l_leg/prosthetic/attack(mob/living/M, mob/user)
 	if(!ishuman(M))
@@ -157,6 +166,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
 	sellprice = 30
+	anvilrepair = /datum/skill/craft/carpentry
 
 /obj/item/bodypart/r_leg/prosthetic/bronzeright
 	name = "bronze right leg"
@@ -172,6 +182,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30
+	anvilrepair = /datum/skill/craft/engineering
+	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/bodypart/r_leg/prosthetic/attack(mob/living/M, mob/user)
 	if(!ishuman(M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds an overload of the normal hammer/anvil item repair to handle prosthetics, fixing their damage and wound conditions. Carpentry for wooden, engineering for bronze. The artificer can do both handily. Also lets you put the bronze limbs in the smelter for a return of 1 bronze bar.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The only other way to repair prosthetic limbs was a weird interaction with surgery "tend damage" code, which can probably be hunted down after this.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
