### PR TITLE
Adds a toggle for black & white mode to Night Eyed virtue

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -262,3 +262,12 @@
 		voice_color = original_voice
 		to_chat(src, span_info("I've returned to my natural voice."))
 	return TRUE
+
+/mob/living/carbon/human/proc/toggleblindness()
+	set name = "Toggle Colorblindness"
+	set category = "Virtue"
+
+	if(!get_client_color(/datum/client_colour/monochrome))
+		add_client_colour(/datum/client_colour/monochrome)
+	else
+		remove_client_colour(/datum/client_colour/monochrome)

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -275,7 +275,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 
 /datum/charflaw/colorblind
 	name = "Colorblind"
-	desc = "I was cursed with flawed eyesight from birth, and can't discern things others can."
+	desc = "I was cursed with flawed eyesight from birth, and can't discern things others can. Incompatible with Night-eyed virtue."
 
 /datum/charflaw/colorblind/on_mob_creation(mob/user)
 	..()

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -203,8 +203,16 @@
 
 /datum/virtue/utility/night_vision
 	name = "Night-eyed"
-	desc = "I have eyes able to see through cloying darkness."
+	desc = "I have eyes able to see through cloying darkness. Incompatible with the vice Colorblind."
 	added_traits = list(TRAIT_DARKVISION)
+	custom_text = "Adds a button to toggle colorblindness to aid seeing in the dark. Taking this with the Colorblind vice will permanently colorblind you."
+
+/datum/virtue/utility/night_vision/apply_to_human(mob/living/carbon/human/recipient)
+	if(recipient.charflaw)
+		if(recipient.charflaw.type == /datum/charflaw/colorblind)
+			to_chat(recipient, "Your eyes have become permanently colorblind.")
+		else
+			recipient.verbs += /mob/living/carbon/human/proc/toggleblindness
 
 /datum/virtue/utility/performer
 	name = "Performer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
A few people have pointed out that it greatly helps seeing in the dark, but didn't like how it was attached to a permanent vice.
This fixes that.

Taking the Night Eyed virtue will now give you a button in the Virtue tab:
![dreamseeker_fdQs1Gdd0F](https://github.com/user-attachments/assets/31e08b70-7e4d-45ba-bda5-32279313ee87)

Clicking it will toggle you into colorblind mode and back out of.
![dreamseeker_nJieGkA1cW](https://github.com/user-attachments/assets/80e3b84e-3dbf-4b4b-8b4e-a8a3cb572294)

Taking it with the colorblind Vice will not give you the toggle, instead it will behave as before and permanently leave you colorblind with an added message:
![dreamseeker_WB6pLX6rtg](https://github.com/user-attachments/assets/a6b2bd0a-b128-4442-9d7d-251010372311)


![dreamseeker_TC9N013xNo](https://github.com/user-attachments/assets/ec45c427-6ae1-4eef-a2db-d64b52f30a3e)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
By a quasi request. In all fairness, it's not the most overtly powerful vice, this might help those that skulk about in the darkness.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
