### PR TITLE
ROCK MUNCHING AND CONSTRUCT FIXES

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -433,6 +433,30 @@
 		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, -healing_on_tick)
 		owner.adjustCloneLoss(-healing_on_tick, 0)
 
+/datum/status_effect/buff/rockmuncher
+	id = "rockmuncher"
+	duration = 10 SECONDS
+	var/healing_on_tick = 4
+
+/datum/status_effect/buff/rockmuncher/on_creation(mob/living/new_owner, new_healing_on_tick)
+	healing_on_tick = new_healing_on_tick
+	return ..()
+
+/datum/status_effect/buff/rockmuncher/tick()
+	var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal_rogue(get_turf(owner))
+	H.color = "#FF0000"
+	var/list/wCount = owner.get_wounds()
+	if(owner.construct)
+		if(wCount.len > 0)
+			owner.heal_wounds(healing_on_tick)
+			owner.update_damage_overlays()
+		owner.adjustBruteLoss(0.15*-healing_on_tick, 0)
+		owner.adjustFireLoss(0.15*-healing_on_tick, 0)
+		owner.adjustOxyLoss(0.15*-healing_on_tick, 0)
+		owner.adjustToxLoss(0.15*-healing_on_tick, 0)
+		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.15*-healing_on_tick)
+		owner.adjustCloneLoss(0.15*-healing_on_tick, 0)
+
 /datum/status_effect/buff/healing/on_remove()
 	owner.remove_filter(MIRACLE_HEALING_FILTER)
 	

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -261,6 +261,17 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			S.start()
 	else
 		..()
+//rock munching
+/obj/item/natural/stone/attack(mob/living/M, mob/user)
+	testing("attack")
+	if(M.construct)
+		var/healydoodle = magic_power+1
+		M.apply_status_effect(/datum/status_effect/buff/rockmuncher, healydoodle)
+		qdel(src)
+		if(M == user)
+			user.visible_message(span_notice("[user] presses the stone to [user]'s body, and it is absorbed."), span_notice("I absorb the stone."))
+		else
+			user.visible_message(span_notice("[user] presses the stone to [M]'s body, and it is absorbed."), span_notice("I press the stone to [M], and it is absorbed."))
 
 /obj/item/natural/rock
 	name = "rock"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -13,14 +13,14 @@
 	construct = 1
 	skin_tone_wording = "Material"
 	default_color = "FFFFFF"
-	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
+	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,NOBLOOD)
 	default_features = MANDATORY_FEATURE_LIST
 	use_skintones = 1
 	possible_ages = ALL_AGES_LIST
 	skinned_type = /obj/item/ingot/steel
 	disliked_food = NONE
 	liked_food = NONE
-	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_BLOODLOSS_IMMUNE, TRAIT_NOBREATH)
+	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_BLOODLOSS_IMMUNE, TRAIT_NOBREATH, TRAIT_NOSLEEP)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mcom.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fcom.dmi'


### PR DESCRIPTION
## About The Pull Request
Allows constructs to munch down on magical rocks for wound/break/crippling healing. Wondrous.
Also makes them TRULY bloodless, and fixes them having insomnia because they lost it when the sleep changes got added. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/6ec3559f-b0be-40c8-bbc6-2dbf43f0fc0a)
_I'm so fucking hungry...._
![image](https://github.com/user-attachments/assets/e1f5fec2-d81f-4f1b-8d6f-0d2848c88332)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Constructs are rather unplayable due to lack of healing from miracles (and wont be able to fix breaks without sleep, which is getting taken from them once more.)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
