### PR TITLE
Quicksilver poultice modify, adding more fyritius to mapgen

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -5942,7 +5942,6 @@
 /obj/structure/closet/crate/roguecloset,
 /obj/item/scomstone,
 /obj/item/rogueweapon/whip/antique,
-/obj/item/quicksilver,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/town/basement)
 "ftb" = (
@@ -21650,6 +21649,9 @@
 	dir = 8;
 	icon_state = "largetable"
 	},
+/obj/item/paper/inquisition_poultice_info,
+/obj/item/quicksilver,
+/obj/item/reagent_containers/food/snacks/grown/rogue/fyritius,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church)
 "tGy" = (

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -204,6 +204,8 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius/attack(mob/living/carbon/human/M, mob/user)
 	if(M == user)
 		return ..() //Eat it
+	if(user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
+		return ..() //Make THEM eat it.
 	if(!M.get_bleed_rate())
 		to_chat(user, span_warning("There is no blood to wick into the flower bud."))
 		return

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -239,7 +239,7 @@
 	tastes = list("tastes like a burning coal and fire and blood" = 1)
 	bitesize = 1
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/fyritiusnectar = 5)
-	rotprocess = 15 SECONDS
+	rotprocess = 10 MINUTES
 
 /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius/bloodied/become_rotten()
 	visible_message(span_danger("[src] burns into ash!"))

--- a/code/modules/roguetown/mapgen/forest.dm
+++ b/code/modules/roguetown/mapgen/forest.dm
@@ -20,7 +20,7 @@
 							/obj/structure/flora/roguegrass = 26,
 							/obj/structure/flora/roguegrass/maneater = 13,
 							/obj/structure/flora/roguegrass/swampweed = 15,
-							/obj/structure/flora/roguegrass/pyroclasticflowers = 1,
+							/obj/structure/flora/roguegrass/pyroclasticflowers = 3,
 							/obj/item/natural/stone = 23,
 							/obj/item/natural/rock = 6,
 							/obj/item/grown/log/tree/stick = 16,

--- a/code/modules/roguetown/mapgen/rogueoutdoors.dm
+++ b/code/modules/roguetown/mapgen/rogueoutdoors.dm
@@ -22,7 +22,7 @@
 							/obj/item/natural/rock = 2,
 							/obj/item/grown/log/tree/stick = 3,
 							/obj/structure/closet/dirthole/closed/loot=3,
-							/obj/structure/flora/roguegrass/pyroclasticflowers = 1)
+							/obj/structure/flora/roguegrass/pyroclasticflowers = 3)
 	spawnableTurfs = list(/turf/open/floor/rogue/dirt/road=5)
 	allowed_areas = list(/area/rogue/outdoors/rtfield)
 

--- a/modular_azurepeak/code/game/objects/items/quicksilver.dm
+++ b/modular_azurepeak/code/game/objects/items/quicksilver.dm
@@ -72,7 +72,7 @@
 			to_chat(M, span_userdanger("This silver concoction burns! It threatens to undo me!"))
 			M.emote("agony", forced = TRUE)
 			M.adjustFireLoss(25)
-			M.fire_act(1,10)
+			M.fire_act(3,3) //Not too bad, but not a single pat to put out.
 			user.visible_message(span_danger("[src] bursts into flames on [M]'s brow, yet [user] vies to complete the anointment."))
 			if(do_after(user, 10 SECONDS, target = M))
 				user.visible_message(span_danger("[user] anoints [M]'s brow with [src]."))
@@ -192,3 +192,8 @@
 			H.adjustFireLoss(25)
 			H.fire_act(1,10)
 
+//A letter to give info on how to make this thing.
+/obj/item/paper/inquisition_poultice_info
+	name = "Inquisitorial Missive"
+	desc = "A letter from the Grand Cathedral in Otava. It reeks of zig smoke."
+	info = "<font face=\"Segoe Script\" color=#00000>Greetings to ye, distant missionaries in Azuria<br><br>This missive serves to inform of a breakthrough of alchemy. Enclosed is a substance, <b>Quicksilver</b>, that may be of keen use in the preservation of lyfe against those unholy creechers that are repelled by divine silver. We speak of the werevolf and the vampyre. Herein lies the method.<br><br>Gather an ingot of silver, a vessel of blessed water- a bottle's worth shall suffice, and a simple strip of cloth to add structure to the poultice. Take the warm bud of a fyritius flower, and immerse it in the bleeding wound of an unholy creecher. The warmth of the bud will congeal this foul ichor- but make haste, as it doth soon burn itself to ash. Induce the bloodied flower to your materials- any expert of the craft of alchemy may intuit the process.<br><br>The ritual anointment is complex, and must be performed by a learned holy cleric in proximity of a cross of the pantheon. Inquisitor, your training doth empower you, as well. When the work is finished, the recipient now is inundated with holy silver- and shall be fortified against the fell turning of these unholy creechers.<br><br>Take heed! This act may also salvage the lyfe of unfortunate souls who have recently been turned to beast. Their body's accursed resistance excites the Quicksilver to fire- but complete the rite, and they too are saved. All, except the eldest of Vampyre and Werevolf- we ascertain even this method cannot save them, and it will be a waste! (Albeit humbling.)<br><br>Share of this missive with any agents or employs that need direction in this rite.<br><br><b>PSYDON ENDURES,</b><br><i>Holy Fellowship of Research, the Grand Cathedral, the Sovereignty of Otava.</i></font>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a letter for how to make the quicksilver poultice to the Inquisition's bunker table. Gives them a single fyritius for expediency, and bumps up wild fyritius bushes to 3 in the grove + 3 in the basin (was 1 and 1 before). Fixed the on-click overwrite so that you can feed the flowers to victims again, easy fire stacks.

## Why It's Good For The Game

This puts the spawn-in poultice "in reach" if there's any orthodoxists / no inquisitor (often the case), so that they can hand it off if necessary. It would be just 1 use with no Inquisitor, so maybe not too overpowered, plus the orthodoxists can't make use of it themselves. Also preempts the urge to break deep into the Inquisitor's office for the stuff if someone was fiending for it. Now it's just two doors in.

![image](https://github.com/user-attachments/assets/582b8d30-9fed-427a-87b3-4ab1607775bd)


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
