### PR TITLE
Soaps, Sewers, and Soothers

### DIFF
--- a/code/datums/stress/_stressevent.dm
+++ b/code/datums/stress/_stressevent.dm
@@ -16,9 +16,9 @@
 /datum/stressevent/test
 	timer = 5 SECONDS
 	stressadd = 3
-	desc = span_red("This is a positive test event.")
+	desc = span_red("This is a negative test event.")
 
 /datum/stressevent/testr
 	timer = 5 SECONDS
 	stressadd = -3
-	desc = span_green("This is a negative test event.")
+	desc = span_green("This is a positive test event.")

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -277,7 +277,6 @@
 	desc = span_red("Eating such a meal without a table? Churlish.")
 	timer = 2 MINUTES
 
-
 /datum/stressevent/soulchurnerhorror
 	timer = 10 SECONDS
 	stressadd = 50
@@ -288,8 +287,12 @@
 	stressadd = 10
 	desc = span_red("The horrid wails of the dead call for relief!")
 
-
 /datum/stressevent/soulchurnerpsydon
 	timer = 1 MINUTES
 	stressadd = 1
 	desc = span_red("The horrid wails of the dead call for relief! I can ENDURE such calls...")
+
+/datum/stressevent/sewertouched
+	timer = 5 MINUTES
+	stressadd = 2
+	desc = span_red("Putrid stinking water!")

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -167,3 +167,13 @@
 	timer = 10 MINUTES
 	stressadd = -1
 	desc = span_green("My meditations were rewarding.")
+
+/datum/stressevent/bathcleaned
+    timer = 20 MINUTES
+    stressadd = -3
+    desc = span_green("I feel immaculate!")
+
+/datum/stressevent/bath
+    timer = 10 MINUTES
+    stressadd = -1
+    desc = span_green("I'm just a bit cleaner.")

--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -84,3 +84,23 @@
 			SEND_SIGNAL(target, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
 			decreaseUses(user)
 	return
+
+
+/obj/item/soap/attack(mob/target, mob/user)
+	var/turf/bathspot = get_turf(target)
+	if(!istype(bathspot, /turf/open/water/bath))
+		return
+	if(istype(target, /mob/living/carbon/human))
+		visible_message(span_info("[user] begins washing [target] with the [src]."))
+		if(do_after(user, 50))
+			if(HAS_TRAIT(user, TRAIT_GOODLOVER))
+				visible_message(span_info("[user] expertly cleans and soothes [target] with the [src]."))
+				to_chat(target, span_love("I feel so relaxed and clean!"))
+				target.add_stress(/datum/stressevent/bathcleaned)
+			else
+				visible_message(span_info("[user] tries their best to scrub [target] with the [src]."))
+				to_chat(target, span_warning("That's a bit nicer, I guess."))
+				target.add_stress(/datum/stressevent/bath)
+			uses -= 1
+			if(uses == 0)
+				qdel(src)

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -67,3 +67,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	item_flags = NOBLUDGEON
+
+/obj/item/bath/soap/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/slippery, 80)

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -25,7 +25,7 @@
 	..()
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
-	r_hand = /obj/item/bath/soap
+	r_hand = /obj/item/soap/bath
 	belt =	/obj/item/storage/belt/rogue/leather/cloth
 	beltl = /obj/item/roguekey/nightmaiden
 	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
@@ -58,7 +58,7 @@
 
 // Washing Implements
 
-/obj/item/bath/soap
+/obj/item/soap/bath
 	name = "herbal soap"
 	desc = "A soap made from various herbs"
 	icon = 'icons/obj/items_and_weapons.dmi'
@@ -67,50 +67,3 @@
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	item_flags = NOBLUDGEON
-	throwforce = 0
-	throw_speed = 1
-	throw_range = 7
-	var/cleanspeed = 35 //slower than mop
-	var/uses = 10
-
-/obj/item/bath/soap/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/slippery, 80)
-
-/obj/item/bath/soap/examine(mob/user)
-	. = ..()
-	var/max_uses = initial(uses)
-	var/msg = "It looks like it was freshly made."
-	if(uses != max_uses)
-		var/percentage_left = uses / max_uses
-		switch(percentage_left)
-			if(0 to 0.2)
-				msg = "There's just a tiny bit left of what it used to be, you're not sure it'll last much longer."
-			if(0.21 to 0.4)
-				msg = "It's dissolved quite a bit, but there's still some life to it."
-			if(0.41 to 0.6)
-				msg = "It's past its prime, but it's definitely still good."
-			if(0.61 to 0.85)
-				msg = "It's started to get a little smaller than it used to be, but it'll definitely still last for a while."
-			else
-				msg = "It's seen some light use, but it's still pretty fresh."
-	. += span_notice("[msg]")
-
-/obj/item/bath/soap/attack(mob/target, mob/user)
-	var/turf/bathspot = get_turf(target)
-	if(!istype(bathspot, /turf/open/water/bath))
-		to_chat(user, span_warning("They must be in the bath water!"))
-		return
-	if(istype(target, /mob/living/carbon/human))
-		visible_message(span_info("[user] begins scrubbing [target] with the [src]."))
-		if(do_after(user, 50))
-			if(HAS_TRAIT(user, TRAIT_GOODLOVER))
-				visible_message(span_info("[user] expertly scrubs and soothes [target] with the [src]."))
-				to_chat(target, span_love("I feel so relaxed and clean!"))
-				SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "bathcleaned", /datum/mood_event/bathcleaned)
-			else
-				visible_message(span_info("[user] tries their best to scrub [target] with the [src]."))
-				to_chat(target, span_warning("Ouch! That hurts!"))
-			uses -= 1
-			if(uses == 0)
-				qdel(src)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -229,10 +229,14 @@
 
 /mob/living/carbon/human/handle_inwater()
 	. = ..()
-	if(!(mobility_flags & MOBILITY_STAND))
-		if(istype(loc, /turf/open/water/bath))
-			if(!wear_armor && !wear_shirt && !wear_pants)
-				add_stress(/datum/stressevent/bathwater)
+	if(istype(loc, /turf/open/water/bath))
+		if(!wear_armor && !wear_shirt && !wear_pants)
+			add_stress(/datum/stressevent/bathwater)
+
+/mob/living/carbon/human/handle_inwater()
+	. = ..()
+	if(istype(loc, /turf/open/water/sewer))
+		add_stress(/datum/stressevent/sewertouched)
 
 /mob/living/carbon/proc/get_complex_pain()
 	var/amt = 0


### PR DESCRIPTION
Goof dropped the soap but now, with great assistance, learned better. 

Introducing second attempt two.
--

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

Fixed the soap types so both soap and herbal soap should do the same things - clean objects and other people. 

Adds moodlet buffs to being washed and washing yourself with soap. 
Furthermore - FIXED the 'get bathed' moodlet to actually properly  apply and exist in the first place. 

Changed it so you don't have to lay down in bathwater to get the bathwater-relaxing moodlet, thus drowning yourself. 

Fixes a typo in the stressevent info tab, where the values were flipped

Lastly, made it so trudging through sewer water actually has a negative. ATM it makes you sad, but I'd like to expand on it in the future.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Bath'ers (gender neutral) now can actually do their namesake. It provides them with a somewhat reasonable buff beyond sex, which was already super limited. 

Encourage people to bathe themselves with a minor reward for doing so. Remind people that sewers suck.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
