### PR TITLE
Quick QoL fix for otavan helmets, changes bardiche to not be dogwater

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -36,6 +36,10 @@
 	damfactor = 0.9
 	swingdelay = 10
 
+/datum/intent/spear/cut/bardiche
+    damfactor = 1.0
+    chargetime = 1
+
 /datum/intent/sword/cut/zwei
 	reach = 2
 
@@ -275,7 +279,7 @@
 
 /obj/item/rogueweapon/halberd/bardiche
 	possible_item_intents = list(/datum/intent/spear/thrust/eaglebeak, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(/datum/intent/spear/thrust/eaglebeak, /datum/intent/spear/cut/halberd, /datum/intent/axe/chop, SPEAR_BASH)
+	gripped_intents = list(/datum/intent/spear/thrust/eaglebeak, /datum/intent/spear/cut/bardiche, /datum/intent/axe/chop, SPEAR_BASH)
 	name = "bardiche"
 	desc = "A beautiful variant of the halberd."
 	icon_state = "bardiche"

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -725,7 +725,7 @@
 	body_parts_covered = FULL_HEAD
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	block2add = FOV_RIGHT|FOV_LEFT
+	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 


### PR DESCRIPTION
## About The Pull Request

Small oversight on the helmets.

Add QoL buffs to the bardiche, makes it a weapon people actually can use now.

## Why It's Good For The Game

updates it to be in line with all the other helmets of its class, removing the cone FOV.

Gives bardiche their own cutting intent for adjusting, now instead of the bardiche having an abysmal 1 second delay for a cutting atack, the weapon works like any other polearm, with a charge one.

buffed its 0.9x damage modifier to 1.0x (making it slightly better than the halberd cutting attack), its still worse off than every other cutting attack (1.1x damage) but should do its job due to the reach advantage.
