### PR TITLE
Rename stall i to Soilson Stall

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -167,7 +167,7 @@
 /obj/structure/mineral_door/wood{
 	locked = 1;
 	lockid = "apartment1";
-	name = "stall i"
+	name = "Soilson Stall"
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
@@ -7827,7 +7827,7 @@
 	icon_state = "largetable"
 	},
 /obj/item/roguekey/apartments/apartment1{
-	name = "stall i key";
+	name = "Soilson Stall Key";
 	pixel_x = -6
 	},
 /turf/open/floor/rogue/ruinedwood{


### PR DESCRIPTION
## About The Pull Request

This is a tiny PR that differentiates the Stall i by the soilson compound and Stall i, the stall directly northeast of the south gate in town. The stall next to the farm has been renamed to the Soilson Stall to prevent confusion.

## Why It's Good For The Game

I've seen no less than 8 people get caught by this minor confusion when planning where to meet later. This fixes that by properly naming a spot in town.

## Proof of Testing

![key](https://github.com/user-attachments/assets/a19cd6bb-337d-4e58-b10f-ddba53ef4594)

![stall](https://github.com/user-attachments/assets/6f29a01c-327b-4cc7-869a-6e2083dac3a7)

