### PR TITLE
Defines cheesecake slice and honeycake slice as plateable

### DIFF
--- a/modular/Neu_Food/code/raw/NeuFood_dough.dm
+++ b/modular/Neu_Food/code/raw/NeuFood_dough.dm
@@ -729,6 +729,7 @@
 	bitesize = 3
 	eat_effect = /datum/status_effect/buff/foodbuff
 	rotprocess = SHELFLIFE_LONG
+	plateable = TRUE
 
 /obj/item/reagent_containers/food/snacks/rogue/hcakeslice/plated
 	icon_state = "honeycakeslice_plated"
@@ -778,6 +779,7 @@
 	bitesize = 2
 	eat_effect = /datum/status_effect/buff/foodbuff
 	rotprocess = SHELFLIFE_LONG
+	plateable = TRUE
 
 /obj/item/reagent_containers/food/snacks/rogue/ccakeslice/plated
 	icon_state = "cheesecake_slice_plated"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

![image](https://github.com/user-attachments/assets/fec3088b-2931-4d23-aad3-d6afd3035044)

The plateable rework missed setting cheesecake and honeycake slices as plateable. This fixes that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/d96faa1d-7943-4e40-91e1-ce5073f228a3)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
