### PR TITLE
Makes Night-eyed not disappear upon an aheal.

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -140,14 +140,7 @@
 /datum/virtue/utility/night_vision
 	name = "Night-eyed"
 	desc = "I have eyes able to see through cloying darkness."
-
-/datum/virtue/utility/night_vision/apply_to_human(mob/living/carbon/human/recipient)
-	var/obj/item/organ/eyes/eyes = recipient.getorganslot(ORGAN_SLOT_EYES)
-	if(!eyes)
-		return
-	eyes.see_in_dark = 12
-	eyes.lighting_alpha = LIGHTING_PLANE_ALPHA_DARKVISION
-	recipient.update_sight()
+	added_traits = list(TRAIT_DARKVISION)
 
 /datum/virtue/utility/performer
 	name = "Performer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This makes the nighteyed virtue work by giving you the Dark Vision trait. I don't know why this was implemented like it was but it disappeared upon receiving an aheal. It's literally equivalent to the darkvision trait.

Tested it by taking the virtue and ahealing myself.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I lag a lot, okay?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
