### PR TITLE
Lets the crown sit in the vault unless the duke calls for it

### DIFF
--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -79,6 +79,11 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 			if(!I)
 				I = new /obj/item/clothing/head/roguetown/crown/serpcrown(src.loc)
 			if(I && !ismob(I.loc))//You MUST MUST MUST keep the Crown on a person to prevent it from being summoned (magical interference)
+				var/area/crown_area = get_area(I)
+				if(crown_area && istype(crown_area, /area/rogue/indoors/town/vault) && notlord) //Anti throat snipe from vault
+					say("The crown is within the vault.")
+					playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+					return
 				I.anti_stall()
 				I = new /obj/item/clothing/head/roguetown/crown/serpcrown(src.loc)
 				say("The crown is summoned!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Puts in a logic check to the throat so that if the crown is in the vault, only the current ruler (Grand Duke) can summon it. Everybody else has to go get it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There was admin concern about someone sniping the crown from the vault with the throat, which is a risk on lower pop. Admittedly, the risk was with the "fake" throat that spawns in the Mad Duke's room on the coast. But this addresses that concern. Not entirely sure about this one. Needs some discussion.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
