### PR TITLE
Wraps garrison SCOM line in red for easier identification

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -1,3 +1,4 @@
+#define GARRISON_SCOM_COLOR "#FF4242"
 
 /obj/structure/roguemachine/scomm
 	name = "SCOM"
@@ -265,6 +266,7 @@
 				return*/
 			raw_message = "<small>[raw_message]</small>"
 		if(garrisonline)
+			raw_message = "<span style='color: [GARRISON_SCOM_COLOR]'>[raw_message]</span>" //Prettying up for Garrison line
 			for(var/obj/item/scomstone/garrison/S in SSroguemachine.scomm_machines)
 				S.repeat_message(raw_message, src, usedcolor, message_language)
 			for(var/obj/item/scomstone/bad/garrison/S in SSroguemachine.scomm_machines)
@@ -724,6 +726,7 @@
 			for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
 				S.repeat_message(input_text, src, usedcolor)
 		if(garrisonline)
+			input_text = "<span style='color: [GARRISON_SCOM_COLOR]'>[input_text]</span>" //Prettying up for Garrison line
 			for(var/obj/item/scomstone/bad/garrison/S in SSroguemachine.scomm_machines)
 				S.repeat_message(input_text, src, usedcolor)
 			for(var/obj/item/scomstone/garrison/S in SSroguemachine.scomm_machines)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Wraps the garrison SCOM messages in a red html color span, allowing for differentiation of things sent on general or garrison frequency. Unfortunately this causes the chat draw on screen to lose the speaker's voice color, but, that information is still available in the name that prints in the side bar. 

SCOMs probably need their procs revisited if there's anything more complicated done to them, but hopefully this is a good bandaid until then.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/94ec51ab-9a2f-4d61-90cb-34720d237ecb)
![image](https://github.com/user-attachments/assets/f73f0fd3-0673-4e75-a853-3981bce12d17)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
