### PR TITLE
Cure Rot surgery and miracle will now leave behind a corpse

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -1,4 +1,4 @@
-/proc/remove_rot(mob/living/carbon/human/target, mob/living/user, method = "unknown", damage = 0, success_message = "The rot is removed.", fail_message = "The rot removal failed.")
+/proc/remove_rot(mob/living/carbon/human/target, mob/living/user, method = "unknown", damage = 0, success_message = "The rot is removed.", fail_message = "The rot removal failed.", lethal = TRUE)
 	if (!istype(target, /mob/living/carbon/human) || QDELETED(target))
 		return FALSE
 
@@ -28,7 +28,7 @@
 		return FALSE
 
 	if (was_zombie)
-		remove_zombie_antag(target, user, method)
+		remove_zombie_antag(target, user, method, lethal)
 
 	//Doing it out of this proc for now
 	//to_chat(user, span_notice(success_message))
@@ -42,16 +42,19 @@
 	return FALSE
 
 
-/proc/remove_zombie_antag(mob/living/carbon/target, mob/living/user, method)
+/proc/remove_zombie_antag(mob/living/carbon/target, mob/living/user, method, lethal = TRUE)
 	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
 	if (!was_zombie)
 		return
 
 	was_zombie.become_rotman = FALSE
 	target.mind.remove_antag_datum(/datum/antagonist/zombie)
-	target.Unconscious(20 SECONDS)
-	target.emote("breathgasp")
-	target.Jitter(100)
+	if(!lethal)
+		target.Unconscious(20 SECONDS)
+		target.emote("breathgasp")
+		target.Jitter(100)
+	else
+		target.death()
 
 	if (!HAS_TRAIT(target, TRAIT_IWASUNZOMBIFIED) && user?.ckey)
 		adjust_playerquality(PQ_GAIN_UNZOMBIFY, user.ckey)

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -13,7 +13,7 @@
 	tutorial = "The Divine is all that matters in a world of the immoral. The Weeping God left his children to rule over us mortals--and you will preach their wisdom to any who still heed their will. The faithless are growing in number. It is up to you to shepard them toward a Gods-fearing future; for you are a priest of Astrata."
 	whitelist_req = FALSE
 
-	spells = list(/obj/effect/proc_holder/spell/invoked/cure_rot, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk)
+	spells = list(/obj/effect/proc_holder/spell/invoked/cure_rot/priest, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk)
 	outfit = /datum/outfit/job/roguetown/priest
 
 	display_order = JDO_PRIEST

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -13,7 +13,7 @@
 	tutorial = "The Divine is all that matters in a world of the immoral. The Weeping God left his children to rule over us mortals--and you will preach their wisdom to any who still heed their will. The faithless are growing in number. It is up to you to shepard them toward a Gods-fearing future; for you are a priest of Astrata."
 	whitelist_req = FALSE
 
-	spells = list(/obj/effect/proc_holder/spell/invoked/cure_rot/priest, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk)
+	spells = list(/obj/effect/proc_holder/spell/invoked/cure_rot, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk)
 	outfit = /datum/outfit/job/roguetown/priest
 
 	display_order = JDO_PRIEST

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -173,6 +173,10 @@
 	devotion_cost = 30
 	/// Amount of PQ gained for curing zombos
 	var/unzombification_pq = PQ_GAIN_UNZOMBIFY
+	var/is_lethal = TRUE
+
+/obj/effect/proc_holder/spell/invoked/cure_rot/priest
+	is_lethal = FALSE
 
 /obj/effect/proc_holder/spell/invoked/cure_rot/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
@@ -187,7 +191,7 @@
 
 		if(remove_rot(target = target, user = user, method = "prayer",
 			success_message = "The rot leaves [target]'s body!",
-			fail_message = "Nothing happens."))
+			fail_message = "Nothing happens.", is_lethal))
 			target.visible_message(span_notice("The rot leaves [target]'s body!"), span_green("I feel the rot leave my body!"))
 			return TRUE
 		else //Attempt failed, no rot

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -191,7 +191,7 @@
 
 		if(remove_rot(target = target, user = user, method = "prayer",
 			success_message = "The rot leaves [target]'s body!",
-			fail_message = "Nothing happens.", is_lethal))
+			fail_message = "Nothing happens.", lethal = is_lethal))
 			target.visible_message(span_notice("The rot leaves [target]'s body!"), span_green("I feel the rot leave my body!"))
 			return TRUE
 		else //Attempt failed, no rot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Deadite's POV:

https://github.com/user-attachments/assets/56533de7-8e7c-4772-adc5-3cd992b7048f

And they are a fresh corpse again:
![dreamseeker_bGCBrMB4hH](https://github.com/user-attachments/assets/7f7e153f-54cd-4443-8ddd-3594fbc9c756)

- Priest's manually-added Cure Rot miracle ignores this and fully revives a deadite
- Necran Acolyte Cure Rot still leaves behind a corpse
- As does the surgery
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
C'mon guys what were you expecting when you openly flaunt that it's "better to wait for them to rot than to revive before with lux"

Since this touched death / dying, if it's seen as a good idea it should be TMed.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
