### PR TITLE
Adds Gronn Highlander migrants to raid Azure Peak

### DIFF
--- a/code/datums/migrants/migrant_waves/antag wave.dm
+++ b/code/datums/migrants/migrant_waves/antag wave.dm
@@ -1,12 +1,12 @@
-/datum/migrant_wave/antag/graggar
-	name = "The Highlanders"
+/datum/migrant_wave/antag/gronnic
+	name = "The Gronnic Warband"
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/antag
 	weight = 50
 	roles = list(
-		/datum/migrant_role/graggar/chief = 1,
-		/datum/migrant_role/graggar/shaman = 1,
-		/datum/migrant_role/graggar/champion = 2,
+		/datum/migrant_role/gronnic/chief = 1,
+		/datum/migrant_role/gronnic/shaman = 1,
+		/datum/migrant_role/gronnic/champion = 2,
 	)
 	greet_text = "The time came, and your shamans read the desires of the Gods in the stars. You have cut your way through the southlands. Taking as you pleased, and burning the rest. Many have died in the raids, and now you are all that remains."
 //Not making downgraded versions as the downgraded version of all other migrant waves have been set to FALSE

--- a/code/datums/migrants/migrant_waves/antag wave.dm
+++ b/code/datums/migrants/migrant_waves/antag wave.dm
@@ -1,0 +1,12 @@
+/datum/migrant_wave/antag/graggar
+	name = "The Highlanders"
+	max_spawns = 1
+	shared_wave_type = /datum/migrant_wave/antag
+	weight = 50
+	roles = list(
+		/datum/migrant_role/graggar/chief = 1,
+		/datum/migrant_role/graggar/shaman = 1,
+		/datum/migrant_role/graggar/champion = 2,
+	)
+	greet_text = "The time came, and your shamans read the desires of the Gods in the stars. You have cut your way through the southlands. Taking as you pleased, and burning the rest. Many have died in the raids, and now you are all that remains."
+//Not making downgraded versions as the downgraded version of all other migrant waves have been set to FALSE

--- a/code/datums/migrants/migrant_waves/gronnic roles.dm
+++ b/code/datums/migrants/migrant_waves/gronnic roles.dm
@@ -1,0 +1,104 @@
+/datum/migrant_role/gronnic/chief
+	name = "Scout Chieftain"
+	greet_text = "You are the Scout Chieftain, favored of the Starving Bear, and chosen to lead a raiding party through the southlands."
+	outfit = /datum/outfit/job/roguetown/gronnic/chief
+	allowed_races = RACES_ALL_KINDS
+	grant_lit_torch = TRUE
+	show_wanderer_examine = FALSE
+
+/datum/outfit/job/roguetown/gronnic/chief/pre_equip(mob/living/carbon/human/H)
+	..()
+	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/red
+	head = /obj/item/clothing/head/roguetown/helmet/horned
+	belt = /obj/item/storage/belt/rogue/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
+	neck = /obj/item/clothing/neck/roguetown/gorget
+	beltl = /obj/item/rogueweapon/stoneaxe/battle
+	beltr = /obj/item/rogueweapon/huntingknife/cleaver/combat
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	backl = /obj/item/storage/backpack/rogue/satchel
+	backr = /obj/item/rogueweapon/shield/wood
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+		H.change_stat("strength", 3)
+		H.change_stat("endurance", 2)
+		H.change_stat("intelligence", 1)
+		H.change_stat("constitution", 2)
+		H.change_stat("perception", 2)
+
+	H.faction = faction = list("viking")
+	H.set_patron(/datum/patron/inhumen/matthios)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DECEIVING_MEEKNESS, TRAIT_GENERIC)
+
+/datum/migrant_role/gronnic/shaman
+	name = "Scout Shaman"
+	greet_text = "You are the Scout Shaman, favored of the Plotting Wolf, and chosen to guide a raiding party through the southlands."
+	outfit = /datum/outfit/job/roguetown/graggar/chief
+	allowed_races = RACES_ALL_KINDS
+	grant_lit_torch = TRUE
+	show_wanderer_examine = FALSE
+
+/datum/outfit/job/roguetown/gronnic/shaman/pre_equip(mob/living/carbon/human/H)
+	..()
+	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/purple
+	head = /obj/item/clothing/head/roguetown/antlerhood
+	belt = /obj/item/storage/belt/rogue/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/furlinedanklets
+	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
+	beltr = /obj/item/rogueweapon/huntingknife/cleaver/combat
+	backl = /obj/item/storage/backpack/rogue/satchel
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/magic/holy, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+		H.change_stat("speed", 1)
+		H.change_stat("endurance", 2)
+		H.change_stat("intelligence", 3)
+		H.change_stat("constitution", 2)
+		H.change_stat("perception", 2)
+
+	H.faction = faction = list("viking")
+	H.set_patron(/datum/patron/inhumen/zizo)
+	ADD_TRAIT(H, TRAIT_PERFECT_TRACKER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_STRONGBITE, TRAIT_GENERIC)
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_spells(H)
+	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+
+/datum/migrant_role/gronnic/champion
+	name = "Scout Champion"
+	greet_text = "You are a Scout, favored of the Starving Bear, and chosen to cut a path through the southlands."
+	outfit = /datum/outfit/job/roguetown/graggar/scout
+	allowed_races = RACES_ALL_KINDS
+	grant_lit_torch = TRUE
+	show_wanderer_examine = FALSE
+
+/datum/outfit/job/roguetown/gronnic/champion/pre_equip(mob/living/carbon/human/H)

--- a/code/datums/migrants/migrant_waves/gronnic roles.dm
+++ b/code/datums/migrants/migrant_waves/gronnic roles.dm
@@ -1,6 +1,6 @@
 /datum/migrant_role/gronnic/chief
-	name = "Scout Chieftain"
-	greet_text = "You are the Scout Chieftain, favored of the Starving Bear, and chosen to lead a raiding party through the southlands."
+	name = "Raider Chieftain"
+	greet_text = "You are the Raider Chieftain, favored of the Starving Bear, and chosen to lead a raiding party through the southlands."
 	outfit = /datum/outfit/job/roguetown/gronnic/chief
 	allowed_races = RACES_ALL_KINDS
 	grant_lit_torch = TRUE
@@ -25,10 +25,10 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/axes, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
@@ -41,6 +41,7 @@
 		H.change_stat("intelligence", 1)
 		H.change_stat("constitution", 2)
 		H.change_stat("perception", 2)
+		H.change_stat("fortune", 2)
 
 	H.faction = faction = list("viking")
 	H.set_patron(/datum/patron/inhumen/matthios)
@@ -48,8 +49,8 @@
 	ADD_TRAIT(H, TRAIT_DECEIVING_MEEKNESS, TRAIT_GENERIC)
 
 /datum/migrant_role/gronnic/shaman
-	name = "Scout Shaman"
-	greet_text = "You are the Scout Shaman, favored of the Plotting Wolf, and chosen to guide a raiding party through the southlands."
+	name = "Raider Shaman"
+	greet_text = "You are the Raider Shaman, favored of the Plotting Wolf, and chosen to guide a raiding party through the southlands."
 	outfit = /datum/outfit/job/roguetown/graggar/chief
 	allowed_races = RACES_ALL_KINDS
 	grant_lit_torch = TRUE
@@ -78,7 +79,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 3, TRUE)
 		H.change_stat("speed", 1)
 		H.change_stat("endurance", 2)
 		H.change_stat("intelligence", 3)
@@ -94,11 +95,47 @@
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 
 /datum/migrant_role/gronnic/champion
-	name = "Scout Champion"
-	greet_text = "You are a Scout, favored of the Starving Bear, and chosen to cut a path through the southlands."
+	name = "Raider Champion"
+	greet_text = "You are a Raider Champion, favored of the Grinning Moose, and chosen to cut a path through the southlands. Listen to your chieftain, and your shaman. They were chosen for their wit, you were not."
 	outfit = /datum/outfit/job/roguetown/graggar/scout
 	allowed_races = RACES_ALL_KINDS
 	grant_lit_torch = TRUE
 	show_wanderer_examine = FALSE
 
 /datum/outfit/job/roguetown/gronnic/champion/pre_equip(mob/living/carbon/human/H)
+	..()
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+	head = /obj/item/clothing/head/roguetown/helmet/horned
+	belt = /obj/item/storage/belt/rogue/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
+	beltl = /obj/item/quiver/arrows
+	beltr = /obj/item/rogueweapon/mace
+	gloves = /obj/item/clothing/gloves/roguetown/chain
+	backl = /obj/item/rogueweapon/sword/iron
+	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
+		H.change_stat("strength", 2)
+		H.change_stat("endurance", 3)
+		H.change_stat("constitution", 3)
+		H.change_stat("perception", 2)
+		H.change_stat("intelligence", -2)
+
+	H.faction = faction = list("viking")
+	H.set_patron(/datum/patron/inhumen/graggar)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_STRONGBITE, TRAIT_GENERIC)	


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a set of antagonistic migrants, specifically Gronnic raiders.
1 Gronnic Chieftain. Matthiosan patron, acts as the leader
1 Gronnic Shaman. Zizoan patron, acts as the spellcaster
2 Gronnic Champions. Basic bruisers
Fluffwise it was a significantly larger expedition, but they took plenty of casualties going by foot raiding hammerhold. This is all that remains.

## Why It's Good For The Game

People want conflict. Men-At-Arms stagnate. Royal Guards decay. And many peoples only job is "Wait for someone to act antagonistic and swarm them. Thus, I provide. On the flipside, given the heavy attrition of the Gronnic Warband, they might be open to negotiations...
