### PR TITLE
adds dales lazily

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -109,7 +109,14 @@
 		"Lalve-Steppes" = SKIN_COLOR_LALVE_NALEDI,
 		"Naledi-Otava" = SKIN_COLOR_NALEDI_OTAVA,
 		"Grezel-Avar" = SKIN_COLOR_GRENZEL_AVAR,
-		"Hammer-Gronn" = SKIN_COLOR_HAMMER_GRONN
+		"Hammer-Gronn" = SKIN_COLOR_HAMMER_GRONN,
+		"Commorah-kin" = SKIN_COLOR_COMMORAH,
+		"Gloomhaven-kin" = SKIN_COLOR_GLOOMHAVEN,
+		"Darkpila-kin" = SKIN_COLOR_DARKPILA,
+		"Sshanntynlan-kin" = SKIN_COLOR_SSHANNTYNLAN,
+		"Llurth Dreir-kin" = SKIN_COLOR_LLURTH_DREIR,
+		"Tafravma-kin" = SKIN_COLOR_TAFRAVMA,
+		"Yuethindrynn-kin" = SKIN_COLOR_YUETHINDRYNN
 	)
 
 /datum/species/human/halfelf/proc/languages(mob/living/carbon/human/literally_him)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

A few people requests half-elves to have dark elf skin tones, so people could roll half-drow. Luckily for them the skintone defines is just a repeat, huh?

The names of the identities are a little lazy, admittedly, but they work and I don't really want to play various References underneath Otava or whatever.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

now people can be half racists

![image](https://github.com/user-attachments/assets/84fc9650-aeae-4d66-a707-98061f26e361)


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
