### PR TITLE
Make some spells requires uncuffed hands

### DIFF
--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -75,6 +75,7 @@
 	var/projectile_amount = 1	//Projectiles per cast.
 	var/current_amount = 0	//How many projectiles left.
 	var/projectiles_per_fire = 1		//Projectiles per fire. Probably not a good thing to use unless you override ready_projectile().
+	gesture_required = TRUE // Projectiles need to be aimed, and is mostly offensive.
 	ignore_los = TRUE
 
 /obj/effect/proc_holder/spell/invoked/projectile/proc/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -9,6 +9,7 @@
 	chargedloop = null
 	sound = 'sound/magic/whiteflame.ogg'
 	associated_skill = /datum/skill/magic/arcane
+	gesture_required = TRUE // Potential offensive use, need a target
 	antimagic_allowed = TRUE
 	charge_max = 15 SECONDS
 	miracle = FALSE
@@ -45,6 +46,7 @@
 	chargedloop = null
 	sound = 'sound/items/beartrap.ogg'
 	associated_skill = /datum/skill/magic/arcane
+	gesture_required = TRUE // Offensive spell
 	antimagic_allowed = TRUE
 	charge_max = 15 SECONDS
 	miracle = FALSE
@@ -73,6 +75,7 @@
 	no_early_release = TRUE
 	charging_slowdown = 1
 	chargedloop = /datum/looping_sound/invokegen
+	gesture_required = TRUE // Summon spell
 	associated_skill = /datum/skill/magic/arcane
 	charge_max = 60 SECONDS
 
@@ -113,6 +116,7 @@
 	no_early_release = TRUE
 	charging_slowdown = 1
 	chargedloop = /datum/looping_sound/invokegen
+	gesture_required = TRUE // Summon spell
 	associated_skill = /datum/skill/magic/arcane
 	charge_max = 30 SECONDS
 	var/cabal_affine = FALSE

--- a/code/modules/spells/roguetown/wizard.dm
+++ b/code/modules/spells/roguetown/wizard.dm
@@ -166,7 +166,6 @@
 	projectile_type = /obj/projectile/magic/aoe/fireball/rogue
 	overlay_state = "fireball"
 	sound = list('sound/magic/fireball.ogg')
-	active = FALSE
 	releasedrain = 30
 	chargedrain = 1
 	chargetime = 15

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -157,6 +157,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/level_max = 4 //The max possible level_max is 4
 	var/cooldown_min = 0 //This defines what spell quickened four times has as a cooldown. Make sure to set this for every spell
 	var/player_lock = TRUE //If it can be used by simple mobs
+	var/gesture_required = FALSE // Can it be cast while cuffed? Rule of thumb: Offensive spells + Mobility cannot be cast
 
 	var/overlay = 0
 	var/overlay_icon = 'icons/obj/wizard.dmi'
@@ -271,6 +272,9 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 		if(miracle && !H.devotion?.check_devotion(src))
 			to_chat(H, span_warning("I don't have enough devotion!"))
+			return FALSE
+		if(H.handcuffed && gesture_required)
+			to_chat(user, span_warning("[name] cannot be cast with my hands tied up!"))
 			return FALSE
 	else
 		if(clothes_req || human_req)

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -519,6 +519,7 @@ GLOBAL_LIST_EMPTY(wizard_spells_list)
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "blade_burst"
+	gesture_required = TRUE
 	var/delay = 14
 	var/damage = 125 //if you get hit by this it's your fault
 	var/area_of_effect = 1
@@ -875,6 +876,7 @@ GLOBAL_LIST_EMPTY(wizard_spells_list)
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	range = 7
+	gesture_required = TRUE // Offensive spell
 	var/delay = 6
 	var/damage = 50 // less then fireball, more then lighting bolt
 	var/area_of_effect = 2
@@ -1333,6 +1335,7 @@ GLOBAL_LIST_EMPTY(wizard_spells_list)
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
+	gesture_required = TRUE // Mobility spell
 	charging_slowdown = 3
 	chargedloop = /datum/looping_sound/wind
 	associated_skill = /datum/skill/magic/arcane
@@ -1530,6 +1533,7 @@ GLOBAL_LIST_EMPTY(wizard_spells_list)
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
+	gesture_required = TRUE // Mobility spell
 	charging_slowdown = 2
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane


### PR DESCRIPTION
## About The Pull Request
I AM NOT CALLING IT SOMATIC. 

A redo of #1555 with a more limited selection of spells. Now, all projectile spells, and a few selected offensive / mobility spells requires your hands to be free to cast. 

The follow spells requires gesture (hands free):
- All projectile spells (fireball, bolt of lightning, arcyne bolt, frost bolt, repel, profane etc. etc. etc.)
- Necromancer's: Bone Chill, Eyebite, Raise Greater & Lesser Undead (Summon spells are pretty offensive)
- Some Mobility Spells: Blink & Leap
- Some Offensive non-projectile spells: Blade Burst, Snap Freeze

This should cover the ground of most spells that directly harm people = can't be cast while chained. You can still send out a message or mindlink to call for help or turn your invisible or buff someone if you want. 

I also noticed that some spells is inconsistently uncastable while chained but I can't figure out how so I am not fixing that yet.

also clean up a useless active = FALSE.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I've tested a few projectile + some invoked spell like snap freeze + blade burst
![dreamseeker_a8dBDz5O0h](https://github.com/user-attachments/assets/a955b890-4d4a-403b-80a7-dea18a81adee)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Currently, mages are basically uncontainable and can blink, fireball or lightning bolt you if they're not killed or gagged. Both options are lame and prevent them from RPing, but if you good faith a mage and then they attempt to escape (as they should), the player learn a harsh lesson and then proceeds to assume other mages will bad faith them, leading to them being gagged / killed on sight. 

This has been the subject of salt on both players fighting mages and mages who are presumed to be bad faith or gagged because you never know. 

It is better for the most common restraint type in game (rope / chains) to be able to contain mage to a **limited** degree instead of making a special, hard to access restraints (else mage will just get killed / gagged, as usual). 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
