### PR TITLE
Fixes smith/artificer door

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -6275,7 +6275,8 @@
 /area/rogue/indoors/town/tavern)
 "ewa" = (
 /obj/structure/mineral_door/bars{
-	lockid = "artificer"
+	lockid = "artificer";
+	name = "artificery's iron door"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
@@ -10691,7 +10692,8 @@
 /area/rogue/indoors/town/dwarfin)
 "hUK" = (
 /obj/structure/mineral_door/bars{
-	lockid = "mason"
+	lockid = "blacksmith";
+	name = "smithy's iron door"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The door on the NE side of town still was tagged with the mason keyid, which has been removed. To make the door useful, I assigned it to the smith ID so the artificer has an entrance and the smith - and the doors are named, for player facing help. A bit hacky, but we currently can't multi-key a door and there were two there anyway.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fix bug, also gives smiths a reason to even use their north facing doors. escape the line, quietly...

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
