### PR TITLE
Tongs no longer take things from bags

### DIFF
--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -124,6 +124,9 @@
 /obj/item/ingot/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/rogueweapon/tongs))
 		var/obj/item/rogueweapon/tongs/T = I
+		if (loc in user.contents)
+			to_chat(user, span_warning("I can't take out \the [src] from inside."))
+			return
 		if(!T.hingot)
 			forceMove(T)
 			T.hingot = src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Prevents tongs from interacting with things inside bags.

## Why It's Good For The Game

to prevent this: 
![image](https://github.com/user-attachments/assets/d72fd0ad-d9ff-4d44-b0d5-24ec7c683667)
(you can pick out ingots from inside bags with tongs and it pulls out the entire grid making it uninteractable)
