### PR TITLE
Defines lich spawned skeleton voicetype so masks properly obfuscate

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -70,6 +70,8 @@
 		return if_no_face		//Likewise for hats
 	if( wear_neck && (wear_neck.flags_inv&HIDEFACE) )
 		return if_no_face		//Likewise for hats
+	if( istype(src, /mob/living/carbon/human/species/skeleton)) //SPOOKY BONES
+		return real_name
 	var/obj/item/bodypart/O = get_bodypart(BODY_ZONE_HEAD)
 	if( !O || (HAS_TRAIT(src, TRAIT_DISFIGURED)) || !real_name || (O.skeletonized && !mind?.has_antag_datum(/datum/antagonist/lich)))	//disfigured. use id-name if possible
 		return if_no_face

--- a/code/modules/mob/living/carbon/human/npc/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton.dm
@@ -52,6 +52,7 @@
 	faction = list("undead")
 	name = "Skeleton"
 	real_name = "Skeleton"
+	voice_type = VOICE_TYPE_MASC //So that "Unknown Man" properly substitutes in with face cover
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOROGSTAM, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

There is a bug where lich-spawned greater skeletons sound as "Skeleton" even with their face covered since they do not init with a voice type, so there is no substitution. This slaps a voice type in their init so they spin up with one. Also puts a special case in for skeleton type mobs to prevent constant reversions of `name` to "Unknown" each check.
## Why It's Good For The Game

Prevents meta of hearing a face-covered Skeleton's speech revealing their true nature.
![image](https://github.com/user-attachments/assets/21b2d68b-a734-4e03-aa05-af296ae07e15)


![image](https://github.com/user-attachments/assets/b4a85f00-9832-4006-aa8a-94f26f0abde1)

![image](https://github.com/user-attachments/assets/c774cdcd-91d6-42aa-95ae-c9d8a4a22c0b)

![image](https://github.com/user-attachments/assets/df8f9c77-2a21-4a0f-b38f-0cb9d8d90252)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
