### PR TITLE
Fix Vicious Mockery

### DIFF
--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -2,16 +2,22 @@
 	name = "Vicious Mockery"
 	releasedrain = 50
 	associated_skill = /datum/skill/misc/music
-	charge_max = 10 MINUTES
+	charge_max = 2 MINUTES
 	range = 7
 
-/obj/effect/proc_holder/spell/invoked/mockery/cast(list/targets, mob/living/user)
+/obj/effect/proc_holder/spell/invoked/mockery/cast(list/targets, mob/user = usr)
 	playsound(get_turf(user), 'sound/magic/mockery.ogg', 40, FALSE)
-	for(var/mob/living/listener in hearers(7))
-		if(listener.can_hear()) // Vicious mockery requires people to be able to hear you.
-			listener.apply_status_effect(/datum/status_effect/debuff/viciousmockery)
-		else
-			return // No debuff for good guys
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		if(target.anti_magic_check(TRUE, TRUE))
+			return FALSE
+		if(!target.can_hear()) // Vicious mockery requires people to be able to hear you.
+			revert_cast()
+			return FALSE
+		target.apply_status_effect(/datum/status_effect/debuff/viciousmockery)	
+		return TRUE
+	revert_cast()
+	return FALSE
 
 /obj/effect/proc_holder/spell/invoked/mockery/invocation(mob/user = usr)
 	if(ishuman(user))


### PR DESCRIPTION
Fixes targetting, and makes the cooldown the same as literal revival, as a 10 minute cooldown seemed a bit extreme for a 1 minute debuff

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes vicious mockery targetting, and reduces the cooldown from _**10 minutes**_ to 2 minutes, the same as Anastasis, the actual revive

## Why It's Good For The Game

I would assume that the spirit of vicious mockery isn't to blanket debuff literally everyone onscreen (including yourself), thus this brings it closer to what it was meant to be.
As for the cooldown, it seemed excessively long 
