### PR TITLE
Makes Rosewater potion brewable.

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -363,8 +363,8 @@
 	alternate_worn_layer  = 8.9 //On top of helmet
 
 	major_pot = /datum/alch_cauldron_recipe/rosewater_potion
-	med_pot = /datum/alch_cauldron_recipe/end_potion
-	minor_pot = /datum/alch_cauldron_recipe/antidote
+	med_pot = /datum/alch_cauldron_recipe/rosewater_potion
+	minor_pot = /datum/alch_cauldron_recipe/rosewater_potion
 
 /obj/item/alch/rosa/equipped(mob/living/carbon/human/user, slot)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Rosewater potion is no longer an impossibility, you can brew it with just one rose as the major, med and minor mods are all set to rosewater. This type of single ingredient potion brewing is already present in the transisdust. Considered adding minor roses to two other items but, it's already worse than regular healing potions and strong healing potions only need two ingredients that are laughably easy.

## Why It's Good For The Game

Rose water flavoring fun for everyone.
