### PR TITLE
Stonekeep/Hearthstone Port - Armor Class Movement Speed

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -57,9 +57,21 @@
 				mod = 6
 
 	var/spdchange = (10-STASPD)*0.1
-	spdchange = clamp(spdchange, -0.5, 1)  //if this is not clamped, maniacs will run at unfathomable speed
+
+	//Checks armor weight, impacts speed - Port of Stonekeep code by Dova
+	var/armorWeight = check_armor_weight()
+	if(armorWeight == "Heavy")
+		spdchange = spdchange + 0.2
+		if(!check_armor_skill())
+			spdchange = spdchange + 0.2		//Extra +0.2 slowdown, so roughly 0.4 if you wear heavy armor without the training.
+	if(armorWeight == "Medium")
+		spdchange = spdchange + 0.1
+		if(!check_armor_skill())
+			spdchange = spdchange + 0.1		//Extra +0.1 slowdown, so roughly 0.2 if you wear medium armor without the training.
+	
+	//maximum speed is achieved at 15 speed. Don't fo higher than that or you will have insanity.
+	spdchange = clamp(spdchange, -0.5, 1)  //if this is not clamped, it can make you go faster than you should be able to.
 	mod = mod+spdchange
-	//maximum speed is achieved at 15spd, everything else results in insanity
 	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -61,13 +61,13 @@
 	//Checks armor weight, impacts speed - Port of Stonekeep code by Dova
 	var/armorWeight = check_armor_weight()
 	if(armorWeight == "Heavy")
-		spdchange = spdchange + 0.2
-		if(!check_armor_skill())
-			spdchange = spdchange + 0.2		//Extra +0.2 slowdown, so roughly 0.4 if you wear heavy armor without the training.
-	if(armorWeight == "Medium")
 		spdchange = spdchange + 0.1
 		if(!check_armor_skill())
-			spdchange = spdchange + 0.1		//Extra +0.1 slowdown, so roughly 0.2 if you wear medium armor without the training.
+			spdchange = spdchange + 0.2		//Extra +0.2 slowdown, so roughly 0.3 if you wear heavy armor without the training.
+	if(armorWeight == "Medium")
+		spdchange = spdchange + 0			//No change, would be too punishing. Mediums aren't that great as is.
+		if(!check_armor_skill())
+			spdchange = spdchange + 0.2		//Extra +0.2 slowdown, so roughly 0.2 if you wear medium armor without the training.
 	
 	//maximum speed is achieved at 15 speed. Don't fo higher than that or you will have insanity.
 	spdchange = clamp(spdchange, -0.5, 1)  //if this is not clamped, it can make you go faster than you should be able to.

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -701,6 +701,26 @@
 					return FALSE
 	return TRUE
 
+/mob/living/proc/check_armor_weight()
+	return "Light"
+
+//Checks heavier armor the user is wearing - Port of Stonekeep code by Dova
+/mob/living/carbon/human/check_armor_weight()
+	var/heaviest = "Light"
+	if(istype(src.wear_armor, /obj/item/clothing))
+		var/obj/item/clothing/CL = src.wear_armor
+		if(CL.armor_class == ARMOR_CLASS_HEAVY && (heaviest == "Light" || heaviest == "Medium"))
+			heaviest = "Heavy"
+		if(CL.armor_class == ARMOR_CLASS_MEDIUM && heaviest == "Light")
+			heaviest = "Medium"
+	if(istype(src.wear_shirt, /obj/item/clothing))
+		var/obj/item/clothing/CL = src.wear_shirt
+		if(CL.armor_class == ARMOR_CLASS_HEAVY && (heaviest == "Light" || heaviest == "Medium"))
+			heaviest = "Heavy"
+		if(CL.armor_class == ARMOR_CLASS_MEDIUM && heaviest == "Light")
+			heaviest = "Medium"
+	return heaviest
+
 /mob/living/proc/check_dodge_skill()
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Got asked to port this system that Dova made on Stonekeep and Hearthstone's changes to it. Here it is, it increases slowdown by armor class slightly (speed still increases speed so will offset by certain amount).

**Heavy Armor**
+0.1 slowdown if wearing heavy armor
+0.2 extra slowdown atop of that if untrained in heavy armor and wearing it.

**Medium Armor**
No added slowdown if trained in medium armor
+0.2 slowdown if untrained in medium armor and wearing it.

## Why It's Good For The Game

Got asked by a dev to port it, seemed a few people were receptive. Unsure of exact popularity, but would encourage people to stick to trained armor classes and make heavy armor have a slight drawback; encouraging heavy armor users to conisder using - say, scale medium armor over shittier types of heavy instead of heavy always being a straight upgrade. (Still will be usually better than 90% of medium armors tho)

Plus I guess it's 'balance' but it may stop kinda meme strats of ignore armor penalty and wield shield to avoid knockover penalty to wearing armor. Thus meaning you just can't jump, run, or dodge but you can still stand parrying fine. Now would make you slower too, which less desirable strat.