### PR TITLE
Adjustment | Heraldry Colors

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -61,19 +61,19 @@
 
 
 //roguetown
-#define CLOTHING_RED			"#a32121"
-#define CLOTHING_PURPLE			"#8747b1"
-#define CLOTHING_BLACK			"#414143"
+#define CLOTHING_RED			"#8b2323"
+#define CLOTHING_PURPLE			"#764b8d"
+#define CLOTHING_BLACK			"#2b292e"
 #define CLOTHING_GREY			"#6c6c6c"
-#define CLOTHING_BROWN			"#685542"
+#define CLOTHING_BROWN			"#61462c"
 #define CLOTHING_GREEN			"#428138"
 #define CLOTHING_DARK_GREEN		"#264d26"
-#define CLOTHING_BLUE			"#537bc6"
-#define CLOTHING_YELLOW			"#b5b004"
+#define CLOTHING_BLUE			"#173266"
+#define CLOTHING_YELLOW			"#ffcd43"
 #define CLOTHING_TEAL			"#249589"
 #define CLOTHING_AZURE			"#007fff"
 #define CLOTHING_WHITE			"#ffffff"
-#define CLOTHING_ORANGE			"#bd6606"
+#define CLOTHING_ORANGE			"#df8405"
 #define CLOTHING_MAJENTA		"#962e5c"
 
 #define CLOTHING_WET			"#bbbbbb"

--- a/code/__HELPERS/lordcolor.dm
+++ b/code/__HELPERS/lordcolor.dm
@@ -21,17 +21,17 @@ GLOBAL_VAR(lordsecondary)
 		addtimer(CALLBACK(src, PROC_REF(lord_color_choice)), 50)
 		return
 	var/list/lordcolors = list(
-"PURPLE"="#865c9c", //RED AND BLACK
-"RED"="#933030", 	//	 I DRESS
-"BLACK"="#2f352f", 	//	  EAGLE
-"BROWN"="#685542", 	// ON MY CHEST
-"GREEN"="#79763f", 	//IT'S GOOD TO BE
-"BLUE"="#395480", 	// AN ALBANIAN
-"YELLOW"="#b5b004", // KEEP MY HEAD
+"PURPLE"="#8747b1", //RED AND BLACK
+"RED"="#8b2323", 	//	 I DRESS
+"BLACK"="#2b292e", 	//	  EAGLE
+"BROWN"="#61462c", 	// ON MY CHEST
+"GREEN"="#264d26", 	//IT'S GOOD TO BE
+"BLUE"="#173266", 	// AN ALBANIAN
+"YELLOW"="#ffcd43", // KEEP MY HEAD
 "TEAL"="#249589", 	//	 UP HIGH
 "AZURE"="#007fff", 	// FOR THE FLAG
 "WHITE"="#ffffff",	//	  I DIE
-"ORANGE"="#b86f0c",	//I'M PROUD TO BE
+"ORANGE"="#df8405",	//I'M PROUD TO BE
 "MAJENTA"="#962e5c")// AN ALBANIAN
 	var/prim
 	var/sec


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adjusts the hexcodes of the heraldry colors, as well as those in the colors.dm of roguetown, to fit better visually.

<details>

![dreamseeker_5wb7OZR1je](https://github.com/user-attachments/assets/df46a7a9-d9c1-4121-9ff9-1afe7b5b67fb)
![dreamseeker_o3gwhUAGne](https://github.com/user-attachments/assets/e6990e6d-b025-4fbf-9634-9e019716d5e3)

Old ones:
![image](https://github.com/user-attachments/assets/5d3dc4ce-91a1-40e3-a38d-aa41c839c2fd)

New ones:
![image](https://github.com/user-attachments/assets/c6f264f1-f086-4e5d-b233-42b89851dc91)

</details>

## Why It's Good For The Game

No more piss-yellow carpets in the Keep.

Plus they're better on the eyes.