### PR TITLE
Excidium masks now apply rites expended to ritualists

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -161,7 +161,8 @@
 		to_chat(user, span_warning("This accursed mask pacifies me!"))
 		ADD_TRAIT(user, TRAIT_PACIFISM, "cursedmask")
 		ADD_TRAIT(user, TRAIT_SPELLCOCKBLOCK, "cursedmask")
-
+		if(HAS_TRAIT(user, TRAIT_RITUALIST))
+			user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)
 		var/timer = 30 MINUTES
 
 		if(bounty_amount >= 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Ritualists are now neutered for 30 minutes after being excidium'd. No longer able to use a ritual to get out of their mask, or do any other Silly rituals:tm: in the future.

## Why It's Good For The Game

No more free mask escapes.
