### PR TITLE
small bugfixes, baothan & trait_norun implementation

### DIFF
--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -165,17 +165,17 @@
 	sellprice = 666
 	var/active_item
 
-/obj/item/clothing/ring/dragon_ring/equipped(mob/living/user)
+/obj/item/clothing/ring/dragon_ring/equipped(mob/living/user, slot)
 	. = ..()
 	if(active_item)
 		return
-	else
+	else if(slot == SLOT_RING)
 		active_item = TRUE
 		to_chat(user, span_notice("Here be dragons."))
 		user.change_stat("strength", 2)
 		user.change_stat("constitution", 2)
 		user.change_stat("endurance", 2)
-		return
+	return
 
 /obj/item/clothing/ring/dragon_ring/dropped(mob/living/user)
 	..()
@@ -185,5 +185,5 @@
 		user.change_stat("constitution", -2)
 		user.change_stat("endurance", -2)
 		active_item = FALSE
-		return
+	return
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -124,6 +124,9 @@
 
 /mob/living/simple_animal/hostile/handle_automated_movement()
 	. = ..()
+	if(QDELETED(src))
+		return
+
 	if(dodging && target && in_melee && isturf(loc) && isturf(target.loc))
 		var/datum/cb = CALLBACK(src,PROC_REF(sidestep))
 		if(sidestep_per_cycle > 1) //For more than one just spread them equally - this could changed to some sensible distribution later

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -173,5 +173,5 @@
 	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
 	embedchance = 100
 	woundclass = BCLASS_STAB
-	flag = "bullet"
+	flag = "piercing"
 	speed = 2

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -624,6 +624,9 @@
 					return
 				if(L.rogstam <= 0)
 					return
+				if(HAS_TRAIT(L, TRAIT_NORUN))
+					to_chat(L, span_warning("My joints have decayed too much for running!"))
+					return
 				if(ishuman(L))
 					var/mob/living/carbon/human/H = L
 					if(!H.check_armor_skill() || H.legcuffed)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -587,6 +587,10 @@
 		rogue_sneaking = TRUE
 		return
 	var/turf/T = get_turf(src)
+
+	if(!T) //if the turf they're headed to is invalid
+		return
+
 	var/light_amount = T.get_lumcount()
 	var/used_time = 50
 	if(mind)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -611,34 +611,40 @@
 			rogue_sneaking = TRUE
 	return
 
+///Checked whenever a mob tries to change their movement intent
 /mob/proc/toggle_rogmove_intent(intent, silent = FALSE)
 	// If we're becoming sprinting from non-sprinting, reset the counter
 	if(!(m_intent == MOVE_INTENT_RUN && intent == MOVE_INTENT_RUN))
 		sprinted_tiles = 0
+
 	switch(intent)
 		if(MOVE_INTENT_SNEAK)
 			m_intent = MOVE_INTENT_SNEAK
 			update_sneak_invis()
+
 		if(MOVE_INTENT_WALK)
 			m_intent = MOVE_INTENT_WALK
+
 		if(MOVE_INTENT_RUN)
 			if(isliving(src))
 				var/mob/living/L = src
-				if(L.rogfat >= L.maxrogfat)
+
+				//If mob is trying to switch to run, fail if any of these are true
+				if (L.rogfat >= L.maxrogfat || L.rogstam <= 0 || HAS_TRAIT(L, TRAIT_NORUN))
+					if (HAS_TRAIT(L, TRAIT_NORUN)) // If has trait blocker then inform them
+						to_chat(L, span_warning("My joints have decayed too much for running!"))
 					return
-				if(L.rogstam <= 0)
-					return
-				if(HAS_TRAIT(L, TRAIT_NORUN))
-					to_chat(L, span_warning("My joints have decayed too much for running!"))
-					return
+
 				if(ishuman(L))
 					var/mob/living/carbon/human/H = L
 					if(!H.check_armor_skill() || H.legcuffed)
 						return
+
 			m_intent = MOVE_INTENT_RUN
-	if(hud_used && hud_used.static_inventory)
+	if(hud_used?.static_inventory) //Update UI
 		for(var/atom/movable/screen/rogmove/selector in hud_used.static_inventory)
 			selector.update_icon()
+			
 	if(!silent)
 		playsound_local(src, 'sound/misc/click.ogg', 100)
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -312,6 +312,8 @@
 	var/list/cached_addictions = addiction_list
 	if(C)
 		expose_temperature(C.bodytemperature, 0.25)
+		if(HAS_TRAIT(C, TRAIT_CRACKHEAD))
+			can_overdose = FALSE
 	var/need_mob_update = 0
 	for(var/reagent in cached_reagents)
 		var/datum/reagent/R = reagent

--- a/modular/Mapping/icons/Mapping_aides.dm
+++ b/modular/Mapping/icons/Mapping_aides.dm
@@ -6,6 +6,7 @@
 	icon_state = "stickyweb1"
 	resistance_flags = FLAMMABLE
 	alpha = 109
+	max_integrity = 30
 	opacity = TRUE
 	debris = list(/obj/item/natural/silk = 1)
 

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/orc.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/orc.dm
@@ -193,7 +193,7 @@
 	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
 	embedchance = 100
 	woundclass = BCLASS_STAB
-	flag = "bullet"
+	flag = "piercing"
 	speed = 2
 
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/ranged

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1153,7 +1153,7 @@
 	armor_penetration = 10
 	woundclass = BCLASS_SMASH
 	nodamage = FALSE
-	flag = "bullet"
+	flag = "magic"
 	hitsound = 'sound/combat/hits/blunt/shovel_hit2.ogg'
 	speed = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Existing bullet damage projectiles replaced by piercing / magic.
Unusual null turf reference in sneaking code - I say unusual because it never happened pre-debloat.
Baothan trait (TRAIT_CRACKHEAD) reimplemented
TRAIT_NORUN for deadites and inbred princes is now implemented. This primarily means deadites will not be able to run.
Spiderweb integrity nerfed to 30 from 300 (the original /obj/structure/spider was lost in debloat)

## Why It's Good For The Game

Bugs

Unsure about the NORUN for deadites. It's listed as a zombie trait but was never implemented properly. Hopefully it doesn't kneecap the antag too much.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
