### PR TITLE
craft blue standing fire

### DIFF
--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -596,6 +596,16 @@
 	wallcraft = TRUE
 	craftdiff = 0
 
+/datum/crafting_recipe/roguetown/structure/wallcandleblue
+	name = "wall candles (blue)"
+	result = /obj/machinery/light/rogue/wallfire/candle/blue
+	reqs = list(/obj/item/natural/stone = 1, /obj/item/candle/yellow = 1, /obj/item/ash = 1)
+	verbage_simple = "build"
+	verbage = "builds"
+	skillcraft = /datum/skill/craft/masonry
+	wallcraft = TRUE
+	craftdiff = 0
+
 /datum/crafting_recipe/roguetown/structure/stonewalldeco
 	name = "stone wall decoration"
 	result = /obj/structure/fluff/walldeco/stone

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -416,6 +416,15 @@
 	verbage_simple = "construct"
 	verbage = "constructs"
 
+/datum/crafting_recipe/roguetown/structure/standingblue
+	name = "standing fire (blue)"
+	result = /obj/machinery/light/rogue/firebowl/standing/blue
+	reqs = list(/obj/item/natural/stone = 1,
+				/obj/item/rogueore/coal = 1,
+				/obj/item/ash = 1)
+	verbage_simple = "construct"
+	verbage = "constructs"
+
 /datum/crafting_recipe/roguetown/structure/oven
 	name = "oven"
 	result = /obj/machinery/light/rogue/oven


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This lets you craft the blue standing fire you see in some places. We have engineers that can make colored bronze lanterns, self-purifying things, I am sure that aesthetic blue standing fire (I added a component to it more than normal standing fire) will probably be fine, especially for those that want to decorate underground with a softer color, or replace ones that get all messed up. (Like 5 people will probably ever use this.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
