### PR TITLE
Grant Nobility Bugfix/tweak

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -266,9 +266,15 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	if(QDELETED(recruit) || QDELETED(recruiter))
 		return FALSE
 	if(HAS_TRAIT(recruit, TRAIT_NOBLE))
-		recruiter.say("I HEREBY STRIP YOU, [uppertext(recruit.name)], OF NOBILITY!!")
-		REMOVE_TRAIT(recruit, TRAIT_NOBLE, TRAIT_GENERIC)
-		return FALSE
+		if(!HAS_TRAIT(recruit,TRAIT_OUTLANDER))
+			recruiter.say("I HEREBY STRIP YOU, [uppertext(recruit.name)], OF NOBILITY!!")
+			REMOVE_TRAIT(recruit, TRAIT_NOBLE, TRAIT_GENERIC)
+			REMOVE_TRAIT(recruit, TRAIT_NOBLE, TRAIT_VIRTUE)
+			return FALSE
+		else
+			to_chat(recruiter, span_warning("Their nobility is not mine to strip!"))
+			return FALSE
 	recruiter.say("I HEREBY GRANT YOU, [uppertext(recruit.name)], NOBILITY!")
 	ADD_TRAIT(recruit, TRAIT_NOBLE, TRAIT_GENERIC)
+	REMOVE_TRAIT(recruit, TRAIT_OUTLANDER, ADVENTURER_TRAIT)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

The Duke's 'Grant Nobility' spell now will:
- Give a text message saying you cannot remove nobility from foreigners instead of fail-casting spectacularly.
- Allow you to remove nobility from towners who take the noble virtue.
- Granting nobility will now REMOVE the outlander trait from those you grant it too, effectively making them no longer foreign.

## Why It's Good For The Game

Shores up the functionality.
