### PR TITLE
Dagger for the Duelist

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -108,7 +108,7 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			backr = /obj/item/rogueweapon/shield/buckler
 			belt = /obj/item/storage/belt/rogue/leather
-			backpack_contents = list(/obj/item/flashlight/flare/torch = 1)
+			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1)
 
 		if("Barbarian")
 			to_chat(H, span_warning("You are a brutal warrior who foregoes armor in order to showcase your raw strength. You specialize in unarmed combat and wrestling."))


### PR DESCRIPTION
Gives a KNIFE to the only _warrior_ class that doesn't starts with one, and it should. (DUELIST)
Particularly the parrying steel dagger, doesn't really adds much to the class but at least gives them a secondary weapon that fits them and makes sense.

Just that :)

![Captura de pantalla 2025-04-08 174656](https://github.com/user-attachments/assets/e073a6bf-5b59-4840-80c1-506ba3c05255)
