### PR TITLE
Gives the zurch key to hymnist Zizo followers.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/bard.dm
@@ -210,6 +210,8 @@
 					neck = /obj/item/clothing/neck/roguetown/psicross/malum
 				if(/datum/patron/divine/eora) //Eora content from Stonekeep
 					neck = /obj/item/clothing/neck/roguetown/psicross/eora
+				if(/datum/patron/inhumen/zizo)
+					neck = /obj/item/roguekey/inhumen
 			H.change_stat("strength", 1)
 			H.change_stat("intelligence", 2)
 			H.change_stat("perception", 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Gives the 'ancient key' to followers of Zizo who pick the Hymnist bard class.  Does not give them the zizo cult theme because I find it annoying and I like the bard theme better.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It arguably fits into the category of 'person associated with magic, holy or arcane in nature' who get access to the Zurch. It also adds some more love for those who pick Hymnist but aren't followers of the Divine Pantheon.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
