### PR TITLE
Adjusts spell scroll dungeon loot table

### DIFF
--- a/_maps/templates/smalldungeons.dm
+++ b/_maps/templates/smalldungeons.dm
@@ -339,13 +339,26 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells
 	loot = list(
 		//spells
+		/obj/item/book/granter/spell/blackstone/spitfire = 5,
+		/obj/item/book/granter/spell/blackstone/lesserknock = 5,
+		/obj/item/book/granter/spell/blackstone/bonechill = 5,
+		/obj/item/book/granter/spell/blackstone/featherfall = 5,
+		/obj/item/book/granter/spell/blackstone/sicknessray = 5,
+		/obj/item/book/granter/spell/blackstone/poisonspray5e = 5,
+		/obj/item/book/granter/spell/blackstone/frostbolt = 5,
+		/obj/item/book/granter/spell/blackstone/forcewall_weak = 4,
+		/obj/item/book/granter/spell/blackstone/guidance = 4,
+		/obj/item/book/granter/spell/blackstone/fortitude = 4,
+		/obj/item/book/granter/spell/blackstone/leap = 4,
+		/obj/item/book/granter/spell/blackstone/enlarge = 4,
+		/obj/item/book/granter/spell/blackstone/repel = 3,
+		/obj/item/book/granter/spell/blackstone/fetch = 3,
 		/obj/item/book/granter/spell/blackstone/fireball = 3,
-		/obj/item/book/granter/spell/blackstone/greaterfireball = 2,
-		/obj/item/book/granter/spell/blackstone/lightning = 3,
-		/obj/item/book/granter/spell/blackstone/fetch = 4,
-		/obj/item/book/granter/spell/blackstone/blindness = 1,
-		/obj/item/book/granter/spell/blackstone/invisibility = 3,
-		/obj/item/book/granter/spell/blackstone/sicknessray = 2,
-		/obj/item/book/granter/spell/blackstone/bonechill = 2
+		/obj/item/book/granter/spell/blackstone/message = 3,
+		/obj/item/book/granter/spell/blackstone/ensnare = 2,
+		/obj/item/book/granter/spell/blackstone/lightning = 2,
+		/obj/item/book/granter/spell/blackstone/blindness = 2,
+		/obj/item/book/granter/spell/blackstone/invisibility = 2,
+		/obj/item/book/granter/spell/blackstone/greaterfireball = 1
 	)
 	lootcount = 1

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -226,6 +226,106 @@
 	icon_state ="scrolldarkred"
 	remarks = list("Mediolanum ventis..", "Sana damnatorum..", "Frigidus ossa mortuorum..")
 
+/obj/item/book/granter/spell/blackstone/acidsplash5e
+	name = "Scroll of Acid Splash"
+	spell = /obj/effect/proc_holder/spell/invoked/projectile/acidsplash5e
+	spellname = "Acid Splash"
+	icon_state ="scrolldarkred"
+	remarks = list("Lapides corrodunt..", "Spuma venenosa..", "Guttae flavescentes..")
+
+/obj/item/book/granter/spell/blackstone/spitfire
+	name = "Scroll of Spitfire"
+	spell = /obj/effect/proc_holder/spell/invoked/projectile/spitfire
+	spellname = "Spitfire"
+	icon_state ="scrollred"
+	remarks = list("Ignis et oleum..", "Flammam continere ad momentum..", "Flammam iactare..", "Sit flamma constructum..")
+
+/obj/item/book/granter/spell/blackstone/lesserknock
+	name = "Scroll of Lesser Knock"
+	spell = /obj/effect/proc_holder/spell/targeted/touch/lesserknock
+	spellname = "Lesser Knock"
+	icon_state ="scrollred"
+	remarks = list("Clavis vetusta portam..", "Perdita numquam..", "Manus tremens..")
+
+/obj/item/book/granter/spell/blackstone/repel
+	name = "Scroll of Repel"
+	spell = /obj/effect/proc_holder/spell/invoked/projectile/repel
+	spellname = "Repel"
+	icon_state ="scrolldarkred"
+	remarks = list("Ventos adversos..", "Terra sibilat..", "Lapides vetusti..")
+
+
+/obj/item/book/granter/spell/blackstone/poisonspray5e
+	name = "Scroll of Aerosolize"
+	spell = /obj/effect/proc_holder/spell/invoked/poisonspray5e
+	spellname = "Aerosolize"
+	icon_state ="scrolldarkred"
+	remarks = list("Lapides corrodunt..", "Spuma venenosa..", "Guttae flavescentes..")
+	
+
+/obj/item/book/granter/spell/blackstone/guidance
+	name = "Scroll of Guidance"
+	spell = /obj/effect/proc_holder/spell/invoked/guidance
+	spellname = "Guidance"
+	icon_state ="scrolldarkred"
+	remarks = list("Lux in tenebris..", "Passus certus umbras non timet..", "Anima viam scit..")
+
+/obj/item/book/granter/spell/blackstone/frostbolt
+	name = "Scroll of Frostbolt"
+	spell = /obj/effect/proc_holder/spell/invoked/projectile/frostbolt
+	spellname = "Frostbolt"
+	icon_state ="scrolldarkred"
+	remarks = list("Gelum serpentibus..", "Crystallum in silentio..", "Nullum ardor glaciem..")
+
+/obj/item/book/granter/spell/blackstone/fortitude
+	name = "Scroll of Fortitude"
+	spell = /obj/effect/proc_holder/spell/invoked/fortitude
+	spellname = "Fortitude"
+	icon_state ="scrolldarkred"
+	remarks = list("Animus in adversis..", "Gravitas oneris..", "Vita renascitur..")
+
+/obj/item/book/granter/spell/blackstone/message
+	name = "Scroll of Message"
+	spell = /obj/effect/proc_holder/spell/self/message
+	spellname = "Message"
+	icon_state ="scrolldarkred"
+	remarks = list("Verba volant..", "Vincula inter mentes..", "Inter verba et silentium..")
+
+/obj/item/book/granter/spell/blackstone/ensnare
+	name = "Scroll of Ensnare"
+	spell = /obj/effect/proc_holder/spell/invoked/slowdown_spell_aoe
+	spellname = "Ensnare"
+	icon_state ="scrolldarkred"
+	remarks = list("Qui intrat..", "Radices in tenebris..", "Nexus occultus..")
+
+/obj/item/book/granter/spell/blackstone/forcewall_weak
+	name = "Scroll of Forcewall"
+	spell = /obj/effect/proc_holder/spell/invoked/forcewall_weak
+	spellname = "Forcewall"
+	icon_state ="scrolldarkred"
+	remarks = list("Murus non solum hostem..", "Manus invisibiles saxa invicem..", "Infracta moenia..")
+
+/obj/item/book/granter/spell/blackstone/featherfall
+	name = "Scroll of Featherfall"
+	spell = /obj/effect/proc_holder/spell/invoked/featherfall
+	spellname = "Featherfall"
+	icon_state ="scrolldarkred"
+	remarks = list("In silentio cadit..", "Alis levitas..", "Plumis taciti dolores..")
+
+/obj/item/book/granter/spell/blackstone/enlarge
+	name = "Scroll of Enlarge"
+	spell = /obj/effect/proc_holder/spell/invoked/enlarge
+	spellname = "Enlarge"
+	icon_state ="scrolldarkred"
+	remarks = list("Immensum agitur..", "Montes tremunt..", "Quantitas expanditur..")
+
+/obj/item/book/granter/spell/blackstone/leap
+	name = "Scroll of Leap"
+	spell = /obj/effect/proc_holder/spell/invoked/leap
+	spellname = "Leap"
+	icon_state ="scrolldarkred"
+	remarks = list("Altitudinem revelat..", "Cuius pedes in aere volant..", "In levitate audacia..")
+
 //scroll for giving the reader a spell point, this should be dungeon loot
 /obj/item/book/granter/spell_points
 	name = "Arcyne Insight"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds a bunch of new spell scrolls that can spawn in dungeons because loot variety is good.

## Why It's Good For The Game

More variety in spell scrolls found in dungeons instead of the same 6 spells spawning in every dungeon with spell scroll spawners. Randomized loot is good.

Also made greater fireball scrolls a lot rarer - they were way too common.
