### PR TITLE
Armor repair tweaks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -573,6 +573,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return FALSE
 	for(var/obj/structure/table/T in src.loc)
 		return TRUE
+	for(var/obj/machinery/anvil/A in src.loc)
+		return TRUE
 	return FALSE
 
 /obj/item/proc/allow_attack_hand_drop(mob/user)

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -67,7 +67,7 @@
 			return
 
 		if(!attacked_item.ontable())
-			to_chat(user, span_warning("I should put this on a table or anvil first."))
+			to_chat(user, span_warning("I should put this on a table or an anvil first."))
 			return
 
 		if(blacksmith_mind.get_skill_level(attacked_item.anvilrepair) <= 0)
@@ -98,6 +98,7 @@
 			return
 		else
 			user.visible_message(span_warning("[user] fumbles trying to repair [attacked_item]!"))
+			attacked_item.obj_integrity = max(0, attacked_item.obj_integrity - (20 - repair_percent))
 			return
 
 	if(isstructure(attacked_object) && !user.cmode)

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -66,6 +66,10 @@
 		if(!attacked_item.anvilrepair || (attacked_item.obj_integrity >= attacked_item.max_integrity) || !isturf(attacked_item.loc))
 			return
 
+		if(!attacked_item.ontable())
+			to_chat(user, span_warning("I should put this on a table or anvil first."))
+			return
+
 		if(blacksmith_mind.get_skill_level(attacked_item.anvilrepair) <= 0)
 			if(HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) && locate(/obj/machinery/anvil) in attacked_object.loc)
 				repair_percent = 0.035

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -98,7 +98,7 @@
 			return
 		else
 			user.visible_message(span_warning("[user] fumbles trying to repair [attacked_item]!"))
-			attacked_item.obj_integrity = max(0, attacked_item.obj_integrity - (20 - repair_percent))
+			attacked_item.obj_integrity = max(0, attacked_item.obj_integrity - (10 - repair_percent))
 			return
 
 	if(isstructure(attacked_object) && !user.cmode)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Repairing armor/weapons now requires a table or an anvil.

- Failing to repair armor/weapons now damages them a bit.

## Why It's Good For The Game

Makes blacksmithing skills a bit more impactful. It's probably pretty hard to repair your own armor if you have literally no experience smithing whatsoever.