### PR TITLE
Bard Bug SQUASHENING

### DIFF
--- a/code/game/objects/items/rogueitems/dmusicbox.dm
+++ b/code/game/objects/items/rogueitems/dmusicbox.dm
@@ -7,7 +7,7 @@
 	extra_range = 5
 	var/stress2give = /datum/stressevent/music
 	persistent_loop = TRUE
-	channel = CHANNEL_MUSIC
+	channel = CHANNEL_CMUSIC
 
 /datum/looping_sound/dmusloop/on_hear_sound(mob/M)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The music channel was being used by bard instruments to host their music, causing it to be interrupted by change of day/zone which also used the music channel. This moves instruments over to the CMUSIC channel, which is free and unused, removing the interruptions.

## Why It's Good For The Game

I JUST WANT TO PLAY A FULL SONG ZIZO PLEASE I BEG OF YOU
