### PR TITLE
Hopefully makes Spymasters actually spawn with their gear.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -98,7 +98,6 @@
 	else
 		cloak = /obj/item/clothing/cloak/raincloak/mortus //cool spymaster cloak
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
-		backr = /obj/item/storage/backpack/rogue/satchel/black
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/hand
 		pants = /obj/item/clothing/under/roguetown/tights/black
 	if(H.mind)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes a duplicate line that seems to be causing certain races of spymaster not spawn with a satchel.
I can't recreate the bug testing locally in the first place to even check if this works but I also can't find anything else that could be the cause.

## Why It's Good For The Game

Bugfix, and even if this doesn't fix it. It removes an unnecessary line regardless.
