### PR TITLE
ZIZO BLAST!! Gives ZIZOID court mage a Zurch key for EVIL field trips (With Music)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -67,3 +67,7 @@
 				head = /obj/item/clothing/head/roguetown/wizhat
 				armor = /obj/item/clothing/suit/roguetown/shirt/robe/wizard
 				H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
+		switch(H.patron?.type)
+			if(/datum/patron/inhumen/zizo)
+				H.cmode_music = 'sound/music/combat_cult.ogg'
+				backpack_contents = list(/obj/item/roguekey/inhumen = 1)

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -70,4 +70,4 @@
 		switch(H.patron?.type)
 			if(/datum/patron/inhumen/zizo)
 				H.cmode_music = 'sound/music/combat_cult.ogg'
-				backpack_contents = list(/obj/item/roguekey/inhumen = 1)
+				backpack_contents += list(/obj/item/roguekey/inhumen = 1)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -43,3 +43,6 @@
 		H.mind.adjust_spellpoints(1)
 	H.change_stat("intelligence", 2)
 	H.change_stat("speed", 1)
+	switch(H.patron?.type)
+		if(/datum/patron/inhumen/zizo)
+			H.cmode_music = 'sound/music/combat_cult.ogg'


### PR DESCRIPTION

## About The Pull Request

Hiiii baby's first PR and it's just a small change. Please Go Easy On Me.

**Changes:**
Zizo-aligned court mages have both the cultist combat music AND Zurch key, for when they wish to bring their (hopefully Z-aligned) apprentices to a field trip

Zizo-aligned mage apprentices DO NOT have the key, but at least have the cultist music. 

Edit: Had to add a + BC Zizo mages lacked the potions and instead had a key. NOW that isn't the case.

Tested both as well and non-Zizo aligned folk don't have the music, nor the key for the court mage. Ten users aren't allowed, ever.


## Why It's Good For The Game

It'd make things a little interesting for those wishing to come together and do some heretical things in the Zurch, which is seldom-visited to begin with in my time playing a Zizoid adventurer mage. Having the court mage be able to access it would make things interesting, especially if they wish to introduce more potential students into the Cabal. I also just believe the music slaps /really/ hard personally. 
