### PR TITLE
Devotee raises your devotion cap to the next tier if you already have miracles

### DIFF
--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -36,6 +36,15 @@
 		// for devotionists, bump up their maximum 1 tier and give them a TINY amount of passive devo gain
 		var/datum/devotion/our_faith = recipient.devotion
 		our_faith.passive_devotion_gain += 0.15
+		switch (our_faith.max_devotion)
+			if (CLERIC_REQ_0)
+				our_faith.max_devotion = CLERIC_REQ_1
+			if (CLERIC_REQ_1)
+				our_faith.max_devotion = CLERIC_REQ_2
+			if (CLERIC_REQ_2)
+				our_faith.max_devotion = CLERIC_REQ_3
+			if (CLERIC_REQ_3)
+				our_faith.max_devotion = CLERIC_REQ_4
 		switch (our_faith.max_progression)
 			if (CLERIC_REQ_0)
 				our_faith.max_progression = CLERIC_REQ_1


### PR DESCRIPTION
## About The Pull Request

To briefly explain how miracles work, miracles are unlocked through an invisible 'progress' stat that is an accumulated total of how much devotion you've gained through prayer in the round; except unlike devotion, 'progress' never gets lowered or spent at all when you cast miracles.

Devotee currently raises your progress cap by a single tier if you already spawn with miracles - this PR makes it also raise your devotion cap by a single tier if you already spawn with miracles.

## Why It's Good For The Game

Devotee currently raises your progress cap by 1 tier (for templars/paladins this goes from 100 to 250) but doesn't raise your actual devotion cap, meaning you can /technically/ unlock tier 2 miracles as a paladin/templar with devotee, but doing so would require you to pray until you hit your cap of 100 devotion, spam abrogation/lesser heal to spend all your devotion, then start praying again. Rinse and repeat this process three times to gain access to T2 miracles.

This sucks and is really annoying and this PR fixes the issue by just making devotee raise your max devotion cap by a single tier alongside your progress cap.
