### PR TITLE
Shovel Cheese Prevention: lets mappers protect areas against digging

### DIFF
--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	var/town_area = FALSE
 	var/keep_area = FALSE
 	var/warden_area = FALSE
+	var/ceiling_protected = FALSE //Prevents tunneling into these from above
 
 /area/rogue/Entered(mob/living/carbon/human/guy)
 
@@ -498,6 +499,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = null
 	droning_sound_night = null
 	converted_type = /area/rogue/outdoors/dungeon1
+	ceiling_protected = TRUE
 
 /area/rogue/under/cave/orcdungeon
 	name = "orcdungeon"
@@ -507,6 +509,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = null
 	droning_sound_night = null
 	converted_type = /area/rogue/outdoors/dungeon1
+	ceiling_protected = TRUE
 
 /area/rogue/under/cave/dukecourt
 	name = "dukedungeon"

--- a/code/modules/roguetown/roguejobs/gravedigger/hole.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/hole.dm
@@ -108,11 +108,13 @@
 		if(stage == 3)
 			var/turf/underT = get_step_multiz(src, DOWN)
 			if(underT && isopenturf(underT) && mastert)
-				attacking_shovel.heldclod = new(attacking_shovel)
-				attacking_shovel.update_icon()
-				playsound(mastert,'sound/items/dig_shovel.ogg', 100, TRUE)
-				mastert.ChangeTurf(/turf/open/transparent/openspace)
-				return
+				var/area/rogue/underA = underT.loc
+				if(underA && !underA.ceiling_protected)
+					attacking_shovel.heldclod = new(attacking_shovel)
+					attacking_shovel.update_icon()
+					playsound(mastert,'sound/items/dig_shovel.ogg', 100, TRUE)
+					mastert.ChangeTurf(/turf/open/transparent/openspace)
+					return
 //					for(var/D in GLOB.cardinals)
 //						var/turf/T = get_step(mastert, D)
 //						if(T)

--- a/code/modules/roguetown/roguejobs/gravedigger/hole.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/hole.dm
@@ -109,7 +109,7 @@
 			var/turf/underT = get_step_multiz(src, DOWN)
 			if(underT && isopenturf(underT) && mastert)
 				var/area/rogue/underA = underT.loc
-				if(underA && !underA.ceiling_protected)
+				if((underA && !underA.ceiling_protected) || !underA)
 					attacking_shovel.heldclod = new(attacking_shovel)
 					attacking_shovel.update_icon()
 					playsound(mastert,'sound/items/dig_shovel.ogg', 100, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Simple fix that makes it so areas can prevent digging into them from above. Until now the fix seemed to have been "put some undiggable turfs on top" so this should free up some mapping real estate.

Marks two areas (the orc ruins and the labyrinth of the ten) as protected.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Right now you can simply dig into loot-filled dungeons, skipping every single mob on the way there. This fixes that. Frees up some space that was reserved for cheese protection, as well.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
