### PR TITLE
bugfix: explosions and simplemobs

### DIFF
--- a/code/datums/actions/mobs/dragonbreath.dm
+++ b/code/datums/actions/mobs/dragonbreath.dm
@@ -43,7 +43,7 @@
 	// Guys we have already hit, no double dipping
 	var/list/hit_list = list(owner) // also don't burn ourselves
 	for(var/turf/target_turf in burn_turfs)
-		if (target_turf.is_blocked_turf(exclude_mobs = FALSE))
+		if (target_turf.is_blocked_turf(exclude_mobs = TRUE))
 			var/exp_heavy = 0
 			var/exp_light = 4
 			var/exp_flash = 0

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -233,12 +233,12 @@
 
 /mob/living/simple_animal/ex_act(severity, target, epicenter, devastation_range, heavy_impact_range, light_impact_range, flame_range)
 	..()
-	if (!severity)
+	if(!severity || !epicenter)
 		return
-	var/ddist = devastation_range
-	var/hdist = heavy_impact_range
-	var/ldist = light_impact_range
-	var/fdist = flame_range
+	var/ddist = devastation_range || 0
+	var/hdist = heavy_impact_range || 0
+	var/ldist = light_impact_range || 0
+	var/fdist = flame_range || 0
 	var/fodist = get_dist(src, epicenter)
 	var/brute_loss = 0
 	var/burn_loss = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Explosions could give simplemobs infinite health if an explosion that hit it had no epicenter: 

get_dist() will return -1 when Loc1 and Loc2 are the same object. If one or both of them is not on the map, an infinite value is returned.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bugfix

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
