### PR TITLE
Graggar blood drink

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -574,8 +574,9 @@
 				to_chat(user, "<span class='notice'>A strange, sweet taste tickles my throat.</span>")
 				addtimer(CALLBACK(user, .mob/living/carbon/human/proc/vampire_infect), 1 MINUTES) // I'll use this for succession later.
 			else */
-			to_chat(user, "<span class='warning'>I'm going to puke...</span>")
-			addtimer(CALLBACK(user, TYPE_PROC_REF(/mob/living/carbon, vomit), 0, TRUE), rand(8 SECONDS, 15 SECONDS))
+			if(!HAS_TRAIT(user, TRAIT_HORDE))
+				to_chat(user, "<span class='warning'>I'm going to puke...</span>")
+				addtimer(CALLBACK(user, TYPE_PROC_REF(/mob/living/carbon, vomit), 0, TRUE), rand(8 SECONDS, 15 SECONDS))
 	else
 		if(user.mind)
 			if(user.mind.has_antag_datum(/datum/antagonist/vampirelord))
@@ -586,8 +587,10 @@
 				else
 					VDrinker.handle_vitae(300)
 
-	C.blood_volume = max(C.blood_volume-5, 0)
+	C.blood_volume = max(C.blood_volume-15, 0)
 	C.handle_blood()
+	if(HAS_TRAIT(user, TRAIT_HORDE))
+		user.adjust_hydration(8)
 
 	playsound(user.loc, 'sound/misc/drink_blood.ogg', 100, FALSE, -4)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

1. Graggarites can now drink blood, they no longer get sick from player blood.
2. They also actually get hydration from it, both from players and carbon mobs.
3. Also makes blood drink *slightly* more lethal. Draining 15 blood rather than 5. This isn't like, hyper lethal. But now you can actually suck someone dry if you drink them alot, rather than it draining so little that it had no effect. Still nothing compared to the VLORD 45 blood drain, but usable for dramatics.

Commissioned by mashimashers

## Why It's Good For The Game

Blood for the blood god.
