### PR TITLE
Fixes double-turfed wall at dun manor north gate

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -16296,10 +16296,6 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
-"mcq" = (
-/turf/closed/wall/mineral/rogue/stone,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/indoors/town)
 "mcz" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/transparent/openspace,
@@ -69167,7 +69163,7 @@ rjf
 rjf
 rjf
 fJa
-mcq
+fJa
 rJM
 hvn
 hvn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Two turfs mapped here meant a dirt tile with a wall sprite. Setting it just to a wall turf.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/085d3acd-da5d-455a-ab65-ad0e6c09666a)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
