### PR TITLE
Crownstones speak louder

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -726,7 +726,7 @@
 			for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
 				S.repeat_message(input_text, src, usedcolor)
 		if(garrisonline)
-			input_text = "<span style='color: [GARRISON_SCOM_COLOR]'>[input_text]</span>" //Prettying up for Garrison line
+			input_text = "<big><span style='color: [GARRISON_SCOM_COLOR]'>[input_text]</span></big>" //Prettying up for Garrison line
 			for(var/obj/item/scomstone/bad/garrison/S in SSroguemachine.scomm_machines)
 				S.repeat_message(input_text, src, usedcolor)
 			for(var/obj/item/scomstone/garrison/S in SSroguemachine.scomm_machines)


### PR DESCRIPTION
## About The Pull Request

Messages from crownstones in the garrison-line are now larger than those from regular SCOMs.

## Testing Evidence

![NVIDIA_Overlay_TaNY51Ctlo](https://github.com/user-attachments/assets/c3b220ab-ac48-40d3-b4e3-e58657fdcb22)

## Why It's Good For The Game

Makes for good differentiation between `head roles` and `non-head` when it comes to the garrison. Relieves a lot of the text mash, good to lead during busy incidents.
Since the text is tied to the crownstone. This won't give away people who've stolen one (and may even legitimise stolen crownstones in a way). Automatically is only for head roles since thats all who get the crownstone.
