### PR TITLE
Blink can't go through gates anymore

### DIFF
--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1757,6 +1757,13 @@
 				revert_cast()
 				return
 
+		// Check for gates
+		for (var/obj/structure/gate/gate in (traversal_turf.contents + T.contents))
+			if(gate.density)
+				to_chat(user, span_warning("I cannot blink through gates!"))
+				revert_cast()
+				return
+
 	var/obj/spot_one = new phase(start, user.dir)
 	var/obj/spot_two = new phase(T, user.dir)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Bugfix. I missed the 3 tile wide gates (like the ones used in the throne room and several dungeons) in the last blink patch. This is hopefully the last PR I have to make related to the blink spell.

## Why It's Good For The Game

Consistent behavior. Blink isn't meant to allow you to phase through dense structures such as walls, windows, bars, shutters, gates, etc.
