### PR TITLE
Removes mentorhelp from meditate verb, adds token destress

### DIFF
--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -162,3 +162,8 @@
 	stressadd = -3
 	desc = span_blue("An absolutely exquisite vintage. Indubitably.")
 	timer = 10 MINUTES
+
+/datum/stressevent/meditation
+	timer = 10 MINUTES
+	stressadd = -1
+	desc = span_green("My meditations were rewarding.")

--- a/code/modules/admin/verbs/schizohelp.dm
+++ b/code/modules/admin/verbs/schizohelp.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_EMPTY_TYPED(schizohelps, /datum/schizohelp)
 	if(!msg)
 		return
 
-	to_chat(src, span_info("<i>You meditate...</i>\n[msg]"))
+	to_chat(src, span_info("<i>You ask the mentors...</i>\n[msg]"))
 	var/datum/schizohelp/ticket = new(src)
 	var/display_name = get_schizo_name()
 	var/message = span_info("<i>[display_name] meditates...</i>\n[msg]")

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -97,7 +97,7 @@
 
 /datum/emote/living/meditate
 	key = "meditate"
-	key_third_person = "meditate"
+	key_third_person = "meditates"
 	message = "meditates."
 	restraint_check = FALSE
 	emote_type = EMOTE_VISIBLE
@@ -109,13 +109,10 @@
 	emote("meditate", intentional = TRUE)
 
 /datum/emote/living/meditate/run_emote(mob/user, params, type_override, intentional)
-	if(isliving(user))
-		if(!COOLDOWN_FINISHED(user, schizohelp_cooldown))
-			to_chat(user, span_warning("I need to wait before meditating again."))
-			return
-		var/msg = input("Say your meditation:", "Voices in your head") as text|null
-		if(msg)
-			user.schizohelp(msg)
+	. = ..()
+	if(do_after(user, 1 MINUTES))
+		user.add_stress(/datum/stressevent/meditation)
+		to_chat(user, span_green("My meditations were rewarding."))
 
 /datum/emote/living/bow
 	key = "bow"

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -61,7 +61,7 @@
 	set desc = ""
 	set category = "Admin"
 	if(mob)
-		var/msg = input("Say your meditation:", "Voices in your head") as text|null
+		var/msg = input("Submit your question to the Voices:", "Mentorhelp Input") as text|null
 		if(msg)
 			mob.schizohelp(msg)
 	else


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

There are complaints of people using meditate as prayer, and thus loading mentorhelp with false queries. This unties mentorhelp from the meditate verb (for some reason it was doubled in the IC emote verb snowflake and also an Admin tab verb); and adds a token destress if you spend a minute meditating. Now it is more clear that mentorhelp is an "OOC" verb.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Anything to give the end user enough information to prevent a skill issue.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
