### PR TITLE
Alphabetical dyes

### DIFF
--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -47,7 +47,7 @@
 		"Royal Blue" = "#173266",
 		"Royal Brown" = "#61462c",
 		"Royal Green" = "#264d26",
-		"Royal Majenta" = "#962e5c",
+		"Royal Magenta" = "#962e5c",
 		"Royal Orange" = "#df8405",
 		"Royal Purple" = "#8747b1",
 		"Royal Red" = "#8b2323",


### PR DESCRIPTION
Rearrange the list of dyes alphabetically. It looks neater and nicer.
Also removes "Majenta" and "Dark Green"... because they were **exactly** the same hex color as "Royal Majenta" and "Royal Green".
That's all.

![ezgif-869bee2406d601](https://github.com/user-attachments/assets/4a9a650d-19a0-4bfc-ba9f-54a3362e549a)
