### PR TITLE
Allows class slots to open  back up.

### DIFF
--- a/modular_azurepeak/code/game/objects/structures/fartravel.dm
+++ b/modular_azurepeak/code/game/objects/structures/fartravel.dm
@@ -40,6 +40,8 @@
 		mob_job = SSjob.GetJob(departing_mob.mind.assigned_role)
 		if(mob_job)
 			mob_job.current_positions = max(0, mob_job.current_positions - 1)
+			var/target_job = SSrole_class_handler.get_advclass_by_name(user.advjob)
+			SSrole_class_handler.adjust_class_amount(target_job, -1)
 	if(!length(departing_mob.contents))
 		dat += " none."
 	else

--- a/modular_azurepeak/code/game/objects/structures/fartravel.dm
+++ b/modular_azurepeak/code/game/objects/structures/fartravel.dm
@@ -41,7 +41,8 @@
 		if(mob_job)
 			mob_job.current_positions = max(0, mob_job.current_positions - 1)
 			var/target_job = SSrole_class_handler.get_advclass_by_name(user.advjob)
-			SSrole_class_handler.adjust_class_amount(target_job, -1)
+			if(target_job)
+				SSrole_class_handler.adjust_class_amount(target_job, -1)
 	if(!length(departing_mob.contents))
 		dat += " none."
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
So this works for Wretch and any other class with limited slots. It just checks what class you were and lowers the total amount of slots currently occupied.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I have had several times where I have round-destroying bugs on my end that cannot be fixed except for respawning just TODAY. Two in a ROW. And the idea that you HAVE to stay in round as a wretch is harmful because you are taking other people's potential spot. If you far travel at round start you're screwing yourself and everyone else.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
