### PR TITLE
Pestra/Astrata rework draft

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -10,8 +10,8 @@
 	worshippers = "The Noble Hearted, Zealots and Farmers"
 	mob_traits = list(TRAIT_APRICITY)
 	t1 = /obj/effect/proc_holder/spell/invoked/sacred_flame_rogue
-	t2 = /obj/effect/proc_holder/spell/invoked/heal
-	t3 = /obj/effect/proc_holder/spell/invoked/revive
+	t2 = /obj/effect/proc_holder/spell/targeted/astrata_projectile
+	t3 = /obj/effect/proc_holder/spell/invoked/flame_shield
 	t4 = /obj/effect/proc_holder/spell/invoked/smite
 	confess_lines = list(
 		"ASTRATA IS MY LIGHT!",

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -12,6 +12,7 @@
 	t1 = /obj/effect/proc_holder/spell/invoked/sacred_flame_rogue
 	t2 = /obj/effect/proc_holder/spell/invoked/heal
 	t3 = /obj/effect/proc_holder/spell/invoked/revive
+	t4 = /obj/effect/proc_holder/spell/invoked/smite
 	confess_lines = list(
 		"ASTRATA IS MY LIGHT!",
 		"ASTRATA BRINGS LAW!",

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -42,80 +42,188 @@
 	revert_cast()
 	return FALSE
 
-/obj/effect/proc_holder/spell/invoked/revive
-	name = "Anastasis"
-	overlay_state = "revive"
-	releasedrain = 90
+/obj/effect/proc_holder/spell/targeted/astrata_projectile
+	name = "Astrata's Wrath"
+	desc = "Launches a projectile that changes based on the time of day."
+	school = "evocation"
+	clothes_req = FALSE
+	invocation = "Astrata's fury, manifest!"
+	invocation_type = "shout"
+	range = 20
+	cooldown_min = 30 SECONDS
+	selection_type = "view"
+	sound = 'sound/magic/fireball.ogg'
+	var/fireball_damage = 20
+	var/spitfire_damage = 15
+	var/spitfire_burn = 10
+	active_msg = "You prepare to channel Astrata's wrath!"
+	action_icon = 'icons/mob/actions/actions_spells.dmi'
+	action_icon_state = "fireball"
+	action_background_icon_state = "bg_spell"
+	antimagic_allowed = TRUE
+	
+/obj/effect/proc_holder/spell/targeted/astrata_projectile/cast(list/targets, mob/living/user)
+	for(var/mob/living/target in targets)
+		if(GLOB.tod == "night")
+			// At night, cast spitfire
+			var/obj/projectile/magic/spitfire/SF = new(get_turf(user))
+			SF.damage = spitfire_damage
+			SF.burn = spitfire_burn
+			SF.firer = user
+			SF.fire(target)
+			user.visible_message(span_danger("[user] spits a stream of blue fire at [target]!"))
+		else
+			// During day, cast fireball
+			var/obj/projectile/magic/fireball/FB = new(get_turf(user))
+			FB.damage = fireball_damage
+			FB.firer = user
+			FB.fire(target)
+			user.visible_message(span_danger("[user] casts a fireball at [target]!"))
+
+/obj/projectile/magic/spitfire
+	name = "spitfire"
+	icon_state = "fireball"
+	damage = 15
+	damage_type = BURN
+	var/burn = 10
+	
+/obj/projectile/magic/spitfire/on_hit(target)
+	. = ..()
+	if(isliving(target))
+		var/mob/living/L = target
+		L.adjust_fire_stacks(1)
+		L.IgniteMob()
+		L.adjustFireLoss(burn)
+
+/obj/effect/proc_holder/spell/invoked/flame_shield
+	name = "Flame Shield"
+	overlay_state = "flame_shield"
+	releasedrain = 60
 	chargedrain = 0
-	chargetime = 50
-	range = 1
+	chargetime = 30
+	range = 2
 	warnie = "sydwarning"
 	no_early_release = TRUE
 	movement_interrupt = TRUE
 	chargedloop = /datum/looping_sound/invokeholy
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
-	sound = 'sound/magic/revive.ogg'
+	sound = 'sound/magic/heal.ogg'
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
-	charge_max = 2 MINUTES
+	charge_max = 1 MINUTES
 	miracle = TRUE
-	devotion_cost = 80
-	/// Amount of PQ gained for reviving people
-	var/revive_pq = PQ_GAIN_REVIVE
+	devotion_cost = 50
+	invocation = "Astrata, shield thy faithful in your holy flames!"
+	invocation_type = "shout"
 
-/obj/effect/proc_holder/spell/invoked/revive/cast(list/targets, mob/living/user)
-	. = ..()
-	if(isliving(targets[1]))
-		testing("revived1")
-		var/mob/living/target = targets[1]
-		if(target == user)
-			return FALSE
-		if(target.stat < DEAD)
-			to_chat(user, span_warning("Nothing happens."))
-			return FALSE
-		if(GLOB.tod == "night")
-			to_chat(user, span_warning("Let there be light."))
-		for(var/obj/structure/fluff/psycross/S in oview(5, user))
-			S.AOE_flash(user, range = 8)
-		if(target.mob_biotypes & MOB_UNDEAD) //positive energy harms the undead
-			target.visible_message(span_danger("[target] is unmade by holy light!"), span_userdanger("I'm unmade by holy light!"))
-			target.gib()
-			return TRUE
-		target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
-		if(!target.revive(full_heal = FALSE))
-			to_chat(user, span_warning("Nothing happens."))
-			return FALSE
-		testing("revived2")
-		var/mob/living/carbon/spirit/underworld_spirit = target.get_spirit()
-		//GET OVER HERE!
-		if(underworld_spirit)
-			var/mob/dead/observer/ghost = underworld_spirit.ghostize()
-			qdel(underworld_spirit)
-			ghost.mind.transfer_to(target, TRUE)
-		target.grab_ghost(force = TRUE) // even suicides
-		target.emote("breathgasp")
-		target.Jitter(100)
-		target.update_body()
-		target.visible_message(span_notice("[target] is revived by holy light!"), span_green("I awake from the void."))
-		if(target.mind)
-			if(revive_pq && !HAS_TRAIT(target, TRAIT_IWASREVIVED) && user?.ckey)
-				adjust_playerquality(revive_pq, user.ckey)
-				ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
-			target.mind.remove_antag_datum(/datum/antagonist/zombie)
-		return TRUE
-	revert_cast()
-	return FALSE
-
-/obj/effect/proc_holder/spell/invoked/revive/cast_check(skipcharge = 0,mob/user = usr)
+/obj/effect/proc_holder/spell/invoked/flame_shield/cast(list/targets, mob/living/user)
 	if(!..())
 		return FALSE
-	var/found = null
-	for(var/obj/structure/fluff/psycross/S in oview(5, user))
-		found = S
-	if(!found)
-		to_chat(user, span_warning("I need a holy cross."))
+
+	if(!isliving(targets[1]))
+		revert_cast()
 		return FALSE
+
+	var/mob/living/L = targets[1]
+	
+	// Protect the target with flame stacks that don't harm them
+	L.visible_message(span_notice("Divine flames engulf [L], forming a protective shield!"), span_green("I feel Astrata's fire shield me from harm!"))
+	
+	// Apply fire stacks but prevent them from hurting the target
+	L.adjust_fire_stacks(15)
+	L.IgniteMob()
+	ADD_TRAIT(L, TRAIT_FIRE_IMMUNE, "flame_shield")
+	
+	// Create a flame shield effect
+	var/obj/effect/flame_shield_effect/shield = new(get_turf(L))
+	shield.target = L
+	shield.shield_health = 100
+	shield.attached_user = user
+	
+	// Start processing the shield effect
+	START_PROCESSING(SSobj, shield)
+	
+	// Let the target know what's happening
+	to_chat(L, span_notice("The divine flames will shield you from [shield.shield_health] damage. The shield will gradually weaken over time."))
+	
 	return TRUE
+
+/obj/effect/flame_shield_effect
+	name = "flame shield"
+	desc = "A shield of divine flames."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "fire_shield"
+	anchored = TRUE
+	var/mob/living/target = null
+	var/shield_health = 100
+	var/shield_decay_rate = 5 // Amount of shield health lost per tick
+	var/last_decay_time = 0
+	var/decay_interval = 3 SECONDS
+	var/mob/living/attached_user = null
+
+/obj/effect/flame_shield_effect/Initialize()
+	. = ..()
+	alpha = 200
+	layer = ABOVE_MOB_LAYER
+	last_decay_time = world.time
+
+/obj/effect/flame_shield_effect/Destroy()
+	if(target)
+		to_chat(target, span_warning("Your flame shield dissipates!"))
+		REMOVE_TRAIT(target, TRAIT_FIRE_IMMUNE, "flame_shield")
+		target.ExtinguishMob()
+		target = null
+	attached_user = null
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/effect/flame_shield_effect/process()
+	if(!target || target.stat == DEAD || !target.fire_stacks)
+		qdel(src)
+		return
+	
+	// Position the effect on the target
+	forceMove(get_turf(target))
+	
+	// Decay shield over time
+	if(world.time >= last_decay_time + decay_interval)
+		shield_health -= shield_decay_rate
+		last_decay_time = world.time
+		
+		// Visual feedback on shield strength
+		alpha = 200 * (shield_health / 100)
+		
+		// Also reduce fire stacks
+		target.adjust_fire_stacks(-1)
+	
+	// If shield depleted or fire stacks gone, remove it
+	if(shield_health <= 0 || target.fire_stacks <= 0)
+		qdel(src)
+
+// When the shielded mob takes damage, reduce shield health instead
+/obj/effect/flame_shield_effect/Crossed(atom/movable/AM)
+	. = ..()
+	if(istype(AM, /obj/projectile))
+		var/obj/projectile/P = AM
+		reduce_shield(P.damage)
+
+/obj/effect/flame_shield_effect/proc/reduce_shield(amount)
+	shield_health -= amount
+	if(shield_health <= 0)
+		qdel(src)
+		return
+	
+	// Visual feedback
+	alpha = 200 * (shield_health / 100)
+	
+	// Reduce fire stacks proportionally to damage absorbed
+	var/stacks_to_reduce = amount / 10
+	if(stacks_to_reduce > 0)
+		target.adjust_fire_stacks(-stacks_to_reduce)
+	
+	// If fire stacks gone, remove shield
+	if(target.fire_stacks <= 0)
+		qdel(src)
 
 /obj/effect/proc_holder/spell/invoked/smite
 	name = "Astrata's Judgment"
@@ -215,7 +323,7 @@
 				if(3)
 					L.visible_message(span_danger("The air crackles with divine fury around [L]!"))
 				if(4)
-					L.visible_message(span_danger("The very air begins to burn!"))
+					L.visible_message(span_danger("The air begins to burn!"))
 				if(5)
 					L.visible_message(span_danger("Reality warps as the sun's fury bears down!"))
 				if(6)

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -135,6 +135,8 @@
 	charge_max = 3 MINUTES
 	miracle = TRUE
 	devotion_cost = 70
+	invocation = "By Astrata's burning gaze, let divine judgment rain!"
+	invocation_type = "shout"
 	var/smite_active = FALSE
 	var/smite_target = null
 	var/warning_stage = 0

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -122,12 +122,12 @@
 	overlay_state = "smite"
 	releasedrain = 60
 	chargedrain = 0
-	chargetime = 100
+	chargetime = 0
 	range = 15
 	warnie = "sydwarning"
-	no_early_release = TRUE
-	movement_interrupt = TRUE
-	chargedloop = /datum/looping_sound/invokeholy
+	no_early_release = FALSE
+	movement_interrupt = FALSE
+	chargedloop = null
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/magic/heal.ogg'
 	associated_skill = /datum/skill/magic/holy
@@ -224,7 +224,7 @@
 			return
 	// After 10 seconds, start applying fire stacks
 	else if(world.time >= last_stack_time + 2 SECONDS)  // Apply fire every 2 seconds after the warning phase
-		L.adjust_fire_stacks(2)
+		L.adjust_fire_stacks(10)  // Changed from 2 to 10 for more intense burning
 		L.IgniteMob()
 		last_stack_time = world.time
 		L.visible_message(span_danger("Divine flames engulf [L] as Astrata's judgment rains down!"))

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -185,14 +185,32 @@
 		for(var/obj/structure/fluff/psycross/S in oview(5, user))
 			S.AOE_flash(user, range = 8)
 
+		// Revive the target if they're dead
+		if(target.stat == DEAD)
+			target.revive(full_heal = FALSE)
+			target.grab_ghost(force = TRUE) // even suicides
+			target.emote("breathgasp")
+			target.Jitter(100)
+			target.update_body()
+			target.visible_message(span_notice("[target] is revived by divine light!"), span_green("I awake from the void."))
+			if(target.mind)
+				target.mind.remove_antag_datum(/datum/antagonist/zombie)
+			return TRUE
+		
+		// Otherwise attempt to cure rot
 		if(remove_rot(target = target, user = user, method = "prayer",
 			success_message = "The rot leaves [target]'s body!",
 			fail_message = "Nothing happens."))
 			target.visible_message(span_notice("The rot leaves [target]'s body!"), span_green("I feel the rot leave my body!"))
 			return TRUE
-		else //Attempt failed, no rot
-			target.visible_message(span_warning("The rot fails to leave [target]'s body!"), span_warning("I feel no different..."))
-			return FALSE
+		else //Attempt failed, no rot but also not dead
+			target.visible_message(span_notice("[target]'s body is purified by the light."), span_green("I feel purified by the light."))
+			// Heal some damage anyway
+			target.adjustBruteLoss(-30)
+			target.adjustFireLoss(-30)
+			target.adjustToxLoss(-30)
+			target.adjustOxyLoss(-60)
+			return TRUE
 	revert_cast()
 	return FALSE
 


### PR DESCRIPTION
This is a preliminary draft pending maintainer approval. Currently, having two gods with overlapping functions and only minor distinctions feels redundant.

Changes proposed:

Pestra’s cure Rot: Now revives any target regardless of their rotted status.
Astrata: Heal and revive removed. Gains a t2 projectile that is spitfire at night and a fireball during the day. Additionally gains t3 Fire Shield, granting fire immunity and a decaying damage-absorbing shield. Fire stacks diminish over time or as damage is absorbed. Only castable during the day.
T4 is smite as proposed here: https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/1789