### PR TITLE
Adds istypes for datum/intent references on click, runtime prevention

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -111,7 +111,7 @@
 			used_hand = 2
 			if(next_rmove > world.time)
 				return
-		if(used_intent.get_chargetime())
+		if(istype(used_intent, /datum/intent) && used_intent.get_chargetime())
 			if(used_intent.no_early_release && client?.chargedprog < 100)
 				var/adf = used_intent.clickcd
 				if(istype(rmb_intent, /datum/rmb_intent/aimed))

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -76,7 +76,7 @@
 
 	var/atom/AD = object
 
-	if(mob.used_intent)
+	if(istype(mob.used_intent, /datum/intent))
 		mob.used_intent.on_mouse_up()
 
 	if(mob.stat != CONSCIOUS)
@@ -167,7 +167,7 @@
 				return
 		mob.atkswinging = "left"
 		mob.used_intent = mob.a_intent
-		if(mob.used_intent.get_chargetime() && !AD.blockscharging && !mob.in_throw_mode)
+		if(istype(mob.used_intent, /datum/intent) && mob.used_intent.get_chargetime() && !AD.blockscharging && !mob.in_throw_mode)
 			updateprogbar()
 		else
 			mouse_pointer_icon = 'icons/effects/mousemice/human_attack.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Something discovered with the witch PR was that simple mobs have a path reference of intent rather than a datum reference, which means that all of the normal clicks that happen while in interface as a simple mob were throwing a runtime trying to access RT's special intent information. This chases the runtime stack down and adds istypes to enforce sanity. Might be super expensive, maybe a test merge / a different solution where simple animals have a valid intent set to them. 

![image](https://github.com/user-attachments/assets/a0550ff4-26a1-4c8c-8930-da395f7d5f39)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chasing runtimes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
