### PR TITLE
Logic changes to fix poison pies bug

### DIFF
--- a/modular/Neu_Food/code/cooked/NeuFood_pies.dm
+++ b/modular/Neu_Food/code/cooked/NeuFood_pies.dm
@@ -398,7 +398,7 @@
 			process_step += 1
 			update_icon()
 			qdel(I)
-		if(meaty && process_step == 4 && do_after(user,short_cooktime, target = src))
+		else if(meaty && process_step == 4 && do_after(user,short_cooktime, target = src))
 			name = "uncooked meat pie"
 			icon_state = "meatpie_raw"
 			cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/meat/meat
@@ -406,35 +406,35 @@
 			process_step += 1
 			update_icon()
 			qdel(I)
-		if(potpie && process_step == 4 && do_after(user,short_cooktime, target = src))
+		else if(potpie && process_step == 4 && do_after(user,short_cooktime, target = src))
 			name = "uncooked pot pie"
 			filling_color = "#755430"
 			cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/pot
 			process_step += 1
 			update_icon()
 			qdel(I)
-		if(applepie && process_step == 4 && do_after(user,short_cooktime, target = src))
+		else if(applepie && process_step == 4 && do_after(user,short_cooktime, target = src))
 			name = "uncooked apple pie"
 			filling_color = "#947a4b"
 			cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple
 			process_step += 1
 			update_icon()
 			qdel(I)
-		if(berrypie && process_step == 4 && do_after(user,short_cooktime, target = src))
-			name = "uncooked berry pie"
-			filling_color = "#4a62cf"
-			cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/berry
-			process_step += 1
-			update_icon()
-			qdel(I)
-		if(poisoning && process_step == 4 && do_after(user,short_cooktime, target = src))
+		else if(poisoning && process_step == 4 && do_after(user,short_cooktime, target = src))
 			name = "uncooked berry pie"
 			filling_color = "#4a62cf"
 			cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/poison
 			process_step += 1
 			update_icon()
 			qdel(I)
-		if(crabby && process_step == 4 && do_after(user,short_cooktime, target = src))
+		else if(berrypie && process_step == 4 && do_after(user,short_cooktime, target = src))
+			name = "uncooked berry pie"
+			filling_color = "#4a62cf"
+			cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/berry
+			process_step += 1
+			update_icon()
+			qdel(I)
+		else if(crabby && process_step == 4 && do_after(user,short_cooktime, target = src))
 			name = "uncooked crab pie"
 			filling_color = "#f1e0cb"
 			cooked_type = /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/crab


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
There was a reported bug where berry poisoned pies were not coming through correctly, especially when cut into slices. This aims to fix it by changing the logic so that any poisoned berry in a berry pie procs the poison pie. The poison reagents properly fall down to slices through initialize_slice 

Put some elses in front of ifs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Sire, this pie is poisoned!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
