### PR TITLE
Fixing unarmed parries[Pls TM first]

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -129,21 +129,6 @@
 	if(istype(user.rmb_intent, /datum/rmb_intent/swift))
 		user.rogfat_add(10)
 	if(M.checkdefense(user.used_intent, user))
-		if(M.d_intent == INTENT_PARRY)
-			if(!M.get_active_held_item() && !M.get_inactive_held_item()) //we parried with a bracer, redirect damage
-				if(M.active_hand_index == 1)
-					user.tempatarget = BODY_ZONE_L_ARM
-				else
-					user.tempatarget = BODY_ZONE_R_ARM
-				if(M.attacked_by(src, user)) //we change intents when attacking sometimes so don't play if we do (embedding items)
-					if(user.used_intent == cached_intent)
-						var/tempsound = user.used_intent.hitsound
-						if(tempsound)
-							playsound(M.loc,  tempsound, 100, FALSE, -1)
-						else
-							playsound(M.loc,  "nodmg", 100, FALSE, -1)
-				log_combat(user, M, "attacked", src.name, "(INTENT: [uppertext(user.used_intent.name)]) (DAMTYPE: [uppertext(damtype)])")
-				add_fingerprint(user)
 		if(M.d_intent == INTENT_DODGE)
 			if(!user.used_intent.swingdelay)
 				if(get_dist(get_turf(user), get_turf(M)) <= user.used_intent.reach)

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -172,7 +172,11 @@
 
 			if(highest_defense <= (H.mind ? (H.mind.get_skill_level(/datum/skill/combat/unarmed) * 20) : 20))
 				defender_skill = H.mind?.get_skill_level(/datum/skill/combat/unarmed)
-				prob2defend += (defender_skill * 20)
+				var/obj/B = H.get_item_by_slot(SLOT_WRISTS)
+				if(istype(B, /obj/item/clothing/wrists/roguetown/bracers))
+					prob2defend += (defender_skill * 30)
+				else
+					prob2defend += (defender_skill * 10)		// no bracers gonna be butts.
 				weapon_parry = FALSE
 			else
 				defender_skill = H.mind?.get_skill_level(used_weapon.associated_skill)


### PR DESCRIPTION
## About The Pull Request

- Fixes unarmed parries(They actually work now). Removed a unused part of item_attack.dm which seemed to be the sole thing breaking them. 
- Unarmed parries now scale at 30% per point of unarmed, compared to 20% with every weapon skill. Statistically, this means, you basically have 1df per point of unarmed. So, a expert unarmed fighter will have a total 120% parry chance, brought down to 40% by any other expert weapon user. Making them have worse than having an actual weapon, but still better defense than before.
- You only get 30% per point if you have bracers on, otherwise, you only get 10% per point, meaning a measly 40% at expert, easily negated by any weapon user.
- You will use unarmed parries if its df calculations somehow beat out whats in your hands. So, you can fight with chairs and such too with decent unarmed(If you wanted to say, tavern brawl)

## Testing Evidence

Please TM first since this touches scary dms(roguetownprocs and item_attack). Everything worked fine in testing but this sort of thing worries me.

https://github.com/user-attachments/assets/82bfd8d3-33d9-44b6-ad49-17445d73fc4c


https://github.com/user-attachments/assets/bfad2cb8-fc48-4b7e-a215-8c582b241036



## Why It's Good For The Game

Basically a bugfix. But also, does buff unarmed parries a bit. They'll still be worse than any other parry defense in the game, but basically just makes it so they're not COMPLETELY useless due to having no df. Before, ANYONE of equal weapon skill would instantly bring them to a 5% parry chance due to no df.
