### PR TITLE
Fixes stockpile for cured leather by defining it before hide

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile.dm
+++ b/code/modules/roguetown/roguestock/stockpile.dm
@@ -104,6 +104,19 @@
 	importexport_amt = 10
 	passive_generation = 4
 
+//natural/hide/cured must be defined/populated in sstreasury before natural/hide, for istype stockpile check to work
+/datum/roguestock/stockpile/cured
+	name = "Cured Leather"
+	desc = "Cured Leather ready to be worked."
+	item_type = /obj/item/natural/hide/cured
+	held_items = list(2, 0)
+	payout_price = 3
+	withdraw_price = 7
+	transport_fee = 3
+	export_price = 7
+	importexport_amt = 10
+	passive_generation = 3
+
 /datum/roguestock/stockpile/hide
 	name = "Hide"
 	desc = "Stripped hide from animals."
@@ -127,18 +140,6 @@
 	export_price = 15
 	importexport_amt = 5
 	passive_generation = 1
-
-/datum/roguestock/stockpile/cured
-	name = "Cured Leather"
-	desc = "Cured Leather ready to be worked."
-	item_type = /obj/item/natural/hide/cured
-	held_items = list(2, 0)
-	payout_price = 3
-	withdraw_price = 7
-	transport_fee = 3
-	export_price = 7
-	importexport_amt = 10
-	passive_generation = 3
 
 /datum/roguestock/stockpile/salt
 	name = "Salt"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
The way stockpile handles istype checks, cured leather was going into the machine as hide. This fixes that by defining cured leather earlier in the file before hide, which populates cured leather into ssTreasury before hide, meaning it gets the istype check first, which satisfies the stockpile logic. Yes, it's terrifying

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/d036b099-802e-46ba-a820-33e817d9d5a8)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
