### PR TITLE
Sets zombie rot to 5 minutes, shuffles rot remove to work preemptively

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -1,4 +1,4 @@
-#define DEAD_TO_ZOMBIE_TIME 3 MINUTES ///Time before death -> raised as zombie (when outside of the city)
+#define DEAD_TO_ZOMBIE_TIME 5 MINUTES ///Time before death -> raised as zombie (when outside of the city)
 
 /datum/component/rot
 	var/amount = 0

--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -16,6 +16,12 @@
 	else if (istype(target, /mob/living/carbon))
 		has_rot = check_bodyparts_for_rot(target)
 
+	// Remove rot component
+	remove_rot_component(target)
+
+	// Clean body parts
+	clean_body_parts(target)
+
 	// Handle failure case
 	if (!has_rot)
 		to_chat(user, span_warning(fail_message))
@@ -23,12 +29,6 @@
 
 	if (was_zombie)
 		remove_zombie_antag(target, user, method)
-
-	// Remove rot component
-	remove_rot_component(target)
-
-	// Clean body parts
-	clean_body_parts(target)
 
 	//Doing it out of this proc for now
 	//to_chat(user, span_notice(success_message))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The issue was raised that bodies are turning deadite too quickly due to lowered ticklag. Also, upon inspection, I spotted the rot modularization lost the feature of pre-emptively "cleaning" the rot out of a corpse to reset the deadite timer. This bumps the rot time up to 5 minutes and also shuffles body cleaning / rot reset before the rot_removal FALSE return, which will let surgeons keep the rot at bay like it used to be.

## Why It's Good For The Game

I did run into a funny bug where I miracle cure-rotted someone immediately as they rotted, which left them in deadite skin. This should fix that collision, too.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
