### PR TITLE
Adds a way to remove feathers or cloth from helmets.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -101,6 +101,17 @@
 		shiftheld = TRUE
 	if(!isliving(user))
 		return
+	if(detail_tag && contents.len)
+		detail_tag = null
+		detail_color = null
+		update_icon()
+		for(var/obj/item/I in contents)
+			user.put_in_hands(I, FALSE, FALSE, FALSE)
+			user.visible_message(span_warning("[user] removes [I] from [src]."))
+		if(loc == user && ishuman(user))
+			var/mob/living/carbon/H = user
+			H.update_inv_head()
+		return
 	if(nodismemsleeves)
 		return
 	var/mob/living/L = user

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -586,7 +586,7 @@
 
 		var/choice = input(user, "Choose a color.", "Orle") as anything in colors
 		user.visible_message(span_warning("[user] adds [W] to [src]."))
-		qdel(W)
+		user.transferItemToLoc(W, src, FALSE, FALSE)
 		detail_color = colors[choice]
 		detail_tag = "_detail"
 		update_icon()
@@ -632,7 +632,7 @@
 
 		var/choice = input(user, "Choose a color.", "Orle") as anything in colors
 		user.visible_message(span_warning("[user] adds [W] to [src]."))
-		qdel(W)
+		user.transferItemToLoc(W, src, FALSE, FALSE)
 		detail_color = colors[choice]
 		detail_tag = "_detail"
 		update_icon()
@@ -682,7 +682,7 @@
 
 		var/choice = input(user, "Choose a color.", "Orle") as anything in colors
 		user.visible_message(span_warning("[user] adds [W] to [src]."))
-		qdel(W)
+		user.transferItemToLoc(W, src, FALSE, FALSE)
 		detail_color = colors[choice]
 		detail_tag = "_detail"
 		update_icon()
@@ -865,7 +865,7 @@
 		detail_color = colors[choice]
 		detail_tag = "_detail"
 		user.visible_message(span_warning("[user] adds [W] to [src]."))
-		qdel(W)
+		user.transferItemToLoc(W, src, FALSE, FALSE)
 		update_icon()
 		if(loc == user && ishuman(user))
 			var/mob/living/carbon/H = user
@@ -913,7 +913,7 @@
 
 		var/choice = input(user, "Choose a color.", "Orle") as anything in colors
 		user.visible_message(span_warning("[user] adds [W] to [src]."))
-		qdel(W)
+		user.transferItemToLoc(W, src, FALSE, FALSE)
 		detail_color = colors[choice]
 		detail_tag = "_detail"
 		update_icon()
@@ -977,7 +977,7 @@
 
 		var/choice = input(user, "Choose a color.", "Orle") as anything in colors
 		user.visible_message(span_warning("[user] adds [W] to [src]."))
-		qdel(W)
+		user.transferItemToLoc(W, src, FALSE, FALSE)
 		detail_color = colors[choice]
 		detail_tag = "_detail"
 		update_icon()
@@ -1114,7 +1114,7 @@
 		detail_color = colors[choice]
 		detail_tag = "_detail"
 		user.visible_message(span_warning("[user] adds [W] to [src]."))
-		qdel(W)
+		user.transferItemToLoc(W, src, FALSE, FALSE)
 		update_icon()
 		if(loc == user && ishuman(user))
 			var/mob/living/carbon/H = user
@@ -1164,7 +1164,7 @@
 
 		var/choice = input(user, "Choose a color.", "Orle") as anything in colors
 		user.visible_message(span_warning("[user] adds [W] to [src]."))
-		qdel(W)
+		user.transferItemToLoc(W, src, FALSE, FALSE)
 		detail_color = colors[choice]
 		detail_tag = "_detail"
 		update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Allows you to recover feathers or cloths from helmets that have been decorated by middleclicking on it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Imagine this: 

You spend 50 mammons on a helmet you've never used before and want to add a cloth or feather to it, then realize the color doesn't match your outfit. Now, you can middleclick on it and recover the decorator item.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
