### PR TITLE
Fixes an examine bug, adds red color to FT / OOC notes if they're not long enough

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1590,8 +1590,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					dat += "((text)) : Decreases the <font size = \"1\">size</font> of the text.<br>"
 					dat += "* item : An unordered list item.<br>"
 					dat += "--- : Adds a horizontal rule.<br><br>"
-					dat += "Minimum Flavortext: <b>200</b> characters.<br>"
-					dat += "Minimum OOC Notes: <b>5</b> characters."
+					dat += "Minimum Flavortext: <b>[MINIMUM_FLAVOR_TEXT]</b> characters.<br>"
+					dat += "Minimum OOC Notes: <b>[MINIMUM_OOC_NOTES]</b> characters."
 					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 350)
 					popup.set_content(dat.Join())
 					popup.open(FALSE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -437,9 +437,9 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			if(is_legacy)
 				dat += "<br><i><font size = 1>(Legacy)<a href='?_src_=prefs;preference=legacyhelp;task=input'>(?)</a></font></i>"
 
-			dat += "<br><b>Flavortext:</b><a href='?_src_=prefs;preference=formathelp;task=input'>(?)</a><a href='?_src_=prefs;preference=flavortext;task=input'>Change</a>"
+			dat += "<br><b>[(length(flavortext) < MINIMUM_FLAVOR_TEXT) ? "<font color = '#802929'>" : ""]Flavortext:[(length(flavortext) < MINIMUM_FLAVOR_TEXT) ? "</font>" : ""]</b><a href='?_src_=prefs;preference=formathelp;task=input'>(?)</a><a href='?_src_=prefs;preference=flavortext;task=input'>Change</a>"
 
-			dat += "<br><b>OOC Notes:</b><a href='?_src_=prefs;preference=formathelp;task=input'>(?)</a><a href='?_src_=prefs;preference=ooc_notes;task=input'>Change</a>"
+			dat += "<br><b>[(length(ooc_notes) < MINIMUM_OOC_NOTES) ? "<font color = '#802929'>" : ""]OOC Notes:[(length(ooc_notes) < MINIMUM_OOC_NOTES) ? "</font>" : ""]</b><a href='?_src_=prefs;preference=formathelp;task=input'>(?)</a><a href='?_src_=prefs;preference=ooc_notes;task=input'>Change</a>"
 
 			dat += "<br><b>OOC Extra:</b> <a href='?_src_=prefs;preference=ooc_extra;task=input'>Change</a>"
 			dat += "<br><a href='?_src_=prefs;preference=ooc_preview;task=input'><b>Preview Examine</b></a>"
@@ -1589,8 +1589,10 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					dat += "^text^ : Increases the <font size = \"4\">size</font> of the text.<br>"
 					dat += "((text)) : Decreases the <font size = \"1\">size</font> of the text.<br>"
 					dat += "* item : An unordered list item.<br>"
-					dat += "--- : Adds a horizontal rule."
-					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 300)
+					dat += "--- : Adds a horizontal rule.<br><br>"
+					dat += "Minimum Flavortext: <b>200</b> characters.<br>"
+					dat += "Minimum OOC Notes: <b>5</b> characters."
+					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 350)
 					popup.set_content(dat.Join())
 					popup.open(FALSE)
 				if("flavortext")

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -14,8 +14,9 @@
 	eye_color = random_eye_color()
 	is_legacy = FALSE
 	flavortext = null
-	flavortext_display = " "
-	ooc_notes_display = " "
+	flavortext_display = " "	//_display left not null to prevent any legacy bugs.
+	ooc_notes_display = " "		//You can't join without filling in the blank FT / OOC notes, so these should be overriden before the character is ever examined.
+	ooc_notes = null
 	ooc_extra_link = null
 	ooc_extra = null
 	headshot_link = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- The bug was caused by OOC notes carrying over between slots. If a player never changed them or pressed OK on unedited ones, examining them would give a blank result in their OOC notes section.

Also adds coloration
![KD2Q4CnI9O](https://github.com/user-attachments/assets/c6968d2d-7ff2-4657-8774-81568d49ed6d)

It disappears if you fill in your FT / OOC notes properly.
![ycEV5RO5iY](https://github.com/user-attachments/assets/9c132096-769c-400f-a263-0a7b56be46a8)

And gets colored if you change it to something too short.
![dreamseeker_q8RhfQAqv6](https://github.com/user-attachments/assets/a5efc911-2bfc-455c-a83e-a69caa537c26)

Also adds the char requirements to the (?) pop up next to the two.
![naEwaq5qZx](https://github.com/user-attachments/assets/3ba5fc64-28f1-462a-a819-f1eaed20b3b5)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fewer bugs, more UX clarity
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
