### PR TITLE
Buff support spells. Add overlay & fix Fortitude.

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -291,20 +291,6 @@
 	to_chat(owner, span_warning("The darkness returns to normal."))
 	REMOVE_TRAIT(owner, TRAIT_DARKVISION, MAGIC_TRAIT)
 
-/atom/movable/screen/alert/status_effect/buff/haste
-	name = "Haste"
-	desc = "I am magically hastened."
-	icon_state = "buff"
-
-/datum/status_effect/buff/haste
-	id = "haste"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/haste
-	effectedstats = list("speed" = 5)
-	duration = 1 MINUTES
-
-/datum/status_effect/buff/haste/nextmove_modifier()
-	return 0.85
-
 /atom/movable/screen/alert/status_effect/buff/longstrider
 	name = "Longstrider"
 	desc = "I can easily walk through rough terrain."
@@ -459,49 +445,6 @@
 	id = "fortify"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/fortify
 	duration = 1 MINUTES
-
-/datum/status_effect/buff/fortitude
-	id = "fortitude"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/fortitude
-	duration = 1 MINUTES
-
-/datum/status_effect/buff/fortitude/on_apply()
-	. = ..()
-	to_chat(owner, span_warning("My body feels lighter..."))
-	ADD_TRAIT(owner, TRAIT_FORTITUDE, MAGIC_TRAIT)
-
-/datum/status_effect/buff/fortitude/on_remove()
-	. = ..()
-	to_chat(owner, span_warning("The weight of the world rests upon my shoulders once more."))
-	REMOVE_TRAIT(owner, TRAIT_FORTITUDE, MAGIC_TRAIT)
-
-#define GUIDANCE_FILTER "guidance_glow"
-/atom/movable/screen/alert/status_effect/buff/guidance
-	name = "Guidance"
-	desc = "Arcyne assistance guides my hands."
-	icon_state = "buff"
-
-/datum/status_effect/buff/guidance
-	var/outline_colour ="#f58e2d"
-	id = "guidance"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/guidance
-	duration = 1 MINUTES
-
-/datum/status_effect/buff/guidance/on_apply()
-	. = ..()
-	var/filter = owner.get_filter(GUIDANCE_FILTER)
-	if (!filter)
-		owner.add_filter(GUIDANCE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
-	to_chat(owner, span_warning("The arcyne aides me in battle."))
-	ADD_TRAIT(owner, TRAIT_GUIDANCE, MAGIC_TRAIT)
-
-/datum/status_effect/buff/guidance/on_remove()
-	. = ..()
-	to_chat(owner, span_warning("My feeble mind muddies my warcraft once more."))
-	owner.remove_filter(GUIDANCE_FILTER)
-	REMOVE_TRAIT(owner, TRAIT_GUIDANCE, MAGIC_TRAIT)
-
-#undef GUIDANCE_FILTER
 
 #define CRANKBOX_FILTER "crankboxbuff_glow"
 /atom/movable/screen/alert/status_effect/buff/churnerprotection

--- a/code/modules/antagonists/roguetown/villain/vampire.dm
+++ b/code/modules/antagonists/roguetown/villain/vampire.dm
@@ -296,22 +296,22 @@
 	if(VD.vitae < 100)
 		to_chat(src, span_warning("Not enough vitae blood."))
 		return
-	if(has_status_effect(/datum/status_effect/buff/fortitude))
+	if(has_status_effect(/datum/status_effect/buff/blood_fortitude))
 		to_chat(src, span_warning("Already active."))
 		return
 	VD.vitae -= 100
 	rogstam_add(2000)
-	apply_status_effect(/datum/status_effect/buff/fortitude)
+	apply_status_effect(/datum/status_effect/buff/blood_fortitude)
 	to_chat(src, span_greentext("! ARMOR OF DARKNESS !"))
 	src.playsound_local(get_turf(src), 'sound/misc/vampirespell.ogg', 100, FALSE, pressure_affected = FALSE)
 
-/datum/status_effect/buff/fortitude
-	id = "fortitude"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/fortitude
+/datum/status_effect/buff/blood_fortitude
+	id = "blood_fortitude"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/blood_fortitude
 	effectedstats = list("endurance" = 20,"constitution" = 20)
 	duration = 30 SECONDS
 
-/atom/movable/screen/alert/status_effect/buff/fortitude
+/atom/movable/screen/alert/status_effect/buff/blood_fortitude
 	name = "Armor of Darkness"
 	desc = ""
 	icon_state = "bleed1"

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -188,10 +188,10 @@
 					prob2defend -= (attacker_skill * 20)
 
 			if(HAS_TRAIT(src, TRAIT_GUIDANCE))
-				prob2defend += 10
+				prob2defend += 15
 
 			if(HAS_TRAIT(user, TRAIT_GUIDANCE))
-				prob2defend -= 10
+				prob2defend -= 15
 
 			// parrying while knocked down sucks ass
 			if(!(mobility_flags & MOBILITY_STAND))
@@ -510,6 +510,12 @@
 		// dodging while knocked down sucks ass
 		if(!(L.mobility_flags & MOBILITY_STAND))
 			prob2defend *= 0.25
+
+		if(HAS_TRAIT(L, TRAIT_GUIDANCE))
+			prob2defend += 15
+
+		if(HAS_TRAIT(U, TRAIT_GUIDANCE))
+			prob2defend -= 15
 
 		if(HAS_TRAIT(H, TRAIT_SENTINELOFWITS))
 			var/sentinel = H.calculate_sentinel_bonus()

--- a/modular_hearthstone/code/modules/spells/roguetown/buffs.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/buffs.dm
@@ -1,0 +1,255 @@
+// Places for most buffs spells. Single-target buffs get duration doubled on other people to encourage support mage (And not buff Zizoite Heretic to high heavens)
+
+/obj/effect/proc_holder/spell/invoked/fortitude
+	name = "Fortitude"
+	desc = "Harden one's humors to the fatigues of the body. (-50% Stamina Usage)"
+	cost = 1
+	xp_gain = TRUE
+	releasedrain = 60
+	chargedrain = 1
+	chargetime = 4 SECONDS
+	charge_max = 2 MINUTES
+	warnie = "spellwarning"
+	school = "transmutation"
+	no_early_release = TRUE
+	movement_interrupt = FALSE
+	charging_slowdown = 2
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+
+/obj/effect/proc_holder/spell/invoked/fortitude/cast(list/targets, mob/user)
+	var/atom/A = targets[1]
+	if(!isliving(A))
+		revert_cast()
+		return
+
+	var/mob/living/spelltarget = A
+	playsound(get_turf(spelltarget), 'sound/magic/haste.ogg', 80, TRUE, soundping = TRUE)
+
+	if(spelltarget != user)
+		user.visible_message("[user] mutters an incantation and [spelltarget] briefly shines green.")
+		to_chat(user, span_notice("With another person as a conduit, my spell's duration is doubled."))
+		spelltarget.apply_status_effect(/datum/status_effect/buff/fortitude/other)
+	else
+		user.visible_message("[user] mutters an incantation and they briefly shine green.")
+		spelltarget.apply_status_effect(/datum/status_effect/buff/fortitude)
+
+	return TRUE
+
+/atom/movable/screen/alert/status_effect/buff/fortitude
+	name = "Fortitude"
+	desc = "My humors has been hardened to the fatigues of the body. (-50% Stamina Usage)"
+	icon_state = "buff"
+
+#define FORTITUDE_FILTER "fortitude_glow"
+/datum/status_effect/buff/fortitude
+	var/outline_colour ="#008000" // Forest green to avoid le sparkle mage
+	id = "fortitude"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/fortitude
+	duration = 1 MINUTES
+
+/datum/status_effect/buff/fortitude/other
+	duration = 2 MINUTES
+
+/datum/status_effect/buff/fortitude/on_apply()
+	. = ..()
+	var/filter = owner.get_filter(FORTITUDE_FILTER)
+	if (!filter)
+		owner.add_filter(FORTITUDE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+	to_chat(owner, span_warning("My body feels lighter..."))
+	ADD_TRAIT(owner, TRAIT_FORTITUDE, MAGIC_TRAIT)
+
+/datum/status_effect/buff/fortitude/on_remove()
+	. = ..()
+	owner.remove_filter(FORTITUDE_FILTER)
+	to_chat(owner, span_warning("The weight of the world rests upon my shoulders once more."))
+	REMOVE_TRAIT(owner, TRAIT_FORTITUDE, MAGIC_TRAIT)
+
+/obj/effect/proc_holder/spell/invoked/guidance
+	name = "Guidance"
+	overlay_state = "guidance"
+	desc = "Makes one's hand travel true, blessing them with arcyne luck in combat. (+15% chance to bypass parry / dodge, +15% chance to parry / dodge)"
+	cost = 1
+	xp_gain = TRUE
+	releasedrain = 60
+	chargedrain = 1
+	chargetime = 4 SECONDS
+	charge_max = 2 MINUTES
+	warnie = "spellwarning"
+	school = "transmutation"
+	no_early_release = TRUE
+	movement_interrupt = FALSE
+	charging_slowdown = 2
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+
+/obj/effect/proc_holder/spell/invoked/guidance/cast(list/targets, mob/user)
+	var/atom/A = targets[1]
+	if(!isliving(A))
+		revert_cast()
+		return
+
+	var/mob/living/spelltarget = A
+	playsound(get_turf(spelltarget), 'sound/magic/haste.ogg', 80, TRUE, soundping = TRUE)
+
+	if(spelltarget != user)
+		user.visible_message("[user] mutters an incantation and [spelltarget] briefly shines orange.")
+		to_chat(user, span_notice("With another person as a conduit, my spell's duration is doubled."))
+		spelltarget.apply_status_effect(/datum/status_effect/buff/guidance/other)
+	else
+		user.visible_message("[user] mutters an incantation and they briefly shine orange.")
+		spelltarget.apply_status_effect(/datum/status_effect/buff/guidance)
+
+	return TRUE
+
+#define GUIDANCE_FILTER "guidance_glow"
+/atom/movable/screen/alert/status_effect/buff/guidance
+	name = "Guidance"
+	desc = "Arcyne assistance guides my hands. (+15% chance to bypass parry / dodge, +15% chance to parry / dodge)"
+	icon_state = "buff"
+
+/datum/status_effect/buff/guidance
+	var/outline_colour ="#f58e2d"
+	id = "guidance"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/guidance
+	duration = 1 MINUTES
+
+/datum/status_effect/buff/guidance/other
+	duration = 2 MINUTES
+
+/datum/status_effect/buff/guidance/on_apply()
+	. = ..()
+	var/filter = owner.get_filter(GUIDANCE_FILTER)
+	if (!filter)
+		owner.add_filter(GUIDANCE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+	to_chat(owner, span_warning("The arcyne aides me in battle."))
+	ADD_TRAIT(owner, TRAIT_GUIDANCE, MAGIC_TRAIT)
+
+/datum/status_effect/buff/guidance/on_remove()
+	. = ..()
+	to_chat(owner, span_warning("My feeble mind muddies my warcraft once more."))
+	owner.remove_filter(GUIDANCE_FILTER)
+	REMOVE_TRAIT(owner, TRAIT_GUIDANCE, MAGIC_TRAIT)
+
+#undef GUIDANCE_FILTER
+
+/obj/effect/proc_holder/spell/invoked/haste
+	name = "Haste"
+	desc = "Cause a target to be magically hastened. (+5 Speed, 0.85 x Action Cooldown)"
+	cost = 2
+	xp_gain = TRUE
+	releasedrain = 60
+	chargedrain = 1
+	chargetime = 1 SECONDS
+	charge_max = 2 MINUTES
+	warnie = "spellwarning"
+	school = "transmutation"
+	no_early_release = TRUE
+	movement_interrupt = FALSE
+	charging_slowdown = 2
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+
+/obj/effect/proc_holder/spell/invoked/haste/cast(list/targets, mob/user)
+	var/atom/A = targets[1]
+	if(!isliving(A))
+		revert_cast()
+		return
+
+	var/mob/living/spelltarget = A
+	playsound(get_turf(spelltarget), 'sound/magic/haste.ogg', 80, TRUE, soundping = TRUE)
+
+	if(spelltarget != user)
+		user.visible_message("[user] mutters an incantation and [spelltarget] briefly shines yellow.")
+		spelltarget.apply_status_effect(/datum/status_effect/buff/haste/other)
+		to_chat(user, span_notice("With another person as a conduit, my spell's duration is doubled."))
+	else
+		user.visible_message("[user] mutters an incantation and they briefly shine yellow.")
+		spelltarget.apply_status_effect(/datum/status_effect/buff/haste)
+
+	return TRUE
+	
+/atom/movable/screen/alert/status_effect/buff/haste
+	name = "Haste"
+	desc = "I am magically hastened."
+	icon_state = "buff"
+
+#define HASTE_FILTER "haste_glow"
+
+/datum/status_effect/buff/haste
+	var/outline_colour ="#F0E68C" // Hopefully not TOO yellow
+	id = "haste"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/haste
+	effectedstats = list("speed" = 5)
+	duration = 1 MINUTES
+
+/datum/status_effect/buff/haste/other
+	duration = 2 MINUTES
+
+/datum/status_effect/buff/haste/on_apply()
+	. = ..()
+	var/filter = owner.get_filter(HASTE_FILTER)
+	if (!filter)
+		owner.add_filter(HASTE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+	to_chat(owner, span_warning("My limbs move with uncanny swiftness."))
+
+/datum/status_effect/buff/haste/on_remove()
+	owner.remove_filter(HASTE_FILTER)
+	to_chat(owner, span_warning("My body move slowly again..."))
+
+#undef HASTE_FILTER
+
+/datum/status_effect/buff/haste/nextmove_modifier()
+	return 0.85
+
+/obj/effect/proc_holder/spell/invoked/featherfall
+	name = "Featherfall"
+	desc = "Grant yourself and any creatures adjacent to you some defense against falls."
+	cost = 1
+	xp_gain = TRUE
+	school = "transmutation"
+	releasedrain = 50
+	chargedrain = 0
+	chargetime = 10 SECONDS
+	charge_max = 2 MINUTES
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	movement_interrupt = TRUE
+	charging_slowdown = 2
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+	overlay_state = "jump"
+
+/obj/effect/proc_holder/spell/invoked/featherfall/cast(list/targets, mob/user = usr)
+
+	user.visible_message("[user] mutters an incantation and a dim pulse of light radiates out from them.")
+
+	for(var/mob/living/L in range(1, usr))
+		L.apply_status_effect(/datum/status_effect/buff/featherfall)
+
+	return TRUE
+
+/obj/effect/proc_holder/spell/invoked/longstrider
+	name = "Longstrider"
+	desc = "Grant yourself and any creatures adjacent to you free movement through rough terrain."
+	cost = 1
+	xp_gain = TRUE
+	school = "transmutation"
+	releasedrain = 50
+	chargedrain = 0
+	chargetime = 4 SECONDS
+	charge_max = 1.5 MINUTES
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	charging_slowdown = 1
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+
+/obj/effect/proc_holder/spell/invoked/longstrider/cast(list/targets, mob/user = usr)
+
+	user.visible_message("[user] mutters an incantation and a dim pulse of light radiates out from them.")
+
+	for(var/mob/living/L in range(1, usr))
+		L.apply_status_effect(/datum/status_effect/buff/longstrider)
+
+	return TRUE

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -2,6 +2,8 @@
 #define PRESTI_SPARK "presti_spark"
 #define PRESTI_MOTE "presti_mote"
 
+GLOBAL_LIST_EMPTY(wizard_spells_list)
+
 /obj/effect/proc_holder/spell/targeted/touch/prestidigitation
 	name = "Prestidigitation"
 	desc = "A few basic tricks many apprentices use to practice basic manipulation of the arcyne."
@@ -236,8 +238,11 @@
 	for(var/i = 1, i <= spell_choices.len, i++)
 		choices["[spell_choices[i].name]: [spell_choices[i].cost]"] = spell_choices[i]
 
+	choices = sortList(choices)
+
 	var/choice = input("Choose a spell, points left: [user.mind.spell_points - user.mind.used_spell_points]") as null|anything in choices
 	var/obj/effect/proc_holder/spell/item = choices[choice]
+
 	if(!item)
 		return     // user canceled;
 	if(alert(user, "[item.desc]", "[item.name]", "Learn", "Cancel") == "Cancel") //gives a preview of the spell's description to let people know what a spell does
@@ -666,67 +671,6 @@
 		attached_spell.remove_hand()
 	return
 
-/obj/effect/proc_holder/spell/invoked/featherfall
-	name = "Featherfall"
-	desc = "Grant yourself and any creatures adjacent to you some defense against falls."
-	cost = 1
-	xp_gain = TRUE
-	school = "transmutation"
-	releasedrain = 50
-	chargedrain = 0
-	chargetime = 10 SECONDS
-	charge_max = 2 MINUTES
-	warnie = "spellwarning"
-	no_early_release = TRUE
-	movement_interrupt = TRUE
-	charging_slowdown = 2
-	chargedloop = /datum/looping_sound/invokegen
-	associated_skill = /datum/skill/magic/arcane
-	overlay_state = "jump"
-
-/obj/effect/proc_holder/spell/invoked/featherfall/cast(list/targets, mob/user = usr)
-
-	user.visible_message("[user] mutters an incantation and a dim pulse of light radiates out from them.")
-
-	for(var/mob/living/L in range(1, usr))
-		L.apply_status_effect(/datum/status_effect/buff/featherfall)
-
-	return TRUE
-
-/obj/effect/proc_holder/spell/invoked/haste
-	name = "Haste"
-	desc = "Cause a target to be magically hastened."
-	cost = 2
-	xp_gain = TRUE
-	releasedrain = 60
-	chargedrain = 1
-	chargetime = 1 SECONDS
-	charge_max = 1.5 MINUTES
-	warnie = "spellwarning"
-	school = "transmutation"
-	no_early_release = TRUE
-	movement_interrupt = FALSE
-	charging_slowdown = 2
-	chargedloop = /datum/looping_sound/invokegen
-	associated_skill = /datum/skill/magic/arcane
-
-/obj/effect/proc_holder/spell/invoked/haste/cast(list/targets, mob/user)
-	var/atom/A = targets[1]
-	if(!isliving(A))
-		revert_cast()
-		return
-
-	var/mob/living/spelltarget = A
-	spelltarget.apply_status_effect(/datum/status_effect/buff/haste)
-	playsound(get_turf(spelltarget), 'sound/magic/haste.ogg', 80, TRUE, soundping = TRUE)
-
-	if(spelltarget != user)
-		user.visible_message("[user] mutters an incantation and [spelltarget] briefly shines yellow.")
-	else
-		user.visible_message("[user] mutters an incantation and they briefly shine yellow.")
-
-	return TRUE
-
 /obj/effect/proc_holder/spell/invoked/knock
 	name = "Knock"
 	desc = "Force open adjacent doors, windows and most containers."
@@ -766,31 +710,6 @@
 /obj/effect/proc_holder/spell/invoked/knock/proc/open_window(obj/structure/roguewindow/openclose/W)
 	if(istype(W))
 		W.force_open()
-
-/obj/effect/proc_holder/spell/invoked/longstrider
-	name = "Longstrider"
-	desc = "Grant yourself and any creatures adjacent to you free movement through rough terrain."
-	cost = 1
-	xp_gain = TRUE
-	school = "transmutation"
-	releasedrain = 50
-	chargedrain = 0
-	chargetime = 4 SECONDS
-	charge_max = 1.5 MINUTES
-	warnie = "spellwarning"
-	no_early_release = TRUE
-	charging_slowdown = 1
-	chargedloop = /datum/looping_sound/invokegen
-	associated_skill = /datum/skill/magic/arcane
-
-/obj/effect/proc_holder/spell/invoked/longstrider/cast(list/targets, mob/user = usr)
-
-	user.visible_message("[user] mutters an incantation and a dim pulse of light radiates out from them.")
-
-	for(var/mob/living/L in range(1, usr))
-		L.apply_status_effect(/datum/status_effect/buff/longstrider)
-
-	return TRUE
 
 //ports -- todo: sfx
 
@@ -936,76 +855,6 @@
 	target.update_vision_cone()
 	target.remove_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT, TRUE)
 	. = ..()
-
-
-/obj/effect/proc_holder/spell/invoked/fortitude
-	name = "Fortitude"
-	desc = "Harden one's humors to the fatigues of the body."
-	cost = 2
-	xp_gain = TRUE
-	releasedrain = 60
-	chargedrain = 1
-	chargetime = 4 SECONDS
-	charge_max = 2 MINUTES
-	warnie = "spellwarning"
-	school = "transmutation"
-	no_early_release = TRUE
-	movement_interrupt = FALSE
-	charging_slowdown = 2
-	chargedloop = /datum/looping_sound/invokegen
-	associated_skill = /datum/skill/magic/arcane
-
-/obj/effect/proc_holder/spell/invoked/fortitude/cast(list/targets, mob/user)
-	var/atom/A = targets[1]
-	if(!isliving(A))
-		revert_cast()
-		return
-
-	var/mob/living/spelltarget = A
-	spelltarget.apply_status_effect(/datum/status_effect/buff/fortitude)
-	playsound(get_turf(spelltarget), 'sound/magic/haste.ogg', 80, TRUE, soundping = TRUE)
-
-	if(spelltarget != user)
-		user.visible_message("[user] mutters an incantation and [spelltarget] briefly shines green.")
-	else
-		user.visible_message("[user] mutters an incantation and they briefly shine green.")
-
-	return TRUE
-
-/obj/effect/proc_holder/spell/invoked/guidance
-	name = "Guidance"
-	overlay_state = "guidance"
-	desc = "Makes one's hand travel true, blessing them with arcyne luck in combat. (+10% chance to hit with melee, +10% chance to defend from melee)"
-	cost = 2
-	xp_gain = TRUE
-	releasedrain = 60
-	chargedrain = 1
-	chargetime = 4 SECONDS
-	charge_max = 5 MINUTES
-	warnie = "spellwarning"
-	school = "transmutation"
-	no_early_release = TRUE
-	movement_interrupt = FALSE
-	charging_slowdown = 2
-	chargedloop = /datum/looping_sound/invokegen
-	associated_skill = /datum/skill/magic/arcane
-
-/obj/effect/proc_holder/spell/invoked/guidance/cast(list/targets, mob/user)
-	var/atom/A = targets[1]
-	if(!isliving(A))
-		revert_cast()
-		return
-
-	var/mob/living/spelltarget = A
-	spelltarget.apply_status_effect(/datum/status_effect/buff/guidance)
-	playsound(get_turf(spelltarget), 'sound/magic/haste.ogg', 80, TRUE, soundping = TRUE)
-
-	if(spelltarget != user)
-		user.visible_message("[user] mutters an incantation and [spelltarget] briefly shines orange.")
-	else
-		user.visible_message("[user] mutters an incantation and they briefly shine orange.")
-
-	return TRUE
 
 /obj/effect/proc_holder/spell/invoked/snap_freeze // to do: get scroll icon
 	name = "Snap Freeze"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2016,6 +2016,7 @@
 #include "modular_hearthstone\code\modules\mob\living\simple_animal\rogue\orc.dm"
 #include "modular_hearthstone\code\modules\mob\living\simple_animal\rogue\rogue_corpse.dm"
 #include "modular_hearthstone\code\modules\reagents\reagent_containers\lux.dm"
+#include "modular_hearthstone\code\modules\spells\roguetown\buffs.dm"
 #include "modular_hearthstone\code\modules\spells\roguetown\wizard.dm"
 // END_INCLUDE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Guidance: Adjust Guidance cost to 1. Guidance now applies +15% and -15% (About equal to one skill level) to both dodge / parry bypass, instead of only parry and only 10%. Cooldown reduced to 2 minutes.
- Haste: Cooldown standardized to 2 minutes instead of 1.5 minute (It is the strongest of the 3 main combat buff spells). 
- Fortitude: Fixed it applying the vampire Armor of Darkness effect giving player 20 END & CON for 30 seconds. It applies the original, intended buff of * 0.5x stamina cost. Cooldown standardized to 2 minutes.
- All three of the above abilities has a duration of 1 minute when cast on self, 2 minutes when cast on others now to encourage support
- The buffs and spell now indicate what it does
- The spell list for wizard is now sorted

## Why It's Good For The Game
Sorted spell list good. 

Right now support spells are pretty underutilized on most mages because of how much more they can do with direct damage spells. This aim to fix that. 

I gave 2x duration on other-buff to encourage support instead of self-buff and hopefully not powercreep Zizoite heretic. 

Guidance in particular is egregious at 5 minutes cooldown for a trivial boost (less than 1 skill level difference). 

There's a long list of problems with magic but this is step 1 to put it in a slightly better state and encourage a more supportive playstyle

## Testing 
- Spawned in as Court Magician
- Cast spells on self, confirmed duration, cast on goblins, confirmed duration
- confirmed the spell list is sorted

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
