### PR TITLE
Makes Perception influence how far ahead you can look

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1911,7 +1911,7 @@
 	if(STAPER > 5)
 		ttime = 10 - (STAPER - 5)
 		if(ttime < 0)
-			ttime = 0
+			ttime = 1
 	if(STAPER <= 10)
 		var/offset = (10 - STAPER) * 2
 		if(STAPER == 10)
@@ -1932,6 +1932,8 @@
 			_y = min(0,_y)
 	else if(STAPER > 11)
 		var/offset = STAPER - 10
+		if(offset > 5)	//Caps the bonus at 15 PER, which is a whole extra screen in an orthogonal direction. Anymore will get disorienting.
+			offset = 5
 		if(STAPER >= 12)
 			message = span_info("[src] easily peers afar.")
 		if(_x > 0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1943,6 +1943,8 @@
 		else if(_y != 0)
 			_y -= offset
 	if(m_intent != MOVE_INTENT_SNEAK)
+		if(_y == 0 && _x == 0)	//Their PER was too low to see anything.
+			message = span_info("[src] oafishly stares in front of themselves.")
 		visible_message(message)
 	animate(client, pixel_x = world.icon_size*_x, pixel_y = world.icon_size*_y, ttime)
 //	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(stop_looking))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1903,16 +1903,47 @@
 	var/_x = T.x-loc.x
 	var/_y = T.y-loc.y
 	var/dist = get_dist(src, T)
+	var/message = span_info("[src] looks into the distance.")
 	if(dist > 7 || dist  <= 2)
 		return
 	hide_cone()
-	var/ttime = 10
+	var/ttime = 11
 	if(STAPER > 5)
 		ttime = 10 - (STAPER - 5)
 		if(ttime < 0)
 			ttime = 0
+	if(STAPER <= 10)
+		var/offset = (10 - STAPER) * 2
+		if(STAPER == 10)
+			offset = 1
+		else
+			message = span_info("[src] struggles to look ahead.")
+		if(_x > 0)
+			_x -= offset
+			_x = max(0, _x)
+		else if(_x != 0)
+			_x += offset
+			_x = min(0, _x)
+		if(_y > 0)
+			_y -= offset
+			_y = max(0,_y)
+		else if(_y != 0)
+			_y += offset
+			_y = min(0,_y)
+	else if(STAPER > 11)
+		var/offset = STAPER - 10
+		if(STAPER >= 12)
+			message = span_info("[src] easily peers afar.")
+		if(_x > 0)
+			_x += offset
+		else if(_x != 0)
+			_x -= offset
+		if(_y > 0)
+			_y += offset
+		else if(_y != 0)
+			_y -= offset
 	if(m_intent != MOVE_INTENT_SNEAK)
-		visible_message(span_info("[src] looks into the distance."))
+		visible_message(message)
 	animate(client, pixel_x = world.icon_size*_x, pixel_y = world.icon_size*_y, ttime)
 //	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(stop_looking))
 	update_cone_show()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
PER now has a direct influence on how many tiles ahead you can look. This consequently has made 10 PER look slightly less ahead.
15 PER:
![dreamseeker_XydOW6qNNB](https://github.com/user-attachments/assets/063ae8a8-a92d-4977-b86d-93f40acdd8f9)

12 PER:
![dreamseeker_LwirfqpUGF](https://github.com/user-attachments/assets/8735c5fd-8bd0-403e-9bad-92bb0e822878)

11 PER (current normal zoom everyone gets):
![dreamseeker_rLq1Y20Wdq](https://github.com/user-attachments/assets/6f697569-0e84-4fb3-a3fb-1ddf9b2c5ec9)

9 & 10 PER:
![dreamseeker_t1NJCHCDuj](https://github.com/user-attachments/assets/329fbfa1-2efd-4b0e-84b5-62302bc111eb)

7 PER:
![dreamseeker_adEThikYol](https://github.com/user-attachments/assets/1aa455df-56d9-4d71-8e6f-312789abaf22)

At 6 or under you can't look ahead at all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tangible influence of your stats on your gameplay! As Free intended.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
