### PR TITLE
Test faith verb clean-up

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -250,6 +250,7 @@
 
 		src.visible_message(span_warning("[src] shoves the silver psycross in [H]'s face!"))
 		say(pick(torture_lines), spans = list("torture"))
+		H.emote("agony", forced = TRUE)
 
 		if(!(do_mob(src, H, 10 SECONDS)))
 			return
@@ -295,6 +296,7 @@
 
 		src.visible_message(span_warning("[src] shoves the silver psycross in [H]'s face!"))
 		say(pick(faith_lines), spans = list("torture"))
+		H.emote("agony", forced = TRUE)
 
 		if(!(do_mob(src, H, 10 SECONDS)))
 			return

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -247,7 +247,13 @@
 			"YOU WILL SPEAK!",
 			"TELL ME!",
 		)
+
+		src.visible_message(span_warning("[src] shoves the silver psycross in [H]'s face!"))
 		say(pick(torture_lines), spans = list("torture"))
+
+		if(!(do_mob(src, H, 10 SECONDS)))
+			return
+
 		src.visible_message(span_warning("[src]'s silver psycross abruptly catches flame, burning away in an instant!"))
 		H.confess_sins("antag")
 		qdel(S)
@@ -286,7 +292,13 @@
 			"ARE YOU FAITHFUL?",
 			"WHO IS YOUR SHEPHERD?",
 		)
+
+		src.visible_message(span_warning("[src] shoves the silver psycross in [H]'s face!"))
 		say(pick(faith_lines), spans = list("torture"))
+
+		if(!(do_mob(src, H, 10 SECONDS)))
+			return
+
 		src.visible_message(span_warning("[src]'s silver psycross abruptly catches flame, burning away in an instant!"))
 		H.confess_sins("patron")
 		qdel(S)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -221,6 +221,7 @@
 	var/obj/item/grabbing/I = get_active_held_item()
 	var/mob/living/carbon/human/H
 	var/obj/item/S = get_inactive_held_item()
+	var/found = null
 	if(!istype(I) || !ishuman(I.grabbed))
 		to_chat(src, span_warning("I don't have a victim in my hands!"))
 		return
@@ -234,6 +235,10 @@
 	if(!istype(S, /obj/item/clothing/neck/roguetown/psicross/silver))
 		to_chat(src, span_warning("I need to be holding a silver psycross to extract this divination!"))
 		return
+	for(var/obj/structure/fluff/psycross/N in oview(5, src))
+		found = N
+	if(!found)
+		to_chat(src, span_warning("I need a large psycross structure nearby to extract this divination!"))
 	if(!H.stat)
 		var/static/list/torture_lines = list(
 			"CONFESS!",
@@ -255,6 +260,7 @@
 	var/obj/item/grabbing/I = get_active_held_item()
 	var/mob/living/carbon/human/H
 	var/obj/item/S = get_inactive_held_item()
+	var/found = null
 	if(!istype(I) || !ishuman(I.grabbed))
 		to_chat(src, span_warning("I don't have a victim in my hands!"))
 		return
@@ -267,6 +273,11 @@
 		return
 	if(!istype(S, /obj/item/clothing/neck/roguetown/psicross/silver))
 		to_chat(src, span_warning("I need to be holding a silver psycross to extract this divination!"))
+		return
+	for(var/obj/structure/fluff/psycross/N in oview(5, src))
+		found = N
+	if(!found)
+		to_chat(src, span_warning("I need a large psycross structure nearby to extract this divination!"))
 		return
 	if(!H.stat)
 		var/static/list/faith_lines = list(

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -288,7 +288,7 @@
 		return
 	if(!H.stat)
 		var/static/list/faith_lines = list(
-			"DO YOU DENY THE TEN?",
+			"DO YOU DENY THE ALLFATHER?",
 			"WHO IS YOUR GOD?",
 			"ARE YOU FAITHFUL?",
 			"WHO IS YOUR SHEPHERD?",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Gives the inquisitor's test faith/extract confession verbs a small do_mob timer - and makes both of them require a large psycross structure nearby.

Paired with a few other small clean-up related tweaks like changing mentions of 'the ten' to 'the allfather' to better fit the inquisitor thematically and clearer visible messages/emotes to better telegraph the entire process.

## Why It's Good For The Game

More sanity checks to ensure inquisitors aren't faith-checking people on the spot with little to no roleplay. This should require them to actually bring someone to the church, or at least to a psycross structure. There's a good few around the city - so it's not exactly a huge ask.

Also this just looks a lot cooler with the do_mob timer and the extra visible messages/emotes.
