### PR TITLE
Alphabetize crafting & smithing list. Change tabard / surcoat names i…

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -564,9 +564,7 @@
 	if(!A.can_craft_here())
 		to_chat(user, span_warning("I can't craft here."))
 		return
-//	if(user != parent)
-//		testing("c2")
-//		return
+
 	var/list/data = list()
 	var/list/catty = list()
 	var/list/surroundings = get_surroundings(user)
@@ -574,9 +572,6 @@
 		var/datum/crafting_recipe/R = rec
 		if(!R.always_availible && !(R.type in user?.mind?.learned_recipes)) //User doesn't actually know how to make this.
 			continue
-
-//		if((R.category != cur_category) || (R.subcategory != cur_subcategory))
-//			continue
 
 		if(check_contents(R, surroundings))
 			if(R.name)
@@ -607,6 +602,7 @@
 				if(t == "Other")
 					realdata += X
 		if(realdata.len)
+			realdata = sortNames(realdata)
 			var/r = input(user, "What should I craft?") as null|anything in realdata
 			if(r)
 				construct_item(user, r)

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -243,7 +243,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/abyssortemplartabard
-	name = "abyssorite templar tabard"
+	name = "tabard, abyssorite templar"
 	result = list(/obj/item/clothing/cloak/abyssortabard)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
@@ -251,88 +251,88 @@
 
 
 /datum/crafting_recipe/roguetown/sewing/psydon
-	name = "psydon tabard"
+	name = "tabard, psydon"
 	result = list(/obj/item/clothing/cloak/templar/psydon)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/astrata
-	name = "astrata tabard"
+	name = "tabard, astrata"
 	result = list(/obj/item/clothing/cloak/templar/astrata)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/noc
-	name = "noc tabard"
+	name = "tabard, noc"
 	result = list(/obj/item/clothing/cloak/templar/noc)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/dendor
-	name = "dendor tabard"
+	name = "tabard, dendor"
 	result = list(/obj/item/clothing/cloak/templar/dendor)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/necra
-	name = "necra tabard"
+	name = "tabard, necra"
 	result = list(/obj/item/clothing/cloak/templar/necra)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/abyssor
-	name = "abyssor tabard"
+	name = "tabard, abyssor"
 	result = list(/obj/item/clothing/cloak/templar/abyssor)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/malum
-	name = "malum tabard"
+	name = "tabard, malum"
 	result = list(/obj/item/clothing/cloak/templar/malum)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/eora
-	name = "eora tabard"
+	name = "tabard, eora"
 	result = list(/obj/item/clothing/cloak/templar/eora)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/pestra
-	name = "pestra tabard"
+	name = "tabard, pestra"
 	result = list(/obj/item/clothing/cloak/templar/pestra)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/ravox
-	name = "ravox tabard"
+	name = "tabard, ravox"
 	result = list(/obj/item/clothing/cloak/templar/ravox)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/xylix
-	name = "xylix tabard"
+	name = "tabard, xylix"
 	result = list(/obj/item/clothing/cloak/templar/xylix)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/stabard/guard
-	name = "guard surcoat"
+	name = "surcoat, guard"
 	result = list(/obj/item/clothing/cloak/stabard/guard)
 
 /datum/crafting_recipe/roguetown/sewing/stabard/bog
-	name = "bog surcoat"
+	name = "surcoat, bog"
 	result = list(/obj/item/clothing/cloak/stabard/bog)
 
 /datum/crafting_recipe/roguetown/sewing/robe

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil.dm
@@ -165,6 +165,7 @@
 			appro_recipe -= R
 
 	if(appro_recipe.len)
+		appro_recipe = sortNames(appro_recipe)
 		var/datum/anvil_recipe/chosen_recipe = input(user, "Choose A Creation", "Anvil") as null|anything in sortNames(appro_recipe.Copy())
 		if(!chosen_recipe)
 			return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Alphabetically sort the crafting list and the smithing list.

To avoid tabard being spread all over the place (and also the two surcoat), I changed their recipe name to tabard, eoran etc. etc. and surcoat, bog etc. - this method keeps all of the surcoat / tabard close to eachother while still sorting it alphabetically

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes it much easier to find an item if you know the alphabet.

## Testing 
![XZ9ZuDbaMI](https://github.com/user-attachments/assets/dad961ea-480f-45e8-ae5e-a4ff52ca5970)
![HRgm2i4HpA](https://github.com/user-attachments/assets/7d1d37d3-a70f-4c1a-a965-39deb04a9721)
![dreamseeker_crabGeUGTV](https://github.com/user-attachments/assets/cc31e468-cb4f-4671-937d-70d094b65638)

I've also crafted some items
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
