### PR TITLE
fixes an obscure goblin runtime, closes a few bugs

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -335,8 +335,10 @@
 				r_hand = /obj/item/rogueweapon/mace/spiked
 			if(prob(20))
 				r_hand = /obj/item/rogueweapon/flail
-			l_hand = /obj/item/rogueweapon/shield/wood
+				l_hand = /obj/item/rogueweapon/shield/wood
 
+	H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
 
 //////////////////   INVADER ZIM	//////////////////
 


### PR DESCRIPTION
## About The Pull Request

goblins have 1 in bows and crossbows now so that they can shoot them without creating runtimes. closes #1043 

also closes a few out of date or unnecessary bug reports:
closes #502 - fixed by #806 
closes #863 - seems to be fixed
closes #1027 - not a bug, just a change in visual style. someone can pr a change if they have a preference for a different color temperature.

## Why It's Good For The Game

fixes a runtime 👍 