### PR TITLE
speeds up bait deploying time to 2 seconds

### DIFF
--- a/code/game/objects/items/rogueitems/bait.dm
+++ b/code/game/objects/items/rogueitems/bait.dm
@@ -15,6 +15,7 @@
 									/mob/living/simple_animal/hostile/retaliate/rogue/chicken = 55)
 	var/attraction_chance = 100
 	var/deployed = 0
+	var/deploy_speed = 2 SECONDS
 	resistance_flags = FLAMMABLE
 
 /obj/item/bait/Initialize()
@@ -25,7 +26,7 @@
 	. = ..()
 	user.visible_message(span_notice("[user] begins deploying the bait..."), \
 						span_notice("I begin deploying the bait..."))
-	if(do_after(user, 100, target = src)) //rogtodo hunting skill
+	if(do_after(user, deploy_speed, target = src)) //rogtodo hunting skill
 		user.dropItemToGround(src)
 		START_PROCESSING(SSobj, src)
 		name = "bait"
@@ -36,7 +37,7 @@
 	if(deployed)
 		user.visible_message(span_notice("[user] begins gathering up the bait..."), \
 							span_notice("I begin gathering up the bait..."))
-		if(do_after(user, 100, target = src)) //rogtodo hunting skill
+		if(do_after(user, deploy_speed, target = src)) //rogtodo hunting skill
 			STOP_PROCESSING(SSobj, src)
 			name = initial(name)
 			deployed = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

See title. This is uh, all it does really.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

So, apparently using baits probably takes as long as it does because in OG roguecode there was a planned hunting skill that never saw the light of day that presumably would influence the speed of deploying/retrieving bait. This skill was never really implemented, so all we have are very inconveniently lengthy bait usage times. This long usage time doesn't really add anything to the gameplay experience at all and really shouldn't be as long as it is anyway, so let's just speed it up.
