### PR TITLE
Adds a Bronze Arm virtue

### DIFF
--- a/code/datums/character_flaw/limbloss.dm
+++ b/code/datums/character_flaw/limbloss.dm
@@ -14,7 +14,7 @@
 
 /datum/charflaw/limbloss/arm_r
 	name = "Wood Arm (R)"
-	desc = "I lost my right arm long ago, but the wooden arm doesn't bleed as much... but it is flammable."
+	desc = "I lost my right arm long ago, but the wooden arm doesn't bleed as much... but it is flammable.<br><i>(Incompatible with Bronze Arm virtue)</i>"
 	lost_zone = BODY_ZONE_R_ARM
 
 /datum/charflaw/limbloss/arm_r/on_mob_creation(mob/user)
@@ -27,7 +27,7 @@
 
 /datum/charflaw/limbloss/arm_l
 	name = "Wood Arm (L)"
-	desc = "I lost my left arm long ago, but the wooden arm doesn't bleed as much... but it is flammable."
+	desc = "I lost my left arm long ago, but the wooden arm doesn't bleed as much... but it is flammable.<br><i>(Incompatible with Bronze Arm virtue)</i>"
 	lost_zone = BODY_ZONE_L_ARM
 
 /datum/charflaw/limbloss/arm_l/on_mob_creation(mob/user)

--- a/code/datums/character_flaw/limbloss.dm
+++ b/code/datums/character_flaw/limbloss.dm
@@ -14,7 +14,7 @@
 
 /datum/charflaw/limbloss/arm_r
 	name = "Wood Arm (R)"
-	desc = "I lost my right arm long ago, but the wooden arm doesn't bleed as much... but it is flammable.<br><i>(Incompatible with Bronze Arm virtue)</i>"
+	desc = "I lost my right arm long ago, but the wooden arm doesn't bleed as much... but it is flammable.<br><i>(Incompatible with Bronze Arm (R) virtue)</i>"
 	lost_zone = BODY_ZONE_R_ARM
 
 /datum/charflaw/limbloss/arm_r/on_mob_creation(mob/user)
@@ -27,7 +27,7 @@
 
 /datum/charflaw/limbloss/arm_l
 	name = "Wood Arm (L)"
-	desc = "I lost my left arm long ago, but the wooden arm doesn't bleed as much... but it is flammable.<br><i>(Incompatible with Bronze Arm virtue)</i>"
+	desc = "I lost my left arm long ago, but the wooden arm doesn't bleed as much... but it is flammable.<br><i>(Incompatible with Bronze Arm (L) virtue)</i>"
 	lost_zone = BODY_ZONE_L_ARM
 
 /datum/charflaw/limbloss/arm_l/on_mob_creation(mob/user)

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -209,8 +209,43 @@
 	added_skills = list(list(/datum/skill/misc/tracking, 3, 6))
 	added_traits = list(TRAIT_KEENEARS)
 
+/datum/virtue/utility/bronzearm_r
+	name = "Bronze Arm (R)"
+	desc = "Through connections or wealth, my arm had been replaced by one of bronze and gears, that can grip and hold onto things. I've learned just a bit of Engineering as a result.<br><i>(Incompatible with Wood Arm vice)</i>"
+	added_skills = list(list(/datum/skill/craft/engineering, 1, 6))
 
-//HERETIC VIRTUES (there's only pne amd it's utility so I didn't want to make a whole file yet)
+/datum/virtue/utility/bronzearm_r/apply_to_human(mob/living/carbon/human/recipient)
+	. = ..()
+	var/obj/item/bodypart/O = recipient.get_bodypart(BODY_ZONE_R_ARM)
+	if(O)
+		O.drop_limb()
+		qdel(O)
+	if(recipient.charflaw)
+		if(recipient.charflaw.type == /datum/charflaw/limbloss/arm_r)
+			to_chat(recipient, span_info("In my foolishness I believed a sharlatan who wished to trade in my wooden arm for one of bronze. It fell apart. Now I've no arm at all."))
+		else
+			var/obj/item/bodypart/r_arm/prosthetic/bronzeright/L = new()
+			L.attach_limb(recipient)
+
+/datum/virtue/utility/bronzearm_l
+	name = "Bronze Arm (L)"
+	desc = "Through connections or wealth, my arm had been replaced by one of bronze and gears, that can grip and hold onto things. I've learned just a bit of Engineering as a result.<br><i>(Incompatible with Wood Arm vice)</i>"
+	added_skills = list(list(/datum/skill/craft/engineering, 1, 6))
+
+/datum/virtue/utility/bronzearm_l/apply_to_human(mob/living/carbon/human/recipient)
+	. = ..()
+	var/obj/item/bodypart/O = recipient.get_bodypart(BODY_ZONE_L_ARM)
+	if(O)
+		O.drop_limb()
+		qdel(O)
+	if(recipient.charflaw)
+		if(recipient.charflaw.type == /datum/charflaw/limbloss/arm_l)
+			to_chat(recipient, span_info("In my foolishness I believed a sharlatan who wished to trade in my wooden arm for one of bronze. It fell apart. Now I've no arm at all."))
+		else
+			var/obj/item/bodypart/l_arm/prosthetic/bronzeleft/L = new()
+			L.attach_limb(recipient)
+
+//HERETIC VIRTUES
 
 /datum/virtue/heretic/seer
 	name = "(ASCENDANT) Seer"

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -211,7 +211,7 @@
 
 /datum/virtue/utility/bronzearm_r
 	name = "Bronze Arm (R)"
-	desc = "Through connections or wealth, my arm had been replaced by one of bronze and gears, that can grip and hold onto things. I've learned just a bit of Engineering as a result.<br><i>(Incompatible with Wood Arm vice)</i>"
+	desc = "Through connections or wealth, my arm had been replaced by one of bronze and gears, that can grip and hold onto things. I've learned just a bit of Engineering as a result.<br><i>(Incompatible with Wood Arm (R) vice)</i>"
 	added_skills = list(list(/datum/skill/craft/engineering, 1, 6))
 
 /datum/virtue/utility/bronzearm_r/apply_to_human(mob/living/carbon/human/recipient)
@@ -229,7 +229,7 @@
 
 /datum/virtue/utility/bronzearm_l
 	name = "Bronze Arm (L)"
-	desc = "Through connections or wealth, my arm had been replaced by one of bronze and gears, that can grip and hold onto things. I've learned just a bit of Engineering as a result.<br><i>(Incompatible with Wood Arm vice)</i>"
+	desc = "Through connections or wealth, my arm had been replaced by one of bronze and gears, that can grip and hold onto things. I've learned just a bit of Engineering as a result.<br><i>(Incompatible with Wood Arm (L) vice)</i>"
 	added_skills = list(list(/datum/skill/craft/engineering, 1, 6))
 
 /datum/virtue/utility/bronzearm_l/apply_to_human(mob/living/carbon/human/recipient)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds two virtues for either arm to be replaced with a Bronze one. (It can hold things)
The virtue also gives the user one level in Engineering. There's no cap for it, and they can stack for a whopping Apprentice in Engineering at roundstart, along with two bronze limbs.

![image](https://github.com/user-attachments/assets/04a30a26-36ac-4833-9a26-d8dcdcd260dc)
![image](https://github.com/user-attachments/assets/3c732c3b-2dc8-4d57-aa97-1d6c69bd34e8)
It's not compatible with the Wood Arm vice of the same arm. I wouldn't recommend taking both.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
By request, though I remember something being potentially problematic about this. A whisper at the back of my mind.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
