### PR TITLE
Merc stable

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -1809,7 +1809,6 @@
 /area/rogue/indoors/town/church)
 "buJ" = (
 /obj/structure/rack/rogue,
-/obj/item/roguekey/apartments/stable3,
 /obj/item/roguekey/apartments/stable2,
 /obj/item/roguekey/apartments/stable1,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -5481,6 +5480,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/magician)
+"eQJ" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame{
+	gender = "male"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/town)
 "eRp" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -7844,6 +7849,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "hcO" = (
@@ -9296,6 +9302,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
+/mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "iwx" = (
@@ -10887,8 +10894,8 @@
 /obj/structure/mineral_door/swing_door{
 	keylock = 1;
 	locked = 1;
-	lockid = "stable3";
-	name = "stable iii"
+	lockid = "merc";
+	name = "Mercenary stable"
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
@@ -64452,7 +64459,7 @@ cxb
 oyZ
 ugU
 nNJ
-qyk
+eQJ
 qyk
 qyk
 iSc

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -462,11 +462,6 @@
 	icon_state = "brownkey"
 	lockid = "stable2"
 
-/obj/item/roguekey/apartments/stable3
-	name = "stable iii key"
-	icon_state = "brownkey"
-	lockid = "stable3"
-
 //custom key
 /obj/item/roguekey/custom
 	name = "custom key"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

also known as wish fulfillment

Converts stable 3 into a mercenary keyed stable, so the various merc riders can park their car freely. For reference, the other two stables are locked behind respective stable keys, which are in turn tucked in the nearby shack that's under the soilson key.

With that in mind, I also populated the stalls with a male and female saiga, respectively, so a would-be farmer can do hor-- antelope things. Right now they have a mating pair of goats and cows, but any saiga has to be procured on site. Or just bought from the steward for a hundred, so it's whatever.

I also put a saiga in the mercenary stable. They get one for free, as a treat. These are the only three saiga on the map.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mercenaries don't have anywhere to park their cars without bringing them inside, so now they do. Soilers can also breed and cultivate a herd of mounts if they feel particularly in the mood to do so, without playing RNG on actually getting them. If this becomes an issue we can nix the starting saiga in the future, but again; they cost a spooooky hundred from the steward, which is small enough that they're typically given away for free when asked.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

![image](https://github.com/user-attachments/assets/b1c19fed-ff4e-4c2f-a07e-f45f77974533)

