### PR TITLE
bugfix update_filter runtime 

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -140,3 +140,7 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 
 /proc/cmp_wound_severity_dsc(datum/wound/A, datum/wound/B)
 	return B.severity - A.severity
+
+/proc/cmp_filter_priority_desc(list/A, list/B) // Compares two lists by their 'priority' key. Used for filters.
+    return (A["priority"] || 0) - (B["priority"] || 0)
+	

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1262,9 +1262,9 @@
 		update_filters()
 	return .
 
-/atom/movable/proc/update_filters()
-	filters = null
-	sortTim(filter_data,associative = TRUE)
+/atom/movable/proc/update_filters() //Determine which filter comes first
+	filters = null                  //note, the cmp_filter is a little flimsy.
+	sortTim(filter_data, /proc/cmp_filter_priority_desc, associative = TRUE) 
 	for(var/f in filter_data)
 		var/list/data = filter_data[f]
 		var/list/arguments = data.Copy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Somewhat of an edge case.

When you have two or more filters applied to a character, it would case a runtime error because the function in atoms wanted it to be sorted to determine which would show first. 

The comparator used was default which would be fine in most cases. However, in the case of filters, it was passed two lists which the default comparator could not accurately compare.

Added a comparator to check the 'priority' key of those lists.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less runtime errors, no issues on my end.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
