### PR TITLE
Auto unlock and lock for bumping into doors with keys in active hand

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -409,10 +409,12 @@
 					src.Open()
 					addtimer(CALLBACK(src, PROC_REF(Close), FALSE, TRUE), 25)
 					src.last_bumper = user
-				break
+				return
 			else
 				if(user.cmode)
 					door_rattle()
+		to_chat(user, span_warning("None of the keys on my keyring go to this door."))
+		door_rattle()
 		return
 	else
 		var/obj/item/roguekey/K = I
@@ -424,6 +426,7 @@
 				src.last_bumper = user
 			return
 		else
+			to_chat(user, span_warning("This is not the correct key that goes to this door."))
 			door_rattle()
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a check to mineral door bump to see if you're carrying a keychain. Automatically try the door with the keychain in your hand. If it works, it keeps you in memory as the last bumper, and if you are next to the door when it closes, it auto-tries to lock with the keys in your active hand.

I think this doesn't runtime viciously in a play environment on account of simplemobs with nohands bumping doors. Tested with 10 volfs in a closet, bumped the door with no issues.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Quality of life, helps with the inventory juggling of opening a door with a keychain in hand. You could already kick the door open/shut, so, this brings down the tech floor.


https://github.com/user-attachments/assets/d53a7691-a62a-4da6-9bc6-b1805f945257



<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
