### PR TITLE
Remove swingdelay on halberd

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -34,7 +34,6 @@
 
 /datum/intent/spear/cut/halberd
 	damfactor = 0.9
-	swingdelay = 10
 
 /datum/intent/spear/cut/bardiche
     damfactor = 1.0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Remove the swing delay on halberd's cut intent

## Why It's Good For The Game
Halberd is the archetypical guard weapon and a mainstay of this time period. It should be versatile. 

Also the chop intent on halberd is 100% superior with 1.0 damfactor, 8 swingdelay instead of 10, and 30 pen. This is inconsistent with most weapons where cut is the fast, no delay option and chop is the stronger, delayed option.

But it is just completely out of the meta because of a 10 swingdelay which no other cutting polearm has - it already has lower cutting damage so this is just plain unfair. This removes the swingdelay so halberd is a viable weapon.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
