### PR TITLE
Longbow availability changes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -153,7 +153,7 @@
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Crossbow","Longbow","Sling")
+	var/weapons = list("Crossbow","Recurve Bow","Sling")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
@@ -161,9 +161,9 @@
 			beltr = /obj/item/quiver/bolts
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 			H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
-		if("Longbow") // They can head down to the armory to sideshift into one of the other bows.
+		if("Recurve Bow")
 			beltr = /obj/item/quiver/arrows
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
+			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			H.mind.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 		if("Sling")
 			beltr = /obj/item/quiver/sling/iron

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -144,7 +144,7 @@
 	tools = /obj/item/rogueweapon/huntingknife
 	verbage_simple = "carve"
 	verbage = "carves"
-	craftdiff = 3
+	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/longbow
 	name = "long bow"
@@ -155,7 +155,7 @@
 		)
 	verbage_simple = "string together"
 	verbage = "strings together"
-	craftdiff = 3
+	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/wickercloak
 	name = "wickercloak"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- MaA no longer gets Longbows, only Recurve Bows and Crossbows
- Longbow shaft recipe raised to Expert
- Longbow recipe raised to Master
- MK / Champion RGs keep their longbow option
- Veteran Scout still keeps their longbow

Given how it currently works (a nuke), it's preferable if anyone wanting to get it themselves would have to spend at least 2 nights for the XP. It also means wretches have a whole hour to actually do something in the grove rather than roughly 30 (or none, if they're a Nocite) minutes before the ballistic missile launcher is deployed.

Tackling projectiles themselves is a bit more of a sensitive pickle, and frankly I'm weary of doing so much balancing as it is. This is simpler and achieves the one thing it's meant to -- delay getting it. Unless you seek out a dedicated crafter role like Town Elder or Artificer. (Both get high Crafting!)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was more of a request.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
