### PR TITLE
Makes Blacksteel Fullplate actually better than regular fullplate

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -628,7 +628,7 @@
 	nodismemsleeves = TRUE
 	do_sound_plate = TRUE
 	blocking_behavior = null
-	max_integrity = 400
+	max_integrity = 600
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/blacksteel
 	armor_class = ARMOR_CLASS_HEAVY


### PR DESCRIPTION
## About The Pull Request

Someone set the Blacksteel Fullplate to have the same durability of the Blacksteel Cuirass, which makes no sense. Fixed it though.

400 >> 600 durability now. 100 more than Full Plate, as is customary for the other Blacksteel armour pieces.

## Why It's Good For The Game

Because I'm fixing a coding oversight, and I wont see people walking about in full Blacksteel except for the actual armour slot. 