### PR TITLE
Sewing Repairs will automatically retry if the item is not fully repaired.

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -99,6 +99,8 @@
 				user.visible_message(span_info("[user] damages [I] due to a lack of skill!"))
 				playsound(src, 'sound/foley/cloth_rip.ogg', 50, TRUE)
 				user.mind.add_sleep_experience(/datum/skill/misc/sewing, (user.STAINT) / 2) // Only failing a repair teaches us something
+				if(do_after(user, CLICK_CD_MELEE, target = I))
+					attack_obj(I, user)
 				return
 			else
 				if(I.obj_broken && istype(I, /obj/item/clothing))
@@ -107,6 +109,8 @@
 				playsound(loc, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
 				user.visible_message(span_info("[user] repairs [I]!"))
 				I.obj_integrity = min(I.obj_integrity + 10 + skill, I.max_integrity)
+				if(do_after(user, CLICK_CD_MELEE, target = I))
+					attack_obj(I, user)
 		return
 	return ..()
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The Sewing repair action is set to repeat itself in the same fashion as the blacksmith's hammer repair action.

Tested: Attacked a shirt with an axe then repaired it from broke to full with a single click on a low sewing skilled character. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Sewing repair is tedious, especially on lower skill levels due to needing to manually initiate it every single time, it just means dozens of extra clicks on something that's random chance anyway. This will atleast automate most of the tedium.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
