### PR TITLE
Fixes hammer construct repair overload to still allow normal hammer strikes

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -121,7 +121,10 @@
 
 /obj/item/rogueweapon/hammer/attack(mob/living/M, mob/user)
 	testing("attack")
-	hammerheal(M, user)
+	if(!user.cmode)
+		hammerheal(M, user)
+	else
+		. = ..() //normal hit
 
 /obj/item/rogueweapon/hammer/proc/hammerheal(mob/living/M, mob/user)
 	if(!M.can_inject(user, TRUE))
@@ -152,6 +155,8 @@
 			user.visible_message(span_notice("[user] hammers [user.p_their()] [affecting]."), span_notice("I hammer my [affecting]."))
 		else
 			user.visible_message(span_notice("[user] hammers [M]'s [affecting]."), span_notice("I hammer [M]'s [affecting]."))
+	else //Non-construct.
+		to_chat(user, span_warning("I can't tinker on living flesh!"))
 
 /obj/item/rogueweapon/hammer/stone
 	name = "stone hammer"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Construct hammer repair overload lacked a parent call to handle strikes of the hammer in normal circumstance. This fixes that, now you can bonk heads with a hammer again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/user-attachments/assets/fb2ba236-ed34-477c-9797-97f91876bccb)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
