### PR TITLE
Removes pommel strike swing delay, lowers damage, increases AP

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -32,7 +32,7 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
-	penfactor = 50
+	penfactor = 30
 	swingdelay = 0
 	damfactor = 0.6
 	item_d_type = "blunt"

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -33,7 +33,7 @@
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
 	penfactor = 20
-	swingdelay = 5
+	swingdelay = 0
 	damfactor = 0.8
 	item_d_type = "blunt"
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -32,9 +32,9 @@
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	chargetime = 0
-	penfactor = 20
+	penfactor = 50
 	swingdelay = 0
-	damfactor = 0.8
+	damfactor = 0.6
 	item_d_type = "blunt"
 
 /datum/intent/sword/chop


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Turns the 5 swing delay on 'pommel strike' to 0. This makes the strike instant like stab or cut. Damage multiplier from 0.8 to 0.6. AP from 20 to 50.

Tested by beating several bums to death. Works as intended. Common helmets have blunt crit resistance so you're not going to get randomly knocked out if you're smart (even bandanas? wtf?). #EpicWin

## Why It's Good For The Game

Pommel strike would normally be a blunt equivalent to stab, but it has a 0.8 damage multiplier on top of swing delay. Having used it in duels and fights, you're better off using any other intent. I'd like to see it used more. I'm happy with the damage multiplier staying (and I have made it more severe), but swing delay combined with the current power of the intent gives people very little reason to use it. 

![image](https://github.com/user-attachments/assets/7c973a61-a814-4b13-8736-43d157bec1aa)

