### PR TITLE
Magicians Associates are no longer on a sabbatical (FIXES THEIR SPAWN LOCATION)

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -402,7 +402,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/wapprentice
-	name = "Magicians Apprentice"
+	name = "Magicians Associate"
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/apothecary

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -7,6 +7,7 @@
 	spawn_positions = 4
 
 	allowed_races = RACES_ALL_KINDS
+	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	advclass_cat_rolls = list(CTAG_WAPPRENTICE = 20)
 
 	tutorial = "Your master once saw potential in you, although you are uncertain if they still do, given how rigorous and difficult your studies have been. The path to using magic is a treacherous and untamed one, and you are still decades away from calling yourself even a journeyman in the field. Listen and serve, and someday you will earn your hat."

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -5,6 +5,7 @@
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 4
+
 	allowed_races = RACES_ALL_KINDS
 	advclass_cat_rolls = list(CTAG_WAPPRENTICE = 20)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Magicians Associates should now spawn in the correct places round-start, and no longer in random places like the inn's bed chambers, or the VAMPIRE LORDS MANSION. The Landmark name needed to be changed. Presti has also been re-added. Don't code at 3 in the morning y'all.

Known bugs, round start mage associates still spawn with two staves for some reason and I cannot figure out why.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes bugs (funny bugs, but still bugs)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
