### PR TITLE
Cantor & Court Musician (And other bard cleanup)

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -235,6 +235,7 @@
 #define JDO_JESTER 7
 #define JDO_BUTLER 7.1
 #define JDO_SERVANT 7.2
+#define JDO_MUSICIAN 7.3
 
 #define JDO_GUARD_CAPTAIN 8
 #define JDO_KNIGHT 8.1
@@ -251,6 +252,7 @@
 #define JDO_TEMPLAR 12
 #define JDO_MONK 13
 #define JDO_DRUID 13.1
+#define JDO_CANTOR 13.2
 #define JDO_CHURCHLING 14
 #define JDO_GRAVEMAN 15
 

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -228,7 +228,9 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_MARSHAL		"CAT_MARSHAL"		// Marshal class
 #define CTAG_SENESCHAL		"CAT_SENESCHAL"		// Seneschal's aesthetic choices. 
 #define CTAG_SERVANT		"CAT_SERVANT"		// Servant's aesthetic choices.
-#define CTAG_CAPTAIN		"CAT_CAPTAIN"		// Handles Captain class selector 
+#define CTAG_CAPTAIN		"CAT_CAPTAIN"		// Handles Captain class selector
+#define CTAG_CANTOR 		"CAT_CANTOR"		// Cantor class - Handles Cantor class selector
+#define CTAG_MUSICIAN 		"CAT_MUSICIAN"		// Court Musician class - Handles Court Musician class selector
 
 /*
 	Defines for the triumph buy datum categories

--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -388,6 +388,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 	"Guard Captain",
 	"Court Magician",
 	"Templar",
+	"Cantor",
 	"Bog Guard",
 	"Bog Master",
 	"Royal Guard"

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -901,7 +901,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 
 /datum/objective/vampirelord/infiltrate/one/check_completion()
 	var/datum/game_mode/chaosmode/C = SSticker.mode
-	var/list/churchjobs = list("Priest", "Priestess", "Cleric", "Acolyte", "Templar", "Churchling", "Crusader", "Inquisitor")
+	var/list/churchjobs = list("Priest", "Priestess", "Cleric", "Acolyte", "Templar", "Cantor", "Churchling", "Crusader", "Inquisitor")
 	for(var/datum/mind/V in C.vampires)
 		if(V.current.job in churchjobs)
 			return TRUE

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
@@ -55,7 +55,10 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger/steel
-			backpack_contents = list(/obj/item/lockpickring/one = 1)
+			backpack_contents = list(
+							/obj/item/lockpickring/one = 1,
+							/obj/item/flashlight/flare/torch = 1,
+							)
 			H.change_stat("intelligence", 1)
 			H.change_stat("perception", 2)
 			H.change_stat("endurance", 1)
@@ -100,7 +103,11 @@
 				cloak = /obj/item/clothing/cloak/raincloak/red
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/rogueweapon/sword/iron
-			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel, /obj/item/storage/belt/rogue/pouch/coins/mid)
+			backpack_contents = list(
+						/obj/item/rogueweapon/huntingknife/idagger/steel,
+						/obj/item/storage/belt/rogue/pouch/coins/mid,
+						/obj/item/flashlight/flare/torch = 1,
+						)
 			H.change_stat("constitution", 2)
 			H.change_stat("strength", 1)
 			H.change_stat("speed", 1)
@@ -142,7 +149,10 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
-			backpack_contents = list(/obj/item/lockpickring/one = 1)
+			backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						/obj/item/lockpickring/one = 1,
+						)
 			H.change_stat("intelligence", 2)
 			H.change_stat("perception", 2)
 			H.change_stat("speed", 2)
@@ -179,6 +189,10 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
+			backpack_contents = list(
+						/obj/item/flashlight/flare/torch = 1,
+						/obj/item/lockpickring/one = 1
+						)
 			switch(H.patron?.type)
 				if(/datum/patron/divine/astrata)
 					neck = /obj/item/clothing/neck/roguetown/psicross/astrata
@@ -196,7 +210,6 @@
 					neck = /obj/item/clothing/neck/roguetown/psicross/malum
 				if(/datum/patron/divine/eora) //Eora content from Stonekeep
 					neck = /obj/item/clothing/neck/roguetown/psicross/eora
-			backpack_contents = list(/obj/item/lockpickring/one = 1)
 			H.change_stat("strength", 1)
 			H.change_stat("intelligence", 2)
 			H.change_stat("perception", 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
@@ -1,4 +1,3 @@
-
 /datum/advclass/bard
 	name = "Bard"
 	tutorial = "Bards make up one of the largest populations of \
@@ -9,7 +8,6 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/bard
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_DODGEEXPERT)
 	category_tags = list(CTAG_ADVENTURER)
 	cmode_music = 'sound/music/combat_bard.ogg'
 
@@ -57,14 +55,14 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger/steel
-			backpack_contents = list(
-							/obj/item/lockpickring/one = 1,
-							/obj/item/flashlight/flare/torch = 1,
-							)
+			backpack_contents = list(/obj/item/lockpickring/one = 1)
 			H.change_stat("intelligence", 1)
 			H.change_stat("perception", 2)
 			H.change_stat("endurance", 1)
 			H.change_stat("speed", 2)
+			ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, TRAIT_GENERIC)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
@@ -102,15 +100,14 @@
 				cloak = /obj/item/clothing/cloak/raincloak/red
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/rogueweapon/sword/iron
-			backpack_contents = list(
-							/obj/item/rogueweapon/huntingknife/idagger/steel,
-							/obj/item/storage/belt/rogue/pouch/coins/mid,
-							/obj/item/flashlight/flare/torch = 1,
-							)
+			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel, /obj/item/storage/belt/rogue/pouch/coins/mid)
 			H.change_stat("constitution", 2)
 			H.change_stat("strength", 1)
 			H.change_stat("speed", 1)
 			H.change_stat("endurance", 1)
+			ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, TRAIT_GENERIC)
 		if("Arcanist") //Magic and some utility skills, less combat prowess
@@ -143,9 +140,6 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/white
 			cloak = /obj/item/clothing/cloak/raincloak/purple
 			backl = /obj/item/storage/backpack/rogue/satchel
-			backpack_contents = list(
-								/obj/item/flashlight/flare/torch = 1,
-								)
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
 			backpack_contents = list(/obj/item/lockpickring/one = 1)
@@ -153,6 +147,8 @@
 			H.change_stat("perception", 2)
 			H.change_stat("speed", 2)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
+			ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
 		if("Hymnist") //Azure Peak Update, Miracles and some utility skills, less combat prowess
 			to_chat(H, span_warning("The tales of the gods are mighty indeed, though your skill in their retelling through song has granted you a touch of their favor as thanks."))
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
@@ -181,9 +177,6 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/white
 			cloak = /obj/item/clothing/cloak/raincloak
 			backl = /obj/item/storage/backpack/rogue/satchel
-			backpack_contents = list(
-								/obj/item/flashlight/flare/torch = 1,
-								)
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
 			switch(H.patron?.type)
@@ -211,7 +204,11 @@
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
 			C.grant_spells_templar(H)
 			H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
-			H.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/churn)//End of Azure Peak Update
+			ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, TRAIT_GENERIC)
 
 	var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
@@ -231,8 +228,3 @@
 			backr = /obj/item/rogue/instrument/viola
 		if("Vocal Talisman")
 			backr = /obj/item/rogue/instrument/vocals
-
-
-	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -74,6 +74,7 @@ GLOBAL_LIST_INIT(noble_positions, list(
 GLOBAL_LIST_INIT(courtier_positions, list(
 	"Court Magician",
 	"Court Physician",
+	"Court Musician",
 	"Jester",
 	"Seneschal",
 ))
@@ -93,6 +94,7 @@ GLOBAL_LIST_INIT(church_positions, list(
 	"Acolyte",
 	"Mortician",
 	"Templar",
+	"Cantor",
 	"Druid",
 ))
 

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/cantor.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/cantor.dm
@@ -1,0 +1,126 @@
+/datum/job/roguetown/cantor
+	title = "Cantor"
+	tutorial = "A church-bound musician, the Cantor is in charge of leading the various chants and hymns of a temple. Their musical talent doesn't stop at vocals, however, as a Cantor spreads the word and sound of their god through any means they see fit."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/cantor
+	display_order = JDO_CANTOR
+	cmode_music = 'sound/music/combat_bard.ogg'
+	department_flag = CHURCHMEN
+	faction = "Station"
+	allowed_patrons = ALL_DIVINE_PATRONS
+	min_pq = 3 //Deus vult, but only according to the proper escalation rules
+	max_pq = null
+	round_contrib_points = 2
+	total_positions = 1
+	spawn_positions = 1
+	give_bank_account = TRUE
+	advclass_cat_rolls = list(CTAG_CANTOR = 20)
+	
+
+/datum/outfit/job/roguetown/cantor
+	has_loadout = TRUE
+	allowed_patrons = ALL_PALADIN_PATRONS
+
+/datum/advclass/cantor
+	name = "Cantor"
+	outfit = /datum/outfit/job/roguetown/cantor/cantor
+	category_tags = list(CTAG_CANTOR)
+
+/datum/job/roguetown/cantor/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.advsetup = 1
+		H.invisibility = INVISIBILITY_MAXIMUM
+		H.become_blind("advsetup")
+
+/datum/outfit/job/roguetown/cantor/cantor/pre_equip(mob/living/carbon/human/H) //hymnist copy
+	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/stealing, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/music, 5, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 3, TRUE)
+	head = /obj/item/clothing/head/roguetown/bardhat
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	pants = /obj/item/clothing/under/roguetown/tights/black
+	gloves = /obj/item/clothing/gloves/roguetown/fingerless
+	belt = /obj/item/storage/belt/rogue/leather
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/white
+	backl = /obj/item/storage/backpack/rogue/satchel
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+	beltr = /obj/item/storage/keyring/churchie
+	switch(H.patron?.type)
+		if(/datum/patron/divine/astrata)
+			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+			cloak = /obj/item/clothing/cloak/templar/astratan
+		if(/datum/patron/divine/noc)
+			neck = /obj/item/clothing/neck/roguetown/psicross/noc
+			cloak = /obj/item/clothing/cloak/tabard/crusader/noc
+		if(/datum/patron/divine/dendor)
+			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
+			cloak = /obj/item/clothing/cloak/tabard/crusader/dendor
+		if(/datum/patron/divine/necra)
+			neck = /obj/item/clothing/neck/roguetown/psicross/necra
+			cloak = /obj/item/clothing/cloak/templar/necran
+		if(/datum/patron/divine/pestra)
+			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
+			cloak = /obj/item/clothing/cloak/tabard/crusader/pestra
+		if(/datum/patron/divine/ravox)
+			neck = /obj/item/clothing/neck/roguetown/psicross/ravox
+			cloak = /obj/item/clothing/cloak/tabard/crusader/ravox
+		if(/datum/patron/divine/malum)
+			neck = /obj/item/clothing/neck/roguetown/psicross/malum
+			cloak = /obj/item/clothing/cloak/templar/malumite
+		if(/datum/patron/divine/eora)
+			neck = /obj/item/clothing/neck/roguetown/psicross/eora
+			cloak = /obj/item/clothing/cloak/tabard/crusader/eora
+		if(/datum/patron/old_god)
+			neck = /obj/item/clothing/neck/roguetown/psicross
+			cloak = /obj/item/clothing/cloak/tabard/crusader/psydon
+	backpack_contents = list(/obj/item/lockpickring/one = 1)
+	H.change_stat("strength", 1)
+	H.change_stat("intelligence", 2)
+	H.change_stat("perception", 1)
+	H.change_stat("speed", 2)
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_spells_templar(H)
+	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	H.set_blindness(0)
+	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
+
+/datum/outfit/job/roguetown/cantor/cantor/choose_loadout(mob/living/carbon/human/H)
+	. = ..()
+
+	var/instruments = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
+	var/instruments_choice = input("Choose your Instrument.", "TAKE UP ARMS") as anything in instruments
+	switch(instruments_choice)
+		if("Harp")
+			H.put_in_hands(new /obj/item/rogue/instrument/harp(H), TRUE)
+		if("Lute")
+			H.put_in_hands(new /obj/item/rogue/instrument/lute(H), TRUE)
+		if("Accordion")
+			H.put_in_hands(new /obj/item/rogue/instrument/accord(H), TRUE)
+		if("Guitar")
+			H.put_in_hands(new /obj/item/rogue/instrument/guitar(H), TRUE)
+		if("Hurdy-Gurdy")
+			H.put_in_hands(new /obj/item/rogue/instrument/hurdygurdy(H), TRUE)
+		if("Viola")
+			H.put_in_hands(new /obj/item/rogue/instrument/viola(H), TRUE)
+		if("Vocal Talisman")
+			H.put_in_hands(new /obj/item/rogue/instrument/vocals(H), TRUE)

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/courtmusician.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/courtmusician.dm
@@ -1,0 +1,100 @@
+/datum/job/roguetown/musician
+	title = "Court Musician"
+	tutorial = "Always at the monarch's beck and call, the Court Musician is there to fill the air with divine music. Through dinner party or royal execution, the Court Musician always has the perfect tune to accompany the moment."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/musician
+	display_order = JDO_MUSICIAN
+	cmode_music = 'sound/music/combat_bard.ogg'
+	department_flag = COURTIERS
+	faction = "Station"
+	min_pq = 3 //Deus vult, but only according to the proper escalation rules
+	max_pq = null
+	round_contrib_points = 2
+	total_positions = 1
+	spawn_positions = 1
+	give_bank_account = TRUE
+	advclass_cat_rolls = list(CTAG_MUSICIAN = 20)
+	
+
+/datum/outfit/job/roguetown/musician
+	has_loadout = TRUE
+
+/datum/advclass/musician
+	name = "Musician"
+	outfit = /datum/outfit/job/roguetown/musician/musician
+	category_tags = list(CTAG_MUSICIAN)
+
+/datum/job/roguetown/musician/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.advsetup = 1
+		H.invisibility = INVISIBILITY_MAXIMUM
+		H.become_blind("advsetup")
+
+/datum/outfit/job/roguetown/musician/musician/pre_equip(mob/living/carbon/human/H) //hymnist copy
+	H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/music, 5, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
+	head = /obj/item/clothing/head/roguetown/grenzelhofthat
+	pants = /obj/item/clothing/under/roguetown/tights
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
+	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	backl = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/storage/keyring/servant
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
+	id = /obj/item/scomstone/bad
+	armor = /obj/item/clothing/suit/roguetown/shirt/grenzelhoft
+	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
+		armor = /obj/item/clothing/suit/roguetown/armor/silkcoat
+	H.change_stat("intelligence", 1)
+	H.change_stat("perception", 2)
+	H.change_stat("endurance", 1)
+	H.change_stat("speed", 2)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
+	H.set_blindness(0)
+	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
+
+/datum/outfit/job/roguetown/musician/musician/choose_loadout(mob/living/carbon/human/H)
+	. = ..()
+
+	var/instruments = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
+	var/instruments_choice = input("Choose your Instrument.", "TAKE UP ARMS") as anything in instruments
+	switch(instruments_choice)
+		if("Harp")
+			H.put_in_hands(new /obj/item/rogue/instrument/harp(H), TRUE)
+		if("Lute")
+			H.put_in_hands(new /obj/item/rogue/instrument/lute(H), TRUE)
+		if("Accordion")
+			H.put_in_hands(new /obj/item/rogue/instrument/accord(H), TRUE)
+		if("Guitar")
+			H.put_in_hands(new /obj/item/rogue/instrument/guitar(H), TRUE)
+		if("Hurdy-Gurdy")
+			H.put_in_hands(new /obj/item/rogue/instrument/hurdygurdy(H), TRUE)
+		if("Viola")
+			H.put_in_hands(new /obj/item/rogue/instrument/viola(H), TRUE)
+		if("Vocal Talisman")
+			H.put_in_hands(new /obj/item/rogue/instrument/vocals(H), TRUE)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3596,6 +3596,8 @@
 #include "modular_azurepeak\code\game\objects\structures\fartravel.dm"
 #include "modular_azurepeak\code\modules\clothing\rogueclothes\cloaks.dm"
 #include "modular_azurepeak\code\modules\clothing\rogueclothes\hats.dm"
+#include "modular_azurepeak\code\modules\jobs\job_types\roguetown\cantor.dm"
+#include "modular_azurepeak\code\modules\jobs\job_types\roguetown\courtmusician.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\beggar.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\courier.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\destitute_scholar.dm"


### PR DESCRIPTION
## About The Pull Request

Adds two new TOWN jobs to the roster, the Cantor and the Court Musician.

### Cantor
The Cantor is an addition to the church fold, using their proficiency in music to spread the words of their gods, while helping out in the daily needs of the church. Much like the hymnist, it can use by default paladin level casting, as to not overshadow the acolyte.

### Court Musician
The Court Musician is a monarch-employed bard, a musician that is tied to the keep. It may not be the most glorious job, but it is for those more musically inclined that wish to have ties and engage in keep RP. They get a set of keep keys and some of the grenzel drip to look the part of a Volo inspired bard. The court musician mirrors the normal bard's stats and skills.

## Why It's Good For The Game

Bards never really had a place in the town. They'd wander about, or go off adventuring-- as is the definition of their job. This gives a town-sanctioned bard position to two different departments of the town, giving them a more set-in-stone place, instead of one up to the mercy of whomever the authority is.


## Further Fixes to bard

Bard.dm was a little bit of a mess, not going to lie. I cleaned it up so some of the specs weren't getting **three copies of traits** in some cases. Under the radar, Arcanist was perhaps the strongest class because of this disorganization, having the ability of full spell casting, dodge, and medium armor traits. This change should make it so that is no longer the case, sorry to whomever was enjoying that.


