### PR TITLE
deadite stat snapshot fix, lich faction fix

### DIFF
--- a/code/modules/antagonists/roguetown/villain/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich.dm
@@ -223,6 +223,7 @@
 	new_body.real_name = old_body.name
 	new_body.dna.real_name = old_body.real_name
 	new_body.mob_biotypes |= MOB_UNDEAD
+	new_body.faction = list("undead")
 	new_body.set_patron(/datum/patron/inhumen/zizo)
 	new_body.mind.grab_ghost(force = TRUE)
 

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -81,7 +81,7 @@
 /*Death transformation process goes:
 	death -> 
 	/mob/living/carbon/human/death(gibbed) -> 
-	zombie_check -> 
+	zombie_check_can_convert() -> 
 	zombie.on_gain() -> 
 	rotting.dm process -> 
 	time passes -> 
@@ -103,7 +103,7 @@
 	time passes -> 
 	wake_zombie
 
-	Infection transformation process goes -> infection -> timered transform in zombie_infect_attempt() -> /datum/antagonist/zombie/proc/wake_zombie -> zombietransform
+	Infection transformation process goes -> infection -> timered transform in zombie_infect_attempt() [drink red/holy water and kill timer?] -> /datum/antagonist/zombie/proc/wake_zombie -> zombietransform
 */
 /datum/antagonist/zombie/on_gain(admin_granted = FALSE)
 	var/mob/living/carbon/human/zombie = owner?.current
@@ -120,6 +120,10 @@
 		soundpack_m = zombie.dna.species.soundpack_m
 		soundpack_f = zombie.dna.species.soundpack_f
 	base_intents = zombie.base_intents
+
+	//Just need to clear it to snapshot. May get things we don't want to get.
+	for(var/status_effect in zombie.status_effects)
+		zombie.remove_status_effect(status_effect)
 
 	src.STASTR = zombie.STASTR
 	src.STASPD = zombie.STASPD
@@ -327,7 +331,7 @@
 			flash_fullscreen("redflash3")
 			to_chat(victim, span_danger("Ow! It hurts. I feel horrible... REALLY horrible..."))
 
-	victim.zombie_check() //They are given zombie antag mind here
+	victim.zombie_check_can_convert() //They are given zombie antag mind here unless they're already an antag.
 
 //Delay on waking up as a zombie. /proc/wake_zombie(mob/living/carbon/zombie, infected_wake = FALSE, converted = FALSE)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(wake_zombie), victim, FALSE, TRUE), wake_delay, TIMER_STOPPABLE)
@@ -396,7 +400,7 @@
 		zombie.Knockdown(1)
 
 ///Making sure they're not any other antag as well as adding the zombie datum to their mind
-/mob/living/carbon/human/proc/zombie_check()
+/mob/living/carbon/human/proc/zombie_check_can_convert()
 	if(!mind)
 		return
 	if(mind.has_antag_datum(/datum/antagonist/vampirelord))

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -64,9 +64,9 @@
 			ZOMBIFICATION BY DEATH BEGINS HERE
 		*/
 		if(!is_in_roguetown(src))
-			zombie_check() //Gives the dead unit the zombie antag flag
-			to_chat(src, span_userdanger("..is this to be my end..?"))
-			to_chat(src, span_danger("The cold consumes the final flicker of warmth in your chest and begins to seep into your limbs...")) 
+			if(!zombie_check_can_convert()) //Gives the dead unit the zombie antag flag
+				to_chat(src, span_userdanger("..is this to be my end..?"))
+				to_chat(src, span_danger("The cold consumes the final flicker of warmth in your chest and begins to seep into your limbs...")) 
 
 	if(client || mind)
 		SSticker.deaths++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

deadite snapshots on antag mind gain (to set reset it on cure) however, STA[stat] are all affected by the temporary status effects.

so when people turned into a deadite with heavy bleeding, hunger or thirst their stats were snapshot in that state and then set to that on cure

this clears all debuffs on antag gain to get an accurate snapshot


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
yay

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
