### PR TITLE
Keen ears no longer recognises people they don't know

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -94,7 +94,22 @@ GLOBAL_LIST_INIT(freqtospan, list(
 				arrowpart += " ⇈"
 			if(speakturf.z < sourceturf.z)
 				arrowpart += " ⇊"
-			if(!HAS_TRAIT(src, TRAIT_KEENEARS))
+			
+			var/hidden = TRUE
+			if(HAS_TRAIT(src, TRAIT_KEENEARS))
+				if(ishuman(speaker) && ishuman(src))
+					var/mob/living/carbon/human/HS = speaker
+					var/mob/living/carbon/human/HL = src
+					if(length(HL.mind?.known_people))
+						if(HS.real_name in HL.mind?.known_people)	//We won't recognise people we don't know w/ Keen Ears
+							hidden = FALSE
+					else
+						hidden = TRUE
+				else
+					hidden = FALSE
+			else
+				hidden = TRUE
+			if(hidden)
 				if(istype(speaker, /mob/living))
 					var/mob/living/L = speaker
 					namepart = "Unknown [(L.gender == FEMALE) ? "Woman" : "Man"]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![dreamseeker_Z01pv7h1VI](https://github.com/user-attachments/assets/313c28c1-de42-4520-a7cb-c59ff76a584e)
![dreamseeker_wXfh1S4dUT](https://github.com/user-attachments/assets/42cda049-67cb-45b0-b161-d4b22ba75441)

No one complained about this or anything, maybe they weren't even aware -- but I'd say this is how it should've worked when I first added the Virtue. It's kinda weird to clock the exact name of someone you've literally never seen before, from behind a wall.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Keen Ears users will hate me...
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
