### PR TITLE
dendor tame beast fix/change for simples, eat_food/eat_body/retal subtree cleanup

### DIFF
--- a/code/__DEFINES/ai/_ai.dm
+++ b/code/__DEFINES/ai/_ai.dm
@@ -53,7 +53,9 @@
 ///time until we should next eat, set by the generic hunger subtree
 #define BB_NEXT_HUNGRY "BB_NEXT_HUNGRY"
 ///what we're going to eat next
-#define BB_FOOD_TARGET "bb_food_target"
+#define BB_BASIC_MOB_FOOD_TARGET "BB_basic_food_target"
+///what corpse we'll next try to eat
+#define BB_BASIC_MOB_CORPSE_TARGET "BB_basic_mob_corpse_target"
 
 #define BB_BASIC_MOB_TAMED "BB_basic_mob_tamed"
 

--- a/code/__DEFINES/ai/hostile.dm
+++ b/code/__DEFINES/ai/hostile.dm
@@ -42,7 +42,6 @@
 #define BB_BASIC_MOB_CURRENT_TARGET "BB_basic_current_target"
 #define BB_BASIC_MOB_CURRENT_TARGET_HIDING_LOCATION "BB_basic_current_target_hiding_location"
 #define BB_TARGETTING_DATUM "targetting_datum"
-#define BB_BASIC_MOB_FOOD_TARGET "BB_basic_food_target"
 #define BB_TARGETTING_DATUM_EQUIPMENT "equip_targetting_datum"
 #define BB_BASIC_MOB_RUN_WITH_ITEM "BB_run_with_item"
 #define BB_BASIC_MOB_EQUIPMENT_TARGET "BB_equipment_target"

--- a/code/datums/ai/behaviors/hostile/find_potential_targets.dm
+++ b/code/datums/ai/behaviors/hostile/find_potential_targets.dm
@@ -2,6 +2,7 @@
 	action_cooldown = 2 SECONDS
 	/// How far can we see stuff?
 	var/vision_range = 9
+	var/tamed_key = BB_BASIC_MOB_TAMED
 
 /datum/ai_behavior/find_potential_targets/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targetting_datum_key, hiding_location_key)
 
@@ -17,6 +18,9 @@
 		return
 
 	controller.clear_blackboard_key(target_key)
+	if(controller.blackboard[tamed_key]) //they are tamed, thusly pacified and will only retaliate.
+		finish_action(controller, succeeded = FALSE)
+		return
 	var/list/potential_targets = hearers(vision_range, controller.pawn) - living_mob //Remove self, so we don't suicide
 
 	if(!potential_targets.len) // Couldn't find valid targets

--- a/code/datums/ai/behaviors/hunger.dm
+++ b/code/datums/ai/behaviors/hunger.dm
@@ -16,9 +16,9 @@
 	if(world.time < next_eat)
 		return
 
-	if(!controller.blackboard[BB_FOOD_TARGET])
-		controller.queue_behavior(/datum/ai_behavior/find_and_set/edible, BB_FOOD_TARGET, /obj/item, 2)
+	if(!controller.blackboard[BB_BASIC_MOB_FOOD_TARGET])
+		controller.queue_behavior(/datum/ai_behavior/find_and_set/edible, BB_BASIC_MOB_FOOD_TARGET, /obj/item, 2)
 		return
 
-	controller.queue_behavior(/datum/ai_behavior/eat_food, BB_FOOD_TARGET, BB_NEXT_HUNGRY)
+	controller.queue_behavior(/datum/ai_behavior/eat_food, BB_BASIC_MOB_FOOD_TARGET, BB_NEXT_HUNGRY)
 	return SUBTREE_RETURN_FINISH_PLANNING

--- a/code/datums/ai/controllers/spider.dm
+++ b/code/datums/ai/controllers/spider.dm
@@ -4,15 +4,14 @@
 	ai_movement = /datum/ai_movement/basic_avoidance
 
 	blackboard = list(
-		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/allow_items()
-
+		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/allow_items(),
+		BB_BASIC_MOB_TAMED  = FALSE
 	)
 
 	planning_subtrees = list(
-
+		/datum/ai_planning_subtree/target_retaliate,
 		/datum/ai_planning_subtree/simple_find_target/spider,
 		/datum/ai_planning_subtree/basic_melee_attack_subtree,
-
 		/datum/ai_planning_subtree/find_dead_bodies,
 		/datum/ai_planning_subtree/eat_dead_body,
 		/datum/ai_planning_subtree/find_food,

--- a/code/datums/ai/controllers/volf.dm
+++ b/code/datums/ai/controllers/volf.dm
@@ -4,7 +4,8 @@
 	ai_movement = /datum/ai_movement/basic_avoidance
 
 	blackboard = list(
-		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic()
+		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic(),
+		BB_BASIC_MOB_TAMED = FALSE,
 	)
 
 	planning_subtrees = list(

--- a/code/datums/ai/subtrees/call_reinforcements.dm
+++ b/code/datums/ai/subtrees/call_reinforcements.dm
@@ -8,10 +8,12 @@
 	var/emote_key = BB_REINFORCEMENTS_EMOTE
 	/// Reinforcement-calling behavior to use
 	var/call_type = /datum/ai_behavior/call_reinforcements
+	/// Key for whether mob is tamed. If it is, won't do this
+	var/tame_key = BB_BASIC_MOB_TAMED
 
 /datum/ai_planning_subtree/call_reinforcements/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	. = ..()
-	if (!decide_to_call(controller) || controller.blackboard[BB_BASIC_MOB_REINFORCEMENTS_COOLDOWN] > world.time)
+	if (!decide_to_call(controller) || controller.blackboard[BB_BASIC_MOB_REINFORCEMENTS_COOLDOWN] > world.time || controller.blackboard[tame_key])
 		return
 
 	var/call_say = controller.blackboard[BB_REINFORCEMENTS_SAY]
@@ -38,7 +40,7 @@
 /datum/ai_behavior/call_reinforcements/perform(seconds_per_tick, datum/ai_controller/controller)
 	var/mob/pawn_mob = controller.pawn
 	for(var/mob/other_mob in get_hearers_in_view(reinforcements_range, pawn_mob))
-		if(pawn_mob.faction_check_mob(target = other_mob, exact_match = FALSE) && !isnull(other_mob.ai_controller))
+		if(pawn_mob.faction_check_mob(target = other_mob, exact_match = FALSE) && !isnull(other_mob.ai_controller) && !other_mob.ai_controller.blackboard[BB_BASIC_MOB_TAMED])
 			// Add our current target to their retaliate list so that they'll attack our aggressor
 			other_mob.ai_controller.insert_blackboard_key_lazylist(BB_BASIC_MOB_RETALIATE_LIST, controller.blackboard[BB_BASIC_MOB_CURRENT_TARGET])
 			other_mob.ai_controller.set_blackboard_key(BB_BASIC_MOB_REINFORCEMENT_TARGET, pawn_mob)

--- a/code/datums/ai/subtrees/eat_body.dm
+++ b/code/datums/ai/subtrees/eat_body.dm
@@ -1,16 +1,17 @@
 /datum/ai_planning_subtree/eat_dead_body
 	var/datum/ai_behavior/eat_dead_body/behavior = /datum/ai_behavior/eat_dead_body
+	var/corpse_key = BB_BASIC_MOB_CORPSE_TARGET
 
 /datum/ai_planning_subtree/eat_dead_body/SelectBehaviors(datum/ai_controller/controller, delta_time)
 	. = ..()
-	var/atom/target = controller.blackboard[BB_BASIC_MOB_FOOD_TARGET]
+	var/atom/target = controller.blackboard[corpse_key]
 	if(QDELETED(target) || !ismob(target)) //Bodies only
-		controller.clear_blackboard_key(BB_BASIC_MOB_FOOD_TARGET)
+		controller.clear_blackboard_key(corpse_key)
 		return FALSE
 	var/mob/living/pawn = controller.pawn
 	if(pawn.doing)
 		return
-	controller.queue_behavior(behavior, BB_BASIC_MOB_FOOD_TARGET, BB_TARGETTING_DATUM, BB_BASIC_MOB_CURRENT_TARGET_HIDING_LOCATION)
+	controller.queue_behavior(behavior, corpse_key, BB_TARGETTING_DATUM, BB_BASIC_MOB_CURRENT_TARGET_HIDING_LOCATION)
 	return SUBTREE_RETURN_FINISH_PLANNING //we are going to eat...no distractions.
 
 

--- a/code/datums/ai/subtrees/eat_body.dm
+++ b/code/datums/ai/subtrees/eat_body.dm
@@ -4,7 +4,8 @@
 /datum/ai_planning_subtree/eat_dead_body/SelectBehaviors(datum/ai_controller/controller, delta_time)
 	. = ..()
 	var/atom/target = controller.blackboard[BB_BASIC_MOB_FOOD_TARGET]
-	if(QDELETED(target) || 	!ismob(target)) //Bodies only
+	if(QDELETED(target) || !ismob(target)) //Bodies only
+		controller.clear_blackboard_key(BB_BASIC_MOB_FOOD_TARGET)
 		return FALSE
 	var/mob/living/pawn = controller.pawn
 	if(pawn.doing)

--- a/code/datums/ai/subtrees/eat_food.dm
+++ b/code/datums/ai/subtrees/eat_food.dm
@@ -5,6 +5,7 @@
 	. = ..()
 	var/obj/item/target = controller.blackboard[BB_BASIC_MOB_FOOD_TARGET]
 	if(QDELETED(target))
+		controller.clear_blackboard_key(BB_BASIC_MOB_FOOD_TARGET)
 		return
 	var/mob/living/pawn = controller.pawn
 	if(pawn.doing)

--- a/code/datums/ai/subtrees/find_food.dm
+++ b/code/datums/ai/subtrees/find_food.dm
@@ -1,20 +1,22 @@
 /// similar to finding a target but looks for food types in the general area
 /datum/ai_planning_subtree/find_food
 	var/vision_range = 9
+	var/food_key = BB_BASIC_MOB_FOOD_TARGET
 
 /datum/ai_planning_subtree/find_food/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	. = ..()
-	var/atom/target = controller.blackboard[BB_BASIC_MOB_FOOD_TARGET]
+	var/atom/target = controller.blackboard[food_key]
 	if(!QDELETED(target))
 		// Busy with something
 		return
 
-	controller.queue_behavior(/datum/ai_behavior/find_and_set/in_list, BB_BASIC_MOB_FOOD_TARGET, controller.blackboard[BB_BASIC_FOODS], vision_range)
+	controller.queue_behavior(/datum/ai_behavior/find_and_set/in_list, food_key, controller.blackboard[BB_BASIC_FOODS], vision_range)
 
 
 /datum/ai_planning_subtree/find_dead_bodies
 	var/vision_range = 9
 	var/datum/ai_behavior/find_and_set/dead_bodies/behavior = /datum/ai_behavior/find_and_set/dead_bodies
+	var/corpse_key = BB_BASIC_MOB_CORPSE_TARGET
 
 /datum/ai_planning_subtree/find_dead_bodies/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	. = ..()
@@ -23,12 +25,12 @@
 		if(mob.food >= mob.food_max && !mob.eat_forever) 
 			return // not hungry
 
-	var/atom/target = controller.blackboard[BB_BASIC_MOB_FOOD_TARGET]
+	var/atom/target = controller.blackboard[corpse_key]
 	if(!QDELETED(target))
 		// Busy with something
 		return
 
-	controller.queue_behavior(behavior, BB_BASIC_MOB_FOOD_TARGET, controller.blackboard[BB_BASIC_FOODS], vision_range)
+	controller.queue_behavior(behavior, corpse_key, controller.blackboard[BB_BASIC_FOODS], vision_range)
 
 /datum/ai_planning_subtree/find_dead_bodies/mole
 	vision_range = 7

--- a/code/datums/ai/subtrees/retaliate_subtree.dm
+++ b/code/datums/ai/subtrees/retaliate_subtree.dm
@@ -66,12 +66,12 @@
 
 	var/list/enemies_list = list() //use shitlist to make new list of potentials
 	for(var/mob/living/living_target in shitlist)
-		if(!living_target.rogue_sneaking) // can't see them
+		if(living_target.rogue_sneaking) // can't see them
 			continue
 		var/extra_chance = (living_mob.health <= living_mob.maxHealth * 50) ? 30 : 0 // if we're below half health, we're way more alert
-		if (!living_mob.npc_detect_sneak(living_target, extra_chance))
+		if(!living_mob.npc_detect_sneak(living_target, extra_chance))
 			continue //still can't see them
-		if(!targetting_datum.can_attack(living_mob, targetted)) //not ok with target strat
+		if(!targetting_datum.can_attack(living_mob, living_target)) //not ok with target strat
 			continue
 		enemies_list += living_target
 

--- a/code/datums/ai/targetting_datum/simple_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simple_targetting_datum.dm
@@ -35,7 +35,7 @@
 
 	if(isliving(the_target)) //Targetting vs living mobs
 		var/mob/living/L = the_target
-		if(L.summoner == the_target) // won't attack whomever summoned it
+		if(L.summoner && L.summoner == the_target.name) // won't attack whomever summoned it
 			return FALSE
 		if(faction_check(living_mob, L) || L.stat)
 			return FALSE

--- a/code/datums/ai/targetting_datum/simple_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simple_targetting_datum.dm
@@ -35,6 +35,8 @@
 
 	if(isliving(the_target)) //Targetting vs living mobs
 		var/mob/living/L = the_target
+		if(L.summoner == the_target) // won't attack whomever summoned it
+			return FALSE
 		if(faction_check(living_mob, L) || L.stat)
 			return FALSE
 		return TRUE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -148,7 +148,7 @@
 
 	var/list/next_attack_msg = list()
 
-	///The mob's summoner and probable master; high up.
+	///The NAME (not the reference) of the mob's summoner and probable master.
 	var/summoner = null
 
 

--- a/code/modules/mob/living/simple_animal/rogue/creacher/honeyspider.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/honeyspider.dm
@@ -68,6 +68,7 @@
 		gender = FEMALE
 	update_icon()
 	ai_controller.set_blackboard_key(BB_BASIC_FOODS, food_type)
+	AddElement(/datum/element/ai_retaliate)
 
 
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/AttackingTarget()

--- a/code/modules/mob/living/simple_animal/rogue/creacher/mossback.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mossback.dm
@@ -51,7 +51,7 @@
 	AddElement(/datum/element/ai_retaliate)
 	ai_controller.set_blackboard_key(BB_BASIC_FOODS, food_type)
 	if(user)
-		summoner += user.name
+		summoner = user.name
 		if (townercrab)
 			faction = list("neutral")
 			tamed(1)

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -52,16 +52,17 @@
 	. = ..()
 	visible_message(span_green("[usr] soothes the beastblood with Dendor's whisper."))
 	var/tamed = FALSE
-	for(var/mob/living/simple_animal/hostile/retaliate/B in get_hearers_in_view(2, usr))
-		if((B.mob_biotypes & MOB_UNDEAD))
+	for(var/mob/living/simple_animal/hostile/retaliate/animal in get_hearers_in_view(2, usr))
+		if((animal.mob_biotypes & MOB_UNDEAD))
 			continue
-		if(faction_check(B.faction, beast_tameable_factions))
-			B.tamed(TRUE)
-			B.aggressive = FALSE
-			if(B.ai_controller)
-				B.ai_controller.clear_blackboard_key(BB_BASIC_MOB_CURRENT_TARGET)
-				B.ai_controller.clear_blackboard_key(BB_BASIC_MOB_RETALIATE_LIST)
-				B.ai_controller.set_blackboard_key(BB_BASIC_MOB_TAMED, TRUE)
+		if(faction_check(animal.faction, beast_tameable_factions))
+			animal.tamed(TRUE)
+			animal.aggressive = FALSE
+			if(animal.ai_controller)
+				animal.ai_controller.clear_blackboard_key(BB_BASIC_MOB_CURRENT_TARGET)
+				animal.ai_controller.clear_blackboard_key(BB_BASIC_MOB_RETALIATE_LIST)
+				animal.ai_controller.set_blackboard_key(BB_BASIC_MOB_TAMED, TRUE)
+			to_chat(usr, "With Dendor's aide, you soothe [animal] of their anger.")
 	return tamed
 
 /obj/effect/proc_holder/spell/targeted/conjure_glowshroom

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -46,15 +46,22 @@
 	invocation_type = "whisper" //can be none, whisper, emote and shout
 	miracle = TRUE
 	devotion_cost = 20
+	var/beast_tameable_factions = list("saiga", "chickens", "cows", "goats", "wolfs", "spiders")
 
 /obj/effect/proc_holder/spell/targeted/beasttame/cast(list/targets,mob/user = usr)
 	. = ..()
 	visible_message(span_green("[usr] soothes the beastblood with Dendor's whisper."))
 	var/tamed = FALSE
-	for(var/mob/living/simple_animal/hostile/retaliate/B in oview(2))
-		if(B.aggressive)
-			tamed = TRUE
-		B.aggressive = 0
+	for(var/mob/living/simple_animal/hostile/retaliate/B in get_hearers_in_view(2, usr))
+		if((B.mob_biotypes & MOB_UNDEAD))
+			continue
+		if(faction_check(B.faction, beast_tameable_factions))
+			B.tamed(TRUE)
+			B.aggressive = FALSE
+			if(B.ai_controller)
+				B.ai_controller.clear_blackboard_key(BB_BASIC_MOB_CURRENT_TARGET)
+				B.ai_controller.clear_blackboard_key(BB_BASIC_MOB_RETALIATE_LIST)
+				B.ai_controller.set_blackboard_key(BB_BASIC_MOB_TAMED, TRUE)
 	return tamed
 
 /obj/effect/proc_holder/spell/targeted/conjure_glowshroom


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Bugfix for the dendorite tame beast spell and gives them some feedback to the spell
tame beast spell is now limited to these animal families: ("saiga", "chickens", "cows", "goats", "wolfs", "spiders")
account for tamed animals in the targetting


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bugfixes + dendor's power no longer extends to every retaliate animal

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
