### PR TITLE
Gate (Potion) Alchemy behind Alchemy skills

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/cauldron.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/cauldron.dm
@@ -88,10 +88,27 @@
 				if(outcomes[outcomes[1]] >= 5)
 					var/result_path = outcomes[1]
 					var/datum/alch_cauldron_recipe/found_recipe = new result_path
+					var/amt2raise = lastuser?.STAINT*2
+					var/in_cauldron = src?.reagents?.get_reagent_amount(/datum/reagent/water)
+					// Handle skillgating
+					if(!lastuser)
+						brewing = 0
+						src.visible_message(span_info("The cauldron can't brew anything without an alchemist to guide it."))
+						return
+					if(found_recipe.skill_required > lastuser?.mind?.get_skill_level(/datum/skill/craft/alchemy))
+						brewing = 0
+						src.visible_message(span_warning("The ingredients iin the cauldron melds together into a disgusting mess! Perhaps a more skilled alchemist is needed for this recipe."))
+						if(reagents)
+							src.reagents.remove_reagent(/datum/reagent/water, in_cauldron)
+						for(var/obj/item/ing in src.ingredients)
+							qdel(ing)
+						src.reagents.add_reagent(/datum/reagent/yuck, in_cauldron) // 1 to 1 transmutation of yuck
+						// Learn from your failure (Yeah you can technically still grind this way you just blow through a lot of ingredients)
+						lastuser?.mind?.adjust_experience(/datum/skill/craft/alchemy, amt2raise, FALSE) 
+						return
 					for(var/obj/item/ing in src.ingredients)
 						qdel(ing)
 					if(reagents)
-						var/in_cauldron = src.reagents.get_reagent_amount(/datum/reagent/water)
 						src.reagents.remove_reagent(/datum/reagent/water, in_cauldron)
 					if(found_recipe.output_reagents.len)
 						src.reagents.add_reagent_list(found_recipe.output_reagents)
@@ -101,7 +118,6 @@
 					//handle player perception and reset for next time
 					src.visible_message("<span class='info'>The cauldron finishes boiling with a faint [found_recipe.smells_like] smell.</span>")
 					//give xp for /datum/skill/craft/alchemy
-					var/amt2raise = lastuser.STAINT*2
 					lastuser?.mind?.adjust_experience(/datum/skill/craft/alchemy, amt2raise, FALSE)
 					playsound(src, "bubbles", 100, TRUE)
 					playsound(src,'sound/misc/smelter_fin.ogg', 30, FALSE)

--- a/code/modules/roguetown/roguecrafting/alchemy/cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/cauldron_recipes.dm
@@ -1,6 +1,7 @@
 /datum/alch_cauldron_recipe
 	var/recipe_name = "" //The name of the recipe, kinda there just in case.
 	var/smells_like = "nothing" //cauldron emits this smell when done, and alchemists can sniff ingredients to find what they do
+	var/skill_required = SKILL_LEVEL_APPRENTICE // Minimum skill to create this recipe successfully (It just won't mix otherwise) - Minimum Apprentice 
 	var/list/output_reagents = list() //list of paths of new reagents to create in the cauldron. Remember, 1 oz is 3 units! [reagent = amnt]
 	var/list/output_items = list() //List of paths for new items that should be created, [path = chance to be created]
 
@@ -17,26 +18,31 @@
 /datum/alch_cauldron_recipe/berrypoison
 	recipe_name = "Poison"
 	smells_like = "death"
+	skill_required = SKILL_LEVEL_JOURNEYMAN // Basic poison should be harder to handle
 	output_reagents = list(/datum/reagent/berrypoison = 81)
 
 /datum/alch_cauldron_recipe/doompoison
 	recipe_name = "Strong Poison"
 	smells_like = "doom"
+	skill_required = SKILL_LEVEL_EXPERT // Strong poison should be more difficult to make
 	output_reagents = list(/datum/reagent/berrypoison = 81,/datum/reagent/additive = 81)
 
 /datum/alch_cauldron_recipe/stam_poison
 	recipe_name = "Stamina Poison"
 	smells_like = "a slow breeze"
+	skill_required = SKILL_LEVEL_JOURNEYMAN // Basic poison should be harder to handle
 	output_reagents = list(/datum/reagent/stampoison = 81)
 
 /datum/alch_cauldron_recipe/big_stam_poison
 	recipe_name = "Strong Stamina Poison"
 	smells_like = "stagnant air"
+	skill_required = SKILL_LEVEL_EXPERT // Strong poison should be more difficult to make
 	output_reagents = list(/datum/reagent/stampoison = 81,/datum/reagent/additive = 81)
 
 /datum/alch_cauldron_recipe/gender_potion
 	recipe_name = "Gender Potion"
 	smells_like = "living beings"
+	skill_required = SKILL_LEVEL_MASTER // If this ever add re-added, it should be hard to make
 	output_reagents = list(/datum/reagent/medicine/gender_potion = 9)
 
 //Healing potions
@@ -48,11 +54,13 @@
 /datum/alch_cauldron_recipe/big_health_potion
 	recipe_name = "Strong Elixir of Health"
 	smells_like = "berry pie"
+	skill_required = SKILL_LEVEL_JOURNEYMAN // If it has "Strong", lock it roundstart for Apothecary or above
 	output_reagents = list(/datum/reagent/medicine/healthpot = 81,/datum/reagent/additive = 81)
 
 /datum/alch_cauldron_recipe/rosewater_potion
 	recipe_name = "Rose Water"
 	smells_like = "roses"
+	skill_required = SKILL_LEVEL_NONE // Everyone can put rose in water
 	output_reagents = list(/datum/reagent/water/rosewater = 81)
 
 /datum/alch_cauldron_recipe/mana_potion
@@ -63,6 +71,7 @@
 /datum/alch_cauldron_recipe/big_mana_potion
 	recipe_name = "Powerful Arcane Elixir"
 	smells_like = "fear"
+	skill_required = SKILL_LEVEL_JOURNEYMAN
 	output_reagents = list(/datum/reagent/medicine/manapot = 81,/datum/reagent/additive = 81)
 
 /datum/alch_cauldron_recipe/stamina_potion
@@ -73,40 +82,48 @@
 /datum/alch_cauldron_recipe/big_stamina_potion
 	recipe_name = "Powerful Stamina Elixir"
 	smells_like = "clean winds"
+	skill_required = SKILL_LEVEL_JOURNEYMAN
 	output_reagents = list(/datum/reagent/medicine/stampot = 81,/datum/reagent/additive = 81)
 
-//S.P.E.C.I.A.L. potions
+//S.P.E.C.I.A.L. potions - Expert or above (roundstart Witch etc.)
 /datum/alch_cauldron_recipe/str_potion
 	recipe_name = "Potion of Mountain Muscles"
 	smells_like = "petrichor"
+	skill_required = SKILL_LEVEL_EXPERT
 	output_reagents = list(/datum/reagent/buff/strength = 27)
 
 /datum/alch_cauldron_recipe/per_potion
 	recipe_name = "Potion of Keen Eye"
 	smells_like = "fire"
+	skill_required = SKILL_LEVEL_EXPERT
 	output_reagents = list(/datum/reagent/buff/perception = 27)
 
 /datum/alch_cauldron_recipe/end_potion
 	recipe_name = "Potion of Enduring Fortitude"
 	smells_like = "mountain air"
+	skill_required = SKILL_LEVEL_EXPERT
 	output_reagents = list(/datum/reagent/buff/endurance = 27)
 
 /datum/alch_cauldron_recipe/con_potion
 	recipe_name = "Potion of Stone Flesh"
 	smells_like = "earth"
+	skill_required = SKILL_LEVEL_EXPERT
 	output_reagents = list(/datum/reagent/buff/constitution = 27)
 
 /datum/alch_cauldron_recipe/int_potion
 	recipe_name = "Potion of Keen Mind"
 	smells_like = "water"
+	skill_required = SKILL_LEVEL_EXPERT
 	output_reagents = list(/datum/reagent/buff/intelligence = 27)
 
 /datum/alch_cauldron_recipe/spd_potion
 	recipe_name = "Potion of Fleet Foot"
 	smells_like = "clean air"
+	skill_required = SKILL_LEVEL_EXPERT
 	output_reagents = list(/datum/reagent/buff/speed = 27)
 
 /datum/alch_cauldron_recipe/lck_potion
 	recipe_name = "Potion of Seven Clovers"
 	smells_like = "calming"
+	skill_required = SKILL_LEVEL_EXPERT
 	output_reagents = list(/datum/reagent/buff/fortune = 27)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- All potion alchemy recipes now requires a minimum skills of Apprentice to create successfully
- All potions that are "Strong" requires Journeyman (Apothecary or above start with it) to make
- All stat buff potions require Expert (Witch start with it) to make
- Exception made for Rose Water - anyone can make it.
- If you make a recipe you can't make, you turn the ingredients into organic slurry instead and get a message indicating it is a skill failure. You will still gain XP.

If this is merged I'll make an account on the wiki to update the alchemy page.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unlike lesser alchemy or nearly all recipes, alchemy is not gated behind any kind of skills, making the alchemy skills functionally useless once someone has codedived / gained basic OOC knowledge. In fact, alchemy's kinda hard to do blind anyway.

This gives apothecaries / alchemist associate some kind of niche instead of everyone brewing potions whenever they find one of 1000 cauldrons in the wild.

Skills can still be grinded up by grinding in an alchemical mortar and / or failing recipes on purpose.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
