### PR TITLE
Restricts priest to new defined CHURCH_FAVORED_RACES (human, half-elf, aasimar)

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -78,6 +78,12 @@
 	/datum/species/goblinp,\
 )
 
+#define CHURCH_FAVORED_RACES list(\
+	/datum/species/human/northern,\
+	/datum/species/human/halfelf,\
+	/datum/species/aasimar,\
+)
+
 #define CLOTHED_RACES_TYPES list(\
 	/datum/species/human/northern,\
 	/datum/species/human/halfelf,\

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 1
 	selection_color = JCOLOR_CHURCH
 	f_title = "Priestess"
-	allowed_races = RACES_ALL_KINDS
+	allowed_races = CHURCH_FAVORED_RACES
 	allowed_patrons = ALL_DIVINE_PATRONS
 	allowed_sexes = list(MALE, FEMALE)
 	tutorial = "The Divine is all that matters in a world of the immoral. The Weeping God left his children to rule over us mortals--and you will preach their wisdom to any who still heed their will. The faithless are growing in number. It is up to you to shepard them toward a Gods-fearing future; for you are a priest of Astrata."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The PR does as the title says.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I think it's a positive move for the theme for the church leadership to be concerned enough with quibbling details on who can be ordained as a priest for the Enigma branch of the Church of the Ten. Based on the opposing pantheon being called the INHUMEN pantheon, making church leadership exclusive to those of (almost completely) humen blood or, in the case of aasimar, the half-humen descendant of celestial beings, would serve to enforce this.

It'd also create (or at least, give a foundation to create, if they so please) tension between a Duke who isn't one of these races and the tacitly racist leadership of the church and the local Priest.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
