### PR TITLE
Fix | Wrong pronouns during /mechanics/

### DIFF
--- a/code/datums/sexcon/sex_actions/sex/vaginal_ride_sex.dm
+++ b/code/datums/sexcon/sex_actions/sex/vaginal_ride_sex.dm
@@ -26,7 +26,7 @@
 	return TRUE
 
 /datum/sex_action/vaginal_ride_sex/on_start(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	user.visible_message(span_warning("[user] gets on top of [target] and begins riding [user.p_them()] with [user.p_their()] cunt!"))
+	user.visible_message(span_warning("[user] gets on top of [target] and begins riding [target.p_them()] with [user.p_their()] cunt!"))
 	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), 20, TRUE, ignore_walls = FALSE)
 
 /datum/sex_action/vaginal_ride_sex/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This pr fixes the pronoun of the instigator being used instead of the targets for a sentence when you use a certain mechanic in Azure.

Uses now target.p_them() during that action, instead of user.p_them().

Don't look inside files changed unless you want to see the **evil** code.

## Why It's Good For The Game

I hate bugs enough that it nagged me into doing this.
