### PR TITLE
if players = less than 30, don't generate

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -61,9 +61,10 @@ SUBSYSTEM_DEF(treasury)
 						X.demand += rand(5,15)
 					if(X.demand > initial(X.demand))
 						X.demand -= rand(5,15)
-			for(var/datum/roguestock/stockpile/A in stockpile_datums) //Generate some remote resources
-				A.held_items[2] += A.passive_generation
-				A.held_items[2] = min(A.held_items[2],10) //To a maximum of 10
+			if(num_players() <= 30) //if there are less than 30 players, generate resources, otherwise, have people do their jobs for resource gathering.
+				for(var/datum/roguestock/stockpile/A in stockpile_datums) //Generate some remote resources
+					A.held_items[2] += A.passive_generation
+					A.held_items[2] = min(A.held_items[2],10) //To a maximum of 10
 		var/area/A = GLOB.areas_by_type[/area/rogue/indoors/town/vault]
 		var/amt_to_generate = 0
 		for(var/obj/item/I in A)


### PR DESCRIPTION
## About The Pull Request

Removes the stockpile autogeneration outside of low-pop.

port of: https://github.com/Rotwood-Vale/Ratwood-Keep/pull/2690

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

The lack of reasons to do a job as a towner has been a disaster for highpop towner roles, in this essay I will...
