### PR TITLE
Blink fixes

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -7809,10 +7809,7 @@
 /area/rogue/indoors/shelter/woods)
 "fqn" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/bars/grille{
-	density = 1
-	},
-/turf/open/floor/rogue/cobble,
+/turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/indoors/town/garrison)
 "fqw" = (
 /obj/structure/fluff/railing/border{
@@ -30423,10 +30420,7 @@
 	},
 /area/rogue/outdoors/town)
 "vqp" = (
-/obj/structure/bars/grille{
-	density = 1
-	},
-/turf/open/floor/rogue/blocks,
+/turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/indoors/town/garrison)
 "vqB" = (
 /obj/structure/bars,
@@ -32335,14 +32329,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains)
 "wLs" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8
-	},
 /obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/bars/grille{
-	density = 1
-	},
-/turf/open/floor/rogue/blocks,
+/turf/closed/wall/mineral/rogue/stone/window,
 /area/rogue/indoors/town/garrison)
 "wLy" = (
 /obj/structure/closet/crate/roguecloset,
@@ -81906,7 +81894,7 @@ xOC
 xOC
 xOC
 xOC
-xOC
+biI
 biI
 biI
 biI
@@ -82064,7 +82052,7 @@ xOC
 xOC
 xOC
 xOC
-xOC
+biI
 biI
 biI
 biI
@@ -82222,14 +82210,14 @@ xOC
 xOC
 xOC
 xOC
-xOC
-xOC
-xOC
-xOC
-xOC
-xOC
-xOC
-xOC
+biI
+biI
+biI
+biI
+biI
+biI
+biI
+biI
 biI
 biI
 biI

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1631,7 +1631,7 @@
 					return
 				to_chat(user, span_info("I begin to meld with the shadows.."))
 				lockon(T, user)
-				if(do_after(user, 70))
+				if(do_after(user, 2 SECONDS))
 					tp(user)
 				else
 					reset(silent = TRUE)
@@ -1669,11 +1669,11 @@
 	name = "Blink"
 	desc = "Teleport to a targeted location within your field of view. Limited to a range of 7 tiles."
 	school = "conjuration"
-	cost = 1
+	cost = 2
 	releasedrain = 30
 	chargedrain = 1
-	chargetime = 15
-	charge_max = 20 SECONDS
+	chargetime = 3 SECONDS
+	charge_max = 30 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
@@ -1721,28 +1721,21 @@
 	// Check for doors and bars in the path
 	for(var/turf/traversal_turf in turf_list)
 		// Check for mineral doors
-		for(var/obj/structure/mineral_door/door in traversal_turf.contents)
+		for(var/obj/structure/mineral_door/door in (traversal_turf.contents + T.contents))
 			if(door.density)
 				to_chat(user, span_warning("I cannot blink through doors!"))
 				revert_cast()
 				return
 				
 		// Check for windows
-		for(var/obj/structure/roguewindow/window in traversal_turf.contents)
+		for(var/obj/structure/roguewindow/window in (traversal_turf.contents + T.contents))
 			if(window.density)
 				to_chat(user, span_warning("I cannot blink through windows!"))
 				revert_cast()
 				return
 				
 		// Check for bars
-		for(var/obj/structure/mineral_door/bars/bars in traversal_turf.contents)
-			if(bars.density)
-				to_chat(user, span_warning("I cannot blink through bars!"))
-				revert_cast()
-				return
-				
-		// Check for destination too
-		for(var/obj/structure/mineral_door/bars/bars in T.contents)
+		for(var/obj/structure/bars/bars in (traversal_turf.contents + T.contents))
 			if(bars.density)
 				to_chat(user, span_warning("I cannot blink through bars!"))
 				revert_cast()

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1673,7 +1673,7 @@
 	releasedrain = 30
 	chargedrain = 1
 	chargetime = 3 SECONDS
-	charge_max = 30 SECONDS
+	charge_max = 20 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Blink clean-up and fixes.
- Prevents blink from being used through bars, passageways, and shutters. The last PR that tried to do this used the wrong path for bars.
- Prevents blink from allowing you to teleport onto the same tile as doors/bars/windows, which wasn't really much different from just teleporting through them.
- Changes the keep gatehouse to use stone windows rather than adding a separate check for the grilles - grilles aren't even supposed to have density and this is the only place where grilles are even used like this across the entire map.
- Raises cost to 2 points, as Blink is essentially a straight upgrade to the Leap spell since it can be used to teleport across Z levels.
- Charge up time is slightly longer to give other players a chance to react to the spell channeling. It's 3 seconds. (For comparison, buff spells like guidance and fortitude are 4 seconds)

## Why It's Good For The Game

This spell is really strong and super buggy. Should fix most of the issues with it.

this is goofy

https://github.com/user-attachments/assets/fcdbf14a-2fed-43ba-9cc8-00fba9eda2eb

https://github.com/user-attachments/assets/8c44a6b3-3744-4b59-b77f-f973c94abdb3
