### PR TITLE
Readds crossbow damfactor = 2 that was lost in debloat

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -23,6 +23,7 @@
 	smeltresult = /obj/item/ingot/steel
 	resistance_flags = FIRE_PROOF
 	obj_flags = UNIQUE_RENAME
+	damfactor = 2
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/getonmobprop(tag)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Crossbows used to have damfactor = 2, but it was lost in https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/commit/471d6bac4d3240ec4eae0bf6e8c3b3da1d61c355#diff-6aca19292fd895d88e8bbd1876a467d1e45af87c2c19075de9ce0b1957b50356

This readds it.
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Longbows are pretty superior to crossbows without this. The old balance world used to have knights carrying crossbows with one bolt for toe-poppers, let's hope that doesn't crop up again. More snowflake nerfs on the horizon to deal with it.