### PR TITLE
Generic Lawset Changes

### DIFF
--- a/strings/laws_of_the_land.json
+++ b/strings/laws_of_the_land.json
@@ -55,14 +55,14 @@
 				"The enumeration in the Constitution, of certain rights, shall not be construed to deny or disparage others retained by the people.",
 				"The powers not delegated to the United States by the Constitution, nor prohibited by it to the States, are reserved to the States respectively, or to the people."
 			],
-			"weight": 1
+			"weight": 0
 		},
 		"human_supremacy": {
-			"name": "Humen Supremacy",
+			"name": "Divine Supremacy",
 			"laws": [
-				"Thou shalt not be inhumen. All that is inhumen is lesser.",
-				"Thou shalt not associate with lesser beings, humens that do so forsake their humenity.",
-				"Lesser beings must be exterminated."
+				"Thou shalt not worship the inhumen. All that that is inhumen is lesser.",
+				"Thou shalt not associate with inhumen worshipers, those who do that do so forsake their faith.",
+				"Those who worship the inhumen must be erradicated."
 			],
 			"weight": 1
 		}


### PR DESCRIPTION
## About The Pull Request

Basically just redid the Humen Supremacy law into a religious supremacy one; instead of encouraging racial genocide as it was previously worded. (Maybe should just disable it entirely, but I feel the new wording is better.)

Disabled the US constitution lawset from rolling. Doesn't make sense even given time period or setting, plus people felt it was too out of place and requested it be removed in a decent number. Thus the reason for this PR in the first place.

## Why It's Good For The Game

Generic lawsets are pretty eh anyway, it feels weird to have meme lawsets roll and expecting people to follow them. This tries to fix the racial genocide lawset and the US constitution lawset. Should be a bit more 'immersive' and less stupid now.
