### PR TITLE
Onion and Potato cut into 2 slices

### DIFF
--- a/modular/Neu_Food/code/raw/NeuFood_veggies.dm
+++ b/modular/Neu_Food/code/raw/NeuFood_veggies.dm
@@ -13,6 +13,7 @@
 	tastes = list("onion" = 1)
 	chopping_sound = TRUE
 	dropshrink = 0.8
+	slices_num = 2
 
 /obj/item/reagent_containers/food/snacks/rogue/veg/onion_sliced
 	name = "sliced onion"
@@ -39,7 +40,7 @@
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue
 	desc = "A spud, dwarven icon of growth."
 	eat_effect = null
-	slices_num = 1
+	slices_num = 2
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/veg/potato_sliced
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/preserved/potato_baked
 	tastes = list("potato" = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Buffs veggies by increasing potato and onion slices to 2 instead of 1.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Veggies are a little cheaper to eat than meat. Make your mammon last longer.
![image](https://github.com/user-attachments/assets/59fb864a-9528-46f1-adc3-080f9972f940)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
