### PR TITLE
Ports some Hearthstone duke spells

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -10,7 +10,8 @@
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Picked out of your political value rather than likely any form of love, you have become the Grand Duke's most trusted confidant--and likely friend--throughout your marriage. Your loyalty and perhaps even your love will be tested this day... for the daggers that threaten your beloved are as equally pointed at your own throat."
 
-	spells = list(/obj/effect/proc_holder/spell/self/convertrole/servant)
+	spells = list(/obj/effect/proc_holder/spell/self/convertrole/servant,
+	/obj/effect/proc_holder/spell/self/grant_nobility)
 	outfit = /datum/outfit/job/roguetown/lady
 
 	display_order = JDO_LADY
@@ -81,3 +82,20 @@
 	accept_message = "FOR THE CROWN!"
 	refuse_message = "I refuse."
 	charge_max = 100
+
+/obj/effect/proc_holder/spell/self/convertrole/mercenary
+	name = "Recruit Mercenary"
+	new_role = "Mercenary"
+	recruitment_faction = "MERCENARIES"
+	recruitment_message = "Serve the Guild, %RECRUIT!"
+	accept_message = "FOR THE GUILD!"
+	refuse_message = "I refuse."
+	charge_max = 100
+
+/obj/effect/proc_holder/spell/self/convertrole/bog
+	name = "Recruit Warden"
+	new_role = "Warden"
+	recruitment_faction = "Bog Guard"
+	recruitment_message = "Serve the Wardens, %RECRUIT!"
+	accept_message = "FOR THE GROVE!"
+	refuse_message = "I refuse."

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -17,6 +17,8 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/obj/effect/proc_holder/spell/self/grant_title,
 		/obj/effect/proc_holder/spell/self/convertrole/servant,
 		/obj/effect/proc_holder/spell/self/convertrole/guard,
+		/obj/effect/proc_holder/spell/self/grant_nobility,
+		/obj/effect/proc_holder/spell/self/convertrole/bog
 	)
 	outfit = /datum/outfit/job/roguetown/lord
 	visuals_only_outfit = /datum/outfit/job/roguetown/lord/visuals
@@ -216,4 +218,57 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		return FALSE
 	recruiter.say("I HEREBY GRANT YOU, [uppertext(recruit.name)], THE TITLE OF [uppertext(granted_title)]!")
 	GLOB.lord_titles[recruit.real_name] = granted_title
+	return TRUE
+
+/obj/effect/proc_holder/spell/self/grant_nobility
+	name = "Grant Nobility"
+	desc = "Make someone a noble, or strip them of their nobility."
+	overlay_state = "recruit_titlegrant"
+	antimagic_allowed = TRUE
+	charge_max = 100
+	/// Maximum range for nobility granting
+	var/nobility_range = 3
+
+/obj/effect/proc_holder/spell/self/grant_nobility/cast(list/targets, mob/user = usr)
+	. = ..()
+	var/list/recruitment = list()
+	for(var/mob/living/carbon/human/village_idiot in (get_hearers_in_view(nobility_range, user) - user))
+		//not allowed
+		if(!can_nobility(village_idiot))
+			continue
+		recruitment[village_idiot.name] = village_idiot
+	if(!length(recruitment))
+		to_chat(user, span_warning("There are no potential honoraries in range."))
+		return
+	var/inputty = input(user, "Select an honorary!", "[name]") as anything in recruitment
+	if(inputty)
+		var/mob/living/carbon/human/recruit = recruitment[inputty]
+		if(!QDELETED(recruit) && (recruit in get_hearers_in_view(nobility_range, user)))
+			INVOKE_ASYNC(src, PROC_REF(grant_nobility), recruit, user)
+		else
+			to_chat(user, span_warning("Honorific failed!"))
+	else
+		to_chat(user, span_warning("Honorific cancelled."))
+
+/obj/effect/proc_holder/spell/self/grant_nobility/proc/can_nobility(mob/living/carbon/human/recruit)
+	//wtf
+	if(QDELETED(recruit))
+		return FALSE
+	//need a mind
+	if(!recruit.mind)
+		return FALSE
+	//need to see their damn face
+	if(!recruit.get_face_name(null))
+		return FALSE
+	return TRUE
+
+/obj/effect/proc_holder/spell/self/grant_nobility/proc/grant_nobility(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
+	if(QDELETED(recruit) || QDELETED(recruiter))
+		return FALSE
+	if(HAS_TRAIT(recruit, TRAIT_NOBLE))
+		recruiter.say("I HEREBY STRIP YOU, [uppertext(recruit.name)], OF NOBILITY!!")
+		REMOVE_TRAIT(recruit, TRAIT_NOBLE, TRAIT_GENERIC)
+		return FALSE
+	recruiter.say("I HEREBY GRANT YOU, [uppertext(recruit.name)], NOBILITY!")
+	ADD_TRAIT(recruit, TRAIT_NOBLE, TRAIT_GENERIC)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds the ability to grant/remove nobility to the Duke/Consort, but does not allow it to be removed if one has the nobility virtue (because they can be a noble from outside the Duke's perview)

Adds the ability to recruit wardens, much like the watchman, to the duke.

Adds the scaffolding of the mercenary recruitment, but doesn't give to anyone. Merc-master role in the future?

![image](https://github.com/user-attachments/assets/b604aadf-5180-4a46-91e6-e8ff6a70f107)

## Why It's Good For The Game

Just a little taste of what was lost for the HS players.
