### PR TITLE
Adds a slot purge button for admins

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -114,6 +114,7 @@
 // /mob/living/carbon/human
 #define VV_HK_APPLY_SPECIAL "apply_special"
 #define VV_HK_REAPPLY_PREFS "reapply_prefs"
+#define VV_HK_PURGE_SLOT "purge_slot"
 #define VV_HK_COPY_OUTFIT "copy_outfit"
 #define VV_HK_MOD_MUTATIONS "quirkmut"
 #define VV_HK_MOD_QUIRKS "quirkmod"

--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -115,6 +115,7 @@
 #define VV_HK_APPLY_SPECIAL "apply_special"
 #define VV_HK_REAPPLY_PREFS "reapply_prefs"
 #define VV_HK_PURGE_SLOT "purge_slot"
+#define VV_HK_PURGE_PARTOF_SLOT "purge_partof_slot"
 #define VV_HK_COPY_OUTFIT "copy_outfit"
 #define VV_HK_MOD_MUTATIONS "quirkmut"
 #define VV_HK_MOD_QUIRKS "quirkmod"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -618,16 +618,50 @@
 	VV_DROPDOWN_OPTION(VV_HK_REAPPLY_PREFS, "Reapply Preferences")
 	VV_DROPDOWN_OPTION(VV_HK_COPY_OUTFIT, "Copy Outfit")
 	VV_DROPDOWN_OPTION(VV_HK_SET_SPECIES, "Set Species")
+	VV_DROPDOWN_OPTION(VV_HK_PURGE_PARTOF_SLOT, "Purge Part of Slot")
 	VV_DROPDOWN_OPTION(VV_HK_PURGE_SLOT, "Purge Slot")
 
 /mob/living/carbon/human/vv_do_topic(list/href_list)
 	. = ..()
+	if(href_list[VV_HK_PURGE_PARTOF_SLOT])
+		if(!check_rights(R_SPAWN))
+			return
+		if(!client || !client.prefs)
+			return
+		if(alert(usr,"This will irreversibly an INDIVIDUAL PORTION of this slot. Is this what you want?","DON'T FATFINGER THIS","PURGE","Nevermind") == "PURGE")
+			if(alert(usr,"The next prompt will not have a Nevermind option. Are you sure you want this?","ITS NOT REVERSIBLE","Yes","Nevermind") == "Yes")
+				var/choice = alert(usr,"What would you like to purge?","ITS TOO LATE NOW","Flavor","Notes","Extra")
+				if(choice)
+					switch(choice)
+						if("Flavor")
+							is_legacy = FALSE
+							flavortext = null
+							flavortext_display = null
+							client.prefs?.flavortext = null
+							client.prefs?.flavortext_display = null
+						if("Notes")
+							is_legacy = FALSE
+							ooc_notes = null
+							ooc_notes_display = null
+							client.prefs?.ooc_notes = null
+							client.prefs?.ooc_notes_display = null
+						if("Extra")
+							is_legacy = FALSE
+							ooc_extra_link = null
+							ooc_extra = null
+							client.prefs?.ooc_extra = null
+							client.prefs?.ooc_extra_link = null
+						else
+							return
+					client.prefs?.save_preferences()
+					client.prefs?.save_character()
+
 	if(href_list[VV_HK_PURGE_SLOT])
 		if(!check_rights(R_SPAWN))
 			return
 		if(!client || !client.prefs)
 			return
-		if(alert(usr,"This will irreversibly purge this character's slot (OOC, FT, OOC Ex.)","PURGE","PURGE","Nevermind") == "PURGE")
+		if(alert(usr,"This will irreversibly purge this ENTIRE character's slot (OOC, FT, OOC Ex.)","PURGE","PURGE","Nevermind") == "PURGE")
 			if(alert(usr,"This cannot be undone. Are you sure?","DON'T FATFINGER THIS","Yes","No") == "Yes")
 				flavortext = null
 				flavortext_display = null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -615,12 +615,39 @@
 /mob/living/carbon/human/vv_get_dropdown()
 	. = ..()
 	VV_DROPDOWN_OPTION("", "---------")
+	VV_DROPDOWN_OPTION(VV_HK_PURGE_SLOT, "Purge Slot")
 	VV_DROPDOWN_OPTION(VV_HK_REAPPLY_PREFS, "Reapply Preferences")
 	VV_DROPDOWN_OPTION(VV_HK_COPY_OUTFIT, "Copy Outfit")
 	VV_DROPDOWN_OPTION(VV_HK_SET_SPECIES, "Set Species")
 
 /mob/living/carbon/human/vv_do_topic(list/href_list)
 	. = ..()
+	if(href_list[VV_HK_PURGE_SLOT])
+		if(!check_rights(R_SPAWN))
+			return
+		if(!client || !client.prefs)
+			return
+		if(alert(usr,"This will irreversibly purge this character's slot (OOC, FT, OOC Ex.)","PURGE","PURGE","Nevermind") == "PURGE")
+			flavortext = null
+			flavortext_display = null
+			is_legacy = FALSE
+			ooc_notes = null
+			ooc_notes_display = null
+			ooc_extra = null
+			ooc_extra_link = null
+			if(client)
+				client.prefs?.flavortext = null
+				client.prefs?.flavortext_display = null
+				client.prefs?.is_legacy = FALSE
+				client.prefs?.ooc_notes = null
+				client.prefs?.ooc_notes_display = null
+				client.prefs?.ooc_extra = null
+				client.prefs?.ooc_extra_link = null
+				client.prefs?.save_preferences()
+				client.prefs?.save_character()
+				to_chat(usr, span_warn("Slot purged successfully."))
+			else
+				to_chat(usr, span_warn("Slot purged partially. (Client inaccessible -- likely disconnected)"))
 	if(href_list[VV_HK_REAPPLY_PREFS])
 		if(!check_rights(R_SPAWN))
 			return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -615,10 +615,10 @@
 /mob/living/carbon/human/vv_get_dropdown()
 	. = ..()
 	VV_DROPDOWN_OPTION("", "---------")
-	VV_DROPDOWN_OPTION(VV_HK_PURGE_SLOT, "Purge Slot")
 	VV_DROPDOWN_OPTION(VV_HK_REAPPLY_PREFS, "Reapply Preferences")
 	VV_DROPDOWN_OPTION(VV_HK_COPY_OUTFIT, "Copy Outfit")
 	VV_DROPDOWN_OPTION(VV_HK_SET_SPECIES, "Set Species")
+	VV_DROPDOWN_OPTION(VV_HK_PURGE_SLOT, "Purge Slot")
 
 /mob/living/carbon/human/vv_do_topic(list/href_list)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -628,26 +628,27 @@
 		if(!client || !client.prefs)
 			return
 		if(alert(usr,"This will irreversibly purge this character's slot (OOC, FT, OOC Ex.)","PURGE","PURGE","Nevermind") == "PURGE")
-			flavortext = null
-			flavortext_display = null
-			is_legacy = FALSE
-			ooc_notes = null
-			ooc_notes_display = null
-			ooc_extra = null
-			ooc_extra_link = null
-			if(client)
-				client.prefs?.flavortext = null
-				client.prefs?.flavortext_display = null
-				client.prefs?.is_legacy = FALSE
-				client.prefs?.ooc_notes = null
-				client.prefs?.ooc_notes_display = null
-				client.prefs?.ooc_extra = null
-				client.prefs?.ooc_extra_link = null
-				client.prefs?.save_preferences()
-				client.prefs?.save_character()
-				to_chat(usr, span_warn("Slot purged successfully."))
-			else
-				to_chat(usr, span_warn("Slot purged partially. (Client inaccessible -- likely disconnected)"))
+			if(alert(usr,"This cannot be undone. Are you sure?","DON'T FATFINGER THIS","Yes","No") == "Yes")
+				flavortext = null
+				flavortext_display = null
+				is_legacy = FALSE
+				ooc_notes = null
+				ooc_notes_display = null
+				ooc_extra = null
+				ooc_extra_link = null
+				if(client)
+					client.prefs?.flavortext = null
+					client.prefs?.flavortext_display = null
+					client.prefs?.is_legacy = FALSE
+					client.prefs?.ooc_notes = null
+					client.prefs?.ooc_notes_display = null
+					client.prefs?.ooc_extra = null
+					client.prefs?.ooc_extra_link = null
+					client.prefs?.save_preferences()
+					client.prefs?.save_character()
+					to_chat(usr, span_warn("Slot purged successfully."))
+				else
+					to_chat(usr, span_warn("Slot purged partially. (Client inaccessible -- likely disconnected)"))
 	if(href_list[VV_HK_REAPPLY_PREFS])
 		if(!check_rights(R_SPAWN))
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
At the BOTTOM of the VV options menu.
![CmmMgR2jpR](https://github.com/user-attachments/assets/5bc23310-a259-4039-8c12-87eb81d536e6)

Clicking it will give you a box
![dreamseeker_41XsVI5j7t](https://github.com/user-attachments/assets/e8ef0139-a39a-4328-a3ae-1b37de53fc3a)

If successful, it'll inform you.
![dreamseeker_bwSdLnVySB](https://github.com/user-attachments/assets/776c001e-8615-43c0-a625-c145afc05853)

This will delete the slot's Flavortext, OOC notes and OOC Extra all at once, and forcefully save their slot, pretty much wiping it completely.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No one requested this, but I have a hunch it might be needed eventually.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
