### PR TITLE
Repel now flings whatever you're holding on cast out of your hands

### DIFF
--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1274,6 +1274,7 @@
 					H.dropItemToGround(I)
 					if(I)	//In case it's something that gets qdel'd on drop
 						I.throw_at(throw_target, 7, 4)
+						H.throw_mode_off()
 
 /obj/projectile/magic/repel/on_hit(target)
 

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1261,6 +1261,19 @@
 	icon_state = "curseblob"
 	range = 15
 
+/obj/effect/proc_holder/spell/invoked/projectile/cast(list/targets, mob/living/user)
+	. = ..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/proj = H.get_active_held_item()
+		if(isobj(proj))
+			var/obj/I = proj
+			if(I && H.in_throw_mode)
+				var/atom/throw_target = get_edge_target_turf(H, get_dir(user,get_step(user,user.dir)))
+				if(throw_target)
+					H.dropItemToGround(I)
+					I.throw_at(throw_target, 7, 4)
+
 /obj/projectile/magic/repel/on_hit(target)
 
 	var/atom/throw_target = get_edge_target_turf(firer, get_dir(firer, target)) //ill be real I got no idea why this worked.

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1272,7 +1272,8 @@
 				var/atom/throw_target = get_edge_target_turf(H, get_dir(user,get_step(user,user.dir)))
 				if(throw_target)
 					H.dropItemToGround(I)
-					I.throw_at(throw_target, 7, 4)
+					if(I)	//In case it's something that gets qdel'd on drop
+						I.throw_at(throw_target, 7, 4)
 
 /obj/projectile/magic/repel/on_hit(target)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
https://github.com/user-attachments/assets/41804ddc-7bed-42c3-a4cf-ad1da0262c00

If you're in throw mode, and are holding something in your active hand (that isn't a grab) it'll get flung out much the same as if it were hit by repel itself.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
By request, it sounds kinda cool, if a bit janky.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
