### PR TITLE
Makes basic windows have more health but break just as easily

### DIFF
--- a/code/game/objects/structures/roguewindow.dm
+++ b/code/game/objects/structures/roguewindow.dm
@@ -8,8 +8,8 @@
 	density = TRUE
 	anchored = TRUE
 	opacity = FALSE
-	max_integrity = 100
-	integrity_failure = 0.1
+	max_integrity = 200
+	integrity_failure = 0.5
 	var/base_state = "window-solid"
 	var/lockdir = 0
 	var/brokenstate = 0
@@ -51,7 +51,7 @@
 	icon_state = null
 	base_state = null
 	opacity = TRUE
-	max_integrity = 100 
+	max_integrity = 200 
 	integrity_failure = 0.5
 
 /obj/structure/roguewindow/stained/silver
@@ -70,7 +70,7 @@
 	icon_state = "woodwindowdir"
 	base_state = "woodwindow"
 	opacity = TRUE
-	max_integrity = 100
+	max_integrity = 200
 	integrity_failure = 0.5
 
 /obj/structure/roguewindow/openclose/reinforced


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
To explain
There are two health thresholds:
- One that breaks the window (custom preset %-age of its max hp)
- One that destroys the window (reducing it to 0 hp)

At the moment you may have noticed that a lot of basic unreinforced windows used to get destroyed completely (and thus not leave any clues behind). This is because their "break" threshold was set to 10%, while having 100 hp. Meaning that to break a basic window without destroying it you had to be doing less than 10 force per hit.

This makes it so their hp is now at 200 and their breakage threshold is at 50% -- 100. So you still need to do the same amount of damage to those windows, but now they'll break instead of getting completely destroyed, leaving a clue behind.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I actually just want more clues to appear I like being a medieval detective
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
