### PR TITLE
Sprint changes and fixes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -693,6 +693,7 @@
 	..()
 	if(dir != olddir)
 		last_dir_change = world.time
+		sprinted_tiles = 0
 
 //debug
 /atom/movable/screen/proc/scale_to(x1,y1)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -158,6 +158,9 @@
 				L.toggle_rogmove_intent(MOVE_INTENT_WALK)
 	else
 		if(L.dir != target_dir)
+			if(abs(dir2angle(L.dir) - dir2angle(target_dir)) == 180)	//If we do a 180 turn, we cancel our run
+				if(L.m_intent == MOVE_INTENT_RUN)
+					L.toggle_rogmove_intent(MOVE_INTENT_WALK)
 			// Reset our sprint counter if we change direction
 			L.sprinted_tiles = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes a bug that allowed you to change dirs without resetting your sprinted tiles counter, allowing you to do a cheesy tokyo drift charge.

### BEFORE:

https://github.com/user-attachments/assets/ed8d0b19-13d8-4494-b8c2-69a56acff365

### AFTER:

https://github.com/user-attachments/assets/20a93b1c-995a-4041-9df8-c330a547bd49


In addition, this adds a sprint reset if you do a full 180 turn:

https://github.com/user-attachments/assets/3de9be6f-a776-42f2-841e-fd04b3c975e3


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fewer bugs, fewer looney tunes sprinting incidents.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
