### PR TITLE
Limits Blink range and verticality, lowers cooldown and chargetime

### DIFF
--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1629,7 +1629,7 @@
 					return
 				to_chat(user, span_info("I begin to meld with the shadows.."))
 				lockon(T, user)
-				if(do_after(user, 2 SECONDS))
+				if(do_after(user, 5 SECONDS))
 					tp(user)
 				else
 					reset(silent = TRUE)
@@ -1666,7 +1666,7 @@
 
 /obj/effect/proc_holder/spell/invoked/blink
 	name = "Blink"
-	desc = "Teleport to a targeted location within your field of view. Limited to a range of 4 tiles. Only works on the same plane as the caster."
+	desc = "Teleport to a targeted location within your field of view. Limited to a range of 5 tiles. Only works on the same plane as the caster."
 	school = "conjuration"
 	cost = 2
 	releasedrain = 30
@@ -1683,7 +1683,7 @@
 	xp_gain = TRUE
 	invocation = "SHIFT THROUGH SPACE!"
 	invocation_type = "shout"
-	var/max_range = 4
+	var/max_range = 5
 	var/phase = /obj/effect/temp_visual/blink
 
 /obj/effect/temp_visual/blink

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1666,7 +1666,7 @@
 
 /obj/effect/proc_holder/spell/invoked/blink
 	name = "Blink"
-	desc = "Teleport to a targeted location within your field of view. Limited to a range of [max_range] tiles. Only works on the same plane as the caster."
+	desc = "Teleport to a targeted location within your field of view. Limited to a range of 3 tiles. Only works on the same plane as the caster."
 	school = "conjuration"
 	cost = 2
 	releasedrain = 30
@@ -1755,7 +1755,7 @@
 				
 		// Check for windows
 		for(var/obj/structure/roguewindow/window in (traversal_turf.contents + T.contents))
-			if(window.density)
+			if(window.density && !window.climbable)
 				to_chat(user, span_warning("I cannot blink through windows!"))
 				revert_cast()
 				return

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1721,6 +1721,10 @@
 		revert_cast()
 		return
 
+	if(T.density)
+		to_chat(user, span_warning("I cannot teleport into a wall!"))
+		revert_cast()
+		return
 	// Check range limit
 	var/distance = get_dist(start, T)
 	if(distance > max_range)

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1725,6 +1725,7 @@
 		to_chat(user, span_warning("I cannot teleport into a wall!"))
 		revert_cast()
 		return
+
 	// Check range limit
 	var/distance = get_dist(start, T)
 	if(distance > max_range)

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1509,7 +1509,7 @@
 	clothes_req = FALSE
 	charge_type = "recharge"
 	associated_skill = /datum/skill/magic/arcane
-	cost = 1
+	cost = 2
 	xp_gain = TRUE
 	// Fix invoked spell variables
 	releasedrain = 35
@@ -1668,7 +1668,7 @@
 	name = "Blink"
 	desc = "Teleport to a targeted location within your field of view. Limited to a range of 5 tiles. Only works on the same plane as the caster."
 	school = "conjuration"
-	cost = 2
+	cost = 1
 	releasedrain = 30
 	chargedrain = 1
 	chargetime = 1.5 SECONDS

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1666,13 +1666,13 @@
 
 /obj/effect/proc_holder/spell/invoked/blink
 	name = "Blink"
-	desc = "Teleport to a targeted location within your field of view. Limited to a range of 7 tiles."
+	desc = "Teleport to a targeted location within your field of view. Limited to a range of [max_range] tiles. Only works on the same plane as the caster."
 	school = "conjuration"
 	cost = 2
 	releasedrain = 30
 	chargedrain = 1
-	chargetime = 3 SECONDS
-	charge_max = 20 SECONDS
+	chargetime = 1.5 SECONDS
+	charge_max = 10 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
@@ -1683,7 +1683,7 @@
 	xp_gain = TRUE
 	invocation = "SHIFT THROUGH SPACE!"
 	invocation_type = "shout"
-	var/max_range = 7
+	var/max_range = 3
 	var/phase = /obj/effect/temp_visual/blink
 
 /obj/effect/temp_visual/blink
@@ -1710,7 +1710,17 @@
 		to_chat(user, span_warning("Invalid target location!"))
 		revert_cast()
 		return
+
+	if(T.z != start.z)
+		to_chat(user, span_warning("I can only teleport on the same plane!"))
+		revert_cast()
+		return
 	
+	if(istransparentturf(T))
+		to_chat(user, span_warning("I cannot teleport to the open air!"))
+		revert_cast()
+		return
+
 	// Check range limit
 	var/distance = get_dist(start, T)
 	if(distance > max_range)

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1666,7 +1666,7 @@
 
 /obj/effect/proc_holder/spell/invoked/blink
 	name = "Blink"
-	desc = "Teleport to a targeted location within your field of view. Limited to a range of 3 tiles. Only works on the same plane as the caster."
+	desc = "Teleport to a targeted location within your field of view. Limited to a range of 4 tiles. Only works on the same plane as the caster."
 	school = "conjuration"
 	cost = 2
 	releasedrain = 30
@@ -1683,7 +1683,7 @@
 	xp_gain = TRUE
 	invocation = "SHIFT THROUGH SPACE!"
 	invocation_type = "shout"
-	var/max_range = 3
+	var/max_range = 4
 	var/phase = /obj/effect/temp_visual/blink
 
 /obj/effect/temp_visual/blink

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -1509,7 +1509,7 @@
 	clothes_req = FALSE
 	charge_type = "recharge"
 	associated_skill = /datum/skill/magic/arcane
-	cost = 2
+	cost = 1
 	xp_gain = TRUE
 	// Fix invoked spell variables
 	releasedrain = 35


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Blink no longer works on transparent turfs (in spite of featherfall combos it's more of an invitation for a misclick death)
![dreamseeker_y9JLl04VQi](https://github.com/user-attachments/assets/84952669-edaa-419a-9729-3fffe86959f7)
- You CAN now use blink to go through **open** windows.
![dreamseeker_GMFnkydjQi](https://github.com/user-attachments/assets/282cce58-9566-496c-adda-5d019791a96a)
- It no longer works vertically, only on the same plane / z level as the user.
- Its range has been reduced from 7 to 5 tiles
- Its cooldown is now 10 seconds, and charge time is 1.5 seconds.

New range reference:
![dreamseeker_Ibl4uKBuIy](https://github.com/user-attachments/assets/65c5e5da-533b-4142-a476-c5161fe1a4d0)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Essentially this brings it in line with the #1540 grappler, making both overt mobility options similar, but unique in their own ways. Which is preferable to a WAY WAY superior option that is not even exclusive to an Artificer or select few classes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
