### PR TITLE
Bathmaster Vault[PT3 Bathmaster stuff]

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -8534,7 +8534,7 @@
 "giB" = (
 /obj/item/reagent_containers/glass/cup/golden,
 /turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
+/area/rogue/outdoors/exposed/bath/vault)
 "giU" = (
 /obj/structure/stairs{
 	dir = 4
@@ -10371,7 +10371,7 @@
 "hHp" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
+/area/rogue/outdoors/exposed/bath/vault)
 "hHv" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -11198,7 +11198,7 @@
 	lockid = "nightman"
 	},
 /turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
+/area/rogue/outdoors/exposed/bath/vault)
 "iqf" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -17104,7 +17104,7 @@
 "mxK" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
+/area/rogue/outdoors/exposed/bath/vault)
 "mxS" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -22330,6 +22330,10 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"qev" = (
+/obj/machinery/light/rogue/wallfire/candle/blue,
+/turf/open/floor/rogue/tile,
+/area/rogue/outdoors/exposed/bath/vault)
 "qey" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
@@ -23720,7 +23724,7 @@
 /obj/item/clothing/ring/silver,
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
+/area/rogue/outdoors/exposed/bath/vault)
 "rfP" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
@@ -23904,7 +23908,7 @@
 /obj/structure/closet/crate/chest/gold,
 /obj/item/roguegem/violet,
 /turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
+/area/rogue/outdoors/exposed/bath/vault)
 "rmL" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -26539,6 +26543,9 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave)
+"tin" = (
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/outdoors/exposed/bath/vault)
 "tiq" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/bed/rogue,
@@ -27364,6 +27371,9 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
+"tKo" = (
+/turf/open/floor/rogue/tile,
+/area/rogue/outdoors/exposed/bath/vault)
 "tKw" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood{
@@ -41592,10 +41602,10 @@ kAA
 kAA
 kAA
 kAA
-kAA
-kAA
-kAA
-kAA
+tin
+tin
+tin
+tin
 qNG
 kyn
 xpt
@@ -41749,10 +41759,10 @@ vXP
 kAA
 lWY
 qUX
-kAA
-qPZ
+tin
+qev
 giB
-kAA
+tin
 mKe
 lmT
 xpt
@@ -41907,9 +41917,9 @@ nJK
 ktR
 ktR
 mxK
-bLX
-bLX
-kAA
+tKo
+tKo
+tin
 qNG
 bBD
 xpt
@@ -42064,9 +42074,9 @@ kAA
 ktR
 ktR
 ipT
-bLX
+tKo
 hHp
-kAA
+tin
 bBD
 bBD
 xpt
@@ -42221,9 +42231,9 @@ kAA
 icN
 icN
 mxK
-bLX
-bLX
-kAA
+tKo
+tKo
+tin
 gdw
 mEu
 oZk
@@ -42377,10 +42387,10 @@ icN
 kAA
 qwu
 xkR
-kAA
+tin
 rfI
 rmy
-kAA
+tin
 gdw
 gHf
 xpt
@@ -42534,10 +42544,10 @@ kAA
 kAA
 kAA
 kAA
-kAA
-kAA
-kAA
-kAA
+tin
+tin
+tin
+tin
 gdw
 gHf
 xpt

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -613,6 +613,10 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	icon_state = "bath"
 	droning_sound = 'sound/music/area/bath.ogg'
 
+/area/rogue/outdoors/exposed/bath/vault
+	name = "Bathmaster vault"
+	icon_state = "bath"
+
 /area/rogue/indoors/town/garrison
 	name = "Garrison"
 	icon_state = "garrison"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds in vault gain for the Bathmaster's vault. This income goes directly into the BRASSFACE. Having double(30%) the interest rate of the steward's vault due to the Bmaster having less easy access to the resources to fill it.  Commissioned by Cleric, and the finale of a 3 part Bathmaster Sweet stuff package <3

![image](https://github.com/user-attachments/assets/680b2aa6-1c80-4e50-b54f-1ebdc6b4383c)


## Why It's Good For The Game

Should hopefully encourage Bathmaster's to have more mammon-power to start stuff up. Further reinforcing their role as a sort of underground master.
