### PR TITLE
Hot Water and Suds

### DIFF
--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -6132,7 +6132,7 @@
 /obj/item/reagent_containers/glass/bucket/wooden{
 	pixel_y = 15
 	},
-/obj/item/bath/soap,
+/obj/item/soap/herbal,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "Vx" = (

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -12567,8 +12567,8 @@
 /area/rogue/indoors/town/shop)
 "myB" = (
 /obj/structure/closet/crate/chest/crafted,
-/obj/item/bath/soap,
-/obj/item/bath/soap,
+/obj/item/soap/herbal,
+/obj/item/soap/herbal,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -25,7 +25,7 @@
 	..()
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
-	r_hand = /obj/item/bath/soap
+	r_hand = /obj/item/soap/herbal
 	belt =	/obj/item/storage/belt/rogue/leather/cloth
 	beltl = /obj/item/roguekey/nightmaiden
 	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
@@ -58,7 +58,7 @@
 
 // Washing Implements
 
-/obj/item/bath/soap
+/obj/item/soap/herbal
 	name = "herbal soap"
 	desc = "A soap made from various herbs"
 	icon = 'icons/obj/items_and_weapons.dmi'
@@ -70,14 +70,14 @@
 	throwforce = 0
 	throw_speed = 1
 	throw_range = 7
-	var/cleanspeed = 35 //slower than mop
-	var/uses = 10
+	cleanspeed = 35 //slower than mop
+	uses = 10
 
-/obj/item/bath/soap/ComponentInitialize()
+/obj/item/soap/herbal/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 80)
 
-/obj/item/bath/soap/examine(mob/user)
+/obj/item/soap/examine(mob/user)
 	. = ..()
 	var/max_uses = initial(uses)
 	var/msg = "It looks like it was freshly made."
@@ -96,7 +96,7 @@
 				msg = "It's seen some light use, but it's still pretty fresh."
 	. += span_notice("[msg]")
 
-/obj/item/bath/soap/attack(mob/target, mob/user)
+/obj/item/soap/attack(mob/target, mob/user)
 	var/turf/bathspot = get_turf(target)
 	if(!istype(bathspot, /turf/open/water/bath))
 		to_chat(user, span_warning("They must be in the bath water!"))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -227,10 +227,9 @@
 
 /mob/living/carbon/human/handle_inwater()
 	. = ..()
-	if(!(mobility_flags & MOBILITY_STAND))
-		if(istype(loc, /turf/open/water/bath))
-			if(!wear_armor && !wear_shirt && !wear_pants)
-				add_stress(/datum/stressevent/bathwater)
+	if(istype(loc, /turf/open/water/bath))
+		if(!wear_armor && !wear_shirt && !wear_pants)
+			add_stress(/datum/stressevent/bathwater)
 
 /mob/living/carbon/proc/get_complex_pain()
 	var/amt = 0


### PR DESCRIPTION
Alters soap use and fixes bathwater moodlet

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

Allows all variants of soap to be used for bathing and alters the 'Relaxing' moodlet to not require you to lay down and subsequently drown in the bathwater. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Gives most soap a use beyond being a worse rag and gives a general bonus to being in the bathhouse. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
