### PR TITLE
Removes Shop and Merchant keys from steward

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -25147,12 +25147,10 @@
 /obj/item/roguekey/garrison,
 /obj/item/roguekey/mercenary,
 /obj/item/roguekey/tavern,
-/obj/item/roguekey/merchant,
 /obj/item/roguekey/physician,
 /obj/item/roguekey/artificer,
 /obj/item/roguekey/farm,
 /obj/item/roguekey/tailor,
-/obj/item/roguekey/shop,
 /obj/item/roguekey/nightmaiden,
 /obj/structure/lever/wall{
 	pixel_x = 32;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
That's it. Simple mapping change.

## Why It's Good For The Game
I have never seen a steward actually take over the merchant's shop in lack of a merchant. I have *only* seen these keys used by pestulent stewards who completely bypass any interaction with the merchant to get their import-price vault goodies. Prevents stewards from just, entering their primary 'competition's' home and taking everything. In the two rounds I have seen these keys used, they have exclusively been used to fuck with the goldface while a shophand/merchant was present. I also considered removing their other yeomen keys to prevent the (steward busts into the smith to hassle them for a 2k order) but I think that's less prevalent
