### PR TITLE
tones down the frequency of new stress indicators

### DIFF
--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -78,12 +78,14 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 		if(diff_abs > 1)
 			if(ascending)
 				to_chat(src, span_smallred("I gain stress."))
-				if(!rogue_sneaking || alpha >= 100)
-					play_stress_indicator()
+				if(diff_abs > 2)
+					if(!rogue_sneaking || alpha >= 100)
+						play_stress_indicator()
 			else
 				to_chat(src, span_smallgreen("I gain peace."))
-				if(!rogue_sneaking || alpha >= 100)
-					play_relief_indicator()
+				if(diff_abs > 2)
+					if(!rogue_sneaking || alpha >= 100)
+						play_relief_indicator()
 
 	var/old_threshold = get_stress_threshold(oldstress)
 	var/new_threshold = get_stress_threshold(new_stress)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This will make them appear... significantly less often, actually. The most common stress addition is 2 (which is why they were so frequent), and this PR makes it check for a value above that for the animation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Maybe it's going too far, maybe not.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
