### PR TITLE
Xylix Patron Miracles

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -91,6 +91,8 @@
 	desc = "The Laughing God, both famous and infamous for his sway over the forces of luck. Xylix is known for the inspiration of many a bards lyric. Speaks through his gift to man; the Tarot deck."
 	worshippers = "Gamblers, Bards, Artists, and the Silver-Tongued"
 	mob_traits = list(TRAIT_XYLIX)
+	t1 = /obj/effect/proc_holder/spell/invoked/wheel
+	t2 = /obj/effect/proc_holder/spell/invoked/mockery
 	confess_lines = list(
 		"ASTRATA IS MY LIGHT!",
 		"NOC IS NIGHT!",

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -157,3 +157,89 @@
 	. = ..()
 	if(.)
 		listening_in = tracker
+
+//Xylix Gambling
+var/wheeleffect
+/datum/status_effect/wheel
+	id = "lucky(?)"
+	status_type = STATUS_EFFECT_UNIQUE
+	effectedstats = list("fortune" = "?")
+	duration = 500
+	
+/datum/status_effect/wheel/on_apply()
+	. = ..()
+	switch(pick(-5,-4,-3,-2,-1,0,1,2,3,4,5))
+		if(-5)
+			owner.change_stat("fortune", -5)
+			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
+			wheeleffect = -5
+		if(-4)
+			owner.change_stat("fortune", -4)
+			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
+			wheeleffect = -4
+		if(-3)
+			owner.change_stat("fortune", -3)
+			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
+			wheeleffect = -3
+		if(-2)
+			owner.change_stat("fortune", -2)
+			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
+			wheeleffect = -2
+		if(-1)
+			owner.change_stat("fortune", -1)
+			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
+			wheeleffect = -1
+		if(0)
+			owner.change_stat("fortune", 0)
+			to_chat(owner, span_boldnotice("My heart beats, I feel as though nothing has changed at all..."))
+			wheeleffect = 0
+		if(1)
+			owner.change_stat("fortune", 1)
+			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
+			wheeleffect = 1
+		if(2)
+			owner.change_stat("fortune", 2)
+			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
+			wheeleffect = 2
+		if(3)
+			owner.change_stat("fortune", 3)
+			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
+			wheeleffect = 3
+		if(4)
+			owner.change_stat("fortune", 4)
+			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
+			wheeleffect = 4
+		if(5)
+			owner.change_stat("fortune", 5)
+			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
+			wheeleffect = 5									
+
+/datum/status_effect/wheel/on_remove()
+	. = ..()
+	if(wheeleffect == -5)
+		owner.change_stat("fortune", 5)
+	if(wheeleffect == -4)
+		owner.change_stat("fortune", 4)
+	if(wheeleffect == -3)
+		owner.change_stat("fortune", 3)
+	if(wheeleffect == -2)
+		owner.change_stat("fortune", 2)
+	if(wheeleffect == -1)
+		owner.change_stat("fortune", 1)
+	if(wheeleffect == 0)
+		owner.change_stat("fortune", 0)
+	if(wheeleffect == 1)
+		owner.change_stat("fortune", -1)
+	if(wheeleffect == 2)
+		owner.change_stat("fortune", -2)
+	if(wheeleffect == 3)
+		owner.change_stat("fortune", -3)
+	if(wheeleffect == 4)
+		owner.change_stat("fortune", -4)
+	if(wheeleffect == 5)
+		owner.change_stat("fortune", -5)
+
+/atom/movable/screen/alert/status_effect/wheel
+	name = "Lucky(?)"
+	desc = "I feel different since my fortune was changed..."
+	icon_state = "asleep"	

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -159,87 +159,29 @@
 		listening_in = tracker
 
 //Xylix Gambling
-var/wheeleffect
 /datum/status_effect/wheel
 	id = "lucky(?)"
 	status_type = STATUS_EFFECT_UNIQUE
-	effectedstats = list("fortune" = "?")
-	duration = 3000 //five minutes
+	duration = 3000 //Lasts five minutes
+	var/wheeleffect
 	
 /datum/status_effect/wheel/on_apply()
 	. = ..()
-	switch(pick(-5,-4,-3,-2,-1,0,1,2,3,4,5))
-		if(-5)
-			owner.change_stat("fortune", -5)
+	wheeleffect = rand(-5,5)
+	owner.change_stat("fortune", wheeleffect)
+	switch(wheeleffect)
+		if(-5 to -1)
 			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
-			wheeleffect = -5
-		if(-4)
-			owner.change_stat("fortune", -4)
-			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
-			wheeleffect = -4
-		if(-3)
-			owner.change_stat("fortune", -3)
-			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
-			wheeleffect = -3
-		if(-2)
-			owner.change_stat("fortune", -2)
-			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
-			wheeleffect = -2
-		if(-1)
-			owner.change_stat("fortune", -1)
-			to_chat(owner, span_boldnotice("My heart sinks, I feel as though I've lost something!"))
-			wheeleffect = -1
 		if(0)
-			owner.change_stat("fortune", 0)
 			to_chat(owner, span_boldnotice("My heart beats, I feel as though nothing has changed at all..."))
-			wheeleffect = 0
-		if(1)
-			owner.change_stat("fortune", 1)
+		if(1 to 5)
 			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
-			wheeleffect = 1
-		if(2)
-			owner.change_stat("fortune", 2)
-			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
-			wheeleffect = 2
-		if(3)
-			owner.change_stat("fortune", 3)
-			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
-			wheeleffect = 3
-		if(4)
-			owner.change_stat("fortune", 4)
-			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
-			wheeleffect = 4
-		if(5)
-			owner.change_stat("fortune", 5)
-			to_chat(owner, span_boldnotice("My heart flutters, I feel as though I won the lottery!"))
-			wheeleffect = 5									
 
 /datum/status_effect/wheel/on_remove()
 	. = ..()
-	if(wheeleffect == -5)
-		owner.change_stat("fortune", 5)
-	if(wheeleffect == -4)
-		owner.change_stat("fortune", 4)
-	if(wheeleffect == -3)
-		owner.change_stat("fortune", 3)
-	if(wheeleffect == -2)
-		owner.change_stat("fortune", 2)
-	if(wheeleffect == -1)
-		owner.change_stat("fortune", 1)
-	if(wheeleffect == 0)
-		owner.change_stat("fortune", 0)
-	if(wheeleffect == 1)
-		owner.change_stat("fortune", -1)
-	if(wheeleffect == 2)
-		owner.change_stat("fortune", -2)
-	if(wheeleffect == 3)
-		owner.change_stat("fortune", -3)
-	if(wheeleffect == 4)
-		owner.change_stat("fortune", -4)
-	if(wheeleffect == 5)
-		owner.change_stat("fortune", -5)
+	owner.change_stat("fortune", -wheeleffect)
 
 /atom/movable/screen/alert/status_effect/wheel
 	name = "Lucky(?)"
 	desc = "I feel different since my fortune was changed..."
-	icon_state = "asleep"	
+	icon_state = "asleep"

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -164,7 +164,7 @@ var/wheeleffect
 	id = "lucky(?)"
 	status_type = STATUS_EFFECT_UNIQUE
 	effectedstats = list("fortune" = "?")
-	duration = 500
+	duration = 3000 //five minutes
 	
 /datum/status_effect/wheel/on_apply()
 	. = ..()

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -1,3 +1,28 @@
+/obj/effect/proc_holder/spell/invoked/wheel
+	name = "The Wheel"
+	releasedrain = 10
+	chargedrain = 0
+	chargetime = 3
+	range = 1
+	no_early_release = TRUE
+	movement_interrupt = TRUE
+	chargedloop = /datum/looping_sound/invokeholy
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	sound = 'sound/misc/letsgogambling.ogg'
+	associated_skill = /datum/skill/magic/holy
+	antimagic_allowed = TRUE
+	charge_max = 5 MINUTES
+	
+/obj/effect/proc_holder/spell/invoked/wheel/cast(list/targets, mob/user = usr)
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		if(target.anti_magic_check(TRUE, TRUE))
+			return FALSE
+		target.apply_status_effect(/datum/status_effect/wheel)		
+		return TRUE
+	revert_cast()
+	return FALSE
+
 /obj/effect/proc_holder/spell/invoked/mockery
 	name = "Vicious Mockery"
 	releasedrain = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gives the Vicious Mockery miracle to Xylix acolytes at t2 devotion

Creates, and adds a new miracle for Xylix acolytes, "The Wheel"
    Changes the targets fortune for 5 minutes by a random value between -5 and 5. Requires a 3 second charge up, with a five minute cooldown

## Why It's Good For The Game

Gives Xylix Acolytes actual miracles, instead of only having the default miracles
