### PR TITLE
Armor protection matters for integrity

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -42,7 +42,8 @@
 			blade_dulling = BCLASS_BLUNT
 		if(used.blocksound)
 			playsound(loc, get_armor_sound(used.blocksound, blade_dulling), 100)
-		used.take_damage(damage, damage_flag = d_type, sound_effect = FALSE, armor_penetration = 100)
+		damage = damage + STASTR/2
+		used.take_damage(damage, BRUTE, d_type, FALSE, null, armor_penetration)
 	if(physiology)
 		protection += physiology.armor.getRating(d_type)
 	return protection


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

This pull request removes the old armor penetration 100 line of code we have and gets the game to actually care about the armor defense calculations when figuring out how to break armor. This makes it so cut intent isn't objectively the best thing to break any and all kinds of armor in the game. I've added a second line that also increases the damage a little, as incoming damage to armor is severely reduced now if the armor is meant to protect against the intent being used against it.

This makes it so, for example, something like mail or plate that has a S+ damage protection against cuts, literally does not take any damage from being cut, since its armor value is 100. Stabs and hits however, damage it much more, as the armor isn't made to defend against those.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

I've been testing this on vscode debug mode with about 10 break points in every step of the armor breaking code. It works as intended, it compiles, there are no errors brought by this. Every intent damages armor differently.

My only complain is that punches and kicks still damage armor more than cutting it with a weapon some times, since they count as blunt attacks. I am not smart nor willing enough to figure a way to make _bare hands_ unable to damage _steel_ yet.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

This adds another layer of nuance to combat. Are you trying to bypass armor, to damage a specific area, or to literally break it first? No longer will I have to use cut intent to spam through plate armor's durability, nor will I be able to break some poor guy's reinforced leather armor with 3 swings.

As a high strength character player this kind of nerfs me since high strength + cut intent currently deletes all armor durability in the game, as it uses _plain force_ to calculate damage.

As things are, I could simply strong intent slice plate armor off someone in half a dozen hits, which makes heavy and high durability armor feel useless against blades and things its meant to protect against.

Hammers will still fuck anything not made to resist a hammer.