### PR TITLE
Buffs Royal Champion so it's more up to par with other knight classes.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -369,8 +369,8 @@
 			beltr = /obj/item/quiver/bolts
 
 		if("Judgement + Crimson Fang")
-		beltl = /obj/item/rogueweapon/sword/long/vlord
-		backl = /obj/item/rogueweapon/sword/long/judgement
+			beltl = /obj/item/rogueweapon/sword/long/vlord
+			backl = /obj/item/rogueweapon/sword/long/judgement
 
 	switch(armor_choice)
 		if("Light Armor")

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -326,18 +326,23 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 10, TRUE)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_BLOODLOSS_IMMUNE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	H.verbs |= /mob/proc/haltyell
 
-	H.change_stat("strength", 1)
-	H.change_stat("endurance", 2)
-	H.change_stat("speed", 2)
-	H.change_stat("intelligence", 1)
+	H.change_stat("strength", 50)
+	H.change_stat("endurance", 50)
+	H.change_stat("speed", 50)
+	H.change_stat("intelligence", 50)
+	H.mind.adjust_spellpoints(100)
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Rapier + Longbow","Estoc + Recurve Bow","Sabre + Buckler","Whip + Crossbow")
+	var/weapons = list("Rapier + Longbow","Estoc + Recurve Bow","Sabre + Buckler","Whip + Crossbow", "Judgement + Crimson Fang")
 	var/armor_options = list("Light Armor", "Medium Armor")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armor_options
@@ -362,6 +367,10 @@
 			beltl = /obj/item/rogueweapon/whip
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 			beltr = /obj/item/quiver/bolts
+
+		if("Judgement + Crimson Fang")
+		beltl = /obj/item/rogueweapon/sword/long/vlord
+		backl = /obj/item/rogueweapon/sword/long/judgement
 
 	switch(armor_choice)
 		if("Light Armor")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
To justify your pull request buffing the Azure Peak Royal Guard Royal Champion class on GitHub by giving it access to magic and dual-wielding Judgement and Crimson Fang, you'll want to focus on the following points to make a compelling case for the change:
1. Class Versatility and Identity:

    Magic and Dual Wielding Synergy: By granting access to magic and dual-wielding two strong weapons (Judgement and Crimson Fang), you're enhancing the overall versatility of the Azure Peak Royal Guard Royal Champion class. Magic typically adds a different layer of combat style, allowing the class to deal with various situations, including ranged combat and elemental weaknesses. Dual wielding two powerful weapons gives players more flexibility in melee combat, offering a chance to deal higher damage or use unique combos.

    Expanding the Role of the Class: This change would broaden the class's role beyond just a physical powerhouse or tank. The ability to wield magic alongside dual weapons makes the Royal Champion more adaptable in different combat scenarios. This could align with the class’s lore or intended design as a powerful, multi-faceted hero capable of handling various threats.

2. Game Balance Considerations:

    Introducing New Playstyles: Giving the Royal Champion class access to both magic and dual-wielding allows players to choose a playstyle that suits them—whether they want to focus on powerful spells for ranged attacks or engage in up-close combat with dual weapons. This creates more dynamic choices in character development and strategy.

    Enhancing Combat Effectiveness: Magic allows for both offensive spells (such as damaging abilities) and defensive options (such as buffs or healing). Dual wielding, especially with powerful weapons like Judgement and Crimson Fang, can make the class more potent in physical combat. The combination of these elements could improve its overall combat effectiveness without necessarily overpowering the class.

3. Flavor and Lore:

    Class Lore Justification: You might tie this buff to the character’s backstory or progression. Perhaps the Azure Peak Royal Guard Royal Champion is an elite figure who has undergone special training to unlock both arcane power and the ability to dual-wield legendary weapons. By making this change, you are aligning the character’s abilities with their narrative, which enhances immersion for players.

    Adding Uniqueness: The Royal Champion could be a unique class in the game, known for its adaptability and mastery over both magic and physical combat. This would set it apart from other classes that focus more on one combat style, making it an exciting choice for players looking for versatility.

4. Player Feedback:

    Community Request or Meta Shift: If the community has expressed a desire for more versatility in the Azure Peak Royal Guard Royal Champion class, or if the current meta (game balance) indicates that the class is underperforming or lacks distinctiveness compared to other high-tier characters, this change could address those concerns. Allowing access to both magic and dual-wielding would give it a unique niche.

    Increasing Appeal: Magic and dual-wielding often appeal to players who enjoy building dynamic characters, so adding these options might make the class more appealing to a broader player base, increasing engagement and satisfaction.

5. Balanced Implementation:

    Limitations and Costs: Ensure that there are trade-offs or limitations that maintain balance. For instance, magic could be limited by mana or casting time, or dual-wielding could require specific attributes to perform effectively. These constraints ensure that the class remains powerful but not overpowered, preserving the game's overall balance.

    Progressive Unlocking: You could propose a system where these abilities (magic and dual wielding) are unlocked as the player progresses through the game or class skill tree, preventing an immediate overwhelming power spike. This gives the player a sense of progression while still giving the class more options.

6. Potential for Interesting Combos:

    With access to both magic and dual weapons, you open up opportunities for interesting combo abilities or synergies. For example, certain spells could interact with the dual weapons, providing buffs when wielding Judgement or Crimson Fang, or maybe casting a specific spell could enable the character to perform a powerful attack sequence with their dual-wielded weapons. These types of interactions would encourage experimentation and strategy.

Conclusion:

In your pull request, emphasize that this buff would enrich the Azure Peak Royal Guard Royal Champion class by providing more strategic options, making the class more versatile and exciting without overwhelming the balance of the game. You'll want to frame it as a way to elevate the character's identity, increase gameplay depth, and potentially bring a new dynamic to the game's combat mechanics, all while maintaining fairness and balance within the broader class system.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
