### PR TITLE
Sprint jumping immobilizes you for a second

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -339,9 +339,10 @@
 				var/jextra = FALSE
 				if(m_intent == MOVE_INTENT_RUN)
 					OffBalance(30)
-					jadded = 15
+					jadded = 20
 					jrange = 3
 					if(!HAS_TRAIT(src, TRAIT_LEAPER))// The Jester lands where the Jester wants.
+						jadded = (maxrogfat / 10) * 3 //30% of green bar
 						jextra = TRUE
 				else
 					OffBalance(20)
@@ -359,6 +360,7 @@
 						while(src.throwing)
 							sleep(1)
 						throw_at(get_step(src, src.dir), 1, 1, src, spin = FALSE)
+						Immobilize(5)
 					else
 						throw_at(A, jrange, 1, src, spin = FALSE)
 						while(src.throwing)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -339,10 +339,9 @@
 				var/jextra = FALSE
 				if(m_intent == MOVE_INTENT_RUN)
 					OffBalance(30)
-					jadded = 20
+					jadded = 15
 					jrange = 3
 					if(!HAS_TRAIT(src, TRAIT_LEAPER))// The Jester lands where the Jester wants.
-						jadded = (maxrogfat / 10) * 3 //30% of green bar
 						jextra = TRUE
 				else
 					OffBalance(20)
@@ -360,7 +359,7 @@
 						while(src.throwing)
 							sleep(1)
 						throw_at(get_step(src, src.dir), 1, 1, src, spin = FALSE)
-						Immobilize(5)
+						Immobilize((HAS_TRAIT(src, TRAIT_LEAPER) ? 5 : 10))
 					else
 						throw_at(A, jrange, 1, src, spin = FALSE)
 						while(src.throwing)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -359,11 +359,12 @@
 						while(src.throwing)
 							sleep(1)
 						throw_at(get_step(src, src.dir), 1, 1, src, spin = FALSE)
-						Immobilize((HAS_TRAIT(src, TRAIT_LEAPER) ? 5 : 10))
 					else
 						throw_at(A, jrange, 1, src, spin = FALSE)
 						while(src.throwing)
 							sleep(1)
+					if(!HAS_TRAIT(src, TRAIT_ZJUMP))	//Jesters and werewolves don't get immobilized at all
+						Immobilize((HAS_TRAIT(src, TRAIT_LEAPER) ? 5 : 10))	//Acrobatics get half the time
 					if(isopenturf(src.loc))
 						var/turf/open/T = src.loc
 						if(T.landsound)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

https://github.com/user-attachments/assets/1ea84ff4-959c-48fa-bff9-cb4e0a6051e9

Currently Acrobatic virtue reduces it to half a second, but there's still a pause.
Jesters & Werewolves (or anyone with z jump capabilities) does not get immobilized at all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
By many small requests overtime.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
