### PR TITLE
Adds mossy walls on the keep gatehouse

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -2689,11 +2689,6 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
-"cpm" = (
-/turf/closed/wall/mineral/rogue/stone{
-	opacity = 0
-	},
-/area/rogue/indoors/town/garrison)
 "cpn" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rogueweapon/shovel,
@@ -66374,7 +66369,7 @@ hRm
 hXp
 jqw
 xXs
-cpm
+hRm
 ruV
 osd
 vjF
@@ -66531,7 +66526,7 @@ hRm
 wOS
 pkG
 sjW
-cpm
+hRm
 vqp
 vqp
 vqp
@@ -66841,7 +66836,7 @@ oUz
 oUz
 iXt
 oUz
-oUz
+hRm
 xtL
 uTA
 pkG
@@ -66998,7 +66993,7 @@ oUz
 oUz
 dZn
 uEa
-oUz
+hRm
 hhg
 mVa
 uEp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

It was mentioned that these walls in the keep gatehouse being non-mossy was a mapping error, so here's the PR to fix that.

![image](https://github.com/user-attachments/assets/ae05206a-8af2-47b1-8be8-be9f598fdb1f)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stops everyone with journeyman climb from being able to climb up into the keep gatehouse murder hole. Now you need expert, or journeyman with a chair. Or a rogue jump. Or the other thousand ways to get into the keep.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
