### PR TITLE
Garrison barracks overhaul + armory keys

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -639,10 +639,8 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
 "auX" = (
-/obj/structure/bars/grille{
-	density = 1
-	},
 /obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/bars/grille,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "avT" = (
@@ -1261,7 +1259,10 @@
 	dir = 6;
 	icon_state = "largetable"
 	},
-/obj/item/book/rogue/law,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -6
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "aXA" = (
@@ -2856,7 +2857,6 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "cvw" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
@@ -6912,22 +6912,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
-"gjG" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/obj/structure/mineral_door/wood/deadbolt/shutter{
-	dir = 2;
-	lockdir = 1;
-	name = "counter hatch"
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/garrison)
 "gjH" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -14653,11 +14637,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "njf" = (
-/obj/structure/bars/grille{
-	density = 1
+/obj/machinery/light/rogue/torchholder{
+	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/fermenting_barrel/water,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "njH" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -17156,7 +17140,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "prO" = (
-/obj/structure/fermenting_barrel/water,
+/obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "prR" = (
@@ -23693,10 +23677,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "vqp" = (
-/obj/structure/bars/grille{
-	density = 1
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/bars/grille,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "vqB" = (
 /obj/structure/bars,
@@ -24303,7 +24285,7 @@
 	dir = 4;
 	icon_state = "largetable"
 	},
-/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "vZe" = (
@@ -25197,7 +25179,9 @@
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
-/turf/closed/wall/mineral/rogue/stone/moss,
+/obj/structure/bars/grille,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "wLy" = (
 /obj/structure/closet/crate/roguecloset,
@@ -26714,8 +26698,12 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "xRO" = (
-/obj/structure/bars/grille,
-/turf/open/floor/rogue/cobblerock,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/obj/structure/table/wood,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "xSg" = (
 /obj/structure/fluff/railing/wood{
@@ -67159,7 +67147,7 @@ wLs
 wzd
 vYw
 aXp
-oUz
+njf
 oUz
 ctF
 ctF
@@ -67312,7 +67300,7 @@ hRm
 xtL
 uTA
 pkG
-njf
+vqp
 spZ
 spZ
 spZ
@@ -67626,13 +67614,13 @@ qBv
 iFm
 pkG
 vvp
-gjG
+xRO
 cBC
 oTI
 spZ
 nXi
 oBq
-prO
+dZn
 rzj
 haW
 goh
@@ -67944,7 +67932,7 @@ oUz
 hRm
 hRm
 hRm
-mjI
+prO
 dZn
 dZn
 hRm
@@ -68100,8 +68088,8 @@ xJI
 xJI
 pPS
 xJI
-hRm
-hRm
+oUz
+oUz
 dZn
 wWa
 hRm
@@ -68415,8 +68403,8 @@ wfx
 qxD
 qxD
 wfx
-jsn
-jsn
+oUz
+oUz
 iXt
 oUz
 oUz

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -2857,10 +2857,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "cvw" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/blocks,
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "cvy" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/trollbog,
@@ -17139,10 +17137,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
-"prO" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "prR" = (
 /obj/effect/landmark/start/artificer{
 	dir = 1
@@ -67304,7 +67298,7 @@ vqp
 spZ
 spZ
 spZ
-cvw
+spZ
 hRm
 hRm
 rzj
@@ -68090,7 +68084,7 @@ xJI
 pPS
 xJI
 jsn
-prO
+cvw
 wWa
 hRm
 pJQ

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -2857,14 +2857,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "cvw" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/garrison)
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town/roofs)
 "cvy" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/trollbog,
 /turf/open/floor/rogue/naturalstone,
@@ -2884,11 +2879,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "cwA" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town/roofs/keep)
 "cxa" = (
 /obj/structure/table/wood{
@@ -3370,6 +3361,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"cUr" = (
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "cUQ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/hexstone,
@@ -3528,9 +3523,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "daH" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/roofs/keep)
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/under/cave)
 "dba" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue/inn/hay,
@@ -5693,12 +5687,6 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"fbf" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "fbi" = (
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
@@ -6499,10 +6487,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
-"fNm" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "fNR" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -6592,6 +6576,16 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"fTh" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "vertw"
+	},
+/area/rogue/indoors/town/garrison)
 "fTF" = (
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/wool,
@@ -8157,6 +8151,9 @@
 "hsv" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
+"htg" = (
+/turf/closed/wall/mineral/rogue/wooddark/window,
+/area/rogue/outdoors/town/roofs/keep)
 "htk" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/cobble,
@@ -9432,6 +9429,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"iBT" = (
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roofg"
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "iCl" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -10361,9 +10364,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
-"jui" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/outdoors/town/roofs/keep)
 "juT" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood{
@@ -12990,8 +12990,17 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "lGq" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "vertw"
+	},
+/area/rogue/indoors/town/garrison)
 "lGI" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -13370,9 +13379,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"maS" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/under/cave)
 "mbj" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
@@ -14251,18 +14257,6 @@
 "mPD" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains)
-"mPJ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
-/area/rogue/indoors/town/garrison)
 "mPR" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/rtfield)
@@ -15678,10 +15672,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
-"obh" = (
-/obj/structure/fluff/walldeco/customflag,
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/town/roofs/keep)
 "obx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
@@ -16436,16 +16426,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
-"oHx" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
-/area/rogue/indoors/town/garrison)
 "oHy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -16545,6 +16525,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"oLx" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "oMI" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/carpet,
@@ -17201,7 +17185,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "prO" = (
-/turf/closed/wall/mineral/rogue/wooddark/window,
+/obj/structure/ladder,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/roofs/keep)
 "prR" = (
 /obj/effect/landmark/start/artificer{
@@ -18204,10 +18189,6 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement/keep)
-"qmd" = (
-/obj/structure/fluff/walldeco/customflag,
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/town/roofs)
 "qmT" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_y = 32
@@ -19099,10 +19080,6 @@
 "rcD" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement/keep)
-"rcH" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/roofs/keep)
 "rcJ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21139,6 +21116,12 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"sRJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "sRP" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 8;
@@ -22063,6 +22046,15 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"tFY" = (
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/garrison)
 "tGm" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23009,6 +23001,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"uAU" = (
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town/roofs/keep)
 "uAV" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_y = 32
@@ -24176,12 +24172,22 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"vOi" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "vPT" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
+"vPW" = (
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/outdoors/town/roofs/keep)
 "vQw" = (
 /obj/structure/lever/wall{
 	dir = 4;
@@ -43007,7 +43013,7 @@ pNQ
 pNQ
 pNQ
 pNQ
-maS
+daH
 qnd
 qnd
 exi
@@ -68160,7 +68166,7 @@ xJI
 pPS
 xJI
 jsn
-fNm
+oLx
 wWa
 hRm
 pJQ
@@ -90603,11 +90609,11 @@ qhb
 qhb
 qhb
 qhb
-qmd
+cvw
 qhb
 qhb
 qhb
-qmd
+cvw
 qhb
 qhb
 qhb
@@ -91388,11 +91394,11 @@ oUz
 aVh
 wsQ
 ebN
-mPJ
+lGq
 tyv
 wdv
-cvw
-fbf
+tFY
+sRJ
 sWd
 ifr
 dZn
@@ -91545,7 +91551,7 @@ hRm
 hGQ
 dZn
 dFN
-oHx
+fTh
 uez
 uez
 uez
@@ -91702,7 +91708,7 @@ hRm
 vYh
 dZn
 sWd
-oHx
+fTh
 uez
 uez
 uez
@@ -91859,7 +91865,7 @@ oUz
 dZn
 dZn
 weZ
-oHx
+fTh
 uez
 uez
 uez
@@ -114939,11 +114945,11 @@ qhb
 qhb
 qhb
 qhb
-obh
-prO
-jui
-prO
-obh
+uAU
+htg
+vPW
+htg
+uAU
 qhb
 qhb
 qhb
@@ -115095,13 +115101,13 @@ qhb
 qhb
 qhb
 qhb
-lGq
-lGq
+cwA
+cwA
 qwC
-daH
+cUr
 qwC
-lGq
-lGq
+cwA
+cwA
 qhb
 qhb
 qhb
@@ -115252,13 +115258,13 @@ qhb
 qhb
 qhb
 qhb
-prO
+htg
 qwC
 qwC
 qwC
 qwC
 qwC
-prO
+htg
 qhb
 qhb
 qhb
@@ -115409,13 +115415,13 @@ qhb
 qhb
 tYX
 tYX
-prO
+htg
 qwC
 qwC
 qwC
 qwC
 qwC
-prO
+htg
 tYX
 tYX
 tYX
@@ -115566,13 +115572,13 @@ qhb
 tYX
 tYX
 tYX
-lGq
-lGq
+cwA
+cwA
 qwC
-rcH
+prO
 qwC
-lGq
-lGq
+cwA
+cwA
 tYX
 tYX
 tYX
@@ -115724,11 +115730,11 @@ tYX
 tYX
 tYX
 tYX
-lGq
 cwA
-jui
+vOi
+vPW
+vOi
 cwA
-lGq
 tYX
 tYX
 tYX
@@ -115881,11 +115887,11 @@ tYX
 tYX
 tYX
 tYX
+iBT
 tYX
 tYX
 tYX
-tYX
-tYX
+iBT
 tYX
 tYX
 tYX

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -17140,7 +17140,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "prO" = (
-/obj/machinery/light/rogue/firebowl/standing,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "prR" = (
@@ -67775,8 +67775,8 @@ auX
 vQw
 jRc
 rBd
-dZn
-dZn
+jTe
+cpW
 dZn
 rzj
 qUD
@@ -67932,9 +67932,9 @@ oUz
 hRm
 hRm
 hRm
-prO
-dZn
-dZn
+hRm
+oUz
+iXt
 hRm
 qZj
 dZn
@@ -68086,11 +68086,11 @@ vvp
 xJI
 xJI
 xJI
+xJI
 pPS
 xJI
-oUz
-oUz
-dZn
+jsn
+prO
 wWa
 hRm
 pJQ
@@ -68403,9 +68403,9 @@ wfx
 qxD
 qxD
 wfx
-oUz
-oUz
-iXt
+jsn
+dZn
+dZn
 oUz
 oUz
 qZS
@@ -68561,7 +68561,7 @@ kUe
 nTw
 mnG
 jsn
-rPD
+dZn
 dZn
 dZn
 rPD

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -277,6 +277,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"agW" = (
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town/roofs/keep)
 "aha" = (
 /obj/structure/flora/roguegrass,
 /obj/machinery/light/rogue/firebowl/stump,
@@ -1232,6 +1236,13 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/church/chapel)
+"aVX" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "aWP" = (
 /obj/structure/fermenting_barrel/random/water,
 /obj/machinery/light/rogue/torchholder/l,
@@ -2857,9 +2868,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "cvw" = (
-/obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/town/roofs)
+/area/rogue/outdoors/town/roofs/keep)
 "cvy" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/trollbog,
 /turf/open/floor/rogue/naturalstone,
@@ -2879,8 +2889,15 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "cwA" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/town/roofs/keep)
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "vertw"
+	},
+/area/rogue/indoors/town/garrison)
 "cxa" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -3361,10 +3378,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"cUr" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/roofs/keep)
 "cUQ" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/hexstone,
@@ -3523,8 +3536,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "daH" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/rooftop{
+	icon_state = "roofg"
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "dba" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue/inn/hay,
@@ -6576,16 +6592,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
-"fTh" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
-/area/rogue/indoors/town/garrison)
 "fTF" = (
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/wool,
@@ -6631,6 +6637,15 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"fUz" = (
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/indoors/town/garrison)
 "fUG" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -8151,9 +8166,6 @@
 "hsv" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/magician)
-"htg" = (
-/turf/closed/wall/mineral/rogue/wooddark/window,
-/area/rogue/outdoors/town/roofs/keep)
 "htk" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/cobble,
@@ -9429,12 +9441,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"iBT" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs/keep)
 "iCl" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -11545,6 +11551,10 @@
 /obj/item/rogueweapon/mace/wsword,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"kzT" = (
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town/roofs)
 "kzW" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -11738,6 +11748,18 @@
 /obj/structure/roguewindow,
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/church/chapel)
+"kHr" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "vertw"
+	},
+/area/rogue/indoors/town/garrison)
 "kHy" = (
 /obj/machinery/light/rogue/oven/south,
 /obj/machinery/light/rogue/hearth,
@@ -12990,16 +13012,10 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "lGq" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1
-	},
 /obj/structure/fluff/railing/border{
-	dir = 6
+	dir = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "lGI" = (
 /obj/structure/table/wood{
@@ -15640,6 +15656,9 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
+"nZk" = (
+/turf/closed/wall/mineral/rogue/wooddark/window,
+/area/rogue/outdoors/town/roofs/keep)
 "nZq" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -16525,10 +16544,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
-"oLx" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "oMI" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/carpet,
@@ -17185,8 +17200,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "prO" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town/roofs/keep)
 "prR" = (
 /obj/effect/landmark/start/artificer{
@@ -17194,6 +17208,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"psd" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "psG" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/concrete,
@@ -18521,6 +18539,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"qCI" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "qDm" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -21018,6 +21040,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"sMa" = (
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "sMc" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
@@ -21116,12 +21142,6 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
-"sRJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
 "sRP" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 8;
@@ -21253,6 +21273,9 @@
 /obj/structure/flora/newbranch/leafless,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
+"sXK" = (
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/under/cave)
 "sXN" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -22046,15 +22069,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"tFY" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "cobbleedge-sread"
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/indoors/town/garrison)
 "tGm" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -23001,10 +23015,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"uAU" = (
-/obj/structure/fluff/walldeco/customflag,
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/town/roofs/keep)
 "uAV" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_y = 32
@@ -24172,22 +24182,12 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"vOi" = (
-/obj/structure/mineral_door/wood{
-	locked = 1;
-	lockid = "garrison"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/roofs/keep)
 "vPT" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
-"vPW" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/outdoors/town/roofs/keep)
 "vQw" = (
 /obj/structure/lever/wall{
 	dir = 4;
@@ -43013,7 +43013,7 @@ pNQ
 pNQ
 pNQ
 pNQ
-daH
+sXK
 qnd
 qnd
 exi
@@ -68166,7 +68166,7 @@ xJI
 pPS
 xJI
 jsn
-oLx
+psd
 wWa
 hRm
 pJQ
@@ -90609,11 +90609,11 @@ qhb
 qhb
 qhb
 qhb
-cvw
+kzT
 qhb
 qhb
 qhb
-cvw
+kzT
 qhb
 qhb
 qhb
@@ -91394,11 +91394,11 @@ oUz
 aVh
 wsQ
 ebN
-lGq
+kHr
 tyv
 wdv
-tFY
-sRJ
+fUz
+lGq
 sWd
 ifr
 dZn
@@ -91551,7 +91551,7 @@ hRm
 hGQ
 dZn
 dFN
-fTh
+cwA
 uez
 uez
 uez
@@ -91708,7 +91708,7 @@ hRm
 vYh
 dZn
 sWd
-fTh
+cwA
 uez
 uez
 uez
@@ -91865,7 +91865,7 @@ oUz
 dZn
 dZn
 weZ
-fTh
+cwA
 uez
 uez
 uez
@@ -114945,11 +114945,11 @@ qhb
 qhb
 qhb
 qhb
-uAU
-htg
-vPW
-htg
-uAU
+agW
+nZk
+prO
+nZk
+agW
 qhb
 qhb
 qhb
@@ -115101,13 +115101,13 @@ qhb
 qhb
 qhb
 qhb
-cwA
-cwA
+cvw
+cvw
 qwC
-cUr
+sMa
 qwC
-cwA
-cwA
+cvw
+cvw
 qhb
 qhb
 qhb
@@ -115258,13 +115258,13 @@ qhb
 qhb
 qhb
 qhb
-htg
+nZk
 qwC
 qwC
 qwC
 qwC
 qwC
-htg
+nZk
 qhb
 qhb
 qhb
@@ -115415,13 +115415,13 @@ qhb
 qhb
 tYX
 tYX
-htg
+nZk
 qwC
 qwC
 qwC
 qwC
 qwC
-htg
+nZk
 tYX
 tYX
 tYX
@@ -115572,13 +115572,13 @@ qhb
 tYX
 tYX
 tYX
-cwA
-cwA
+cvw
+cvw
 qwC
-prO
+qCI
 qwC
-cwA
-cwA
+cvw
+cvw
 tYX
 tYX
 tYX
@@ -115730,11 +115730,11 @@ tYX
 tYX
 tYX
 tYX
-cwA
-vOi
-vPW
-vOi
-cwA
+cvw
+aVX
+prO
+aVX
+cvw
 tYX
 tYX
 tYX
@@ -115887,11 +115887,11 @@ tYX
 tYX
 tYX
 tYX
-iBT
+daH
 tYX
 tYX
 tYX
-iBT
+daH
 tYX
 tYX
 tYX
@@ -116337,7 +116337,7 @@ wfx
 dZn
 dZn
 dZn
-wfx
+iXt
 tYX
 tYX
 tYX
@@ -116384,7 +116384,7 @@ tYX
 tYX
 tYX
 tYX
-wfx
+iXt
 dZn
 dZn
 cnf

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -4341,6 +4341,12 @@
 "dKO" = (
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/cave)
+"dLb" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/rogue/bread,
+/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/garrison)
 "dLv" = (
 /obj/item/chair/rogue,
 /turf/open/floor/rogue/concrete,
@@ -6897,7 +6903,7 @@
 	dir = 4;
 	lockid = "garrison"
 	},
-/turf/open/floor/rogue/blocks,
+/turf/closed,
 /area/rogue/indoors/town/cell)
 "gii" = (
 /obj/structure/fluff/railing/border{
@@ -8093,12 +8099,11 @@
 	},
 /area/rogue/indoors/town/manor)
 "hpA" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "hpC" = (
@@ -12087,11 +12092,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "kSx" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
 /obj/structure/table/wood{
-	dir = 6;
+	dir = 4;
 	icon_state = "largetable"
 	},
-/obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "kSP" = (
@@ -14421,8 +14429,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/shop)
 "mXZ" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/food/snacks/rogue/bread,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "mZc" = (
@@ -17863,11 +17874,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "pSu" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
-	},
-/obj/structure/fluff/millstone,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "pTw" = (
@@ -19944,11 +19955,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "rQG" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
+/obj/machinery/light/rogue/hearth,
+/obj/item/cooking/pan,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "rQI" = (
@@ -22733,11 +22741,22 @@
 	},
 /area/rogue/indoors/town)
 "unf" = (
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 6
+	},
 /obj/structure/table/wood{
 	dir = 5;
 	icon_state = "largetable"
 	},
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/natural/feather,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "ung" = (
@@ -22768,8 +22787,18 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
 "upc" = (
-/obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-w"
+	},
+/obj/effect/decal/cobbleedge{
+	dir = 5
+	},
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/book/rogue/law,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "upZ" = (
@@ -69589,9 +69618,9 @@ sRc
 uez
 lpp
 ntT
-lpp
 ghS
 lpp
+ntT
 oUb
 hef
 hef
@@ -69895,7 +69924,7 @@ mDF
 jsn
 hpA
 wJI
-spZ
+dLb
 wfx
 spZ
 dZn

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -1257,6 +1257,11 @@
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/obj/item/book/rogue/law,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "aXA" = (
@@ -1976,19 +1981,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
-"bDW" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_y = 5
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
 "bEq" = (
 /obj/item/roguekey/farm,
 /obj/item/roguekey/farm,
@@ -2864,7 +2856,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "cvw" = (
-/obj/structure/fermenting_barrel/water,
+/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cvy" = (
@@ -6918,14 +6913,18 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "gjG" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
 /obj/structure/mineral_door/wood/deadbolt/shutter{
 	dir = 2;
 	lockdir = 1;
 	name = "counter hatch"
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
@@ -14657,6 +14656,7 @@
 /obj/structure/bars/grille{
 	density = 1
 	},
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "njH" = (
@@ -17156,7 +17156,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "prO" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "prR" = (
@@ -24300,10 +24300,10 @@
 	icon_state = "cobbleedge-w"
 	},
 /obj/structure/table/wood{
-	dir = 6;
+	dir = 4;
 	icon_state = "largetable"
 	},
-/obj/item/book/rogue/law,
+/obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "vZe" = (
@@ -25197,11 +25197,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
-/obj/structure/bars/grille{
-	density = 1
-	},
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/cobblerock,
+/turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/garrison)
 "wLy" = (
 /obj/structure/closet/crate/roguecloset,
@@ -25514,6 +25510,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"wWa" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "wWu" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /obj/item/roguecoin/gold/pile,
@@ -26417,12 +26419,6 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
-"xIE" = (
-/obj/structure/bars/grille{
-	density = 1
-	},
-/turf/closed,
-/area/rogue/indoors/town/garrison)
 "xIK" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -26718,9 +26714,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "xRO" = (
-/obj/machinery/light/rogue/firebowl/stump,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/obj/structure/bars/grille,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/town/garrison)
 "xSg" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -67004,7 +67000,7 @@ pkG
 sjW
 hRm
 vqp
-xIE
+vqp
 vqp
 oUz
 oUz
@@ -67163,7 +67159,7 @@ wLs
 wzd
 vYw
 aXp
-bDW
+oUz
 oUz
 ctF
 ctF
@@ -67473,7 +67469,7 @@ hRm
 hhg
 mVa
 uEp
-njf
+xRO
 spZ
 spZ
 spZ
@@ -67636,7 +67632,7 @@ oTI
 spZ
 nXi
 oBq
-dZn
+prO
 rzj
 haW
 goh
@@ -67791,7 +67787,7 @@ auX
 vQw
 jRc
 rBd
-jTe
+dZn
 dZn
 dZn
 rzj
@@ -67948,7 +67944,7 @@ oUz
 hRm
 hRm
 hRm
-oUz
+mjI
 dZn
 dZn
 hRm
@@ -68101,13 +68097,13 @@ gFH
 vvp
 xJI
 xJI
+xJI
 pPS
 xJI
-xJI
-xRO
 hRm
-prO
+hRm
 dZn
+wWa
 hRm
 pJQ
 dZn
@@ -68420,7 +68416,7 @@ qxD
 qxD
 wfx
 jsn
-oUz
+jsn
 iXt
 oUz
 oUz

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -377,7 +377,7 @@
 "alh" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "garrison"
+	lockid = "armory"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -427,10 +427,6 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
 "amw" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
 /obj/item/roguekey/walls,
 /obj/item/roguekey/manor,
 /obj/item/roguekey/manor,
@@ -438,6 +434,11 @@
 /obj/item/storage/keyring,
 /obj/item/storage/keyring,
 /obj/item/roguekey/manor,
+/obj/structure/closet/crate/roguecloset/dark{
+	lockid = "garrison";
+	locked = 1;
+	keylock = 1
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -638,15 +639,11 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
 "auX" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+/obj/structure/bars/grille{
+	density = 1
 	},
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/obj/item/natural/cloth,
-/turf/open/floor/rogue/tile,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "avT" = (
 /obj/structure/roguewindow/openclose,
@@ -1260,7 +1257,6 @@
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
-/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "aXA" = (
@@ -1939,6 +1935,13 @@
 "bCv" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town)
+"bCC" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "bCE" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -1974,18 +1977,14 @@
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/tavern)
 "bDW" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = -32
+	},
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = -32
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks,
@@ -2050,9 +2049,11 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "bHt" = (
-/obj/structure/fluff/statue/knight,
+/obj/structure/roguewindow/openclose/reinforced{
+	dir = 1
+	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
+/area/rogue/indoors/town/garrison)
 "bHA" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
@@ -2072,7 +2073,7 @@
 	},
 /obj/structure/mineral_door/bars{
 	locked = 1;
-	lockid = "garrison"
+	lockid = "armory"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
@@ -2358,6 +2359,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"bVH" = (
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/obj/item/natural/cloth,
+/obj/structure/table/wood,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/garrison)
 "bVY" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/purple,
@@ -2469,13 +2478,8 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
 "cba" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cbd" = (
 /obj/structure/table/wood{
@@ -2860,13 +2864,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "cvw" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/fermenting_barrel/water,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cvy" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/trollbog,
@@ -2889,6 +2888,16 @@
 "cwA" = (
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
+/area/rogue/indoors/town/garrison)
+"cxa" = (
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cxb" = (
 /turf/open/floor/rogue/grass,
@@ -3000,15 +3009,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
-/obj/structure/lever/wall{
-	dir = 4;
-	icon_state = "leverwall1";
-	name = "inner passage lever";
-	pixel_x = 6;
-	pixel_y = -9;
-	redstone_id = "keepgate_inner";
-	toggled = 1
-	},
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cBU" = (
@@ -4587,11 +4588,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "dWJ" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/obj/item/roguekey/manor,
-/turf/open/floor/rogue/tile,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "dXO" = (
 /obj/structure/closet/crate/chest/neu_fancy,
@@ -4711,12 +4711,9 @@
 /area/rogue/outdoors/town)
 "edu" = (
 /obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "eev" = (
 /obj/structure/table/wood{
@@ -4803,7 +4800,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "ein" = (
-/turf/closed/wall/mineral/rogue/wooddark/end,
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "eip" = (
 /obj/structure/table/wood{
@@ -4844,7 +4845,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "ekh" = (
-/obj/structure/roguewindow/openclose{
+/obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -5204,8 +5205,7 @@
 	dir = 8
 	},
 /obj/structure/fluff/railing/border{
-	dir = 9;
-	pixel_y = -22
+	dir = 9
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
@@ -5566,9 +5566,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "eUY" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/food/snacks/rogue/bread,
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "eVd" = (
@@ -6482,9 +6485,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "fME" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
-	},
+/obj/structure/fermenting_barrel/water,
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "fNg" = (
@@ -6559,6 +6561,10 @@
 "fQW" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/dwarfin)
+"fRl" = (
+/obj/structure/fluff/dryingrack,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "fRr" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield)
@@ -6724,10 +6730,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "gbh" = (
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/garrison)
 "gbn" = (
 /turf/open/transparent/openspace,
@@ -6912,10 +6918,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "gjG" = (
-/obj/structure/bars/grille{
-	density = 1
+/obj/structure/mineral_door/wood/deadbolt/shutter{
+	dir = 2;
+	lockdir = 1;
+	name = "counter hatch"
 	},
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "gjH" = (
@@ -7383,7 +7394,6 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "gJP" = (
-/obj/structure/closet/crate/chest/neu,
 /obj/item/roguekey/walls,
 /obj/item/roguekey/walls,
 /obj/item/roguekey/garrison,
@@ -7392,6 +7402,11 @@
 /obj/item/storage/keyring,
 /obj/item/storage/keyring,
 /obj/item/roguekey/manor,
+/obj/structure/closet/crate/roguecloset/dark{
+	lockid = "garrison";
+	locked = 1;
+	keylock = 1
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -8071,12 +8086,13 @@
 	},
 /area/rogue/indoors/town/manor)
 "hpA" = (
-/obj/item/book/rogue/law,
-/obj/structure/bed/rogue,
-/obj/effect/landmark/start/manorguardsman,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/closet/crate/roguecloset,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "hpC" = (
 /turf/closed/wall/mineral/rogue/pipe,
@@ -8498,6 +8514,13 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"hIZ" = (
+/obj/structure/mirror{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/garrison)
 "hJn" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -8721,10 +8744,11 @@
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
 "hWO" = (
-/obj/structure/roguemachine/scomm{
-	pixel_y = -32
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 5
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "hWZ" = (
 /obj/structure/chair/wood/rogue{
@@ -9408,13 +9432,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "iCl" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "iCU" = (
 /obj/structure/fluff/railing/border{
@@ -10207,6 +10228,7 @@
 	lockid = "steward"
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
+/obj/item/roguekey/armory,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "jnF" = (
@@ -10338,16 +10360,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "juT" = (
+/obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/garrison)
 "jvd" = (
 /turf/open/transparent/openspace,
@@ -10440,8 +10456,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "jBR" = (
-/obj/structure/mineral_door/wood{
-	lockid = "garrison"
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 8
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -10509,6 +10525,7 @@
 /area/rogue/indoors/town/church)
 "jGs" = (
 /obj/structure/closet/crate/chest,
+/obj/item/rope/chain,
 /obj/item/rope/chain,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -10762,6 +10779,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"jRc" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "outer passage lever";
+	pixel_x = 6;
+	redstone_id = "keepgate_outer"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "jRf" = (
 /obj/structure/bed/rogue/shit{
 	name = "makeshift bed"
@@ -12032,7 +12058,7 @@
 /area/rogue/indoors/town/bath)
 "kSx" = (
 /obj/structure/table/wood{
-	dir = 5;
+	dir = 6;
 	icon_state = "largetable"
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
@@ -13314,14 +13340,9 @@
 "lZW" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/table/wood{
-	dir = 10;
-	icon_state = "tablewood2"
+	icon_state = "longtable"
 	},
-/obj/structure/fluff/millstone{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/cup,
-/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/book/rogue/law,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "mag" = (
@@ -14265,10 +14286,6 @@
 /area/rogue/under/town/basement)
 "mTX" = (
 /obj/machinery/light/rogue/torchholder/l,
-/obj/effect/landmark/start/squire{
-	dir = 4
-	},
-/obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -14373,10 +14390,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/shop)
 "mXZ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/rogue/bread,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "mZc" = (
 /obj/structure/roguemachine/scomm/r,
@@ -14702,13 +14718,18 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/rtfield)
 "nlw" = (
-/obj/structure/closet/crate/roguecloset,
 /obj/item/roguekey/dungeon,
 /obj/item/roguekey/walls,
 /obj/item/roguekey/manor,
 /obj/item/storage/backpack/rogue/satchel,
 /obj/item/storage/keyring,
 /obj/item/clothing/suit/roguetown/armor/brigandine,
+/obj/item/roguekey/armory,
+/obj/structure/closet/crate/roguecloset/dark{
+	lockid = "sheriff";
+	locked = 1;
+	keylock = 1
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "nlJ" = (
@@ -15039,8 +15060,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "nBk" = (
-/obj/structure/fermenting_barrel/water,
-/turf/open/floor/rogue/cobble,
+/obj/structure/table/wood{
+	dir = 6;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "nBF" = (
 /obj/effect/landmark/events/haunts,
@@ -15497,7 +15521,7 @@
 	},
 /area/rogue/indoors/town)
 "nUn" = (
-/obj/structure/roguewindow/openclose{
+/obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
 	},
 /turf/open/floor/rogue/wood,
@@ -15561,7 +15585,6 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "nXi" = (
-/obj/structure/roguemachine/scomm/r,
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
@@ -16394,8 +16417,13 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "oHQ" = (
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/blocks,
+/obj/structure/bed/rogue,
+/obj/effect/landmark/start/squire{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/garrison)
 "oId" = (
 /obj/structure/closet/crate/roguecloset,
@@ -16639,12 +16667,6 @@
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
-/obj/structure/lever/wall{
-	dir = 4;
-	name = "outer passage lever";
-	pixel_x = 6;
-	redstone_id = "keepgate_outer"
-	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "oUb" = (
@@ -16805,12 +16827,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pbB" = (
-/obj/structure/table/wood{
-	dir = 4;
-	icon_state = "largetable"
-	},
 /obj/item/roguekey/garrison,
 /obj/item/storage/keyring,
+/obj/item/roguekey/garrison,
+/obj/structure/closet/crate/roguecloset/dark{
+	lockid = "garrison";
+	locked = 1;
+	keylock = 1
+	},
+/obj/item/roguekey/garrison,
+/obj/item/roguekey/garrison,
 /obj/item/roguekey/garrison,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -17404,6 +17430,17 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs/keep)
+"pGm" = (
+/obj/structure/table/wood{
+	icon_state = "largetable";
+	dir = 9
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/garrison)
 "pGp" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -17778,8 +17815,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
 "pSu" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/blocks,
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "tablewood2"
+	},
+/obj/structure/fluff/millstone,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "pTw" = (
 /obj/structure/chair/wood/rogue{
@@ -18915,7 +18956,8 @@
 "qZS" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
-	lockid = "garrison"
+	lockid = "garrison";
+	locked = 1
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -19431,6 +19473,9 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/structure/bars/passage{
+	redstone_id = "keepgate_inner"
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "rxw" = (
@@ -19470,6 +19515,18 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"rzN" = (
+/obj/item/clothing/cloak/stabard,
+/obj/item/clothing/cloak/stabard,
+/obj/item/rope/chain,
+/obj/structure/closet/crate/chest/neu{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/garrison)
 "rAA" = (
 /obj/structure/stairs{
 	dir = 8
@@ -19835,12 +19892,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "rQG" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/book/rogue/law,
-/turf/open/floor/rogue/cobble,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "rQI" = (
 /obj/effect/decal/cobbleedge{
@@ -20750,6 +20807,13 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/magician)
+"sDG" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "armory"
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/basement/keep)
 "sDO" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -21015,10 +21079,8 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "sRc" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "sRz" = (
 /obj/structure/flora/roguegrass/bush,
@@ -21264,6 +21326,15 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/church/chapel)
+"tdU" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/bars/passage{
+	redstone_id = "keepgate_inner"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/exposed/town/keep)
 "tei" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/fluff/railing/border{
@@ -21328,7 +21399,8 @@
 /area/rogue/indoors/town/physician)
 "tfY" = (
 /obj/structure/mineral_door/wood{
-	lockid = "garrison"
+	lockid = "armory";
+	locked = 1
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -21821,7 +21893,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
 "tBo" = (
-/obj/effect/decal/cobbleedge,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "tBr" = (
@@ -22450,7 +22522,7 @@
 "ugy" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
-	lockid = "garrison"
+	lockid = "armory"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
@@ -22601,11 +22673,12 @@
 	},
 /area/rogue/indoors/town)
 "unf" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/blocks,
+/obj/structure/table/wood{
+	dir = 5;
+	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/food/snacks/rogue/meat/salami,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "ung" = (
 /obj/structure/bookcase,
@@ -23937,12 +24010,15 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
 "vIC" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
 /obj/item/flashlight/flare/torch/metal,
 /obj/item/flashlight/flare/torch/metal,
-/turf/open/floor/rogue/blocks,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "vIQ" = (
 /obj/structure/stairs{
@@ -24055,11 +24131,17 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor)
 "vQw" = (
-/obj/structure/bars/passage{
-	redstone_id = "keepgate_inner"
+/obj/structure/lever/wall{
+	dir = 4;
+	icon_state = "leverwall1";
+	name = "inner passage lever";
+	pixel_x = 6;
+	pixel_y = -9;
+	redstone_id = "keepgate_inner";
+	toggled = 1
 	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/exposed/town/keep)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "vQA" = (
 /obj/machinery/light/rogue/campfire/densefire{
 	fueluse = 1.8e+06
@@ -24108,13 +24190,10 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "vUi" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/clothing/cloak/stabard,
-/obj/item/clothing/cloak/stabard,
-/obj/item/rope/chain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "vVs" = (
 /obj/structure/fluff/railing/border,
@@ -24163,11 +24242,11 @@
 /area/rogue/indoors/town)
 "vWP" = (
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+	dir = 10;
+	icon_state = "tablewood2"
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "vWW" = (
@@ -24631,10 +24710,6 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "wsf" = (
-/obj/structure/mirror{
-	pixel_x = -32;
-	pixel_y = 0
-	},
 /obj/structure/table/wood{
 	dir = 10;
 	icon_state = "tablewood2"
@@ -24659,7 +24734,7 @@
 /area/rogue/indoors/town/tavern)
 "wsA" = (
 /obj/machinery/light/rogue/torchholder/r,
-/obj/structure/closet/crate/roguecloset,
+/obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "wsQ" = (
@@ -24706,11 +24781,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "wuO" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/turf/open/floor/rogue/cobble,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "wvc" = (
 /obj/structure/fluff/railing/border,
@@ -25122,6 +25200,7 @@
 /obj/structure/bars/grille{
 	density = 1
 	},
+/obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/garrison)
 "wLy" = (
@@ -25294,7 +25373,8 @@
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
 	locked = 1;
-	lockid = "garrison"
+	lockid = "garrison";
+	name = "barracks"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -25415,13 +25495,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "wVx" = (
-/obj/structure/mineral_door/wood/window{
-	locked = 1;
-	lockid = "dungeon";
-	name = "dungeoneer's room door"
+/obj/structure/bars/passage{
+	redstone_id = "keepgate_inner"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/exposed/town/keep)
 "wVz" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/royalblack,
@@ -25436,10 +25514,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
-"wWa" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/garrison)
 "wWu" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /obj/item/roguecoin/gold/pile,
@@ -25495,16 +25569,13 @@
 	},
 /area/rogue/under/town/basement)
 "wZH" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
+/obj/structure/mineral_door/wood{
+	icon_state = "wcr";
+	locked = 1;
+	lockid = "dungeon";
+	name = "dungeoneer's room"
 	},
-/obj/structure/mineral_door/wood/deadbolt/shutter{
-	dir = 2;
-	lockdir = 1;
-	name = "counter hatch"
-	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "wZK" = (
 /obj/structure/stairs,
@@ -25585,13 +25656,10 @@
 	},
 /area/rogue/indoors/town/magician)
 "xcM" = (
-/obj/effect/landmark/start/squire{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/obj/structure/bed/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "xcU" = (
 /obj/structure/table/wood{
@@ -26229,6 +26297,17 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"xDn" = (
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/structure/table/wood{
+	dir = 10;
+	icon_state = "largetable"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/garrison)
 "xDC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -26338,6 +26417,12 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
+"xIE" = (
+/obj/structure/bars/grille{
+	density = 1
+	},
+/turf/closed,
+/area/rogue/indoors/town/garrison)
 "xIK" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
@@ -45254,7 +45339,7 @@ xsI
 heh
 cVE
 cVE
-leX
+sDG
 fvy
 iuO
 rzM
@@ -66919,7 +67004,7 @@ pkG
 sjW
 hRm
 vqp
-vqp
+xIE
 vqp
 oUz
 oUz
@@ -67232,10 +67317,10 @@ xtL
 uTA
 pkG
 njf
-jPT
 spZ
 spZ
 spZ
+cvw
 hRm
 hRm
 rzj
@@ -67388,7 +67473,7 @@ hRm
 hhg
 mVa
 uEp
-wZH
+njf
 spZ
 spZ
 spZ
@@ -67548,10 +67633,10 @@ vvp
 gjG
 cBC
 oTI
-rBd
+spZ
 nXi
 oBq
-nBk
+dZn
 rzj
 haW
 goh
@@ -67699,16 +67784,16 @@ jCV
 lnv
 dGX
 oUz
+pkG
+pkG
+pkG
+auX
 vQw
-vQw
-vQw
-oUz
-hRm
-hRm
-hRm
-oUz
-iXt
-oUz
+jRc
+rBd
+jTe
+dZn
+dZn
 rzj
 qUD
 qUD
@@ -67856,16 +67941,16 @@ oUz
 dGX
 dGX
 oUz
-sDT
+tdU
 rxe
-xJI
+wVx
 oUz
-bHt
+hRm
 hRm
 hRm
 oUz
 dZn
-rPD
+dZn
 hRm
 qZj
 dZn
@@ -68020,8 +68105,8 @@ pPS
 xJI
 xJI
 xRO
-oUz
-dZn
+hRm
+prO
 dZn
 hRm
 pJQ
@@ -68335,8 +68420,8 @@ qxD
 qxD
 wfx
 jsn
-dZn
-hWO
+oUz
+iXt
 oUz
 oUz
 qZS
@@ -68492,13 +68577,13 @@ kUe
 nTw
 mnG
 jsn
+rPD
 dZn
 dZn
-wfx
+rPD
 dZn
-dZn
-wWa
-oHQ
+spZ
+spZ
 fME
 lpp
 tte
@@ -68649,13 +68734,13 @@ sMc
 sMc
 sMc
 jsn
-dZn
-dZn
-iXt
-dZn
+iCl
+jPT
+jPT
+jPT
 dZn
 spZ
-oHQ
+spZ
 vWP
 gRI
 jDN
@@ -68806,10 +68891,10 @@ sMc
 oHy
 iAu
 jsn
-ett
-mjI
-bqd
-dZn
+mgE
+pGm
+ein
+xDn
 dZn
 dZn
 spZ
@@ -68963,9 +69048,9 @@ kni
 iYk
 vbj
 jsn
-wMD
-wMD
-wfx
+idl
+hWO
+cxa
 nBk
 dZn
 dZn
@@ -69121,9 +69206,9 @@ qxD
 wfx
 jsn
 iCl
-spZ
-ein
-wfx
+jPT
+jPT
+jPT
 dZn
 dZn
 dZn
@@ -69277,14 +69362,14 @@ kni
 lpX
 vbj
 jsn
-vIC
-spZ
-spZ
-bqd
-mgE
+mjI
 dZn
 dZn
-cba
+dZn
+dZn
+dZn
+sRc
+xrN
 gRI
 dWx
 dWx
@@ -69434,14 +69519,14 @@ sMc
 ggH
 tjy
 jsn
-unf
-spZ
-spZ
 wfx
-idl
+wuO
+wuO
+wfx
+tBo
 dZn
-dZn
-edu
+sRc
+uez
 lpp
 ntT
 lpp
@@ -69591,19 +69676,19 @@ sMc
 sMc
 sMc
 jsn
-jsn
-wMS
+rQG
 spZ
-iXt
+spZ
+ixN
+spZ
+dZn
+dWJ
+xcM
+vUi
 dZn
 dZn
 dZn
-dZn
-dZn
-dZn
-dZn
-dZn
-dZn
+wMS
 jsn
 hef
 pkG
@@ -69748,18 +69833,18 @@ kUe
 mxz
 mDF
 jsn
-jsn
-jsn
+hpA
 wJI
+spZ
 wfx
-prO
+spZ
 dZn
-dZn
-dZn
-dZn
-dZn
-dZn
-dZn
+spZ
+cba
+spZ
+spZ
+spZ
+spZ
 hRm
 hRm
 pkG
@@ -91571,7 +91656,7 @@ hJq
 sWd
 dWu
 dZn
-dZn
+hRm
 hRm
 oUz
 ybe
@@ -91728,11 +91813,11 @@ kCo
 sWd
 dZn
 dZn
-dZn
+hRm
 cBd
 uxX
-tBo
-oUz
+spZ
+spZ
 spZ
 spZ
 spZ
@@ -91741,7 +91826,7 @@ spZ
 spZ
 spZ
 spZ
-spZ
+oJE
 spZ
 spZ
 spZ
@@ -91885,10 +91970,6 @@ njH
 weZ
 bqq
 cpW
-dZn
-dZn
-dZn
-mXZ
 iXt
 spZ
 spZ
@@ -91899,7 +91980,11 @@ spZ
 spZ
 spZ
 spZ
-pSu
+spZ
+spZ
+spZ
+spZ
+spZ
 spZ
 spZ
 spZ
@@ -92199,12 +92284,12 @@ tYX
 tYX
 hRm
 jsn
-jsn
-oUz
-pZU
-csj
+bqd
+rzN
+oHQ
+oHQ
 mTX
-xcM
+csj
 jiX
 dZn
 meT
@@ -92356,12 +92441,12 @@ hCZ
 tYX
 tYX
 jsn
-juT
+bqd
 gbh
+vSF
+vSF
+vSF
 bWd
-vSF
-vSF
-vSF
 bqd
 dZn
 dZn
@@ -92513,12 +92598,12 @@ hCZ
 tYX
 tYX
 jsn
-wMD
-wfx
 bqd
-bqd
-vUi
+gJP
+oHQ
+oHQ
 vSF
+pZU
 wfx
 dZn
 dZn
@@ -92670,11 +92755,11 @@ tYX
 tYX
 tYX
 jsn
-xOg
-sRc
-oSV
-bqd
-gJP
+wfx
+wMD
+wMD
+wfx
+vSF
 vSF
 wuw
 dZn
@@ -92827,9 +92912,9 @@ tYX
 tYX
 tYX
 jsn
-wMD
-wfx
-ocH
+bqd
+xOg
+oSV
 wfx
 wMD
 wMD
@@ -92984,8 +93069,8 @@ tYX
 tYX
 tYX
 jsn
-dWJ
-oSV
+bqd
+ocH
 oSV
 bqd
 lZW
@@ -93141,20 +93226,20 @@ tYX
 tYX
 tYX
 jsn
-auX
-oSV
+bqd
+bVH
 oSV
 bqd
-upc
+vIC
 spZ
 llR
 cpW
-cvw
+xrN
 dZn
 dZn
-nBk
+unf
 kSx
-rQG
+upc
 jsn
 tYX
 hCZ
@@ -93306,13 +93391,13 @@ wMD
 wMD
 wfx
 ett
-cwA
+uez
+edu
 dZn
 dZn
 dZn
 dZn
-wuO
-jsn
+bHt
 tYX
 hCZ
 hCZ
@@ -93463,13 +93548,13 @@ gkl
 amw
 pbB
 wfx
-cwA
+uez
+edu
 dZn
-dZn
-dZn
-dZn
-dZn
-nUn
+mXZ
+fRl
+pSu
+jsn
 tYX
 hCZ
 hCZ
@@ -93613,18 +93698,18 @@ tYX
 tYX
 tYX
 jsn
-jGs
+juT
 vSF
 vSF
 vSF
 vSF
-jGs
+vSF
 ett
 wfx
-dZn
+bCC
 dZn
 wfx
-wVx
+wMD
 wfx
 jsn
 tYX
@@ -93780,8 +93865,8 @@ vSF
 wQS
 dZn
 dZn
-bqd
-oSV
+wZH
+hIZ
 wsf
 jsn
 tYX
@@ -94086,7 +94171,7 @@ tYX
 tYX
 hRm
 jGs
-hpA
+nrC
 jGs
 nrC
 jGs

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -2857,8 +2857,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "cvw" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/cobble,
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "cvy" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/trollbog,
@@ -2879,9 +2884,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "cwA" = (
-/obj/structure/fluff/railing/border,
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/garrison)
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "garrison"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "cxa" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -3077,7 +3085,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement)
 "cEg" = (
-/turf/closed/wall/mineral/rogue/stone,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/dirt/ambush,
 /area/rogue/outdoors/town)
 "cEi" = (
 /obj/structure/fluff/railing/border{
@@ -3519,11 +3528,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "daH" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/garrison)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "dba" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bed/rogue/inn/hay,
@@ -5686,6 +5693,12 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"fbf" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "fbi" = (
 /obj/machinery/light/rogue/torchholder/l{
 	dir = 8
@@ -6486,6 +6499,10 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"fNm" = (
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/garrison)
 "fNR" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -8234,7 +8251,7 @@
 /area/rogue/indoors/town/church)
 "hxo" = (
 /obj/structure/fluff/walldeco/customflag,
-/turf/closed/wall/mineral/rogue/stone/moss,
+/turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
 "hxq" = (
 /obj/effect/decal/cleanable/blood,
@@ -8511,6 +8528,9 @@
 "hJq" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "hJr" = (
@@ -9936,6 +9956,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-w"
 	},
+/obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "jaW" = (
@@ -10340,6 +10361,9 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
+"jui" = (
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/outdoors/town/roofs/keep)
 "juT" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood{
@@ -11574,6 +11598,9 @@
 /obj/structure/rack/rogue,
 /obj/item/quiver/arrows,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "kCr" = (
@@ -12963,10 +12990,8 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "lGq" = (
-/obj/structure/closet/crate/chest/neu_iron,
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/garrison)
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town/roofs/keep)
 "lGI" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -13345,6 +13370,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"maS" = (
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/under/cave)
 "mbj" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
@@ -14223,6 +14251,18 @@
 "mPD" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains)
+"mPJ" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "vertw"
+	},
+/area/rogue/indoors/town/garrison)
 "mPR" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/rtfield)
@@ -14645,6 +14685,9 @@
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/rack/rogue,
 /obj/item/quiver/arrows,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "njK" = (
@@ -14805,6 +14848,9 @@
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
+	},
+/obj/effect/decal/cobbleedge{
+	icon_state = "cobbleedge-sread"
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
@@ -15632,6 +15678,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"obh" = (
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town/roofs/keep)
 "obx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
@@ -16386,6 +16436,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"oHx" = (
+/obj/effect/decal/cobbleedge{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/ruinedwood{
+	dir = 1;
+	icon_state = "vertw"
+	},
+/area/rogue/indoors/town/garrison)
 "oHy" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -16839,6 +16899,9 @@
 "pdx" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rope/chain,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "pdC" = (
@@ -17137,6 +17200,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"prO" = (
+/turf/closed/wall/mineral/rogue/wooddark/window,
+/area/rogue/outdoors/town/roofs/keep)
 "prR" = (
 /obj/effect/landmark/start/artificer{
 	dir = 1
@@ -17543,6 +17609,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
+/obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "vertw"
@@ -18137,6 +18204,10 @@
 	icon_state = "greenstone"
 	},
 /area/rogue/under/town/basement/keep)
+"qmd" = (
+/obj/structure/fluff/walldeco/customflag,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town/roofs)
 "qmT" = (
 /obj/structure/fluff/walldeco/painting/seraphina{
 	pixel_y = 32
@@ -19028,6 +19099,10 @@
 "rcD" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement/keep)
+"rcH" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/roofs/keep)
 "rcJ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21818,13 +21893,14 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "tyv" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
 /obj/structure/fluff/railing/border{
-	dir = 1
+	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "tyJ" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -24332,9 +24408,9 @@
 /area/rogue/under/town/basement)
 "wdv" = (
 /obj/structure/fluff/railing/border{
-	dir = 8
+	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "wdX" = (
 /obj/structure/fluff/railing/border,
@@ -42303,7 +42379,7 @@ qOY
 qOY
 pNQ
 pNQ
-pNQ
+qnd
 qnd
 qnd
 qnd
@@ -42460,8 +42536,8 @@ qOY
 qOY
 qOY
 qOY
-pNQ
 qnd
+exi
 exi
 exi
 exi
@@ -42615,10 +42691,10 @@ hWI
 qOY
 qOY
 pNQ
-pNQ
 qOY
 qOY
 qnd
+exi
 exi
 exi
 txp
@@ -42773,9 +42849,9 @@ qOY
 pNQ
 pNQ
 pNQ
-pNQ
 qOY
 qOY
+exi
 exi
 exi
 exi
@@ -42931,7 +43007,7 @@ pNQ
 pNQ
 pNQ
 pNQ
-pNQ
+maS
 qnd
 qnd
 exi
@@ -65697,7 +65773,7 @@ ptN
 hmF
 oyZ
 waT
-cEg
+wze
 xAg
 xAg
 cxb
@@ -65854,7 +65930,7 @@ oLw
 bPQ
 mKF
 doE
-cEg
+wze
 cxb
 cjQ
 cjQ
@@ -66638,10 +66714,10 @@ bUe
 dby
 doE
 cxb
-waT
-oyZ
-waT
-lbV
+cxb
+wze
+tVC
+jQH
 hvn
 hvn
 hvn
@@ -66689,9 +66765,9 @@ hvn
 lbV
 jQH
 tVC
-waT
-oyZ
-waT
+tVC
+wze
+cxb
 uHq
 hvn
 hvn
@@ -66795,9 +66871,9 @@ lAt
 fNR
 doE
 cxb
-doE
-bKO
-doE
+cxb
+wze
+tVC
 ctF
 ctF
 ctF
@@ -66846,9 +66922,9 @@ ctF
 ctF
 ctF
 ctF
-doE
-bKO
-doE
+tVC
+wze
+cxb
 uHq
 hvn
 hvn
@@ -66952,9 +67028,9 @@ oyZ
 oyZ
 waT
 cxb
-doE
+cxb
 fJa
-doE
+tVC
 ctF
 ctF
 ctF
@@ -67003,9 +67079,9 @@ ctF
 ctF
 ctF
 ctF
-doE
+tVC
 dQZ
-doE
+cxb
 cxb
 hvn
 hvn
@@ -68084,7 +68160,7 @@ xJI
 pPS
 xJI
 jsn
-cvw
+fNm
 wWa
 hRm
 pJQ
@@ -72916,8 +72992,8 @@ xOC
 doE
 iwJ
 doE
+rfP
 dUc
-ujB
 pkG
 pkG
 pkG
@@ -90527,11 +90603,11 @@ qhb
 qhb
 qhb
 qhb
+qmd
 qhb
 qhb
 qhb
-qhb
-qhb
+qmd
 qhb
 qhb
 qhb
@@ -90974,9 +91050,9 @@ bPQ
 iwd
 oyZ
 qhb
-lcT
-lcT
-lcT
+qhb
+qhb
+qhb
 qhb
 qhb
 qhb
@@ -91025,9 +91101,9 @@ qhb
 qhb
 qhb
 qhb
-lcT
-lcT
-lcT
+qhb
+qhb
+qhb
 qhb
 qhb
 qhb
@@ -91131,9 +91207,9 @@ jzM
 reZ
 oyZ
 qhb
-lcT
-lcT
-lcT
+qhb
+qhb
+qhb
 qhb
 qhb
 qhb
@@ -91162,7 +91238,7 @@ npT
 meT
 dFN
 ifr
-lGq
+meT
 oUz
 oUz
 ouw
@@ -91182,9 +91258,9 @@ qhb
 qhb
 qhb
 qhb
-lcT
-lcT
-lcT
+qhb
+qhb
+qhb
 qhb
 qhb
 qhb
@@ -91288,9 +91364,9 @@ doE
 doE
 waT
 qhb
-lcT
+qhb
 hRm
-lcT
+qhb
 qhb
 qhb
 qhb
@@ -91312,11 +91388,11 @@ oUz
 aVh
 wsQ
 ebN
-ifr
+mPJ
 tyv
 wdv
-aVh
-dZn
+cvw
+fbf
 sWd
 ifr
 dZn
@@ -91339,9 +91415,9 @@ qhb
 qhb
 qhb
 qhb
-lcT
+qhb
 hRm
-lcT
+qhb
 qhb
 qhb
 qhb
@@ -91469,10 +91545,10 @@ hRm
 hGQ
 dZn
 dFN
-ifr
-daH
+oHx
 uez
-cwA
+uez
+uez
 pdx
 sWd
 ifr
@@ -91626,10 +91702,10 @@ hRm
 vYh
 dZn
 sWd
-ifr
-daH
+oHx
 uez
-cwA
+uez
+uez
 hJq
 sWd
 dWu
@@ -91783,10 +91859,10 @@ oUz
 dZn
 dZn
 weZ
-ifr
-daH
+oHx
 uez
-cwA
+uez
+uez
 kCo
 sWd
 dZn
@@ -91941,9 +92017,9 @@ dZn
 dZn
 eWI
 pJL
-daH
 uez
-cwA
+uez
+uez
 njH
 weZ
 bqq
@@ -92061,9 +92137,9 @@ idl
 oUz
 oUz
 rcn
-phM
-phM
-phM
+cQy
+cQy
+cQy
 cQy
 cQy
 cQy
@@ -114863,11 +114939,11 @@ qhb
 qhb
 qhb
 qhb
-qhb
-qhb
-qhb
-qhb
-qhb
+obh
+prO
+jui
+prO
+obh
 qhb
 qhb
 qhb
@@ -115019,13 +115095,13 @@ qhb
 qhb
 qhb
 qhb
-qhb
-qhb
-qhb
-qhb
-qhb
-qhb
-qhb
+lGq
+lGq
+qwC
+daH
+qwC
+lGq
+lGq
 qhb
 qhb
 qhb
@@ -115176,13 +115252,13 @@ qhb
 qhb
 qhb
 qhb
-qhb
-qhb
-qhb
-qhb
-qhb
-qhb
-qhb
+prO
+qwC
+qwC
+qwC
+qwC
+qwC
+prO
 qhb
 qhb
 qhb
@@ -115331,18 +115407,18 @@ qhb
 qhb
 qhb
 qhb
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
+tYX
+tYX
+prO
+qwC
+qwC
+qwC
+qwC
+qwC
+prO
+tYX
+tYX
+tYX
 qhb
 qhb
 qhb
@@ -115487,20 +115563,20 @@ qhb
 qhb
 qhb
 qhb
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
+tYX
+tYX
+tYX
+lGq
+lGq
+qwC
+rcH
+qwC
+lGq
+lGq
+tYX
+tYX
+tYX
+tYX
 qhb
 qhb
 qhb
@@ -115644,20 +115720,20 @@ qhb
 qhb
 qhb
 qhb
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
+tYX
+tYX
+tYX
+tYX
+lGq
+cwA
+jui
+cwA
+lGq
+tYX
+tYX
+tYX
+tYX
+tYX
 qhb
 qhb
 qhb
@@ -115801,20 +115877,20 @@ qhb
 qhb
 qhb
 qhb
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
-ouw
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
+tYX
 qhb
 qhb
 qhb

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -234,7 +234,7 @@
 	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/councillor
-	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/guard
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/warden)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -237,7 +237,7 @@
 	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/guard
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/warden)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/warden, /obj/item/roguekey/armory, /obj/item/roguekey/walls)
 
 /obj/item/storage/keyring/guardcastle
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/armory)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -228,10 +228,10 @@
 	keys = list(/obj/item/roguekey/farm, /obj/item/roguekey/butcher)
 
 /obj/item/storage/keyring/sheriff
-	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard, /obj/item/roguekey/armory)
 
 /obj/item/storage/keyring/judge
-	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/armory, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/councillor
 	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
@@ -240,7 +240,7 @@
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/warden)
 
 /obj/item/storage/keyring/guardcastle
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/armory)
 
 /obj/item/storage/keyring/velder
 	keys = list(/obj/item/roguekey/velder, /obj/item/roguekey/blacksmith/town, /obj/item/roguekey/farm, /obj/item/roguekey/butcher)
@@ -249,13 +249,13 @@
 	keys = list(/obj/item/roguekey/tavern/village, /obj/item/roguekey/roomvi/village, /obj/item/roguekey/roomv/village, /obj/item/roguekey/roomiv/village, /obj/item/roguekey/roomiii/village, /obj/item/roguekey/roomii/village, /obj/item/roguekey/roomi/village)
 
 /obj/item/storage/keyring/gatemaster
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/armory)
 
 /obj/item/storage/keyring/merchant
 	keys = list(/obj/item/roguekey/shop, /obj/item/roguekey/merchant)
 
 /obj/item/storage/keyring/mguard
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/armory)
 
 /obj/item/storage/keyring/mage
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/tower, /obj/item/roguekey/mage)
@@ -276,31 +276,31 @@
 	keys = list(/obj/item/roguekey/nightman, /obj/item/roguekey/nightmaiden)
 
 /obj/item/storage/keyring/hand
-	keys = list(/obj/item/roguekey/hand, /obj/item/roguekey/steward, /obj/item/roguekey/tavern, /obj/item/roguekey/church, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/hand, /obj/item/roguekey/steward, /obj/item/roguekey/tavern, /obj/item/roguekey/church, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard, /obj/item/roguekey/armory)
 
 /obj/item/storage/keyring/steward
-	keys = list(/obj/item/roguekey/steward, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/steward, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/clerk
-	keys = list(/obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/dungeoneer
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/garrison, /obj/item/roguekey/archive)
+	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/garrison, /obj/item/roguekey/armory)
 
 /obj/item/storage/keyring/servant
-	keys = list(/obj/item/roguekey/manor)
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/garrison)
 
 /obj/item/storage/keyring/archivist
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/archive)
 
 /obj/item/storage/keyring/physician
-	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/physician)
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/garrison, /obj/item/roguekey/physician)
 
 /obj/item/storage/keyring/royal
-	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/royal)
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/royal, /obj/item/roguekey/garrison)
 
 /obj/item/storage/keyring/lord
-	keys = list(/obj/item/roguekey/hand, /obj/item/roguekey/steward, /obj/item/roguekey/tavern, /obj/item/roguekey/church, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard, /obj/item/roguekey/royal)
+	keys = list(/obj/item/roguekey/hand, /obj/item/roguekey/steward, /obj/item/roguekey/tavern, /obj/item/roguekey/church, /obj/item/roguekey/walls, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard, /obj/item/roguekey/royal, /obj/item/roguekey/armory)
 
 /obj/item/storage/keyring/heir
-	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/heir)
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/heir, /obj/item/roguekey/garrison)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -234,7 +234,7 @@
 	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/councillor
-	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/guard
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/warden)
@@ -288,13 +288,13 @@
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/manor, /obj/item/roguekey/garrison, /obj/item/roguekey/archive)
 
 /obj/item/storage/keyring/servant
-	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/garrison)
+	keys = list(/obj/item/roguekey/manor)
 
 /obj/item/storage/keyring/archivist
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/archive)
 
 /obj/item/storage/keyring/physician
-	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/garrison, /obj/item/roguekey/physician)
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/physician)
 
 /obj/item/storage/keyring/royal
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/royal)

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -126,6 +126,12 @@
 	icon_state = "cheesekey"
 	lockid = "sheriff"
 
+/obj/item/roguekey/armory
+	name = "armory key"
+	desc = "This key opens the garrison's armory."
+	icon_state = "hornkey"
+	lockid = "armory"
+
 /obj/item/roguekey/merchant
 	name = "merchant's key"
 	desc = "A merchant's key."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

TLDR; touches up the garrison building and gatehouse a bit, makes the keep and the garrison building a bit harder to break into, gives the armory a separate keyset from the rest of the garrison building.

<details>

<summary>Screenshots:</summary>

Downstairs:
![image](https://github.com/user-attachments/assets/45cd7e64-e59f-4997-ba07-02ef7e742b54)

Upstairs:
![image](https://github.com/user-attachments/assets/52437f4f-352c-4909-a36d-90d360ab244d)


</details>

<details>

<summary>Full list of changes:</summary>

- Reworks the downstairs area of the garrison building into a common room with tables for eating/drinking and hanging out. 
- Replaces the windows in the garrison building with reinforced windows, the same kind the merchant & steward's buildings get.
- Moves the extra manor/garrison keys into locked closets/chests.
- The squire room actually has four beds now - for four squires.
- Moves some things around upstairs. All of the food and random cooking equipment that was previously laden around the barracks is now confined to one little miniature-kitchen-space.
- The gatehouse is a bit less cramped and a bit harder to break into.
- The garrison now has significantly better roof access; with several watchtowers leading up onto the roofs of the keep for those without climbing skills.
- Reduces the amount of easy rooftop routes to break into the keep that require no setup whatsoever from 6 to 3.

This PR also adds a separate keyset for the armory.
- The duke, the hand, the marshal, the veteran, the captain, the dungeoneer, the royal guards, the men at arms, the squires, and the wardens all have armory access.
- The consort, the two heirs, councilors, the court physician, and the servants all have basic garrison access, but cannot access the armory without asking someone to let them in.
- The guard captain and the steward both have spare armory keys in their office they can hand out if they want to.

</details>

## Why It's Good For The Game

The garrison building and the keep in general are comically easy to break into; this tightens up security just a bit and also makes it harder for other non-garrison keep roles like servants, councilors, and court physicians to raid the armory by making the armory use a separate key, while still allowing them entry to the garrison building itself for roleplay reasons such as tending to prisoners or cooking/cleaning.