### PR TITLE
Squire Truthnuke Balancejak

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -54,28 +54,27 @@
 /datum/outfit/job/roguetown/squire/lancer/pre_equip(mob/living/carbon/human/H)
 	r_hand = /obj/item/rogueweapon/spear
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
-	gloves = /obj/item/clothing/gloves/roguetown/leather
+	gloves = /obj/item/clothing/gloves/roguetown/chain
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+	pants = /obj/item/clothing/under/roguetown/chainlegs/
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch,
 		/obj/item/clothing/neck/roguetown/chaincoif
 	)
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE) //Every other subclass gets at least 1 other respective skill in apprentice
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE) //They deserve this
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE) ///Riding literally doesn't matter anyway
 		H.change_stat("strength", 1)
-		H.change_stat("perception", 1)
+		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 1)
 		H.change_stat("intelligence", 1)
 		H.change_stat("speed", 1)
@@ -92,9 +91,9 @@
 
 /datum/outfit/job/roguetown/squire/footman/pre_equip(mob/living/carbon/human/H)
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
-	gloves = /obj/item/clothing/gloves/roguetown/leather
+	gloves = /obj/item/clothing/gloves/roguetown/chain
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+	pants = /obj/item/clothing/under/roguetown/chainlegs/
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch,
@@ -102,17 +101,17 @@
 	)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE) ///The chvds won't like this one...
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE) ///i can swing my sword sword sword my diamond sword sword...
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.change_stat("strength", 1)
-		H.change_stat("perception", 1)
+		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 1)
 		H.change_stat("intelligence", 1)
 		H.change_stat("speed", 1)
@@ -120,12 +119,12 @@
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Iron Sword","Cudgel",)
+	var/weapons = list("Shortsword","Cudgel",)
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
-		if("Iron Sword")
-			beltr = /obj/item/rogueweapon/sword/iron
+		if("Shortsword")	////More fitting than a full-on sword.
+			beltr = /obj/item/rogueweapon/sword/short
 		if("Cudgel")	
 			beltr = /obj/item/rogueweapon/mace/cudgel
 
@@ -149,11 +148,11 @@
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger,
 		/obj/item/storage/belt/rogue/pouch,
-		/obj/item/clothing/neck/roguetown/chaincoif,
+		/obj/item/clothing/neck/roguetown/gorget,
 		)
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)


### PR DESCRIPTION

## About The Pull Request

Gives all 3 Squire subclasses a couple tweaks here and there to catch them up to the current state of the Garrison. 

Lancer Squire
- Journeyman Polearms + Riding
- Apprentice Flails
- +1 Perception --> +1 Endurance
- Other minor stuff in loadouts

Footman Squire
- Journeyman Swords (Duelist bumps it up to expert I know but idc you always grind it to expert anyway)
- Journeyman Athletics
- Apprentice Shields, shitty at Crossbows now
- Shortsword option instead of the iron sword nobody takes (Shortsword balancejak plug)
- +1 Perception --> +1 Endurance

Irregular Squire
- Gorget instead of chain coif
- Journeyman bows, apprentice crossbows

## Why It's Good For The Game

Mostly QOL changes and updating Squires to fit into the other Garrison changes that have been made lately. Squires are often neglected in PR changes because people freak the fuck out over anything related to them for some reason. 

Currently, about 80% of squire players pick irregular because of le dodge expert and superior stats. This should give the other subclasses some more love. 
