### PR TITLE
Raises ambush chance + reduces cooldown, makes ambush variables admin configurable

### DIFF
--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -1,3 +1,4 @@
+GLOBAL_VAR_INIT(ambush_chance_pct, 10)
 
 /mob/living/proc/ambushable()
 	if(mob_timers["ambushlast"])
@@ -8,7 +9,7 @@
 	return ambushable
 
 /mob/living/proc/consider_ambush()
-	if(prob(95))
+	if(prob(100 - GLOB.ambush_chance_pct))
 		return
 	if(mob_timers["ambush_check"])
 		if(world.time < mob_timers["ambush_check"] + 15 SECONDS)

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -1,8 +1,10 @@
 GLOBAL_VAR_INIT(ambush_chance_pct, 10) // Please don't raise this over 100 admins :')
+GLOBAL_VAR_INIT(ambush_global_cooldown, 3 MINUTES) // Cooldown for the game spawning ambushes on anyone
+GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 15 SECONDS) // Cooldown for each individual mob being considered for an ambush
 
 /mob/living/proc/ambushable()
 	if(mob_timers["ambushlast"])
-		if(world.time < mob_timers["ambushlast"] + 300 SECONDS)
+		if(world.time < mob_timers["ambushlast"] + GLOB.ambush_global_cooldown)
 			return FALSE
 	if(stat)
 		return FALSE
@@ -12,7 +14,7 @@ GLOBAL_VAR_INIT(ambush_chance_pct, 10) // Please don't raise this over 100 admin
 	if(prob(100 - GLOB.ambush_chance_pct))
 		return
 	if(mob_timers["ambush_check"])
-		if(world.time < mob_timers["ambush_check"] + 15 SECONDS)
+		if(world.time < mob_timers["ambush_check"] + GLOB.ambush_mobconsider_cooldown)
 			return
 	mob_timers["ambush_check"] = world.time
 	if(!ambushable())

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -1,4 +1,4 @@
-GLOBAL_VAR_INIT(ambush_chance_pct, 10)
+GLOBAL_VAR_INIT(ambush_chance_pct, 10) // Please don't raise this over 100 admins :')
 
 /mob/living/proc/ambushable()
 	if(mob_timers["ambushlast"])


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

See title.
The % chance of a player being ambushed has been raised from 5% to 10%.
The GLOBAL cooldown for ambushes has been reduced from 5 minutes to 3 minutes.
These variables have also been made into global variables which admins can freely change as they wish, (`ambush_chance_pct`, `ambush_global_cooldown`, and `ambush_mobconsider_cooldown`)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Let's be honest, the bogs and forests aren't dangerous enough, nor are their dangers able to persist in any meaningful capacity. That latter part is something I really believe needs fixing. I've talked about this in the discord already, but soon I'd like to implement a mechanic that procedurally spawns more hostile mobs in key locations in the bogs/coasts as a round goes on.
But, until I get to that, I think this is a good first step. As it stands, what usually happens is the adventurer tide spawns in the bogs, wipes out all goblins and skeletons in and around the roads within 20 to 30 minutes, and leaves the wardens, whose job is supposed to be making sure the forests are safe, with nothing to do as the adventurer tide has already done their job for them. Additionally, this causes late joiners to not really have much danger at all to look forward to aside from the odd missed skeleton or maneater. Let's fix that!

Also I made the % chance for ambushes a global variable, as well as the cooldowns for when the game spawns ambushes and cooldowns for each mob being considered for an ambush, so that admins can freely tweak it in-round if they want to test out different values themselves. Just please don't set it to above 100, I have NO idea what will happen then.