### PR TITLE
Armor sleep fix

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -79,18 +79,16 @@
 							sleepy_mod = 1.5 //Worse than a bedroll, better than nothing.
 			if(sleepy_mod > 0)
 				if(eyesclosed)
-					var/armor_blocked
-					if(ishuman(src))
-						if(stat == CONSCIOUS)
-							var/mob/living/carbon/human/H = src
-							var/list/gear_to_check = list(H.wear_armor, H.head)
-							for(var/obj/item/clothing/gear in gear_to_check)
-								if(gear.armor_class == ARMOR_CLASS_HEAVY || gear.armor_class == ARMOR_CLASS_MEDIUM)
-									armor_blocked = TRUE
-									if(!fallingas)
-										to_chat(src, span_warning("I can't sleep like this. My armor is burdening me."))
-									fallingas = TRUE
-									break
+					var/armor_blocked = FALSE
+					if(ishuman(src) && stat == CONSCIOUS)
+						var/mob/living/carbon/human/H = src
+						if(H.head && H.head.armor?.blunt > 70)
+							armor_blocked = TRUE
+						if(H.wear_armor && (H.wear_armor.armor_class in list(ARMOR_CLASS_HEAVY, ARMOR_CLASS_MEDIUM)))
+							armor_blocked = TRUE
+						if(armor_blocked && !fallingas)
+							to_chat(src, span_warning("I can't sleep like this. My armor is burdening me."))
+							fallingas = TRUE
 					if(!armor_blocked)
 						if(!fallingas)
 							to_chat(src, span_warning("I'll fall asleep soon..."))
@@ -104,18 +102,16 @@
 			// Resting on the ground (not sleeping or with eyes closed and about to fall asleep)
 			else if(!(mobility_flags & MOBILITY_STAND))
 				if(eyesclosed)
-					var/armor_blocked
-					if(ishuman(src))
-						if(stat == CONSCIOUS)
-							var/mob/living/carbon/human/H = src
-							var/list/gear_to_check = list(H.wear_armor, H.head)
-							for(var/obj/item/clothing/gear in gear_to_check)
-								if(gear.armor_class == ARMOR_CLASS_HEAVY || gear.armor_class == ARMOR_CLASS_MEDIUM)
-									armor_blocked = TRUE
-									if(!fallingas)
-										to_chat(src, span_warning("I can't sleep like this. My armor is burdening me."))
-									fallingas = TRUE
-									break
+					var/armor_blocked = FALSE
+					if(ishuman(src) && stat == CONSCIOUS)
+						var/mob/living/carbon/human/H = src
+						if(H.head && H.head.armor?.blunt > 70)
+							armor_blocked = TRUE
+						if(H.wear_armor && (H.wear_armor.armor_class in list(ARMOR_CLASS_HEAVY, ARMOR_CLASS_MEDIUM)))
+							armor_blocked = TRUE
+						if(armor_blocked && !fallingas)
+							to_chat(src, span_warning("I can't sleep like this. My armor is burdening me."))
+							fallingas = TRUE
 					if(!armor_blocked)
 						if(!fallingas)
 							to_chat(src, span_warning("I'll fall asleep soon, although a bed would be more comfortable..."))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -83,9 +83,9 @@
 					if(ishuman(src))
 						if(stat == CONSCIOUS)
 							var/mob/living/carbon/human/H = src
-							var/list/gear_to_check = list(H.wear_shirt, H.wear_armor, H.head)
+							var/list/gear_to_check = list(H.wear_armor, H.head)
 							for(var/obj/item/clothing/gear in gear_to_check)
-								if(gear.armor.blunt > 70)
+								if(gear.armor_class == ARMOR_CLASS_HEAVY || gear.armor_class == ARMOR_CLASS_MEDIUM)
 									armor_blocked = TRUE
 									if(!fallingas)
 										to_chat(src, span_warning("I can't sleep like this. My armor is burdening me."))
@@ -108,9 +108,9 @@
 					if(ishuman(src))
 						if(stat == CONSCIOUS)
 							var/mob/living/carbon/human/H = src
-							var/list/gear_to_check = list(H.wear_shirt, H.wear_armor, H.head)
+							var/list/gear_to_check = list(H.wear_armor, H.head)
 							for(var/obj/item/clothing/gear in gear_to_check)
-								if(gear.armor.blunt > 70)
+								if(gear.armor_class == ARMOR_CLASS_HEAVY || gear.armor_class == ARMOR_CLASS_MEDIUM)
 									armor_blocked = TRUE
 									if(!fallingas)
 										to_chat(src, span_warning("I can't sleep like this. My armor is burdening me."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Armor burden when trying to sleep now works off of armor class rather than blunt resist stat. Haubergeons and other items in the shirt slot rather than the armor slot won't count.

Helmets still function the same as before and still just work off the blunt resist stat, because none of them have armor class flags.

## Why It's Good For The Game

Leather armors had their blunt damage values increased recently and they prevent you from sleeping now. Oops. It makes more sense that armor sleep prevention would just work off of weight class rather than the blunt resist stat, anyways.