### PR TITLE
Bugfix: Defines fishspear as fishspear and not eagle beak duplicate

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -269,7 +269,7 @@
 	craftdiff = 0
 	createditem_num = 4
 
-/datum/anvil_recipe/weapons/steel/eaglebeak
+/datum/anvil_recipe/weapons/steel/fishspear
 	name = "Fishing Spear (+1 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fish spear implementation overwrote the define of the eagle beak datum, meaning eagle beaks could no longer be smithed. This fixes that. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Eagle beak my beloved

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
