### PR TITLE
Adds Message Spell Contact List

### DIFF
--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -391,16 +391,19 @@
 
 /obj/effect/proc_holder/spell/self/message/cast(list/targets, mob/user)
 	. = ..()
-	var/input = input(user, "Who are you trying to contact?")
-	if(!input)
+
+	var/list/eligible_players = list()
+
+	if(user.mind.known_people.len)
+		for(var/people in user.mind.known_people)
+			eligible_players += people
+	else
+		to_chat(user, span_warning("I don't know anyone."))
 		revert_cast()
 		return
-	if(!user.key)
-		to_chat(user, span_warning("I sense a body, but the mind does not seem to be there."))
-		revert_cast()	//if the spell fails, cooldown is reset (waiting 1 minute cause your bad at spelling sux)
-		return
-	if(!user.mind || !user.mind.do_i_know(name=input))
-		to_chat(user, span_warning("I don't know anyone by that name."))
+	var/input = input(user, "Who do you wish to contact?", src) as null|anything in eligible_players
+	if(isnull(input))
+		to_chat(user, span_warning("No target selected."))
 		revert_cast()
 		return
 	for(var/mob/living/carbon/human/HL in GLOB.human_list)


### PR DESCRIPTION
## About The Pull Request

For the message spell, this change makes it no longer need you to type in the exact case sensitive name of who you are trying to message, only pick their name from a list. The list should contain only names of people who are in your mind.known_people.

## Why It's Good For The Game

If I have to manually type Hubbobbert Skrinklebonken of Grenzelfops one more time for this spell I may just krill myself.
