### PR TITLE
Removes mercenary key from inn's basement spare keys

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -30254,7 +30254,6 @@
 /obj/item/roguekey/roomiii,
 /obj/item/roguekey/roomii,
 /obj/item/roguekey/roomi,
-/obj/item/roguekey/mercenary,
 /obj/item/roguekey/fancyroomi,
 /obj/item/roguekey/fancyroomii,
 /obj/item/roguekey/fancyroomiii,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Spare key was still left mapped in from when mercenaries bunked in the inn. Now that they have a guild, this key shouldn't be here anymore.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/4bf0f57b-a4ef-4cda-bf49-408962150a8a)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
