### PR TITLE
Mace skill, inspect for frypan. Add skill to weapon inspect. Wdefense to 1

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -133,7 +133,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	var/canMouseDown = FALSE
 	var/can_parry = FALSE
-	var/associated_skill
+	var/datum/skill/associated_skill
 
 	var/list/possible_item_intents = list(/datum/intent/use)
 
@@ -439,6 +439,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			inspec += "\n<b>SHARPNESS:</b> "
 			var/meme = round(((blade_int / max_blade_int) * 100), 1)
 			inspec += "[meme]%"
+
+		if(associated_skill && associated_skill.name)
+			inspec += "\n<b>SKILL:</b> [associated_skill.name]"
 
 //**** CLOTHING STUFF
 

--- a/code/modules/roguetown/roguejobs/cook/tools/pan.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/pan.dm
@@ -10,6 +10,8 @@
 	//dropshrink = 0.8
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
 	can_parry = TRUE
+	associated_skill = /datum/skill/combat/maces
+	has_inspect_verb = TRUE // For snowflake and allowing you to examine the pan's properties lmao
 	swingsound = list('sound/combat/wooshes/blunt/shovel_swing.ogg','sound/combat/wooshes/blunt/shovel_swing2.ogg')
 	drop_sound = 'sound/foley/dropsound/shovel_drop.ogg'
 	wdefense = 5

--- a/code/modules/roguetown/roguejobs/cook/tools/pan.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/pan.dm
@@ -14,7 +14,7 @@
 	has_inspect_verb = TRUE // For snowflake and allowing you to examine the pan's properties lmao
 	swingsound = list('sound/combat/wooshes/blunt/shovel_swing.ogg','sound/combat/wooshes/blunt/shovel_swing2.ogg')
 	drop_sound = 'sound/foley/dropsound/shovel_drop.ogg'
-	wdefense = 5
+	wdefense = 2
 	ingsize = 3
 	grid_width = 32
 	grid_height = 64


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Add an associated skill to frying pan: Mace
- Allows people to inspect frying pan as a weapon
- Add the associated skills to all weapon inspection.
- Change frying pan w defense from 5 to 1 to match the lowest tier club (Wooden)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Let people actually see what skills is used to use a weapon and stop spreading misinformation (Frying pan was NOT associated with any skills and it keep spreading on the discord)
Frying pan is a weapon and giving it inspect helps reinforce that.
Also, this is funny.

## Testing
![dreamseeker_LHONE1dY6S](https://github.com/user-attachments/assets/42ca1dc7-a4ba-4828-9147-bba9aefab228)


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
