### PR TITLE
Fixes the Keffiyeh to Adjust Properly

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -12,6 +12,7 @@
 	experimental_onhip = TRUE
 	var/mask_override = FALSE //override if we want to always respect our inv flags if the helm is in a mask slot
 	experimental_inhand = FALSE
+	var/hidesnoutADJ = FALSE
 
 /obj/item/clothing/head/roguetown/equipped(mob/user, slot)
 	. = ..()
@@ -82,6 +83,7 @@
 	edelay_type = 1
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
+	hidesnoutADJ = TRUE
 	blocksound = SOFTHIT
 	max_integrity = 100
 	sewrepair = TRUE
@@ -96,6 +98,7 @@
 	desc = "Flowing like blood from a wound, this tithe of cloth-and-silk spills out to the shoulders. It carries the telltale mark of Naledian stitcheries."
 	item_state = "hijab"
 	icon_state = "deserthood"
+	hidesnoutADJ = FALSE
 
 /obj/item/clothing/head/roguetown/roguehood/shalal/heavyhood
 	name = "heavy hood"
@@ -104,6 +107,7 @@
 	color = CLOTHING_BROWN
 	item_state = "heavyhood"
 	icon_state = "heavyhood"
+	hidesnoutADJ = FALSE
 
 /obj/item/clothing/head/roguetown/roguehood/astrata
 	name = "sun hood"
@@ -233,6 +237,8 @@
 			if(toggle_icon_state)
 				icon_state = "[initial(icon_state)]_t"
 			flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+			if(hidesnoutADJ == TRUE)
+				flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 			body_parts_covered = NECK|HAIR|EARS|HEAD
 			if(ishuman(user))
 				var/mob/living/carbon/H = user


### PR DESCRIPTION


## About The Pull Request

Shit was bromken, figured out why. Added a little tag for future use if people need to hide EVERYTHING on an adjust, unlike most hoods that now allow for snouts to show through.

## Testing Evidence


https://github.com/user-attachments/assets/53cbf19f-616a-4882-b417-98a25b1ea842


## Why It's Good For The Game

onmob fixup
Don't ask me what black hole their snouts get sucked into. Someone needs to sprite some snout-alts for a lot of masks, but hell if it'll be me.
