### PR TITLE
Adds spell point limit for non magicians + removes spell point debuff from arcyne potential

### DIFF
--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -230,6 +230,7 @@
 	backpack_contents = list(/obj/item/reagent_containers/glass/bottle/rogue/poison,/obj/item/reagent_containers/glass/bottle/rogue/healthpot)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, "[type]")
 	if(H.mind)
+		H.mind.max_spell_points = 0
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 5, TRUE)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -47,7 +47,7 @@
 
 	var/spell_points
 	var/used_spell_points
-	var/max_spell_points = 4 // anything above 0 limits the max amount of spell points a person can possibly acquire
+	var/max_spell_points = 3 // anything above 0 limits the max amount of spell points a person can possibly acquire
 	var/movemovemovetext = "Move!!"
 	var/takeaimtext = "Take aim!!"
 	var/holdtext = "Hold!!"
@@ -404,12 +404,11 @@
 	var/points_to_add = points
 	
 	if(max_spell_points) // there is an actual limit to the amount of spell points someone can earn
-		var/total_earned_points = spell_points + used_spell_points
-		var/total_potential_points = total_earned_points + points
-		if(max_spell_points > total_potential_points)
-			points_to_add = points - (total_potential_points - max_spell_points) // subtract whatever amount that would take points over max_spell_points
-
-	spell_points += points_to_add
+		var/potential_points = spell_points + points
+		spell_points = min(max_spell_points, potential_points) // never let spell_points go over max_spell_points
+	else
+		spell_points += points_to_add
+	
 	check_learnspell() //check if we need to add or remove the learning spell
 
 ///Gets the skill's singleton and returns the result of its get_skill_speed_modifier

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -47,7 +47,7 @@
 
 	var/spell_points
 	var/used_spell_points
-	var/max_spell_points = 0 // anything above 0 limits the max amount of spell points a person can possibly acquire
+	var/max_spell_points = 4 // anything above 0 limits the max amount of spell points a person can possibly acquire
 	var/movemovemovetext = "Move!!"
 	var/takeaimtext = "Take aim!!"
 	var/holdtext = "Hold!!"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -47,6 +47,7 @@
 
 	var/spell_points
 	var/used_spell_points
+	var/max_spell_points = 0 // anything above 0 limits the max amount of spell points a person can possibly acquire
 	var/movemovemovetext = "Move!!"
 	var/takeaimtext = "Take aim!!"
 	var/holdtext = "Hold!!"
@@ -400,7 +401,15 @@
 
 // adjusts the amount of available spellpoints
 /datum/mind/proc/adjust_spellpoints(points)
-	spell_points += points
+	var/points_to_add = points
+	
+	if(max_spell_points) // there is an actual limit to the amount of spell points someone can earn
+		var/total_earned_points = spell_points + used_spell_points
+		var/total_potential_points = total_earned_points + points
+		if(max_spell_points > total_potential_points)
+			points_to_add = points - (total_potential_points - max_spell_points) // subtract whatever amount that would take points over max_spell_points
+
+	spell_points += points_to_add
 	check_learnspell() //check if we need to add or remove the learning spell
 
 ///Gets the skill's singleton and returns the result of its get_skill_speed_modifier

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
@@ -28,6 +28,7 @@
 
 	r_hand = /obj/item/rogueweapon/woodstaff
 	if(H.mind)
+		H.mind.max_spell_points = 0
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -31,6 +31,7 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			backr = /obj/item/rogueweapon/woodstaff
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/spellbook_unfinished/pre_arcyne = 1)
+			H.mind.max_spell_points = 0
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
@@ -66,6 +67,7 @@
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			beltr = /obj/item/rogueweapon/sword/sabre
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1)
+			H.mind.max_spell_points = 0
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/wretch.dm
@@ -205,6 +205,7 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			backr = /obj/item/rogueweapon/woodstaff
 			backpack_contents = list(/obj/item/spellbook_unfinished/pre_arcyne = 1, /obj/item/roguegem/amethyst = 1, /obj/item/roguekey/inhumen = 1, /obj/item/flashlight/flare/torch = 1)
+			H.mind.max_spell_points = 0
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -39,6 +39,7 @@
 	ADD_TRAIT(H, TRAIT_SEEPRICES, "[type]")
 	ADD_TRAIT(H, TRAIT_INTELLECTUAL, TRAIT_GENERIC)
 	if(H.mind)
+		H.mind.max_spell_points = 0
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -87,6 +87,7 @@
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 
 		if("Blade Caster")
+			H.mind.max_spell_points = 0
 			H.set_blindness(0)
 			to_chat(H, span_warning("Blade Casters are those skilled in both magyck and swordsmanship, but excelling in nothing."))
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -47,6 +47,7 @@
 		if("Hierophant")
 			H.set_blindness(0)
 			to_chat(H, span_warning("Hierophants are magicians who studied under cloistered sages, well-versed in all manners of arcyne. They prioritize enhancing their teammates and distracting foes while staying in the backline."))
+			H.mind.max_spell_points = 0
 			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -37,6 +37,7 @@
 	id = /obj/item/scomstone/bad
 
 	if(H.mind)
+		H.mind.max_spell_points = 0
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 6, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -51,6 +51,7 @@
 	head = /obj/item/clothing/head/roguetown/roguehood/mage
 	backpack_contents = list(/obj/item/roguegem/amethyst = 1, /obj/item/spellbook_unfinished/pre_arcyne = 1)
 	if(H.mind)
+		H.mind.max_spell_points = 0
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
@@ -87,6 +88,7 @@
 /datum/outfit/job/roguetown/wapprentice/alchemist/pre_equip(mob/living/carbon/human/H)
 	backpack_contents = list(/obj/item/roguegem/amethyst = 1, /obj/item/seeds/sweetleaf = 1, /obj/item/seeds/pipeweed = 1)
 	if(H.mind)
+		H.mind.max_spell_points = 0
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 4, TRUE)
@@ -125,6 +127,7 @@
 /datum/outfit/job/roguetown/wapprentice/apprentice/pre_equip(mob/living/carbon/human/H)
 	backpack_contents = list(/obj/item/roguegem/amethyst = 1)
 	if(H.mind)
+		H.mind.max_spell_points = 0
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/failed_apprentice.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/failed_apprentice.dm
@@ -25,6 +25,7 @@
 	r_hand = /obj/item/rogueweapon/woodstaff
 
 	if (H.mind)
+		H.mind.max_spell_points = 0
 		H.mind.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 1, TRUE)

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -5,7 +5,6 @@
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
 	if (!recipient.mind?.get_skill_level(/datum/skill/magic/arcane)) // we can do this because apply_to is always called first
-		recipient.mind?.adjust_spellpoints(-4) // Limits skill gain through for non-initial arcynes
 		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a maximum number of spell points (right now 3) that non-magicians can possibly earn over the course of a round. Also removes the spell point debuff from arcyne potential, as a spell point limit should solve the same problem that the debuff was intended to solve.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think this is a better way of nerfing arcyne potential, yet still leaving it actually useful as a virtue. This should also just permanently solve the problem of ALL non-magician classes being able to (theoretically) Arcynemaxx and become more powerful than the actual magicians.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
