### PR TITLE
Less deadly Noc's Shine

### DIFF
--- a/code/modules/farming/fermenting_barrel.dm
+++ b/code/modules/farming/fermenting_barrel.dm
@@ -214,7 +214,7 @@
 	reagents.add_reagent(/datum/reagent/consumable/ethanol/beer/murkwine,900)
 
 /obj/structure/fermenting_barrel/nocshine
-	desc = "A barrel with a blue, Crescent moon mark. The wisest choice of drinks."
+	desc = "A barrel with a blue, Crescent moon mark. Not the wisest choice of drinks, but certainly the strongest."
 
 /obj/structure/fermenting_barrel/nocshine/Initialize()
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2233,7 +2233,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(HAS_TRAIT(M, TRAIT_CRACKHEAD))
 		M.adjustToxLoss(0.2, 0)
 	else
-		M.adjustToxLoss(1, 0)
+		M.adjustToxLoss(0.75, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2231,7 +2231,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/beer/nocshine/on_mob_life(mob/living/carbon/M)
 	M.apply_status_effect(/datum/status_effect/buff/nocshine)
 	if(HAS_TRAIT(M, TRAIT_CRACKHEAD))
-		M.adjustToxLoss(0.2, 0)
+		M.adjustToxLoss(0.1, 0)
 	else
 		M.adjustToxLoss(0.75, 0)
 	..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2230,7 +2230,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/beer/nocshine/on_mob_life(mob/living/carbon/M)
 	M.apply_status_effect(/datum/status_effect/buff/nocshine)
-	M.adjustToxLoss(1, 0)
+	if(HAS_TRAIT(M, TRAIT_CRACKHEAD))
+		M.adjustToxLoss(0.2, 0)
+	else
+		M.adjustToxLoss(1.2, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2233,7 +2233,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(HAS_TRAIT(M, TRAIT_CRACKHEAD))
 		M.adjustToxLoss(0.2, 0)
 	else
-		M.adjustToxLoss(1.2, 0)
+		M.adjustToxLoss(1, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2206,7 +2206,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/beer/murkwine // not Toilet wine
 	name = "mürkwine"
 	boozepwr = 50  // bubba's best
-	taste_description = "hints of questionable choices and a bouqet of murkwater and pure ethanol"
+	taste_description = "hints of questionable choices--a bouqet of murkwater and pure ethanol"
 	color = "#4b1e00"
 
 /datum/reagent/consumable/ethanol/beer/murkwine/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2230,7 +2230,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/beer/nocshine/on_mob_life(mob/living/carbon/M)
 	M.apply_status_effect(/datum/status_effect/buff/nocshine)
-	M.adjustToxLoss(1.5, 0)
+	M.adjustToxLoss(1, 0)
 	..()
 	. = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Cuts Nocshine toxdmg in half (to 0.75), adds an exemption for Crackheads to take 0.1. Adjusts some flavor descriptions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having a glass of moonshine is a terrible idea. Having a glass of Noc's Shine will at least no longer murder you super-dead. Baothian Drunken Beserkers can now be a thing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
