### PR TITLE
(Lore Request) No More Psydon Monarchy

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -154,6 +154,8 @@
 
 #define ALL_INHUMEN_PATRONS list(/datum/patron/inhumen/zizo, /datum/patron/inhumen/graggar, /datum/patron/inhumen/matthios, /datum/patron/inhumen/baotha)
 
+#define NON_PSYDON_PATRONS list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/ravox, /datum/patron/divine/necra, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora, /datum/patron/inhumen/zizo, /datum/patron/inhumen/graggar, /datum/patron/inhumen/matthios, /datum/patron/inhumen/baotha)	//For lord/heir usage
+
 #define ALL_PATRONS  list(/datum/patron/divine/astrata, /datum/patron/divine/noc, /datum/patron/divine/dendor, /datum/patron/divine/abyssor, /datum/patron/divine/ravox, /datum/patron/divine/necra, /datum/patron/divine/xylix, /datum/patron/divine/pestra, /datum/patron/divine/malum, /datum/patron/divine/eora, /datum/patron/old_god, /datum/patron/inhumen/zizo, /datum/patron/inhumen/graggar, /datum/patron/inhumen/matthios, /datum/patron/inhumen/baotha)
 
 #define PLATEHIT "plate"

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -32,6 +32,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	give_bank_account = 1000
 	required = TRUE
 	cmode_music = 'sound/music/combat_noble.ogg'
+	allowed_patrons = NON_PSYDON_PATRONS		//No Psydonites - Lore reason: Town is Astratan town, you are crowned by Astrata for right to rule. (Inhumen people pose as Ten worshipers.)
 
 /datum/job/roguetown/exlord //just used to change the lords title
 	title = "Duke Emeritus"
@@ -43,7 +44,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	spawn_positions = 0
 	display_order = JDO_LADY
 	give_bank_account = TRUE
-
 
 /datum/job/roguetown/lord/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -21,7 +21,9 @@
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'
-	
+	allowed_patrons = NON_PSYDON_PATRONS		//Same reason as lord. See Lord.
+
+
 /datum/job/roguetown/prince/after_spawn(mob/living/H, mob/M, latejoin)
 	. = ..()
 	if(ishuman(H))


### PR DESCRIPTION
## About The Pull Request

Was asked by lore team to do this PR. Simply makes the Duke and princes/princesses not be able to be Psydonites.

Makes sense from a lore point of view, given this is an Astratan duchy where the monarch is given the right to rule through Astrata. Plus inhumen believers are little cretin liars unlike Psydonians.

(Psydon is dead........ And lore killed him......)

## Testing Evidence

Greys out selection from class selection, doesn't appear on late-join as Psydonite. Works for Ascendants/Divine
![image](https://github.com/user-attachments/assets/ddab9d02-7f00-48f3-b9a8-5553c16667f7)

## Why It's Good For The Game

Lore stuff; I can see why given people want a stress-point between the Inquisition and the Monarchy rather than being chummy. Plus, a Psydonite rejects the divinity - and thus right-to-rule - blessed by Astrata reasonably.
