### PR TITLE
Squire repair applies to sewing too

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -92,6 +92,9 @@
 			var/skill = (user.mind.get_skill_level(/datum/skill/misc/sewing) + user.mind.get_skill_level(/datum/skill/craft/tanning)) * 10
 			var/repairskill = (user.mind.get_skill_level(/datum/skill/misc/sewing) + user.mind.get_skill_level(/datum/skill/craft/tanning)) * 5
 			var/sewtime = max(5, (60 - skill))
+			if(HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR))
+				skill = max(30, skill) // Squire can't fail a repair
+				sewtime = min(skill, 30) // Squire have half sewing time minimum
 			if(!do_after(user, sewtime, target = I))
 				return
 			if(prob(max(0, 60 - (skill * 2)))) //The more knowlegeable we are the less chance we damage the object


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Squire repair trait applies to sewing / repairing armor
- Squire can't fail to repair light armor (I think)
- Same effect as having 3 levels in skincrafting + sewing combined, just for repair

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Light armor are used by the Keep a lot and it seems odd that squires can repair weapons + armor but not clothes.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
