### PR TITLE
Fixing advmenu display for BYOND 516

### DIFF
--- a/code/controllers/subsystem/rogue/role_class_handler/class_select_handler/class_select_handler.dm
+++ b/code/controllers/subsystem/rogue/role_class_handler/class_select_handler/class_select_handler.dm
@@ -195,10 +195,12 @@
 		return
 	//Opening tags and empty head
 	var/data = {"
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+	<!DOCTYPE html>
+	<html lang='en'>
 	<html>
 		<head>
+			<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+			<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 			<style>
 				@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
 				@import url('https://fonts.googleapis.com/css2?family=Jacquarda+Bastarda+9&display=swap');
@@ -275,10 +277,12 @@
 /datum/class_select_handler/proc/class_select_slop()
 
 	var/data = {"
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+	<!DOCTYPE html>
+	<html lang='en'>	
 	<html>
 		<head>
+			<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+			<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 			<style>
 				@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
 				@import url('https://fonts.googleapis.com/css2?family=Jacquarda+Bastarda+9&display=swap');

--- a/code/controllers/subsystem/rogue/triumphs/triumph_buy_menu.dm
+++ b/code/controllers/subsystem/rogue/triumphs/triumph_buy_menu.dm
@@ -30,10 +30,12 @@
 	if(!linked_client)
 		return
 	var/data = {"
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+	<!DOCTYPE html>
+	<html lang='en'>
 	<html>
 		<head>
+			<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+			<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 			<style>
 				@import url('https://fonts.googleapis.com/css2?family=Aclonica&display=swap');
 				@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -302,7 +302,8 @@
 	if(!check_rights(0))
 		return
 
-	var/dat = {"
+	var/dat = "<html><meta charset='UTF-8'><head><title>Game Panel</title></head><body>"
+	dat += {"
 		<center><B>Game Panel</B></center><hr>\n
 		<A href='?src=[REF(src)];[HrefToken()];c_mode=1'>Change Game Mode</A><br>
 		"}
@@ -337,6 +338,7 @@
 	if(marked_datum && istype(marked_datum, /atom))
 		dat += "<A href='?src=[REF(src)];[HrefToken()];dupe_marked_datum=1'>Duplicate Marked Datum</A><br>"
 
+	dat += "</body></html>"
 	usr << browse(dat, "window=admin2;size=240x280")
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Beta branch of BYOND was not agreeing with the meta tags being outside of the \<head\>, this places them where they need to be. Checked advanced role selection menu, plus sleep menu, on 515 and 516. No issues that I could find.

## Why It's Good For The Game
Fixes one of the big issues with playing AP on 516.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
