### PR TITLE
Enable simple wounds & no embedded projectiles on simple mobs.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -97,6 +97,8 @@
 	return simple_woundcritroll(P.woundclass, P.damage, null, def_zone, crit_message = TRUE)
 
 /mob/living/proc/check_projectile_embed(obj/projectile/P, def_zone)
+	if(HAS_TRAIT(src, TRAIT_SIMPLE_WOUNDS)) // Just flat out don't allow embed in simple mobs and simplify things
+		return FALSE
 	if(!prob(P.embedchance) || !P.dropped)
 		return FALSE
 	simple_add_embedded_object(P.dropped, crit_message = TRUE)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -226,11 +226,6 @@
 		apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
 		return TRUE
 
-/mob/living/simple_animal/bullet_act(obj/projectile/Proj)
-	apply_damage(Proj.damage, Proj.damage_type)
-	Proj.on_hit(src)
-	return BULLET_ACT_HIT
-
 /mob/living/simple_animal/ex_act(severity, target, epicenter, devastation_range, heavy_impact_range, light_impact_range, flame_range)
 	..()
 	if(!severity || !epicenter)

--- a/code/modules/mob/living/simple_animal/hostile/roguetown/werewolf/werewolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/roguetown/werewolf/werewolf.dm
@@ -29,4 +29,3 @@
 /mob/living/simple_animal/hostile/rogue/werewolf/Initialize()
 	. = ..()
 	regenerate_icons()
-	ADD_TRAIT(src, TRAIT_SIMPLE_WOUNDS, TRAIT_GENERIC)

--- a/code/modules/mob/living/simple_animal/rogue/rogueanimals.dm
+++ b/code/modules/mob/living/simple_animal/rogue/rogueanimals.dm
@@ -174,7 +174,6 @@
 		udder = new()
 	if(tame)
 		tamed()
-	ADD_TRAIT(src, TRAIT_SIMPLE_WOUNDS, TRAIT_GENERIC)
 
 /mob/living/simple_animal/hostile/retaliate/rogue/LoseTarget()
 	..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -185,6 +185,7 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 	if(!loc)
 		stack_trace("Simple animal being instantiated in nullspace")
 	update_simplemob_varspeed()
+	ADD_TRAIT(src, TRAIT_SIMPLE_WOUNDS, TRAIT_GENERIC) // Because anti-embed code will not work otherwise 
 //	if(dextrous)
 //		AddComponent(/datum/component/personal_crafting)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
- Projectiles NO LONGER DISAPPEAR when it hits simple mobs, can't embed either. This is done by:
- Move simple wounds trait up to all simple_animals, instead of only applying to werewolves and wolves (???)
- Remove checks that snowflake bullet act and make them disappear when it hit simple mobs

Might have balance implications on how easy simple_animals are to kill (I think wounds are mostly aesthetics atm on them). Also enables crits on them.

Also make hunter not need to switch weapon because a mob is a complex mob or simple mob I hate that shit. The world should be immersive and not make me switch weapons.

(Known issue: Idk why wolf says armor stops the damage when it doesn't, to be fixed later)

## Why It's Good For The Game
Why one skeleton eat my arrow and the other embeds? Makes no sense.

TESTING:
- I shot 3 cats
- I shot a skeleton
- I shot a wolf
- I shot a dragger

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
