### PR TITLE
Update adventurer.dm

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 
 	display_order = JDO_ADVENTURER
 	show_in_credits = FALSE
-	min_pq = 0
+	min_pq = 3
 	max_pq = null
 
 	advclass_cat_rolls = list(CTAG_ADVENTURER = 20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

All it does is adjust the minimum PQ required for adventurer from 0 to 3

## Why It's Good For The Game

Adventurer is a relatively poor first choice for playing roguetown, as the mechanics are different from other servers.
This should push new players to play roles which are intwined with others, so as to encourage them to roleplay, and try new things before falling into the adventurer routine.
