### PR TITLE
The Great Peasant Militia Era Arrives (Warden Spear Bugfixing)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -39,7 +39,7 @@ Also given some non-combat skills that a peasent would have, just to support the
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backl = /obj/item/rogueweapon/spear
+	r_hand = /obj/item/rogueweapon/spear
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1, /obj/item/signal_horn = 1, /obj/item/flashlight/flare/torch/lantern = 1)
 	if(H.mind)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Did you know that Wardens have been meaning to spawn with a spear since their creation? Yet, through an oversight, their spear was set to the back slot. As spears cannot spawn in the back slot... well, Wardens don't get their spear. 

They don't have a great weapon strap, so they'll have to craft one to holster it, or just carry it around like a proper bog guard wannabe. If people want, I can give them a spawning strap, it's one line change, I just wasn't sure if I should or not.

## Why It's Good For The Game

Spears cannot spawn in the back slot.
