### PR TITLE
Fix for hammer repair for rogueweapons

### DIFF
--- a/code/game/objects/items/rogueweapons/rogueweapon.dm
+++ b/code/game/objects/items/rogueweapons/rogueweapon.dm
@@ -21,7 +21,7 @@
 	has_inspect_verb = TRUE
 	parrysound = list('sound/combat/parry/parrygen.ogg')
 	anvilrepair = /datum/skill/craft/weaponsmithing
-	obj_flags = CAN_BE_HIT
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	blade_dulling = DULLING_BASH
 	max_integrity = 200
 	wdefense = 3
@@ -35,7 +35,6 @@
 	var/initial_sl
 	var/list/possible_enhancements
 	resistance_flags = FIRE_PROOF
-	obj_flags = UNIQUE_RENAME
 
 /obj/item/rogueweapon/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes weapons not being able to be hit with a hammer due to obj_flags overwrite from the weapon naming PR.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You gotta fix your weapons
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
