### PR TITLE
QoL: Lets players quick-fill item bundles by using them on a turf

### DIFF
--- a/code/game/objects/items/rogueitems/natural.dm
+++ b/code/game/objects/items/rogueitems/natural.dm
@@ -111,6 +111,29 @@
 			user.visible_message("[user] removes [F] from [src].", "I remove [F] from [src].")
 	update_bundle()
 
+/obj/item/natural/bundle/attack_turf(turf/T, mob/living/user)
+	var/list/obj/item/stackables = list()
+	for(var/obj/I in T.contents)
+		if(I.type == stacktype)
+			stackables += I
+	if(stackables.len)
+		if(amount >= maxamount)
+			to_chat(user, span_info("[src] can't hold any more without falling apart."))
+			return
+		to_chat(user, span_info("I begin filling [src]..."))
+		for(var/obj/I in stackables)
+			if(amount >= maxamount)
+				break
+			if(I.type == stacktype)
+				if(!do_after(user, 5, TRUE, src))
+					break
+				if(!(I in T.contents))
+					continue
+				qdel(I)
+				src.amount++
+				update_bundle()
+
+
 /obj/item/natural/bundle/examine(mob/user)
 	. = ..()
 	to_chat(user, span_notice("There are [amount] [stackname] in this bundle."))

--- a/code/game/objects/items/rogueitems/natural.dm
+++ b/code/game/objects/items/rogueitems/natural.dm
@@ -113,7 +113,7 @@
 
 /obj/item/natural/bundle/attack_turf(turf/T, mob/living/user)
 	var/list/obj/item/stackables = list()
-	for(var/obj/I in T.contents)
+	for(var/obj/item/I in T.contents)
 		if(I.type == stacktype)
 			stackables += I
 	if(stackables.len)

--- a/code/game/objects/items/rogueitems/natural.dm
+++ b/code/game/objects/items/rogueitems/natural.dm
@@ -113,7 +113,7 @@
 
 /obj/item/natural/bundle/attack_turf(turf/T, mob/living/user)
 	var/list/obj/item/stackables = list()
-	for(var/obj/item/I in T.contents)
+	for(var/obj/I in T.contents)
 		if(I.type == stacktype)
 			stackables += I
 	if(stackables.len)

--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -343,6 +343,29 @@
 	icon2step = 7
 	icon3 = "stickbundle3"
 
+/obj/item/natural/bundle/stick/attackby(obj/item/W, mob/living/user)
+	. = ..()
+	user.changeNext_move(CLICK_CD_MELEE)
+	if(user.used_intent?.blade_class == BCLASS_CUT)
+		playsound(get_turf(src.loc), 'sound/items/wood_sharpen.ogg', 100)
+		if(do_after(user, 20))
+			user.visible_message(span_notice("[user] sharpens a stick in [src]."), span_notice("I sharpen a stick in [src]."))
+			var/obj/item/grown/log/tree/stake/S = new /obj/item/grown/log/tree/stake(get_turf(src.loc))
+			amount--
+			if (amount == 1)
+				var/turf/T = get_turf(user.loc)
+				var/obj/item/ST = new stacktype(T)
+				if(user.is_holding(src))
+					user.doUnEquip(src, TRUE, T, silent = TRUE)
+				user.put_in_hands(ST)
+				qdel(src)
+			else
+				update_bundle()
+			user.put_in_hands(S)
+			S.pixel_x = rand(-3, 3)
+			S.pixel_y = rand(-3, 3)
+		return
+
 /obj/item/natural/bundle/bone
 	name = "stack of bones"
 	icon_state = "bonestack1"

--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -367,7 +367,7 @@
 				if(!do_after(user, 20))
 					break
 				S = new /obj/item/grown/log/tree/stake(T)
-a				if(holding)
+				if(holding)
 					user.doUnEquip(ST, TRUE, T, silent = TRUE)
 				qdel(ST)
 			else

--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -348,17 +348,28 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(user.used_intent?.blade_class == BCLASS_CUT)
 		playsound(get_turf(src.loc), 'sound/items/wood_sharpen.ogg', 100)
-		if(do_after(user, 20))
-			user.visible_message(span_notice("[user] sharpens a stick in [src]."), span_notice("I sharpen a stick in [src]."))
-			var/obj/item/grown/log/tree/stake/S = new /obj/item/grown/log/tree/stake(get_turf(src.loc))
+		user.visible_message(span_info("[user] starts sharpening the sticks in [src]..."), span_info("I start sharpening the sticks in [src]...."))
+		for(var/i in 1 to (amount - 1))
+			if(!do_after(user, 20))
+				break
+			var/turf/T = get_turf(user.loc)
+			var/obj/item/grown/log/tree/stake/S = new /obj/item/grown/log/tree/stake(T)
 			amount--
+			// If there's only one stick left in the bundle...
 			if (amount == 1)
-				var/turf/T = get_turf(user.loc)
+				// Replace the bundle with a single stick
 				var/obj/item/ST = new stacktype(T)
 				if(user.is_holding(src))
 					user.doUnEquip(src, TRUE, T, silent = TRUE)
-				user.put_in_hands(ST)
 				qdel(src)
+				var/holding = user.put_in_hands(ST)
+				// And automatically have us try and carve the last new stick, assuming we're still holding it!
+				if(!do_after(user, 20))
+					break
+				S = new /obj/item/grown/log/tree/stake(T)
+a				if(holding)
+					user.doUnEquip(ST, TRUE, T, silent = TRUE)
+				qdel(ST)
 			else
 				update_bundle()
 			user.put_in_hands(S)

--- a/code/modules/clothing/rogueclothes/quiver.dm
+++ b/code/modules/clothing/rogueclothes/quiver.dm
@@ -21,9 +21,9 @@
 
 /obj/item/quiver/attack_turf(turf/T, mob/living/user)
 	if(arrows.len >= max_storage)
-		to_chat(user, span_warning("Your [src.name] is full!"))
+		to_chat(user, span_warning("My [src.name] is full!"))
 		return
-	to_chat(user, span_notice("You begin to gather the ammunition..."))
+	to_chat(user, span_notice("I begin to gather the ammunition..."))
 	for(var/obj/item/ammo_casing/caseless/rogue/arrow in T.contents)
 		if(do_after(user, 5))
 			if(!eatarrow(arrow))


### PR DESCRIPTION
Also minor proofread on quiver messages

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You know how you can quickly refill a quiver with all arrows on a turf by clicking on a turf with the quiver?
This change lets you do that with ALL item bundles!!!
All you need to do is take an item bundle and click on a turf with it, and if the turf has and items that go into the bundle, your character will quickly gather them all up!

![dreamseeker_2024-11-29_20-10-07](https://github.com/user-attachments/assets/d3d9541a-471a-481a-a8d3-728e77e452c7)

![dreamseeker_2024-11-29_20-14-18](https://github.com/user-attachments/assets/7c74bc84-9e38-4f5f-8a7e-ccd405638664)

### Update:
Also allows players to cut stakes from bundles of sticks. Because that's nice to have for people making lots of palisades!
![dreamseeker_2024-12-01_01-18-50](https://github.com/user-attachments/assets/26ee1d3b-4d7a-4322-aab0-9f4de753b1e9)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

It's a nice QoL feature that will hopefully streamline the process of gathering items into a bundle.
