### PR TITLE
Powercreeps Xylix Miracles Greatly (not really)

### DIFF
--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -7,7 +7,6 @@
 	no_early_release = TRUE
 	movement_interrupt = TRUE
 	chargedloop = /datum/looping_sound/invokeholy
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/misc/letsgogambling.ogg'
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes it so that the wheel (the one xylix miracle we have right now) doesn't require an amulet to cast.

## Why It's Good For The Game
Xylix doesn't have an amulet for his worshippers, meaning that anyone who spawns as a Xylix miracle-caster will not have the option to actually.. well, cast the miracle. They have to go find a psicross (is it psycross like psydon or psicross? who knows) or the amulet of another god in order to cast their one miracle. While, yeah, we could add a xylix amulet or just give them a generic psycross, that feels against the spirit of it. Xylix worshippers tend not to advertise their status. I don't think this'll really break balance, since the wheel is particularly mediocre.

Unrelated, while making this PR, I found that "what miracles need an amulet" is incredibly inconsistent. Noc miracles are entirely amulet-free casting, despite having two of the strongest combat miracles (invisibility and blindness), and most amulets are interchangible (you can use an amulet of astrata to cast dendor miracles, for example) with the exception of Eora. Eora miracles can only be a cast with an Eoran amulet. Wacky. 