### PR TITLE
Update knives.dm

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -384,13 +384,13 @@
 	name = "psydonian tossblade"
 	desc = "An unconventional method of delivering silver to a heretic; but one PSYDON smiles at, all the same. Doubles as an actual knife in a pinch, though obviously not as well."
 	item_state = "bone_dagger"
-	force = 12
-	throwforce = 28
+	force = 8
+	throwforce = 20
 	throw_speed = 4
-	max_integrity = 150
+	max_integrity = 40
 	wdefense = 3
 	icon_state = "throw_knifep"
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 50, "embedded_fall_chance" = 0)
+	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 25, "embedded_fall_chance" = 12)
 	is_silver = TRUE
 	sellprice = 6
 	smeltresult = null


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Reduces force and sharpness of silver tossdaggers, since silver is a softer metal than iron or steel.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
For some reason the psydonite knives are much better than other knives. Their greatest asset is that they are silver. They should not be stronger then steel or iron, since the trope of witchers and others who use silver weapons to hunt monsters is that it is weaker than iron, but the "weakness" of monsters to silver makes them worthwhile. They should use different weapons to kill/fight non monsters, instead of using silver for everything.

I think making the silver throwdaggers better than even the iron and steel ones to kill normal mortals goes against that logic and just plainly makes them unjustifiably stronger.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
