### PR TITLE
Bathmaster vault income from 30% ->20%

### DIFF
--- a/code/modules/roguetown/roguemachine/bathmaster.dm
+++ b/code/modules/roguetown/roguemachine/bathmaster.dm
@@ -207,7 +207,7 @@ SUBSYSTEM_DEF(BMtreasury)
 	priority = FIRE_PRIORITY_WATER_LEVEL
 	var/treasury_value = 0
 	var/multiple_item_penalty = 0.66
-	var/interest_rate = 0.30 // double the interest, since it's gonna be much harder for the BMaster to get valuables.
+	var/interest_rate = 0.20 // Bit more interest, since it's gonna be much harder for the BMaster to get valuables.
 	var/next_treasury_check = 0
 	var/list/vault_accounting = list()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Applies a nerf to the Bmaster vault, which was apparently rather readily becoming richer than the court. Should still be a powerful tool, just maybe not -as- strong. Done by request of original commissioner

## Why It's Good For The Game

BMaster probably shouldnt be **that** rich.
