### PR TITLE
Zizo worshippers are allied with undead

### DIFF
--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -24,6 +24,9 @@
 		"ZIZO IS QUEEN!",
 	)
 
+/datum/patron/inhumen/zizo/on_gain(mob/living/pious)
+	pious.faction |= "undead"
+
 /datum/patron/inhumen/graggar
 	name = "Graggar"
 	domain = "God of Conquest, War, Murder, Pillaging"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds the undead faction to Zizo worshippers. The effect is that necromancer summoned skeletons and ambush skeletons will not attack Zizo worshippers.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Getting horrifically murdered by random skeletons as a heretic or necromancer of Zizo feels stupid every time. Skeletons being a "tell" for covert Zizo worshippers also seems like it could be an interesting way for people to sniff out heretics amongst their number.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
