### PR TITLE
Removes restraint_check define from subtle emote

### DIFF
--- a/modular/code/modules/living/emote.dm
+++ b/modular/code/modules/living/emote.dm
@@ -4,7 +4,6 @@
 #ifdef MATURESERVER
 	message_param = "%t"
 #endif
-	restraint_check = TRUE
 
 /datum/emote/living/subtle/can_run_emote(mob/user, status_check, intentional)
 	. = ..() && intentional


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Subtle emotes were hitting a hard return false due to restraint_check. Removes that, letting people subtle emote while restrained.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/47d42c7f-60c2-469f-87ba-bdb8c8d4c181)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
