### PR TITLE
Desert Rider/Naledi Sword Fix

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -391,35 +391,28 @@
 			if("onbelt") 
 				return list("shrink" = 0.4,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/rogueweapon/sword/long/rider
-	force = 26
-	force_wielded = 31
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/strike, /datum/intent/sword/chop)
-	icon_state = "tabi"
-	icon = 'icons/roguetown/weapons/64.dmi'
-	item_state = "tabi"
-	lefthand_file = 'icons/mob/inhands/weapons/roguebig_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/roguebig_righthand.dmi'
+/obj/item/rogueweapon/sword/sabre/shamshir
+	force = 24
+	minstr = 5
+	wdefense = 5
+	wbalance = 1
 	name = "shamshir"
 	desc = "A one-handed sword with elegant curves and deadly sharpness."
-	parrysound = "bladedmedium"
-	swingsound = BLADEWOOSH_LARGE
-	pickup_sound = 'sound/foley/equip/swordlarge2.ogg'
-	bigboy = 1
-	wlength = WLENGTH_LONG
-	gripsprite = TRUE
+	icon_state = "tabi"
+	icon = 'icons/roguetown/weapons/64.dmi'
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/strike)
+	gripped_intents = null
+	parrysound = list('sound/combat/parry/bladed/bladedthin (1).ogg', 'sound/combat/parry/bladed/bladedthin (2).ogg', 'sound/combat/parry/bladed/bladedthin (3).ogg')
+	swingsound = BLADEWOOSH_SMALL
+	bigboy = TRUE
 	pixel_y = -16
 	pixel_x = -16
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	associated_skill = /datum/skill/combat/swords
-	throwforce = 15
-	thrown_bclass = BCLASS_CUT
 	dropshrink = 0.75
 	smeltresult = /obj/item/ingot/steel
-
-/obj/item/rogueweapon/sword/long/rider/getonmobprop(tag)
+	
+/obj/item/rogueweapon/sword/sabre/shamshir/getonmobprop(tag)
 	. = ..()
 	if(tag)
 		switch(tag)

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -400,7 +400,7 @@
 	desc = "A one-handed sword with elegant curves and deadly sharpness."
 	icon_state = "tabi"
 	icon = 'icons/roguetown/weapons/64.dmi'
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/strike)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
 	gripped_intents = null
 	parrysound = list('sound/combat/parry/bladed/bladedthin (1).ogg', 'sound/combat/parry/bladed/bladedthin (2).ogg', 'sound/combat/parry/bladed/bladedthin (3).ogg')
 	swingsound = BLADEWOOSH_SMALL

--- a/code/modules/cargo/packsrogue/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/Sellsword.dm
@@ -8,7 +8,7 @@
 /datum/supply_pack/rogue/Sellsword/dridersword
 	name = "Old Zybantine package..."
 	cost = 10
-	contains = list(/obj/item/rogueweapon/sword/long/rider)
+	contains = list(/obj/item/rogueweapon/sword/sabre/shamshir)
 
 
 /datum/supply_pack/rogue/Sellsword/driderhead

--- a/code/modules/cargo/packsrogue/weapons.dm
+++ b/code/modules/cargo/packsrogue/weapons.dm
@@ -92,7 +92,7 @@
 	name = "Shamshir"
 	cost = 80
 	contains = list(
-					/obj/item/rogueweapon/sword/long/rider,
+					/obj/item/rogueweapon/sword/sabre/shamshir,
 				)
 
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -71,7 +71,7 @@
 			H.change_stat("endurance", 2)
 			H.change_stat("intelligence", 1)
 			H.change_stat("speed", 3)
-			backl = /obj/item/rogueweapon/sword/long/rider
+			backl = /obj/item/rogueweapon/sword/sabre/shamshir
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
@@ -81,7 +81,7 @@
 			H.set_blindness(0)
 			switch(weapon_choice)
 				if("Shamshir")
-					backl = /obj/item/rogueweapon/sword/long/rider
+					backl = /obj/item/rogueweapon/sword/sabre/shamshir
 				if("Whips and Knives")	///They DO enslave people after all
 					r_hand = /obj/item/rogueweapon/whip
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
@@ -109,9 +109,9 @@
 			H.change_stat("speed", 3)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/push_spell)
-			r_hand = /obj/item/rogueweapon/sword/long/rider
+			r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/magered
-			backl = /obj/item/rogueweapon/sword/long/rider
+			backl = /obj/item/rogueweapon/sword/sabre/shamshir
 
 			H.grant_language(/datum/language/celestial)
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -135,7 +135,7 @@
 			H.change_stat("endurance", 2)
 			H.change_stat("intelligence", 2)
 			H.change_stat("speed", 3)
-			r_hand = /obj/item/rogueweapon/sword/long/rider
+			r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 			armor = /obj/item/clothing/suit/roguetown/shirt/robe/magered
 
 			mask = /obj/item/clothing/mask/rogue/lordmask/tarnished


### PR DESCRIPTION
## About The Pull Request
Alters the classification and utility of the shamshir to reflect the sword it should actually be.

## Why It's Good For The Game
The current shamshir is incredibly misleading. The description states it is a 'deadly one handed sword' yet, in the code, it is a subtype of longsword and is meant to be two-handed. This goes against the power fantasy of all of the classes who use it, as well as the logic of the weapon itself.

I have based the new statline off of the sabre, because these two weapons are very similar and fulfil a similar niche in terms of power fantasy. In order to make them unique, however, the shamshir retains 2 more force than the sabre with one less defence, to reflect a heavier blade but less hand protection.

![nicolas-noel-boutet-sabre-de-recompense-dit-du-19-brumaire-1799-paris-musee-de-larmee-dist-rmn-grand-palais-pascal-segrette-tt-width-637-height-357-crop-1-bgcolor-ffffff-lazyload-0](https://github.com/user-attachments/assets/1fa3bc92-99a0-40df-ab7a-88f79e4f0c11)
_A sabre on top, shamshir on bottom. Very similar swords. A shamshir and longsword? Not so much._

I would go so far as to liken this to a bug rather than a balance change. Imagine if you loaded up Skyrim for the first time, but the steel dagger you were using had the stats and animations of a war hammer. 
Worse yet, the description of the shamshir and the classes who get it - mainly the blade dancer - instruct the player to use it in one hand and dance around as a lightly-armoured fighter. As the weapon currently exists in-game, it's fairly poor for this role and should be used in two hands.