### PR TITLE
Dying to Cure Rot no longer plays the death cutscene

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -58,7 +58,7 @@
 				to_chat(H, span_warning("Daylight shines around me... the curse begins to fade."))
 
 
-/mob/living/carbon/human/species/werewolf/death(gibbed)
+/mob/living/carbon/human/species/werewolf/death(gibbed, nocutscene = FALSE)
 	werewolf_untransform(TRUE, gibbed)
 
 /mob/living/carbon/human/proc/werewolf_transform()

--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -53,7 +53,7 @@
 		target.emote("breathgasp")
 		target.Jitter(100)
 	else if(was_zombie.has_turned)
-		target.death()
+		target.death(nocutscene = TRUE)
 	target.mind.remove_antag_datum(/datum/antagonist/zombie)
 
 	if (!HAS_TRAIT(target, TRAIT_IWASUNZOMBIFIED) && user?.ckey)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/death(gibbed)
+/mob/living/carbon/death(gibbed, nocutscene = FALSE)
 	if(stat == DEAD)
 		return
 	stop_looking()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -27,7 +27,7 @@
 			if(HAS_TRAIT(L, TRAIT_BLIND))
 				. -= L
 
-/mob/living/carbon/human/death(gibbed)
+/mob/living/carbon/human/death(gibbed, nocutscene = FALSE)
 	if(stat == DEAD)
 		return
 

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -4,6 +4,6 @@
 /mob/living/carbon/monkey/dust_animation()
 	new /obj/effect/temp_visual/dust_animation(loc, "dust-m")
 
-/mob/living/carbon/monkey/death(gibbed)
+/mob/living/carbon/monkey/death(gibbed, nocutscene = FALSE)
 	walk(src,0) // Stops dead monkeys from fleeing their attacker or climbing out from inside His Grace
 	. = ..()

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -37,7 +37,7 @@
 		memory_saved = TRUE
 	..()
 
-/mob/living/carbon/monkey/punpun/death(gibbed)
+/mob/living/carbon/monkey/punpun/death(gibbed, nocutscene = FALSE)
 	if(!memory_saved)
 		Write_Memory(TRUE, gibbed)
 	..()

--- a/code/modules/mob/living/carbon/spirit/death.dm
+++ b/code/modules/mob/living/carbon/spirit/death.dm
@@ -4,6 +4,6 @@
 /mob/living/carbon/spirit/dust_animation()
 	new /obj/effect/temp_visual/dust_animation(loc, "dust-m")
 
-/mob/living/carbon/spirit/death(gibbed)
+/mob/living/carbon/spirit/death(gibbed, nocutscene = FALSE)
 	walk(src,0) // Stops dead monkeys from fleeing their attacker or climbing out from inside His Grace
 	. = ..()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -58,7 +58,7 @@
 		new /obj/item/ash(loc)
 
 
-/mob/living/death(gibbed)
+/mob/living/death(gibbed, nocutscene = FALSE)
 	var/was_dead_before = stat == DEAD
 	stat = DEAD
 	unset_machine()
@@ -79,7 +79,8 @@
 	SSdroning.kill_rain(src.client)
 	SSdroning.kill_loop(src.client)
 	SSdroning.kill_droning(src.client)
-	src.playsound_local(src, 'sound/misc/deth.ogg', 100)
+	if(!nocutscene)
+		src.playsound_local(src, 'sound/misc/deth.ogg', 100)
 
 	set_drugginess(0)
 	set_disgust(0)
@@ -97,14 +98,15 @@
 	SEND_SIGNAL(src, COMSIG_LIVING_DEATH, gibbed) 
 	if(client)
 		client.move_delay = initial(client.move_delay)
-		var/atom/movable/screen/gameover/hog/H = new()
-		H.layer = SPLASHSCREEN_LAYER+0.1
-		client.screen += H
+		if(!nocutscene)
+			var/atom/movable/screen/gameover/hog/H = new()
+			H.layer = SPLASHSCREEN_LAYER+0.1
+			client.screen += H
+			H.Fade()
+			addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable/screen/gameover, Fade), TRUE), 100)
 //		flick("gameover",H)
 //		addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable/screen/gameover, Fade)), 29)
-		H.Fade()
 		mob_timers["lastdied"] = world.time
-		addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable/screen/gameover, Fade), TRUE), 100)
 //		addtimer(CALLBACK(client, PROC_REF(ghostize), 1, src), 150)
 		add_client_colour(/datum/client_colour/monochrome)
 		client.verbs.Add(GLOB.ghost_verbs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a parameter to death() proc called nocutscene, by default it's set to FALSE, if set to TRUE (by cure rot in this case), it will skip playing the sound and the cutscene for the client.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it was kind of jarring to treat the deadite cure rot "death" as a true death.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
