### PR TITLE
Removes the trapdoor in the keep (again)

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -648,12 +648,6 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"avz" = (
-/obj/structure/floordoor{
-	redstone_id = "manortrapdoor"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/manor)
 "avT" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/blocks,
@@ -12995,11 +12989,6 @@
 /area/rogue/indoors/town/bath)
 "lHD" = (
 /obj/structure/table/wood,
-/obj/structure/lever{
-	pixel_y = 14;
-	layer = 3;
-	redstone_id = "manortrapdoor"
-	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "lHX" = (
@@ -70200,7 +70189,7 @@ iNg
 oQd
 sZw
 bDL
-avz
+oQd
 oQd
 oQd
 rDb


### PR DESCRIPTION
## About The Pull Request

Removes the manor trapdoor.

## Why It's Good For The Game

Trap door was removed because it explicitly ended RP in an extremely shitty-to-be-on-the-receiving-end-of-manner. Lord already has the scepter to punish people. No need for another. Ratwood/Roguetown-ism 'oops too bad so sad sucks to be you!' garbage. Lowkey the goofiest shit in the world. This isn't looneytoons. If a peasant is disrespecting you, order them beaten. Or use your silencing, insta-stun infini-shock scepter. Who knows- you might even get roleplay out of it. And if you want to end the roleplay? Point at guard. 'Out of my sight with this peasant'. Boom.