### PR TITLE
Fixes detail color reset on the dye station

### DIFF
--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -179,7 +179,7 @@
 		if(!inserted)
 			return
 		var/obj/item/inserted_item = inserted
-		inserted_item.detail_color = initial(inserted_item.detail_color)
+		inserted_item.detail_color = "#FFFFFF" //We don't initial() this in case it goes null
 		inserted_item.update_icon()
 		playsound(src, "bubbles", 50, 1)
 		updateUsrDialog()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Little fix for the reset coloring option on the dye station making details disappear on items that started with it set to null (like helmets or tabards).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

My feather... where did my feather go...

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
