### PR TITLE
Fixes omni-run consequence of last-step dir change supercharge

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -189,6 +189,12 @@
 			// Randomize con roll from -1 to +1 to make it less consistent
 			self_points += rand(-1, 1)
 
+			//Safety check for changing direction at the last step
+			if(src.dir != src.sprint_dir)
+				self_points -= 99
+				instafail = TRUE
+				to_chat(src, span_warning("I changed direction too late!"))
+
 			if(self_points > target_points)
 				L.Knockdown(1)
 			if(self_points < target_points)
@@ -861,6 +867,7 @@
 
 	if(m_intent == MOVE_INTENT_RUN)
 		sprinted_tiles++
+		sprint_dir = dir
 
 	if(wallpressed)
 		update_wallpress(T, newloc, direct)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -290,3 +290,4 @@
 	var/music_playing = FALSE
 	/// Tracker for amount of turfs we sprinted over, for things like bumping and charging
 	var/sprinted_tiles = 0
+	var/sprint_dir = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Sprinting's dir change to reset the sprinted_tiles increment happened after proc/Move, which meant you could charge into someone by juking into them at the termination of your charge. This adds var/sprint_dir to track dir that increments with sprinted_tiles++, which lets us check at the end. Fixes the issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

https://github.com/user-attachments/assets/348e8939-1b5d-454b-8846-08930fc5735c


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
