### PR TITLE
Fixes: Guillotine Bug

### DIFF
--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -239,6 +239,7 @@
 
 			if (istype(S))
 				H.cut_overlays()
+				H.regenerate_icons()
 				H.update_body_parts_head_only()
 				H.set_mob_offsets("bed_buckle", _x = 0, _y = -GUILLOTINE_HEAD_OFFSET)
 				H.layer += GUILLOTINE_LAYER_DIFF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

It was always a bug being stripped being put on the guillotine because a regenerate icons call needed to be made after a cut overlay call.
![](https://puu.sh/KmnKy/f032824e8d.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more naked hobo executions unless you request to be a naked hobo...and they let you.
You do you..
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
