### PR TITLE
Gives towner hunter conjure bait spell

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -16,8 +16,6 @@
 	var/classes = list("Sentinel","Assassin","Bombadier")
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_item/conjure_bait)
-
 	switch(classchoice)
 	
 		if("Sentinel")
@@ -53,6 +51,7 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_item/conjure_bait)
 			var/weapons = list("Recurve Bow","Crossbow")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			H.set_blindness(0)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
@@ -55,3 +55,4 @@
 		H.change_stat("intelligence", 1)
 		H.change_stat("perception", 3)
 		H.change_stat("speed", 1)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_item/conjure_bait)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gives towner hunters the conjure bait spell that was given to rangers recently.

Also moves conjure bait to the sentinel subclass rather than every ranger getting it. Doesn't really thematically fit for assassins or bombadiers.

## Why It's Good For The Game

Towners literally make a career out of hunting - makes sense they'd get a spell themed around hunting game.
