### PR TITLE
The Great Stockpile Debate + Fixes Selling-Meat Exploit

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -475,7 +475,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "anU" = (
-/obj/structure/roguemachine/withdraw,
+/obj/structure/roguemachine/stockpile,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "aoe" = (
@@ -5128,7 +5128,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "dtx" = (
-/obj/structure/roguemachine/stockpile,
+/obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "dtN" = (
@@ -6719,7 +6719,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/obj/structure/roguemachine/stockpile,
+/obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "eBz" = (
@@ -8509,7 +8509,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "fSC" = (
-/obj/structure/roguemachine/stockpile,
+/obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "fSO" = (
@@ -11030,7 +11030,7 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/kitchen/rollingpin,
-/obj/structure/roguemachine/stockpile{
+/obj/structure/roguemachine/withdraw{
 	pixel_y = 0;
 	pixel_x = -32
 	},
@@ -27413,7 +27413,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "thu" = (
-/obj/structure/roguemachine/stockpile,
+/obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "thH" = (
@@ -28217,7 +28217,7 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/exposed/town/keep)
 "tHr" = (
-/obj/structure/roguemachine/stockpile,
+/obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "tHu" = (
@@ -70587,7 +70587,7 @@ hvn
 hvn
 hvn
 xqr
-tHr
+anU
 vpP
 vpP
 xqr
@@ -71707,7 +71707,7 @@ pJn
 pJn
 pJn
 xqr
-anU
+tHr
 jlY
 vpP
 vpP

--- a/code/modules/roguetown/roguestock/_roguestock.dm
+++ b/code/modules/roguetown/roguestock/_roguestock.dm
@@ -35,6 +35,11 @@
 /datum/roguestock/proc/check_item(obj/item/I) //for checking monster heads if they belong to monsters and other stuff
 	if(import_only) //so you can't submit crackers to stockpile
 		return FALSE
+	//To stop people selling half-eaten food and rotten meat to the stockpile
+	if(istype(I, /obj/item/reagent_containers/food/snacks))
+		var/obj/item/reagent_containers/food/snacks/food = I
+		if(food.eat_effect == /datum/status_effect/debuff/rotfood || food.bitecount > 0)
+			return FALSE
 	return TRUE
 
 /datum/roguestock/proc/get_export_price()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Does two things, that's legit it.
- Replaces **ALL** stockpiles with vomitoriums, except that in the Steward's front room. Thus allowing them to lock-down selling into the economy as needed. 
- Stops you from selling rotted meat to the stockpile for free money. Stop doing that, you're gross. I'm calling the FDA.

## Why It's Good For The Game

Argument has raged for over a year across how many servers of how easy it is to mass-produce and sell stuff without the steward being able to monitor the flow of sales of materials. This has been an issue a few times before where it is really hard to stop mass-runs on the stockpile for massive deposits to train the economy.

This just aims to allow the steward more control. Only downsides I can see is:
- Wretches would have to go to the middle of town to sell their goods. No more sitting at the outskirts and mass-selling.
- Soilsons/Miners will have to walk an extra maybe 20 tiles. Probably less.

## Why It's Good For The Discord

This ends the debate. Merged or declined, it ends it. No more of the hour long "But the stockpiles, there are too many" discussions.