### PR TITLE
Xylix passive - Trickster's joy

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -791,6 +791,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/xylix_joy
 	effectedstats = list("fortune" = 1)
 	duration = 5 MINUTES
+	status_type = STATUS_EFFECT_REFRESH
 
 /datum/status_effect/buff/xylix_joy/on_apply()
 	. = ..()

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -780,3 +780,22 @@
 	name = "Call to Slaughter"
 	desc = span_bloody("LAMBS TO THE SLAUGHTER!")
 	icon_state = "call_to_slaughter"
+
+/atom/movable/screen/alert/status_effect/buff/xylix_joy
+	name = "Trickster's Joy"
+	desc = "The sound of merriment fills me with fortune."
+	icon_state = "buff"
+
+/datum/status_effect/buff/xylix_joy
+	id = "xylix_joy"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/xylix_joy
+	effectedstats = list("fortune" = 1)
+	duration = 5 MINUTES
+
+/datum/status_effect/buff/xylix_joy/on_apply()
+	. = ..()
+	to_chat(owner, span_info("The sounds of joy fill me with fortune!"))
+
+/datum/status_effect/buff/xylix_joy/on_remove()
+	. = ..()
+	to_chat(owner, span_info("My fortune returns to normal."))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -10,6 +10,10 @@
 		user.add_stress(/datum/stressevent/jesterphobia)
 	if(HAS_TRAIT(src, TRAIT_BEAUTIFUL))
 		user.add_stress(/datum/stressevent/beautiful)
+		// Apply Xylix buff when examining someone with the beautiful trait
+		if(HAS_TRAIT(user, TRAIT_XYLIX) && !user.has_status_effect(/datum/status_effect/buff/xylix_joy))
+			user.apply_status_effect(/datum/status_effect/buff/xylix_joy)
+			to_chat(user, span_info("Their beauty brings a smile to my face, and fortune to my steps!"))
 	if(HAS_TRAIT(src, TRAIT_UNSEEMLY))
 		if(!HAS_TRAIT(user, TRAIT_UNSEEMLY))
 			user.add_stress(/datum/stressevent/unseemly)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -1,4 +1,3 @@
-
 /* EMOTE DATUMS */
 /datum/emote/living
 	mob_type_allowed_typecache = /mob/living
@@ -370,6 +369,18 @@
 	emote_type = EMOTE_AUDIBLE
 	show_runechat = FALSE
 
+/datum/emote/living/giggle/run_emote(mob/living/user, params, type_override, intentional)
+	. = ..()
+	if(.)
+		// Apply Xylix buff to those with the trait who hear the giggling
+		// Only apply if the hearer is not the one laughing
+		for(var/mob/living/carbon/human/H in hearers(7, user))
+			if(H == user || !H.client)
+				continue
+			if(HAS_TRAIT(H, TRAIT_XYLIX) && !H.has_status_effect(/datum/status_effect/buff/xylix_joy))
+				H.apply_status_effect(/datum/status_effect/buff/xylix_joy)
+				to_chat(H, span_info("The giggling brings a smile to my face, and fortune to my steps!"))
+
 /mob/living/carbon/human/verb/emote_giggle()
 	set name = "Giggle"
 	set category = "Noises"
@@ -383,6 +394,18 @@
 	message_muffled = "makes a muffled chuckle."
 	emote_type = EMOTE_AUDIBLE
 	show_runechat = FALSE
+
+/datum/emote/living/chuckle/run_emote(mob/living/user, params, type_override, intentional)
+	. = ..()
+	if(.)
+		// Apply Xylix buff to those with the trait who hear the chuckling
+		// Only apply if the hearer is not the one chuckling
+		for(var/mob/living/carbon/human/H in hearers(7, user))
+			if(H == user || !H.client)
+				continue
+			if(HAS_TRAIT(H, TRAIT_XYLIX) && !H.has_status_effect(/datum/status_effect/buff/xylix_joy))
+				H.apply_status_effect(/datum/status_effect/buff/xylix_joy)
+				to_chat(H, span_info("The chuckling brings a smile to my face, and fortune to my steps!"))
 
 /mob/living/carbon/human/verb/emote_chuckle()
 	set name = "Chuckle"
@@ -647,6 +670,18 @@
 	if(. && iscarbon(user))
 		var/mob/living/carbon/C = user
 		return !C.silent
+
+/datum/emote/living/laugh/run_emote(mob/living/user, params, type_override, intentional)
+	. = ..()
+	if(.)
+		// Apply Xylix buff to those with the trait who hear the laughter
+		// Only apply if the hearer is not the one laughing
+		for(var/mob/living/carbon/human/H in hearers(7, user))
+			if(H == user || !H.client)
+				continue
+			if(HAS_TRAIT(H, TRAIT_XYLIX) && !H.has_status_effect(/datum/status_effect/buff/xylix_joy))
+				H.apply_status_effect(/datum/status_effect/buff/xylix_joy)
+				to_chat(H, span_info("The laughter brings a smile to my face, and fortune to my steps!"))
 
 /mob/living/carbon/human/verb/emote_laugh()
 	set name = "Laugh"

--- a/code/modules/spells/roguetown/jester.dm
+++ b/code/modules/spells/roguetown/jester.dm
@@ -22,6 +22,15 @@
 		if(CA.get_stress_amount() <= 0)
 			CA.add_stress(/datum/stressevent/joke)
 			CA.emote(pick("laugh","chuckle","giggle"), forced = TRUE)
+			
+			// Apply Xylix buff to those with the trait who hear the laughter
+			// Only apply if the hearer is not the one laughing and not the spell caster
+			for(var/mob/living/carbon/human/H in hearers(7, CA))
+				if(H == CA || H == user || !H.client)
+					continue
+				if(HAS_TRAIT(H, TRAIT_XYLIX) && !H.has_status_effect(/datum/status_effect/buff/xylix_joy))
+					H.apply_status_effect(/datum/status_effect/buff/xylix_joy)
+					to_chat(H, span_info("The laughter brings a smile to my face, and fortune to my steps!"))
 		sleep(rand(1,5))
 
 /obj/effect/proc_holder/spell/self/telltragedy

--- a/modular_azurepeak/code/game/objects/effects/temporary_visuals/music.dm
+++ b/modular_azurepeak/code/game/objects/effects/temporary_visuals/music.dm
@@ -46,4 +46,10 @@
 				H.add_stress(stress_to_apply)
 				if (prob(50))
 					to_chat(H, stress_to_apply.desc)
+			
+			// Apply Xylix buff to those with the trait who hear the music
+			// Only apply if the hearer is not the one playing the music
+			if (H != owner && HAS_TRAIT(H, TRAIT_XYLIX) && !H.has_status_effect(/datum/status_effect/buff/xylix_joy))
+				H.apply_status_effect(/datum/status_effect/buff/xylix_joy)
+				to_chat(H, span_info("The music brings a smile to my face, and fortune to my steps!"))
 


### PR DESCRIPTION
Those who worship Xylix receive a +1 Fortune buff for 5 minutes whenever they hear another person laugh or play music, as these are Xylix’s gifts to mortals. However, this effect does not trigger if they themselves are the one laughing or playing music.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
