### PR TITLE
Disables commas in character names

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -156,15 +156,15 @@
 				number_of_alphanumeric++
 				last_char_group = 3
 
-			// '  -  . ,
-			if(39,45,46,44)			//Common name punctuation
+			// '  -  . 
+			if(39,45,46)			//Common name punctuation
 				if(!last_char_group)
 					continue
 				t_out += ascii2text(ascii_char)
 				last_char_group = 2
 
-			// ~   |   @  :  #  $  %  &  *  +
-			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
+			// ~   |   @  :  #  $  %  &  *  +  ,
+			if(126,124,64,58,35,36,37,38,42,43,44)			//Other symbols that we'll allow (mainly for AI)
 				if(!last_char_group)
 					continue	//suppress at start of string
 				if(!allow_numbers)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -732,8 +732,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 		dat = list("<center>REGISTER!</center>")
 
 	winshow(user, "preferencess_window", TRUE)
-	var/datum/browser/noclose/popup = new(user, "preferences_browser", "<div align='center'>[used_title]</div>")
-	popup.set_window_options("can_close=0")
+	var/datum/browser/popup = new(user, "preferences_browser", "<div align='center'>[used_title]</div>", nheight = 1000, nwidth = 1000)
 	popup.set_content(dat.Join())
 	popup.open(FALSE)
 	update_preview_icon()
@@ -1418,7 +1417,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						if(new_name)
 							real_name = new_name
 						else
-							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ', . and ,.</font>")
+							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
 				if("nickname")
 					var/new_name = input(user, "Choose your character's nickname (For Highlighting):", "Nickname (For Chat Highlighting)")  as text|null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
A bit of a weird one, but let's not have the main lobby name separator be available IN the names. This almost got me freaking out over a bug that was miscounting lobby players. Just use "The" or "-" or something man, don't confuse the coders (not that it was your fault)

![R39oRjdxUX](https://github.com/user-attachments/assets/c4e4bfdd-10b0-490f-b642-f1076dbda603)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was a very niche issue and probably more personal than not, but it freaked me out a bit
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
