### PR TITLE
Reverts Recall Spell

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -138,8 +138,7 @@
 		/obj/effect/proc_holder/spell/invoked/counterspell,
 		/obj/effect/proc_holder/spell/invoked/enlarge,
 		/obj/effect/proc_holder/spell/invoked/leap,
-		/obj/effect/proc_holder/spell/invoked/mirror_transform,
-		/obj/effect/proc_holder/spell/invoked/blink
+		/obj/effect/proc_holder/spell/invoked/mirror_transform
 	)
 
 /obj/effect/proc_holder/spell/invoked/rituos/miracle

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -138,6 +138,7 @@
 		/obj/effect/proc_holder/spell/invoked/counterspell,
 		/obj/effect/proc_holder/spell/invoked/enlarge,
 		/obj/effect/proc_holder/spell/invoked/leap,
+		/obj/effect/proc_holder/spell/invoked/blink,
 		/obj/effect/proc_holder/spell/invoked/mirror_transform
 	)
 

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -139,8 +139,7 @@
 		/obj/effect/proc_holder/spell/invoked/enlarge,
 		/obj/effect/proc_holder/spell/invoked/leap,
 		/obj/effect/proc_holder/spell/invoked/mirror_transform,
-		/obj/effect/proc_holder/spell/invoked/blink,
-    	/obj/effect/proc_holder/spell/self/recall
+		/obj/effect/proc_holder/spell/invoked/blink
 	)
 
 /obj/effect/proc_holder/spell/invoked/rituos/miracle

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -230,7 +230,6 @@
 		/obj/effect/proc_holder/spell/invoked/leap,
 		/obj/effect/proc_holder/spell/invoked/mirror_transform,
 		/obj/effect/proc_holder/spell/invoked/blink,
-		/obj/effect/proc_holder/spell/self/recall,
 		/obj/effect/proc_holder/spell/invoked/mindlink
 
 		
@@ -1709,7 +1708,7 @@
 	playsound(get_turf(user), 'sound/magic/unmagnet.ogg', 50, TRUE)
 	return TRUE
 
-
+/*	-Teleport to lumby
 /obj/effect/proc_holder/spell/self/recall
 	name = "Recall"
 	desc = "Memorize your current location, allowing you to return to it after a delay."
@@ -1766,6 +1765,7 @@
 	else
 		to_chat(H, span_warning("Your concentration was broken!"))
 		return FALSE
+*/
 /obj/effect/proc_holder/spell/invoked/mindlink
 	name = "Mindlink"
 	desc = "Establish a telepathic link with an ally for one minute. Use ,y before a message to communicate telepathically."

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -228,11 +228,11 @@
 		/obj/effect/proc_holder/spell/invoked/counterspell,
 		/obj/effect/proc_holder/spell/invoked/enlarge,
 		/obj/effect/proc_holder/spell/invoked/leap,
+		/obj/effect/proc_holder/spell/invoked/blink,
 		/obj/effect/proc_holder/spell/invoked/mirror_transform,
 		/obj/effect/proc_holder/spell/invoked/mindlink
-
-		
 	)
+
 	for(var/i = 1, i <= spell_choices.len, i++)
 		choices["[spell_choices[i].name]: [spell_choices[i].cost]"] = spell_choices[i]
 
@@ -1663,7 +1663,7 @@
 	destination_turf = T
 	user_turf.add_overlay(target_effect)
 	destination_turf.add_overlay(tile_effect)
-/*
+
 /obj/effect/proc_holder/spell/invoked/blink
 	name = "Blink"
 	desc = "Teleport to a targeted location within your field of view. Limited to a range of 7 tiles."
@@ -1712,7 +1712,7 @@
 		turf_list.len--
 	
 	for(var/turf/turf in turf_list)
-		if(turf.density || structure.density)
+		if(turf.density)
 			to_chat(user, span_warning("I cannot blink through walls!"))
 			revert_cast()
 			return
@@ -1761,7 +1761,7 @@
 	user.visible_message(span_danger("<b>[user] vanishes in a brilliant flash of sparks!</b>"), span_notice("<b>I blink through space in an instant!</b>"))
 	playsound(get_turf(user), 'sound/magic/unmagnet.ogg', 50, TRUE)
 	return TRUE
-
+/*	- Teleporting to Lumby, lumby drop 500g
 /obj/effect/proc_holder/spell/self/recall
 	name = "Recall"
 	desc = "Memorize your current location, allowing you to return to it after a delay."

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -229,7 +229,6 @@
 		/obj/effect/proc_holder/spell/invoked/enlarge,
 		/obj/effect/proc_holder/spell/invoked/leap,
 		/obj/effect/proc_holder/spell/invoked/mirror_transform,
-		/obj/effect/proc_holder/spell/invoked/blink,
 		/obj/effect/proc_holder/spell/invoked/mindlink
 
 		
@@ -1664,6 +1663,7 @@
 	destination_turf = T
 	user_turf.add_overlay(target_effect)
 	destination_turf.add_overlay(tile_effect)
+/*
 /obj/effect/proc_holder/spell/invoked/blink
 	name = "Blink"
 	desc = "Teleport to a targeted location within your field of view."
@@ -1698,7 +1698,7 @@
 		turf_list.len--
 	
 	for(var/turf/turf in turf_list)
-		if(turf.density)
+		if(turf.density || structure.density)
 			to_chat(user, span_warning("I cannot blink through walls!"))
 			revert_cast()
 			return
@@ -1708,7 +1708,6 @@
 	playsound(get_turf(user), 'sound/magic/unmagnet.ogg', 50, TRUE)
 	return TRUE
 
-/*	-Teleport to lumby
 /obj/effect/proc_holder/spell/self/recall
 	name = "Recall"
 	desc = "Memorize your current location, allowing you to return to it after a delay."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

got asked to do so because exactly what i thought would happen happened apparently. 

im kinda annoyed about this not because the spell or even that it got merged but players felt negatively about it but didn't voice it despite - talking about it in the discord, getting buried, for ages. but w/e, that's the literal norm for ss13 servers.

can search the word 'recall' and see how many complaints it got so fast.

## Why It's Good For The Game

recall isn't great for the game. it has no counterplay, allows across-the-map teleport, the suggestions and requests given on the pr such as casting time, etc weren't taken into account, etc.

if someone plans to fix it instead of revert, go for it - im just not really wanting to fix this rn, i kept the code in, just commented it out so maybe could get future use as something else (or maybe antag-unique thing, idk.)