### PR TITLE
[Tested]Halves well filling time

### DIFF
--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -20,7 +20,7 @@
 		if(W.reagents.holder_full())
 			to_chat(user, span_warning("[W] is full."))
 			return
-		if(do_after(user, 60, target = src))
+		if(do_after(user, 30, target = src))
 			var/list/waterl = list(/datum/reagent/water = 100)
 			W.reagents.add_reagent_list(waterl)
 			to_chat(user, "<span class='notice'>I fill [W] from [src].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Cuts the time it takes to fill a bucket from a well in half
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Filling a barrel from a bucket via a well takes _fucking ages_ and doesn't really benefit RP. Wells make up the majority of water sources in the town, and yet people often bypass them for standing water, which fills buckets instantly. This retains that benefit, while also minimizing the amount of "sit-and-wait" time.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
