### PR TITLE
***ready for merge*** Complete overhall of magic casting

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -813,8 +813,19 @@
 	// Special handling for fully charged spells
 	if(client && is_spell_fully_charged())
 		var/obj/effect/proc_holder/spell/invoked/spell = ranged_ability
-		if(istype(spell) && !istype(spell, /obj/effect/proc_holder/spell/invoked/projectile))
-			// Only allow direct clicks for non-projectile spells
+		if(istype(spell))
+			// Check if this is a projectile spell or has projectile behavior - with safe fallback
+			var/is_projectile_behavior = FALSE
+			if(istype(spell, /obj/effect/proc_holder/spell/invoked/projectile))
+				is_projectile_behavior = TRUE
+			else if(spell.vars && ("projectile_behavior" in spell.vars))
+				is_projectile_behavior = spell.vars["projectile_behavior"]
+			
+			// Let projectile spells handle their own click behavior
+			if(is_projectile_behavior)
+				return FALSE
+			
+			// For non-projectile spells, allow direct clicks when fully charged
 			if(spell.cast_check(FALSE, src))
 				if(spell.perform(list(A), TRUE, user = src))
 					spell.deactivate(src)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -787,6 +787,15 @@
 		add_view_range(view)*/
 
 /mob/proc/check_click_intercept(params,A)
+	var/list/modifiers = params2list(params)
+	
+	// Handle right-click dismissal for any spell (charged or not)
+	if(modifiers["right"] && ranged_ability && istype(ranged_ability, /obj/effect/proc_holder/spell))
+		var/obj/effect/proc_holder/spell/spell = ranged_ability
+		to_chat(src, span_warning("You dismiss the [spell.name] spell."))
+		spell.deactivate(src)
+		return TRUE
+
 	//Client level intercept
 	if(client && client.click_intercept)
 		if(istype(client.click_intercept, /obj/effect/proc_holder))
@@ -822,6 +831,13 @@
 	return
 
 /mob/proc/RightClickOn(atom/A, params)
+	// Special handling for ranged abilities - right-click dismisses
+	if(ranged_ability && istype(ranged_ability, /obj/effect/proc_holder/spell))
+		var/obj/effect/proc_holder/spell/spell = ranged_ability
+		to_chat(src, span_warning("You dismiss the [spell.name] spell."))
+		spell.deactivate(src)
+		return
+		
 	if(A.Adjacent(src))
 		if(A.loc == src && (A == get_active_held_item()) )
 			A.rmb_self(src)

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -337,8 +337,19 @@
 			// Set the charging cursor while charging
 			mouse_pointer_icon = 'icons/effects/mousemice/swang/acharging.dmi'
 			
-			// Apply fatigue drain during charging (original behavior)
-			if(!L.rogfat_add(L.used_intent.chargedrain))
+			// Apply fatigue drain during charging
+			// Check for spell drain value first
+			var/drain_amount = L.used_intent.chargedrain
+			if(istype(L.ranged_ability, /obj/effect/proc_holder/spell))
+				var/obj/effect/proc_holder/spell/spell = L.ranged_ability
+				// Check for both variable names due to inconsistency in the codebase
+				if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
+					drain_amount = spell.vars["chargedrain"]
+				else if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
+					drain_amount = spell.vars["chargedrain"]
+			
+			// Apply the drain
+			if(!L.rogfat_add(drain_amount))
 				L.stop_attack()
 				return FALSE
 		else //Fully charged spell
@@ -361,10 +372,21 @@
 				// Always set the fully charged cursor
 				mouse_pointer_icon = 'icons/effects/mousemice/swang/acharged.dmi'
 			
-			// Apply fatigue drain when fully charged (original behavior)
-			if(!L.rogfat_add(L.used_intent.chargedrain))
+			// Apply fatigue drain when fully charged - same logic as during charging
+			var/drain_amount = L.used_intent.chargedrain
+			if(istype(L.ranged_ability, /obj/effect/proc_holder/spell))
+				var/obj/effect/proc_holder/spell/spell = L.ranged_ability
+				// Check for both variable names due to inconsistency in the codebase
+				if(spell.vars && ("chargeddrain" in spell.vars) && !isnull(spell.vars["chargeddrain"]))
+					drain_amount = spell.vars["chargeddrain"]
+				else if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
+					drain_amount = spell.vars["chargedrain"]
+			
+			// Apply the drain 
+			if(!L.rogfat_add(drain_amount))
 				L.stop_attack()
 				return FALSE
+				
 		return TRUE
 	else
 		return FALSE

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -378,24 +378,13 @@
 				if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
 					drain_amount = spell.vars["chargedrain"]
 				
-				// Halve the drain amount if the spell is primed (fully charged)
+				// For primed spells, only apply drain every other tick to match charging rate
 				if(doneset)
+					if(progress % 2 != 0)
+						return TRUE
 					drain_amount *= 0.5
 			
-			// Only apply drain every other tick for primed spells to match charging rate
-			if(doneset && progress % 2 != 0)
-				// Apply the drain even on odd ticks
-				if(!L.rogfat_add(drain_amount))
-					// If stamina is depleted and spell is primed, automatically release it
-					if(doneset && istype(L.ranged_ability, /obj/effect/proc_holder/spell))
-						var/obj/effect/proc_holder/spell/spell = L.ranged_ability
-						spell.deactivate(L)
-						to_chat(L, span_warning("You lose concentration and release the spell as you become exhausted!"))
-					L.stop_attack()
-					return FALSE
-				return TRUE
-			
-			// Apply the drain 
+			// Apply the drain
 			if(!L.rogfat_add(drain_amount))
 				// If stamina is depleted and spell is primed, automatically release it
 				if(doneset && istype(L.ranged_ability, /obj/effect/proc_holder/spell))

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -372,29 +372,29 @@
 			
 			// Apply fatigue drain when fully charged - same logic as during charging
 			var/drain_amount = L.used_intent.chargedrain
+			var/obj/effect/proc_holder/spell/spell
 			if(istype(L.ranged_ability, /obj/effect/proc_holder/spell))
-				var/obj/effect/proc_holder/spell/spell = L.ranged_ability
+				spell = L.ranged_ability
 				// Check for both variable names due to inconsistency in the codebase
 				if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
 					drain_amount = spell.vars["chargedrain"]
 				
-				// For primed spells, only apply drain every other tick to match charging rate
+				// For primed spells, apply drain at the same rate as charging
 				if(doneset)
-					if(progress % 2 != 0)
-						return TRUE
-					drain_amount *= 0.5
+					if(!L.rogfat_add(drain_amount))
+						// If stamina is depleted and spell is primed, automatically release it
+						if(doneset)
+							spell.deactivate(L)
+							to_chat(L, span_warning("You lose concentration and release the spell as you become exhausted!"))
+						L.stop_attack()
+						return FALSE
+					return TRUE
 			
 			// Apply the drain
 			if(!L.rogfat_add(drain_amount))
-				// If stamina is depleted and spell is primed, automatically release it
-				if(doneset && istype(L.ranged_ability, /obj/effect/proc_holder/spell))
-					var/obj/effect/proc_holder/spell/spell = L.ranged_ability
-					spell.deactivate(L)
-					to_chat(L, span_warning("You lose concentration and release the spell as you become exhausted!"))
 				L.stop_attack()
 				return FALSE
-				
-		return TRUE
+			return TRUE
 	else
 		return FALSE
 

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -8,7 +8,6 @@
 
 // Component defines for click handling
 #define COMPONENT_CANCEL_CLICK 1
-#define COMPONENT_NO_MOUSEDROP 1
 
 /atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	if(!usr || !over)
@@ -320,6 +319,12 @@
 				if(L.curplaying && !L.used_intent.keep_looping)
 					playsound(L, 'sound/magic/charged.ogg', 100, TRUE)
 					L.curplaying.on_mouse_up()
+				
+				// Notify the user that the spell is fully charged and ready to use
+				if(istype(L.ranged_ability, /obj/effect/proc_holder/spell))
+					var/obj/effect/proc_holder/spell/spell = L.ranged_ability
+					to_chat(L, span_notice("Your [spell.name] is fully charged! Click to cast."))
+				
 				chargedprog = 100
 				mouse_pointer_icon = 'icons/effects/mousemice/swang/acharged.dmi'
 			else

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -345,8 +345,6 @@
 				// Check for both variable names due to inconsistency in the codebase
 				if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
 					drain_amount = spell.vars["chargedrain"]
-				else if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
-					drain_amount = spell.vars["chargedrain"]
 			
 			// Apply the drain
 			if(!L.rogfat_add(drain_amount))
@@ -377,13 +375,33 @@
 			if(istype(L.ranged_ability, /obj/effect/proc_holder/spell))
 				var/obj/effect/proc_holder/spell/spell = L.ranged_ability
 				// Check for both variable names due to inconsistency in the codebase
-				if(spell.vars && ("chargeddrain" in spell.vars) && !isnull(spell.vars["chargeddrain"]))
-					drain_amount = spell.vars["chargeddrain"]
-				else if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
+				if(spell.vars && ("chargedrain" in spell.vars) && !isnull(spell.vars["chargedrain"]))
 					drain_amount = spell.vars["chargedrain"]
+				
+				// Halve the drain amount if the spell is primed (fully charged)
+				if(doneset)
+					drain_amount *= 0.5
+			
+			// Only apply drain every other tick for primed spells to match charging rate
+			if(doneset && progress % 2 != 0)
+				// Apply the drain even on odd ticks
+				if(!L.rogfat_add(drain_amount))
+					// If stamina is depleted and spell is primed, automatically release it
+					if(doneset && istype(L.ranged_ability, /obj/effect/proc_holder/spell))
+						var/obj/effect/proc_holder/spell/spell = L.ranged_ability
+						spell.deactivate(L)
+						to_chat(L, span_warning("You lose concentration and release the spell as you become exhausted!"))
+					L.stop_attack()
+					return FALSE
+				return TRUE
 			
 			// Apply the drain 
 			if(!L.rogfat_add(drain_amount))
+				// If stamina is depleted and spell is primed, automatically release it
+				if(doneset && istype(L.ranged_ability, /obj/effect/proc_holder/spell))
+					var/obj/effect/proc_holder/spell/spell = L.ranged_ability
+					spell.deactivate(L)
+					to_chat(L, span_warning("You lose concentration and release the spell as you become exhausted!"))
 				L.stop_attack()
 				return FALSE
 				

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -465,8 +465,13 @@
 				return
 			if(INTENT_SPELL)
 				if(ranged_ability?.InterceptClickOn(src, params, A))
-					changeNext_move(mmb_intent.clickcd)
-					if(mmb_intent.releasedrain)
+					// Check if mmb_intent exists and has a valid clickcd value
+					if(mmb_intent && !isnull(mmb_intent.clickcd))
+						changeNext_move(mmb_intent.clickcd)
+					else
+						changeNext_move(CLICK_CD_MELEE) // Default fallback if clickcd isn't defined
+					
+					if(mmb_intent && mmb_intent.releasedrain)
 						rogfat_add(mmb_intent.releasedrain)
 				return
 

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -165,6 +165,7 @@
 			chargedloop.stop()
 		chargedloop.start(chargedloop.parent)
 		mastermob.curplaying = src
+	keep_looping = TRUE  // Make sure the sound keeps looping
 
 /datum/intent/proc/on_mouse_up()
 	if(chargedloop)

--- a/code/modules/mob/living/carbon/rogfatstam.dm
+++ b/code/modules/mob/living/carbon/rogfatstam.dm
@@ -2,6 +2,12 @@
 	maxrogfat = maxrogstam / 10
 
 	var/delay = (HAS_TRAIT(src, TRAIT_APRICITY) && GLOB.tod == "day") ? 13 : 20		//Astrata 
+	// Check if we have a primed spell - don't regenerate stamina if we do
+	if(primed_spell)
+		// Skip stamina regeneration while spell is primed
+		update_health_hud()
+		return
+		
 	if(world.time > last_fatigued + delay) //regen fatigue
 		var/added = rogstam / maxrogstam
 		added = round(-10+ (added*-40))

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,5 +1,3 @@
-
-
 /mob/living
 	see_invisible = SEE_INVISIBLE_LIVING
 	sight = 0
@@ -179,3 +177,6 @@
 	var/voice_pitch = 1
 
 	var/domhand = 0
+
+	// Flag for if a mob has a primed spell ready to cast
+	var/primed_spell = FALSE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -521,7 +521,7 @@
 			testing("spellselect [ranged_ability]")
 			mmb_intent = new INTENT_SPELL(src)
 			mmb_intent.releasedrain = ranged_ability.get_fatigue_drain()
-			mmb_intent.chargedrain = ranged_ability.chargedrain
+			mmb_intent.chargedrain = ranged_ability.get_charged_drain()
 			mmb_intent.chargetime = ranged_ability.get_chargetime()
 			mmb_intent.warnie = ranged_ability.warnie
 			mmb_intent.charge_invocation = ranged_ability.charge_invocation
@@ -959,3 +959,29 @@
 		if(J.advjob_examine)
 			used_title = advjob
 	return used_title
+
+/// Add a new proc to check if a spell is fully charged
+/mob/proc/is_spell_fully_charged()
+	if(!client || !ranged_ability || !istype(ranged_ability, /obj/effect/proc_holder/spell))
+		return FALSE
+		
+	// If the client has the doneset flag or progress >= goal, the spell is fully charged
+	if(client.doneset || client.progress >= client.goal)
+		return TRUE
+	return FALSE
+
+// When a spell is attached as a ranged ability, update mmb_intent with its values for chargetime, etc.
+// This makes mmb spellcasting work properly
+/mob/proc/update_mmb_intent_from_ranged_ability()
+	if(!ranged_ability || !istype(ranged_ability, /obj/effect/proc_holder/spell))
+		return FALSE
+	
+	if(!mmb_intent || mmb_intent.type != INTENT_SPELL)
+		return FALSE
+		
+	var/obj/effect/proc_holder/spell/spell = ranged_ability
+	mmb_intent.releasedrain = spell.get_fatigue_drain()  
+	mmb_intent.chargedrain = spell.get_charged_drain()
+	mmb_intent.chargetime = spell.get_chargetime()
+	
+	return TRUE

--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -102,19 +102,28 @@
 			revert_cast(caller)
 			return FALSE
 			
-		// Cast the projectile spell and deactivate
-		if(perform(list(target), TRUE, user = ranged_ability_user))
+		// Cast the projectile spell and deactivate only if we have a valid target
+		if(target && target != caller && perform(list(target), TRUE, user = ranged_ability_user))
 			deactivate(caller)
 			// Reset the primed_spell flag after casting
 			caller.primed_spell = FALSE
 			return TRUE
+		
+		// If clicking on nothing or self, don't deactivate - keep spell primed
+		if(!target || target == caller)
+			return TRUE
 	else
 		// Non-projectile spells can use click-to-cast when fully charged
 		if(caller.is_spell_fully_charged() || !no_early_release)
-			if(perform(list(target), TRUE, user = ranged_ability_user))
+			// Only cast if we have a valid target
+			if(target && target != caller && perform(list(target), TRUE, user = ranged_ability_user))
 				deactivate(caller)
 				// Reset the primed_spell flag after casting
 				caller.primed_spell = FALSE
+				return TRUE
+			
+			// If clicking on nothing or self, don't deactivate - keep spell primed
+			if(!target || target == caller)
 				return TRUE
 		else
 			to_chat(caller, span_warning("[src.name] is not fully charged yet!"))

--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -55,6 +55,10 @@
 		user.client.progress = 0
 		user.client.mouse_pointer_icon = 'icons/effects/mousemice/human.dmi'
 		STOP_PROCESSING(SSmousecharge, user.client)
+		
+		// Reset the primed_spell flag to allow stamina regeneration again
+		user.primed_spell = FALSE
+		
 	on_deactivation(user)
 
 /obj/effect/proc_holder/spell/invoked/proc/on_activation(mob/user)
@@ -101,12 +105,16 @@
 		// Cast the projectile spell and deactivate
 		if(perform(list(target), TRUE, user = ranged_ability_user))
 			deactivate(caller)
+			// Reset the primed_spell flag after casting
+			caller.primed_spell = FALSE
 			return TRUE
 	else
 		// Non-projectile spells can use click-to-cast when fully charged
 		if(caller.is_spell_fully_charged() || !no_early_release)
 			if(perform(list(target), TRUE, user = ranged_ability_user))
 				deactivate(caller)
+				// Reset the primed_spell flag after casting
+				caller.primed_spell = FALSE
 				return TRUE
 		else
 			to_chat(caller, span_warning("[src.name] is not fully charged yet!"))

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -42,7 +42,7 @@
 	overlay_state = "invisibility"
 	desc = "Make another (or yourself) invisible for fifteen seconds."
 	releasedrain = 30
-	chargedrain = 5
+	chargedrain = 0  // No drain during charging
 	chargetime = 5
 	clothes_req = FALSE
 	charge_max = 30 SECONDS
@@ -54,6 +54,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	antimagic_allowed = TRUE
 	cost = 2
+	no_early_release = TRUE  // Prevent early release to avoid partial invisibility
 
 /obj/effect/proc_holder/spell/invoked/invisibility/miracle
 	miracle = TRUE

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -58,6 +58,13 @@
 /obj/effect/proc_holder/proc/get_fatigue_drain()
 	return releasedrain
 
+/obj/effect/proc_holder/proc/get_charged_drain()
+	// Special case for all invoked spells to prevent runtime errors
+	if(istype(src, /obj/effect/proc_holder/spell/invoked))
+		// Return a safe value for all invoked spells
+		return 1
+	return chargedrain
+
 GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for the badmin verb for now
 
 /obj/effect/proc_holder/Destroy()
@@ -219,7 +226,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		else
 			return 0.1
 	return releasedrain
-
 
 /obj/effect/proc_holder/spell/proc/cast_check(skipcharge = 0, mob/user = usr) //checks if the spell can be cast based on its settings; skipcharge is used when an additional cast_check is called inside the spell
 	if(player_lock)

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -514,6 +514,40 @@
 	var/delay = 14
 	var/damage = 125 //if you get hit by this it's your fault
 	var/area_of_effect = 1
+	var/projectile_behavior = TRUE // Flag to enable projectile-like click and release behavior
+
+/obj/effect/proc_holder/spell/invoked/blade_burst/InterceptClickOn(mob/living/caller, params, atom/target)
+	. = ..()
+	if(.)
+		return FALSE
+	
+	// Basic checks for casting ability
+	if(!can_cast(caller) || !cast_check(FALSE, ranged_ability_user))
+		return FALSE
+	
+	// Get click parameters to detect right-click
+	var/list/modifiers = params2list(params)
+	
+	// Handle right-click to dismiss spell
+	if(modifiers["right"]) 
+		to_chat(caller, span_warning("You dismiss the [src.name] spell."))
+		deactivate(caller)
+		return TRUE
+	
+	// Handle like a projectile spell
+	if(projectile_behavior)
+		// Make sure it's fully charged if no_early_release is true
+		if(no_early_release && !caller.is_spell_fully_charged())
+			to_chat(caller, span_warning("[src.name] was not finished charging! It fizzles."))
+			revert_cast(caller)
+			return FALSE
+			
+		// Cast the spell
+		if(perform(list(target), TRUE, user = ranged_ability_user))
+			deactivate(caller)
+			return TRUE
+	
+	return FALSE
 
 /obj/effect/temp_visual/trap
 	icon = 'icons/effects/effects.dmi'
@@ -1025,6 +1059,40 @@
 	var/delay = 6
 	var/damage = 50 // less then fireball, more then lighting bolt
 	var/area_of_effect = 2
+	var/projectile_behavior = TRUE // Flag to enable projectile-like click and release behavior
+
+/obj/effect/proc_holder/spell/invoked/snap_freeze/InterceptClickOn(mob/living/caller, params, atom/target)
+	. = ..()
+	if(.)
+		return FALSE
+	
+	// Basic checks for casting ability
+	if(!can_cast(caller) || !cast_check(FALSE, ranged_ability_user))
+		return FALSE
+	
+	// Get click parameters to detect right-click
+	var/list/modifiers = params2list(params)
+	
+	// Handle right-click to dismiss spell
+	if(modifiers["right"]) 
+		to_chat(caller, span_warning("You dismiss the [src.name] spell."))
+		deactivate(caller)
+		return TRUE
+	
+	// Handle like a projectile spell
+	if(projectile_behavior)
+		// Make sure it's fully charged if no_early_release is true
+		if(no_early_release && !caller.is_spell_fully_charged())
+			to_chat(caller, span_warning("[src.name] was not finished charging! It fizzles."))
+			revert_cast(caller)
+			return FALSE
+			
+		// Cast the spell
+		if(perform(list(target), TRUE, user = ranged_ability_user))
+			deactivate(caller)
+			return TRUE
+	
+	return FALSE
 
 /obj/effect/temp_visual/trapice
 	icon = 'icons/effects/effects.dmi'


### PR DESCRIPTION
When a non-projectile spell is fully charged, the mouse charging icon locks in place. It remains frozen until the spell is either cast with a left click on a target, or dismissed with a right click. If you left click on nothing, nothing happens.

Also sends you a message in chat when your spell is charged.

Edit: made a new flag so you can grant exceptions to spells like blade burst and snap freeze.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
