### PR TITLE
Stress indicators now move with the mob

### DIFF
--- a/code/modules/mob/living/overhead_effects.dm
+++ b/code/modules/mob/living/overhead_effects.dm
@@ -30,7 +30,7 @@
 						can_see += M
 			
 			for(var/mob/M in can_see)
-				new /obj/effect/temp_visual/stress_event/invisible(get_turf(src.loc), M, icon_path, overlay_name, offset_list)
+				vis_contents += new /obj/effect/temp_visual/stress_event/invisible(null, M, icon_path, overlay_name, offset_list)
 				if(soundin)
 					var/turf/T = get_turf(src)
 					M.playsound_local(T, soundin, 100, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![dreamseeker_GddN0dzdIh](https://github.com/user-attachments/assets/bc3bf92e-8e3a-4e4f-80a6-d9fed6ac3aee)

Thanks to the frankly obvious approach a port did in https://github.com/Vanderlin-Tales-Of-Wine/Vanderlin/pull/1197
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They no longer get plopped on the ground and move with the mob.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
