### PR TITLE
Virtues + Statpacks

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1421,10 +1421,10 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						statpack = statpack_chosen
 						to_chat(user, "<font color='purple'>[statpack.name]</font>")
 						to_chat(user, "<font color='purple'>[statpack.description_string()]</font>")
-						// also, unset our virtue if we're not a virtuous statpack.
+						/* also, unset our virtue if we're not a virtuous statpack.
 						if (!istype(statpack, /datum/statpack/wildcard/virtuous) && virtue.type != /datum/virtue/none)
 							virtue = new /datum/virtue/none
-							to_chat(user, span_info("Your virtue has been removed due to taking a stat-altering statpack."))
+							to_chat(user, span_info("Your virtue has been removed due to taking a stat-altering statpack.")) */
 				// LETHALSTONE EDIT: add pronouns
 				if ("pronouns")
 					var pronouns_input = input(user, "Choose your character's pronouns", "Pronouns") as null|anything in GLOB.pronouns_list
@@ -1593,9 +1593,9 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						virtue = virtue_chosen
 						if (virtue.desc)
 							to_chat(user, span_purple(virtue.desc))
-						if (statpack.type != /datum/statpack/wildcard/virtuous)
+					/*	if (statpack.type != /datum/statpack/wildcard/virtuous)
 							statpack = new /datum/statpack/wildcard/virtuous
-							to_chat(user, span_purple("Your statpack has been set to virtuous (no stats) due to selecting a virtue."))
+							to_chat(user, span_purple("Your statpack has been set to virtuous (no stats) due to selecting a virtue.")) */
 
 				if("charflaw")
 					var/list/coom = GLOB.character_flaws.Copy()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -208,13 +208,7 @@
 						else
 							thrown_range = 1
 						stop_pulling()
-						if(G.grab_state < GRAB_AGGRESSIVE)		//If we have the Giant Virtue, and aren't throwing another Giant, we can do it w/o aggro grab
-							if(HAS_TRAIT(throwable_mob, TRAIT_BIGGUY))
-								return
-							if(!HAS_TRAIT(src,TRAIT_BIGGUY))
-								return
-						if(HAS_TRAIT(src, TRAIT_PACIFISM))
-							to_chat(src, "<span class='notice'>I gently let go of [throwable_mob].</span>")
+						if(G.grab_state < GRAB_AGGRESSIVE)
 							return
 						var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 						var/turf/end_T = get_turf(target)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -182,7 +182,6 @@
 				// Five or above tiles between people
 				if(6 to INFINITY)
 					self_points += 1
-			// If we have Giant virtue
 			// If charging into the BACK of the enemy (facing away)
 			if(L.dir == get_dir(src, L))
 				self_points += 2

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -183,8 +183,6 @@
 				if(6 to INFINITY)
 					self_points += 1
 			// If we have Giant virtue
-			if(HAS_TRAIT(src,TRAIT_BIGGUY))
-				self_points += 2
 			// If charging into the BACK of the enemy (facing away)
 			if(L.dir == get_dir(src, L))
 				self_points += 2

--- a/modular_azurepeak/statpacks/wildcard.dm
+++ b/modular_azurepeak/statpacks/wildcard.dm
@@ -14,7 +14,8 @@
 	name = "Frail"
 	desc = "The growing dark limns your vision more with every passing day: your flesh and mind are failing you, and destiny has turned her gaze from you. How will your tale endure such hardship?"
 	stat_array = list(STAT_STRENGTH = -4, STAT_PERCEPTION = -4, STAT_INTELLIGENCE = -4, STAT_CONSTITUTION = -4, STAT_ENDURANCE = -4, STAT_SPEED = -4, STAT_FORTUNE = -4)
-
+/*
 /datum/statpack/wildcard/virtuous
 	name = "Virtuous"
 	desc = "The breadth of my being is one of a singular, defining virtue. \n (Allows access to 'virtues', special traits/quirks that replace the bonus normally given by a statpack.)"
+*/

--- a/modular_azurepeak/virtues/size.dm
+++ b/modular_azurepeak/virtues/size.dm
@@ -1,9 +1,7 @@
 /datum/virtue/size/giant
 	name = "Giant"
 	desc = "I've always been larger, stronger and hardier than the average person. I tend to lumber around a lot, and my immense size can break down frail, wooden doors."
-	added_stats = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 1, STAT_SPEED = -2)
 	added_traits = list(TRAIT_BIGGUY)
-	triumph_cost = 2
 
 /datum/virtue/size/giant/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.transform = recipient.transform.Scale(1.25, 1.25)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Comments out the virtue/statpack restrictions. Now you can take both. Also nerfs Giant, since it used to be a statpack + also some mechanical bonuses. Now It's just door ramming and the larger sprite. Also removed its triumph cost. I think the other virtues should be fine when combined with statpacks? Only other problematic one might be acrobatic, but I havent really seen anyone abuse the z-level fall yet so probably fine? We will c.

## Why It's Good For The Game

Now people can choose their Neat Flavor Options without being at a disadvantage statswise. Virtues are really cool for flavor, and I imagine we'll see more people taking stuff like Beautiful, or Rich, or etc now. Also reigns in Giant, which was a statpack + alot of boons already.
