### PR TITLE
Fix Eyes of Matthios not working for mobs with obscured faces

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -149,12 +149,6 @@
 			if(has_flaw(/datum/charflaw/addiction/sadist) && user.has_flaw(/datum/charflaw/masochist))
 				. += span_secradio("[m1] looking with eyes filled with a desire to inflict pain. So exciting.")
 
-		if(user != src)
-			if(HAS_TRAIT(user, TRAIT_MATTHIOS_EYES))
-				var/atom/item = get_most_expensive()
-				if(item)
-					. += span_notice("You get the feeling [m2] most valuable possession is \a [item.name].")
-
 		var/villain_text = get_villain_text(user)
 		if(villain_text)
 			. += villain_text
@@ -185,6 +179,11 @@
 					. += span_redtext("[m1] repugnant!")
 				if (THEY_THEM, THEY_THEM_F, IT_ITS)
 					. += span_redtext("[m1] repulsive!")
+
+	if(user != src && HAS_TRAIT(user, TRAIT_MATTHIOS_EYES))
+		var/atom/item = get_most_expensive()
+		if(item)
+			. += span_notice("You get the feeling [m2] most valuable possession is \a [item].")
 
 	var/is_stupid = FALSE
 	var/is_smart = FALSE


### PR DESCRIPTION
it was indented inside a block that only runs if someone's face isn't covered. see:
```dm
	if(obscure_name)
		. = list(span_info("ø ------------ ø\nThis is <EM>Unknown</EM>."))
	else
		// it was in this block
```
the fix is to move it later.