### PR TITLE
Removes -4 spell point debuff from non-magician arcyne potential users

### DIFF
--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -5,7 +5,6 @@
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
 	if (!recipient.mind?.get_skill_level(/datum/skill/magic/arcane)) // we can do this because apply_to is always called first
-		recipient.mind?.adjust_spellpoints(-4) // Limits skill gain through for non-initial arcynes
 		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removes the -4 spell point debuff given to arcyne potential users who play a non-magician occupation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This debuff is fucking INSANE. You have to grind to LEGENDARY in arcane magic to learn FIREBALL (a two point spell). This shit is ON TOP of having no easy access to gems as a non-magician occupation, forcing you to most likely rely on magic stones, which give a -20% chance of even being able to level up using spell books. Having -4 spell points out the gate is psychotic and makes this virtue completely fucking useless.

Just Let Me Play My Mage Catboy.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
