### PR TITLE
Fix for the "Feinting Speedsters" PR

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -284,6 +284,8 @@
 					return FALSE
 			if(has_status_effect(/datum/status_effect/debuff/riposted))
 				return FALSE
+			if(has_status_effect(/datum/status_effect/debuff/feinted))
+				return FALSE
 			last_dodge = world.time
 			if(src.loc == user.loc)
 				return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Dodges themselves were unaffected by the "feinted" status effect. Making the earlier PR mostly redundant.

## Why It's Good For The Game

Fixes thing that not work as intended. 
