### PR TITLE
Poison / Pyro Arrow Changes

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -142,7 +142,7 @@
 
 /obj/projectile/bullet/reusable/arrow/poison
 	name = "poison arrow"
-	damage = 50
+	damage = 20				//You deal a bunch of posion damage as it is, regardless of armor protection.
 	damage_type = BRUTE
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"
@@ -194,7 +194,7 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
-		M.adjust_fire_stacks(6)
+		M.adjust_fire_stacks(5)
 //		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, my at about 65 damage if you stop drop and roll immediately
 	var/turf/T
 	if(isturf(target))
@@ -244,7 +244,7 @@
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
-		M.adjust_fire_stacks(6)
+		M.adjust_fire_stacks(4)
 //		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, my at about 65 damage if you stop drop and roll immediately
 	var/turf/T
 	if(isturf(target))


### PR DESCRIPTION
## About The Pull Request

People complained about his for awhile but I just didn't touch it because I was guilty of using them as well + felt I'd be biased on it given I've suffered from it as well. Poison arrows were a bit cracked due to their high damage, AP, and doing poison atop of it.

This does the following:
- Lowers poison arrow damage from 50 to 20 (Poison effects the mob regardless of damage/pen anyway, and it can cause vomit-stunlock)
- Pyro arrows now do firestack 4 instead of 6 (They explode still, plus have damage, so it's plenty effective without the higher firestack)
- Pyro bolts now do firestack 5 instead of 6 (Same deal, but you fire a crossbow slower than bow so makes sense to leave it a BIT stronger.)

## Why It's Good For The Game

Poison arrows feel like ass to play against since they were doing the same exact damage and pen as normal arrows just with bonus damage, and could be mass-crafted. So this makes them still good but you'll have to shoot someone at least a few times to get the lethality verses a legit 1-tap and guaranteed dead half the time.

Pyro arrows are finnicky due to the fire stack, damage, AND explosion - this just lowers the firestack which feels like it's the most lethal part. You used to be able to 2 tap anyone with them it seemed.