### PR TITLE
allows renaming of everything childed to obj/item/rogueweapon, crossbows and bows, and all clothing and armor items

### DIFF
--- a/code/game/objects/items/rogueitems/natural/feather.dm
+++ b/code/game/objects/items/rogueitems/natural/feather.dm
@@ -17,7 +17,7 @@
 	spitoutmouth = FALSE
 	w_class = WEIGHT_CLASS_TINY
 
-//reproduces some code from pens so that we can utilize them for renaming items using existent roguecode items
+//reproduces some code from pens so that we can utilize feathers for renaming objects
 
 /obj/item/natural/feather/afterattack(obj/O, mob/living/user, proximity)
 	. = ..()
@@ -33,7 +33,7 @@
 			if(oldname == input)
 				to_chat(user, span_notice("I changed \the [O.name] to... well... \the [O.name]."))
 			else
-				O.name = input
+				O.name = "[input] ([oldname])"
 				to_chat(user, span_notice("\The [oldname] has been successfully been renamed to \the [input]."))
 				O.renamedByPlayer = TRUE
 

--- a/code/game/objects/items/rogueitems/natural/feather.dm
+++ b/code/game/objects/items/rogueitems/natural/feather.dm
@@ -16,3 +16,30 @@
 	muteinmouth = TRUE
 	spitoutmouth = FALSE
 	w_class = WEIGHT_CLASS_TINY
+
+//reproduces some code from pens so that we can utilize them for renaming items using existent roguecode items
+
+/obj/item/natural/feather/afterattack(obj/O, mob/living/user, proximity)
+	. = ..()
+	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
+		var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
+		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+			return
+		if(penchoice == "Rename")
+			var/input = stripped_input(user,"What do you want to name \the [O.name]?", ,"", MAX_NAME_LEN)
+			var/oldname = O.name
+			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+				return
+			if(oldname == input)
+				to_chat(user, span_notice("I changed \the [O.name] to... well... \the [O.name]."))
+			else
+				O.name = input
+				to_chat(user, span_notice("\The [oldname] has been successfully been renamed to \the [input]."))
+				O.renamedByPlayer = TRUE
+
+		if(penchoice == "Change description")
+			var/input = stripped_input(user,"Describe \the [O.name] here", ,"", 100)
+			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
+				return
+			O.desc = input
+			to_chat(user, span_notice("I have successfully changed \the [O.name]'s description."))

--- a/code/game/objects/items/rogueweapons/ranged/bows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/bows.dm
@@ -26,6 +26,7 @@
 	cartridge_wording = "arrow"
 	load_sound = 'sound/foley/nockarrow.ogg'
 	var/damfactor = 1
+	obj_flags = UNIQUE_RENAME
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -24,6 +24,7 @@
 	smeltresult = /obj/item/ingot/steel
 	var/damfactor = 2
 	resistance_flags = FIRE_PROOF
+	obj_flags = UNIQUE_RENAME
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/rogueweapon.dm
+++ b/code/game/objects/items/rogueweapons/rogueweapon.dm
@@ -34,8 +34,8 @@
 	)
 	var/initial_sl
 	var/list/possible_enhancements
-	var/renamed_name
 	resistance_flags = FIRE_PROOF
+	obj_flags = UNIQUE_RENAME
 
 /obj/item/rogueweapon/Initialize()
 	. = ..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -6,7 +6,7 @@
 /obj/item/clothing
 	name = "clothing"
 	resistance_flags = FLAMMABLE
-	obj_flags = CAN_BE_HIT
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	blade_dulling = DULLING_CUT
 	max_integrity = 200


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/5fcd377d-8a76-4add-8cbd-185d85d91aad)

you can now rename anything childed to rogueweapon by using a feather on it. yay!

## Why It's Good For The Game

its cool :3c
