### PR TITLE
lowers bandit slots that can roll.

### DIFF
--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -198,7 +198,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 	"Knight")
 	var/num_bandits = 0
 	if(num_players() >= 10)
-		num_bandits = CLAMP(round(num_players() / 5), 4, 6)
+		num_bandits = CLAMP(round(num_players() / 5), 3, 5) // minimum is now 3, increased by 1 for every 5 players readied up beyond 20, with a maximum of 5 bandits.
 		var/datum/job/bandit_job = SSjob.GetJob("Bandit")
 		bandit_job.total_positions = num_bandits
 		bandit_job.spawn_positions = num_bandits


### PR DESCRIPTION
## About The Pull Request

Minimum amount of bandits that can roll at 20 readies is now 3, increasing by 1 for every 5 players readied past 20, with a max of 5 bandits

## Testing Evidence

Needs a TM in ensure proper working order, since I don't have 30 pop on my local server

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/b3679268-445f-4ab4-ad65-796d74a39b51)
