### PR TITLE
Dye Station can now change detail colors

### DIFF
--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -7,6 +7,7 @@
 	anchored = TRUE
 	var/atom/movable/inserted
 	var/activecolor = "#FFFFFF"
+	var/activecolor_detail = "#FFFFFF"
 	/// Allow holder'd mobs
 	var/allow_mobs = TRUE
 
@@ -109,8 +110,16 @@
 		dat += "Item inserted: [inserted]<HR>"
 		dat += "<A href='?src=\ref[src];select=1'>Select new color.</A><BR>"
 		dat += "Color: <font color='[activecolor]'>&#9899;</font>"
-		dat += "<A href='?src=\ref[src];paint=1'>Apply new color.</A><BR><BR>"
+		dat += "<A href='?src=\ref[src];paint=1'>Apply new color.</A> | "
 		dat += "<A href='?src=\ref[src];clear=1'>Remove paintjob.</A><BR><BR>"
+		if(istype(inserted,/obj/item))
+			var/obj/item/inserted_item = inserted
+			if(inserted_item.detail_color)
+				dat += "<A href='?src=\ref[src];select_detail=1'>Select new detail color.</A><BR>"
+				dat += "Detail Color: <font color='[activecolor_detail]'>&#9899;</font>"
+				dat += "<A href='?src=\ref[src];paint_detail=1'>Apply new color.</A> | "
+				dat += "<A href='?src=\ref[src];clear_detail=1'>Remove paintjob.</A><BR><BR>"
+		
 		dat += "<A href='?src=\ref[src];eject=1'>Eject item.</A><BR><BR>"
 
 	var/datum/browser/menu = new(user, "colormate","Dye Station", 400, 400, src)
@@ -134,6 +143,13 @@
 		activecolor = selectable_colors[choice]
 		updateUsrDialog()
 
+	if(href_list["select_detail"])
+		var/choice = input(usr,"Choose your dye:","Dyes",null) as null|anything in selectable_colors
+		if(!choice)
+			return
+		activecolor_detail = selectable_colors[choice]
+		updateUsrDialog()
+
 	if(href_list["paint"])
 		if(!inserted)
 			return
@@ -141,10 +157,30 @@
 		playsound(src, "bubbles", 50, 1)
 		updateUsrDialog()
 
+	if(href_list["paint_detail"])
+		if(!inserted)
+			return
+		var/obj/item/inserted_item = inserted
+		inserted_item.detail_color = activecolor_detail
+		inserted_item.update_icon()
+		if(inserted_item in GLOB.lordcolor) //Prevent a latejoining duke from changing this color
+			GLOB.lordcolor -= inserted_item
+		playsound(src, "bubbles", 50, 1)
+		updateUsrDialog()
+
 	if(href_list["clear"])
 		if(!inserted)
 			return
 		inserted.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+		playsound(src, "bubbles", 50, 1)
+		updateUsrDialog()
+
+	if(href_list["clear_detail"])
+		if(!inserted)
+			return
+		var/obj/item/inserted_item = inserted
+		inserted_item.detail_color = initial(inserted_item.detail_color)
+		inserted_item.update_icon()
 		playsound(src, "bubbles", 50, 1)
 		updateUsrDialog()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Ever sewn a royal shirt, just to stare at the ugly purple color the Duke picked at the start of the round and that you are unable to now change? Ever regretted your pick of tabard colors and had to toss it away to find a new one?

Let me present to you: The Humble Dye Station.

![image](https://github.com/user-attachments/assets/d9fe9ed7-bf62-4669-89e0-c7058720645d)

Dye Stations will now show up an option for secondary color on applicable items. They will only display a primary color selection for clothes that lack this feature. I've changed the dialog a little so it's more condensed.

![image](https://github.com/user-attachments/assets/0172c4d3-306e-4e7b-b931-688ddd1b5e95)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Customization is good. Being stuck with the duchy's colors as a foreign noble is bad, for example.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
