### PR TITLE
Bugfix for reading var in arcane tomes locking up as true

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -50,8 +50,6 @@
 		return FALSE
 	if(already_known(user))
 		return FALSE
-	if(!user.can_read(src))
-		return FALSE
 /*	AZURE PEAK REMOVAL -- UNUSED ANYWAY
 	if(user.STAINT < 12)
 			to_chat(user, span_warning("You can't make sense of the sprawling runes!"))
@@ -64,13 +62,15 @@
 	reading = TRUE
 	for(var/i=1, i<=pages_to_mastery, i++)
 		if(!turn_page(user))
-			on_reading_stopped()
 			reading = FALSE
-			return
-	if(do_after(user,50, user))
-		on_reading_finished(user)
+			on_reading_stopped()
+			return FALSE
+	if(do_after(user, 50, user))
 		reading = FALSE
-	return TRUE
+		on_reading_finished(user)
+		return TRUE
+	reading = FALSE //failsafe
+	return FALSE
 
 /obj/item/book/granter/spell
 	var/spell

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -44,7 +44,7 @@
 		recoil(user)
 		return FALSE
 	if(reading)
-		to_chat(user, span_warning("You're already reading this!"))
+		to_chat(user, span_warning("I'm already reading this!"))
 		return FALSE
 	if(!user.can_read(src))
 		return FALSE
@@ -54,9 +54,9 @@
 	if(user.STAINT < 12)
 			to_chat(user, span_warning("You can't make sense of the sprawling runes!"))
 			return FALSE */
-	if(used)
-		if(oneuse)
-			recoil(user)
+	if(used && oneuse)
+		to_chat(user, span_warning("This fount of knowledge was not meant to be sipped from twice!"))
+		recoil(user)
 		return FALSE
 	on_reading_start(user)
 	reading = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![image](https://github.com/user-attachments/assets/94a8d71d-5fc1-4f2e-9d9d-d7080d1b0cd9)

Fringe situation where the final do_after for reading an arcyne book would be interrupted and then lock the reading sanity var to true. This adds a catch to the end that should prevent it from happening.

There appeared to be an issue with used/oneuse logic that I also tried to fix. But that is only pertinent to spell granting scrolls I think.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Arcane tomes do arcane things
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
