### PR TITLE
Stops arm markings from showing up through armor and shirts.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -33,13 +33,13 @@
 #define LEG_DAMAGE_LAYER		34
 #define LEGSLEEVE_LAYER			33
 #define SHOESLEEVE_LAYER		32
-#define SHIRT_LAYER				31
-#define WRISTS_LAYER			30
-#define ARMOR_LAYER				29
-#define TABARD_LAYER			28
-#define BELT_LAYER				27		//only when looking south
-#define UNDER_CLOAK_LAYER		26
-#define HANDS_PART_LAYER		25
+#define HANDS_PART_LAYER		31
+#define SHIRT_LAYER				30
+#define WRISTS_LAYER			29
+#define ARMOR_LAYER				28
+#define TABARD_LAYER			27
+#define BELT_LAYER				26		//only when looking south
+#define UNDER_CLOAK_LAYER		25
 #define GLOVES_LAYER			24
 #define ARM_DAMAGE_LAYER		23
 #define SHIRTSLEEVE_LAYER		22


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adjusts the arm marking layer to below armor and shirts. This was previously above them, so it was visible through armor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
look man it's just stupid
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
