### PR TITLE
spellcast rightclick fix, comment out goblin carbon archery

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -337,8 +337,8 @@
 				r_hand = /obj/item/rogueweapon/flail
 				l_hand = /obj/item/rogueweapon/shield/wood
 
-	H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
+	//H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+	//H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
 
 //////////////////   INVADER ZIM	//////////////////
 

--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -58,10 +58,11 @@
 	if(!can_cast(caller) || !cast_check(FALSE, ranged_ability_user))
 		return FALSE
 	var/client/client = caller.client
-	var/charge_progress = client?.chargedprog
+	var/percentage_progress = client?.chargedprog
+	var/charge_progress = client?.progress // This is in seconds, same unit as chargetime
 	var/goal = src.get_chargetime() //if we have no chargetime then we can freely cast (and no early release flag was not set)
 	if(src.no_early_release) //This is to stop half-channeled spells from casting as the repeated-casts somehow bypass into this function.
-		if(charge_progress < 100 && goal) //If it is not at 100% charge progress.
+		if(percentage_progress < 100 && charge_progress < goal)//Conditions for failure: a) not 100% progress, b) charge progress less than goal
 			to_chat(usr, span_warning("[src.name] was not finished charging! It fizzles."))
 			src.revert_cast()
 			return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes mbutton->right click interaction with validly charged spells
stops giving 'mind'less goblins archery skills for now

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bugfixes

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
