### PR TITLE
Hides certain jobs (Adventurer / Vagabond) in the Nervemaster

### DIFF
--- a/code/modules/roguetown/roguemachine/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward.dm
@@ -19,6 +19,7 @@
 	var/keycontrol = "steward"
 	var/current_tab = TAB_MAIN
 	var/compact = FALSE
+	var/list/excluded_jobs = list("Wretch","Vagabond","Adventurer")
 
 
 /obj/structure/roguemachine/steward/attackby(obj/item/P, mob/user, params)
@@ -259,7 +260,7 @@
 				for(var/mob/living/carbon/human/A in SStreasury.bank_accounts)
 					if(ishuman(A))
 						var/mob/living/carbon/human/tmp = A
-						contents += "[tmp.real_name] ([tmp.advjob ? tmp.advjob : tmp.job]) - [SStreasury.bank_accounts[A]]m"
+						contents += "[tmp.real_name] ([job_filter(tmp.advjob, tmp.job)]) - [SStreasury.bank_accounts[A]]m"
 					else
 						contents += "[A.real_name] - [SStreasury.bank_accounts[A]]m"
 					contents += " / <a href='?src=\ref[src];givemoney=\ref[A]'>\[PAY\]</a> <a href='?src=\ref[src];fineaccount=\ref[A]'>\[FINE\]</a><BR><BR>"
@@ -267,7 +268,7 @@
 				for(var/mob/living/carbon/human/A in SStreasury.bank_accounts)
 					if(ishuman(A))
 						var/mob/living/carbon/human/tmp = A
-						contents += "[tmp.real_name] ([tmp.advjob ? tmp.advjob : tmp.job]) - [SStreasury.bank_accounts[A]]m<BR>"
+						contents += "[tmp.real_name] ([job_filter(tmp.advjob, tmp.job)]) - [SStreasury.bank_accounts[A]]m<BR>"
 					else
 						contents += "[A.real_name] - [SStreasury.bank_accounts[A]]m<BR>"
 					contents += "<a href='?src=\ref[src];givemoney=\ref[A]'>\[Give Money\]</a> <a href='?src=\ref[src];fineaccount=\ref[A]'>\[Fine Account\]</a><BR><BR>"
@@ -349,6 +350,17 @@
 	var/datum/browser/popup = new(user, "VENDORTHING", "", 500, 800)
 	popup.set_content(contents)
 	popup.open()
+
+/obj/structure/roguemachine/steward/proc/job_filter(advj, j)
+	if(advj in excluded_jobs)
+		return "Adventurer"
+	if(j in excluded_jobs)
+		return "Adventurer"
+	if(advj)
+		return advj
+	else
+		return j
+
 
 #undef TAB_MAIN
 #undef TAB_BANK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![IJFWawGfm0](https://github.com/user-attachments/assets/cb38c78d-d263-419e-b536-4e0515bfeb07)
This PR removes the nervemaster showing distinct subclasses of Adventurers and Vagabonds, and replaces them with the generic word "Adventurer". Bandits are unaffected, and will still show up as such.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
By partial request, as to not have the Nerve Master identify hobos by blood, or necromancers.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
