### PR TITLE
Bugfix: Removing zombie faction "station" add/neg for deadites

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -190,7 +190,6 @@
 				zombie.mob_biotypes &= ~MOB_UNDEAD
 			zombie.faction -= "undead"
 			zombie.faction -= "zombie"
-			zombie.faction += "station"
 			zombie.faction += "neutral"
 			zombie.regenerate_organs()
 			if(has_turned)
@@ -245,7 +244,6 @@
 	zombie.mob_biotypes |= MOB_UNDEAD
 	zombie.faction += "undead"
 	zombie.faction += "zombie"
-	zombie.faction -= "station"
 	zombie.faction -= "neutral"
 	zombie.verbs |= /mob/living/carbon/human/proc/zombie_seek
 	for(var/obj/item/bodypart/zombie_part as anything in zombie.bodyparts)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Bug with the "station" faction being added to un-deadited individuals, making aggressive NPCs in dungeons non-aggro. This removes the station flags from un-deaditing, which is probably deprecated. They have their own zombie faction stuff anyway.

![image](https://github.com/user-attachments/assets/bb6e0a83-40df-41f0-8ea5-ebd4ba6f6be7)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Should prevent anomalies with un-zombified people being friends with sea raiders, etc.
![image](https://github.com/user-attachments/assets/1e628ed9-1df6-4830-94f2-e8ee97eab9dc)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
