### PR TITLE
Silent casting fix

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -245,18 +245,20 @@
 	if(!L.used_intent.can_charge())
 		return
 	L.used_intent.prewarning()
-	if(!charging)
-		charging = 1
+
+	if(!charging) //This is for spell charging
+		charging = 1 
 		L.used_intent.on_charge_start()
 		L.update_charging_movespeed(L.used_intent)
 //		L.update_warning(L.used_intent)
-		progress = 0
-//		if(L.used_intent.charge_invocation)
+		progress = 0 
+
+//		if(L.used_intent.charge_invocation) 
 //			sections = 100/L.used_intent.charge_invocation.len
 //		else
 //			sections = null
-		sections = null //commented
-		goal = L.used_intent.get_chargetime()
+		sections = null //commented //From what I can tell, this used to be for the mouse icon changing per % of the cast.
+		goal = L.used_intent.get_chargetime() //How much charge to get in order to cast
 		part = 1
 		lastplayed = 0
 		doneset = 0
@@ -286,12 +288,12 @@
 	//		mouseprog = round(text2num("[((progress / goal) * 20)]"), 1)
 	//		mouse_pointer_icon = GLOB.mouseicons_human[mouseprog]
 	//		testing("mouse[mouseprog]")
-//			if(sections && chargedprog > lastplayed)
+//			if(sections && chargedprog > lastplayed) //used for changing icon based on action progress
 //				L.say(L.used_intent.charge_invocation[part])
 //				part++
 //				lastplayed = sections * part
-		else
-			if(!doneset)
+		else //Fully charged spell
+			if(!doneset) 
 				doneset = 1
 //				if(sections)
 //					L.say(L.used_intent.charge_invocation[L.used_intent.charge_invocation.len])

--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -39,7 +39,7 @@
 	update_icon()
 	start_recharge()
 
-/obj/effect/proc_holder/spell/invoked/deactivate(mob/living/user)
+/obj/effect/proc_holder/spell/invoked/deactivate(mob/living/user) //Deactivates the currently active spell (icon click)
 	..()
 	active = FALSE
 	remove_ranged_ability(null)
@@ -51,7 +51,7 @@
 /obj/effect/proc_holder/spell/invoked/proc/on_deactivation(mob/user)
 	return
 
-/obj/effect/proc_holder/spell/invoked/InterceptClickOn(mob/living/caller, params, atom/target)
+/obj/effect/proc_holder/spell/invoked/InterceptClickOn(mob/living/caller, params, atom/target) 
 	. = ..()
 	if(.)
 		return FALSE
@@ -61,7 +61,8 @@
 	var/charge_progress = client?.chargedprog
 	var/goal = src.get_chargetime() //if we have no chargetime then we can freely cast (and no early release flag was not set)
 	if(src.no_early_release) //This is to stop half-channeled spells from casting as the repeated-casts somehow bypass into this function.
-		if(charge_progress < 100 && goal)
+		if(charge_progress < 100 && goal) //If it is not at 100% charge progress.
+			src.start_recharge()		  //We ensure the spell recharges as without, the recharging var can be set to false by switching away from the spell
 			return FALSE
 	if(perform(list(target), TRUE, user = ranged_ability_user))
 		return TRUE

--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -57,6 +57,12 @@
 		return FALSE
 	if(!can_cast(caller) || !cast_check(FALSE, ranged_ability_user))
 		return FALSE
+	var/client/client = CLIENT_FROM_VAR(caller) 
+	var/charge_progress = client?.chargedprog
+	var/goal = src.get_chargetime() //if we have no chargetime then we can freely cast (and no early release flag was not set)
+	if(src.no_early_release) //This is to stop half-channeled spells from casting as the repeated-casts somehow bypass into this function.
+		if(charge_progress < 100 && goal)
+			return FALSE
 	if(perform(list(target), TRUE, user = ranged_ability_user))
 		return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

I have no idea how tracking mouse clicks works here or how the spell system works.

The original issue is that you can, via repeated clicks, bypass into: /obj/effect/proc_holder/spell/invoked/InterceptClickOn by attempting to cast repeatedly. Once it's there, neither of the conditional checking functions in:
 can_cast
 cast_check

check for how long the spell is casting nor whether the spell is set to not be released early so the spell simply insta casts, This fixes it with some caveats.
 Firstly, the spell icons have a chance to be set to be on cooldown if you cancel your cast after starting it. I suspect there's a flag in a function I'm missing

Somehow the 'doneset' variable accurately tracks the min-cast time of the spell that's being cast and when it's up, the spells is fully charged and can be safely cast. However, the entire function is called by various hud elements

'curplaying' also seems to be an important variable.

There is a more elegant solution but I can't think of it right now. Hoping someone has a more concrete idea.

## Why It's Good For The Game
Pros
- It fixes it

Cons
- It's not a good fix

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
