### PR TITLE
Moves & expands zhurch

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -336,13 +336,6 @@
 /obj/item/rogueweapon/mace/goden/steel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"aje" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "ajW" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/clothing/neck/roguetown/psicross,
@@ -398,6 +391,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"alE" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 5
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "alU" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -454,12 +457,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "anQ" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/reagent_containers/food/snacks/rogue/friedrat,
-/obj/item/reagent_containers/food/snacks/rogue/friedrat,
-/obj/item/reagent_containers/food/snacks/rogue/friedrat,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "anU" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/herringbone,
@@ -470,12 +470,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
-"aoj" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "aoA" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/hexstone,
@@ -560,6 +554,13 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"ass" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "asx" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/blacksmith{
@@ -604,6 +605,12 @@
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town)
+"aud" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "auk" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
@@ -759,6 +766,14 @@
 	name = "chimney"
 	},
 /area/rogue/outdoors/mountains)
+"aAW" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/reagent_containers/powder/health,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "aBy" = (
 /obj/structure/flora/roguetree/wise,
 /turf/open/floor/rogue/naturalstone,
@@ -1127,6 +1142,10 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"aSH" = (
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "aSI" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/concrete,
@@ -1476,6 +1495,17 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"bhv" = (
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "bhU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -1505,8 +1535,10 @@
 	},
 /area/rogue/under/town/basement/keep)
 "biU" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/blood/splatter,
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "biZ" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 1;
@@ -2143,6 +2175,10 @@
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
+"bMq" = (
+/obj/structure/chair/bench/church,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "bMu" = (
 /obj/structure/fluff/railing/fence,
 /obj/structure/flora/roguegrass/bush,
@@ -2307,6 +2343,10 @@
 	},
 /turf/open/water/bath,
 /area/rogue/under/town/basement/keep)
+"bUx" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "bUB" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/reagent_containers/glass/cup/wooden,
@@ -2562,13 +2602,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"chS" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "cia" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/robe/necra,
@@ -2597,9 +2630,12 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "cjv" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "cjy" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -2640,10 +2676,6 @@
 /obj/item/natural/worms,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
-"clE" = (
-/obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "clS" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -2820,6 +2852,16 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"ctN" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
+"cuR" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "cuW" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
@@ -2854,25 +2896,9 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
-"cwO" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "cxb" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"cxd" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/church{
-	light_color = "#b30202"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "cxD" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/table/wood{
@@ -2894,10 +2920,6 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
-"cxX" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "cyh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
@@ -2937,12 +2959,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/roofs)
-"czG" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "czZ" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/herringbone,
@@ -3102,11 +3118,10 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "cGL" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/obj/machinery/light/rogue/hearth,
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "cGR" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -3421,6 +3436,13 @@
 	},
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/physician)
+"cXe" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "cXw" = (
 /obj/structure/roguemachine/scomm,
 /obj/structure/flora/roguegrass,
@@ -3832,6 +3854,12 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"dmL" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "dmS" = (
 /turf/open/water/bath{
 	desc = "clear, lightly foamy water, perfect for dipping into after a long day."
@@ -3954,10 +3982,6 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/exposed/town/keep)
-"dse" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "dsk" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/armor/plate/half,
@@ -4277,10 +4301,6 @@
 "dIf" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
-"dIp" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "dIL" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -4304,13 +4324,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
-"dJr" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "dKq" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks,
@@ -4323,6 +4336,10 @@
 "dKO" = (
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
+"dLv" = (
+/obj/item/chair/rogue,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "dLO" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/vagrant,
@@ -4474,6 +4491,16 @@
 /obj/structure/fluff/walldeco/painting/queen,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor)
+"dSx" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/church{
+	light_color = "#b30202"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "dSB" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grass,
@@ -4498,10 +4525,6 @@
 "dUc" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
-"dVa" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "dVi" = (
 /obj/structure/stairs{
 	dir = 8
@@ -4607,11 +4630,6 @@
 /obj/effect/landmark/start/prisonerr,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell)
-"dYP" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "dZj" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -4893,11 +4911,6 @@
 "emP" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/dwarfin)
-"emY" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 4
-	},
-/area/rogue/outdoors/mountains)
 "enl" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -5088,7 +5101,11 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "evs" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
+/obj/item/natural/worms/leech,
+/obj/item/natural/worms/leech{
+	pixel_x = 8
+	},
+/turf/open/water/swamp,
 /area/rogue/outdoors/mountains)
 "evJ" = (
 /obj/structure/mineral_door/wood/window{
@@ -5127,10 +5144,12 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "ewV" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 8
+/obj/structure/bars/passage{
+	density = 0;
+	icon_state = "passage1"
 	},
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "exe" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
@@ -5264,9 +5283,12 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "eFZ" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "eGr" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
@@ -5440,12 +5462,6 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel/special,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"ePC" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "ePO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/fluff/wallclock,
@@ -5522,9 +5538,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "eTF" = (
-/obj/structure/roguewindow/stained/zizo,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "eTM" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -5859,6 +5874,12 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/random,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"fhE" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "fhF" = (
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble,
@@ -6137,10 +6158,6 @@
 /obj/item/roguecoin/gold/pile,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
-"fwP" = (
-/obj/item/rogueweapon/pick,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
 "fwW" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood{
@@ -6155,10 +6172,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"fxK" = (
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
 "fyl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -6283,6 +6296,10 @@
 	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/dwarfin)
+"fDO" = (
+/obj/structure/fluff/walldeco/chains,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "fDU" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -6305,11 +6322,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/under/town/basement)
-"fEJ" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
-/obj/structure/stairs/stone/d,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "fEQ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -6478,10 +6490,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"fMS" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "fNg" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -6634,6 +6642,11 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/exposed/town/keep)
+"fWm" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/table/optable,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "fWw" = (
 /obj/structure/lever/wall{
 	dir = 8;
@@ -6662,9 +6675,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fXl" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
+	},
+/area/rogue/indoors/shelter/mountains)
 "fXV" = (
 /obj/structure/composter/halffull,
 /obj/effect/decal/cobbleedge{
@@ -6697,6 +6711,10 @@
 /obj/item/scomstone,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
+"gaq" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "gaU" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/grassyel,
@@ -7322,6 +7340,12 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
+"gFY" = (
+/obj/structure/pillory{
+	lockid = "inhumen"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "gGO" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
@@ -7343,6 +7367,10 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"gHv" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "gJj" = (
 /obj/structure/closet/crate/drawer/random,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -7647,13 +7675,6 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
-"gVb" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "gVe" = (
 /obj/structure/bars,
 /turf/open/water/sewer,
@@ -7753,6 +7774,14 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"gZS" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "inhumen";
+	name = "Forgotten Chapel"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "haD" = (
 /obj/effect/landmark/start/churchling,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -7786,12 +7815,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "hbs" = (
-/obj/structure/bars/passage{
-	density = 0;
-	icon_state = "passage1"
-	},
 /turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "hby" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -7831,6 +7856,13 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"hcP" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "hdu" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -7889,6 +7921,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"hgf" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "hgu" = (
 /obj/structure/stairs/fancy/r{
 	dir = 1
@@ -8019,12 +8055,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "hpe" = (
-/obj/structure/table/church{
-	icon_state = "churchtable_end"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "hpn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -8584,6 +8617,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"hQs" = (
+/obj/structure/fluff/walldeco/chains,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "hQQ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
@@ -8829,10 +8866,20 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"ial" = (
+/obj/item/rogueweapon/pick,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "iaH" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church)
+"ibn" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "ibF" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
@@ -8865,6 +8912,12 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
+"idP" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "iee" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/ruinedwood,
@@ -9033,6 +9086,13 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"inf" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "inm" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/short,
@@ -9201,6 +9261,14 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"iur" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
+	},
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "iuG" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -9233,6 +9301,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"iwx" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "iwB" = (
 /obj/structure/bars/passage/shutter/open{
 	redstone_id = "stewardshutter"
@@ -9284,8 +9359,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "izn" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 8
+	},
+/area/rogue/indoors/shelter/mountains)
 "izp" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks,
@@ -9308,6 +9385,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
+"iAL" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "iAW" = (
 /obj/structure/fluff/statue/myth{
 	icon_state = "knightstatue_l"
@@ -9459,6 +9543,14 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/physician)
+"iJJ" = (
+/obj/structure/fluff/statue/femalestatue/zizo{
+	desc = "An ancient statue depicting an elven woman.";
+	name = "Ancient Statue";
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "iKC" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -9557,6 +9649,10 @@
 	icon_state = "linoleum"
 	},
 /area/rogue/indoors/town/vault)
+"iNW" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "iOl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -9616,13 +9712,6 @@
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"iQh" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "iQQ" = (
 /obj/structure/fermenting_barrel/blackgoat,
 /turf/open/floor/rogue/blocks,
@@ -9763,6 +9852,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"iXE" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "iXP" = (
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
@@ -9776,12 +9872,6 @@
 /obj/structure/roguemachine/mail/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
-"iYj" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "iYk" = (
 /obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l{
@@ -10312,13 +10402,11 @@
 	},
 /area/rogue/indoors/town)
 "jBi" = (
-/obj/structure/fluff/statue/femalestatue/zizo{
-	desc = "An ancient statue depicting an elven woman.";
-	name = "Ancient Statue";
-	pixel_y = 0
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "jBv" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/wood/rogue{
@@ -10341,10 +10429,6 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"jBM" = (
-/obj/structure/chair/bench/church,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "jBO" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -10364,10 +10448,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"jCX" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
 "jDt" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -10436,16 +10516,6 @@
 "jGx" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/cell)
-"jGA" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "jHo" = (
 /obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -10530,9 +10600,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "jKZ" = (
-/obj/structure/stairs/stone/d,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
 /turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "jLc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -10775,10 +10847,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"jUx" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
+"jTM" = (
+/obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "jUJ" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -10834,13 +10906,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/physician)
-"jWg" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "jWq" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -10901,16 +10966,6 @@
 "jYo" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/magician)
-"jYF" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "jYN" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -10976,6 +11031,11 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"kcN" = (
+/obj/structure/bed/rogue/shit,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "kcU" = (
 /obj/item/reagent_containers/food/snacks/grown/apple,
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -11033,11 +11093,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/roofs)
 "kfY" = (
-/obj/structure/stairs/stone{
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "kgo" = (
 /obj/structure/rogue/trophy/deer,
 /obj/structure/table/wood{
@@ -11260,17 +11320,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"ksw" = (
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "ksK" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood,
@@ -11501,13 +11550,6 @@
 "kAA" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
-"kBu" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "kBx" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/shoes/roguetown/boots,
@@ -11680,11 +11722,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
-"kJu" = (
-/obj/structure/bed/rogue/shit,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "kJD" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -11905,11 +11942,8 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town)
 "kPt" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
+/area/rogue/indoors/shelter/mountains)
 "kPv" = (
 /obj/structure/table/wood,
 /obj/item/rogueweapon/surgery/scalpel,
@@ -12071,6 +12105,16 @@
 /obj/item/natural/saddle,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
+"kUu" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "kUC" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 1
@@ -12367,10 +12411,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
-"lgH" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "lgQ" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
@@ -12401,6 +12441,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"liJ" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "liZ" = (
 /obj/structure/fluff/littlebanners/bluewhite{
 	pixel_y = -6
@@ -12910,6 +12954,16 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"lGI" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "lGO" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 1
@@ -13349,6 +13403,13 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
+"meu" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 5
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "meT" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
@@ -13544,11 +13605,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
 "mlS" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/whip,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/indoors/shelter/mountains)
 "mlU" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church)
@@ -13745,9 +13803,9 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "mwd" = (
-/obj/structure/chair/bench/church/mid,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "mwr" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement/keep)
@@ -13870,9 +13928,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "mBU" = (
-/obj/structure/chair/bench/church/r,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "mCu" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -13974,14 +14032,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
-"mHf" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
-	},
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "mHT" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/tile/bath,
@@ -14024,9 +14074,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "mJn" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench/church/mid,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "mJH" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -14143,6 +14193,14 @@
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"mOz" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "mPd" = (
 /obj/structure/underworld/barrier,
 /obj/structure/underworld/carriage_normal{
@@ -14153,12 +14211,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "mPD" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
-	},
 /turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "mPR" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/rtfield)
@@ -14243,6 +14297,16 @@
 "mVe" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"mVk" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "mVt" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town)
@@ -14322,7 +14386,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "mZF" = (
-/turf/open/floor/rogue/concrete,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "mZT" = (
 /obj/structure/table/wood,
@@ -14620,6 +14685,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"nlo" = (
+/obj/structure/fluff/statue/gargoyle/moss/candles,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "nlp" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/blocks,
@@ -14963,22 +15032,14 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
-"nzQ" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "nAP" = (
-/obj/effect/decal/cleanable/blood,
+/obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "nBk" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"nBC" = (
-/obj/structure/fermenting_barrel/random/beer,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "nBF" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/wood,
@@ -15786,9 +15847,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "onk" = (
-/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "ono" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -15846,10 +15907,6 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town)
-"opz" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "opJ" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -16062,13 +16119,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
-"oyq" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "oyt" = (
 /obj/structure/fluff/wallclock{
 	dir = 3
@@ -16880,6 +16930,10 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"piB" = (
+/obj/structure/flora/roguegrass,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "pja" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -16911,6 +16965,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"pkf" = (
+/obj/structure/chair/bench/church/r,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "pkG" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
@@ -16985,8 +17043,9 @@
 	},
 /area/rogue/under/town/sewer)
 "pmX" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
-/area/rogue/outdoors/mountains)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "pnh" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -17085,12 +17144,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "psG" = (
-/obj/item/natural/worms/leech,
-/obj/item/natural/worms/leech{
-	pixel_x = 8
-	},
-/turf/open/water/swamp,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "ptr" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/book/rogue/bibble,
@@ -17180,10 +17236,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement)
-"pwM" = (
-/obj/item/chair/rogue,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "pwS" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -17765,6 +17817,10 @@
 "pUC" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/bath)
+"pUJ" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "pUO" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/random,
@@ -17810,16 +17866,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"pXD" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "pYi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -18193,6 +18239,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
+"qwg" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/whip,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "qws" = (
 /obj/structure/roguemachine/mail{
 	mailtag = "Hand"
@@ -18499,6 +18551,12 @@
 "qGI" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/town/sewer)
+"qHw" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "qHJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -18595,10 +18653,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "qNj" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/table/optable,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "qNG" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -18724,10 +18781,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell)
-"qUR" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "qVf" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
@@ -19257,15 +19310,6 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"rsI" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/obj/item/storage/belt/rogue/surgery_bag/full,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "rtf" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -19304,10 +19348,6 @@
 /obj/item/rogueweapon/mace/spiked,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"ruF" = (
-/obj/structure/table/church/m,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "ruG" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
@@ -19363,11 +19403,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/dwarfin)
-"rvK" = (
-/obj/structure/table/church,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "rwd" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -19612,6 +19647,10 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"rJz" = (
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "rJK" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town)
@@ -19877,11 +19916,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "rRR" = (
-/obj/structure/mineral_door/bars{
-	lockid = "inhumen"
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 1
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "rSa" = (
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/pelt,
@@ -19909,14 +19947,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
-"rSD" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/obj/item/reagent_containers/powder/health,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "rSG" = (
 /obj/item/roguebin,
 /turf/open/floor/carpet/royalblack,
@@ -20047,10 +20077,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "rZO" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 1
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "sac" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
@@ -20423,6 +20452,11 @@
 "srJ" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/mountains)
+"ssr" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 4
+	},
+/area/rogue/indoors/shelter/mountains)
 "ssF" = (
 /obj/structure/roguemachine/lottery_roguetown{
 	pixel_y = -32
@@ -20764,13 +20798,6 @@
 /obj/structure/table/wood/crafted,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
-"sGe" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "sGz" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/flora/roguegrass,
@@ -20821,12 +20848,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
 "sJB" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
+/turf/open/transparent/openspace,
+/area/rogue/indoors/shelter/mountains)
 "sJK" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /obj/effect/decal/cobbleedge{
@@ -21025,9 +21048,11 @@
 	},
 /area/rogue/indoors/town/manor)
 "sTs" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "sTt" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/red,
@@ -21319,6 +21344,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"tgF" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/storage/belt/rogue/surgery_bag/full,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "tgJ" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/table/wood{
@@ -21497,6 +21531,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"tnf" = (
+/obj/structure/table/church,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "tng" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/woodturned,
@@ -21829,6 +21868,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"tCF" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "tDo" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/woodturned,
@@ -22023,6 +22068,11 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/shop)
+"tNG" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/obj/structure/stairs/stone/d,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "tNQ" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
@@ -22215,6 +22265,13 @@
 "tVZ" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/town/basement/keep)
+"tWc" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "tWL" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -22510,10 +22567,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "umC" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
-	dir = 1
-	},
-/area/rogue/outdoors/mountains)
+/obj/structure/roguewindow/stained/zizo,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/shelter/mountains)
 "umP" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grassred,
@@ -22626,12 +22682,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"usJ" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "usO" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -22668,13 +22718,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
-"uuq" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "uut" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22695,9 +22738,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "uuR" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/indoors/shelter/mountains)
 "uuU" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
@@ -22814,6 +22856,10 @@
 /obj/item/candle/skull,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave)
+"uyY" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "uzB" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -22861,12 +22907,6 @@
 /obj/item/rogueweapon/stoneaxe/woodcut/steel,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"uBw" = (
-/obj/structure/pillory{
-	lockid = "inhumen"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "uBD" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/rack/rogue,
@@ -23295,13 +23335,6 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"uWC" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "uXf" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rogue/instrument/drum,
@@ -23346,10 +23379,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"uZO" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "uZR" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -23508,10 +23537,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"vmr" = (
-/obj/structure/flora/roguegrass,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/mountains)
 "vnd" = (
 /obj/item/ingot/copper,
 /obj/item/ingot/copper,
@@ -23705,9 +23730,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "vwK" = (
-/obj/structure/fluff/walldeco/chains,
+/obj/structure/stairs/stone/d,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "vwW" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -23745,10 +23770,6 @@
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
-"vzi" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "vzy" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder/salt,
@@ -23896,14 +23917,6 @@
 "vHc" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town/dwarfin)
-"vHe" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "inhumen";
-	name = "Forgotten Chapel"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "vHo" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassred,
@@ -24182,14 +24195,28 @@
 /obj/item/paper,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"vXW" = (
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "vYe" = (
-/obj/structure/spider/stickyweb,
+/obj/effect/decal/remains/human,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/area/rogue/indoors/shelter/mountains)
 "vYh" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"vYi" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "vYw" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -24282,6 +24309,13 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town)
+"weC" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "weU" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 4;
@@ -24319,13 +24353,6 @@
 "wfx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
-"wfC" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "wgk" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/naturalstone,
@@ -24862,9 +24889,11 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "wBF" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
+/obj/structure/mineral_door/bars{
+	lockid = "inhumen"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "wBY" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/tile/masonic{
@@ -24958,9 +24987,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "wHq" = (
-/obj/structure/fluff/statue/gargoyle/moss/candles,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "wHt" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -25079,6 +25110,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"wLn" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "wLs" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -25637,8 +25675,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "xfA" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red,
-/area/rogue/outdoors/mountains)
+/obj/structure/bars,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "xfD" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grass,
@@ -25748,11 +25787,9 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "xiL" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/obj/structure/table/church/m,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "xiX" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -25763,6 +25800,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"xjN" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/mountains)
 "xkV" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bucket,
@@ -25775,8 +25819,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "xlv" = (
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "xlI" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
@@ -25847,12 +25892,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
-"xnu" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "xnB" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -26160,10 +26199,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
-"xCC" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "xCI" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -26173,18 +26208,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
-"xDb" = (
-/obj/item/reagent_containers/food/snacks/smallrat,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "xDh" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"xDs" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "xDC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -26384,12 +26411,6 @@
 /obj/item/bedsheet/rogue/fabric,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
-"xMU" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "xMY" = (
 /obj/structure/rack/rogue/shelf,
 /obj/structure/rack/rogue/shelf/big{
@@ -26466,12 +26487,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
-"xOP" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "xOU" = (
 /obj/structure/stairs{
 	dir = 4
@@ -26676,6 +26691,10 @@
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
+"xUA" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "xVD" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/long,
@@ -27058,26 +27077,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "ylI" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
+/area/rogue/indoors/shelter/mountains)
 "ylN" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "ylP" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/shelter/mountains)
 "ymf" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -75925,22 +75933,22 @@ srJ
 srJ
 srJ
 srJ
-xfA
-biU
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-rZO
-xfA
+uuR
+ylI
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+rRR
+uuR
 fam
 fam
 fam
@@ -76082,22 +76090,22 @@ srJ
 srJ
 srJ
 srJ
-evs
-iQh
-xlv
-xlv
-jKZ
-xfA
 kPt
-nBC
+cXe
+hbs
+hbs
 vwK
-dse
-kPt
-xfA
-rsI
-qNj
-rSD
-emY
+uuR
+tCF
+jTM
+fDO
+xUA
+tCF
+uuR
+tgF
+fWm
+aAW
+ssr
 fam
 fam
 fam
@@ -76239,22 +76247,22 @@ srJ
 srJ
 srJ
 srJ
-umC
-wHq
-xlv
-xlv
-jKZ
-xfA
-vYe
-xlv
-xlv
-xlv
-xlv
-emY
+fXl
+nlo
+hbs
+hbs
 vwK
-mZF
-dVa
-umC
+uuR
+pmX
+hbs
+hbs
+hbs
+hbs
+ssr
+hQs
+mPD
+mwd
+fXl
 fam
 fam
 fam
@@ -76396,22 +76404,22 @@ srJ
 srJ
 srJ
 srJ
-evs
 kPt
-xlv
-xlv
-jKZ
+tCF
+hbs
+hbs
+vwK
+uuR
+hbs
+hbs
+hbs
+bUx
+hbs
 xfA
-xlv
-xlv
-xlv
-cxX
-xlv
-sTs
-xlv
-xDb
-xlv
-umC
+hbs
+rJz
+hbs
+fXl
 fam
 fam
 fam
@@ -76553,22 +76561,22 @@ srJ
 srJ
 srJ
 rOV
-umC
-xfA
+fXl
+uuR
+ewV
+ewV
+uuR
+uuR
+mwd
+hbs
+mPD
 hbs
 hbs
-xfA
-xfA
-dVa
-lgH
-mZF
-xlv
-xlv
-rRR
-xlv
-mZF
-mJn
-umC
+wBF
+hbs
+mPD
+vYe
+fXl
 fam
 fam
 fam
@@ -76710,22 +76718,22 @@ srJ
 srJ
 rOV
 rOV
-umC
-vYe
-xlv
-xlv
-kPt
-emY
-xlv
-mZF
-mZF
-xDs
-xlv
-sTs
-dVa
-mZF
-vwK
-umC
+fXl
+pmX
+hbs
+hbs
+dmL
+ssr
+hbs
+mPD
+mPD
+psG
+hbs
+xfA
+mwd
+mPD
+hQs
+fXl
 fam
 fam
 fam
@@ -76867,22 +76875,22 @@ rOV
 rOV
 rOV
 rcv
-umC
-xMU
-xlv
-xlv
-cxX
-umC
-xlv
-xOP
-xOP
-pwM
-xlv
-ewV
-onk
-xlv
-kJu
-umC
+fXl
+jBi
+hbs
+hbs
+bUx
+fXl
+hbs
+sTs
+sTs
+dLv
+hbs
+izn
+rZO
+hbs
+kcN
+fXl
 fam
 fam
 fam
@@ -77024,24 +77032,24 @@ rOV
 rOV
 rcv
 rcv
-umC
-xCC
-mZF
-mZF
-xlv
-umC
-xCC
-mHf
-aje
-jYF
-xlv
-xfA
-biU
-sTs
-rZO
-umC
-fam
+fXl
+gHv
+mPD
+mPD
+hbs
+fXl
+gHv
+iur
 cjv
+lGI
+hbs
+uuR
+ylI
+xfA
+rRR
+fXl
+fam
+aSH
 tQp
 srJ
 srJ
@@ -77181,22 +77189,22 @@ rcv
 rcv
 rcv
 tQp
-umC
-xMU
-nzQ
-mZF
-xlv
-ewV
-xlv
-sGe
-ylP
-pXD
-xlv
-emY
-mlS
-xlv
-uZO
-umC
+fXl
+jBi
+biU
+mPD
+hbs
+izn
+hbs
+meu
+mOz
+mVk
+hbs
+ssr
+qwg
+hbs
+iNW
+fXl
 fam
 tQp
 tQp
@@ -77335,25 +77343,25 @@ fam
 (11,1,3) = {"
 fam
 rcv
-psG
-fxK
+evs
+mZF
 tQp
+ewV
 hbs
-xlv
-mZF
-mZF
-xlv
+mPD
+mPD
 hbs
-xlv
-oyq
-mZF
-oyq
-xlv
-sTs
-mZF
-mZF
-nzQ
-umC
+ewV
+hbs
+iXE
+mPD
+iXE
+hbs
+xfA
+mPD
+mPD
+qNj
+fXl
 fam
 tQp
 tQp
@@ -77492,25 +77500,25 @@ fam
 (12,1,3) = {"
 fam
 rcv
-psG
-jCX
+evs
+gaq
 tQp
+ewV
 hbs
-xlv
-mZF
-mZF
-xlv
+mPD
+mPD
 hbs
-xlv
-mZF
-nzQ
-mZF
-xlv
-rRR
-mZF
-uBw
-mZF
-umC
+ewV
+hbs
+mPD
+biU
+mPD
+hbs
+wBF
+mPD
+gFY
+mPD
+fXl
 fam
 tQp
 tQp
@@ -77649,25 +77657,25 @@ fam
 (13,1,3) = {"
 fam
 rcv
-psG
-fwP
+evs
+ial
 tQp
+ewV
 hbs
-xlv
-xDs
-mZF
-xlv
+psG
+mPD
 hbs
-xlv
-xOP
-mZF
-uWC
-xlv
+ewV
+hbs
 sTs
-mZF
-mZF
-mZF
-umC
+mPD
+ass
+hbs
+xfA
+mPD
+mPD
+mPD
+fXl
 fam
 tQp
 tQp
@@ -77809,22 +77817,22 @@ rcv
 rcv
 rcv
 tQp
-umC
-gVb
-mZF
-mZF
-xlv
-emY
-xlv
-dJr
+fXl
+iAL
 mPD
-ksw
-xlv
-ewV
-iYj
-cxX
-uZO
-umC
+mPD
+hbs
+ssr
+hbs
+wLn
+xjN
+bhv
+hbs
+izn
+fhE
+bUx
+iNW
+fXl
 fam
 tQp
 tQp
@@ -77966,22 +77974,22 @@ rOV
 rOV
 rcv
 rcv
-umC
-xCC
-mZF
-mZF
-vYe
-umC
-xCC
-jGA
+fXl
+gHv
+mPD
+mPD
+pmX
+fXl
+gHv
+alE
+kUu
+vYi
+hbs
+uuR
 ylI
-sJB
-xlv
 xfA
-biU
-sTs
-rZO
-umC
+rRR
+fXl
 fam
 fam
 tQp
@@ -78123,22 +78131,22 @@ rOV
 rOV
 rOV
 rOV
-umC
-xMU
-xlv
-cxX
-xlv
-umC
-xlv
-pwM
-mZF
-czG
-xlv
-emY
-xlv
-xlv
-xlv
-umC
+fXl
+jBi
+hbs
+bUx
+hbs
+fXl
+hbs
+dLv
+mPD
+idP
+hbs
+ssr
+hbs
+hbs
+hbs
+fXl
 fam
 fam
 fam
@@ -78280,22 +78288,22 @@ srJ
 srJ
 rOV
 rOV
-umC
-xlv
-xlv
-xlv
-kPt
-ewV
-vwK
-mZF
-mZF
-nzQ
-xlv
-sTs
-onk
-mZF
-vwK
-umC
+fXl
+hbs
+hbs
+hbs
+dmL
+izn
+hQs
+mPD
+mPD
+qNj
+hbs
+xfA
+rZO
+mPD
+hQs
+fXl
 fam
 fam
 fam
@@ -78437,22 +78445,22 @@ srJ
 srJ
 srJ
 srJ
-umC
-xfA
+fXl
+uuR
+ewV
+ewV
+uuR
+uuR
+hbs
+vYe
+mPD
 hbs
 hbs
-xfA
-xfA
-xlv
-mJn
-mZF
-xlv
-xlv
-rRR
-xlv
-mZF
-xlv
-umC
+wBF
+hbs
+mPD
+hbs
+fXl
 fam
 fam
 fam
@@ -78594,22 +78602,22 @@ srJ
 srJ
 srJ
 srJ
-evs
 kPt
-xlv
-xlv
-jKZ
+tCF
+hbs
+hbs
+vwK
+uuR
+tWc
+mwd
+hbs
+hbs
+hbs
 xfA
-anQ
-dVa
-xlv
-lgH
-xlv
-sTs
-cxX
-dIp
-xlv
-umC
+bUx
+pUJ
+hbs
+fXl
 fam
 fam
 fam
@@ -78751,22 +78759,22 @@ srJ
 srJ
 srJ
 srJ
-umC
-wHq
-xlv
-xlv
-jKZ
-xfA
-ePC
-xnu
-aoj
-xiL
-xlv
-ewV
+fXl
+nlo
+hbs
+hbs
 vwK
-mZF
-onk
-umC
+uuR
+aud
+qHw
+ctN
+jKZ
+hbs
+izn
+hQs
+mPD
+rZO
+fXl
 fam
 fam
 fam
@@ -78908,22 +78916,22 @@ srJ
 srJ
 srJ
 srJ
-evs
 kPt
-vYe
-xlv
-jKZ
-xfA
-wfC
-opz
-dYP
-cwO
-kPt
-xfA
+tCF
+pmX
+hbs
+vwK
+uuR
+weC
+hgf
+cGL
+kfY
+tCF
+uuR
+rZO
 onk
-fMS
-vYe
-ewV
+pmX
+izn
 fam
 fam
 fam
@@ -79065,22 +79073,22 @@ srJ
 srJ
 srJ
 srJ
-xfA
-biU
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-rZO
-xfA
+uuR
+ylI
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+rRR
+uuR
 fam
 fam
 fam
@@ -79222,7 +79230,7 @@ fam
 fam
 fam
 fam
-vmr
+piB
 fam
 fam
 fam
@@ -100262,17 +100270,17 @@ fam
 fam
 fam
 fam
-biU
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-rZO
+ylI
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+rRR
 fam
 fam
 fam
@@ -100419,17 +100427,17 @@ fam
 fam
 fam
 fam
-evs
-qUR
-tXZ
-tXZ
-jKZ
-xlv
-xlv
-vYe
-xlv
 kPt
-evs
+anQ
+sJB
+sJB
+vwK
+hbs
+hbs
+pmX
+hbs
+dmL
+kPt
 fam
 fam
 fam
@@ -100576,17 +100584,17 @@ fam
 fam
 fam
 fam
-biU
-clE
-tXZ
-tXZ
-jKZ
-xlv
-lgH
-xlv
-mJn
-xlv
-biU
+ylI
+nAP
+sJB
+sJB
+vwK
+hbs
+hpe
+hbs
+vYe
+hbs
+ylI
 fam
 fam
 fam
@@ -100733,17 +100741,17 @@ fam
 fam
 fam
 fam
-evs
-izn
-tXZ
-tXZ
-jKZ
-xlv
-xlv
-xlv
-xlv
 kPt
-evs
+eTF
+sJB
+sJB
+vwK
+hbs
+hbs
+hbs
+hbs
+dmL
+kPt
 fam
 fam
 srJ
@@ -100890,17 +100898,17 @@ fam
 fam
 fam
 fam
-biU
-pmX
-pmX
-pmX
-pmX
-hbs
-hbs
-hbs
-pmX
-rZO
-biU
+ylI
+mlS
+mlS
+mlS
+mlS
+ewV
+ewV
+ewV
+mlS
+rRR
+ylI
 fam
 fam
 srJ
@@ -101048,16 +101056,16 @@ fam
 fam
 fam
 fam
-xfA
-xfA
-jWg
-chS
-xlv
-cxX
-xlv
-kPt
-xfA
-xfA
+uuR
+uuR
+hcP
+eFZ
+hbs
+bUx
+hbs
+dmL
+uuR
+uuR
 fam
 fam
 srJ
@@ -101204,18 +101212,18 @@ fam
 fam
 fam
 fam
-xfA
-xfA
-kBu
-izn
-kfY
-xlv
-xlv
-xlv
-xlv
-xlv
-xfA
-emY
+uuR
+uuR
+inf
+eTF
+ibn
+hbs
+hbs
+hbs
+hbs
+hbs
+uuR
+ssr
 fam
 fam
 fam
@@ -101358,21 +101366,21 @@ fam
 fam
 fam
 fam
-emY
-xfA
-evs
-xfA
-cGL
+ssr
+uuR
+kPt
+uuR
+tCF
+eTF
+eTF
+ibn
+hbs
+wHq
+wHq
+bMq
+mwd
+hbs
 izn
-izn
-kfY
-xlv
-usJ
-usJ
-jBM
-dVa
-xlv
-ewV
 fam
 fam
 tQp
@@ -101515,22 +101523,22 @@ fam
 fam
 fam
 fam
-eTF
-wBF
-nAP
-vzi
-izn
-izn
-izn
-chS
-mJn
-mwd
-mwd
-mwd
-cxX
+umC
+uyY
 xlv
+liJ
 eTF
-cjv
+eTF
+eTF
+eFZ
+vYe
+mJn
+mJn
+mJn
+bUx
+hbs
+umC
+aSH
 tQp
 tQp
 tQp
@@ -101672,21 +101680,21 @@ fam
 fam
 fam
 fam
-ewV
-wBF
-mZF
-mZF
-mZF
-jUx
-rvK
-chS
-dVa
-mBU
-mBU
-mBU
-xlv
-xlv
-xfA
+izn
+uyY
+mPD
+mPD
+mPD
+eTF
+tnf
+eFZ
+mwd
+pkf
+pkf
+pkf
+hbs
+hbs
+uuR
 tQp
 tQp
 tQp
@@ -101829,23 +101837,23 @@ fam
 fam
 fam
 fam
-evs
-izn
-mZF
-jBi
-mZF
-eFZ
-ruF
-cxd
-xlv
-xlv
-xlv
-xlv
-lgH
-xlv
-vHe
-uuR
-uuR
+kPt
+eTF
+mPD
+iJJ
+pUJ
+mBU
+xiL
+dSx
+hbs
+hbs
+hbs
+hbs
+hbs
+hbs
+gZS
+cuR
+cuR
 tQp
 tQp
 tXZ
@@ -101986,21 +101994,21 @@ fam
 fam
 fam
 fam
-emY
-izn
-mZF
-mZF
-mZF
-izn
-hpe
-chS
-xlv
-usJ
-usJ
-jBM
-mJn
-xlv
-xfA
+ssr
+eTF
+mPD
+mPD
+mPD
+eTF
+vXW
+eFZ
+hbs
+wHq
+wHq
+bMq
+vYe
+hbs
+uuR
 tQp
 tQp
 tQp
@@ -102143,22 +102151,22 @@ fam
 fam
 fam
 fam
+umC
+ylP
+uyY
 eTF
-fXl
-wBF
-izn
-izn
-nAP
-izn
-chS
-cxX
-mwd
-mwd
-mwd
+eTF
 xlv
-cxX
 eTF
-cjv
+eFZ
+bUx
+mJn
+mJn
+mJn
+hpe
+bUx
+umC
+aSH
 tQp
 tQp
 tQp
@@ -102300,21 +102308,21 @@ fam
 fam
 fam
 fam
-ewV
-xfA
-evs
-xfA
-cGL
 izn
-izn
-kfY
-xlv
-mBU
-mBU
-mBU
-xlv
-xlv
-emY
+uuR
+kPt
+uuR
+tCF
+eTF
+eTF
+ibn
+hbs
+pkf
+pkf
+pkf
+hbs
+hbs
+ssr
 fam
 fam
 tQp
@@ -102460,18 +102468,18 @@ fam
 fam
 fam
 fam
-xfA
-xfA
-jWg
-vzi
-kfY
-xlv
-xlv
-lgH
-dVa
-xlv
-xfA
-ewV
+uuR
+uuR
+hcP
+liJ
+ibn
+hbs
+hbs
+hbs
+mwd
+hbs
+uuR
+izn
 fam
 fam
 fam
@@ -102618,16 +102626,16 @@ fam
 fam
 fam
 fam
-xfA
-xfA
-uuq
-chS
-xlv
-cxX
-xlv
-kPt
-xfA
-xfA
+uuR
+uuR
+iwx
+eFZ
+hbs
+bUx
+hbs
+dmL
+uuR
+uuR
 fam
 fam
 srJ
@@ -102774,17 +102782,17 @@ fam
 fam
 fam
 fam
-biU
-pmX
-pmX
-pmX
-pmX
-hbs
-hbs
-hbs
-pmX
-pmX
-rZO
+ylI
+mlS
+mlS
+mlS
+mlS
+ewV
+ewV
+ewV
+mlS
+mlS
+rRR
 fam
 fam
 srJ
@@ -102931,17 +102939,17 @@ fam
 fam
 fam
 fam
-evs
-izn
-tXZ
-tXZ
-jKZ
-xlv
-xlv
-xlv
-xlv
 kPt
-evs
+eTF
+sJB
+sJB
+vwK
+hbs
+hbs
+hbs
+hbs
+dmL
+kPt
 fam
 srJ
 srJ
@@ -103088,17 +103096,17 @@ fam
 fam
 fam
 fam
-biU
-clE
-tXZ
-tXZ
-fEJ
-xlv
-xlv
-xlv
-cxX
-xlv
-biU
+ylI
+nAP
+sJB
+sJB
+tNG
+hbs
+hbs
+hbs
+bUx
+hbs
+ylI
 fam
 srJ
 rOV
@@ -103245,17 +103253,17 @@ fam
 fam
 fam
 fam
-evs
-fXl
-tXZ
-tXZ
-jKZ
-vYe
-mJn
-xlv
-xlv
 kPt
-evs
+ylP
+sJB
+sJB
+vwK
+pmX
+vYe
+hbs
+hbs
+dmL
+kPt
 fam
 srJ
 rOV
@@ -103402,17 +103410,17 @@ fam
 fam
 fam
 fam
-biU
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-pmX
-rZO
+ylI
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+mlS
+rRR
 fam
 fam
 rOV

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -336,6 +336,13 @@
 /obj/item/rogueweapon/mace/goden/steel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"aje" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "ajW" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/clothing/neck/roguetown/psicross,
@@ -447,8 +454,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "anQ" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/rogue/concrete,
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "anU" = (
 /obj/structure/roguemachine/withdraw,
@@ -460,6 +470,12 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
+"aoj" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "aoA" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/hexstone,
@@ -719,10 +735,6 @@
 "azO" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
-"azU" = (
-/obj/structure/fluff/walldeco/chains,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "aAn" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -854,10 +866,6 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/town/roofs)
-"aGh" = (
-/obj/item/rogueweapon/pick,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
 "aGn" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/effect/decal/mossy{
@@ -1194,16 +1202,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
-"aVP" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "aVR" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -1507,10 +1505,7 @@
 	},
 /area/rogue/under/town/basement/keep)
 "biU" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/turf/open/floor/rogue/hexstone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
 /area/rogue/outdoors/mountains)
 "biZ" = (
 /turf/closed/wall/mineral/rogue/pipe{
@@ -1677,13 +1672,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
-"bpZ" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "bqd" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/garrison)
@@ -1916,13 +1904,6 @@
 /obj/structure/mirror,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"bBW" = (
-/obj/structure/table/church{
-	icon_state = "churchtable_end"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "bBY" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/manor)
@@ -2049,10 +2030,6 @@
 "bId" = (
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach)
-"bIe" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
 "bIi" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -2225,11 +2202,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"bPU" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 8
-	},
-/area/rogue/outdoors/mountains)
 "bPY" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -2255,13 +2227,6 @@
 "bSn" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
-/area/rogue/outdoors/mountains)
-"bSy" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	icon_state = "chair2"
-	},
-/turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "bSE" = (
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -2597,6 +2562,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"chS" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "cia" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/robe/necra,
@@ -2625,8 +2597,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "cjv" = (
-/obj/structure/bars,
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "cjy" = (
 /obj/structure/mineral_door/wood/fancywood{
@@ -2668,6 +2640,10 @@
 /obj/item/natural/worms,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"clE" = (
+/obj/structure/fluff/statue/gargoyle,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "clS" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -2784,14 +2760,6 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
-"crn" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
-	},
-/obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "cru" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/tile/masonic{
@@ -2886,9 +2854,25 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"cwO" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "cxb" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"cxd" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/church{
+	light_color = "#b30202"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "cxD" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/table/wood{
@@ -2910,6 +2894,10 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"cxX" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "cyh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/tavern)
@@ -2949,6 +2937,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/roofs)
+"czG" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "czZ" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/herringbone,
@@ -3108,8 +3102,10 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "cGL" = (
-/obj/structure/chair/bench/church/mid,
-/turf/open/floor/rogue/concrete,
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains)
 "cGR" = (
 /obj/structure/mineral_door/wood{
@@ -3430,11 +3426,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
-"cXB" = (
-/obj/structure/table/church,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "cXC" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -3963,6 +3954,10 @@
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/exposed/town/keep)
+"dse" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "dsk" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/armor/plate/half,
@@ -4282,6 +4277,10 @@
 "dIf" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement)
+"dIp" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "dIL" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -4305,6 +4304,13 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
+"dJr" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "dKq" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks,
@@ -4322,12 +4328,6 @@
 /obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
-"dMb" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "dML" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newleaf,
@@ -4498,6 +4498,10 @@
 "dUc" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
+"dVa" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "dVi" = (
 /obj/structure/stairs{
 	dir = 8
@@ -4578,11 +4582,6 @@
 /obj/item/roguecoin/silver/pile,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
-"dXX" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/table/optable,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "dYe" = (
 /obj/structure/table/wood,
 /obj/structure/fluff/millstone{
@@ -4608,6 +4607,11 @@
 /obj/effect/landmark/start/prisonerr,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell)
+"dYP" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "dZj" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -4889,6 +4893,11 @@
 "emP" = (
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/dwarfin)
+"emY" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 4
+	},
+/area/rogue/outdoors/mountains)
 "enl" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/rogue/cobble,
@@ -5079,8 +5088,7 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "evs" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/hexstone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
 /area/rogue/outdoors/mountains)
 "evJ" = (
 /obj/structure/mineral_door/wood/window{
@@ -5119,8 +5127,9 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "ewV" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/hexstone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 8
+	},
 /area/rogue/outdoors/mountains)
 "exe" = (
 /turf/open/floor/rogue/tile,
@@ -5255,9 +5264,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "eFZ" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains)
 "eGr" = (
 /obj/structure/fluff/psycross/copper,
@@ -5432,6 +5440,12 @@
 /obj/item/rogueweapon/huntingknife/idagger/steel/special,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"ePC" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "ePO" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /obj/structure/fluff/wallclock,
@@ -5457,10 +5471,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
-"eRk" = (
-/obj/structure/flora/roguegrass,
-/turf/closed/mineral/rogue/bedrock,
-/area/rogue/outdoors/mountains)
 "eRp" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5512,9 +5522,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "eTF" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 1
-	},
+/obj/structure/roguewindow/stained/zizo,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/mountains)
 "eTM" = (
 /obj/structure/fluff/railing/border{
@@ -5741,10 +5750,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
-"fet" = (
-/obj/structure/chair/bench/church/r,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "feH" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -6132,6 +6137,10 @@
 /obj/item/roguecoin/gold/pile,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
+"fwP" = (
+/obj/item/rogueweapon/pick,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "fwW" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood{
@@ -6146,6 +6155,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"fxK" = (
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "fyl" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -6292,6 +6305,11 @@
 	icon_state = "horzw"
 	},
 /area/rogue/under/town/basement)
+"fEJ" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/obj/structure/stairs/stone/d,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "fEQ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -6460,6 +6478,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"fMS" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "fNg" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -6640,7 +6662,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fXl" = (
-/turf/open/floor/rogue/concrete,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains)
 "fXV" = (
 /obj/structure/composter/halffull,
@@ -6854,10 +6877,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"giX" = (
-/obj/structure/fluff/statue/gargoyle/moss/candles,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "gjb" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -7271,21 +7290,6 @@
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"gDW" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
-"gEk" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "gFq" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -7448,12 +7452,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
-"gNi" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "gNo" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -7649,6 +7647,13 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor)
+"gVb" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "gVe" = (
 /obj/structure/bars,
 /turf/open/water/sewer,
@@ -7781,8 +7786,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "hbs" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/concrete,
+/obj/structure/bars/passage{
+	density = 0;
+	icon_state = "passage1"
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "hby" = (
 /obj/structure/fluff/railing/border{
@@ -7816,12 +7824,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
-"hcN" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "hcO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -7841,13 +7843,6 @@
 "heh" = (
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
-"hew" = (
-/obj/item/natural/worms/leech,
-/obj/item/natural/worms/leech{
-	pixel_x = 8
-	},
-/turf/open/water/swamp,
-/area/rogue/outdoors/mountains)
 "heR" = (
 /obj/structure/closet/crate/chest{
 	base_icon_state = "woodchestalt";
@@ -8001,13 +7996,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
-"hnE" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "hnK" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
@@ -8031,8 +8019,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "hpe" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/naturalstone,
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains)
 "hpn" = (
 /obj/structure/fluff/railing/wood{
@@ -8593,13 +8584,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"hQm" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "hQQ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
@@ -8653,13 +8637,6 @@
 /obj/item/book/rogue/blackmountain,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
-"hTx" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "hTE" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/cobble,
@@ -9250,10 +9227,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"iwo" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "iww" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -9311,9 +9284,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "izn" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 4
-	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains)
 "izp" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -9645,6 +9616,13 @@
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"iQh" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "iQQ" = (
 /obj/structure/fermenting_barrel/blackgoat,
 /turf/open/floor/rogue/blocks,
@@ -9754,10 +9732,6 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
-"iWy" = (
-/obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "iWT" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -9802,6 +9776,12 @@
 /obj/structure/roguemachine/mail/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/shop)
+"iYj" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "iYk" = (
 /obj/structure/fluff/railing/border,
 /obj/machinery/light/rogue/torchholder/l{
@@ -9959,12 +9939,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
-"jeS" = (
-/obj/structure/pillory{
-	lockid = "inhumen"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "jeY" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -10338,9 +10312,10 @@
 	},
 /area/rogue/indoors/town)
 "jBi" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 9
+/obj/structure/fluff/statue/femalestatue/zizo{
+	desc = "An ancient statue depicting an elven woman.";
+	name = "Ancient Statue";
+	pixel_y = 0
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
@@ -10366,6 +10341,10 @@
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"jBM" = (
+/obj/structure/chair/bench/church,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "jBO" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
@@ -10385,6 +10364,10 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"jCX" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "jDt" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -10453,6 +10436,16 @@
 "jGx" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/cell)
+"jGA" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 5
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "jHo" = (
 /obj/item/roguebin/water,
 /obj/machinery/light/rogue/wallfire/candle,
@@ -10537,7 +10530,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "jKZ" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/obj/structure/stairs/stone/d,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "jLc" = (
 /obj/effect/decal/cobbleedge{
@@ -10625,13 +10619,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"jOf" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "jOp" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10788,6 +10775,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"jUx" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "jUJ" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -10843,6 +10834,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/physician)
+"jWg" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "jWq" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -10903,6 +10901,16 @@
 "jYo" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/magician)
+"jYF" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "jYN" = (
 /obj/structure/chair/bench/ultimacouch/r{
 	icon_state = "ultimacochright"
@@ -10933,12 +10941,6 @@
 "kaC" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/woods)
-"kbk" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "kbt" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -11011,10 +11013,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"kep" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "keS" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine{
@@ -11035,7 +11033,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/roofs)
 "kfY" = (
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/stairs/stone{
+	dir = 1
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "kgo" = (
@@ -11186,12 +11186,6 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"kph" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "kpv" = (
 /obj/structure/roguemachine/mail{
 	mailtag = "Bathhouse"
@@ -11266,6 +11260,17 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"ksw" = (
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "ksK" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/ruinedwood,
@@ -11496,6 +11501,13 @@
 "kAA" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
+"kBu" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "kBx" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/shoes/roguetown/boots,
@@ -11668,6 +11680,11 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
+"kJu" = (
+/obj/structure/bed/rogue/shit,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "kJD" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -11888,7 +11905,9 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town)
 "kPt" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "kPv" = (
@@ -12259,12 +12278,6 @@
 "lcT" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
-"lda" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "ldT" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -12354,6 +12367,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/shop)
+"lgH" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "lgQ" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
@@ -13270,14 +13287,6 @@
 "mbI" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/under/town/sewer)
-"mbK" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "inhumen";
-	name = "Forgotten Chapel"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "mbO" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -13383,13 +13392,6 @@
 /obj/item/rogueweapon/sword/iron,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"mfN" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "mfP" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -13542,9 +13544,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
 "mlS" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/whip,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "mlU" = (
@@ -13743,8 +13745,8 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "mwd" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/blocks,
+/obj/structure/chair/bench/church/mid,
+/turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "mwr" = (
 /turf/open/floor/rogue/ruinedwood,
@@ -13773,13 +13775,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
-"mxC" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "mxK" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/tile,
@@ -13875,11 +13870,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "mBU" = (
-/obj/structure/fluff/statue/femalestatue/zizo{
-	desc = "An ancient statue depicting an elven woman.";
-	name = "Ancient Statue";
-	pixel_y = 0
-	},
+/obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "mCu" = (
@@ -13983,6 +13974,14 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
+"mHf" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
+	},
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "mHT" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/tile/bath,
@@ -14025,7 +14024,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "mJn" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/effect/decal/remains/human,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "mJH" = (
@@ -14154,10 +14153,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "mPD" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "mPR" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -14211,13 +14211,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"mUB" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "mUJ" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -14329,8 +14322,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "mZF" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "mZT" = (
 /obj/structure/table/wood,
@@ -14971,8 +14963,8 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
-"nAB" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
+"nzQ" = (
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "nAP" = (
@@ -14983,6 +14975,10 @@
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"nBC" = (
+/obj/structure/fermenting_barrel/random/beer,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "nBF" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/wood,
@@ -15335,13 +15331,6 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"nRa" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "nRB" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/structure/curtain/bounty{
@@ -15757,11 +15746,6 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
-"oji" = (
-/obj/structure/bed/rogue/shit,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "ojV" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rogueweapon/hoe,
@@ -15802,8 +15786,8 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "onk" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/blocks,
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "ono" = (
 /obj/structure/table/wood{
@@ -15862,6 +15846,10 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town)
+"opz" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "opJ" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -16074,6 +16062,13 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
+"oyq" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "oyt" = (
 /obj/structure/fluff/wallclock{
 	dir = 3
@@ -16327,13 +16322,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"oHg" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "oHy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -16908,12 +16896,6 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
-"pjN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "pjV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -17003,14 +16985,7 @@
 	},
 /area/rogue/under/town/sewer)
 "pmX" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/concrete,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/outdoors/mountains)
 "pnh" = (
 /obj/structure/mineral_door/wood{
@@ -17110,10 +17085,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "psG" = (
-/obj/structure/mineral_door/bars{
-	lockid = "inhumen"
+/obj/item/natural/worms/leech,
+/obj/item/natural/worms/leech{
+	pixel_x = 8
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/water/swamp,
 /area/rogue/outdoors/mountains)
 "ptr" = (
 /obj/structure/table/wood/fancy/royalblack,
@@ -17204,6 +17180,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement)
+"pwM" = (
+/obj/item/chair/rogue,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "pwS" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -17830,6 +17810,16 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"pXD" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "pYi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -17945,17 +17935,6 @@
 "qey" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"qeH" = (
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "qeJ" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/ruinedwood/chevron,
@@ -18413,13 +18392,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"qBU" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/reagent_containers/food/snacks/rogue/friedrat,
-/obj/item/reagent_containers/food/snacks/rogue/friedrat,
-/obj/item/reagent_containers/food/snacks/rogue/friedrat,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "qDm" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -18623,7 +18595,8 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "qNj" = (
-/obj/structure/stairs/stone/d,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/table/optable,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "qNG" = (
@@ -18751,6 +18724,10 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell)
+"qUR" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "qVf" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
@@ -18941,14 +18918,6 @@
 "raW" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
-"rbf" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
-/obj/item/rogueweapon/huntingknife/cleaver,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "rbh" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -18991,10 +18960,6 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"rdg" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
 "rdm" = (
 /obj/structure/telescope,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -19292,6 +19257,15 @@
 /obj/structure/fermenting_barrel/random/beer,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"rsI" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/storage/belt/rogue/surgery_bag/full,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "rtf" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -19330,6 +19304,10 @@
 /obj/item/rogueweapon/mace/spiked,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"ruF" = (
+/obj/structure/table/church/m,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "ruG" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
@@ -19385,8 +19363,9 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/dwarfin)
-"rvU" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+"rvK" = (
+/obj/structure/table/church,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains)
 "rwd" = (
@@ -19560,16 +19539,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
-"rEt" = (
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	dir = 5
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "rEw" = (
 /obj/item/paper/confession,
 /obj/item/paper/confession,
@@ -19908,7 +19877,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "rRR" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
+/obj/structure/mineral_door/bars{
+	lockid = "inhumen"
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "rSa" = (
 /obj/structure/bed/rogue,
@@ -19937,6 +19909,14 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor)
+"rSD" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/reagent_containers/powder/health,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "rSG" = (
 /obj/item/roguebin,
 /turf/open/floor/carpet/royalblack,
@@ -20067,8 +20047,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "rZO" = (
-/obj/item/reagent_containers/food/snacks/smallrat,
-/turf/open/floor/rogue/concrete,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 1
+	},
 /area/rogue/outdoors/mountains)
 "sac" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -20187,16 +20168,6 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town)
-"sgU" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/church{
-	light_color = "#b30202"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "sgY" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -20452,13 +20423,6 @@
 "srJ" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/mountains)
-"ssj" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "ssF" = (
 /obj/structure/roguemachine/lottery_roguetown{
 	pixel_y = -32
@@ -20595,10 +20559,6 @@
 "swO" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
-"swW" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "sxl" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -20804,6 +20764,13 @@
 /obj/structure/table/wood/crafted,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
+"sGe" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 5
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "sGz" = (
 /obj/effect/decal/cobbleedge,
 /obj/structure/flora/roguegrass,
@@ -20854,8 +20821,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
 "sJB" = (
-/obj/structure/fermenting_barrel/random/beer,
-/turf/open/floor/rogue/hexstone,
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "sJK" = (
 /obj/machinery/light/rogue/firebowl/standing,
@@ -21005,10 +20975,6 @@
 /obj/item/mundane/puzzlebox/easy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"sPW" = (
-/obj/item/storage/roguebag,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/mountains)
 "sQg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -21059,9 +21025,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "sTs" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
+/obj/structure/bars,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "sTt" = (
@@ -21123,10 +21087,6 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
-"sWG" = (
-/obj/item/chair/rogue,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "sWM" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -21565,13 +21525,6 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"tok" = (
-/obj/structure/bars/passage{
-	density = 0;
-	icon_state = "passage1"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "too" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/concrete,
@@ -22031,13 +21984,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"tKd" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/mountains)
 "tKw" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood{
@@ -22564,8 +22510,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "umC" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/hexstone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
+	},
 /area/rogue/outdoors/mountains)
 "umP" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -22679,6 +22626,12 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"usJ" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "usO" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -22715,6 +22668,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
+"uuq" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "uut" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -22735,8 +22695,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "uuR" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/hexstone,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "uuU" = (
 /obj/structure/chair/wood/rogue/fancy{
@@ -22901,6 +22861,12 @@
 /obj/item/rogueweapon/stoneaxe/woodcut/steel,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"uBw" = (
+/obj/structure/pillory{
+	lockid = "inhumen"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "uBD" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/rack/rogue,
@@ -23048,10 +23014,6 @@
 /obj/structure/fluff/walldeco/artificerflag,
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town)
-"uFO" = (
-/obj/structure/table/church/m,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "uGz" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -23333,6 +23295,13 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"uWC" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "uXf" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rogue/instrument/drum,
@@ -23377,6 +23346,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"uZO" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "uZR" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -23535,6 +23508,10 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"vmr" = (
+/obj/structure/flora/roguegrass,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "vnd" = (
 /obj/item/ingot/copper,
 /obj/item/ingot/copper,
@@ -23629,15 +23606,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"vqO" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/obj/item/storage/belt/rogue/surgery_bag/full,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "vrR" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	icon_state = "iron_corner"
@@ -23737,8 +23705,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "vwK" = (
-/obj/structure/roguewindow/stained/zizo,
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/structure/fluff/walldeco/chains,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "vwW" = (
 /obj/structure/mineral_door/wood/fancywood{
@@ -23777,6 +23745,10 @@
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor)
+"vzi" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "vzy" = (
 /obj/structure/closet/crate/chest,
 /obj/item/reagent_containers/powder/salt,
@@ -23924,6 +23896,14 @@
 "vHc" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town/dwarfin)
+"vHe" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "inhumen";
+	name = "Forgotten Chapel"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "vHo" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassred,
@@ -24125,10 +24105,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
-"vUD" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/mountains)
 "vVs" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
@@ -24190,14 +24166,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"vWY" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/obj/item/reagent_containers/powder/health,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "vXl" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/wood,
@@ -24215,6 +24183,7 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "vYe" = (
+/obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "vYh" = (
@@ -24287,12 +24256,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
-"wdS" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/whip,
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "wdX" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -24356,6 +24319,13 @@
 "wfx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/garrison)
+"wfC" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "wgk" = (
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/naturalstone,
@@ -24892,7 +24862,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "wBF" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains)
 "wBY" = (
 /obj/structure/chair/wood/rogue,
@@ -24987,7 +24958,8 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "wHq" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
+/obj/structure/fluff/statue/gargoyle/moss/candles,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "wHt" = (
 /obj/structure/fluff/walldeco/customflag{
@@ -25665,8 +25637,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "xfA" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/hexstone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/outdoors/mountains)
 "xfD" = (
 /obj/effect/spawner/roguemap/stump,
@@ -25777,8 +25748,10 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "xiL" = (
-/obj/structure/chair/bench/church,
-/turf/open/floor/rogue/concrete,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "xiX" = (
 /obj/structure/roguemachine/withdraw,
@@ -25802,9 +25775,6 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "xlv" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/thresher,
-/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
 "xlI" = (
@@ -25877,6 +25847,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
+"xnu" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "xnB" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -26184,6 +26160,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/dwarfin)
+"xCC" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "xCI" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -26193,10 +26173,18 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
+"xDb" = (
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "xDh" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"xDs" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "xDC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -26396,6 +26384,12 @@
 /obj/item/bedsheet/rogue/fabric,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/basement/keep)
+"xMU" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "xMY" = (
 /obj/structure/rack/rogue/shelf,
 /obj/structure/rack/rogue/shelf/big{
@@ -26472,6 +26466,12 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
+"xOP" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "xOU" = (
 /obj/structure/stairs{
 	dir = 4
@@ -26710,11 +26710,6 @@
 "xWK" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors)
-"xWV" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
-/obj/structure/stairs/stone/d,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "xWX" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -26780,10 +26775,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
-"yav" = (
-/obj/structure/fermenting_barrel/random/water,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/outdoors/mountains)
 "yaE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -27067,16 +27058,25 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "ylI" = (
-/turf/open/floor/rogue/blocks,
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "ylN" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "ylP" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/hexstone,
+/obj/item/rogueweapon/huntingknife/cleaver,
+/turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "ymf" = (
 /obj/structure/roguewindow/openclose{
@@ -75925,22 +75925,22 @@ srJ
 srJ
 srJ
 srJ
-jKZ
-wHq
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-eTF
-jKZ
+xfA
+biU
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+rZO
+xfA
 fam
 fam
 fam
@@ -76082,22 +76082,22 @@ srJ
 srJ
 srJ
 srJ
-izn
-hTx
-vYe
-vYe
+evs
+iQh
+xlv
+xlv
+jKZ
+xfA
+kPt
+nBC
+vwK
+dse
+kPt
+xfA
+rsI
 qNj
-jKZ
-biU
-sJB
-azU
-yav
-biU
-jKZ
-vqO
-dXX
-vWY
-izn
+rSD
+emY
 fam
 fam
 fam
@@ -76239,22 +76239,22 @@ srJ
 srJ
 srJ
 srJ
-eFZ
-giX
-vYe
-vYe
-qNj
+umC
+wHq
+xlv
+xlv
 jKZ
 xfA
 vYe
-vYe
-vYe
-vYe
-izn
-azU
-fXl
-kfY
-eFZ
+xlv
+xlv
+xlv
+xlv
+emY
+vwK
+mZF
+dVa
+umC
 fam
 fam
 fam
@@ -76396,22 +76396,22 @@ srJ
 srJ
 srJ
 srJ
-eFZ
-biU
-vYe
-vYe
-qNj
-jKZ
-vYe
-vYe
-vYe
 evs
-vYe
-cjv
-vYe
-rZO
-vYe
-eFZ
+kPt
+xlv
+xlv
+jKZ
+xfA
+xlv
+xlv
+xlv
+cxX
+xlv
+sTs
+xlv
+xDb
+xlv
+umC
 fam
 fam
 fam
@@ -76553,22 +76553,22 @@ srJ
 srJ
 srJ
 rOV
-eFZ
-vYe
-vYe
-vYe
-jKZ
-jKZ
-kfY
-kPt
-fXl
-vYe
-vYe
-psG
-vYe
-fXl
-uuR
-eFZ
+umC
+xfA
+hbs
+hbs
+xfA
+xfA
+dVa
+lgH
+mZF
+xlv
+xlv
+rRR
+xlv
+mZF
+mJn
+umC
 fam
 fam
 fam
@@ -76710,22 +76710,22 @@ srJ
 srJ
 rOV
 rOV
-eFZ
-xfA
+umC
 vYe
-vYe
-biU
-izn
-vYe
-fXl
-fXl
-hbs
-vYe
-cjv
-kfY
-fXl
-azU
-eFZ
+xlv
+xlv
+kPt
+emY
+xlv
+mZF
+mZF
+xDs
+xlv
+sTs
+dVa
+mZF
+vwK
+umC
 fam
 fam
 fam
@@ -76867,22 +76867,22 @@ rOV
 rOV
 rOV
 rcv
-eFZ
-sTs
-vYe
-vYe
-evs
-eFZ
-vYe
-lda
-lda
-sWG
-vYe
-bPU
-mZF
-vYe
-oji
-eFZ
+umC
+xMU
+xlv
+xlv
+cxX
+umC
+xlv
+xOP
+xOP
+pwM
+xlv
+ewV
+onk
+xlv
+kJu
+umC
 fam
 fam
 fam
@@ -77024,24 +77024,24 @@ rOV
 rOV
 rcv
 rcv
-eFZ
-mJn
-fXl
-fXl
-vYe
-eFZ
-mJn
-crn
-oHg
-gDW
-vYe
-jKZ
-wHq
-cjv
-eTF
-eFZ
+umC
+xCC
+mZF
+mZF
+xlv
+umC
+xCC
+mHf
+aje
+jYF
+xlv
+xfA
+biU
+sTs
+rZO
+umC
 fam
-hpe
+cjv
 tQp
 srJ
 srJ
@@ -77181,22 +77181,22 @@ rcv
 rcv
 rcv
 tQp
-eFZ
-sTs
-anQ
-fXl
-vYe
-bPU
-vYe
-jOf
-rbf
-aVP
-vYe
-izn
-wdS
-vYe
-swW
-eFZ
+umC
+xMU
+nzQ
+mZF
+xlv
+ewV
+xlv
+sGe
+ylP
+pXD
+xlv
+emY
+mlS
+xlv
+uZO
+umC
 fam
 tQp
 tQp
@@ -77335,25 +77335,25 @@ fam
 (11,1,3) = {"
 fam
 rcv
-hew
-sPW
+psG
+fxK
 tQp
-tok
-vYe
-fXl
-fXl
-vYe
-tok
-vYe
-bSy
-fXl
-bSy
-vYe
-cjv
-fXl
-fXl
-anQ
-eFZ
+hbs
+xlv
+mZF
+mZF
+xlv
+hbs
+xlv
+oyq
+mZF
+oyq
+xlv
+sTs
+mZF
+mZF
+nzQ
+umC
 fam
 tQp
 tQp
@@ -77492,25 +77492,25 @@ fam
 (12,1,3) = {"
 fam
 rcv
-hew
-rdg
-tQp
-tok
-vYe
-fXl
-fXl
-vYe
-tok
-vYe
-fXl
-anQ
-fXl
-vYe
 psG
-fXl
-jeS
-fXl
-eFZ
+jCX
+tQp
+hbs
+xlv
+mZF
+mZF
+xlv
+hbs
+xlv
+mZF
+nzQ
+mZF
+xlv
+rRR
+mZF
+uBw
+mZF
+umC
 fam
 tQp
 tQp
@@ -77649,25 +77649,25 @@ fam
 (13,1,3) = {"
 fam
 rcv
-hew
-aGh
+psG
+fwP
 tQp
-tok
-vYe
 hbs
-fXl
-vYe
-tok
-vYe
-lda
-fXl
-nRa
-vYe
-cjv
-fXl
-fXl
-fXl
-eFZ
+xlv
+xDs
+mZF
+xlv
+hbs
+xlv
+xOP
+mZF
+uWC
+xlv
+sTs
+mZF
+mZF
+mZF
+umC
 fam
 tQp
 tQp
@@ -77809,22 +77809,22 @@ rcv
 rcv
 rcv
 tQp
-eFZ
-mxC
-fXl
-fXl
-vYe
-izn
-vYe
-jBi
-hQm
-qeH
-vYe
-bPU
+umC
+gVb
+mZF
+mZF
 xlv
-evs
-swW
-eFZ
+emY
+xlv
+dJr
+mPD
+ksw
+xlv
+ewV
+iYj
+cxX
+uZO
+umC
 fam
 tQp
 tQp
@@ -77966,22 +77966,22 @@ rOV
 rOV
 rcv
 rcv
-eFZ
-mJn
-fXl
-fXl
-xfA
-eFZ
-mJn
-rEt
-pmX
-tKd
+umC
+xCC
+mZF
+mZF
 vYe
-jKZ
-wHq
-cjv
-eTF
-eFZ
+umC
+xCC
+jGA
+ylI
+sJB
+xlv
+xfA
+biU
+sTs
+rZO
+umC
 fam
 fam
 tQp
@@ -78123,22 +78123,22 @@ rOV
 rOV
 rOV
 rOV
-eFZ
-sTs
-vYe
-evs
-vYe
-eFZ
-vYe
-sWG
-fXl
-pjN
-vYe
-izn
-vYe
-vYe
-vYe
-eFZ
+umC
+xMU
+xlv
+cxX
+xlv
+umC
+xlv
+pwM
+mZF
+czG
+xlv
+emY
+xlv
+xlv
+xlv
+umC
 fam
 fam
 fam
@@ -78280,22 +78280,22 @@ srJ
 srJ
 rOV
 rOV
-eFZ
-vYe
-vYe
-vYe
-biU
-bPU
-azU
-fXl
-fXl
-anQ
-vYe
-cjv
+umC
+xlv
+xlv
+xlv
+kPt
+ewV
+vwK
 mZF
-fXl
-azU
-eFZ
+mZF
+nzQ
+xlv
+sTs
+onk
+mZF
+vwK
+umC
 fam
 fam
 fam
@@ -78437,22 +78437,22 @@ srJ
 srJ
 srJ
 srJ
-eFZ
-vYe
-vYe
-vYe
-jKZ
-jKZ
-vYe
-uuR
-fXl
-vYe
-vYe
-psG
-vYe
-fXl
-vYe
-eFZ
+umC
+xfA
+hbs
+hbs
+xfA
+xfA
+xlv
+mJn
+mZF
+xlv
+xlv
+rRR
+xlv
+mZF
+xlv
+umC
 fam
 fam
 fam
@@ -78594,22 +78594,22 @@ srJ
 srJ
 srJ
 srJ
-eFZ
-biU
-vYe
-vYe
-qNj
-jKZ
-qBU
-kfY
-vYe
-kPt
-vYe
-cjv
 evs
-nAB
-vYe
-eFZ
+kPt
+xlv
+xlv
+jKZ
+xfA
+anQ
+dVa
+xlv
+lgH
+xlv
+sTs
+cxX
+dIp
+xlv
+umC
 fam
 fam
 fam
@@ -78751,22 +78751,22 @@ srJ
 srJ
 srJ
 srJ
-eFZ
-giX
-vYe
-vYe
-qNj
+umC
+wHq
+xlv
+xlv
 jKZ
-hcN
-ylP
-mlS
-kph
-vYe
-bPU
-azU
-fXl
+xfA
+ePC
+xnu
+aoj
+xiL
+xlv
+ewV
+vwK
 mZF
-eFZ
+onk
+umC
 fam
 fam
 fam
@@ -78908,22 +78908,22 @@ srJ
 srJ
 srJ
 srJ
-bPU
-biU
-xfA
+evs
+kPt
 vYe
-qNj
+xlv
 jKZ
-ssj
-umC
-gEk
-dMb
-biU
-jKZ
-mZF
-ewV
 xfA
-bPU
+wfC
+opz
+dYP
+cwO
+kPt
+xfA
+onk
+fMS
+vYe
+ewV
 fam
 fam
 fam
@@ -79065,22 +79065,22 @@ srJ
 srJ
 srJ
 srJ
-jKZ
-wHq
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-eTF
-jKZ
+xfA
+biU
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+rZO
+xfA
 fam
 fam
 fam
@@ -79222,7 +79222,7 @@ fam
 fam
 fam
 fam
-eRk
+vmr
 fam
 fam
 fam
@@ -100262,17 +100262,17 @@ fam
 fam
 fam
 fam
-wHq
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-eTF
+biU
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+rZO
 fam
 fam
 fam
@@ -100419,17 +100419,17 @@ fam
 fam
 fam
 fam
-rRR
-vUD
+evs
+qUR
 tXZ
 tXZ
-qNj
+jKZ
+xlv
+xlv
 vYe
-vYe
-xfA
-vYe
-biU
-rRR
+xlv
+kPt
+evs
 fam
 fam
 fam
@@ -100576,17 +100576,17 @@ fam
 fam
 fam
 fam
-wHq
-iWy
+biU
+clE
 tXZ
 tXZ
-qNj
-vYe
-kPt
-vYe
-uuR
-vYe
-wHq
+jKZ
+xlv
+lgH
+xlv
+mJn
+xlv
+biU
 fam
 fam
 fam
@@ -100733,17 +100733,17 @@ fam
 fam
 fam
 fam
-rRR
-ylI
+evs
+izn
 tXZ
 tXZ
-qNj
-vYe
-vYe
-vYe
-vYe
-biU
-rRR
+jKZ
+xlv
+xlv
+xlv
+xlv
+kPt
+evs
 fam
 fam
 srJ
@@ -100890,17 +100890,17 @@ fam
 fam
 fam
 fam
-wHq
-wBF
-wBF
-wBF
-wBF
-tok
-tok
-tok
-wBF
-eTF
-wHq
+biU
+pmX
+pmX
+pmX
+pmX
+hbs
+hbs
+hbs
+pmX
+rZO
+biU
 fam
 fam
 srJ
@@ -101048,16 +101048,16 @@ fam
 fam
 fam
 fam
-jKZ
-jKZ
-bpZ
-hnE
-vYe
-evs
-vYe
-biU
-jKZ
-jKZ
+xfA
+xfA
+jWg
+chS
+xlv
+cxX
+xlv
+kPt
+xfA
+xfA
 fam
 fam
 srJ
@@ -101204,18 +101204,18 @@ fam
 fam
 fam
 fam
-jKZ
-jKZ
-mfN
-ylI
-mPD
-vYe
-vYe
-vYe
-vYe
-vYe
-jKZ
+xfA
+xfA
+kBu
 izn
+kfY
+xlv
+xlv
+xlv
+xlv
+xlv
+xfA
+emY
 fam
 fam
 fam
@@ -101358,21 +101358,21 @@ fam
 fam
 fam
 fam
+emY
+xfA
+evs
+xfA
+cGL
 izn
-jKZ
-rRR
-jKZ
-kbk
-ylI
-ylI
-mPD
-vYe
-gNi
-gNi
-xiL
+izn
 kfY
-vYe
-bPU
+xlv
+usJ
+usJ
+jBM
+dVa
+xlv
+ewV
 fam
 fam
 tQp
@@ -101515,22 +101515,22 @@ fam
 fam
 fam
 fam
-vwK
-mwd
+eTF
+wBF
 nAP
-onk
-ylI
-ylI
-ylI
-hnE
-uuR
-cGL
-cGL
-cGL
-evs
-vYe
-vwK
-hpe
+vzi
+izn
+izn
+izn
+chS
+mJn
+mwd
+mwd
+mwd
+cxX
+xlv
+eTF
+cjv
 tQp
 tQp
 tQp
@@ -101672,21 +101672,21 @@ fam
 fam
 fam
 fam
-bPU
-mwd
-fXl
-fXl
-fXl
-iwo
-cXB
-hnE
-kfY
-fet
-fet
-fet
-vYe
-vYe
-jKZ
+ewV
+wBF
+mZF
+mZF
+mZF
+jUx
+rvK
+chS
+dVa
+mBU
+mBU
+mBU
+xlv
+xlv
+xfA
 tQp
 tQp
 tQp
@@ -101829,23 +101829,23 @@ fam
 fam
 fam
 fam
-rRR
-ylI
-fXl
-mBU
-fXl
-kep
-uFO
-sgU
-vYe
-vYe
-vYe
-vYe
-kPt
-vYe
-mbK
-bIe
-bIe
+evs
+izn
+mZF
+jBi
+mZF
+eFZ
+ruF
+cxd
+xlv
+xlv
+xlv
+xlv
+lgH
+xlv
+vHe
+uuR
+uuR
 tQp
 tQp
 tXZ
@@ -101986,21 +101986,21 @@ fam
 fam
 fam
 fam
+emY
 izn
-ylI
-fXl
-fXl
-fXl
-ylI
-bBW
-hnE
-vYe
-gNi
-gNi
-xiL
-uuR
-vYe
-jKZ
+mZF
+mZF
+mZF
+izn
+hpe
+chS
+xlv
+usJ
+usJ
+jBM
+mJn
+xlv
+xfA
 tQp
 tQp
 tQp
@@ -102143,22 +102143,22 @@ fam
 fam
 fam
 fam
-vwK
-rvU
-mwd
-ylI
-ylI
+eTF
+fXl
+wBF
+izn
+izn
 nAP
-ylI
-hnE
-evs
-cGL
-cGL
-cGL
-vYe
-evs
-vwK
-hpe
+izn
+chS
+cxX
+mwd
+mwd
+mwd
+xlv
+cxX
+eTF
+cjv
 tQp
 tQp
 tQp
@@ -102300,21 +102300,21 @@ fam
 fam
 fam
 fam
-bPU
-jKZ
-rRR
-jKZ
-kbk
-ylI
-ylI
-mPD
-vYe
-fet
-fet
-fet
-vYe
-vYe
+ewV
+xfA
+evs
+xfA
+cGL
 izn
+izn
+kfY
+xlv
+mBU
+mBU
+mBU
+xlv
+xlv
+emY
 fam
 fam
 tQp
@@ -102460,18 +102460,18 @@ fam
 fam
 fam
 fam
-jKZ
-jKZ
-bpZ
-onk
-mPD
-vYe
-vYe
-kPt
+xfA
+xfA
+jWg
+vzi
 kfY
-vYe
-jKZ
-bPU
+xlv
+xlv
+lgH
+dVa
+xlv
+xfA
+ewV
 fam
 fam
 fam
@@ -102618,16 +102618,16 @@ fam
 fam
 fam
 fam
-jKZ
-jKZ
-mUB
-hnE
-vYe
-evs
-vYe
-biU
-jKZ
-jKZ
+xfA
+xfA
+uuq
+chS
+xlv
+cxX
+xlv
+kPt
+xfA
+xfA
 fam
 fam
 srJ
@@ -102774,17 +102774,17 @@ fam
 fam
 fam
 fam
-wHq
-wBF
-wBF
-wBF
-wBF
-tok
-tok
-tok
-wBF
-wBF
-eTF
+biU
+pmX
+pmX
+pmX
+pmX
+hbs
+hbs
+hbs
+pmX
+pmX
+rZO
 fam
 fam
 srJ
@@ -102931,17 +102931,17 @@ fam
 fam
 fam
 fam
-rRR
-ylI
+evs
+izn
 tXZ
 tXZ
-qNj
-vYe
-vYe
-vYe
-vYe
-biU
-rRR
+jKZ
+xlv
+xlv
+xlv
+xlv
+kPt
+evs
 fam
 srJ
 srJ
@@ -103088,17 +103088,17 @@ fam
 fam
 fam
 fam
-wHq
-iWy
+biU
+clE
 tXZ
 tXZ
-xWV
-vYe
-vYe
-vYe
-evs
-vYe
-wHq
+fEJ
+xlv
+xlv
+xlv
+cxX
+xlv
+biU
 fam
 srJ
 rOV
@@ -103245,17 +103245,17 @@ fam
 fam
 fam
 fam
-rRR
-rvU
+evs
+fXl
 tXZ
 tXZ
-qNj
-xfA
-uuR
+jKZ
 vYe
-vYe
-biU
-rRR
+mJn
+xlv
+xlv
+kPt
+evs
 fam
 srJ
 rOV
@@ -103402,17 +103402,17 @@ fam
 fam
 fam
 fam
-wHq
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-wBF
-eTF
+biU
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+pmX
+rZO
 fam
 fam
 rOV

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -447,8 +447,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "anQ" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
-/area/rogue/under/cave)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "anU" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/herringbone,
@@ -718,6 +719,10 @@
 "azO" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"azU" = (
+/obj/structure/fluff/walldeco/chains,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "aAn" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -849,6 +854,10 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/outdoors/town/roofs)
+"aGh" = (
+/obj/item/rogueweapon/pick,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "aGn" = (
 /obj/structure/flora/roguegrass/bush,
 /obj/effect/decal/mossy{
@@ -1185,6 +1194,16 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
+"aVP" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "aVR" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -1488,8 +1507,11 @@
 	},
 /area/rogue/under/town/basement/keep)
 "biU" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "biZ" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 1;
@@ -1655,6 +1677,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
+"bpZ" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "bqd" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town/garrison)
@@ -1887,6 +1916,13 @@
 /obj/structure/mirror,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"bBW" = (
+/obj/structure/table/church{
+	icon_state = "churchtable_end"
+	},
+/obj/item/reagent_containers/glass/cup/silver,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "bBY" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/manor)
@@ -2013,6 +2049,10 @@
 "bId" = (
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach)
+"bIe" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "bIi" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -2185,6 +2225,11 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"bPU" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 8
+	},
+/area/rogue/outdoors/mountains)
 "bPY" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -2210,6 +2255,13 @@
 "bSn" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
+/area/rogue/outdoors/mountains)
+"bSy" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8;
+	icon_state = "chair2"
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/mountains)
 "bSE" = (
 /obj/item/reagent_containers/food/snacks/grown/apple,
@@ -2573,9 +2625,9 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "cjv" = (
-/obj/structure/roguewindow/stained/zizo,
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/under/cave)
+/obj/structure/bars,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "cjy" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -2732,6 +2784,14 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"crn" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
+	},
+/obj/item/reagent_containers/food/snacks/butter,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "cru" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/tile/masonic{
@@ -3048,9 +3108,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church/chapel)
 "cGL" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/obj/structure/chair/bench/church/mid,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "cGR" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -3105,11 +3165,6 @@
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
 	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	pixel_x = 24;
-	pixel_y = 24
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
@@ -3375,6 +3430,11 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"cXB" = (
+/obj/structure/table/church,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "cXC" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -4262,6 +4322,12 @@
 /obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield)
+"dMb" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "dML" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newleaf,
@@ -4512,6 +4578,11 @@
 /obj/item/roguecoin/silver/pile,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
+"dXX" = (
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/table/optable,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "dYe" = (
 /obj/structure/table/wood,
 /obj/structure/fluff/millstone{
@@ -5008,10 +5079,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "evs" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave)
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "evJ" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -5049,9 +5119,9 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "ewV" = (
-/obj/effect/decal/remains/human,
+/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/area/rogue/outdoors/mountains)
 "exe" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
@@ -5185,9 +5255,10 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "eFZ" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
+	},
+/area/rogue/outdoors/mountains)
 "eGr" = (
 /obj/structure/fluff/psycross/copper,
 /turf/open/floor/rogue/church,
@@ -5386,6 +5457,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
+"eRk" = (
+/obj/structure/flora/roguegrass,
+/turf/closed/mineral/rogue/bedrock,
+/area/rogue/outdoors/mountains)
 "eRp" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5437,9 +5512,10 @@
 	},
 /area/rogue/indoors/town/manor)
 "eTF" = (
-/obj/structure/chair/bench/church,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 1
+	},
+/area/rogue/outdoors/mountains)
 "eTM" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -5665,6 +5741,10 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"fet" = (
+/obj/structure/chair/bench/church/r,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "feH" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood{
@@ -6560,12 +6640,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fXl" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "fXV" = (
 /obj/structure/composter/halffull,
 /obj/effect/decal/cobbleedge{
@@ -6778,6 +6854,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"giX" = (
+/obj/structure/fluff/statue/gargoyle/moss/candles,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "gjb" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -7191,6 +7271,21 @@
 /obj/structure/fluff/statue/knight/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"gDW" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
+"gEk" = (
+/obj/machinery/light/rogue/hearth,
+/obj/item/cooking/pan,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "gFq" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -7353,6 +7448,12 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
+"gNi" = (
+/obj/structure/chair/bench/church{
+	dir = 1
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "gNo" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -7680,13 +7781,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "hbs" = (
-/obj/structure/fluff/statue/femalestatue/zizo{
-	desc = "An ancient statue depicting an elven woman.";
-	name = "Ancient Statue";
-	pixel_y = 0
-	},
+/obj/effect/decal/remains/human,
 /turf/open/floor/rogue/concrete,
-/area/rogue/under/cave)
+/area/rogue/outdoors/mountains)
 "hby" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -7719,6 +7816,12 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"hcN" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "hcO" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -7738,6 +7841,13 @@
 "heh" = (
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
+"hew" = (
+/obj/item/natural/worms/leech,
+/obj/item/natural/worms/leech{
+	pixel_x = 8
+	},
+/turf/open/water/swamp,
+/area/rogue/outdoors/mountains)
 "heR" = (
 /obj/structure/closet/crate/chest{
 	base_icon_state = "woodchestalt";
@@ -7891,6 +8001,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"hnE" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "hnK" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
@@ -7914,11 +8031,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "hpe" = (
-/obj/structure/chair/bench/church{
-	dir = 1
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/firebowl/standing/blue,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "hpn" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -8478,6 +8593,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"hQm" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "hQQ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
@@ -8531,6 +8653,13 @@
 /obj/item/book/rogue/blackmountain,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"hTx" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "hTE" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/cobble,
@@ -9121,6 +9250,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"iwo" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "iww" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -9178,9 +9311,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "izn" = (
-/obj/structure/table/church/m,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 4
+	},
+/area/rogue/outdoors/mountains)
 "izp" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks,
@@ -9620,6 +9754,10 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"iWy" = (
+/obj/structure/fluff/statue/gargoyle,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "iWT" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -9821,6 +9959,12 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
+"jeS" = (
+/obj/structure/pillory{
+	lockid = "inhumen"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "jeY" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood{
@@ -10194,9 +10338,12 @@
 	},
 /area/rogue/indoors/town)
 "jBi" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "jBv" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/chair/wood/rogue{
@@ -10390,15 +10537,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "jKZ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
-/obj/machinery/light/rogue/firebowl/church{
-	light_color = "#b30202"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/outdoors/mountains)
 "jLc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -10485,6 +10625,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"jOf" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 5
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "jOp" = (
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -10786,6 +10933,12 @@
 "kaC" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/woods)
+"kbk" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "kbt" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -10858,6 +11011,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"kep" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "keS" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine{
@@ -10878,12 +11035,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/roofs)
 "kfY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall"
-	},
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/area/rogue/outdoors/mountains)
 "kgo" = (
 /obj/structure/rogue/trophy/deer,
 /obj/structure/table/wood{
@@ -11032,6 +11186,12 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"kph" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "kpv" = (
 /obj/structure/roguemachine/mail{
 	mailtag = "Bathhouse"
@@ -11728,9 +11888,9 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town)
 "kPt" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "kPv" = (
 /obj/structure/table/wood,
 /obj/item/rogueweapon/surgery/scalpel,
@@ -12099,6 +12259,12 @@
 "lcT" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs)
+"lda" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "ldT" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -13104,6 +13270,14 @@
 "mbI" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/under/town/sewer)
+"mbK" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "inhumen";
+	name = "Forgotten Chapel"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "mbO" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -13209,6 +13383,13 @@
 /obj/item/rogueweapon/sword/iron,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"mfN" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "mfP" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -13361,12 +13542,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
 "mlS" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "mlU" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church)
@@ -13563,9 +13743,9 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "mwd" = (
-/obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "mwr" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement/keep)
@@ -13593,6 +13773,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
+"mxC" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "mxK" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/tile,
@@ -13688,9 +13875,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "mBU" = (
-/mob/living/carbon/human/species/skeleton/npc/ambush,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/obj/structure/fluff/statue/femalestatue/zizo{
+	desc = "An ancient statue depicting an elven woman.";
+	name = "Ancient Statue";
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "mCu" = (
 /obj/structure/fluff/statue{
 	name = "The Veiled Lady"
@@ -13834,10 +14025,9 @@
 	},
 /area/rogue/indoors/town/manor)
 "mJn" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 8
-	},
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "mJH" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -13964,13 +14154,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "mPD" = (
-/obj/structure/mineral_door/wood/donjon/stone{
-	locked = 1;
-	lockid = "inhumen";
-	name = "Forgotten Chapel"
+/obj/structure/stairs/stone{
+	dir = 1
 	},
 /turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/area/rogue/outdoors/mountains)
 "mPR" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/rtfield)
@@ -14023,6 +14211,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"mUB" = (
+/obj/structure/fluff/walldeco/stone{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "mUJ" = (
 /obj/structure/table/wood{
 	dir = 5;
@@ -14134,9 +14329,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "mZF" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "mZT" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -14776,11 +14971,14 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
+"nAB" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "nAP" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 4
-	},
-/area/rogue/under/cave)
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "nBk" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
@@ -15137,6 +15335,13 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"nRa" = (
+/obj/structure/chair/wood/rogue{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "nRB" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/structure/curtain/bounty{
@@ -15552,6 +15757,11 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"oji" = (
+/obj/structure/bed/rogue/shit,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "ojV" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rogueweapon/hoe,
@@ -15592,8 +15802,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "onk" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red,
-/area/rogue/under/cave)
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "ono" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -16116,6 +16327,13 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"oHg" = (
+/obj/structure/table/wood{
+	dir = 8;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "oHy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -16690,6 +16908,12 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield)
+"pjN" = (
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "pjV" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -16779,9 +17003,15 @@
 	},
 /area/rogue/under/town/sewer)
 "pmX" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "pnh" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -16880,8 +17110,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "psG" = (
+/obj/structure/mineral_door/bars{
+	lockid = "inhumen"
+	},
 /turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/area/rogue/outdoors/mountains)
 "ptr" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/book/rogue/bibble,
@@ -17712,6 +17945,17 @@
 "qey" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
+"qeH" = (
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "qeJ" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/ruinedwood/chevron,
@@ -18169,6 +18413,13 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"qBU" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/obj/item/reagent_containers/food/snacks/rogue/friedrat,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "qDm" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -18372,9 +18623,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "qNj" = (
-/obj/structure/chair/bench/church/mid,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave)
+/obj/structure/stairs/stone/d,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "qNG" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -18690,6 +18941,14 @@
 "raW" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
+"rbf" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "rbh" = (
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
@@ -18732,6 +18991,10 @@
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"rdg" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "rdm" = (
 /obj/structure/telescope,
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -19122,6 +19385,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/dwarfin)
+"rvU" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "rwd" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -19293,6 +19560,16 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"rEt" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 5
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "rEw" = (
 /obj/item/paper/confession,
 /obj/item/paper/confession,
@@ -19631,8 +19908,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "rRR" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
-/area/rogue/under/cave)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
+/area/rogue/outdoors/mountains)
 "rSa" = (
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/pelt,
@@ -19790,11 +20067,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "rZO" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "sac" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
@@ -19912,6 +20187,16 @@
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town)
+"sgU" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall"
+	},
+/obj/machinery/light/rogue/firebowl/church{
+	light_color = "#b30202"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "sgY" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -20167,6 +20452,13 @@
 "srJ" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/mountains)
+"ssj" = (
+/obj/machinery/light/rogue/firebowl{
+	light_color = "#b30202"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "ssF" = (
 /obj/structure/roguemachine/lottery_roguetown{
 	pixel_y = -32
@@ -20303,6 +20595,10 @@
 "swO" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
+"swW" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "sxl" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -20558,10 +20854,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/town/basement/keep)
 "sJB" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 1
-	},
-/area/rogue/under/cave)
+/obj/structure/fermenting_barrel/random/beer,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "sJK" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /obj/effect/decal/cobbleedge{
@@ -20710,6 +21005,10 @@
 /obj/item/mundane/puzzlebox/easy,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"sPW" = (
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/mountains)
 "sQg" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -20763,8 +21062,8 @@
 /obj/structure/fluff/walldeco/stone{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "sTt" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/red,
@@ -20824,6 +21123,10 @@
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"sWG" = (
+/obj/item/chair/rogue,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "sWM" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -21262,6 +21565,13 @@
 /obj/item/storage/roguebag,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"tok" = (
+/obj/structure/bars/passage{
+	density = 0;
+	icon_state = "passage1"
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "too" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/concrete,
@@ -21721,6 +22031,13 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"tKd" = (
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "tKw" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood{
@@ -22247,9 +22564,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "umC" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave)
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "umP" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grassred,
@@ -22418,11 +22735,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "uuR" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
+/obj/effect/decal/remains/human,
 /turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/area/rogue/outdoors/mountains)
 "uuU" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
@@ -22733,6 +23048,10 @@
 /obj/structure/fluff/walldeco/artificerflag,
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town)
+"uFO" = (
+/obj/structure/table/church/m,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "uGz" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -23310,6 +23629,15 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"vqO" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/storage/belt/rogue/surgery_bag/full,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "vrR" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	icon_state = "iron_corner"
@@ -23409,9 +23737,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "vwK" = (
-/obj/structure/chair/bench/church/r,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave)
+/obj/structure/roguewindow/stained/zizo,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/mountains)
 "vwW" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -23797,6 +24125,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/garrison)
+"vUD" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/mountains)
 "vVs" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/hexstone,
@@ -23858,6 +24190,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"vWY" = (
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/reagent_containers/powder/health,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "vXl" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/wood,
@@ -23875,12 +24215,8 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "vYe" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "vYh" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
@@ -23951,6 +24287,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"wdS" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/whip,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "wdX" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -24550,9 +24892,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "wBF" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/outdoors/mountains)
 "wBY" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/tile/masonic{
@@ -24646,8 +24987,8 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "wHq" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
+/area/rogue/outdoors/mountains)
 "wHt" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -25324,10 +25665,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "xfA" = (
-/obj/structure/table/church,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "xfD" = (
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grass,
@@ -25437,9 +25777,9 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "xiL" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/under/cave)
+/obj/structure/chair/bench/church,
+/turf/open/floor/rogue/concrete,
+/area/rogue/outdoors/mountains)
 "xiX" = (
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -25462,9 +25802,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "xlv" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/thresher,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "xlI" = (
 /turf/open/floor/rogue/tile{
 	icon_state = "linoleum"
@@ -26368,6 +26710,11 @@
 "xWK" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/indoors)
+"xWV" = (
+/mob/living/carbon/human/species/skeleton/npc/ambush,
+/obj/structure/stairs/stone/d,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "xWX" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -26433,6 +26780,10 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"yav" = (
+/obj/structure/fermenting_barrel/random/water,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "yaE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -26716,21 +27067,17 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
 "ylI" = (
-/obj/structure/table/church{
-	icon_state = "churchtable_end"
-	},
-/obj/item/reagent_containers/glass/cup/silver,
 /turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/area/rogue/outdoors/mountains)
 "ylN" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "ylP" = (
-/obj/machinery/light/rogue/firebowl{
-	light_color = "#b30202"
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/hexstone,
+/area/rogue/outdoors/mountains)
 "ymf" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -27887,14 +28234,14 @@ etD
 etD
 etD
 etD
-anQ
-rRR
-rRR
-rRR
-rRR
-rRR
-rRR
-sJB
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -28043,16 +28390,16 @@ etD
 etD
 etD
 etD
-onk
-onk
-mlS
-kfY
-psG
-xiL
-cGL
-rZO
-onk
-onk
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -28199,18 +28546,18 @@ etD
 etD
 etD
 etD
-onk
-onk
-fXl
-wHq
-uuR
-psG
-psG
-mBU
-psG
-psG
-onk
-nAP
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -28353,21 +28700,21 @@ etD
 etD
 etD
 etD
-nAP
-onk
-biU
-onk
-ylP
-wHq
-wHq
-uuR
-psG
-hpe
-hpe
-eTF
-eFZ
-cGL
-mJn
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -28510,24 +28857,24 @@ etD
 etD
 etD
 etD
-cjv
-xlv
-kPt
-wBF
-wHq
-wHq
-wHq
-kfY
-ewV
-qNj
-qNj
-qNj
-xiL
-cGL
-cjv
-mwd
-dSI
-mLS
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
 uBR
 mLS
 dSI
@@ -28667,24 +29014,24 @@ etD
 etD
 etD
 etD
-mJn
-xlv
-cVR
-cVR
-cVR
-jBi
-xfA
-kfY
-eFZ
-vwK
-vwK
-vwK
-psG
-psG
-onk
-dSI
-dSI
-dSI
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
 dSI
 mLS
 dSI
@@ -28824,24 +29171,24 @@ etD
 etD
 etD
 etD
-biU
-wHq
-cVR
-hbs
-cVR
-pmX
-izn
-jKZ
-psG
-mBU
-psG
-psG
-mBU
-psG
-mPD
-umC
-evs
-dSI
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
 dSI
 dSI
 dSI
@@ -28981,24 +29328,24 @@ etD
 etD
 etD
 etD
-nAP
-wHq
-cVR
-cVR
-cVR
-jBi
-ylI
-kfY
-psG
-hpe
-hpe
-eTF
-ewV
-psG
-onk
-dSI
-dSI
-dSI
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
 mLS
 dSI
 dSI
@@ -29138,23 +29485,23 @@ etD
 etD
 etD
 etD
-cjv
-mZF
-xlv
-wHq
-wHq
-kPt
-wHq
-kfY
-xiL
-qNj
-qNj
-qNj
-psG
-xiL
-cjv
-mwd
-dSI
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
+uBR
+uBR
 uBR
 uBR
 dSI
@@ -29295,21 +29642,21 @@ etD
 etD
 etD
 etD
-mJn
-onk
-biU
-onk
-ylP
-wHq
-wHq
-uuR
-psG
-vwK
-vwK
-vwK
-psG
-cGL
-nAP
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -29455,18 +29802,18 @@ etD
 etD
 etD
 etD
-onk
-onk
-sTs
-wBF
-uuR
-psG
-cGL
-mBU
-eFZ
-psG
-onk
-mJn
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -29613,16 +29960,16 @@ etD
 etD
 etD
 etD
-onk
-onk
-vYe
-kfY
-cGL
-xiL
-psG
-rZO
-onk
-onk
+etD
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -29771,14 +30118,14 @@ etD
 etD
 etD
 etD
-anQ
-rRR
-rRR
-rRR
-rRR
-rRR
-rRR
-sJB
+etD
+etD
+etD
+etD
+etD
+etD
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -29934,8 +30281,8 @@ etD
 etD
 etD
 etD
-etD
-etD
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -30091,7 +30438,7 @@ etD
 etD
 etD
 etD
-etD
+uBR
 uBR
 uBR
 uBR
@@ -30248,7 +30595,7 @@ etD
 etD
 etD
 etD
-etD
+uBR
 uBR
 uBR
 uBR
@@ -30405,8 +30752,8 @@ etD
 etD
 etD
 etD
-etD
-etD
+uBR
+uBR
 uBR
 uBR
 uBR
@@ -35922,8 +36269,8 @@ ptA
 ptA
 fnh
 gdw
-lpm
 xpt
+lpm
 xpt
 xpt
 xpt
@@ -52991,8 +53338,8 @@ jMT
 dPz
 dPz
 dPz
-dPz
-dPz
+eUz
+eUz
 dPz
 dPz
 dPz
@@ -53147,8 +53494,8 @@ jMT
 jMT
 dPz
 dPz
-dPz
-dPz
+eUz
+eUz
 biI
 dPz
 dPz
@@ -53304,7 +53651,7 @@ jMT
 jMT
 dPz
 dPz
-dPz
+eUz
 biI
 biI
 biI
@@ -53461,7 +53808,7 @@ jMT
 dPz
 jMT
 dPz
-dPz
+eUz
 biI
 biI
 biI
@@ -53618,8 +53965,8 @@ jMT
 jMT
 jMT
 dPz
-dPz
-dPz
+eUz
+eUz
 biI
 biI
 dPz
@@ -53776,8 +54123,8 @@ jMT
 jMT
 jMT
 dPz
-dPz
-dPz
+eUz
+eUz
 biI
 biI
 biI
@@ -75574,26 +75921,26 @@ cdY
 "}
 (2,1,3) = {"
 fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
+srJ
+srJ
+srJ
+srJ
+jKZ
+wHq
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+eTF
+jKZ
 fam
 fam
 fam
@@ -75731,29 +76078,29 @@ fam
 "}
 (3,1,3) = {"
 fam
+srJ
+srJ
+srJ
+srJ
+izn
+hTx
+vYe
+vYe
+qNj
+jKZ
+biU
+sJB
+azU
+yav
+biU
+jKZ
+vqO
+dXX
+vWY
+izn
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
 srJ
 srJ
 srJ
@@ -75888,29 +76235,29 @@ fam
 "}
 (4,1,3) = {"
 fam
+srJ
+srJ
+srJ
+srJ
+eFZ
+giX
+vYe
+vYe
+qNj
+jKZ
+xfA
+vYe
+vYe
+vYe
+vYe
+izn
+azU
+fXl
+kfY
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
 srJ
 srJ
 srJ
@@ -76045,29 +76392,29 @@ fam
 "}
 (5,1,3) = {"
 fam
+srJ
+srJ
+srJ
+srJ
+eFZ
+biU
+vYe
+vYe
+qNj
+jKZ
+vYe
+vYe
+vYe
+evs
+vYe
+cjv
+vYe
+rZO
+vYe
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
 srJ
 srJ
 srJ
@@ -76202,29 +76549,29 @@ fam
 "}
 (6,1,3) = {"
 fam
+srJ
+srJ
+srJ
+rOV
+eFZ
+vYe
+vYe
+vYe
+jKZ
+jKZ
+kfY
+kPt
+fXl
+vYe
+vYe
+psG
+vYe
+fXl
+uuR
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
 srJ
 srJ
 srJ
@@ -76359,29 +76706,29 @@ fam
 "}
 (7,1,3) = {"
 fam
+srJ
+srJ
+rOV
+rOV
+eFZ
+xfA
+vYe
+vYe
+biU
+izn
+vYe
+fXl
+fXl
+hbs
+vYe
+cjv
+kfY
+fXl
+azU
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
 srJ
 srJ
 srJ
@@ -76516,29 +76863,29 @@ fam
 "}
 (8,1,3) = {"
 fam
+rOV
+rOV
+rOV
+rcv
+eFZ
+sTs
+vYe
+vYe
+evs
+eFZ
+vYe
+lda
+lda
+sWG
+vYe
+bPU
+mZF
+vYe
+oji
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
 srJ
 srJ
 srJ
@@ -76673,29 +77020,29 @@ fam
 "}
 (9,1,3) = {"
 fam
+rOV
+rOV
+rcv
+rcv
+eFZ
+mJn
+fXl
+fXl
+vYe
+eFZ
+mJn
+crn
+oHg
+gDW
+vYe
+jKZ
+wHq
+cjv
+eTF
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+hpe
+tQp
 srJ
 srJ
 srJ
@@ -76830,30 +77177,30 @@ fam
 "}
 (10,1,3) = {"
 fam
+rcv
+rcv
+rcv
+tQp
+eFZ
+sTs
+anQ
+fXl
+vYe
+bPU
+vYe
+jOf
+rbf
+aVP
+vYe
+izn
+wdS
+vYe
+swW
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+tQp
+tQp
+tQp
 rOV
 rOV
 rOV
@@ -76987,30 +77334,30 @@ fam
 "}
 (11,1,3) = {"
 fam
+rcv
+hew
+sPW
+tQp
+tok
+vYe
+fXl
+fXl
+vYe
+tok
+vYe
+bSy
+fXl
+bSy
+vYe
+cjv
+fXl
+fXl
+anQ
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+tQp
+tQp
+tQp
 rOV
 rOV
 rOV
@@ -77144,30 +77491,30 @@ fam
 "}
 (12,1,3) = {"
 fam
+rcv
+hew
+rdg
+tQp
+tok
+vYe
+fXl
+fXl
+vYe
+tok
+vYe
+fXl
+anQ
+fXl
+vYe
+psG
+fXl
+jeS
+fXl
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+tQp
+tQp
+tQp
 rOV
 rOV
 rcv
@@ -77301,30 +77648,30 @@ fam
 "}
 (13,1,3) = {"
 fam
+rcv
+hew
+aGh
+tQp
+tok
+vYe
+hbs
+fXl
+vYe
+tok
+vYe
+lda
+fXl
+nRa
+vYe
+cjv
+fXl
+fXl
+fXl
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+tQp
+tQp
+tQp
 rOV
 rOV
 rcv
@@ -77458,34 +77805,34 @@ fam
 "}
 (14,1,3) = {"
 fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-rOV
-rOV
-rOV
-rOV
-rOV
 rcv
+rcv
+rcv
+tQp
+eFZ
+mxC
+fXl
+fXl
+vYe
+izn
+vYe
+jBi
+hQm
+qeH
+vYe
+bPU
+xlv
+evs
+swW
+eFZ
+fam
+tQp
+tQp
+tQp
+tQp
+tQp
+tQp
+tXZ
 rcv
 rcv
 rcv
@@ -77615,34 +77962,34 @@ fam
 "}
 (15,1,3) = {"
 fam
+rOV
+rOV
+rcv
+rcv
+eFZ
+mJn
+fXl
+fXl
+xfA
+eFZ
+mJn
+rEt
+pmX
+tKd
+vYe
+jKZ
+wHq
+cjv
+eTF
+eFZ
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-rOV
-rOV
-rOV
-rOV
-rcv
-rcv
+fam
+tQp
+tQp
+tQp
+tQp
+tXZ
+tXZ
 rcv
 rcv
 rcv
@@ -77772,35 +78119,35 @@ fam
 "}
 (16,1,3) = {"
 fam
+rOV
+rOV
+rOV
+rOV
+eFZ
+sTs
+vYe
+evs
+vYe
+eFZ
+vYe
+sWG
+fXl
+pjN
+vYe
+izn
+vYe
+vYe
+vYe
+eFZ
 fam
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rcv
-rcv
-rcv
+fam
+fam
+tQp
+tQp
+tQp
+tXZ
+tXZ
+tXZ
 rcv
 rcv
 rcv
@@ -77929,35 +78276,35 @@ fam
 "}
 (17,1,3) = {"
 fam
+srJ
+srJ
+rOV
+rOV
+eFZ
+vYe
+vYe
+vYe
+biU
+bPU
+azU
+fXl
+fXl
+anQ
+vYe
+cjv
+mZF
+fXl
+azU
+eFZ
+fam
+fam
 fam
 rOV
 rOV
 rOV
 rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rcv
-rcv
-rcv
+tXZ
+tXZ
 rcv
 rcv
 rcv
@@ -78086,29 +78433,29 @@ fam
 "}
 (18,1,3) = {"
 fam
+srJ
+srJ
+srJ
+srJ
+eFZ
+vYe
+vYe
+vYe
+jKZ
+jKZ
+vYe
+uuR
+fXl
+vYe
+vYe
+psG
+vYe
+fXl
+vYe
+eFZ
 fam
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
+fam
+fam
 rOV
 rOV
 rOV
@@ -78243,29 +78590,29 @@ fam
 "}
 (19,1,3) = {"
 fam
+srJ
+srJ
+srJ
+srJ
+eFZ
+biU
+vYe
+vYe
+qNj
+jKZ
+qBU
+kfY
+vYe
+kPt
+vYe
+cjv
+evs
+nAB
+vYe
+eFZ
 fam
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rOV
-rcv
-rcv
-rcv
-rOV
-rOV
-rOV
+fam
+fam
 rOV
 rOV
 rcv
@@ -78400,29 +78747,29 @@ fam
 "}
 (20,1,3) = {"
 fam
+srJ
+srJ
+srJ
+srJ
+eFZ
+giX
+vYe
+vYe
+qNj
+jKZ
+hcN
+ylP
+mlS
+kph
+vYe
+bPU
+azU
+fXl
+mZF
+eFZ
 fam
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rOV
-rOV
-rOV
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
+fam
+fam
 rcv
 rcv
 rcv
@@ -78557,29 +78904,29 @@ fam
 "}
 (21,1,3) = {"
 fam
+srJ
+srJ
+srJ
+srJ
+bPU
+biU
+xfA
+vYe
+qNj
+jKZ
+ssj
+umC
+gEk
+dMb
+biU
+jKZ
+mZF
+ewV
+xfA
+bPU
 fam
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
+fam
+fam
 rcv
 rcv
 rcv
@@ -78714,35 +79061,35 @@ fam
 "}
 (22,1,3) = {"
 fam
+srJ
+srJ
+srJ
+srJ
+jKZ
+wHq
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+eTF
+jKZ
+fam
+fam
 fam
 rcv
 rcv
 rcv
 rcv
 rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
+fam
 rcv
 rcv
 tXZ
@@ -78875,31 +79222,31 @@ fam
 fam
 fam
 fam
-kFF
-hoU
+eRk
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
+fam
 rcv
 rcv
 rcv
 rcv
-rcv
-rcv
-hoU
-kFF
-kFF
-hoU
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
+fam
+fam
 tXZ
 tXZ
 tXZ
@@ -79047,15 +79394,15 @@ hoU
 hoU
 hoU
 hoU
+fam
+fam
+fam
+fam
 rcv
 rcv
 rcv
-rcv
-rcv
-rcv
-rcv
-rcv
-rcv
+fam
+fam
 tXZ
 tXZ
 tXZ
@@ -79207,11 +79554,11 @@ hoU
 hoU
 hoU
 bSn
+fam
 rcv
-rcv
-rcv
-rcv
-rcv
+fam
+fam
+fam
 tXZ
 tXZ
 tXZ
@@ -79347,7 +79694,7 @@ fam
 jlc
 ent
 ent
-ent
+yjc
 ent
 ent
 yjc
@@ -79364,9 +79711,9 @@ ent
 ent
 ent
 eLf
-rcv
-rcv
-rcv
+fam
+fam
+fam
 tXZ
 tXZ
 tXZ
@@ -79662,7 +80009,7 @@ jlc
 ent
 ent
 ent
-ent
+yjc
 ent
 ent
 ent
@@ -79975,14 +80322,14 @@ fam
 fam
 bSn
 hoU
-kFF
+hoU
 kFF
 hoU
 hoU
 hoU
 hoU
 bSn
-ent
+hoU
 ent
 ent
 ent
@@ -80137,7 +80484,7 @@ hoU
 rcv
 rcv
 rcv
-hoU
+kFF
 hoU
 hoU
 hoU
@@ -99915,17 +100262,17 @@ fam
 fam
 fam
 fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
+wHq
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+eTF
 fam
 fam
 fam
@@ -100072,17 +100419,17 @@ fam
 fam
 fam
 fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
+rRR
+vUD
+tXZ
+tXZ
+qNj
+vYe
+vYe
+xfA
+vYe
+biU
+rRR
 fam
 fam
 fam
@@ -100229,17 +100576,17 @@ fam
 fam
 fam
 fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
+wHq
+iWy
+tXZ
+tXZ
+qNj
+vYe
+kPt
+vYe
+uuR
+vYe
+wHq
 fam
 fam
 fam
@@ -100386,19 +100733,19 @@ fam
 fam
 fam
 fam
+rRR
+ylI
+tXZ
+tXZ
+qNj
+vYe
+vYe
+vYe
+vYe
+biU
+rRR
 fam
 fam
-fam
-fam
-fam
-fam
-fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
 srJ
 srJ
 srJ
@@ -100543,19 +100890,19 @@ fam
 fam
 fam
 fam
+wHq
+wBF
+wBF
+wBF
+wBF
+tok
+tok
+tok
+wBF
+eTF
+wHq
 fam
 fam
-fam
-fam
-fam
-fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
 srJ
 srJ
 srJ
@@ -100701,18 +101048,18 @@ fam
 fam
 fam
 fam
+jKZ
+jKZ
+bpZ
+hnE
+vYe
+evs
+vYe
+biU
+jKZ
+jKZ
 fam
 fam
-fam
-fam
-fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
 srJ
 srJ
 srJ
@@ -100857,25 +101204,25 @@ fam
 fam
 fam
 fam
+jKZ
+jKZ
+mfN
+ylI
+mPD
+vYe
+vYe
+vYe
+vYe
+vYe
+jKZ
+izn
 fam
 fam
 fam
 fam
 fam
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
 srJ
 rOV
 rOV
@@ -101011,29 +101358,29 @@ fam
 fam
 fam
 fam
+izn
+jKZ
+rRR
+jKZ
+kbk
+ylI
+ylI
+mPD
+vYe
+gNi
+gNi
+xiL
+kfY
+vYe
+bPU
 fam
 fam
+tQp
+tQp
+tQp
+tXZ
 fam
 fam
-fam
-fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
 rOV
 rOV
 rOV
@@ -101168,29 +101515,29 @@ fam
 fam
 fam
 fam
+vwK
+mwd
+nAP
+onk
+ylI
+ylI
+ylI
+hnE
+uuR
+cGL
+cGL
+cGL
+evs
+vYe
+vwK
+hpe
+tQp
+tQp
+tQp
+tXZ
+tXZ
+tXZ
 fam
-fam
-fam
-fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
 rOV
 rOV
 rOV
@@ -101325,29 +101672,29 @@ fam
 fam
 fam
 fam
+bPU
+mwd
+fXl
+fXl
+fXl
+iwo
+cXB
+hnE
+kfY
+fet
+fet
+fet
+vYe
+vYe
+jKZ
+tQp
+tQp
+tQp
+tQp
+tXZ
+tXZ
+tXZ
 fam
-fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
 rOV
 rOV
 rOV
@@ -101482,29 +101829,29 @@ fam
 fam
 fam
 fam
+rRR
+ylI
+fXl
+mBU
+fXl
+kep
+uFO
+sgU
+vYe
+vYe
+vYe
+vYe
+kPt
+vYe
+mbK
+bIe
+bIe
+tQp
+tQp
+tXZ
+tXZ
+tXZ
 fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-rOV
 rOV
 rOV
 rOV
@@ -101639,29 +101986,29 @@ fam
 fam
 fam
 fam
+izn
+ylI
+fXl
+fXl
+fXl
+ylI
+bBW
+hnE
+vYe
+gNi
+gNi
+xiL
+uuR
+vYe
+jKZ
+tQp
+tQp
+tQp
+tQp
+tXZ
+tXZ
+tXZ
 fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-rOV
 rOV
 rOV
 rOV
@@ -101796,29 +102143,29 @@ fam
 fam
 fam
 fam
+vwK
+rvU
+mwd
+ylI
+ylI
+nAP
+ylI
+hnE
+evs
+cGL
+cGL
+cGL
+vYe
+evs
+vwK
+hpe
+tQp
+tQp
+tQp
+tXZ
+tXZ
+tXZ
 fam
-fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-rOV
 rOV
 rOV
 rOV
@@ -101953,29 +102300,29 @@ fam
 fam
 fam
 fam
+bPU
+jKZ
+rRR
+jKZ
+kbk
+ylI
+ylI
+mPD
+vYe
+fet
+fet
+fet
+vYe
+vYe
+izn
 fam
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-rOV
-rOV
-rOV
+tQp
+tQp
+tQp
+tXZ
+fam
+fam
 rOV
 rOV
 rOV
@@ -102111,27 +102458,27 @@ fam
 fam
 fam
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-rOV
-rOV
-rOV
+fam
+fam
+jKZ
+jKZ
+bpZ
+onk
+mPD
+vYe
+vYe
+kPt
+kfY
+vYe
+jKZ
+bPU
+fam
+fam
+fam
+fam
+fam
+fam
+fam
 rOV
 rOV
 rOV
@@ -102268,21 +102615,21 @@ fam
 fam
 fam
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
+fam
+jKZ
+jKZ
+mUB
+hnE
+vYe
+evs
+vYe
+biU
+jKZ
+jKZ
+fam
+fam
 srJ
 srJ
 srJ
@@ -102425,21 +102772,21 @@ fam
 fam
 fam
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
+wHq
+wBF
+wBF
+wBF
+wBF
+tok
+tok
+tok
+wBF
+wBF
+eTF
+fam
+fam
 srJ
 srJ
 rOV
@@ -102582,20 +102929,20 @@ fam
 fam
 fam
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
+rRR
+ylI
+tXZ
+tXZ
+qNj
+vYe
+vYe
+vYe
+vYe
+biU
+rRR
+fam
 srJ
 srJ
 rOV
@@ -102739,20 +103086,20 @@ fam
 fam
 fam
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
+wHq
+iWy
+tXZ
+tXZ
+xWV
+vYe
+vYe
+vYe
+evs
+vYe
+wHq
+fam
 srJ
 rOV
 rOV
@@ -102896,20 +103243,20 @@ fam
 fam
 fam
 fam
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
-srJ
+fam
+fam
+rRR
+rvU
+tXZ
+tXZ
+qNj
+xfA
+uuR
+vYe
+vYe
+biU
+rRR
+fam
 srJ
 rOV
 rOV
@@ -103053,19 +103400,19 @@ fam
 fam
 fam
 fam
-srJ
-srJ
-srJ
-srJ
 fam
 fam
-fam
-fam
-fam
-fam
-fam
-fam
-fam
+wHq
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+wBF
+eTF
 fam
 fam
 rOV
@@ -103217,12 +103564,12 @@ fam
 fam
 fam
 fam
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
-tXZ
+fam
+fam
+fam
+fam
+fam
+fam
 fam
 fam
 fam


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Moves the zizo church in the sewers to a more discreet location outside of the town and expands it a bit.

https://github.com/user-attachments/assets/038e0735-06f4-4baf-b266-e9914deec3bc

Screenshots below.

<details> 

![image](https://github.com/user-attachments/assets/e74a8995-c42d-4ab5-b10e-5be40920d380)

![image](https://github.com/user-attachments/assets/968e39b2-2255-4651-8195-36849308999f)

</details>

## Why It's Good For The Game

Having a chapel dedicated to zizo directly below the church of the ten was kinda weird. This moves it somewhere a bit more hidden and further away from the actual church; while also making it a bit larger to accommodate for people actually gathering/roleplaying inside it.

It's still in the same zone as the town; just a bit further away and outside of the town itself. The idea here's just to have a cool little roleplay space for heretics to gather and potentially get up to shenanigans.
