### PR TITLE
Limb accuracy PER changes

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -33,10 +33,10 @@
 		if(I.wlength == WLENGTH_SHORT)
 			chance2hit += 10
 
-	if(user.STAPER > 11)
+	if(user.STAPER > 10)
 		chance2hit += ((user.STAPER-10)*6)
 
-	if(user.STAPER < 9)
+	if(user.STAPER < 10)
 		chance2hit -= ((10-user.STAPER)*6)
 
 	if(istype(user.rmb_intent, /datum/rmb_intent/aimed))

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -33,11 +33,11 @@
 		if(I.wlength == WLENGTH_SHORT)
 			chance2hit += 10
 
-	if(user.STAPER > 10)
-		chance2hit += ((user.STAPER-10)*3)
+	if(user.STAPER > 11)
+		chance2hit += ((user.STAPER-10)*6)
 
-	if(user.STAPER < 10)
-		chance2hit -= ((10-user.STAPER)*3)
+	if(user.STAPER < 9)
+		chance2hit -= ((10-user.STAPER)*6)
 
 	if(istype(user.rmb_intent, /datum/rmb_intent/aimed))
 		chance2hit += 20

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -49,11 +49,11 @@
 	if(prob(chance2hit))
 		return zone
 	else
-		if(prob(chance2hit+5))
+		if(prob(chance2hit+(user.STAPER - 10)))
 			if(check_zone(zone) == zone)
 				return zone
 			to_chat(user, span_warning("Accuracy fail! [chance2hit]%"))
-			if(user.STAPER > 11)
+			if(user.STAPER >= 11)
 				if(user.client?.prefs.showrolls)
 					return check_zone(zone)
 			else

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -44,7 +44,7 @@
 	if(istype(user.rmb_intent, /datum/rmb_intent/swift))
 		chance2hit -= 20
 
-	chance2hit = CLAMP(chance2hit, 5, 99)
+	chance2hit = CLAMP(chance2hit, 5, 95)
 
 	if(prob(chance2hit))
 		return zone
@@ -52,10 +52,12 @@
 		if(prob(chance2hit+5))
 			if(check_zone(zone) == zone)
 				return zone
-			else
+			to_chat(user, span_warning("Accuracy fail! [chance2hit]%"))
+			if(user.STAPER > 11)
 				if(user.client?.prefs.showrolls)
-					to_chat(user, span_warning("Accuracy fail! [chance2hit]%"))
-				return check_zone(zone)
+					return check_zone(zone)
+			else
+				return BODY_ZONE_CHEST
 		else
 			if(user.client?.prefs.showrolls)
 				to_chat(user, span_warning("Double accuracy fail! [chance2hit]%"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Doubles the accuracy malus (or bonus) coming from PER.
- If you have less than 11 PER, if you aim for the hand and miss, you will hit the chest. Anyone above 11 PER will hit the arm instead.

This is meant to combine with the statpack changes in #1820 to make the -PER statpacks have a more tangible consequence.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This doesn't affect ranged classes (Wardens, Poachers, etc) that much, as their boon was already high enough. This mostly will be felt by anyone taking those changed statpacks.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
