### PR TITLE
Changes vocalist talisman to musical talisman

### DIFF
--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -256,8 +256,8 @@
 	"Gasgow's Reel" = 'sound/music/instruments/viola (5).ogg')
 
 /obj/item/rogue/instrument/vocals
-	name = "vocalist's talisman"
-	desc = "This talisman eminates a small shimmer of light. When held, it can amplify and even change a bard's voice."
+	name = "Musical talisman"
+	desc = "This talisman eminates a small shimmer of light. When held, it can amplify and even change sound."
 	icon_state = "vtalisman"
 	song_list = list("Harpy's Call (Feminine)" = 'sound/music/instruments/vocalsf (1).ogg',
 	"Necra's Lullaby (Feminine)" = 'sound/music/instruments/vocalsf (2).ogg',


### PR DESCRIPTION
Since the talisman is a fictional instrument, it can justify making any sound—much like the dwarven boombox. This change aims to expand creative freedom and allow players to do more with the custom songs feature.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
