### PR TITLE
Gatemaster is Back, Baby

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -3656,6 +3656,7 @@
 	dir = 8
 	},
 /obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/gatemaster,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "cBU" = (

--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -231,6 +231,7 @@ GLOBAL_LIST_EMPTY(round_join_times)
 
 #define CTAG_WATCH			"CAT_WATCH"			// Watch class - Handles Town Watch class selector
 #define CTAG_MENATARMS		"CAT_MENATARMS"		// Men-at-Arms class - Handles Men-at-Arms class selector
+#define CTAG_GATEMASTER		"CAT_GATEMASTER"	// Gatemaster class - Handles Gatemaster class selector
 #define CTAG_ROYALGUARD		"CAT_ROYALGUARD"	// Royal Guard class - Handles Royal Guard class selector
 #define CTAG_MERCENARY		"CAT_MERCENARY"		// Mercenary class - Handles Mercenary class selector
 #define CTAG_HAND			"CAT_HAND"			// Hand class - Handles Hand class selector

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -171,6 +171,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	name = "Court Physician"
 	icon_state = "arrow"
 
+/obj/effect/landmark/start/gatemaster
+	name = "Gatemaster"
+	icon_state = "arrow"
+
 /obj/effect/landmark/start/guardsman
 	name = "Watchman"
 	icon_state = "arrow"

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -1,19 +1,21 @@
 /datum/job/roguetown/gatemaster
 	title = "Gatemaster"
+	f_title = "Gatemistress"
 	flag = GATEMASTER
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 1
+	spawn_positions = 1
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	allowed_patrons = ALL_DIVINE_PATRONS
-	tutorial = "Tales speak of the Gatemaster's legendary ability to stand still at a gate and ask people questions."
+	tutorial = "Tales speak of the Gatemaster's legendary ability to stand still at a gate and ask people questions. Noble or commoner, you fill the same boots. To keep the Court and its Courtiers safe."
 	display_order = JDO_GATEMASTER
 
 	outfit = /datum/outfit/job/roguetown/gatemaster
+	advclass_cat_rolls = list(CTAG_GATEMASTER = 20)
 	give_bank_account = 3
-	min_pq = 0
+	min_pq = 3	//idk same as MAA why not
 	max_pq = null
 	round_contrib_points = 2
 
@@ -31,6 +33,7 @@
 			if(!index)
 				index = H.real_name
 			S.name = "gatemaster jupon ([index])"
+			
 /datum/outfit/job/roguetown/gatemaster
 	name = "Gatemaster"
 	jobtype = /datum/job/roguetown/gatemaster
@@ -45,39 +48,67 @@
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	shoes = /obj/item/clothing/shoes/roguetown/boots
 	belt = /obj/item/storage/belt/rogue/leather/black
-	beltl = /obj/item/rogueweapon/mace/cudgel
-	beltr = /obj/item/quiver/arrows
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
 	backpack_contents = list(/obj/item/keyring/gatemaster = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
-	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 5, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
+	if(H.mind)		//Stuff here is universal. Some skills are what will differ.
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 		H.change_stat("strength", 2)
 		H.change_stat("perception", 2)
 		H.change_stat("constitution", 1)
-		H.change_stat("endurance", 1)
-		H.change_stat("speed", 1)
-	if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
-		var/acceptable = list("Tomboy", "Bob", "Curly Short")
-		if(!(H.hairstyle in acceptable))
-			H.hairstyle = pick(acceptable)
-			H.update_hair()
 	H.verbs |= /mob/proc/haltyell
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)	//Only medium because otherwise you could be a bootleg RG. Sorry, nobles, you're not getting that.
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_GUARDSMAN, TRAIT_GENERIC)	//They get this in exchange for slightly lower over-all stats, because we want them in the keep.
+
+// Man-at-Arms Gatemaster - Shares skill-stats similar to MAA, mostly in maces and sling
+/datum/advclass/gatemaster/manatarms
+	name = "Men-at-Arms Gatemaster"
+	tutorial = "You are a member of the Men-at-Arms, this week assigned to handling the gate. You're not expected to handle calls to aid those in town, or elsewhere, unless directly requested."
+	outfit = /datum/outfit/job/roguetown/gatemaster/manatarms
+
+	category_tags = list(CTAG_GATEMASTER)
+
+/datum/outfit/job/roguetown/gatemaster/manatarms/pre_equip(mob/living/carbon/human/H)
+	..()
+	H.mind.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)			//Your main skill for this. Equal to MAA.
+	H.mind.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE)		//Low bow skill to avoid being too aggressive, but good sling skill so - works.
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)	
+	H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)		//Noble one gets better swords.
+
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	belt = /obj/item/storage/belt/rogue/leather/black
+	beltl = /obj/item/rogueweapon/mace/cudgel
+	beltr = /obj/item/quiver/sling/iron
+	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
+
+// Royal Guard / Courtier Gatemaster - Shares skill-stats similar to Royal Guard, mostly in sword and bows
+/datum/advclass/gatemaster/noble
+	name = "Noble Gatemaster"
+	tutorial = "Perhaps you are a royal guard assigned to see to gate duties, or a courtier unlucky enough to be forced "
+	outfit = /datum/outfit/job/roguetown/gatemaster/noble
+
+	category_tags = list(CTAG_GATEMASTER)
+
+/datum/outfit/job/roguetown/gatemaster/noble/pre_equip(mob/living/carbon/human/H)
+..()
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)		//Your main skill for this. Equal to MAA.
+	H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)			//Still not great bow skill but stops aggression. Defense still good.
+	H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)	
+
+	shoes = /obj/item/clothing/shoes/roguetown/nobleboot	//Very slightly better than normal but - I guess drip.
+	belt = /obj/item/storage/belt/rogue/leather/black
+	beltl = /obj/item/rogueweapon/sword
+	beltr = /obj/item/quiver/arrows
+	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -100,7 +100,7 @@
 	category_tags = list(CTAG_GATEMASTER)
 
 /datum/outfit/job/roguetown/gatemaster/noble/pre_equip(mob/living/carbon/human/H)
-..()
+	..()
 	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)		//Your main skill for this. Equal to MAA.
 	H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)			//Still not great bow skill but stops aggression. Defense still good.
 	H.mind.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -112,3 +112,4 @@
 	beltl = /obj/item/rogueweapon/sword
 	beltr = /obj/item/quiver/arrows
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
+	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)				//Nobleman at da gate, what he gonna do???

--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -50,7 +50,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backpack_contents = list(/obj/item/keyring/gatemaster = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(/obj/item/storage/keyring/guardcastle = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
 	if(H.mind)		//Stuff here is universal. Some skills are what will differ.
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
@@ -94,7 +94,7 @@
 // Royal Guard / Courtier Gatemaster - Shares skill-stats similar to Royal Guard, mostly in sword and bows
 /datum/advclass/gatemaster/noble
 	name = "Noble Gatemaster"
-	tutorial = "Perhaps you are a royal guard assigned to see to gate duties, or a courtier unlucky enough to be forced "
+	tutorial = "Perhaps you are a royal guard assigned to see to gate duties, or a courtier unlucky enough to be forced to do so. Your post may not be as noble as you, but you serve your purpose."
 	outfit = /datum/outfit/job/roguetown/gatemaster/noble
 
 	category_tags = list(CTAG_GATEMASTER)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1309,6 +1309,7 @@
 #include "code\modules\jobs\job_types\roguetown\courtier\physician.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\bogguard.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\dungeoneer.dm"
+#include "code\modules\jobs\job_types\roguetown\garrison\gatemaster.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\manorguard.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\sergeant.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\townguard.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Just re-adds Gatemaster (Or Gatemistress, slay) back to job list. Basically nerfed the hell out of the jobs stats and skills and made it a semi-combat able job that'll be mostly expected to.. you know. Sit at the gate.

Has two loadouts, one a Man-at-arms loadout that just doesn't give you the noble trait and gives you a mace and sling skill, and the noble one which gives you the noble trait, sword skill, and slight bow skill.

OK at combat, not great, but capable. It's a defense-only role really anyway and processing gate people.

## Why It's Good For The Game

I shit you not I've been asked for this, unironically, by at least 4 people. Who said they prefer manning the gate rather than being an active running around royal guard or MAA. If people want to sit at the gate, let them I guess as this role rather than the slots for the other two since then they'd be obligated to do more duties to an extent.

I think this is fine as a role because it's barely combat oriented and it's not like guard slots are commonly maxed out anyway. It's weaker than an MAA by far skills-wise, so seems fine. Could always axe an MAA slot from 8 to 7 if it's REALLY needed but.. honestly no one would even notice that.