### PR TITLE
Excidium fixes

### DIFF
--- a/_maps/map_files/dun_manor/azure_coast.dmm
+++ b/_maps/map_files/dun_manor/azure_coast.dmm
@@ -1447,6 +1447,12 @@
 "iG" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/cave)
+"iH" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/beach/forest)
 "iJ" = (
 /obj/structure/fluff/statue/femalestatue,
 /obj/structure/fluff/railing/border,
@@ -1649,6 +1655,12 @@
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/cave)
+"kq" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/beach/forest)
 "kr" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /obj/structure/table/wood/fancy/black,
@@ -2282,6 +2294,13 @@
 	},
 /area/rogue/outdoors/beach/forest)
 "pa" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/beach/forest)
+"pd" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	icon_state = "border"
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest)
 "pe" = (
@@ -4964,6 +4983,10 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"GM" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/beach/forest)
 "GN" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/silver{
@@ -5477,6 +5500,10 @@
 /obj/item/clothing/neck/roguetown/psicross/eora,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
+"JU" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/beach/forest)
 "JW" = (
 /obj/structure/lever/wall{
 	redstone_id = "entryduke"
@@ -6152,6 +6179,10 @@
 /obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter)
+"Or" = (
+/obj/structure/chair/arrestchair,
+/turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/outdoors/beach/forest)
 "Ot" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/naturalstone,
@@ -7722,6 +7753,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"Zp" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/beach/forest)
 "Zu" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/ruinedwood{
@@ -47383,8 +47420,8 @@ zK
 kB
 SW
 kB
-pa
-pa
+iH
+Zp
 XK
 XK
 XK
@@ -47513,8 +47550,8 @@ RE
 bX
 QP
 SW
-pa
-pa
+Or
+XK
 XK
 XK
 XK
@@ -47643,8 +47680,8 @@ Na
 Ba
 Ul
 SW
-pa
-pa
+mK
+GM
 XK
 XK
 XK
@@ -47773,8 +47810,8 @@ ZP
 kB
 pm
 SW
-pa
-pa
+JU
+XK
 XK
 XK
 XK
@@ -47903,8 +47940,8 @@ xJ
 SW
 ps
 SW
-pa
-pa
+pd
+kq
 XK
 XK
 XK

--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -458,6 +458,10 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves)
+"dG" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/woods)
 "dH" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
@@ -1380,6 +1384,12 @@
 /obj/structure/closet/dirthole/closed/loot,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"lp" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "lr" = (
 /turf/open/floor/rogue/rooftop{
 	icon_state = "roofg"
@@ -2827,6 +2837,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/basement)
+"xt" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/shelter/woods)
 "xv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
 /turf/open/floor/rogue/dirt/road,
@@ -3713,6 +3727,12 @@
 /obj/structure/spacevine,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/town/basement)
+"Er" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "Eu" = (
 /obj/machinery/light/small{
 	mouse_opacity = 0;
@@ -3965,6 +3985,12 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"Gu" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/shelter/woods)
 "Gv" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/hexstone,
@@ -4079,6 +4105,10 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"Hn" = (
+/obj/structure/chair/arrestchair,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/shelter/woods)
 "Hp" = (
 /obj/structure/closet/crate/chest/neu,
 /obj/item/rogueore/coal{
@@ -4388,6 +4418,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"Js" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/shelter/woods)
 "Ju" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/cobble/mossy,
@@ -5846,6 +5882,10 @@
 "VR" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/mountains)
+"VU" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/indoors/shelter/woods)
 "VV" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -48667,10 +48707,10 @@ nt
 nt
 jW
 Yi
-Yi
-jW
-jW
-jW
+QO
+vo
+vo
+vo
 By
 jW
 jW
@@ -48824,10 +48864,10 @@ nt
 nt
 jW
 jW
-Yi
-Yi
-jW
-jW
+QO
+QO
+vo
+vo
 jW
 yo
 jW
@@ -48981,10 +49021,10 @@ nt
 nt
 nt
 jW
-Yi
-Yi
-jW
-LA
+QO
+QO
+vo
+ey
 MK
 yo
 yo
@@ -50081,9 +50121,9 @@ vo
 Yv
 vo
 vo
-vo
 QO
-XC
+QO
+QO
 jm
 XC
 nt
@@ -50237,10 +50277,10 @@ vo
 vo
 vo
 vo
-vo
-vE
-vE
-XC
+Gu
+lp
+QO
+QO
 qV
 XC
 Ek
@@ -50394,10 +50434,10 @@ nt
 nt
 jW
 By
-jW
-XC
-XC
-vE
+xt
+Hn
+QO
+QO
 vo
 yo
 yo
@@ -50551,11 +50591,11 @@ LA
 MK
 jW
 jW
-MK
-MK
-vo
-vo
-By
+xt
+mO
+VU
+QO
+jW
 yo
 yo
 MK
@@ -50708,12 +50748,12 @@ jW
 jW
 MK
 jW
-MK
-LA
-MK
+xt
+dG
+QO
+QO
 nt
-nt
-nt
+Ek
 nt
 LA
 MK
@@ -50865,10 +50905,10 @@ MK
 MK
 jW
 jW
-jW
-jW
-jW
-nt
+Er
+Js
+QO
+QO
 ST
 nt
 nt

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -9466,9 +9466,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town)
 "gVJ" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/turf/open/floor/carpet/red,
-/area/rogue/under/town/sewer)
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/mountains)
 "gVO" = (
 /obj/structure/roguemachine/stockpile{
 	pixel_y = 0;
@@ -20388,6 +20388,10 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
+"oJr" = (
+/obj/structure/roguemachine/bounty,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "oJC" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -20680,6 +20684,12 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town)
+"oTx" = (
+/obj/structure/rack/rogue,
+/obj/item/clothing/shoes/roguetown/boots,
+/obj/item/clothing/shoes/roguetown/boots,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "oTI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -22544,9 +22554,7 @@
 /area/rogue/under/town/basement)
 "qnG" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
-/obj/structure/rack/rogue,
-/obj/item/clothing/shoes/roguetown/boots,
-/obj/item/clothing/shoes/roguetown/boots,
+/obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "qol" = (
@@ -45994,13 +46002,13 @@ cVE
 cVE
 heh
 pmA
-oYS
+lEv
 wGj
 wGj
 wGj
 wGj
 bHA
-lEv
+oYS
 pmA
 exi
 exi
@@ -46308,13 +46316,13 @@ cVE
 cVE
 heh
 pmA
-bHA
-bHA
+hZC
+hZC
 itN
 itN
 itN
-bHA
-bHA
+hZC
+hZC
 pmA
 exi
 exi
@@ -46465,13 +46473,13 @@ vrR
 cVE
 heh
 pmA
-hZC
-hZC
+fQy
+kDA
 itN
-gVJ
 itN
-hZC
-hZC
+itN
+tnr
+osY
 pmA
 exi
 exi
@@ -46622,13 +46630,13 @@ pmA
 cVE
 heh
 pmA
-fQy
-kDA
+oGp
+sSf
 itN
 itN
 itN
-tnr
-osY
+mGX
+fDU
 pmA
 exi
 sjE
@@ -46779,13 +46787,13 @@ pmA
 cVE
 heh
 pmA
-oGp
-sSf
+qGv
+qGv
 itN
 itN
 itN
-mGX
-fDU
+qGv
+qGv
 pmA
 exi
 exi
@@ -46936,13 +46944,13 @@ pmA
 cVE
 heh
 pmA
-qGv
-qGv
+bHA
+bHA
 itN
 itN
 itN
-qGv
-qGv
+bHA
+bHA
 pmA
 exi
 exi
@@ -47093,13 +47101,13 @@ pmA
 xsI
 heh
 pmA
-bHA
+oJr
 bHA
 itN
 itN
 itN
 bHA
-bHA
+oTx
 pmA
 exi
 exi
@@ -47255,8 +47263,8 @@ bHA
 bHA
 bHA
 bHA
+bHA
 oBK
-oYS
 pmA
 exi
 exi
@@ -109652,7 +109660,7 @@ hbs
 hbs
 hbs
 bUx
-hbs
+gVJ
 ylI
 fam
 srJ

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -878,7 +878,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	for(var/datum/bounty/removing_bounty in GLOB.head_bounties)
 		if(removing_bounty.target == target_name)
 			GLOB.head_bounties -= removing_bounty
-			scom_announce("Ravox is displeased! The bounty posting on [target_name] has been struck down by the gods!")
+			scom_announce("An unknown force has erased the bounty on [target_name]. The gods are displeased.")
 			message_admins("[ADMIN_LOOKUPFLW(src)] has removed the bounty on [ADMIN_LOOKUPFLW(target_name)]")
 			return
 	to_chat(src, "Error. Bounty no longer active.") 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -35,6 +35,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/adminwho,
 	/client/proc/admin_spread_effect,
 	/client/proc/open_bounty_menu,
+	/client/proc/remove_bounty,
 	// RATWOOD MODULAR START
 	/client/proc/bunker_bypass,
 	// RATWOOD MODULAR END
@@ -854,3 +855,30 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	else
 		to_chat(src, span_notice("Either the book file doesn't exist or you have failed to type something in properly (you can look up the file name by the verb 'database book file names'"))
 
+/client/proc/remove_bounty()
+	set category = "Admin"
+	set name = "Remove Bounty"
+	if(!holder)
+		return
+	var/list/bounty_list = list()
+
+	for(var/datum/bounty/removable_bounties in GLOB.head_bounties)
+		bounty_list += removable_bounties.target
+
+	if(!bounty_list.len)
+		to_chat(src, "There are no active bounties to remove.")
+		return
+
+	var/target_name = input(src, "Whose name shall be struck from the wanted list?", src) as null|anything in bounty_list
+	if(!target_name)
+		return
+
+	to_chat(src,"Removing [target_name] from bounty list...")
+
+	for(var/datum/bounty/removing_bounty in GLOB.head_bounties)
+		if(removing_bounty.target == target_name)
+			GLOB.head_bounties -= removing_bounty
+			scom_announce("Ravox is displeased! The bounty posting on [target_name] has been struck down by the gods!")
+			message_admins("[ADMIN_LOOKUPFLW(src)] has removed the bounty on [ADMIN_LOOKUPFLW(target_name)]")
+			return
+	to_chat(src, "Error. Bounty no longer active.") 

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -163,12 +163,12 @@
 		ADD_TRAIT(user, TRAIT_SPELLCOCKBLOCK, "cursedmask")
 		if(HAS_TRAIT(user, TRAIT_RITUALIST))
 			user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)
-		var/timer = 20 MINUTES
+		var/timer = 20 SECONDS
 
 		if(bounty_amount >= 100)
 			var/additional_time = bounty_amount * 0.1
 			additional_time = round(additional_time)
-			timer += additional_time MINUTES
+			timer += additional_time SECONDS
 
 		var/timer_minutes = timer / 600
 

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -163,7 +163,7 @@
 		ADD_TRAIT(user, TRAIT_SPELLCOCKBLOCK, "cursedmask")
 		if(HAS_TRAIT(user, TRAIT_RITUALIST))
 			user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)
-		var/timer = 30 MINUTES
+		var/timer = 20 MINUTES
 
 		if(bounty_amount >= 100)
 			var/additional_time = bounty_amount * 0.1

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -313,7 +313,7 @@
 		my_crime = "crimes against the Crown"
 	var/bounty_total
 	bounty_total = rand(151, 250)
-	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "the Holy See")
+	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Holy See")
 	H.cmode_music = 'sound/music/combat_cult.ogg'
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 
@@ -371,4 +371,4 @@
 		my_crime = "crimes against the Crown"
 	var/bounty_total
 	bounty_total = rand(151, 250)
-	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "the Holy See")
+	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Holy See")

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/wanted.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/wanted.dm
@@ -43,5 +43,5 @@
 			if ("Massive")
 				bounty_total = rand(150, 200)
 	
-		add_bounty(H.real_name, bounty_total, FALSE, my_crime, "the Justiciary of Azuria")
+		add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
 		to_chat(H, span_notice("I'm on the run from the law, and there's a [lowertext(bounty_amount)] sum of mammons out on my head... better lay low."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Adds a 'remove bounty' verb for admins.
- Fixes some grammatical errors in the Excidium.
- Adds a few more Excidium stations around the map outside of the city to better enable antagonistic characters to potentially use the bounty system.
- Fixes the penance timer being 10 minutes longer than intended due to an oversight. The 100 mammon bounty minimum meant the timer minimum was actually 40 minutes instead of the intended 30.

## Why It's Good For The Game

Fixes for the Excidium along with better tools for admins to curb people potentially abusing the system.