### PR TITLE
Adds check for Astrata ritual that doesn't burn priests

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -201,7 +201,7 @@
 
 /obj/item/clothing/head/roguetown/priestmask/pickup(mob/living/user)
 	..()
-	if((user.job != "Priest") && (user.job != "Priestess"))
+	if(!HAS_TRAIT(user, TRAIT_CHOSEN))
 		to_chat(user, "<font color='yellow'>UNWORTHY HANDS TOUCH THE VISAGE, CEASE OR BE PUNISHED</font>")
 		spawn(30)
 			if(loc == user)

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -42,12 +42,13 @@
 						user.say("Place your gaze upon me, oh Radiant one!!")
 						to_chat(user,span_danger("You feel the eye of Astrata turned upon you. Her warmth dances upon your cheek. You feel yourself warming up...")) // A bunch of flavor stuff, slow incanting.
 						icon_state = "astrata_active"
-						loc.visible_message(span_warning("[user]'s bursts to flames! Embraced by Her Warmth wholly!"))
-						playsound(loc, 'sound/combat/hits/burn (1).ogg', 100, FALSE, -1)
-						user.adjust_fire_stacks(10)
-						user.IgniteMob()
-						user.flash_fullscreen("redflash3")
-						user.emote("firescream")
+						if(!HAS_TRAIT(user, TRAIT_CHOSEN)) //Priests don't burst into flames.
+							loc.visible_message(span_warning("[user]'s bursts to flames! Embraced by Her Warmth wholly!"))
+							playsound(loc, 'sound/combat/hits/burn (1).ogg', 100, FALSE, -1)
+							user.adjust_fire_stacks(10)
+							user.IgniteMob()
+							user.flash_fullscreen("redflash3")
+							user.emote("firescream")
 						guidinglight(src) // Actually starts the proc for applying the buff
 						user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)
 						spawn(120)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Buffs priests by letting them use the Astrata ritual without bursting into flames. Other Astratans using the ritual still burst into flames, as Astrata intends.

I believe this ritual was pitched with the idea of a % risk of bursting into flames, but the Priest/notPriest risk seems fair now. 
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Throws the Priest a gimme that they can light up the area without having to jump into the water or have a bucket on standby.

Fun fact, this is the 2nd use of the Chosen trait. The 1st was the Priest's vestments. The Solar Visage was using a job check, so, moved that to check Chosen too. Now there's 3 checks for Chosen, yippee