### PR TITLE
Nerfing spewium to not hurl brain

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -631,6 +631,8 @@
 		if(!internal_organs.len)
 			break //Guess we're out of organs!
 		var/obj/item/organ/guts = pick(internal_organs)
+		if(istype(guts, /obj/item/organ/brain)) //Don't hurl brains for mind sanity reasons
+			continue
 		var/turf/T = get_turf(src)
 		guts.Remove(src)
 		guts.forceMove(T)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -626,7 +626,7 @@
 
 /datum/reagent/toxin/spewium
 	name = "Spewium"
-	description = "A powerful emetic, causes uncontrollable vomiting."
+	description = "A powerful emetic, causes uncontrollable vomiting.  May result in vomiting organs at high doses."
 	reagent_state = LIQUID
 	color = "#2f6617" //A sickly green color
 	metabolization_rate = REAGENTS_METABOLISM
@@ -645,9 +645,8 @@
 /datum/reagent/toxin/spewium/overdose_process(mob/living/carbon/C)
 	. = ..()
 	if(current_cycle >=33 && prob(15))
-		//C.spew_organ()
+		C.spew_organ()
 		C.vomit(0, TRUE, TRUE, 4)
-		C.adjustToxLoss(3)
 		to_chat(C, span_danger("I feel something lumpy come up..."))
 
 /datum/reagent/toxin/curare

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -626,7 +626,7 @@
 
 /datum/reagent/toxin/spewium
 	name = "Spewium"
-	description = "A powerful emetic, causes uncontrollable vomiting.  May result in vomiting organs at high doses."
+	description = "A powerful emetic, causes uncontrollable vomiting."
 	reagent_state = LIQUID
 	color = "#2f6617" //A sickly green color
 	metabolization_rate = REAGENTS_METABOLISM
@@ -645,9 +645,10 @@
 /datum/reagent/toxin/spewium/overdose_process(mob/living/carbon/C)
 	. = ..()
 	if(current_cycle >=33 && prob(15))
-		C.spew_organ()
+		//C.spew_organ()
 		C.vomit(0, TRUE, TRUE, 4)
-		to_chat(C, span_danger("I feel something lumpy come up as you vomit."))
+		C.adjustToxLoss(3)
+		to_chat(C, span_danger("I feel something lumpy come up..."))
 
 /datum/reagent/toxin/curare
 	name = "Curare"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Takes away Spewium's gimmick of upchucking organs, since this could lead to round removal from vomiting brain. Tucked in a bit of toxin damage on the overdose so that it's not completely neutered.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Someone vomited up their penis.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
