### PR TITLE
Spell invocations are now only spoken on a successful cast

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -382,12 +382,12 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = TRUE, mob/user = usr) //if recharge is started is important for the trigger spells
 	before_cast(targets, user = user)
-	invocation(user)
 	if(user && user.ckey)
 		user.log_message(span_danger("cast the spell [name]."), LOG_ATTACK)
 	if(recharge)
 		recharging = TRUE
 	if(cast(targets, user = user))
+		invocation(user)
 		start_recharge()
 		if(sound)
 			playMagSound()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![dreamseeker_oVEyUcjRvP](https://github.com/user-attachments/assets/8d748d64-6dd3-43e0-8035-b7f9323b553e)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If you were ever off-screen from a blink user and heard the invocation repeated several times in quick succession - it was far more likely the guy was just failing his casts.

This HAS implications, as failing a spell is now a lot more quiet.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
