### PR TITLE
Small Collection of Oversight Fixes

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -131,6 +131,7 @@
 	force = 25
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/axe/cut/battle, /datum/intent/axe/chop/battle, /datum/intent/axe/bash)
+	wlength = WLENGTH_LONG		//It's a big battle-axe.
 	name = "battle axe"
 	desc = "A steel battleaxe of war. Has a wicked edge."
 	icon_state = "battleaxe"

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -27,6 +27,7 @@
 	neck = /obj/item/clothing/neck/roguetown/talkstone
 	cloak = /obj/item/clothing/cloak/black_cloak
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/black
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 	pants = /obj/item/clothing/under/roguetown/tights/random
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	belt = /obj/item/storage/belt/rogue/leather/plaquesilver

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
@@ -20,7 +20,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	beltr = /obj/item/rogueweapon/shield/buckler
 	beltl= /obj/item/quiver/arrows
-	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Does three small fixes pointed out to me today.
- The battle axe was a short weapon, despite.. being a big fucking two-handed axe. It's now long. Should actually help it be viable for combat too now instead of a shittier longsword type.
- Steppesman had a regular undershirt while its speed-class counterparts had gambeson, or even heavy gambeson. This was likely forgotten about because Steppesman used to have crit resistence. (I guess it's balance-jak but - it's.. basic as shit.)
- Court magician had **no shirt** on round start for some reason. Gives this wizard a shirt so they stop flashing their associates. Our court does not need a registry......

## Why It's Good For The Game

Small collection of oversights, overall just QOL or seemingly forgotten/unintended/missing stuff fixes.
