### PR TITLE
Add instructions to pick up ammo on the floor

### DIFF
--- a/code/modules/clothing/rogueclothes/quiver.dm
+++ b/code/modules/clothing/rogueclothes/quiver.dm
@@ -79,6 +79,7 @@
 	. = ..()
 	if(arrows.len)
 		. += span_notice("[arrows.len] inside.")
+	. += span_notice("Click on the ground to pick up ammos on the floor.")
 
 /obj/item/quiver/update_icon()
 	if(arrows.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Add an examine text to a quiver saying you can pick up ammo from the floor
Originally wanted to add this feature only to realize it actually exists and no one knew about it. What the fuck.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Document an important feature.

## Testing
![dreamseeker_4wL3QDaNQC](https://github.com/user-attachments/assets/cb0b7223-790d-4d40-823c-394c0b32e7d1)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
