### PR TITLE
Fixes fireman carry and piggyback z level transitions

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -144,5 +144,9 @@
 		L.stop_pulling()
 		pulling.forceMove(newtarg)
 		L.start_pulling(pulling, supress_message = TRUE)
-		if(was_pulled_buckled) // Assume this was a fireman carry since piggybacking is not a thing
-			L.buckle_mob(pulling, TRUE, TRUE, 90, 0, 0)
+		if(was_pulled_buckled) 
+			var/mob/living/M = pulling
+			if(M.mobility_flags & MOBILITY_STAND)	// piggyback carry
+				L.buckle_mob(pulling, TRUE, TRUE, FALSE, 0, 0)
+			else				// fireman carry
+				L.buckle_mob(pulling, TRUE, TRUE, 90, 0, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![dreamseeker_zL4WXMVQ6F](https://github.com/user-attachments/assets/d195cd52-f132-4d39-9396-3688a383f424)
![dreamseeker_zWFEYTkwsl](https://github.com/user-attachments/assets/c1f9d6d7-761d-4c16-ae74-9d353f6b50b5)

They now respect whether you were fireman carrying or piggyback carrying.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
