### PR TITLE
Blade Dancer is no longer meta (No more master skill fragging)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -51,9 +51,9 @@
 		if("Blade Dancer")
 			H.set_blindness(0)
 			to_chat(H, span_warning("Zybantian 'Blade Dancers' are famed and feared the world over. Their expertise in blades both long and short is well known..."))
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE) //they have literally nothing else going for them and swords suck ass, do not use this as an excuse to powercreep
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE) 
 			H.mind.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
@@ -64,10 +64,9 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-			H.change_stat("strength", 1)
 			H.change_stat("endurance", 2)
 			H.change_stat("intelligence", 1)
 			H.change_stat("speed", 3)
@@ -76,6 +75,17 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 			H.grant_language(/datum/language/celestial)
+
+		H.adjust_blindness(-3)
+		var/weapons = list("Shamshir","Whips and Knives",)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Shamshir")
+				backl = /obj/item/rogueweapon/sword/long/rider
+			if("Whips and Knives")	///They DO enslave people after all
+				r_hand = /obj/item/rogueweapon/whip
+				l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 
 		if("Blade Caster")
 			H.set_blindness(0)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -75,17 +75,15 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 			H.grant_language(/datum/language/celestial)
-
-		H.adjust_blindness(-3)
-		var/weapons = list("Shamshir","Whips and Knives",)
-		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-		H.set_blindness(0)
-		switch(weapon_choice)
-			if("Shamshir")
-				backl = /obj/item/rogueweapon/sword/long/rider
-			if("Whips and Knives")	///They DO enslave people after all
-				r_hand = /obj/item/rogueweapon/whip
-				l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
+			var/weapons = list("Shamshir","Whips and Knives",)
+			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			H.set_blindness(0)
+			switch(weapon_choice)
+				if("Shamshir")
+					backl = /obj/item/rogueweapon/sword/long/rider
+				if("Whips and Knives")	///They DO enslave people after all
+					r_hand = /obj/item/rogueweapon/whip
+					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 
 		if("Blade Caster")
 			H.set_blindness(0)


### PR DESCRIPTION

## About The Pull Request

- Master Swords ---> Expert Swords/Knives/Whips/Athletics
- No more strength buff
- Pick between Shamshir or Whips + Parrying Dagger

The fact I'm taking Master swords off of everyone's favorite meta mercenary is going to cause like 20 comments from people who want to keep their precious meta pick.

## Why It's Good For The Game

1. A disproportionate amount of Mercenaries in-game are Blade Dancers (I wonder why) 
2. A mercenary class shouldn't have Bandit-tier or Middle-Aged Veteran-tier skills in swords (Master).
3. This PR will actually encourage people to play literally anything else in the Mercenary category.
4. Because Blade Dancers are THE Meta Merc class for Fragging. 
5. They singlehandedly outclass 80% of roles in combat situations. 
6. It's stupid that they:
             - Get dodge expert and +3 Speed
             - Master-tier parries with swords
             - Spawn with the sword
7. You will see a dozen comments get pissed that they don't get their gamer skills anymore, which only reinforces my claim that people only care for the frag meta. 
