### PR TITLE
Adds fish mince to stockpile list

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -187,6 +187,18 @@
 	importexport_amt = 5
 	passive_generation = 2
 
+/datum/roguestock/stockpile/fishmince
+	name = "Fish Mince"
+	desc = "Descaled and ground fish meat."
+	item_type = /obj/item/reagent_containers/food/snacks/rogue/meat/mince/fish
+	held_items = list(0, 0)
+	payout_price = 2
+	withdraw_price = 4
+	transport_fee = 1
+	export_price = 3
+	importexport_amt = 10
+	passive_generation = 2
+
 /datum/roguestock/stockpile/poultry
 	name = "Bird Meat"
 	desc = "Edible flesh harvested from birds."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Chop up the fish and put it in the stockpile.
![image](https://github.com/user-attachments/assets/6e3b50ab-73b6-49ca-8405-543194f11ef1)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Instead of snowflaking a bunch of different fish in the stockpile datum, we have the almighty assorted fish product. Selling whole fish to the balloon via merchant is phenomenally more profitable. This is to let the stockpile in #1170 have something to be put in it other than salt. Tooled with numbers approximate to jacksberries so the economy doesn't flounder.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
