### PR TITLE
fuck sewers

### DIFF
--- a/_maps/templates/sewers.dm
+++ b/_maps/templates/sewers.dm
@@ -1,70 +1,68 @@
-
 // TODO: Weight this thing so 90% of stuff is garbage
 /obj/effect/spawner/lootdrop/roguetown/sewers
 	name = "sewer spawner"
+	lootcount = 3
 	loot = list(
 		// Materials
-		/obj/item/natural/bundle/stick = 2,
-		/obj/item/natural/fibers = 4,
-		/obj/item/natural/stone = 4,
-		/obj/item/rogueore/coal	= 4,
+		/obj/item/natural/bundle/stick = 4,
+		/obj/item/natural/fibers = 8,
+		/obj/item/natural/stone = 8,
+		/obj/item/rogueore/coal	= 8,
 		/obj/item/ingot/iron = 1,
 		/obj/item/ingot/steel = 1,
 		/obj/item/rogueore/iron = 3,
-		/obj/item/natural/bundle/fibers = 2,
+		/obj/item/natural/bundle/fibers = 4,
 
 		// Clothing
-		/obj/item/clothing/cloak/stabard = 3,
+		/obj/item/clothing/cloak/stabard = 6,
 		/obj/item/storage/backpack/rogue/satchel = 3,
-		/obj/item/clothing/shoes/roguetown/simpleshoes = 4,
-		/obj/item/clothing/suit/roguetown/shirt/undershirt/random = 5,
-		/obj/item/storage/belt/rogue/leather/cloth = 4,
-		/obj/item/clothing/cloak/raincloak/mortus = 3,
+		/obj/item/clothing/shoes/roguetown/simpleshoes = 8,
+		/obj/item/clothing/suit/roguetown/shirt/undershirt/random = 10,
+		/obj/item/storage/belt/rogue/leather/cloth = 8,
+		/obj/item/clothing/cloak/raincloak/mortus = 6,
 		/obj/item/clothing/head/roguetown/armingcap = 4,
-		/obj/item/clothing/cloak/apron/waist = 3,
-		/obj/item/storage/belt/rogue/leather/rope = 3,
-		/obj/item/clothing/under/roguetown/tights/vagrant = 4,
+		/obj/item/clothing/cloak/apron/waist = 6,
+		/obj/item/storage/belt/rogue/leather/rope = 6,
+		/obj/item/clothing/under/roguetown/tights/vagrant = 8,
 		/obj/item/clothing/gloves/roguetown/leather = 4,
-		/obj/item/clothing/shoes/roguetown/boots = 4,
-		/obj/item/clothing/shoes/roguetown/boots/leather = 4,
+		/obj/item/clothing/shoes/roguetown/boots = 8,
+		/obj/item/clothing/shoes/roguetown/boots/leather = 8,
 		/obj/item/storage/belt/rogue/leather/knifebelt/iron = 1,
 
 		// Money
-		/obj/item/roguecoin/copper = 5,
+		/obj/item/roguecoin/copper = 10,
 		/obj/item/roguecoin/silver = 5,
 		/obj/item/roguecoin/gold = 5,
 		/obj/item/roguecoin/copper/pile = 3,
-		/obj/item/roguecoin/silver/pile = 2,
-		/obj/item/roguecoin/gold/pile = 1,
 
 		// Garbage and Miscellanous
-		/obj/item/rogue/instrument/flute = 3,
-		/obj/item/ash = 5,
-		/obj/item/shard = 5,
-		/obj/item/candle/yellow = 3,
-		/obj/item/flashlight/flare/torch = 3,
-		/obj/item/reagent_containers/glass/bowl = 4,
-		/obj/item/reagent_containers/glass/cup = 4,
-		/obj/item/reagent_containers/glass/cup/wooden = 4,
-		/obj/item/reagent_containers/glass/cup/steel = 3,
+		/obj/item/rogue/instrument/flute = 6,
+		/obj/item/ash = 10,
+		/obj/item/shard = 10,
+		/obj/item/candle/yellow = 6,
+		/obj/item/flashlight/flare/torch = 6,
+		/obj/item/reagent_containers/glass/bowl = 8,
+		/obj/item/reagent_containers/glass/cup = 8,
+		/obj/item/reagent_containers/glass/cup/wooden = 8,
+		/obj/item/reagent_containers/glass/cup/steel = 6,
 		/obj/item/reagent_containers/glass/cup/golden = 1,
 		/obj/item/reagent_containers/glass/cup/skull = 1,
-		/obj/item/reagent_containers/glass/bucket/wooden = 3,
-		/obj/item/natural/feather = 4,
-		/obj/item/paper/scroll = 3,
-		/obj/item/rope = 3,
-		/obj/item/rope/chain = 3,
+		/obj/item/reagent_containers/glass/bucket/wooden = 6,
+		/obj/item/natural/feather = 8,
+		/obj/item/paper/scroll = 6,
+		/obj/item/rope = 6,
+		/obj/item/rope/chain = 6,
 		/obj/item/storage/roguebag/crafted = 3,
-		/obj/item/clothing/mask/cigarette/pipe = 3,
-		/obj/item/paper = 3,
-		/obj/item/reagent_containers/glass/bowl = 3,
-		/obj/item/storage/bag/tray = 3,
+		/obj/item/clothing/mask/cigarette/pipe = 6,
+		/obj/item/paper = 6,
+		/obj/item/reagent_containers/glass/bowl = 6,
+		/obj/item/storage/bag/tray = 6,
 		/obj/item/mundane/puzzlebox/medium = 2,
-		/obj/item/mundane/puzzlebox/easy = 2,
+		/obj/item/mundane/puzzlebox/easy = 4,
 
 		//medical
 		/obj/item/needle = 4,
-		/obj/item/natural/cloth = 5,
+		/obj/item/natural/cloth = 10,
 		/obj/item/natural/bundle/cloth = 3,
 
 		//weapons
@@ -76,22 +74,22 @@
 		/obj/item/ammo_casing/caseless/rogue/bolt = 4,
 		/obj/item/rogueweapon/mace/woodclub/crafted = 3,
 		/obj/item/rogueweapon/mace/cudgel = 2,
-		/obj/item/rogueweapon/mace/wsword = 3,
+		/obj/item/rogueweapon/mace/wsword = 6,
 		/obj/item/rogueweapon/huntingknife = 3,
-		/obj/item/rogueweapon/huntingknife/stoneknife = 3,
+		/obj/item/rogueweapon/huntingknife/stoneknife = 6,
 		/obj/item/rogueweapon/halberd = 1,
 		/obj/item/rogueweapon/woodstaff = 3,
 		/obj/item/rogueweapon/spear = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/navaja = 1,
 
 		// tools
-		/obj/item/rogueweapon/shovel = 3,
-		/obj/item/rogueweapon/thresher = 3,
-		/obj/item/flint = 4,
+		/obj/item/rogueweapon/shovel = 6,
+		/obj/item/rogueweapon/thresher = 6,
+		/obj/item/flint = 8,
 		/obj/item/rogueweapon/stoneaxe/woodcut = 3,
-		/obj/item/rogueweapon/stoneaxe = 3,
-		/obj/item/rogueweapon/hammer = 3,
-		/obj/item/rogueweapon/tongs = 3,
+		/obj/item/rogueweapon/stoneaxe = 6,
+		/obj/item/rogueweapon/hammer = 6,
+		/obj/item/rogueweapon/tongs = 6,
 		/obj/item/rogueweapon/pick = 3,
 
 		//armor
@@ -112,12 +110,11 @@
 
 		//food
 		/obj/item/reagent_containers/food/snacks/rogue/crackerscooked = 3,
-		/obj/item/reagent_containers/food/snacks/butterslice = 3,
-		/obj/item/reagent_containers/powder/salt = 3,
-		/obj/item/reagent_containers/food/snacks/egg = 3,
+		/obj/item/reagent_containers/food/snacks/butterslice = 6, //ew
+		/obj/item/reagent_containers/powder/salt = 6,
+		/obj/item/reagent_containers/food/snacks/egg = 6,
 
 	)
-	lootcount = 5
 
 
 ///////////////////////

--- a/_maps/templates/sewers.dm
+++ b/_maps/templates/sewers.dm
@@ -1,4 +1,3 @@
-// TODO: Weight this thing so 90% of stuff is garbage
 /obj/effect/spawner/lootdrop/roguetown/sewers
 	name = "sewer spawner"
 	lootcount = 3

--- a/code/game/objects/effects/spawners/roguemapgen.dm
+++ b/code/game/objects/effects/spawners/roguemapgen.dm
@@ -69,3 +69,6 @@
 	name = "beartrap"
 	probby = 50
 	spawned = list(/obj/item/restraints/legcuffs/beartrap/armed/camouflage)
+
+/obj/effect/spawner/lootdrop/roguetown
+	fan_out_items = TRUE


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/6cb69e0a-e72d-47fa-bfff-f68d60534bc2)

well, alright then!

this pr severely nerfs the sewer loot spawners because we've all been acting out of pocket about them. specifically, it:

- drops the loot count to 3 items from the list instead of 5
- (basically) doubles the probability of the sewer spawners dropping random trash or utility items over gear and money
- removes piles of silver and gold coins from the spawner entirely. single coins of each can still spawn
- creates a parent object of /obj/effect/spawner/lootdrop/roguetown and sets fan_out_items to TRUE so that loot will be in slightly less neat little piles across the board, not just for sewer spawners

## Why It's Good For The Game

![izutsumi-lord-taketh](https://github.com/user-attachments/assets/eb7ed2c5-9cd0-4d2e-81c0-9c4dc9ae283d)

everyone in the damn town running down there to find piles of coin and grab a bunch of steel daggers to throw at the smith is getting a little silly. i'll cook something more complex up to sate the hunger of loot crawlers in a later pr, promise.