### PR TITLE
Gives merchant Cicerone trait

### DIFF
--- a/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
@@ -40,6 +40,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
 		backpack_contents = /obj/item/rogueweapon/huntingknife/idagger/navaja
 	ADD_TRAIT(H, TRAIT_SEEPRICES, type)
+	ADD_TRAIT(H, TRAIT_CICERONE, TRAIT_GENERIC) //Makes up for loss of alchemy to see reagents.
 	neck = /obj/item/clothing/neck/roguetown/horus
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/merchant
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Merchant loss alchemy, which means it lost the ability to see reagents inside bottles. For the sake of wines and whatnot, good to give it back to him.
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
I hope this trait works, I coded it
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Merchant shouldn't be sweat grinding alchemy, but knowing what is in bottles is good business.