### PR TITLE
Adds innkeeper's key to steward chest of keys

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -24414,6 +24414,7 @@
 /obj/item/roguekey/archive,
 /obj/item/roguekey/apartments/stable1,
 /obj/item/roguekey/apartments/stable2,
+/obj/item/roguekey/tavernkeep,
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town)
 "tzS" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Big Steward chest of keys conspiracy pulls ahead with the Innkeeper's key, which only goes to the Innkeeper's room, which is filled with more tavern keys.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/a9413106-06f7-47d3-8d8d-cdff045f1920)
Better than breaking this window.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
