### PR TITLE
Fixes pillory locks

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -12697,7 +12697,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "luM" = (
-/obj/structure/pillory,
+/obj/structure/pillory{
+	lockid = list("church")
+	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "lvh" = (

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -812,7 +812,9 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/obj/structure/pillory/reinforced,
+/obj/structure/pillory/reinforced{
+	lockid = list("garrison")
+	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "aDd" = (
@@ -12740,7 +12742,9 @@
 	},
 /area/rogue/indoors/town/dwarfin)
 "lwz" = (
-/obj/structure/pillory/reinforced,
+/obj/structure/pillory/reinforced{
+	lockid = list("garrison")
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "lwV" = (
@@ -20378,7 +20382,9 @@
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/obj/structure/pillory/reinforced,
+/obj/structure/pillory/reinforced{
+	lockid = list("garrison")
+	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "soK" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Lets you lock pillories with a town watch key. They didn't have their lockids set before.

## Why It's Good For The Game

We love locking pillories!!
