### PR TITLE
Fixes item inspection showing "Pick" as "Stab"

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -454,6 +454,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				if(length(C.prevent_crits))
 					inspec += "\n<b>PREVENTS CRITS:</b>"
 					for(var/X in C.prevent_crits)
+						if(X == BCLASS_PICK)	//BCLASS_PICK is named "stab", and "stabbing" is its own damage class. Prevents confusion.
+							X = "pick"
 						inspec += ("\n<b>[capitalize(X)]</b>")
 				inspec += "<br>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Before
![dreamseeker_faXDCMG8xP](https://github.com/user-attachments/assets/1889113d-f840-47c7-82e2-e092d99de157)

After
![dreamseeker_5T88c3qYZi](https://github.com/user-attachments/assets/f84855d2-fb04-4e91-992a-7791cf8a4e2c)

For whatever reason in the backend Pick intent is actually "stab", which is very confusing because "stabbing" is a distinct damage type of its own. This snowflakes a check to prevent confusion for anyone inspecting items with that resistance.
<!-- Describe The Pull Request
st. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it's an oopsie all the way back from Assess PR
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
