### PR TITLE
Are you smoking yet? | Ports Poison Spray from Hearthstones 5e spells.

### DIFF
--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -226,7 +226,8 @@
 		/obj/effect/proc_holder/spell/invoked/projectile/frostbolt,
 		/obj/effect/proc_holder/spell/invoked/projectile/arcynebolt,
 		/obj/effect/proc_holder/spell/invoked/gravity,
-		/obj/effect/proc_holder/spell/invoked/projectile/repel
+		/obj/effect/proc_holder/spell/invoked/projectile/repel,
+		/obj/effect/proc_holder/spell/invoked/poisonspray5e
 	)
 	for(var/i = 1, i <= spell_choices.len, i++)
 		choices["[spell_choices[i].name]: [spell_choices[i].cost]"] = spell_choices[i]
@@ -1278,7 +1279,62 @@
 				if (carbon_firer?.can_catch_item())
 					throw_target = get_edge_target_turf(firer, get_dir(firer, target))
 			I.throw_at(throw_target, 7, 4)
-			
+
+/obj/effect/proc_holder/spell/invoked/poisonspray5e
+	name = "Aerosolize" //once again renamed to fit better :)
+	desc = "Turns a container of liquid into a smoke containing the reagents of that liquid."
+	overlay_state = "null"
+	releasedrain = 50
+	chargetime = 3
+	charge_max = 20 SECONDS
+	//chargetime = 10
+	//charge_max = 30 SECONDS
+	range = 6
+	warnie = "spellwarning"
+	movement_interrupt = FALSE
+	no_early_release = FALSE
+	chargedloop = null
+	sound = 'sound/magic/whiteflame.ogg'
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane //can be arcane, druidic, blood, holy
+	cost = 1
+
+	xp_gain = TRUE
+	miracle = FALSE
+
+	invocation = ""
+	invocation_type = "shout" //can be none, whisper, emote and shout
+	
+/obj/effect/proc_holder/spell/invoked/poisonspray5e/cast(list/targets, mob/living/user)
+	var/turf/T = get_turf(targets[1]) //check for turf
+	if(T)
+		var/obj/item/held_item = user.get_active_held_item() //get held item
+		var/obj/item/reagent_containers/con = held_item //get held item
+		if(con)
+			if(con.spillable)
+				if(con.reagents.total_volume > 0)
+					var/datum/reagents/R = con.reagents
+					var/datum/effect_system/smoke_spread/chem/smoke = new
+					smoke.set_up(R, 1, T, FALSE)
+					smoke.start()
+
+					user.visible_message(span_warning("[user] sprays the contents of the [held_item], creating a cloud!"), span_warning("You spray the contents of the [held_item], creating a cloud!"))
+					con.reagents.clear_reagents() //empty the container
+					playsound(user, 'sound/magic/webspin.ogg', 100)
+				else
+					to_chat(user, "<span class='warning'>The [held_item] is empty!</span>")
+					revert_cast()
+			else
+				to_chat(user, "<span class='warning'>I can't get access to the contents of this [held_item]!</span>")
+				revert_cast()
+		else
+			to_chat(user, "<span class='warning'>I need to hold a container to cast this!</span>")
+			revert_cast()
+	else
+		to_chat(user, "<span class='warning'>I couldn't find a good place for this!</span>")
+		revert_cast()
+
+
 #undef PRESTI_CLEAN
 #undef PRESTI_SPARK
 #undef PRESTI_MOTE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Ports one of my favorite spells from the Hearthstone 5e spell additions. Poison Spray (Renamed Aerosolize) 

Aerosolize does the following:
Turns a container of liquid into a smoke containing the reagents of that liquid.

Simple spell, very versatile in its uses. Thirsty? Aerosolize some water. Want to try and poison someone (pretty obviously)? Aerosolize some poison on them. Someone on the ground dying but you're too busy trying to not die yourself? Aerosolize a health potion to let them slowly heal.

Fun fact, Deathless cannot benefit from this spell because they don't breath! Anyone who does not breath cannot be affected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More spells, fun spells.
![cat-kitty](https://github.com/user-attachments/assets/9aba1ae4-c3cd-442d-8185-1b6d19f9f1e3)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
