### PR TITLE
Bugfixes: guidance spell, double dragonscale necklaces, subtle emote for revived

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -1319,7 +1319,7 @@
 	if(slot == SLOT_NECK)
 		active_item = TRUE
 		if(user.mind.special_role == "Bandit")
-			to_chat(user, span_notice("I feel bolstered by Matthios Power!..."))
+			to_chat(user, span_notice("I feel bolstered by Matthios' Power!"))
 			user.change_stat("strength", 2)
 			user.change_stat("perception", 2)
 			user.change_stat("intelligence", 2)
@@ -1328,7 +1328,7 @@
 			user.change_stat("speed", 2)
 			armor = getArmor("blunt" = 100, "slash" = 100, "stab" = 100, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
 		else
-			to_chat(user, span_notice("I feel an evil power about that necklace.."))
+			to_chat(user, span_notice("I feel an evil power about that necklace..."))
 			armor = getArmor("blunt" = 0, "slash" = 0, "stab" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/neck/roguetown/blkknight/dropped(mob/living/user)

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -1312,23 +1312,24 @@
 	static_price = TRUE
 	var/active_item = FALSE
 
-/obj/item/clothing/neck/roguetown/blkknight/equipped(mob/living/user)
+/obj/item/clothing/neck/roguetown/blkknight/equipped(mob/living/user, slot)
 	. = ..()
 	if(active_item)
 		return
-	active_item = TRUE
-	if(user.mind.special_role == "Bandit")
-		to_chat(user, span_notice("I feel bolstered by Matthios Power!..."))
-		user.change_stat("strength", 2)
-		user.change_stat("perception", 2)
-		user.change_stat("intelligence", 2)
-		user.change_stat("constitution", 2)
-		user.change_stat("endurance", 2)
-		user.change_stat("speed", 2)
-		armor = getArmor("blunt" = 100, "slash" = 100, "stab" = 100, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
-	else
-		to_chat(user, span_notice("I feel an evil power about that necklace.."))
-		armor = getArmor("blunt" = 0, "slash" = 0, "stab" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	if(slot == SLOT_NECK)
+		active_item = TRUE
+		if(user.mind.special_role == "Bandit")
+			to_chat(user, span_notice("I feel bolstered by Matthios Power!..."))
+			user.change_stat("strength", 2)
+			user.change_stat("perception", 2)
+			user.change_stat("intelligence", 2)
+			user.change_stat("constitution", 2)
+			user.change_stat("endurance", 2)
+			user.change_stat("speed", 2)
+			armor = getArmor("blunt" = 100, "slash" = 100, "stab" = 100, "bullet" = 100, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 0)
+		else
+			to_chat(user, span_notice("I feel an evil power about that necklace.."))
+			armor = getArmor("blunt" = 0, "slash" = 0, "stab" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/neck/roguetown/blkknight/dropped(mob/living/user)
 	..()

--- a/modular/code/modules/living/emote.dm
+++ b/modular/code/modules/living/emote.dm
@@ -39,7 +39,8 @@
 		var/T = get_turf(user)
 		if(M.stat == DEAD && M.client && (M.client.prefs?.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))
 			M.show_message(message)*/
-	var/list/ghostless = get_hearers_in_view(1, user) - GLOB.dead_mob_list
+	var/list/ghostless = get_hearers_in_view(1, user)
 	for(var/mob/living/L in ghostless)
-		to_chat(L, "<i>[message]</i>")
+		if(L.stat == CONSCIOUS) // To those conscious only. Slightly more expensive but subtle is not spammed
+			to_chat(L, "<i>[message]</i>")
 

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -978,7 +978,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 
-/obj/effect/proc_holder/spell/invoked/fortitude/cast(list/targets, mob/user)
+/obj/effect/proc_holder/spell/invoked/guidance/cast(list/targets, mob/user)
 	var/atom/A = targets[1]
 	if(!isliving(A))
 		revert_cast()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/issues/1043
The icon is still missing but the spell now correctly assigns a buff after casting. (need to channel then target someone)

Dragonscale necklace buffs could be stacked by wearing one in the neck slot and holding one. Code now checks the slot before assigning buff

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

They are bugs
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
