### PR TITLE
Replaced Mounted Knight Sabre w/ Bastard Sword

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -257,12 +257,12 @@
 	H.change_stat("intelligence", 1)
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Sabre + Crossbow","Billhook + Recurve Bow")
+	var/weapons = list("Bastard Sword + Crossbow","Billhook + Recurve Bow")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
-		if("Sabre + Crossbow")
-			beltl = /obj/item/rogueweapon/sword/sabre
+		if("Bastard Sword + Crossbow")
+			beltl = /obj/item/rogueweapon/sword/long
 			beltr = /obj/item/quiver/bolts
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This replaces the mounted Royal Guard class' sabre with a bastard sword. Let me know if I fucked up somewhere. I'm rusty. This PR is tested, though, and it appears in-game just fine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sabres aren't a very fitting weapon for a knight. When you think of a knight on horseback, it comes to polearms, lances, straight swords, skull-smashing weapons like maces and warhammers. Sabres are designed for speedy classes, it'd make more sense for a mounted mercenary like a Steppesman or something. Those folk should feel different from a traditional knight. All for soul.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
