### PR TITLE
Hoardmaster additions + Sawbones buff

### DIFF
--- a/code/modules/cargo/packsrogue/Brigand.dm
+++ b/code/modules/cargo/packsrogue/Brigand.dm
@@ -93,6 +93,12 @@
 	cost = 30
 	contains = list(/obj/item/clothing/head/roguetown/helmet/sallet/visored)
 
+
+/datum/supply_pack/rogue/Brigand/wolfhelm
+	name = "Volf Plate Helm"
+	cost = 30
+	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/volfplate)
+
 /datum/supply_pack/rogue/Brigand/steelflail
 	name = "Steel Flail"
 	cost = 20
@@ -124,10 +130,20 @@
 	cost = 40
 	contains = list(/obj/item/rogueweapon/mace/goden/steel)
 
-/datum/supply_pack/rogue/Brigand/warhammer
+/datum/supply_pack/rogue/Brigand/silverwarhammer
 	name = "Silver Warhammer"
 	cost = 80
 	contains = list(/obj/item/rogueweapon/mace/silver)
+
+/datum/supply_pack/rogue/Brigand/steelwarhammer
+	name = "Steel Warhammer"
+	cost = 20
+	contains = list(/obj/item/rogueweapon/mace/warhammer/steel)
+
+/datum/supply_pack/rogue/Brigand/Ironwarhammer
+	name = "Iron Warhammer"
+	cost = 10
+	contains = list(/obj/item/rogueweapon/mace/warhammer)
 
 /datum/supply_pack/rogue/Brigand/axe
 	name = "Iron Axe"
@@ -151,3 +167,7 @@
 	cost = 10
 	contains = list(/obj/item/rogueweapon/shield/tower)
 
+/datum/supply_pack/rogue/Brigand/heatshield
+	name = "Heater Shield"
+	cost = 10
+	contains = list(/obj/item/rogueweapon/shield/heater)

--- a/code/modules/cargo/packsrogue/Knave.dm
+++ b/code/modules/cargo/packsrogue/Knave.dm
@@ -55,21 +55,27 @@
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/steel)
 
 
-/datum/supply_pack/rogue/Knave/leather/parrydag
+/datum/supply_pack/rogue/Knave/parrydag
 	name = "Parry Dagger"
 	cost = 20
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/steel/parrying)
 
 
-/datum/supply_pack/rogue/Knave/leather/Navaja
+/datum/supply_pack/rogue/Knave/Navaja
 	name = "Navaja"
 	cost = 20
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/navaja)
 
-/datum/supply_pack/rogue/Knave/leather/elfdagger
+/datum/supply_pack/rogue/Knave/elfdagger
 	name = "Elven Dagger"
 	cost = 40
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish)
+
+
+/datum/supply_pack/rogue/Knave/steeltossblades
+	name = "Steel Tossblade Belt"
+	cost = 20
+	contains = list(/obj/item/storage/belt/rogue/leather/knifebelt/black/steel)
 
 
 /datum/supply_pack/rogue/Knave/crossbow

--- a/code/modules/cargo/packsrogue/Knight.dm
+++ b/code/modules/cargo/packsrogue/Knight.dm
@@ -15,6 +15,11 @@
 	cost = 60
 	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/frogmouth)
 
+/datum/supply_pack/rogue/Knight/wolfhelm
+	name = "Volf Plate Helm"
+	cost = 30
+	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/volfplate)
+
 /datum/supply_pack/rogue/Knight/pigface
 	name = "Pigface Bascinet"
 	cost = 40

--- a/code/modules/cargo/packsrogue/Sawbones.dm
+++ b/code/modules/cargo/packsrogue/Sawbones.dm
@@ -32,32 +32,47 @@
 	contains = list(/obj/item/clothing/wrists/roguetown/bracers/leather)
 
 
-/datum/supply_pack/rogue/Sawbones/leather/surgery_bag
+/datum/supply_pack/rogue/Sawbones/surgery_bag
 	name = "Surgery Bag"
 	cost = 30
 	contains = list(/obj/item/storage/belt/rogue/surgery_bag/full/physician)
 
-/datum/supply_pack/rogue/Sawbones/leather/rapier
+/datum/supply_pack/rogue/Sawbones/rapier
 	name = "Rapier"
 	cost = 20
 	contains = list(/obj/item/rogueweapon/sword/rapier)
 
-/datum/supply_pack/rogue/Sawbones/leather/estoc
+/datum/supply_pack/rogue/Sawbones/estoc
 	name = "Estoc"
 	cost = 40
 	contains = list(/obj/item/rogueweapon/estoc)
 
-/datum/supply_pack/rogue/Sawbones/leather/gbottle
+/datum/supply_pack/rogue/Sawbones/gbottle
 	name = "Glass bottle"
 	cost = 5
 	contains = list(/obj/item/reagent_containers/glass/bottle)
 
-/datum/supply_pack/rogue/Sawbones/leather/botbomb
+/datum/supply_pack/rogue/Sawbones/botbomb
 	name = "Bottle bomb"
-	cost = 30
+	cost = 20
 	contains = list(/obj/item/bomb)
 
-/datum/supply_pack/rogue/Sawbones/leather/poison
+/datum/supply_pack/rogue/Sawbones/poison
 	name = "High-Potency poison"
 	cost = 100
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/poison)
+
+/datum/supply_pack/rogue/Sawbones/trustworthyhat
+	name = "Trustworthy Hat"
+	cost = 5
+	contains = list(/obj/item/clothing/head/roguetown/physician)
+
+/datum/supply_pack/rogue/Sawbones/trustworthyrobes
+	name = "Trustworthy Robes"
+	cost = 5
+	contains = list(/obj/item/clothing/suit/roguetown/shirt/robe/physician)
+
+/datum/supply_pack/rogue/Sawbones/bedroll
+	name = "Bedroll"
+	cost = 5
+	contains = list(/obj/item/bedroll)

--- a/code/modules/cargo/packsrogue/Sawbones.dm
+++ b/code/modules/cargo/packsrogue/Sawbones.dm
@@ -76,3 +76,23 @@
 	name = "Bedroll"
 	cost = 5
 	contains = list(/obj/item/bedroll)
+
+/datum/supply_pack/rogue/Sawbones/bronzeleftarm
+	name = "Prosthetic Left Arm"
+	cost = 5
+	contains = list(/obj/item/bodypart/l_arm/prosthetic/bronzeleft)
+
+/datum/supply_pack/rogue/Sawbones/bronzerightarm
+	name = "Prosthetic Right Arm"
+	cost = 5
+	contains = list(/obj/item/bodypart/r_arm/prosthetic/bronzeright)
+
+/datum/supply_pack/rogue/Sawbones/bronzeleftleg
+	name = "Prosthetic Left Leg"
+	cost = 5
+	contains = list(/obj/item/bodypart/l_leg/prosthetic/bronzeleft)
+
+/datum/supply_pack/rogue/Sawbones/bronzerightleg
+	name = "Prosthetic Right Leg"
+	cost = 5
+	contains = list(/obj/item/bodypart/r_leg/prosthetic/bronzeright)

--- a/code/modules/cargo/packsrogue/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/Sellsword.dm
@@ -119,6 +119,11 @@
 	cost = 30
 	contains = list(/obj/item/clothing/head/roguetown/helmet/sallet/visored)
 
+/datum/supply_pack/rogue/Sellsword/wolfhelm
+	name = "Volf Plate Helm"
+	cost = 30
+	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/volfplate)
+
 
 /datum/supply_pack/rogue/Sellsword/ssword
 	name = "Steel Sword"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -14,7 +14,7 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/belt/rogue/surgery_bag/full
+	beltl = /obj/item/storage/belt/rogue/surgery_bag/full/physician
 	beltr = /obj/item/rogueweapon/sword/rapier
 	pants = /obj/item/clothing/under/roguetown/trou
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
@@ -24,21 +24,25 @@
 					/obj/item/natural/worms/leech/cheele = 1,
 					/obj/item/natural/cloth = 2,
 					/obj/item/flashlight/flare/torch = 1,
+					/obj/item/bedroll = 1,
 					)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/labor/lumberjacking, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE) //needed for getting into hideout
 	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 5, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 6, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DECEIVING_MEEKNESS, TRAIT_GENERIC)
 	H.change_stat("speed", 3)
 	H.change_stat("intelligence", 4)
 	H.change_stat("fortune", 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds in some stuff to the Hoardmaster lists of relevant classes. Knaves get tossblades, brigands and sellswords get the wolf plate helmet, brigands get warhammers + heater shields. 

Buffs Sawbones to master swords, gives them deceiving meekness, no stink, and empathy + legendary medicine. Pretty much a doctor/duelist on steroids. Also gives them the Cool Outfit:tm: in their hoardmaster + cheapens bottle bombs.

## Why It's Good For The Game

Sawbones has been a bit bleak for a time. Also just adds some little things to hoardmaster lists. I'll probably buff rogue mage after arcane decoupling is done? And try to figure out something for sellsword? These three being the less popular/less good bandit classes.
