### PR TITLE
Fixes to looping sounds

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -207,3 +207,5 @@ GLOBAL_LIST_INIT(roundid, world.file2list("strings/roundid.txt"))
 GLOBAL_LIST_INIT(station_numerals, greek_letters + phonetic_alphabet + numbers_as_words + generate_number_strings())
 
 GLOBAL_LIST_INIT(admiral_messages, list("Do you know how expensive these stations are?","Stop wasting my time.","I was sleeping, thanks a lot.","Stand and fight you cowards!","You knew the risks coming in.","Stop being paranoid.","Whatever's broken just build a new one.","No.", "<i>null</i>","<i>Error: No comment given.</i>", "It's a good day to die!"))
+
+GLOBAL_LIST_EMPTY(persistent_sound_loops) //Used in sound subsystem to keep track of persistent sounds (musicboxes and instruments mostly)

--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -6,6 +6,7 @@ SUBSYSTEM_DEF(soundloopers)
 	priority = FIRE_PRIORITY_DEFAULT
 	var/list/processing = list()
 	var/list/currentrun = list()
+	var/client_ticker = 0
 
 /datum/controller/subsystem/soundloopers/fire(resumed = 0)
 	if (!resumed || !currentrun.len)
@@ -22,7 +23,121 @@ SUBSYSTEM_DEF(soundloopers)
 			if (MC_TICK_CHECK)
 				return
 			continue
-		if(thing.sound_loop())
-			STOP_PROCESSING(SSsoundloopers, thing)
+
+		if(world.time > thing.starttime + thing.mid_length) //Make sure we don't try to trigger it while a loop is playing
+			if(thing.sound_loop())
+				STOP_PROCESSING(SSsoundloopers, thing)
+
+		client_ticker++ //Evaluate on a per client basis, not on a per sound basis, for speed
+		if(client_ticker >= 5) //half a second, no need to spam this insano style
+			client_ticker = 0
+			for(var/client/C in GLOB.clients)
+				if(C.mob) //Not in the lobby
+					C.update_sounds()
+
 		if (MC_TICK_CHECK)
 			return
+
+/client/proc/update_sounds()
+
+	//First we need to periodically scan if we moved into range of an already-playing sound
+	for(var/datum/looping_sound/PS in GLOB.persistent_sound_loops)
+		if(PS in played_loops) //Make sure it's not already on the list
+			continue
+
+		var/turf/parent_turf = get_turf(PS.parent)
+		if(get_dist(get_turf(mob),parent_turf) > world.view + PS.extra_range) //Too far away. get_dist shouldn't be too awful for repeated calcs
+			continue
+
+		//otherwise add it to the client loops and off we go from there
+		var/sound/our_sound = PS.cursound
+		if(!istype(our_sound)) //somehow it doesn't have a correct sound
+			our_sound = sound(our_sound)
+		if(!our_sound)
+			continue //something fucked up and the loop has no cursound, wups. this should basically never happen
+
+		mob.playsound_local(parent_turf, PS.cursound, PS.volume, PS.vary, PS.frequency, PS.falloff, PS.channel, FALSE, our_sound, repeat = PS)
+
+	//Now we check how far away etc we are
+	for(var/datum/looping_sound/loop in played_loops)
+		if(mob && loop.parent == mob) //the sound's coming from inside the house!
+			continue
+
+		var/max_distance = world.view + loop.extra_range
+		var/turf/source_turf = get_turf(loop.parent)
+		var/distance_between = get_dist(mob,loop.parent)
+
+		if(isturf(loop.parent))
+			source_turf = loop.parent
+		if(!source_turf) //somehow
+			continue
+
+		var/list/found_loop = played_loops[loop]
+		var/sound/found_sound = found_loop["SOUND"]
+
+		if(!found_loop || !istype(found_sound)) //somethin fucky goin on. lets ignore it
+			played_loops -= loop
+			continue
+
+		if(distance_between > max_distance || mob.IsSleeping()) // || !mob in hearers(max_distance,source_turf))
+			//We are too far away, turn it off, or suppress it if its a persistent tune like music boxes
+			if(loop.persistent_loop)
+				found_loop["MUTESTATUS"] = TRUE
+				found_loop["VOL"] = 0
+				mob.mute_sound(found_sound)
+			else
+				played_loops -= loop
+				loop.thingshearing -= mob
+				mob.stop_sound_channel(found_sound.channel)
+
+		else if(distance_between <= max_distance)
+			//We are close enough to hear, check if volume should be changed
+
+			var/new_volume = loop.volume
+			var/old_volume = found_loop["VOL"]
+
+			new_volume -= (distance_between * (0.1 * new_volume)) //reduce volume by 10% per tile
+
+			if(new_volume > 100)
+				new_volume = 100 //could just min() this but whatever. we old skool
+
+			if(new_volume <= 0) //Too quiet to hear despite being in range
+				if(loop.persistent_loop) //Copy pasting instead of making a new proc? egads you monster
+					found_loop["MUTESTATUS"] = TRUE
+					found_loop["VOL"] = 0
+					mob.mute_sound(found_sound)
+				else
+					played_loops -= loop
+					loop.thingshearing -= mob
+					mob.stop_sound_channel(found_sound.channel)
+				continue
+
+			if(source_turf.z == mob.z + 1 || source_turf.z == mob.z - 1) //Some hacks for z-levels
+				new_volume = new_volume / 2
+			else if (source_turf.z == mob.z + 2 || source_turf.z == mob.z - 2)
+				new_volume = new_volume / 4
+
+			new_volume = new_volume * (prefs.mastervol * 0.01) //Modify it at the end by the player's volume setting
+
+			if(old_volume != new_volume)
+				var/turf/T = get_turf(mob)
+				var/dx = source_turf.x - T.x // Stolen/replicated from sound.dm
+				if(dx <= 1 && dx >= -1)
+					found_sound.x = 0
+				else
+					found_sound.x = dx
+				var/dy = source_turf.y - T.y
+				if(dy <= 1 && dy >= -1)
+					found_sound.y = 0
+				else
+					found_sound.y = dy
+				var/dz = (source_turf.z - T.z)
+				found_sound.z = dz
+
+				if(loop.persistent_loop && found_loop["MUTESTATUS"] == TRUE) //It was out of range and now back in range, reset it
+					found_loop["MUTESTATUS"] = FALSE
+					mob.unmute_sound(found_sound)
+				found_loop["VOL"] = new_volume
+				mob.update_sound_volume(played_loops[loop]["SOUND"], new_volume)
+
+

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -137,7 +137,7 @@
 	flags_1 = null
 	possible_item_intents = list(/datum/intent/use, /datum/intent/hit)
 	slot_flags = ITEM_SLOT_HIP
-	var/datum/looping_sound/torchloop/soundloop
+	var/datum/looping_sound/torchloop/soundloop = null         //remove the = null to re-add the torch crackle sounds.
 	var/should_self_destruct = TRUE //added for torch burnout
 	max_integrity = 40
 	fuel = 30 MINUTES
@@ -159,7 +159,8 @@
 /obj/item/flashlight/flare/torch/Initialize()
 	GLOB.weather_act_upon_list += src
 	. = ..()
-	soundloop = new(src, FALSE)
+	if(soundloop)
+		soundloop = new(src, FALSE)
 
 /obj/item/flashlight/flare/torch/Destroy()
 	GLOB.weather_act_upon_list -= src
@@ -208,7 +209,8 @@
 
 /obj/item/flashlight/flare/torch/turn_off()
 	playsound(src.loc, 'sound/items/firesnuff.ogg', 100)
-	soundloop.stop()
+	if(soundloop)
+		soundloop.stop()
 	STOP_PROCESSING(SSobj, src)
 	..()
 	if(ismob(loc))
@@ -225,7 +227,8 @@
 			damtype = BURN
 			update_brightness()
 			force = on_damage
-			soundloop.start()
+			if(soundloop)
+				soundloop.start()
 			if(ismob(loc))
 				var/mob/M = loc
 				M.update_inv_hands()

--- a/code/game/objects/items/rogueitems/dmusicbox.dm
+++ b/code/game/objects/items/rogueitems/dmusicbox.dm
@@ -1,7 +1,7 @@
 
 /datum/looping_sound/dmusloop
 	mid_sounds = list()
-	mid_length = 60
+	mid_length = 2400
 	volume = 100
 	falloff = 2
 	extra_range = 5

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -35,6 +35,10 @@
 	soundloop = new(src, FALSE)
 	. = ..()
 
+/obj/item/rogue/instrument/Destroy()
+	qdel(soundloop)
+	. = ..()
+
 /obj/item/rogue/instrument/dropped(mob/living/user, silent)
 	..()
 	if(soundloop)
@@ -49,7 +53,7 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(!playing)
 		var/note_color = "#7f7f7f" // uses MMO item rarity color grading
-		var/curfile = input(user, "Which song?", "Roguetown", name) as null|anything in song_list
+		var/curfile = input(user, "Which song?", "Music", name) as null|anything in song_list
 		if(!user)
 			return
 		if(user.mind)
@@ -72,11 +76,11 @@
 				if(6)
 					note_color = "#ff8000"
 					stressevent = /datum/stressevent/music/six
-		if(playing)
+/*		if(playing) //We already checked this???
 			playing = FALSE
 			soundloop.stop()
 			user.remove_status_effect(/datum/status_effect/buff/playing_music)
-			return
+			return*/
 		if(!(src in user.held_items))
 			return
 		if(user.get_inactive_held_item())

--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -5,7 +5,7 @@
 	fueluse = 60 MINUTES
 	bulb_colour = "#f9ad80"
 	bulb_power = 1
-	var/datum/looping_sound/soundloop = /datum/looping_sound/fireloop
+	var/datum/looping_sound/soundloop = null // = /datum/looping_sound/fireloop
 	pass_flags = LETPASSTHROW
 	flags_1 = NODECONSTRUCT_1
 	var/cookonme = FALSE

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -330,6 +330,7 @@
 	climb_offset = 14
 	on = FALSE
 	cookonme = TRUE
+	soundloop = /datum/looping_sound/fireloop
 	var/obj/item/attachment = null
 	var/obj/item/reagent_containers/food/snacks/food = null
 	var/datum/looping_sound/boilloop/boilloop
@@ -565,6 +566,7 @@
 	bulb_colour = "#da5e21"
 	cookonme = TRUE
 	max_integrity = 30
+	soundloop = /datum/looping_sound/fireloop
 
 /obj/machinery/light/rogue/campfire/process()
 	..()

--- a/code/game/objects/structures/roguetown/musicbox.dm
+++ b/code/game/objects/structures/roguetown/musicbox.dm
@@ -31,9 +31,9 @@
 
 /datum/looping_sound/musloop
 	mid_sounds = list()
-	mid_length = 18000 // This is 30 minutes - just in case something wierd happens.
-	volume = 50
-	extra_range = 6
+	mid_length = 2400 // Whoever wrote this is giving me an aneurism
+	volume = 70
+	extra_range = 8
 	falloff = 0
 	persistent_loop = TRUE
 	var/stress2give = /datum/stressevent/music
@@ -66,40 +66,34 @@
 	curfile = pick(init_curfile)
 	soundloop = new(src, FALSE)
 	if(playuponspawn)
-		playmusic("START")
-		update_icon()
+		start_playing()
 
 /obj/structure/roguemachine/musicbox/Destroy()
 	. = ..()
-	del(soundloop)
+	qdel(soundloop) //jesus fuck who is using hard dels in this day and age
 
 /obj/structure/roguemachine/musicbox/update_icon()
 	icon_state = "music[playing]"
 
-/obj/structure/roguemachine/musicbox/proc/playmusic(mode="TOGGLE") // "TOGGLE" | "START" | "STOP"
-	playsound(loc, 'sound/misc/Bug.ogg', 100, FALSE, -1)
-	if(mode=="TOGGLE")
-		if(!playing)
-			if(curfile)
-				playing = TRUE
-				soundloop.mid_sounds = list(curfile)
-				soundloop.cursound = null
-				soundloop.volume = curvol
-				soundloop.start()
-		else
-			playing = FALSE
-			soundloop.stop()
-	if(mode=="START")
-		if(!playing)
-			if(curfile)
-				playing = TRUE
-				soundloop.mid_sounds = list(curfile)
-				soundloop.cursound = null
-				soundloop.volume = curvol
-				soundloop.start()
-	if(mode=="STOP")
-		playing = FALSE
-		soundloop.stop()
+/obj/structure/roguemachine/musicbox/proc/toggle_music()
+	if(!playing)
+		start_playing()
+	else
+		stop_playing()
+
+/obj/structure/roguemachine/musicbox/proc/start_playing()
+	playing = TRUE
+	soundloop.mid_sounds = list(curfile)
+	soundloop.cursound = null
+	soundloop.volume = curvol
+	soundloop.start()
+	testing("Music: V[soundloop.volume] C[soundloop.cursound] T[soundloop.thingshearing]")
+	update_icon()
+
+/obj/structure/roguemachine/musicbox/proc/stop_playing()
+	playing = FALSE
+	soundloop.stop()
+	update_icon()
 
 /obj/structure/roguemachine/musicbox/attack_hand(mob/living/user)
 	. = ..()
@@ -118,8 +112,8 @@
 	playsound(loc, pick('sound/misc/keyboard_select (1).ogg','sound/misc/keyboard_select (2).ogg','sound/misc/keyboard_select (3).ogg','sound/misc/keyboard_select (4).ogg'), 100, FALSE, -1)
 
 	if(button_selection=="Stop/Start")
-		playmusic("TOGGLE")
-	
+		toggle_music()
+
 	if(button_selection=="Change Song")
 		var/songlists_selection = input(user, "Which song list?", "\The [src]") as null | anything in list("OTHERWORLDLY"=MUSIC_TAVCAT_OTHERWORLDLY, "GENERIC"=MUSIC_TAVCAT_GENERIC, "OLDSCHOOL"=MUSIC_TAVCAT_OLDSCHOOL)
 		playsound(loc, pick('sound/misc/keyboard_select (1).ogg','sound/misc/keyboard_select (2).ogg','sound/misc/keyboard_select (3).ogg','sound/misc/keyboard_select (4).ogg'), 100, FALSE, -1)
@@ -140,8 +134,8 @@
 		playsound(loc, pick('sound/misc/keyboard_select (1).ogg','sound/misc/keyboard_select (2).ogg','sound/misc/keyboard_select (3).ogg','sound/misc/keyboard_select (4).ogg'), 100, FALSE, -1)
 		user.visible_message(span_info("[user] presses a button on \the [src]."),span_info("I press a button on \the [src]."))
 		curfile = chosen_songlists_selection[song_selection]
-		playmusic("STOP")
-		playmusic("START")
+		stop_playing()
+		start_playing()
 
 	if(button_selection=="Change Volume")
 		var/volume_selection = input(user, "How loud do you wish me to be?", "\The [src] (Volume Currently : [curvol]/[100])") as num|null
@@ -155,17 +149,14 @@
 			return
 		playsound(loc, pick('sound/misc/keyboard_select (1).ogg','sound/misc/keyboard_select (2).ogg','sound/misc/keyboard_select (3).ogg','sound/misc/keyboard_select (4).ogg'), 100, FALSE, -1)
 		user.visible_message(span_info("[user] presses a button on \the [src]."),span_info("I press a button on \the [src]."))
-		volume_selection = clamp(volume_selection, 0, 100)
+		volume_selection = clamp(volume_selection, 1, 100)
 		if(curvol<volume_selection)
 			to_chat(user, span_info("I make \the [src] get louder."))
 		else
 			to_chat(user, span_info("I make \the [src] get quieter."))
 		curvol = volume_selection
-		playsound(loc, 'sound/misc/Bug.ogg', 100, FALSE, -1)
-		playmusic("STOP")
-		playmusic("START")
-
-	update_icon()
+		stop_playing()
+		start_playing()
 
 /obj/structure/roguemachine/musicbox/tavern
 	init_curfile = list(\
@@ -178,8 +169,9 @@
 	)
 	curvol = 65
 	playuponspawn = TRUE
-	
+/* The fuck is this
 /obj/structure/roguemachine/musicbox/Initialize()
 	. = ..()
 	soundloop.extra_range = 12
 	soundloop.falloff = 6
+*/

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -155,13 +155,13 @@
 			S.x = 0
 		else
 			S.x = dx
-		var/dz = turf_source.y - T.y // Hearing from infront/behind
-		if(dz <= 1 && dz >= -1) //if we're  close enough we're heard in both ears
-			S.z = 0
+		var/dy = turf_source.y - T.y // Hearing from infront/behind Edit: someone fucked up. why is this z
+		if(dy <= 1 && dy >= -1) //if we're  close enough we're heard in both ears
+			S.y = 0
 		else
-			S.z = dz
-		var/dy = (turf_source.z - T.z) * 2 // Hearing from  above / below, multiplied by 5 because we assume height is further along coords.
-		S.y = dy
+			S.y = dy
+		var/dz = (turf_source.z - T.z) * 2 // Hearing from  above / below, multiplied by 5 because we assume height is further along coords.
+		S.z = dz
 
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
 
@@ -182,9 +182,9 @@
 							update_sound_volume(DS, S.volume)
 							if(client.played_loops[D]["MUTESTATUS"]) //we have sound so turn this off
 								client.played_loops[D]["MUTESTATUS"] = null
-						return TRUE
-			else
-				D.thingshearing += src
+//							return TRUE
+
+			D.thingshearing += src
 			client.played_loops[D] = list()
 			client.played_loops[D]["SOUND"] = S
 			client.played_loops[D]["VOL"] = S.volume


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Looping sounds were causing a massive amount of unnecessary overhead due to someone removing a timer and bombarding the game with sounds (20,000 per second to be exact). The looper now instead loops through clients rather than objects, puts repeating sounds (music boxes + instruments) on a global list for speed and fixes a few other outstanding bugs  in the sound code.

Note this could break sound things in strange and unexpected ways, but it should still be many times more efficient than what nonsense was going on before. 

This should probably be testmerged and checked in case something does in fact explode. Instruments and music boxes are most affected by this change. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should ease a lot of current lag, fixes a few oddities with the sound system.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
