### PR TITLE
Swaps the MaA Glaive option for a Flail (and accompanying skills)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -182,7 +182,7 @@
 
 /datum/outfit/job/roguetown/manorguard/cavalry/pre_equip(mob/living/carbon/human/H)
 	..()
-	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE) // Still have a cugel.
@@ -194,6 +194,7 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/riding, 4, TRUE) // Like the other horselords.
 	H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
@@ -212,14 +213,13 @@
 	neck = /obj/item/clothing/neck/roguetown/gorget
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Glaive","Sword & Shield")
+	var/weapons = list("Flail","Sword & Shield")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
-		if("Glaive")
-			r_hand = /obj/item/rogueweapon/halberd/glaive // Better then a halberd, but the only other polearm that makes sense is the spear, which is iron-tier.
-			backl = /obj/item/gwstrap
-			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+		if("Flail")
+			r_hand = /obj/item/rogueweapon/flail
+			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 		if("Sword & Shield")
 			beltr = /obj/item/rogueweapon/sword/sabre
 			backl = /obj/item/rogueweapon/shield/wood


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
By sort-of request-ish?
Glaive has been attached to the Black Oaks -- while I can't say they lay exclusive claim on the weapon (unlike the armor), It's preferred it was kept to unique fringes rather than the rank and file troops.

Conveniently, this change also means that MaA cover p. much all combat skills now in their weapon options.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Swingswingswing BAM.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
