### PR TITLE
Warden keyring adjustments

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -1165,6 +1165,13 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"awM" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "walls"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town)
 "awQ" = (
 /obj/structure/bars/pipe{
 	dir = 1
@@ -36866,7 +36873,7 @@
 /area/rogue/under/town/basement/keep)
 "pnE" = (
 /obj/structure/mineral_door/wood/donjon{
-	lockid = "garrison";
+	lockid = "walls";
 	locked = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -40159,7 +40166,7 @@
 "qEG" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
-	lockid = "dungeon"
+	lockid = "warden"
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave)
@@ -40568,6 +40575,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"qLu" = (
+/obj/structure/mineral_door/wood{
+	locked = 1;
+	lockid = "walls"
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town)
 "qLH" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/herringbone,
@@ -51914,7 +51928,7 @@
 "vzl" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
-	lockid = "garrison"
+	lockid = "walls"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
@@ -52217,7 +52231,7 @@
 "vED" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
-	lockid = "garrison";
+	lockid = "walls";
 	locked = 1
 	},
 /turf/open/floor/rogue/cobble,
@@ -252161,7 +252175,7 @@ dyE
 eVO
 qfA
 sns
-kAi
+awM
 jdu
 tSF
 jdu
@@ -252569,7 +252583,7 @@ tSF
 jdu
 jdu
 jdu
-kAi
+awM
 exD
 ehB
 ehB
@@ -348393,7 +348407,7 @@ jdu
 jdu
 jdu
 jdu
-kAi
+awM
 iEn
 aUO
 aUO
@@ -348408,22 +348422,22 @@ aUO
 aUO
 aUO
 iEn
-kAi
+awM
 jdu
 jdu
 jdu
 jdu
-kAi
+awM
 bZZ
 bZZ
 bZZ
 bZZ
-kAi
+awM
 jdu
 jdu
 jdu
 jdu
-kAi
+awM
 iEn
 aUO
 aUO
@@ -348438,7 +348452,7 @@ aUO
 aUO
 aUO
 iEn
-kAi
+awM
 jdu
 jdu
 jdu
@@ -349746,7 +349760,7 @@ aBB
 aBB
 aBB
 phl
-kAi
+awM
 phl
 bGf
 bGf
@@ -349797,7 +349811,7 @@ bGf
 bGf
 bGf
 phl
-kAi
+awM
 phl
 aBB
 aBB
@@ -360193,7 +360207,7 @@ bGf
 bGf
 phl
 phl
-lXU
+qLu
 phl
 phl
 aBB
@@ -360594,7 +360608,7 @@ aBB
 aBB
 aBB
 phl
-lXU
+qLu
 phl
 phl
 phl
@@ -362905,7 +362919,7 @@ bGf
 phl
 gyu
 gyu
-lXU
+qLu
 gyu
 gyu
 phl
@@ -363307,7 +363321,7 @@ aBB
 phl
 gyu
 gyu
-lXU
+qLu
 gyu
 gyu
 phl
@@ -367889,7 +367903,7 @@ aUO
 aUO
 aUO
 aUO
-kAi
+awM
 jdu
 jdu
 jdu
@@ -368795,7 +368809,7 @@ sGj
 bGf
 bGf
 phl
-kAi
+awM
 phl
 aBB
 aBB
@@ -390943,7 +390957,7 @@ bGf
 bGf
 bGf
 phl
-kAi
+awM
 phl
 aBB
 aBB
@@ -391845,7 +391859,7 @@ aUO
 aUO
 aUO
 aUO
-kAi
+awM
 jdu
 jdu
 jdu

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -224,7 +224,7 @@
 	keys = list(/obj/item/roguekey/sheriff, /obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/graveyard)
 
 /obj/item/storage/keyring/guard
-	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/warden, /obj/item/roguekey/armory, /obj/item/roguekey/walls)
+	keys = list(/obj/item/roguekey/warden, /obj/item/roguekey/walls)
 
 /obj/item/storage/keyring/guardcastle
 	keys = list(/obj/item/roguekey/dungeon, /obj/item/roguekey/garrison, /obj/item/roguekey/walls, /obj/item/roguekey/manor, /obj/item/roguekey/armory)


### PR DESCRIPTION
## About The Pull Request

Repost of #1985 with request changes from maintainers because I accidentally fucked up my branch.

Removes armory and garrison keys from the wardens key ring. They probably shouldn't be hanging around in the keep or taking equipment from the keep. They still get keys to the city walls and their own watchtower.

Mapping changes are just changing the doors on the city walls to actually use the 'walls' key - which wasn't used anywhere previously.

## Why It's Good For The Game

There's no real reason for wardens to have access to the garrison building and the armory. They already have their own barracks and their own mini-armory filled with spare equipment in their watchtower anyways.

They don't currently even have access to the keep gatehouse to reach the armory (they don't get manor keys) which means they already either need to break into the keep or ask someone to let them in anyways. This just encourages wardens to actually ask the sergeant/marshal if they need to get into the armory rather than scaling the gatehouse and breaking into the keep just to rush the keep's armory for gear.

## Testing Evidence

Launched localhost, spawned in as warden. Works fine.
