### PR TITLE
Warden Update

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -44,7 +44,7 @@ Also given some non-combat skills that a peasent would have, just to support the
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
@@ -52,7 +52,7 @@ Also given some non-combat skills that a peasent would have, just to support the
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)// Environmental advantages are key to setting a tone and actual place for the Warden's skill set

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -64,9 +64,7 @@ Also given some non-combat skills that a peasent would have, just to support the
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)	//Peasent levy, so some skill
 		H.mind.adjust_skillrank(/datum/skill/labor/farming, 2, TRUE)		//Peasent levy, so some skill
 		H.change_stat("strength", 1)
-		H.change_stat("perception", 2)
-		H.change_stat("constitution", 1)
-		H.change_stat("endurance", 2)
+		H.change_stat("perception", 1)
 		H.change_stat("speed", 1)
 		H.verbs |= /mob/proc/haltyell
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request
A small (salt PR!) nerf to the Warden stat block. Most people seem to agree that the wardens are overtuned, specially taking into account their massive buff when being outdoors (90% of the time they're outdoors). The keep already has a strong lineup in the garrison proper, with knights, squires, men at arms, agents of court, and mercenaries they hire. Ontop of that, the church often behaves like an extension of the keep in matters of antags.  I think wardens should be weak, but strong in numbers, and encourage them to play together. Since they're peasants, I think they should have poor physical endurance, hence why I lowered their con and endurance, while also bringing their weighted stats down to be in line with mercenaries.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I've been testing fighting with wardens often as wretch, and played a few rounds as warden, and found them quite strong, specially since due to their organization and base they spawn in, they can rapidly massproduce poison arrows, which paired with abundant saiga mounts, make them quite a deadly force.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I think the game will be much healthier by giving antags more breathing room instead of being accosted and being more like prey who get asked to take their mask off  if they run into a pair of wardens. I've played with very robust players and yet wardens are a challenge to play against, and I don't think that should be the case. The wretches' job is to make fun conflict for the round and spice it with their antagonism. Currently, that dynamic is turned on its head with wretches hiding excessively as the wardens and keep hunt them down.

I know warden players will likely not like losing stats, but the role isn't meant to be powerful. It's meant to be volunteers, people who are not trained for war, nor trained to fight monsters, forced to fight threats much greater than them.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
