### PR TITLE
Fixes Nadeli Orthos lacking an inquisition key

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -57,6 +57,7 @@
 		ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 
 /datum/outfit/job/roguetown/disciple/proc/nadeli_equip(mob/living/carbon/human/H)
+	backpack_contents = list(/obj/item/roguekey/inquisition = 1)
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 	cloak = /obj/item/clothing/cloak/psydontabard/alt
 	if(H.mind)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This subclass didn't spawn with a key when they should. This fixes it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If you are so great a wizard, why don't you spell yourself up a key
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
