### PR TITLE
Updates Admin Send to Lobby Tools

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -840,6 +840,23 @@
 	set name = "Return to Lobby"
 
 	var/mob/living/carbon/human/H = mob
+	var/datum/job/mob_job
+
+	if(H.mind)
+		mob_job = SSjob.GetJob(H.mind.assigned_role)
+		if(mob_job)
+			mob_job.current_positions = max(0, mob_job.current_positions - 1)
+		H.mind.unknow_all_people()
+		for(var/datum/mind/MF in get_minds())
+			H.mind.become_unknown_to(MF)
+		for(var/datum/bounty/removing_bounty in GLOB.head_bounties)
+			if(removing_bounty.target == H.real_name)
+				GLOB.head_bounties -= removing_bounty
+	else
+		alert(usr, "Target has no mind!") // Optional Error check that may or may not be neccessary
+	GLOB.chosen_names -= H.real_name
+	LAZYREMOVE(GLOB.actors_list, H.mobid)
+	LAZYREMOVE(GLOB.roleplay_ads, H.mobid)
 	H.returntolobby()
 
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -841,11 +841,14 @@
 
 	var/mob/living/carbon/human/H = mob
 	var/datum/job/mob_job
+	var/target_job = SSrole_class_handler.get_advclass_by_name(H.advjob)
 
 	if(H.mind)
 		mob_job = SSjob.GetJob(H.mind.assigned_role)
 		if(mob_job)
 			mob_job.current_positions = max(0, mob_job.current_positions - 1)
+		if(target_job)
+			SSrole_class_handler.adjust_class_amount(target_job, -1)
 		H.mind.unknow_all_people()
 		for(var/datum/mind/MF in get_minds())
 			H.mind.become_unknown_to(MF)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -882,10 +882,13 @@
 			to_chat(usr, span_warning("[M] doesn't seem to have an active client."))
 			return
 		var/datum/job/mob_job = SSjob.GetJob(M.mind.assigned_role)
+		var/target_job = SSrole_class_handler.get_advclass_by_name(M.advjob)
 		if(M.mind)
 			mob_job = SSjob.GetJob(M.mind.assigned_role)
 			if(mob_job)
 				mob_job.current_positions = max(0, mob_job.current_positions - 1)
+			if(target_job)
+				SSrole_class_handler.adjust_class_amount(target_job, -1)
 			M.mind.unknow_all_people()
 			for(var/datum/mind/MF in get_minds())
 				M.mind.become_unknown_to(MF)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -881,7 +881,21 @@
 		if(!M.client)
 			to_chat(usr, span_warning("[M] doesn't seem to have an active client."))
 			return
+		var/datum/job/mob_job = SSjob.GetJob(M.mind.assigned_role)
+		if(M.mind)
+			mob_job = SSjob.GetJob(M.mind.assigned_role)
+			if(mob_job)
+				mob_job.current_positions = max(0, mob_job.current_positions - 1)
+			M.mind.unknow_all_people()
+			for(var/datum/mind/MF in get_minds())
+				M.mind.become_unknown_to(MF)
+			for(var/datum/bounty/removing_bounty in GLOB.head_bounties)
+				if(removing_bounty.target == M.real_name)
+					GLOB.head_bounties -= removing_bounty
 		log_admin("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
+		GLOB.chosen_names -= M.real_name
+		LAZYREMOVE(GLOB.actors_list, M.mobid)
+		LAZYREMOVE(GLOB.roleplay_ads, M.mobid)
 
 		var/mob/dead/new_player/NP = new()
 		NP.ckey = M.ckey


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Neither the Debug verb 'Return to Lobby' nor the Player Panel command 'Send to Lobby' accounted for job slots, bounties, or 'known' status. This updates them to automatically account for and remove these things.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins no longer inadvertently freeze job slots when they send players back to lobby. Bounties won't get stuck uncompleted either.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
