### PR TITLE
Harlequin [New Adventurer Trader subclass]

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -10,7 +10,7 @@
 					"Brewer" = "You make your coin peddling imported alcohols from all over the world, though you're no stranger to the craft, and have experience brewing your own ale in a pinch.",
 					"Jeweler" = "You make your coin peddling exotic jewelry, gems, and shiny things.",
 					"Doomsayer" = "THE WORLD IS ENDING!!! At least, that's what you want your clients to believe. You'll offer them a safe place in the new world, of course - built by yours truly.",
-					"Scholar" = "You are a scholar traveling the world in order to write a book about your ventures. You trade in stories and tales of your travels."
+					"Scholar" = "You are a scholar traveling the world in order to write a book about your ventures. You trade in stories and tales of your travels.",
 					"Harlequin" = "You are a travelling entertainer - a jester by trade. Where you go, chaos follows - and mischief is made.")
 
 /datum/outfit/job/roguetown/adventurer/trader/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -16,7 +16,7 @@
 /datum/outfit/job/roguetown/adventurer/trader/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_blindness(-3)
-	var/classes = list("Peddler","Brewer","Jeweler","Doomsayer","Scholar")
+	var/classes = list("Peddler","Brewer","Jeweler","Doomsayer","Scholar","Harlequin")
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -168,7 +168,7 @@
 			H.change_stat("endurance", 1)
 
 		if ("Harlequin")
-			to_chat(H, spawn_warning ("You are a travelling entertainer - a jester by trade. Where you go, chaos follows - and mischief is made."))
+			to_chat(H, span_warning ("You are a travelling entertainer - a jester by trade. Where you go, chaos follows - and mischief is made."))
 			shoes = /obj/item/clothing/shoes/roguetown/jester
 			pants = /obj/item/clothing/under/roguetown/tights
 			armor = /obj/item/clothing/suit/roguetown/shirt/jester

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -10,7 +10,8 @@
 					"Brewer" = "You make your coin peddling imported alcohols from all over the world, though you're no stranger to the craft, and have experience brewing your own ale in a pinch.",
 					"Jeweler" = "You make your coin peddling exotic jewelry, gems, and shiny things.",
 					"Doomsayer" = "THE WORLD IS ENDING!!! At least, that's what you want your clients to believe. You'll offer them a safe place in the new world, of course - built by yours truly.",
-					"Scholar" = "You are a scholar traveling the world in order to write a book about your ventures. You trade in stories and tales of your travels.")
+					"Scholar" = "You are a scholar traveling the world in order to write a book about your ventures. You trade in stories and tales of your travels."
+					"Harlequin" = "You are a travelling entertainer - a jester by trade. Where you go, chaos follows - and mischief is made.")
 
 /datum/outfit/job/roguetown/adventurer/trader/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -166,6 +167,30 @@
 			H.change_stat("speed", 1)
 			H.change_stat("endurance", 1)
 
+		if ("Harlequin")
+			to_chat(H, spawn_warning ("You are a travelling entertainer - a jester by trade. Where you go, chaos follows - and mischief is made."))
+			hoes = /obj/item/clothing/shoes/roguetown/jester
+			pants = /obj/item/clothing/under/roguetown/tights
+			armor = /obj/item/clothing/suit/roguetown/shirt/jester
+			belt = /obj/item/storage/belt/rogue/leather
+			beltr = /obj/item/rogueweapon/huntingknife/idagger
+			beltl = /obj/item/flashlight/flare/torch/lantern
+			head = /obj/item/clothing/head/roguetown/jester
+			neck = /obj/item/storage/belt/rogue/pouch/coins/mid
+			H.cmode_music = 'sound/music/combat_jester.ogg'
+			backpack_contents = list(/obj/item/smokebomb = 3, /obj/item/storage/pill_bottle/dice = 1, /obj/item/toy/cards/deck = 1)
+			H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/stealing, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/music, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
+			ADD_TRAIT(H, TRAIT_NUTCRACKER, TRAIT_GENERIC)
+			H.change_stat("intelligence", 1)
+			H.change_stat("perception", 1)
+			H.change_stat("endurance", 1)
+			H.change_stat("speed", 2)
 
 /obj/item/clothing/mask/rogue/ragmask/black
 	color = CLOTHING_BLACK

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -175,7 +175,7 @@
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
 			beltl = /obj/item/flashlight/flare/torch/lantern
-			backr = /obj/item/storage/backpack/rogue/satchel
+			backl = /obj/item/storage/backpack/rogue/satchel
 			head = /obj/item/clothing/head/roguetown/jester
 			neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 			H.cmode_music = 'sound/music/combat_jester.ogg'
@@ -192,6 +192,24 @@
 			H.change_stat("perception", 1)
 			H.change_stat("endurance", 1)
 			H.change_stat("speed", 2)
+			var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
+			var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+			H.set_blindness(0)
+			switch(weapon_choice)
+				if("Harp")
+					backr = /obj/item/rogue/instrument/harp
+				if("Lute")
+					backr = /obj/item/rogue/instrument/lute
+				if("Accordion")
+					backr = /obj/item/rogue/instrument/accord
+				if("Guitar")
+					backr = /obj/item/rogue/instrument/guitar
+				if("Hurdy-Gurdy")
+					backr = /obj/item/rogue/instrument/hurdygurdy
+				if("Viola")
+					backr = /obj/item/rogue/instrument/viola
+				if("Vocal Talisman")
+					backr = /obj/item/rogue/instrument/vocals
 
 /obj/item/clothing/mask/rogue/ragmask/black
 	color = CLOTHING_BLACK

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -169,7 +169,7 @@
 
 		if ("Harlequin")
 			to_chat(H, spawn_warning ("You are a travelling entertainer - a jester by trade. Where you go, chaos follows - and mischief is made."))
-			hoes = /obj/item/clothing/shoes/roguetown/jester
+			shoes = /obj/item/clothing/shoes/roguetown/jester
 			pants = /obj/item/clothing/under/roguetown/tights
 			armor = /obj/item/clothing/suit/roguetown/shirt/jester
 			belt = /obj/item/storage/belt/rogue/leather

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -175,6 +175,7 @@
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
 			beltl = /obj/item/flashlight/flare/torch/lantern
+			backr = /obj/item/storage/backpack/rogue/satchel
 			head = /obj/item/clothing/head/roguetown/jester
 			neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 			H.cmode_music = 'sound/music/combat_jester.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds the Harlequin, a new adventurer trader subclass. It's essentially a travelling jester.

They spawn with jester's clothing, an instrument of their choosing, a bag of dice, some playing cards, an iron dagger, and 3 smoke bombs.

None of the crazy z-jumper traits or unique spells that actual jesters get, sorry. The actual court jester should still retain some unique content - he's Xylix's top guy.

## Why It's Good For The Game

Variety. A new adventurer class with some unique flavor. Debated making this a towner class, but decided it might better fit the trader adventurer class. If people would prefer it as a towner class instead let me know in the comments, I guess.

i'm just a silly little guy

![image](https://github.com/user-attachments/assets/d607262e-8fd3-44a6-bda1-5a71604cb3e7)