### PR TITLE
Visual feedback on whether nerve master is locked or not

### DIFF
--- a/code/modules/roguetown/roguemachine/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward.dm
@@ -27,6 +27,7 @@
 		if(K.lockid == keycontrol || istype(K, /obj/item/roguekey/lord)) //Master key
 			locked = !locked
 			playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+			(locked) ? (icon_state = "steward_machine_off") : (icon_state = "steward_machine")
 			update_icon()
 			return
 		else
@@ -41,6 +42,7 @@
 			if(KE.lockid == keycontrol)
 				locked = !locked
 				playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+				(locked) ? (icon_state = "steward_machine_off") : (icon_state = "steward_machine")
 				update_icon()
 				return
 		to_chat(user, span_warning("Wrong key."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Quick ternary check to swap the nerve master's icon state, whether his eye is illuminated or not based on whether he's locked. Sprite was already there, just wasn't used for whatever reason.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
this is what ternary operators were made for

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
