### PR TITLE
Uplifts mob/living/canUseTopic functionality to mob/living/carbon/human

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -410,6 +410,12 @@
 	if(!(mobility_flags & MOBILITY_UI))
 		to_chat(src, span_warning("I can't do that right now!"))
 		return FALSE
+	if(incapacitated())
+		to_chat(src, span_warning("I can't do that right now!"))
+		return FALSE
+	if(be_close && !in_range(M, src))
+		to_chat(src, span_warning("I am too far away!"))
+		return FALSE
 	return TRUE
 
 /mob/living/carbon/human/resist_restraints()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

mob/living/carbon/human/canUseTopic was only checking mobility, having lost some of its checks with respect to parent typing. This redefines those checks further up. I *should* return ..() at the end, but, the monkey dexterity checks are depreciated and it feels nasty.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Prevents things like using Vomitoriums while far away from them / unconscious. Probably need to gut monkey dexterity checks for canUseTopic at some point. Who uses inheritance in BYOND anyway, it's not like that's the whole point

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
