### PR TITLE
Minor RG role touch-up

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -58,7 +58,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	id = /obj/item/scomstone/garrison
+	id = /obj/item/scomstone/bad/garrison
 	backpack_contents = list(/obj/item/storage/keyring/guardcastle = 1)
 
 /datum/advclass/knight/heavy

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -58,7 +58,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	id = /obj/item/scomstone/bad/garrison
+	id = /obj/item/scomstone/garrison
 	backpack_contents = list(/obj/item/storage/keyring/guardcastle = 1)
 
 /datum/advclass/knight/heavy
@@ -132,7 +132,7 @@
 		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
 		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
 		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Visored Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
 		"None"
 	)
 	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
@@ -204,7 +204,7 @@
 		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
 		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
 		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Visored Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
 		"None"
 	)
 	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
@@ -282,7 +282,7 @@
 		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
 		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
 		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Visored Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
 		"None"
 	)
 	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a visored sallet and a proper SCOM stone to the Royal Guard role, bringing it to parity with the Sergeant.

## Why It's Good For The Game

The Royal Guard is higher than the Sergeant role in importance to the Keep, below the Captain, and yet doesn't get a proper SCOM stone. As for the helmet choice, the reason is simple. All the other helmets in the selections are visored or have face protection built in, the fact that the sallet stands alone to be the only unvisored helmet doesn't make sense, especially since the Sergeant role gets the visored variant and it breaks the pattern of RG-loadout helms.