### PR TITLE
Makes Physician mask work vs miasma, adds 3 masks to map

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -327,6 +327,7 @@
 /obj/item/roguekey/physician{
 	pixel_y = 9
 	},
+/obj/item/clothing/mask/rogue/physician,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -1333,10 +1334,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/clothing/suit/roguetown/shirt/tunic,
 /obj/item/clothing/suit/roguetown/shirt/tunic,
-/obj/item/clothing/suit/roguetown/shirt/tunic,
-/obj/item/clothing/suit/roguetown/shirt/tunic,
-/obj/item/clothing/suit/roguetown/shirt/tunic/black,
-/obj/item/clothing/suit/roguetown/shirt/tunic/black,
 /obj/item/clothing/suit/roguetown/shirt/tunic/black,
 /obj/item/clothing/suit/roguetown/shirt/tunic/black,
 /obj/item/flashlight/flare/torch/lantern,
@@ -18675,6 +18672,7 @@
 	dir = 8;
 	icon_state = "largetable"
 	},
+/obj/item/clothing/mask/rogue/physician,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -24689,6 +24687,7 @@
 	dir = 4;
 	icon_state = "largetable"
 	},
+/obj/item/clothing/mask/rogue/physician,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},

--- a/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
@@ -49,3 +49,4 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	H.change_stat("intelligence", 3)
 	H.change_stat("perception", 2)
+	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)

--- a/code/modules/reagents/chemistry/reagents/roguetown.dm
+++ b/code/modules/reagents/chemistry/reagents/roguetown.dm
@@ -6,10 +6,20 @@
 	metabolization_rate = 1
 
 /datum/reagent/miasmagas/on_mob_life(mob/living/carbon/M)
-	if(!HAS_TRAIT(M, TRAIT_NOSTINK))
+	if(!HAS_TRAIT(M, TRAIT_NOSTINK) && !physician_mask_check(M))
 		M.add_nausea(15)
 		M.add_stress(/datum/stressevent/miasmagas)
 	return ..()
+
+/proc/physician_mask_check(mob/living/carbon/M)
+	if(!M)
+		return FALSE
+	if(!istype(M, /mob/living/carbon/human))
+		return FALSE
+	var/mob/living/carbon/human/H = M
+	if(!H.wear_mask)
+		return FALSE
+	return istype(H.wear_mask, /obj/item/clothing/mask/rogue/physician)
 
 /datum/reagent/rogueacid
 	name = "rogueacid"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gives a check to the physician mask to make it useful, and not just rogue fashion. Also hands two of them to the apothecary desks, they need it more than the actual physician since they don't spawn with the nostink trait.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Physician mask had a strange collision with glasses on spawn, so near-sighted physicians never got a mask. A couple spares for him and his two apothecaries is cool, also means it's useful fashion.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
