### PR TITLE
Adds Court Agent latejoin

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -165,6 +165,7 @@
 #define LUNATIC		(1<<17)
 #define MIGRANT		(1<<18)
 #define BANDIT		(1<<19)
+#define COURTAGENT	(1<<20)
 
 #define YOUNGFOLK	(1<<6)
 
@@ -282,6 +283,7 @@
 #define JDO_PILGRIM 30.2
 #define JDO_MIGRANT 32.3
 #define JDO_BANDIT 31.3
+#define JDO_COURTAGENT 30.3
 
 #define JDO_MERCENARY 31
 #define JDO_GRENZELHOFT 31.1

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/courtagent.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/courtagent.dm
@@ -1,12 +1,14 @@
 /datum/job/roguetown/adventurer/courtagent
 	title = "Court Agent"
+	flag = COURTAGENT
+	display_order = JDO_COURTAGENT
 	total_positions = 2
 	spawn_positions = 2
 	round_contrib_points = 2
 	tutorial = "Whether acquired by merit, shrewd negotiation or fulfilled bounties, you have found yourself under the underhanded employ of the Hand. Fulfill desires and whims of the court that they would rather not be publicly known. Your position is anything but secure, and any mistake can leave you disowned and charged like the petty criminal are. Garrison and Court members know who you are."
 	min_pq = 5
-	always_show_on_latechoices = FALSE
 	job_reopens_slots_on_death = FALSE
+	show_in_credits = TRUE
 
 //Hooking in here does not mess with their equipment procs
 /datum/job/roguetown/adventurer/courtagent/after_spawn(mob/living/L, mob/M, latejoin = TRUE)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -136,6 +136,7 @@ GLOBAL_LIST_INIT(peasant_positions, list(
 	"Adventurer",
 	"Pilgrim",
 	"Bandit",
+	"Court Agent",
 ))
 
 GLOBAL_LIST_INIT(mercenary_positions, list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
By partial request:
![dreamseeker_WoQORhEga3](https://github.com/user-attachments/assets/2412e6f7-cb03-4d65-be16-3c270c6dd23e)

It is no longer roundstart only.
Consequently, it means you can tell when there are (or aren't) any court agents in a round.
Any latejoin court agents will also not have their names beamed to the mind of the Hand, unfortunately.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not everyone gets to roll the dice and be available on a specific time every three hours.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
