### PR TITLE
Give Otavan Routiers Apprentice Ride + Fix Otavan Boots

### DIFF
--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -183,6 +183,7 @@
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	salvage_amount = 1
 	salvage_result = /obj/item/natural/hide/cured
+	sewrepair = TRUE
 
 /obj/item/clothing/shoes/roguetown/boots/armor/iron
 	name = "iron plated boots"

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
@@ -31,6 +31,7 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
 	H.change_stat("strength", 2)
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 4)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Seems like Otavan Boots have no way to be repaired! No anvil nor needle will fix it. This, of course, fixes it!

Also - Otavan Routiers are meant to be a sort of noble knight mercenary company, and yet they can't ride for shit whilst Forlorn (for example) gets 1! They can get 2. Lower than Riders (3), more than Forlorn (1). It's nice.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I think the leathery thing that is made out of leather like the other leathery things should be able to be repaired.

And a knight who doesn't even have an IDEA how to ride, sucks ass. Give them a bone.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
