### PR TITLE
Fixing stamina potions (FINNALY)

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -156,7 +156,7 @@
 	description = "Rapidly regenerates stamina."
 	color = "#13df00"
 	taste_description = "sparkly static"
-	metabolization_rate = REAGENTS_METABOLISM * 3
+	metabolization_rate = REAGENTS_METABOLISM
 
 /datum/reagent/medicine/strongstam/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.99)


### PR DESCRIPTION
## About The Pull Request

Stamina potions did not work at all at the beginning, restoring TG stamina instead of rogue one. Then they were made the same as blue potions, since wording in code is misleading. Now it works properly, restoring green bar on tick.

I didn't play with the balance much, just basic amounts that will feel impactful as you drink the potion. It can be tweaked in the future, the plan was just to make the potion work as intended.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence


https://github.com/user-attachments/assets/056841df-e951-48bf-b024-435961c94e82



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

We will have one more potion working as intended from the beginning, now it's not just a Manna potion clone.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
