### PR TITLE
Removes full heal from shapeshift restore damage transfer

### DIFF
--- a/code/game/objects/shapeshift_holder.dm
+++ b/code/game/objects/shapeshift_holder.dm
@@ -72,11 +72,8 @@
 	if(death)
 		stored.death()
 	else if(source.convert_damage)
-		stored.revive(full_heal = TRUE, admin_revive = FALSE)
-
 		var/damage_percent = (shape.maxHealth - shape.health)/shape.maxHealth;
 		var/damapply = stored.maxHealth * damage_percent
-
 		stored.apply_damage(damapply, source.convert_damage_type, forced = TRUE)
 	qdel(shape)
 	qdel(src)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Vampire powers meant that VLs got a free full heal out of their escape shapeshift, if their simplemob took no damage in the escape. Which is redundant since VLs have blood point heal anyhow. Anyhow, it trickled into Witch zad, which is not intended. This removes that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's dangerous being a zad

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
