### PR TITLE
Fixes typepath to bone for zizo situational bonus miracle healing

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -112,8 +112,10 @@
 				target.visible_message(span_info("Vital energies are sapped towards [target]!"), span_notice("The life around me pales as I am restored!"))
 				// set up a ritual pile of bones (or just cast near a stack of bones whatever) around us for massive bonuses, cap at 50 for 75 healing total (wowie)
 				situational_bonus = 0
-				for (var/obj/item/stack/sheet/bone/O in oview(5, user))
-					situational_bonus += (O.amount * 0.5)
+				for (var/obj/item/natural/bone/O in oview(5, user))
+					situational_bonus += (0.5)
+				for (var/obj/item/natural/bundle/bone/S in oview(5, user))
+					situational_bonus += (S.amount * 0.5)
 				if (situational_bonus > 0)
 					conditional_buff = TRUE
 					situational_bonus = min(situational_bonus, 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
> Zizo miracles are currently bugged and thus are not receiving the conditional bonus right now.

> Zizo miracles are meant to receive a conditional bonus based on the number of bones you have nearby, but are currently searching for obj/item/stack/sheet/bone/O, however, the variable name for a bone stack is /obj/item/natural/bundle/bone


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Throwing Zizo clerics a bone (bugfix)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
