### PR TITLE
Hair Overlay Index Tweak [SUGGESTION]

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -50,8 +50,8 @@
 #define GLASSES_LAYER			17
 #define NECK_LAYER				16
 #define CLOAK_LAYER				15		//only when looking north or west/east
-#define HAIR_LAYER				14		//TODO: make part of head layer?
-#define MASK_LAYER				13
+#define MASK_LAYER				14
+#define HAIR_LAYER				13		//TODO: make part of head layer?
 #define HAIREXTRA_LAYER			12
 #define MOUTH_LAYER				11
 #define HEAD_LAYER				10

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -48,7 +48,7 @@
 	item_state = "basichood"
 	icon = 'icons/roguetown/clothing/head.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/head.dmi' //Overrides slot icon behavior
-	alternate_worn_layer  = 8.9 //On top of helmet
+	alternate_worn_layer = MASK_LAYER //Under helmets (And HAIR)
 	body_parts_covered = NECK
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
 	sleevetype = null
@@ -92,6 +92,7 @@
 	desc = "Flowing like blood from a wound, this tithe of cloth-and-silk spills out to the shoulders. It carries the telltale mark of Naledian stitcheries."
 	item_state = "hijab"
 	icon_state = "deserthood"
+	alternate_worn_layer = MASK_LAYER //Under helmets (And HAIR)
 
 /obj/item/clothing/head/roguetown/roguehood/shalal/heavyhood
 	name = "heavy hood"

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/roguetown/clothing/masks.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/masks.dmi'
 	body_parts_covered = FACE
+	alternate_worn_layer = MASK_LAYER
 	slot_flags = ITEM_SLOT_MASK
 
 /obj/item/clothing/mask/rogue/spectacles


### PR DESCRIPTION
**_What it does?_**
Re-adjust hair overlay layers for most hoods and masks, except the dessert raider one.
It only changes the way the hood looks when they are not being worn over the head, and also how masks look in general.

**_Why?_** 
So women (and long-haired folks) can actually WEAR HOODS without it being ugly and overlapped over the hair sprite, and it looks much better imo.
It's weird how hoods/masks sprites are OVER and not UNDER the hair.

![image](https://github.com/user-attachments/assets/4ede8973-7885-43a4-9f1b-e9fded2a3481)
![image](https://github.com/user-attachments/assets/f75034f1-d672-405c-ab8b-c24db3b42d2b)
![image](https://github.com/user-attachments/assets/1e94cf4f-5afb-4970-93b9-cd920f0e4a6b)

Note that it inevitably changes the way hoods looks as they are being worn with helmets (It never looked good).

![image](https://github.com/user-attachments/assets/e08b9e36-51db-4e49-b027-96dd59bfe395)
![image](https://github.com/user-attachments/assets/476fcdd7-98a0-4189-99d1-4ea09949e735)

