### PR TITLE
Fixes some drone sound ambience collisions with end round music

### DIFF
--- a/code/modules/droning/droning.dm
+++ b/code/modules/droning/droning.dm
@@ -32,6 +32,9 @@ SUBSYSTEM_DEF(droning)
 /datum/controller/subsystem/droning/proc/play_area_sound(area/area_player, client/listener)
 	if(!area_player || !listener)
 		return
+	
+	if(SSticker.current_state >= GAME_STATE_FINISHED) //stop drones in round end
+		return
 
 	if(area_player.we_droning_here)
 
@@ -147,7 +150,7 @@ SUBSYSTEM_DEF(droning)
 /datum/controller/subsystem/droning/proc/kill_droning(client/victim)
 	if(!victim?.droning_sound)
 		return
-	var/sound/sound_killer = sound()
+	var/sound/sound_killer = sound('sound/blank.ogg')
 	sound_killer.channel = victim.droning_sound.channel
 	SEND_SOUND(victim, sound_killer)
 	victim.droning_sound = null

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -554,6 +554,9 @@
 	set name = "cmode-change"
 	set hidden = 1
 
+	if(SSticker.current_state >= GAME_STATE_FINISHED)
+		return
+
 	var/mob/living/L
 	if(isliving(src))
 		L = src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Puts in a game state check for the droning play_area_sound proc, stops it from repopulating the drone into a client after end of round. Also prevents toggling combat state after end of round, since that caused another music collision.
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
multi-layered droning is so 2024