### PR TITLE
Removes additional time variables from the bounty mask code.

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -164,11 +164,6 @@
 
 		var/timer = 30 MINUTES
 
-		if(bounty_amount >= 100)
-			var/additional_time = bounty_amount * 0.1
-			additional_time = round(additional_time)
-			timer += additional_time MINUTES
-
 		var/timer_minutes = timer / 600
 
 		addtimer(CALLBACK(src, PROC_REF(timerup), user), timer)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removes the variable adding extra time based on bounty value. Most bounties generate at 150-250 mammons, which means 15-20 more minutes based on variables you have NO control over.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You're almost guaranteed a 1 hour bounty which means if you get caught at 2 hours in or so (which is very, very often in my experience) you are masked for the rest of the round. Bar RP or cut your head off and risk being valided, your choice. Keep in mind that outlaws are the one this is intended for - heretics are often sent to the Inquisition after being masked, which means RRing is probable.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
