### PR TITLE
Cudgel size change

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -196,7 +196,7 @@
 	wdefense = 3
 	resistance_flags = FLAMMABLE
 	grid_width = 32
-	grid_height = 64
+	grid_height = 96
 
 /obj/item/rogueweapon/mace/cudgel/justice
 	name = "'Justice'"
@@ -211,8 +211,6 @@
 	wbalance = 4
 	minstr = 7
 	wdefense = 5
-	grid_width = 32
-	grid_height = 64
 
 /obj/item/rogueweapon/mace/cudgel/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -195,6 +195,8 @@
 	minstr = 7
 	wdefense = 3
 	resistance_flags = FLAMMABLE
+	grid_width = 32
+	grid_height = 64
 
 /obj/item/rogueweapon/mace/cudgel/justice
 	name = "'Justice'"
@@ -209,6 +211,8 @@
 	wbalance = 4
 	minstr = 7
 	wdefense = 5
+	grid_width = 32
+	grid_height = 64
 
 /obj/item/rogueweapon/mace/cudgel/getonmobprop(tag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Updates Cudgel sizes to be _proper_, blunt-enjoyers rejoice.

## Why It's Good For The Game
The Cudgel has always been a "Secondary" weapon, intended to be stowed and used if you wish (usually) not kill someone.

This PR makes the "stubby little clubs" into "stubby little clubs" for your inventory. 
(As they were intended)

-Originally, such clubs were INVENTORY hogs, taking up half your satchel. (Shameful when compared to arguably larger weapons) Now they can sit all nice and neat among your other small bits of gear. The Watchman's best friend just got a whole lot better.
