### PR TITLE
Adds the ability to clean up remains by clicking on them.

### DIFF
--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -12,7 +12,18 @@
 /obj/effect/decal/remains/human
 	desc = ""
 	icon_state = "remains"
-
+	var/harvestable_bones = list(/obj/item/natural/bone = 3, /obj/item/skull = 1)
+/obj/effect/decal/remains/human/attack_hand(mob/living/user)
+	. = ..()
+	user.visible_message(span_warning("[user] begins sorting through [src]."), span_warning("You begin sorting through [src]."))
+	if(do_after(user, 5 SECONDS, needhand = TRUE, target = src))
+		playsound(src, 'sound/foley/equip/rummaging-02.ogg', 100, FALSE)
+		var/atom/L = drop_location()
+		for(var/item in harvestable_bones)
+			for(var/num in 1 to harvestable_bones[item])
+				new item(L)
+		user.visible_message(span_warning("[user] sorts through [src]."), span_warning("You sort through [src]."))
+		qdel(src)
 /obj/effect/decal/remains/plasma
 	icon_state = "remainsplasma"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This adds the ability to clean up the remains you often find in places like the Zurch and other places by clicking on them, waiting 5 seconds and then salvaging bones and skulls from the piles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These things were impossible to clean, even if you WANTED to restore an area - they just didn't go away.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
