### PR TITLE
Water Reagent Changes (mainly the ocean)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -48,6 +48,7 @@
 #define TRAIT_INQUISITION "Member of the Otavan Inquisition"
 #define TRAIT_GOODTRAINER "Good Trainer"
 #define TRAIT_OUTDOORSMAN "Outdoorsman"
+#define TRAIT_SEA_DRINKER "Denizen of the Deep"
 
 //Hearthstone port (Tracking)
 #define TRAIT_PERFECT_TRACKER "Perfect Tracker" //Will always find any tracks and analyzes them perfectly.
@@ -179,7 +180,8 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_DEPRAVED = span_info("The languid scent of Her debauchery is known to me, and I can detect its sordid presence upon others."),
 	TRAIT_SILVER_BLESSED = span_info("I am anointed with holy silver, which preserves me from curses that bite."),
 	TRAIT_GOODTRAINER = span_info("I am a good teacher, and when it comes to weaponry I can train others to be just as skilled as I am."),
-	TRAIT_OUTDOORSMAN = span_info("My experience in the wilds allows me to fall asleep on surfaces like treebranches as if they were beds.")
+	TRAIT_OUTDOORSMAN = span_info("My experience in the wilds allows me to fall asleep on surfaces like treebranches as if they were beds."),
+	TRAIT_SEA_DRINKER = span_info("As a denizen of the deep, I can drink salty ocean water safely.")
 ))
 
 // trait accessor defines

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -52,7 +52,7 @@
 	domain = "God of the Ocean, Storms and the Tide"
 	desc = "The strongest of the Ten; when awakened, the world flooded for a thousand daes and a thousand nights before he was put to slumber. Resting fitfully did Dendor split from his skull like a gaping wound. Communes rarely with his followers, only offering glimpses in dreams. Gifted primordial Man water. "
 	worshippers = "Men of the Sea, Primitive Aquatics"
-	mob_traits = list(TRAIT_ABYSSOR_SWIM)
+	mob_traits = list(TRAIT_ABYSSOR_SWIM, TRAIT_SEA_DRINKER)
 	t1 = /obj/effect/proc_holder/spell/invoked/abyssor_bends
 	t2 = /obj/effect/proc_holder/spell/invoked/abyssheal
 	t3 = /obj/effect/proc_holder/spell/invoked/call_mossback

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -233,13 +233,13 @@
 
 /turf/open/water/bath
 	name = "water"
-	desc = "Soothing water, although don't drink the soap."
+	desc = "Soothing water, with soapy bubbles on the surface."
 	icon = 'icons/turf/roguefloor.dmi'
 	icon_state = "bathtileW"
 	water_level = 2
 	water_color = "#FFFFFF"
 	slowdown = 3
-	water_reagent = /datum/reagent/water/gross
+	water_reagent = /datum/reagent/water/bathwater
 
 /turf/open/water/bath/Initialize()
 	.  = ..()
@@ -393,7 +393,7 @@
 	slowdown = 4
 	swim_skill = TRUE
 	wash_in = TRUE
-	water_reagent = /datum/reagent/water/gross
+	water_reagent = /datum/reagent/water/salty
 
 /turf/open/water/ocean/deep
 	name = "salt water"
@@ -404,7 +404,7 @@
 	water_color = "#3e7459"
 	slowdown = 8
 	swim_skill = TRUE
-	wash_in = FALSE
+	wash_in = TRUE
 
 /turf/open/water/pond
 	name = "pond"

--- a/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/akula.dm
@@ -15,7 +15,7 @@
 	(+1 Endurance)"
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
 	species_traits = list(EYECOLOR,LIPS,STUBBLE,MUTCOLORS)
-	inherent_traits = list(TRAIT_WATERBREATHING)
+	inherent_traits = list(TRAIT_WATERBREATHING, TRAIT_SEA_DRINKER)
 	possible_ages = ALL_AGES_LIST
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mt.dmi'

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -79,7 +79,7 @@
 	..()
 
 /datum/reagent/water/gross
-	taste_description = "lead"
+	taste_description = "something vile"
 	color = "#98934bc6"
 
 /datum/reagent/water/gross/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
@@ -93,6 +93,52 @@
 	M.adjustToxLoss(1)
 	M.add_nausea(12) //Over 8 units will cause puking
 
+/datum/chemical_reaction/grosswaterboil //boiling water purifies it
+	name = "gross water purification"
+	id = /datum/reagent/water
+	results = list(/datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/water/gross = 1)
+	required_temp = 375
+
+/datum/reagent/water/bathwater
+	taste_description = "bathwater"
+	color = "#c9e5eec6"
+
+/datum/reagent/water/salty
+	taste_description = "salt"
+	color = "#417ac5c6"
+
+/datum/reagent/water/salty/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
+	if(method == INGEST) // Make sure you DRANK the salty water before losing hydration
+		..()
+
+/datum/reagent/water/salty/on_mob_life(mob/living/carbon/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!HAS_TRAIT(H, TRAIT_NOHUNGER)&&!HAS_TRAIT(H, TRAIT_SEA_DRINKER))
+			H.adjust_hydration(-6)  //saltwater dehydrates more than it hydrates
+		else if(HAS_TRAIT(H, TRAIT_SEA_DRINKER))
+			H.adjust_hydration(hydration)  //saltwater dehydrates more than it hydrates
+	..()
+
+/datum/chemical_reaction/saltwaterify
+	name = "saltwater"
+	id = /datum/reagent/water/salty
+	results = list(/datum/reagent/water/salty = 2)
+	required_reagents = list(/datum/reagent/water/salty = 1, /datum/reagent/water = 1)
+
+/datum/chemical_reaction/saltwaterboil //boiling water purifies it
+	name = "saltwater purification"
+	id = /datum/reagent/water
+	results = list(/datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/water/salty = 1)
+	required_temp = 375
+
+/datum/chemical_reaction/saltwaterboil/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	new /obj/item/reagent_containers/powder/salt(location)
+	new /obj/item/reagent_containers/powder/salt(location)
+	new /obj/item/reagent_containers/powder/salt(location)
 
 /*
  *	Water reaction to turf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR changes water reagents for some sources to more be more accurate, as well as giving some extra utility to some.
The current list of changed liquids is not very high, but it paves the way for some variety in them.

Changed water types:
**Salt water (ocean water) and it's deep variant:** 
Actually saltwater now, instead of killing you when drinking it, it will simply dehydrate you, similarly to real ocean water.
Can be boiled in a full pot (on a hearth, unless you can place pots on fires in the future) to purify it into drinkable water, as well as a few piles of salt.
Axians and Abyssorites can drink saltwater without any negative effects as well. (This is given by "Denizen of the Deep" trait)
You can also wash in deep saltwater tiles now, cuz why not.
Tastes salty now.

![image](https://github.com/user-attachments/assets/5274761d-9266-45d6-9d34-594264058481)


**Bathwater:**
No longer kills you when drinking it. Now the only negative effects are on your personal sanity, you weirdos.
Also tastes like bathwater now.

**Murk:**
Doesn't taste like lead anymore. It tastes like "sometime vile." No more lead in the moats.
Can also be boiled in a pot to purify it into drinkable water, but will not yield any salt when doing so.

### Testing
Tested to make sure each aspect works, so there should be no issues upon merging. 
In testing there /was/ a point where I accidentally caused the saltwater boiling to spawn infinite salt piles, but that was very easily fixed. Set to 3 salt piles for now.

Also streamed the testing to Free, who aided immensely in troubleshooting as well as some additions.

## Why It's Good For The Game

The ocean is no longer filled with lead, and our sea-dwelling folks can swim and drink to the fullest.
We also don't bathe in lead-water anymore, since soap in ye olden days was mostly animal fat and organic materials.
Plus some extra survival utility for murk/ocean water for immersion. 
Doesn't really affect balance since it takes a few minutes to make 3 piles of salt, and there are definitely faster ways to get it.
The hope for this PR is to begin to introduce more use to the ocean and survival-living. In the future I was hoping for some more content to be added into the ocean parts of the map, or even more dungeons there.

All in all though, this is just a small immersion and QoL PR.
A harmless little "salt" PR, if you would...