### PR TITLE
Miracles, bumps devotion cost to 30 and adds proximity check

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -123,7 +123,7 @@
 	if(!H || !H.mind || !patron)
 		return
 		
-	var/list/spelllist = list(patron.extra_spell, /obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0)
+	var/list/spelllist = list(patron.extra_spell, /obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1)
 	if(istype(patron,/datum/patron/divine))
 		spelllist += /obj/effect/proc_holder/spell/targeted/abrogation
 	for(var/spell_type in spelllist)
@@ -132,9 +132,10 @@
 		var/newspell = new spell_type
 		H.mind.AddSpell(newspell)
 		LAZYADD(granted_spells, newspell)
-	level = CLERIC_T0
+	level = CLERIC_T1
 	max_devotion = CLERIC_REQ_1 //Max devotion limit - Paladins are stronger but cannot pray to gain all abilities beyond t1
 	max_progression = CLERIC_REQ_1
+	devotion = CLERIC_REQ_1
 
 /datum/devotion/proc/grant_spells_churchling(mob/living/carbon/human/H)
 	if(!H || !H.mind || !patron)

--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -229,6 +229,7 @@
 			
 	if(prayerbuddy)
 		to_chat(src, "<font color='purple'>I am praying with [prayerbuddy.name] for a bonus of [prayerbuddy.devotion.level].</font>")
+		to_chat(prayerbuddy, "<font color='purple'>[src.name] is praying alongside me.</font>")
 	else
 		to_chat(src, "<font color='purple'>I am praying alone.</font>")
 

--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -219,6 +219,19 @@
 		return FALSE
 
 	var/prayersesh = 0
+	var/mob/living/carbon/human/prayerbuddy = null //Adjacency bonus - pray next to others to get a gain
+	for(var/mob/living/carbon/human/H in orange(1, src))
+		if(prayerbuddy == null)
+			if(H.devotion && H.devotion.level > 0 && H.stat == CONSCIOUS)
+				prayerbuddy = H
+		else if(H.devotion && H.devotion.level > prayerbuddy.devotion.level && H.stat == CONSCIOUS)
+			prayerbuddy = H
+			
+	if(prayerbuddy)
+		to_chat(src, "<font color='purple'>I am praying with [prayerbuddy.name] for a bonus of [prayerbuddy.devotion.level].</font>")
+	else
+		to_chat(src, "<font color='purple'>I am praying alone.</font>")
+
 	visible_message("[src] kneels their head in prayer to the Gods.", "I kneel my head in prayer to [devotion.patron.name].")
 	for(var/i in 1 to 50)
 		if(devotion.devotion >= devotion.max_devotion)
@@ -230,6 +243,11 @@
 		if(mind)
 			devotion_multiplier += (mind.get_skill_level(/datum/skill/magic/holy) / SKILL_LEVEL_LEGENDARY)
 		var/prayer_effectiveness = round(devotion.prayer_effectiveness * devotion_multiplier)
+		if(prayerbuddy && (!usr.Adjacent(prayerbuddy) || prayerbuddy.stat != CONSCIOUS))
+			prayerbuddy = null
+			to_chat(src, "<font color='purple'>I have lost my prayer buddy.</font>")
+		if(prayerbuddy)
+			prayer_effectiveness += prayerbuddy.devotion.level
 		devotion.update_devotion(prayer_effectiveness, prayer_effectiveness)
 		prayersesh += prayer_effectiveness
 	visible_message("[src] concludes their prayer.", "I conclude my prayer.")

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -14,12 +14,16 @@
 	antimagic_allowed = TRUE
 	charge_max = 10 SECONDS
 	miracle = TRUE
-	devotion_cost = 10
+	devotion_cost = 30
 
 /obj/effect/proc_holder/spell/invoked/lesser_heal/cast(list/targets, mob/living/user)
 	. = ..()
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
+		if(get_dist(user, target) > 2) //Proximity check
+			to_chat(user, "I must get closer before I can invoke a miracle!")
+			revert_cast()
+			return FALSE
 		if(user.patron?.undead_hater && (target.mob_biotypes & MOB_UNDEAD)) //positive energy harms the undead
 			target.visible_message(span_danger("[target] is burned by holy light!"), span_userdanger("I'm burned by holy light!"))
 			target.adjustFireLoss(10)

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -15,6 +15,7 @@
 	charge_max = 10 SECONDS
 	miracle = TRUE
 	devotion_cost = 30
+	devotion_self_refund = 20 //Total cost of 10 if casting on self
 
 /obj/effect/proc_holder/spell/invoked/lesser_heal/cast(list/targets, mob/living/user)
 	. = ..()

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -175,6 +175,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/associated_skill = /datum/skill/magic/arcane
 	var/miracle = FALSE
 	var/devotion_cost = 0
+	var/devotion_self_refund = 0
 	var/ignore_cockblock = FALSE //whether or not to ignore TRAIT_SPELLCOCKBLOCK
 
 	action_icon_state = "spell0"
@@ -442,8 +443,13 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 				smoke.start()
 	if(devotion_cost && ishuman(user))
 		var/mob/living/carbon/human/devotee = user
-		devotee.devotion?.update_devotion(-devotion_cost)
-		to_chat(devotee, "<font color='purple'>I [devotion_cost > 0 ? "lost" : "gained"] [abs(devotion_cost)] devotion.</font>")
+		if(user in targets) //Casting on ourself, check for devotion_self_refund
+			var/refund_calc = devotion_cost - devotion_self_refund
+			devotee.devotion?.update_devotion(-refund_calc)
+			to_chat(devotee, "<font color='purple'>I [refund_calc > 0 ? "lost" : "gained"] [abs(refund_calc)] devotion.</font>")
+		else
+			devotee.devotion?.update_devotion(-devotion_cost)
+			to_chat(devotee, "<font color='purple'>I [devotion_cost > 0 ? "lost" : "gained"] [abs(devotion_cost)] devotion.</font>")
 	//Add xp based on the fatigue used -- AZURE EDIT: REMOVED!! THIS SHIT WAS TINY AND SUUUUCKED
 	/* if(xp_gain)
 		adjust_experience(usr, associated_skill, round(get_fatigue_drain() * MAGIC_XP_MULTIPLIER)) */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Miracles cost 30 devotion to cast instead of 10. Added a proximity check for miracles, 2 tiles, to prevent "across the screen" miracles

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Miracles are considered to be "free". They're not supposed to be! They're supposed to draw legitimacy from the spending of the devotion pool. However, with the proliferation of the healing miracle / upgrade from the "lesser miracle" of last year, miracles are now considered to be "free". This PR hopes to re-legitimize miracle in some small fashion by increasing the cost of it. Resource economy, blah blah blah

Devotees go from 8 miracles in the bank to 2.66.