### PR TITLE
Fixes Merchant infinite money glitch

### DIFF
--- a/code/modules/cargo/packsrogue/luxury.dm
+++ b/code/modules/cargo/packsrogue/luxury.dm
@@ -93,7 +93,7 @@
 
 /datum/supply_pack/rogue/luxury/riddleofsteel
 	name = "Riddle of Steel"
-	cost = 400
+	cost = 500
 	contains = list(/obj/item/riddleofsteel)
 
 /datum/supply_pack/rogue/luxury/polishing_kit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Bumps up the price of riddles of steel in the goldface a bit in order to patch an exploit that allows the merchant to generate literal infinite amounts of money by buying riddles of steel from the goldface and then immediately selling them at the balloon for a net profit.

## Why It's Good For The Game

Riddles of steel currently have the same base sell value as their base buy value in the vendor, and because of price/value variation, riddles of steel can occasionally be significantly cheaper in the goldface vendor than what they actually sell for at the balloon if the merchant gets lucky - which allows the merchant to generate infinite amounts of money by repeatedly buying and immediately selling them at the balloon.
