### PR TITLE
Custom bounties + bounties changes

### DIFF
--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -70,8 +70,13 @@
 	return TRUE
 
 /datum/antagonist/bandit/after_name_change()
+	var/my_crime = input(owner.current, "What is your crime?", "Crime") as text|null
+	if (!my_crime)
+		my_crime = "crimes against the Crown"
+	var/bounty_total
+	bounty_total = rand(251, 400)
 	if(owner && owner.current)
-		add_bounty(owner.current.real_name, 80, TRUE, "bandit activity", "The [SSticker.rulertype]")
+		add_bounty(owner.current.real_name, bounty_total, TRUE, my_crime, "The [SSticker.rulertype]")
 
 /datum/antagonist/bandit/roundend_report()
 	if(owner?.current)

--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -69,14 +69,16 @@
 
 	return TRUE
 
-/datum/antagonist/bandit/after_name_change()
-	var/my_crime = input(owner.current, "What is your crime?", "Crime") as text|null
-	if (!my_crime)
+// commenting this stuff out since bandits weren't intended to have roundstart bounties and this is actual holdover code from before we even had the bounty system
+/*	
+	/datum/antagonist/bandit/after_name_change() 
+	//var/my_crime = input(owner.current, "What is your crime?", "Crime") as text|null
+	//if (!my_crime)
 		my_crime = "crimes against the Crown"
 	var/bounty_total
 	bounty_total = rand(251, 400)
 	if(owner && owner.current)
-		add_bounty(owner.current.real_name, bounty_total, TRUE, my_crime, "The [SSticker.rulertype]")
+		add_bounty(owner.current.real_name, bounty_total, TRUE, my_crime, "The [SSticker.rulertype]")*/
 
 /datum/antagonist/bandit/roundend_report()
 	if(owner?.current)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/wretch.dm
@@ -79,9 +79,12 @@
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1)
 			GLOB.outlawed_players += H.real_name
+			var/my_crime = input(H, "What is your crime?", "Crime") as text|null
+			if (!my_crime)
+				my_crime = "crimes against the Crown"
 			var/bounty_total
 			bounty_total = rand(151, 250)
-			add_bounty(H.real_name, bounty_total, FALSE, "Desertion", "The Justiciary of Azuria")
+			add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
 
 		if("Outlaw")
 			to_chat(H, span_warning("You're a seasoned criminal known for your heinous acts, your face plastered on wanted posters across the region. A life of theft, robbery, and ill-gotten-gains comes naturally to you."))
@@ -201,9 +204,12 @@
 			H.change_stat("perception", 2)
 			H.change_stat("speed", 2)
 			GLOB.outlawed_players += H.real_name
+			var/my_crime = input(H, "What is your crime?", "Crime") as text|null
+			if (!my_crime)
+				my_crime = "crimes against the Crown"
 			var/bounty_total
 			bounty_total = rand(151, 250)
-			add_bounty(H.real_name, bounty_total, FALSE, "Poaching", "The Justiciary of Azuria")
+			add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
 
 		if("Heretic")
 			to_chat(H, span_warning("You are a heretic, spurned by the church, cast out from society - frowned upon by Psydon and his children for your faith."))
@@ -260,6 +266,12 @@
 			C.grant_spells(H)
 			START_PROCESSING(SSobj, C)
 			GLOB.excommunicated_players += H.real_name
+			var/my_crime = input(H, "What is your crime?", "Crime") as text|null
+			if (!my_crime)
+				my_crime = "crimes against the Crown"
+			var/bounty_total
+			bounty_total = rand(151, 250)
+			add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
 			H.cmode_music = 'sound/music/combat_cult.ogg'
 			H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 
@@ -306,6 +318,12 @@
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/necromancer)
 			H.mind.adjust_spellpoints(1)
 			GLOB.excommunicated_players += H.real_name
+			var/my_crime = input(H, "What is your crime?", "Crime") as text|null
+			if (!my_crime)
+				my_crime = "crimes against the Crown"
+			var/bounty_total
+			bounty_total = rand(151, 250)
+			add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
 
 /obj/item/clothing/gloves/roguetown/chain/blk
 		color = CLOTHING_GREY

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/wretch.dm
@@ -271,7 +271,7 @@
 				my_crime = "crimes against the Crown"
 			var/bounty_total
 			bounty_total = rand(151, 250)
-			add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
+			add_bounty(H.real_name, bounty_total, FALSE, my_crime, "the Holy See")
 			H.cmode_music = 'sound/music/combat_cult.ogg'
 			H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 
@@ -323,7 +323,7 @@
 				my_crime = "crimes against the Crown"
 			var/bounty_total
 			bounty_total = rand(151, 250)
-			add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
+			add_bounty(H.real_name, bounty_total, FALSE, my_crime, "the Holy See")
 
 /obj/item/clothing/gloves/roguetown/chain/blk
 		color = CLOTHING_GREY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Allows for every Wretch subclass to write out their own bounty, like only Outlaws can currently do.
- Gives starting bounties to heretics and necromancers (also customizable)
- Does the same for bandits and also raises their bounty value to a range that's double that of wretches, it was set to a flat 80 mammon bounty for some reason. They're big bads, they should have big bounties.

## Why It's Good For The Game

Lets people roleplay whatever crimes they want. Maybe the poacher class doesn't want to be just known for poaching. Maybe they insulted a noble. Maybe they consorted with heretics. Also encourages heretics/necromancers to actually be naughty since now they have bounties. 
