### PR TITLE
Covetous Crown / Meister / Steward update

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -178,6 +178,12 @@
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"aew" = (
+/obj/structure/roguemachine/atm{
+	location_tag = "Tailor"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "aez" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -1281,7 +1287,9 @@
 /area/rogue/indoors/town)
 "aTK" = (
 /obj/structure/chair/bench/couch,
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Keep Sideroom"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "aUo" = (
@@ -3544,7 +3552,9 @@
 	},
 /area/rogue/indoors/town/physician)
 "cAM" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Stewardry"
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town)
 "cBd" = (
@@ -3963,7 +3973,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cRT" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
+	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "cSc" = (
@@ -5879,7 +5891,9 @@
 /area/rogue/indoors/town/physician)
 "ekn" = (
 /obj/structure/flora/roguegrass,
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Southern Gate"
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "ekq" = (
@@ -6144,7 +6158,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "euY" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Tavern Backroom"
+	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "evf" = (
@@ -12021,7 +12037,9 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Tavern Lobby"
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "jbj" = (
@@ -12194,7 +12212,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/exposed/town/keep)
 "jgO" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Merchant"
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/shop)
 "jgQ" = (
@@ -12325,7 +12345,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
 "jlQ" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Archivist"
+	},
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
@@ -12886,7 +12908,8 @@
 /area/rogue/outdoors/town)
 "jKm" = (
 /obj/structure/roguemachine/atm{
-	mammonsiphoned = 250
+	mammonsiphoned = 250;
+	location_tag = "the Bathhouse"
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
@@ -13036,7 +13059,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "jOp" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Apothecary"
+	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
 "jOv" = (
@@ -14269,7 +14294,8 @@
 "kIf" = (
 /obj/structure/roguemachine/atm{
 	pixel_x = -32;
-	pixel_y = 0
+	pixel_y = 0;
+	location_tag = "Soilson Stall"
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -19387,7 +19413,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "oin" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Mercenary House"
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "oiA" = (
@@ -23738,7 +23766,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
 "rrb" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Throne Room"
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
 "rrk" = (
@@ -23908,7 +23938,9 @@
 /obj/structure/bars/passage/shutter{
 	redstone_id = "artificer_shutter"
 	},
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Artificer"
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "rys" = (
@@ -27743,7 +27775,8 @@
 "ukV" = (
 /obj/structure/roguemachine/atm{
 	pixel_x = -32;
-	pixel_y = 0
+	pixel_y = 0;
+	location_tag = "Far West of Town"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
@@ -27844,7 +27877,9 @@
 /area/rogue/indoors/town)
 "unU" = (
 /obj/structure/roguemachine/scomm/l,
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Tailor's Interior"
+	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "uoG" = (
@@ -29525,7 +29560,9 @@
 /area/rogue/outdoors/town/roofs)
 "vJu" = (
 /obj/item/roguebin/water,
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Keep Front Gate"
+	},
 /turf/open/floor/rogue/tile{
 	icon_state = "bfloorz"
 	},
@@ -29621,7 +29658,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "vOh" = (
-/obj/structure/roguemachine/atm,
+/obj/structure/roguemachine/atm{
+	location_tag = "Blacksmith"
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "vPT" = (
@@ -68080,7 +68119,7 @@ hvn
 kPr
 oyZ
 waT
-vOh
+aew
 hvn
 liZ
 aQw

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -7,6 +7,7 @@
 	spawn_positions = 1
 
 	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/ravox, /datum/patron/divine/necra, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora, /datum/patron/old_god, /datum/patron/inhumen/zizo, /datum/patron/inhumen/graggar, /datum/patron/inhumen/baotha)
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = JDO_STEWARD
 	tutorial = "Coin, Coin, Coin! Oh beautiful coin: You're addicted to it, and you hold the position as the Grand Duke's personal treasurer of both coin and information. You know the power silver and gold has on a man's mortal soul, and you know just what lengths they'll go to in order to get even more. Keep your festering economy and your rats alive--they're the only two things you can weigh any trust into anymore."

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -252,7 +252,7 @@
 						if(do_after(user, 25))
 							SStreasury.bank_accounts[H] -= fast_drain
 							sum += fast_drain
-							new /obj/item/roguecoin/gold(T, fast_drain)
+							new /obj/item/roguecoin/gold(T, fast_drain / 10)
 							SStreasury.log_to_steward("-[fast_drain] exported mammon to the Freefolks!")
 							if(prob(needed_cycles*2))
 								drain_effect_fast(H)
@@ -280,10 +280,10 @@
 					H.apply_damage(10, BRUTE, head)
 					for(var/i = 1,i<=needed_cycles,i++)
 						if(do_after(user, 10))
-							SStreasury.bank_accounts[H] -= fast_drain
-							sum += fast_drain
-							new /obj/item/roguecoin/gold(T, fast_drain)
-							SStreasury.log_to_steward("-[fast_drain] exported mammon to the Freefolks!")
+							SStreasury.bank_accounts[H] -= slow_drain
+							sum += slow_drain
+							new /obj/item/roguecoin/gold(T, slow_drain / 10)
+							SStreasury.log_to_steward("-[slow_drain] exported mammon to the Freefolks!")
 							if(prob(needed_cycles*2))
 								drain_effect_fast(H)
 							if(i == needed_cycles)	//Last cycle.

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -9,6 +9,8 @@
 	var/mammonsiphoned = 0
 	var/drilling = FALSE
 	var/drilled = FALSE
+	var/has_reported = FALSE
+	var/location_tag
 	
 /obj/structure/roguemachine/atm/attack_hand(mob/user)
 	if(!ishuman(user))
@@ -109,6 +111,13 @@
 			if(!HAS_TRAIT(H, TRAIT_COMMIE))
 				to_chat(user, "<font color='red'>I don't know what I'm doing with this thing!</font>")
 				return
+			var/can_anyone_know = FALSE
+			for(var/mob/living/carbon/human/H in GLOB.player_list)
+				if(H.job == "Steward" || H.job == "Grand Duke")
+					can_anyone_know = TRUE
+			if(!can_anyone_know)
+				to_chat(user, span_info("There is no one important for the transaction to flow through."))
+				return
 			if(SStreasury.treasury_value <50)
 				to_chat(user, "<font color='red'>These fools are completely broke. We'll get nothing out of this...</font>")
 				return
@@ -121,6 +130,7 @@
 					if(!drilling)
 						user.visible_message(span_warning("[user] mounts the Crown atop the meister!"))
 						icon_state = "crown_meister"
+						has_reported = FALSE
 						drilling = TRUE
 						drill(src)
 						qdel(P)
@@ -144,6 +154,7 @@
 		playsound(src, 'sound/misc/DrillDone.ogg', 70, TRUE)
 		icon_state = "atm"
 		drilling = FALSE
+		has_reported = FALSE
 		return
 	if(mammonsiphoned >499) // The cap variable for siphoning. 
 		new /obj/item/coveter(loc)
@@ -152,9 +163,13 @@
 		icon_state = "meister_broken"
 		drilled = TRUE
 		drilling = FALSE
+		has_reported = FALSE
 		return
 	else
 		loc.visible_message(span_warning("A horrible scraping sound emanates from the Crown as it does its work..."))
+		if(!has_reported)
+			send_ooc_note("A parasite of the Freefolk is draining a Meister! Location: [location_tag ? location_tag : "Unknown"]", job = list("Grand Duke", "Steward", "Clerk"))
+			has_reported = TRUE
 		playsound(src, 'sound/misc/TheDrill.ogg', 70, TRUE)
 		spawn(100) // The time it takes to complete an interval. If you adjust this, please adjust the sound too. It's 'about' perfect at 100. Anything less It'll start overlapping.
 			loc.visible_message(span_warning("The meister spills its bounty!"))
@@ -188,6 +203,142 @@
 	dropshrink = 0.8
 	w_class = WEIGHT_CLASS_NORMAL
 	obj_flags = CAN_BE_HIT
+	var/is_active
+	var/needed_cycles
+	var/slow_drain = 10
+	var/slow_delay = 10
+	var/fast_drain = 50
+	var/static/list/fast_effects =	list("agony","crunch","whimper","cry","silence")
+	var/static/list/slow_effects =	list("whimper","cry","silence")
 	sellprice = 100
 
+/obj/item/coveter/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	. = ..()
+	if(!proximity_flag)	//Not adjacent
+		return
+	if(!ishuman(target)) //We're not robbing goats with this
+		return
+	if(is_active)		//We're already draining
+		to_chat(user,span_info("It's already extracting!"))
+		return
+	var/mob/living/carbon/human/H = target
+	if(!H.client)	//The target's DCed or bugged out or is an NPC
+		return
+	if(H.stat)	//They're dead
+		to_chat(user,span_info("Their blood is still. You need someone living for this."))
+		return
+	if(!H.restrained())
+		to_chat(user,span_info("They need to be restrained."))
+		return
+	if(H.head)
+		to_chat(user,span_info("Their head is covered."))
+		return
+	if(H in SStreasury.bank_accounts)
+		if(SStreasury.bank_accounts[H] > 0)
+			var/turf/T = get_turf(H)
+			var/sum
+			var/choice = alert(user,"How would you like to take it? Fast and Loud or Slow and Quiet?","CHOOSE","Fast","Slow","Nevermind")
+			switch(choice)
+				if("Fast")
+					is_active = TRUE
+					needed_cycles = round(SStreasury.bank_accounts[H] / fast_drain)
+					if(needed_cycles == 0)	//If you have less than 50 mammon, you'll still get drained at least once.
+						needed_cycles = 1
+					user.visible_message(span_warn("[user] hastily shoves \the [src] into [H]'s forehead!"))
+					playsound(H, 'sound/combat/hits/pick/genpick (1).ogg', 100)
+					playsound(src, 'sound/misc/TheDrill.ogg', 70, TRUE)
+					to_chat(H,span_info("<font color ='red'>Sharp claws dig into your skull. There's a warmth trickling down your head.</font>"))
+					for(var/i = 1,i<=needed_cycles,i++)
+						if(do_after(user, 25))
+							SStreasury.bank_accounts[H] -= fast_drain
+							sum += fast_drain
+							new /obj/item/roguecoin/gold(T, fast_drain)
+							SStreasury.log_to_steward("-[fast_drain] exported mammon to the Freefolks!")
+							if(prob(needed_cycles*2))
+								drain_effect_fast(H)
+							if(i == needed_cycles)	//Last cycle.
+								playsound(src, 'sound/misc/DrillDone.ogg', 70, TRUE)
+								is_active = FALSE
+								to_chat(H,span_info("<font color ='red'>You feel very drained.</font>"))
+								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Nervemaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
+						else
+							is_active = FALSE
+							if(sum)
+								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Nervemaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
+							break
+				if("Slow")
+					is_active = TRUE
+					needed_cycles = round(SStreasury.bank_accounts[H] / slow_drain)
+					if(needed_cycles == 0)	//If you have less than 10 mammon, you'll still get drained at least once.
+						needed_cycles = 1
+					user.visible_message(span_warn("[user] carefully and methodically aligns \the [src] with [H]'s forehead..."))
+					to_chat(H,span_info("Tiny claws prick into your head. There's a trickling warmth running down your cheeks."))
+					playsound(H, 'sound/gore/flesh_eat_01.ogg', 100)
+					var/obj/item/bodypart/head = H.get_bodypart(BODY_ZONE_HEAD)
+					head.add_wound(/datum/wound/slash)
+					head.update_disabled()
+					H.apply_damage(10, BRUTE, head)
+					for(var/i = 1,i<=needed_cycles,i++)
+						if(do_after(user, 10))
+							SStreasury.bank_accounts[H] -= fast_drain
+							sum += fast_drain
+							new /obj/item/roguecoin/gold(T, fast_drain)
+							SStreasury.log_to_steward("-[fast_drain] exported mammon to the Freefolks!")
+							if(prob(needed_cycles*2))
+								drain_effect_fast(H)
+							if(i == needed_cycles)	//Last cycle.
+								is_active = FALSE
+								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Nervemaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
+						else
+							is_active = FALSE
+							if(sum)
+								send_ooc_note("A parasite of the Freefolk has siphoned [H.real_name] of [sum] from the Nervemaster's veins.", job = list("Grand Duke", "Steward", "Clerk"))
+							break
+				if("Nevermind")
+					return
+				else
+					return
+		else
+			to_chat(user,span_info("They have nothing for us to take."))
+			return
 
+	else
+		to_chat(user,span_info("Their blood is unsoiled by the Duchy's Nervemaster. There is nothing to take."))
+		return
+
+/obj/item/coveter/proc/drain_effect_fast(mob/living/carbon/human/H)
+	var/consequence = pick(fast_effects)
+	var/obj/item/bodypart/head = H.get_bodypart(BODY_ZONE_HEAD)
+	switch(consequence)
+		if("crunch")
+			playsound(src.loc, 'sound/items/beartrap.ogg', 300, TRUE, -1)
+			visible_message(span_info("<font color ='red'>It pierces bone as it extracts!</font>"))
+			head.add_wound(/datum/wound/fracture)
+			head.update_disabled()
+			H.apply_damage(50, BRUTE, head)
+			H.emote("agony")
+		if("agony")
+			H.apply_damage(10, BRUTE, head)
+			H.emote("agony")
+		if("whimper")
+			H.apply_damage(10, BRUTE, head)
+			H.emote("whimper")
+		if("cry")
+			H.apply_damage(10, BRUTE, head)
+			H.emote("cry")
+		if("silence")
+			return
+		else
+			return
+
+/obj/item/coveter/proc/drain_effect_slow(mob/living/carbon/human/H)
+	var/consequence = pick(slow_effects)
+	switch(consequence)
+		if("whimper")
+			H.emote("whimper")
+		if("cry")
+			H.emote("cry")
+		if("silence")
+			return
+		else
+			return

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -156,7 +156,7 @@
 		drilling = FALSE
 		has_reported = FALSE
 		return
-	if(mammonsiphoned >499) // The cap variable for siphoning. 
+	if(mammonsiphoned >199) // The cap variable for siphoning. 
 		new /obj/item/coveter(loc)
 		loc.visible_message(span_warning("Maximum withdrawal reached! The meister weeps."))
 		playsound(src, 'sound/misc/DrillDone.ogg', 70, TRUE)
@@ -173,11 +173,11 @@
 		playsound(src, 'sound/misc/TheDrill.ogg', 70, TRUE)
 		spawn(100) // The time it takes to complete an interval. If you adjust this, please adjust the sound too. It's 'about' perfect at 100. Anything less It'll start overlapping.
 			loc.visible_message(span_warning("The meister spills its bounty!"))
-			SStreasury.treasury_value -= 50 // Takes from the treasury
-			mammonsiphoned += 50
-			budget2change(50, null, "SILVER")
+			SStreasury.treasury_value -= 20 // Takes from the treasury
+			mammonsiphoned += 20
+			budget2change(20, null, "SILVER")
 			playsound(src, 'sound/misc/coindispense.ogg', 70, TRUE)
-			SStreasury.log_to_steward("-[50] exported mammon to the Freefolks!")
+			SStreasury.log_to_steward("-[20] exported mammon to the Freefolks!")
 			drill(src)
 
 /obj/structure/roguemachine/atm/attack_right(mob/living/carbon/human/user)

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -112,8 +112,8 @@
 				to_chat(user, "<font color='red'>I don't know what I'm doing with this thing!</font>")
 				return
 			var/can_anyone_know = FALSE
-			for(var/mob/living/carbon/human/H in GLOB.player_list)
-				if(H.job == "Steward" || H.job == "Grand Duke")
+			for(var/mob/living/carbon/human/HJ in GLOB.player_list)
+				if(HJ.job == "Steward" || HJ.job == "Grand Duke")
 					can_anyone_know = TRUE
 			if(!can_anyone_know)
 				to_chat(user, span_info("There is no one important for the transaction to flow through."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Covetous Crown can now be used on people to drain their Meister accounts directly.

https://github.com/user-attachments/assets/396d505c-2b06-4d6d-8f4d-724f19223e2f

You can pick to be "fast and loud" or "slow and quiet". Fast will get you more mammon quicker, Slow will be slower, but the target won't scream, or get hurt as much.
(Each progress bar dropped 50 mammon in this case)
![dreamseeker_9izOhYGasn](https://github.com/user-attachments/assets/a33a9f51-50a5-4164-9180-b974da80812a)

Once done, it will send a message to Steward / Duke:
![dreamseeker_RFPQ4fq7qS](https://github.com/user-attachments/assets/a38a3d14-3d9b-4e15-b164-7477a1d54b10)

The target needs to:
- Have a client attached (be played by a player who isn't disconnected)
- Be restrained (chains etc)
- Not have anything on their head.

Further changes:
- Covetous Crown CANNOT be applied TO MEISTERS if there is no Duke or Steward in-round.
- Once applied to a Meister, it will send a message to the Duke and Steward (and Clerks) about its location:
![dreamseeker_G8CdyetTT7](https://github.com/user-attachments/assets/979868d3-3246-4477-a524-81e4ed848357)
- Steward cannot be Matthiosan anymore. I'm not allowing circumstance of meister muggings being wilfully ignored cus they're your homies.
- Maximum meister drain is now 200 rather than 500.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should, hopefully, make Covetous Crowns more fun, to some extent.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
