### PR TITLE
performance: remove draw_organ from get_limb_icon

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -630,12 +630,9 @@
 			if(aux_zone && !hideaux)
 				aux.color = "#[draw_color]"
 	
-	var/draw_organ_features = TRUE
 	var/draw_bodypart_features = TRUE
 	if(owner && owner.dna)
 		var/datum/species/owner_species = owner.dna.species
-		if(NO_ORGAN_FEATURES in owner_species.species_traits)
-			draw_organ_features = FALSE
 		if(NO_BODYPART_FEATURES in owner_species.species_traits)
 			draw_bodypart_features = FALSE
 	
@@ -644,15 +641,6 @@
 		var/list/marking_overlays = get_markings_overlays(override_color)
 		if(marking_overlays)
 			. += marking_overlays
-	
-	// Organ overlays
-	if(!skeletonized && draw_organ_features)
-		for(var/obj/item/organ/organ as anything in get_organs())
-			if(!organ.is_visible())
-				continue
-			var/mutable_appearance/organ_appearance = organ.get_bodypart_overlay(src)
-			if(organ_appearance)
-				. += organ_appearance
 	
 	// Feature overlays
 	if(!skeletonized && draw_bodypart_features)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

For every limb a carbon has, the function this code calls (get_organs) which iterates through all the organs in the owner's body just in case there's a reason for it to show meaning each carbon mob compounds this issue (by every limb they have) which often leads to overtime.

I can't notice a difference with it removed (but I'm no eagle-eyed expert in SS13 graphics). Recommend test merging to see if anyone does. If they do, I'll work out a better way to do it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Sacrifice graphical fidelity (?) for some performance.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
