### PR TITLE
Reloading crossbows takes slightly longer, but skill level reduces reload time.

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -101,7 +101,7 @@
 	else
 		if(!cocked)
 			to_chat(user, span_info("I step on the stirrup and use all my might..."))
-			if(do_after(user, 50 - user.STASTR, target = user))
+			if(do_after(user, (55 - user.STASTR) - (user.mind.get_skill_level(/datum/skill/combat/crossbows)*4), target = user))
 				playsound(user, 'sound/combat/Ranged/crossbow_medium_reload-01.ogg', 100, FALSE)
 				cocked = TRUE
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This changes crossbow reload time from (50 - Strength) to ((55 - Strength) - (Skill*4))
IE:
Worse for Novices and untrained, better for Apprentices and above.

## Why It's Good For The Game

Reload time is currently not affected by crossbow skill, its weird and bad. 
Now it is, that's makes sense and is good.
