### PR TITLE
Move guidance check on dodge before mobility check

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -509,15 +509,16 @@
 						prob2defend = prob2defend - (UH.mind.get_skill_level(/datum/skill/combat/unarmed) * 10)
 					if(H.mind)
 						prob2defend = prob2defend + (H.mind.get_skill_level(/datum/skill/combat/unarmed) * 10)
-		// dodging while knocked down sucks ass
-		if(!(L.mobility_flags & MOBILITY_STAND))
-			prob2defend *= 0.25
 
 		if(HAS_TRAIT(L, TRAIT_GUIDANCE))
 			prob2defend += 15
 
 		if(HAS_TRAIT(U, TRAIT_GUIDANCE))
 			prob2defend -= 15
+
+		// dodging while knocked down sucks ass
+		if(!(L.mobility_flags & MOBILITY_STAND))
+			prob2defend *= 0.25
 
 		if(HAS_TRAIT(H, TRAIT_SENTINELOFWITS))
 			var/sentinel = H.calculate_sentinel_bonus()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Move guidance check on dodge before mobility check

## Why It's Good For The Game
Someone pointed out I put the guidance check on dodge after the mobility check instead of before on parry. This fixes it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
