### PR TITLE
Bugfix: Touches Purity machine to fix some bathmaster interactions

### DIFF
--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -114,20 +114,28 @@
 			return
 		switch(select)
 			if("Withdraw Cut")
-				options = list("To Bank", "Direct")
+				if(secret_budget < 1)
+					say("There is no mammon to move, Master.")
+					return
+				options = list("To Bank (Taxed)", "Direct")
 				select = input(usr, "Please select an option.", "", null) as null|anything in options
 				if(!select)
 					return
 				if(!usr.canUseTopic(src, BE_CLOSE) || locked)
 					return
+				if(secret_budget < 1)
+					say("There is no mammon to move, Master.")
+					return
 				switch(select)
-					if("To Bank")
+					if("To Bank (Taxed)")
 						var/mob/living/carbon/human/H = usr
-						SStreasury.generate_money_account(secret_budget, H)
+						if(!(SStreasury.generate_money_account(floor(secret_budget), H))) //We returned false on executing the transfer
+							say("I could not put your cut in your account, Master. My apologies.")
+							return
 						secret_budget = 0
 					if("Direct")
-						if(secret_budget > 0)
-							budget2change(secret_budget, usr)
+						if(secret_budget >= 1)
+							budget2change(floor(secret_budget), usr)
 							secret_budget = 0
 			if("Enable Paying Taxes")
 				drugrade_flags &= ~DRUGRADE_NOTAX
@@ -180,9 +188,11 @@
 	var/mob/living/carbon/human/H = user
 	if(H.job == "Bathmaster")
 		if(canread)
-			contents = "<a href='?src=[REF(src)];secrets=1'>Secrets</a>"
+			contents += "<a href='?src=[REF(src)];secrets=1'>Secrets</a><BR>"
+			contents += "Mammon Washing: [recent_payments] -- Your cut, Master! [secret_budget]<BR>"
 		else
-			contents = "<a href='?src=[REF(src)];secrets=1'>[stars("Secrets")]</a>"
+			contents += "<a href='?src=[REF(src)];secrets=1'>[stars("Secrets")]</a><BR>"
+			contents += "[stars("Mammon Washing:")] [recent_payments] -- [stars("Your cut, Master!")] [secret_budget]<BR>"
 
 	contents += "</center>"
 

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -134,9 +134,8 @@
 							return
 						secret_budget = 0
 					if("Direct")
-						if(secret_budget >= 1)
-							budget2change(floor(secret_budget), usr)
-							secret_budget = 0
+						budget2change(floor(secret_budget), usr)
+						secret_budget = 0
 			if("Enable Paying Taxes")
 				drugrade_flags &= ~DRUGRADE_NOTAX
 				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Window content was being overwritten by Bathmaster jobslot, preventing Bathmaster from being able to access mammon inserted in the machine. This fixes that. Also tightens up some of the withdraw cut logic to ensure payout.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/83631318-616c-47d5-8107-3b8b0da0189c)


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
