### PR TITLE
Buffs master key to make it work on bump

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -407,7 +407,7 @@
 		return
 	else
 		var/obj/item/roguekey/K = I
-		if(K.lockhash == lockhash)
+		if(K.lockhash == lockhash || istype(K, /obj/item/roguekey/lord)) //master key cares not for lockhashes
 			lock_toggle(user)
 			if(autobump)
 				src.Open()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Master key had a weird lockhash copy property onclick that was sometimes troublesome when compared to the usual understanding of keys. This short-circuits the bump check so that master key is always valid to lock/unlock any door (which is effectively the case already with the lockhash copy onclick), letting it be used like a normal key in-hand walking around. Also should prevent weird can't-lock situation-bugs that have been reported.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gotta protect the all access ID
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
