### PR TITLE
No more wallbangs/combat uppies

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -220,8 +220,9 @@
 								return
 						var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 						var/turf/end_T = get_turf(target)
-						if(start_T.z != end_T.z && throwable_mob.mobility_flags & MOBILITY_STAND)
-							return
+						if(throwable_mob.cmode)
+							if(start_T.z != end_T.z && throwable_mob.mobility_flags & MOBILITY_STAND)
+								return
 						if(start_T && end_T)
 							log_combat(src, throwable_mob, "thrown", addition="grab from tile in [AREACOORD(start_T)] towards tile at [AREACOORD(end_T)]")
 				else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -138,8 +138,9 @@
 	var/hurt = TRUE
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
-			Paralyze(20)
 			take_bodypart_damage(10,check_armor = TRUE)
+			if(IsOffBalanced())
+				Paralyze(20)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.movement_type & FLYING)
@@ -219,6 +220,8 @@
 								return
 						var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 						var/turf/end_T = get_turf(target)
+						if(start_T.z != end_T.z && throwable_mob.mobility_flags & MOBILITY_STAND)
+							return
 						if(start_T && end_T)
 							log_combat(src, throwable_mob, "thrown", addition="grab from tile in [AREACOORD(start_T)] towards tile at [AREACOORD(end_T)]")
 				else


### PR DESCRIPTION
## About The Pull Request

- You can no longer stun someone by throwing them into a wall unless they're already off-balance.
- You can no longer throw someone up(who's in cmode) if they're not laying down

Basically just adds back in some stuff from https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/344 that I suspect was removed during debloat on mistake.

## Testing Evidence

https://github.com/user-attachments/assets/f033bad2-1f6a-475e-8aea-1a15e8387e3d

https://github.com/user-attachments/assets/5013cc2a-8b79-4ce4-9425-0a362fb668c5


https://github.com/user-attachments/assets/8bfe62fa-a07e-4a90-94da-ba5b524dc6a8

## Why It's Good For The Game

I tire greatly of seeing people infinitely chain-stunned on a wall or instantly having their legs broken.

Permastuns are insanely bad and were already removed once:

https://github.com/user-attachments/assets/7b2f891c-8a0a-4b23-b8e4-dd0d4acc20b2

Non-giants can also do this, leaving a whopping 0.3 seconds of being in an aggro-grab and on the floor to do something(you will be stunned again)

https://github.com/user-attachments/assets/b319bfdc-21ca-4218-8229-b286692f2b51




