### PR TITLE
Adds a warning to the Wretch role.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -105,7 +105,8 @@
 	var/bounty_total
 	bounty_total = rand(151, 250)
 	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
-
+	to_chat(H, span_danger("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards."))
+	alert("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards.")
 
 /datum/advclass/wretch/outlaw
 	name = "Outlaw"
@@ -173,6 +174,8 @@
 	var/bounty_total
 	bounty_total = rand(151, 250)
 	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
+	to_chat(H, span_danger("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards."))
+	alert("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards.")
 
 /datum/advclass/wretch/poacher
 	name = "Poacher"
@@ -245,6 +248,8 @@
 	var/bounty_total
 	bounty_total = rand(151, 250)
 	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
+	to_chat(H, span_danger("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards."))
+	alert("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards.")
 
 /datum/advclass/wretch/heretic
 	name = "Heretic"
@@ -316,6 +321,8 @@
 	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Holy See")
 	H.cmode_music = 'sound/music/combat_cult.ogg'
 	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	to_chat(H, span_danger("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards."))
+	alert("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards.")
 
 /datum/advclass/wretch/necromancer
 	name = "Necromancer"
@@ -372,7 +379,8 @@
 	var/bounty_total
 	bounty_total = rand(151, 250)
 	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Holy See")
-
+	to_chat(H, span_danger("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards."))
+	alert("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards.")
 
 /datum/advclass/wretch/berserker
 	name = "Berserker"
@@ -448,3 +456,5 @@
 	var/bounty_total
 	bounty_total = rand(151, 250)
 	add_bounty(H.real_name, bounty_total, FALSE, my_crime, "The Justiciary of Azuria")
+	to_chat(H, span_danger("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards."))
+	alert("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards.")


### PR DESCRIPTION
## About The Pull Request

Adds an alert AND a to_chat to wretches, which reminds them that they're an antag role, even if they're available from round start.
just incase they miss the alert box, the red text should help.

## Testing Evidence

![image](https://github.com/user-attachments/assets/ffa58590-dab2-49ba-9801-a09214d8b08a)

## Why It's Good For The Game

It's disappointing seeing issues of players taking wretch just to be better adventurers and then, not doing any antagonistic actions what-so-ever, this should help.
