### PR TITLE
Two simple fixes to tossblade/spellLOS

### DIFF
--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -256,7 +256,7 @@
 				break
 
 /obj/item/storage/belt/rogue/leather/knifebelt/proc/eatknife(obj/A)
-	if(A.type in subtypesof(/obj/item/rogueweapon/huntingknife/throwingknife))
+	if(A.type in typesof(/obj/item/rogueweapon/huntingknife/throwingknife))
 		if(knives.len < max_storage)
 			A.forceMove(src)
 			knives += A
@@ -266,7 +266,7 @@
 			return FALSE
 
 /obj/item/storage/belt/rogue/leather/knifebelt/attackby(obj/A, loc, params)
-	if(A.type in subtypesof(/obj/item/rogueweapon/huntingknife/throwingknife))
+	if(A.type in typesof(/obj/item/rogueweapon/huntingknife/throwingknife))
 		if(knives.len < max_storage)
 			if(ismob(loc))
 				var/mob/M = loc

--- a/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
+++ b/modular_hearthstone/code/modules/spells/roguetown/wizard.dm
@@ -452,6 +452,7 @@ GLOBAL_LIST_EMPTY(wizard_spells_list)
 	chargedrain = 1
 	chargetime = 5
 	charge_max = 30 SECONDS
+	ignore_los = TRUE
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
@@ -1755,7 +1756,7 @@ GLOBAL_LIST_EMPTY(wizard_spells_list)
 	movement_interrupt = FALSE
 	charging_slowdown = 2
 	warnie = "spellwarning"
-	range = 7
+	ignore_los = TRUE
 
 /obj/effect/proc_holder/spell/invoked/mindlink/cast(list/targets, mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

- Tossblade belts can now be reloaded with iron tossblades, fixing a type bug.
- Repulse and Mind Link no longer require LoS to use, making repulse feel a lot better in a tight situation.

## Testing Evidence

Tested.

## Why It's Good For The Game

Fixes bug and restores spell use/feel.
