### PR TITLE
Disentangles the Night-Eyed Virtue from Nocsight (Also fixes it)

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -80,7 +80,7 @@
 	if (!eyes)
 		return
 	eyes.see_in_dark = 12
-	eyes.lighting_alpha = min(eyes.lighting_alpha, LIGHTING_PLANE_ALPHA_NOCVISION)
+	eyes.lighting_alpha = min(eyes.lighting_alpha, LIGHTING_PLANE_ALPHA_NV_TRAIT)
 	recipient.update_sight()
 
 /datum/virtue/utility/learned

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -80,7 +80,7 @@
 	if (!eyes)
 		return
 	eyes.see_in_dark = 12
-	eyes.lighting_alpha = min(eyes.lighting_alpha, LIGHTING_PLANE_ALPHA_NV_TRAIT)
+	eyes.lighting_alpha = min(eyes.lighting_alpha, 225)
 	recipient.update_sight()
 
 /datum/virtue/utility/learned

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -80,7 +80,7 @@
 	if (!eyes)
 		return
 	eyes.see_in_dark = 12
-	eyes.lighting_alpha = min(eyes.lighting_alpha, 225)
+	eyes.lighting_alpha = 225
 	recipient.update_sight()
 
 /datum/virtue/utility/learned


### PR DESCRIPTION
Swaps the Nocsight flag for the Night Vision flag. Technically worse, but probably better in the long term

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Swaps the Nocsight flag for the Night Vision flag. Technically worse, but probably better in the long term.
Having the chosen of the god of night see just as good at night as someone who's good at seeing in the dark seems off

## Why It's Good For The Game

I still cant see with it, but presumably this will prevent weird interactions with having Noc as your patron
