### PR TITLE
Pixel Shift Bugfix

### DIFF
--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -1,5 +1,3 @@
-
-
 //IMPORTANT: Multiple animate() calls do not stack well, so try to do them all at once if you can.
 /mob/living/carbon/update_transform(forcepixel)
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
@@ -26,14 +24,18 @@
 	if(changed)
 //		animate(src, transform = ntransform, time = (lying_prev == 0 || !lying) ? 2 : 0, pixel_y = final_pixel_y, dir = final_dir, easing = (EASE_IN|EASE_OUT))
 		transform = ntransform
-		pixel_x = get_standard_pixel_x_offset()
-		pixel_y = final_pixel_y
+		// Only reset pixel_x if we're not in a custom pixel shift
+		if(!is_shifted)
+			pixel_x = get_standard_pixel_x_offset()
+			pixel_y = final_pixel_y
 		dir = final_dir
 		setMovetype(movement_type & ~FLOATING)  // If we were without gravity, the bouncing animation got stopped, so we make sure we restart it in next life().
 		update_vision_cone()
 	else
-		pixel_x = get_standard_pixel_x_offset()
-		pixel_y = get_standard_pixel_y_offset(lying)
+		// Only reset pixel_x if we're not in a custom pixel shift
+		if(!is_shifted)
+			pixel_x = get_standard_pixel_x_offset()
+			pixel_y = get_standard_pixel_y_offset(lying)
 
 /mob/living
 	var/list/overlays_standing[TOTAL_LAYERS]

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -864,9 +864,6 @@
 	if(wallpressed)
 		update_wallpress(T, newloc, direct)
 
-	if(is_shifted)
-		update_pixel_shifting(TRUE)
-
 	if(lying)
 		if(direct & EAST)
 			lying = 90


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes your pixel shift being reset to the middle of the tile while you are debuffed


<details>
  <summary>Before/After</summary>
  
  **Before:**

https://github.com/user-attachments/assets/a2d144e1-6455-4423-bec1-8423d5fc8347

**After:**

https://github.com/user-attachments/assets/63e01cd2-a54f-4e78-9fb1-75902c3ca8a0
  
</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
its a bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
