### PR TITLE
Adds some things to the warden tower

### DIFF
--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -14,6 +14,14 @@
 /obj/item/quiver/arrows,
 /obj/item/quiver/arrows,
 /obj/item/quiver/arrows,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
+/obj/item/quiver/arrows,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/woods)
 "ad" = (
@@ -1705,6 +1713,7 @@
 /obj/item/clothing/mask/rogue/wildguard,
 /obj/item/clothing/mask/rogue/wildguard,
 /obj/item/flashlight/flare/torch/lantern,
+/obj/item/rope/chain,
 /obj/item/rope/chain,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
@@ -5921,6 +5930,9 @@
 /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick,
 /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick,
 /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
+/obj/item/rogueweapon/huntingknife/idagger/steel,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/woods)
 "WL" = (
@@ -6226,6 +6238,7 @@
 /obj/item/clothing/mask/rogue/wildguard,
 /obj/structure/rogue/trophy/deer,
 /obj/item/flashlight/flare/torch/lantern,
+/obj/item/rope/chain,
 /obj/item/rope/chain,
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds extra recurve bows and quivers to the warden's tower, as there were currently only *two* bows and there are more warden slots than that. Also added some spare chains, and steel daggers for anti-grapple(as every other garrison member gets)

## Why It's Good For The Game

Weyyy cant really play the warden gimmick without a bow.
![wardenarmory](https://github.com/user-attachments/assets/79c6da51-17e3-4cec-92a6-f44c3ef3b1af)
![image](https://github.com/user-attachments/assets/d949945f-2d3d-4110-be0c-5adbf3f55772)
