### PR TITLE
Updates Veterans with Houndstones

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -57,6 +57,7 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	cloak = /obj/item/clothing/cloak/half/vet
 	belt = /obj/item/storage/belt/rogue/leather/black
+	id = /obj/item/scomstone/bad/garrison
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
@@ -118,6 +119,7 @@
 	r_hand = /obj/item/rogueweapon/spear/billhook
 	belt = /obj/item/storage/belt/rogue/leather/black
 	cloak = /obj/item/clothing/cloak/half/vet
+	id = /obj/item/scomstone/bad/garrison
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
@@ -174,6 +176,7 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather/black
 	cloak = /obj/item/clothing/cloak/half/vet
+	id = /obj/item/scomstone/bad/garrison
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
@@ -256,6 +259,7 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather/black
 	cloak = /obj/item/clothing/cloak/half/vet
+	id = /obj/item/scomstone/bad/garrison	///Unsure how I should feel about giving the former merc class a garrison ring, but it'd also feel unfair.
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
@@ -328,6 +332,7 @@
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 	belt = /obj/item/storage/belt/rogue/leather/black
 	cloak = /obj/item/clothing/cloak/half/vet
+	id = /obj/item/scomstone/bad/garrison
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/storage/keyring/guardcastle = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
@@ -390,6 +395,7 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather/knifebelt/iron
 	cloak = /obj/item/clothing/cloak/raincloak/mortus
+	id = /obj/item/scomstone/bad/garrison
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish = 1, /obj/item/storage/keyring/guardcastle = 1, /obj/item/reagent_containers/glass/bottle/rogue/poison = 1)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)

--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -118,7 +118,7 @@
 /obj/structure/roguemachine/scomm/MiddleClick(mob/living/carbon/human/user)
 	if(.)
 		return
-	if((HAS_TRAIT(user, TRAIT_GUARDSMAN) || (HAS_TRAIT(user, TRAIT_KNIGHTSMAN)) || (HAS_TRAIT(user, TRAIT_WOODSMAN)) || (user.job = "Squire")))
+	if((HAS_TRAIT(user, TRAIT_GUARDSMAN) || (HAS_TRAIT(user, TRAIT_KNIGHTSMAN)) || (HAS_TRAIT(user, TRAIT_WOODSMAN)) || (user.job = "Squire")) || (user.job = "Veteran"))
 		if(alert("Would you like to swap lines or connect to a jabberline?",, "swap", "jabberline") != "jabberline")
 			garrisonline = !garrisonline
 			to_chat(user, span_info("I [garrisonline ? "connect to the garrison SCOMline" : "connect to the general SCOMLINE"]"))


### PR DESCRIPTION

## About The Pull Request

Houndstones (Garrison serfstones) are now added to Veteran loadouts. That's it. That's the entire PR. 

## Why It's Good For The Game

First of all, they're literally filed into the Garrison folder, and they spawn with Garrison keys, y'know? I know they aren't COMBATIVE members of the Garrison, but considered a consulting part of them nonetheless. 

Besides, the Garrison practically consider Veterans as one of their own as well - retired, maybe, but someone to be respected nonetheless within the Keep. Additionally, Veterans have classes that explicitly state that they were a former active member of the Garrison/Keep - follows up with the generalized lore and the server culture that surrounds the Veteran and their expectations as well. 

This would be really helpful with keeping track of the squires they oftentimes train, and be better organized for incoming threats. 

Example:
You hear on the houndstone that there's a threat to the kingdom coming in soon. You hear that, and get to work bolstering defenses by training the townsfolk who want it, topping off men-at-arms or watchmen to a good skill level, etc. 

It's not disruptive at all to the game, and it'll be a massive game-changer for organizing Veteran-related activities (that doesn't involve drinking and complaining about the youth). 

##Addressing Points of Contention

Yes, I'm aware that, despite Vet being literally filed under Garrison, they're still tagged as Mercenary for some reason. I'm pretty sure this is a code oversight. 

Yes, I'm aware Veteran isn't exclusive to training members of the Keep. No, this does not mean they don't deserve a houndstone ring - hell, they probably deserve it more for how much they're willing to put out for the town. 