### PR TITLE
Visual Fix: South Facing Saiga riding.

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
+++ b/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
@@ -190,7 +190,7 @@
 	if(can_buckle)
 		var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 8), TEXT_SOUTH = list(0, 8), TEXT_EAST = list(-2, 8), TEXT_WEST = list(2, 8)))
-		D.set_vehicle_dir_layer(SOUTH, OBJ_LAYER)
+		D.set_vehicle_dir_layer(SOUTH, MOB_LAYER+0.1)
 		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 		D.set_vehicle_dir_layer(EAST, OBJ_LAYER)
 		D.set_vehicle_dir_layer(WEST, OBJ_LAYER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

With the help of our friend GOAT RIDING CODE i fixed it so you no longer look like you are sitting on a saigas head while facing south. Now someone add ridable mossbacks so sunglade stops pulling a gun to my head.
![](https://puu.sh/KmLDP/6db2d4a838.png)

This same bug happens to guillotine and while out of scope i will leave my findings here as i did on discord for anyone else wanting to go figure out the Guillotine layering.

" upon compareing to the pillory code i saw it uses a icon state for being over/on someone all well and good for the fact the pillory is a standing game punishment(Litterly you are standing). FOR GUILLOTINES to make you look 'behind' the sprite properly you would need an icon state like that, remove ' H.layer += GUILLOTINE_LAYER_DIFF' in the code and somehow figure out how to not make it look goofy cause now your mob is offet lower and your legs are 'under/behind' the bottom of the object sprite. but fixed saiga south dir!"

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Saiga do not like you sitting on thier head to ride them

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
