### PR TITLE
Removes racelock for Underdweller

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
@@ -1,13 +1,9 @@
-// Meant for cave-races, less boons than other mercs but unique weapon + mining skill and helmet-torch combo.
+// less boons than other mercs but unique weapon + mining skill and helmet-torch combo.
 /datum/advclass/mercenary/underdweller
 	name = "Underdweller"
-	tutorial = "A member of the Underdwellers, you've taken many of the deadliest contracts known to man in literal underground circles. Drow or Dwarf, you've put your differences aside for coin and adventure."
+	tutorial = "A member of the Underdwellers, you've taken many of the deadliest contracts known to man in literal underground circles. You've put your differences aside for coin and adventure."
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = list(
-		/datum/species/dwarf/mountain,
-		/datum/species/elf/dark,
-		/datum/species/kobold,
-	)
+	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/underdweller
 	category_tags = list(CTAG_MERCENARY)
 	traits_applied = list(TRAIT_OUTLANDER)


### PR DESCRIPTION
## About The Pull Request

**No changes are made other than Flavortext and the Race lock.**

## Why It's Good For The Game

Underdweller being race-locked was the main reason it's never played by many. I'd much rather see more variety in mercenaries.
On top of that, it'll provide more Roleplaying Opportunities for those _who play/want to play_ the class.
