### PR TITLE
removes qdel(src) from returntolobby

### DIFF
--- a/code/modules/client/verbs/ghost.dm
+++ b/code/modules/client/verbs/ghost.dm
@@ -85,5 +85,4 @@ GLOBAL_LIST_INIT(ghost_verbs, list(
 
 	client?.verbs -= GLOB.ghost_verbs
 	M.key = key
-	qdel(src)
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Returntolobby (journey to the underworld) was calling a deletion of the src atom after the ckey exchange, which meant bodies would go POOF from existence upon returning to lobby. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
hey I was going to loot that corpse!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
