### PR TITLE
A Yuletide Tweak - Alters 'flail.dmi' by removing the 'swingdelay' variable, and by introducing the 'chargedrain' variable.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -44,10 +44,10 @@
 /datum/intent/flail/strike/smash
 	name = "smash"
 	chargetime = 5
+	chargedrain = 2
 	no_early_release = TRUE
 	penfactor = 80
 	recovery = 10
-	swingdelay = 7
 	damfactor = 1.2
 	chargedloop = /datum/looping_sound/flailswing
 	keep_looping = TRUE
@@ -60,12 +60,12 @@
 /datum/intent/flail/strike/smashrange
 	name = "ranged smash"
 	chargetime = 25
+	chargedrain = 2
 	no_early_release = TRUE
 	penfactor = 50
 	recovery = 30
-	damfactor = 1.5
+	damfactor = 1.2
 	reach = 2
-	swingdelay = 8
 	chargedloop = /datum/looping_sound/flailswing
 	keep_looping = TRUE
 	icon_state = "insmash"


### PR DESCRIPTION
## About The Pull Request

Hello. This is the first _(and likely only time)_ that I'll be making a pull request.
Merry Christmas to those that're reading this, by the way! I hope you're all staying warm, festive, and jovial.

This pull request - assuming I haven't accidentally messed anything - tweaks the Flail's performance..
- ..by removing the **'swingdelay'** variable, which determines how long it takes for an attack to be attempted post-release, and..
- ..by adding the **'chargedrain'** variable from the bows, which gradually drains stamina while the weapon is being 'charged' up.

In addition, the damage modifier for the Peasant War Flail has been brought down to be in-line with the regular Flail.

## Why It's Good For The Game

A couple months ago, Kavrick made a pull request that nerfed the Flail's effectiveness. This was done because Flails were extraordinarily powerful, and could essentially vaporize most plate-armored people in a single swing.

While I agree with their changes to the Flail's damage, I did not agree with their addition of the **'swingdelay'** variable. This - in combination with the Flail's oft-tweaked _'charging'_ mechanic - made it borderline-impossible to actually hit someone.

_(For those who aren't familiar with the code, the 'swingdelay' variable determines how long it takes for an attack to be attempted after the weapon-in-question is swung. This is why attacks from axes and claws can occasionally be dodged by sidestepping. Because of how this works in conjunction with the other mechanics inherent to the Flail, however, this results in the weapon being mechanically unable to hit targets that aren't completely immobilized. Such a predicament has been observed-and-noted by many others in the community, and has led to the Flail's abandonment.)_

_(I've been waiting for a couple months for someone to make a promised change to the Flail, as a result. No one has stepped up to the plate, however, so I've reluctantly taken up the mantle of doing it myself.)_

In lieu of the **'swingdelay'** variable, I've ported over the **'chargedrain'** variable instead as a balancing agent. Charging up an attack with the Flail should now drain stamina at a _modest_ rate, which can leave its wielder exhausted if haphazardly used.

My hope is that this would restore the Flail's capacity as a _relatively_ balanced sidegrade to the Mace, sacrificing defense and pacability in favor of damage and style. Such a cool-looking _(and cool-sounding)_ weapon deserves to live once more.

If any of you have any thoughts on the matter, feel free to let me know on here or in the community's **'#dev-general'** channel.