### PR TITLE
Prevents surgery cauterization spawning flesh for carbon skeletons

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -2,6 +2,11 @@
 	if (!istype(target, /mob/living/carbon/human) || QDELETED(target))
 		return FALSE
 
+	//Special check preventing skeletons being cautery burned to regrow flesh
+	if(istype(target, /mob/living/carbon/human/species/skeleton) && method == "surgery")
+		to_chat(user, span_warning("It's going to take a miracle to put flesh back on these bones."))
+		return FALSE
+
 	// Check if the target has rot
 	var/has_rot = FALSE
 	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Wild barber surgeons in the brush were taking dead ambush carbon skeletons, using the cautery on their chest to invoke cure_rot, spawning the skeletons a flesh suit, then butchering the flesh body for meat. This fixes that.

You can still do that with a Pestran miracle if you like though!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Soul removal.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
