### PR TITLE
Fix | Floating Door 

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -7764,13 +7764,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach/forest)
 "dki" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wcv";
-	locked = 1;
-	lockid = "shop"
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/machinery/light/rogue/wallfire/candle,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town/shop)
 "dkk" = (
 /obj/machinery/light/rogue/oven/north,
 /turf/closed/wall/mineral/rogue/decowood,
@@ -482038,7 +482034,7 @@ bGf
 bGf
 bGf
 bGf
-dki
+bGf
 bGf
 bGf
 bGf
@@ -487926,7 +487922,7 @@ ikL
 bDh
 lAs
 ikL
-gca
+dki
 gAl
 rwp
 ikL
@@ -488380,7 +488376,7 @@ udZ
 ikL
 gca
 gca
-gca
+lEy
 ikL
 kSK
 bGf


### PR DESCRIPTION
## About The Pull Request

Removed the floating door next to the stewardry third floor. Also added more lights in the merchant place.

## Testing Evidence

Before:

![image](https://github.com/user-attachments/assets/5139c848-c9b6-46f0-af6a-cacac764fb48)

After:

![image](https://github.com/user-attachments/assets/f9ec9471-6d94-4708-abcc-e1d0dd7a706f)

## Why It's Good For The Game

I almost had a heart attack when I noticed this bug.