### PR TITLE
Added water reagent to jacksberries

### DIFF
--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -137,7 +137,7 @@
 	icon_state = "berries"
 	tastes = list("berry" = 1)
 	bitesize = 5
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/water = 1)
 	faretype = FARE_NEUTRAL
 	dropshrink = 0.75
 	var/color_index = "good"
@@ -181,7 +181,7 @@
 	seed = /obj/item/seeds/berryrogue/poison
 	icon_state = "berries"
 	tastes = list("berry" = 1)
-	list_reagents = list(/datum/reagent/berrypoison = 5, /datum/reagent/consumable/nutriment = 3)
+	list_reagents = list(/datum/reagent/berrypoison = 5, /datum/reagent/consumable/nutriment = 3, /datum/reagent/water = 1)
 	grind_results = list(/datum/reagent/berrypoison = 5)
 	color_index = "bad"
 

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -137,7 +137,7 @@
 	icon_state = "berries"
 	tastes = list("berry" = 1)
 	bitesize = 5
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/water = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/water = 5)
 	faretype = FARE_NEUTRAL
 	dropshrink = 0.75
 	var/color_index = "good"
@@ -181,7 +181,7 @@
 	seed = /obj/item/seeds/berryrogue/poison
 	icon_state = "berries"
 	tastes = list("berry" = 1)
-	list_reagents = list(/datum/reagent/berrypoison = 5, /datum/reagent/consumable/nutriment = 3, /datum/reagent/water = 1)
+	list_reagents = list(/datum/reagent/berrypoison = 5, /datum/reagent/consumable/nutriment = 3, /datum/reagent/water = 5)
 	grind_results = list(/datum/reagent/berrypoison = 5)
 	color_index = "bad"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This change will add five units of water to both regular and poison Jacksberries (This comes out to 1 unit per bite)

## Why It's Good For The Game

Jacksberries are the "foraging" food and giving them a slight boost to hydration will allow players to get by for a bit longer in the wild without having to seek the main river.
