### PR TITLE
Fix bronze left leg and arm max damage

### DIFF
--- a/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
+++ b/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
@@ -27,7 +27,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 110
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30
@@ -128,7 +128,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 110
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Bronze left leg and left arm had 20 max_damage instead of 110 that right arm / right leg had, same as wooden. Clearly not intended. Changed to 110

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ends bigotry against left leg and arm.

## Testing
Chopped myself left and right arm before and after code changes

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
