### PR TITLE
Xylix language is now only visible to Xylixians

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -141,7 +141,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	else
 		return verb_say
 
-/atom/movable/proc/say_quote(input, list/spans=list(speech_span), message_mode)
+/atom/movable/proc/say_quote(input, list/spans=list(speech_span), message_mode, visible = TRUE)
+	if(!input && !visible)
+		return ""
 	if(!input)
 		input = "..."
 
@@ -154,6 +156,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		var/mob/living/L = src
 		if(L.cmode)
 			return "— \"[spanned]\""
+			
 	return "[say_mod(input, message_mode)], \"[spanned]\""
 
 /atom/movable/proc/quoteless_say_quote(input, list/spans = list(speech_span), message_mode)
@@ -176,9 +179,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		var/datum/language/D = GLOB.language_datum_instances[language]
 		raw_message = D.scramble(raw_message)
 		if(AM)
-			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mode) : AM.say_quote(raw_message, spans, message_mode)
+			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mode) : AM.say_quote(raw_message, spans, message_mode, D.invisible)
 		else
-			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mode) : speaker.say_quote(raw_message, spans, message_mode)
+			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mode) : speaker.say_quote(raw_message, spans, message_mode, D.invisible)
 	else
 		return "makes a strange sound."
 

--- a/code/modules/language/language.dm
+++ b/code/modules/language/language.dm
@@ -27,6 +27,7 @@
 	// if you are seeing someone speak popcorn language, then something is wrong.
 	var/icon = 'icons/misc/language.dmi'
 	var/icon_state = "popcorn"
+	var/invisible = FALSE
 
 /datum/language/proc/display_icon(atom/movable/hearer)
 	var/understands = hearer.has_language(src.type)

--- a/code/modules/language/roguetown/thievescant.dm
+++ b/code/modules/language/roguetown/thievescant.dm
@@ -17,3 +17,8 @@
 		"look", "see", "watch", "hear", "peep", "smell", "taste", "no", "yes", "silver", "gold", "sand", "grass", "rock",
 		"mud", "hah", "save", "cave","over", "under", "carkin", "lark", "tosser", "knobhead", "daft", "gnerd", "knave",
 		"fort", "cave","through the","hand","leg","foot","head","arrow","knee","elbow","eye","for a","reach","the","a","an","ask","tell","pray","travel","journey","quest")
+	invisible = TRUE
+
+/datum/language/thievescant/scramble(input)
+	input = ""
+	return input

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -348,6 +348,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		var/atom/movable/AM = _AM
 		var/turf/listener_turf = get_turf(AM)
 		var/turf/listener_ceiling = get_step_multiz(listener_turf, UP)
+
+		//Thieves cant language is not sent to those who don't know it.
+		if(message_language)
+			var/datum/language/L = GLOB.language_datum_instances[message_language]
+			if(istype(L, /datum/language/thievescant) && !AM.has_language(/datum/language/thievescant))
+				continue
+
 		if(listener_ceiling)
 			listener_has_ceiling = TRUE
 			if(istransparentturf(listener_ceiling))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -348,12 +348,15 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		var/atom/movable/AM = _AM
 		var/turf/listener_turf = get_turf(AM)
 		var/turf/listener_ceiling = get_step_multiz(listener_turf, UP)
+		var/lang_filter = FALSE
 
 		//Thieves cant language is not sent to those who don't know it.
 		if(message_language)
 			var/datum/language/L = GLOB.language_datum_instances[message_language]
-			if(istype(L, /datum/language/thievescant) && !AM.has_language(/datum/language/thievescant))
-				continue
+			if(istype(L, /datum/language/thievescant))
+				lang_filter = TRUE
+				if(!AM.has_language(/datum/language/thievescant))				
+					continue
 
 		if(listener_ceiling)
 			listener_has_ceiling = TRUE
@@ -373,6 +376,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			else
 				if(abs((listener_turf.z - speaker_turf.z)) >= 2)	//We're yelling with only one "!", and the listener is 2 or more z levels above or below us.
 					continue
+			if(lang_filter)	//We do not hear special invisible languages across z levels
+				continue
 			var/listener_obstructed = TRUE
 			var/speaker_obstructed = TRUE
 			if(src != AM && !Zs_yell && !HAS_TRAIT(AM, TRAIT_KEENEARS))	//We always hear ourselves. Zs_yell will allow a "!" shout to bypass walls one z level up or below.
@@ -388,6 +393,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 							listener_obstructed = FALSE
 				if(listener_obstructed && speaker_obstructed)
 					continue
+		if(lang_filter)		//If we have a special invisible language, we only hear it if we're in view of the speaker.
+			if(!(AM in viewers(world.view, src.loc)))
+				continue
 		var/highlighted_message
 		var/keenears
 		if(ishuman(AM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
What a Xylixian sees when another Xylixian is speaking the thieves cant:
![dreamseeker_fsAtsSrvNu](https://github.com/user-attachments/assets/ff6ad95d-86a9-4176-8940-4f1c53a7fc5b)
![dreamseeker_Kac0eNj0Xi](https://github.com/user-attachments/assets/3bd5389d-a77a-4acc-aaaf-562533726a59)
(the font is weird for listeners, not sure what's causing that yet)

What a non-Xylixian sees:
![dreamseeker_POvT4ofSWa](https://github.com/user-attachments/assets/b33d240a-f7b3-4d3d-9172-2117bca3eb25)

Nothing. At all.

I do believe that paranoid people will still get a stress event due to this, making them the only non-Xylixian to be able to tell that something fucky is going on.

You must be in view of the speaker to see it as a Xylixian. It does not go through z levels / walls and even yelling's extra range won't apply.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
let's be xylixian together (secretively)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
