### PR TITLE
Disable projectile embed on simple, 2.0

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -97,10 +97,8 @@
 	return simple_woundcritroll(P.woundclass, P.damage, null, def_zone, crit_message = TRUE)
 
 /mob/living/proc/check_projectile_embed(obj/projectile/P, def_zone)
-	if(!prob(P.embedchance) || !P.dropped)
-		return FALSE
-	simple_add_embedded_object(P.dropped, crit_message = TRUE)
-	return TRUE
+	// Disable embeds on simples, allowing it to override on complex.
+	return FALSE
 
 /obj/item/proc/get_volume_by_throwforce_and_or_w_class()
 	if(throwforce && w_class)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -226,11 +226,6 @@
 		apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
 		return TRUE
 
-/mob/living/simple_animal/bullet_act(obj/projectile/Proj)
-	apply_damage(Proj.damage, Proj.damage_type)
-	Proj.on_hit(src)
-	return BULLET_ACT_HIT
-
 /mob/living/simple_animal/ex_act(severity, target, epicenter, devastation_range, heavy_impact_range, light_impact_range, flame_range)
 	..()
 	if(!severity || !epicenter)


### PR DESCRIPTION
## About The Pull Request
Currently, whenever you shoot a simple mob, your arrows / bolts / slingstones get devoured because shitcode.

This is because of a snowflake override on bullet act and embed. The simple embedded system is untested and unused (disabled for melee). This PR:
- Remove the snowflake bullet_act (Arrows no longer disappear)
- Disable projectile embed on simples (a lot of simples weren't designed with them in mind anyway)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested vs volf, saiga (no embed), tested vs goblin - embeds worked correctly due to override.
![dreamseeker_Yvt2hiPrly](https://github.com/user-attachments/assets/0945773d-fcc8-4b1e-98c3-21e2d22949e5)
![dreamseeker_1r91ksmbV1](https://github.com/user-attachments/assets/3074d362-cf02-4c60-a843-ae611961cac7)
![dreamseeker_E9J4XiLFi1](https://github.com/user-attachments/assets/aed9fe4c-058e-4e9d-981a-396422e51f2b)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Arrows disappearing on half of the mob type isn't fun

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
