### PR TITLE
Tweaks some math with sewing repairs

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -103,7 +103,7 @@
 					cloth.obj_fix()
 				playsound(loc, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
 				user.visible_message(span_info("[user] repairs [I]!"))
-				I.obj_integrity = min(I.obj_integrity + skill, I.max_integrity)
+				I.obj_integrity = min(I.obj_integrity + 20 + skill, I.max_integrity)
 		return
 	return ..()
 

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -92,7 +92,7 @@
 			if(!do_after(user, sewtime, target = I))
 				return
 			if(prob(60 - skill)) //The more knowlegeable we are the less chance we damage the object
-				I.obj_integrity -= (30 - repairskill)
+				I.obj_integrity = max(0, I.obj_integrity - (30 - repairskill))
 				user.visible_message(span_info("[user] damages [I] due to a lack of skill!"))
 				playsound(src, 'sound/foley/cloth_rip.ogg', 50, TRUE)
 				user.mind.add_sleep_experience(/datum/skill/misc/sewing, (user.STAINT) / 2) // Only failing a repair teaches us something

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -103,7 +103,7 @@
 					cloth.obj_fix()
 				playsound(loc, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
 				user.visible_message(span_info("[user] repairs [I]!"))
-				I.obj_integrity = min(I.obj_integrity + 20 + skill, I.max_integrity)
+				I.obj_integrity = min(I.obj_integrity + 10 + skill, I.max_integrity)
 		return
 	return ..()
 

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -87,11 +87,12 @@
 				return
 			playsound(loc, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
 			var/skill = ((user.mind.get_skill_level(/datum/skill/misc/sewing)) * 10)
+			var/repairskill = ((user.mind.get_skill_level(/datum/skill/misc/sewing)) * 5)
 			var/sewtime = (60 - skill)
 			if(!do_after(user, sewtime, target = I))
 				return
 			if(prob(60 - skill)) //The more knowlegeable we are the less chance we damage the object
-				I.obj_integrity -= (60 - skill)
+				I.obj_integrity -= (30 - repairskill)
 				user.visible_message(span_info("[user] damages [I] due to a lack of skill!"))
 				playsound(src, 'sound/foley/cloth_rip.ogg', 50, TRUE)
 				user.mind.add_sleep_experience(/datum/skill/misc/sewing, (user.STAINT) / 2) // Only failing a repair teaches us something


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Prevents clothing integrity from going below 0 and into the negatives when failing a repair.

Reduces sewing repair failure damage by half.

Increases the amount of durability repaired per success across the board.

## Why It's Good For The Game

This was really harsh by comparison to blacksmithing repairs. This should make repairing leather armor a bit less punishing.
