### PR TITLE
sentinels can have apprentice cooking as a treat

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -47,6 +47,7 @@
 			H.mind.adjust_skillrank(/datum/skill/labor/fishing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/labor/butchering, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

gives ranger sentinels apprentice cooking

## Why It's Good For The Game

i gave them apprentice in a few other survival-themed skills but forgot cooking