### PR TITLE
Fix | Town Elder alchemy oversight.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -62,6 +62,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/alchemy, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/tanning, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gives Town Elders the missing alchemy skill they didn't have yet.

## Why It's Good For The Game

Bug bad.
