### PR TITLE
Fixes runtime in dye station destruction causing invincible dye stations

### DIFF
--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -62,7 +62,8 @@
 		"Royal Brown"="#61462c")
 		
 /obj/machinery/gear_painter/Destroy()
-	inserted.forceMove(drop_location())
+	if(inserted)
+		inserted.forceMove(drop_location())
 	return ..()
 
 /obj/machinery/gear_painter/attackby(obj/item/I, mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Someone was being naughty and spamming down invincible dye stations that were not able to be destroyed, because of a runtime of integrity reaching 0 while Inserted was null. This fixes that runtime and lets dye stations be destroyed normally.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more invincible non-crossable dye machines
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
