### PR TITLE
Learning not to touch fire (Campfire healing)

### DIFF
--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -123,6 +123,11 @@
 	desc = span_boldgreen("PURE moondust surges through me!")
 	timer = 4 MINUTES
 
+/datum/stressevent/campfire
+	stressadd = -1
+	desc = span_green("The warmth of the fire is comforting.")
+	timer = 5 MINUTES
+
 /datum/stressevent/puzzle_easy
 	stressadd = -1
 	desc = span_green("That puzzle was a nice distraction from this drudgery.")

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -598,6 +598,7 @@
 
 			if(do_after(H, 100, target = src))
 				H.apply_status_effect(/datum/status_effect/buff/healing, 1)
+				H.add_stress(/datum/stressevent/campfire)
 				to_chat(H, "<span class='info'>The warmth of the fire comforts me, affording me a short rest.</span>")
 		return TRUE //fires that are on always have this interaction with lmb unless its a torch
 

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -597,10 +597,8 @@
 			H.visible_message("<span class='info'>[H] warms \his hand near the fire.</span>")
 
 			if(do_after(H, 100, target = src))
-				var/obj/item/bodypart/affecting = H.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
-				to_chat(H, "<span class='warning'>HOT!</span>")
-				if(affecting && affecting.receive_damage( 0, 5 ))		// 5 burn damage
-					H.update_damage_overlays()
+				H.apply_status_effect(/datum/status_effect/buff/healing, 1)
+				to_chat(H, "<span class='info'>The warmth of the fire comforts me, affording me a short rest.</span>")
 		return TRUE //fires that are on always have this interaction with lmb unless its a torch
 
 /obj/machinery/light/rogue/campfire/densefire


### PR DESCRIPTION
## About The Pull Request

Small change, basically adds a little buff of healing when you rest at a campfire, like a worse version of just sleeping, but you know, you can sit around a bonfire and heal while chatting with friends.

I like this better than being an actual dent brain and sticking your hand in the fire when interacting with it, getting 5 points of burn.

## Why It's Good For The Game

Another tiny way to top off superfluous damage, also gives campfires a little more use.


https://github.com/user-attachments/assets/00079007-5360-4c59-b467-9fdec30dc4d5


