### PR TITLE
finally giving regular pick intent AP 

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -296,17 +296,17 @@
 	chargetime = 0
 	swingdelay = 0
 
-/datum/intent/pick //not sure if it should be 80 or 60?
+/datum/intent/pick //now like icepick intent, we really went in a circle huh
 	name = "pick"
 	icon_state = "inpick"
 	attack_verb = list("picks","impales")
 	hitsound = list('sound/combat/hits/pick/genpick (1).ogg', 'sound/combat/hits/pick/genpick (2).ogg')
-	penfactor = 60 
+	penfactor = 80
 	animname = "strike"
 	item_d_type = "stab"
 	blade_class = BCLASS_PICK
 	chargetime = 0
-	swingdelay = 3
+	swingdelay = 12
 
 /datum/intent/shoot //shooting crossbows or other guns, no parrydrain
 	name = "shoot"

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -296,11 +296,12 @@
 	chargetime = 0
 	swingdelay = 0
 
-/datum/intent/pick
+/datum/intent/pick //not sure if it should be 80 or 60?
 	name = "pick"
 	icon_state = "inpick"
 	attack_verb = list("picks","impales")
 	hitsound = list('sound/combat/hits/pick/genpick (1).ogg', 'sound/combat/hits/pick/genpick (2).ogg')
+	penfactor = 60 
 	animname = "strike"
 	item_d_type = "stab"
 	blade_class = BCLASS_PICK

--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -199,8 +199,8 @@
 	name = "Pulaski axe"
 	desc = "An odd mix of a pickaxe front and a hatchet blade back, capable of being switched between."
 	icon_state = "paxe"
-	possible_item_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/pick, /datum/intent/axe/bash)
-	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/pick, /datum/intent/axe/bash)
+	possible_item_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
+	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
 	smeltresult = /obj/item/ingot/steel
 	wlength = WLENGTH_NORMAL
 	toolspeed = 2
@@ -211,8 +211,8 @@
 	icon_state = "wardenpax"
 	force = 22
 	force_wielded = 28
-	possible_item_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/pick, /datum/intent/axe/bash)
-	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/pick, /datum/intent/axe/bash)
+	possible_item_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
+	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop, /datum/intent/mace/warhammer/pick, /datum/intent/axe/bash)
 	smeltresult = /obj/item/ingot/steel
 	wlength = WLENGTH_NORMAL
 	toolspeed = 2


### PR DESCRIPTION
something something first commit
Warden's axe and pickaxes never actually had any AP innately due to the datum/intent pick never having it in the first place. I THINK this should be right, let me know if 60 is too high. This should affect only pickaxes, pulowski axes, and the warden's axes? (other pick types use either icepick or warhammer pick)

as above 
quite literally just adds ap to the pick intent datum (i hope i did that right?)

Why It's Good For The Game

Gives the pulowski and warden's axes actual pen on their pick intents, and some to picks. If that's too powerful on pickaxes then it can probably be slapped down?? stuff like the warhammer already has something like it, but this has no chargeup. 