### PR TITLE
gives swords armor

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -63,6 +63,8 @@
 	force_wielded = 25
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust)
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
+	armor = list("blunt" = 50, "slash" = 50, "stab" = 50, "piercing" = 0)
+	damage_deflection = 15
 	name = "sword"
 	desc = "A simple steel sword, clean and effective."
 	icon_state = "sword1"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
no really you can do that

Anyway! What this PR does is:
- Gives basic sword type a minimum damage taken requirement of 15
- Armor at 50 for blunt / slash / stab.

What does this mean? It means swords will now take 50% less damage when parrying those types, and will require 15 damage minimum to even count it as damage. This will make them significantly more sturdier as far as holding up in longer battles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was aired around as a suggestion for distinguishing swords -- after all they have literally no wood in them to splinter or cut, it's all metal, so this makes them harder to destroy through parries.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
