### PR TITLE
Buffs Naledi Warstaff

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -491,3 +491,6 @@
 	name = "naledian warstaff"
 	desc = "A staff carrying the crescent moon of Psydon's knowledge, as well as the black and gold insignia of the war scholars."
 	icon_state = "naledistaff"
+	force = 18
+	force_wielded = 22
+	max_integrity = 250


### PR DESCRIPTION
Naledi warstaves, despitely looking so poggy, were entirely identical to wooden staves. I've increased their damage and integrity to rectify this.