### PR TITLE
Ghetto surgery and stone pickaxe double bugfix power hour.

### DIFF
--- a/code/modules/roguetown/roguejobs/gravedigger/tools.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/tools.dm
@@ -11,6 +11,7 @@
 	wdefense = 3
 	wlength = WLENGTH_LONG
 	w_class = WEIGHT_CLASS_BULKY
+	tool_behaviour = TOOL_SHOVEL
 	slot_flags = ITEM_SLOT_BACK
 	swingsound = list('sound/combat/wooshes/blunt/shovel_swing.ogg','sound/combat/wooshes/blunt/shovel_swing2.ogg')
 	drop_sound = 'sound/foley/dropsound/shovel_drop.ogg'

--- a/code/modules/roguetown/roguejobs/miner/tools.dm
+++ b/code/modules/roguetown/roguejobs/miner/tools.dm
@@ -58,9 +58,10 @@
 /obj/item/rogueweapon/pick/stone
 	name = "stone pick"
 	desc = "Stone versus sharp stone, who wins?"
+	force = 12
 	force_wielded = 17
 	icon_state = "stonepick"
 	possible_item_intents = list(/datum/intent/pick)
 	gripped_intents = list(/datum/intent/pick)
 	max_integrity = 250
-	smeltresult = /obj/item/ingot/steel
+	smeltresult = null

--- a/code/modules/roguetown/roguejobs/miner/tools.dm
+++ b/code/modules/roguetown/roguejobs/miner/tools.dm
@@ -1,6 +1,8 @@
 /obj/item/rogueweapon/pick
-	force = 21
+	force = 17
+	force_wielded = 21
 	possible_item_intents = list(/datum/intent/pick)
+	gripped_intents = list(/datum/intent/pick)
 	name = "iron pick"
 	desc = "This tool is essential to mine in the dark depths."
 	icon_state = "pick"
@@ -48,6 +50,7 @@
 /obj/item/rogueweapon/pick/steel
 	name = "steel pick"
 	desc = "With a reinforced handle and sturdy shaft, this is a superior tool for delving in the darkness."
+	force = 21
 	force_wielded = 28
 	icon_state = "steelpick"
 	possible_item_intents = list(/datum/intent/pick)

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -507,10 +507,12 @@
 	var/static/list/retracting_behaviors = list(
 		TOOL_RETRACTOR,
 		TOOL_CROWBAR,
+		TOOL_IMPROVISED_RETRACTOR,
 	)
 	var/static/list/clamping_behaviors = list(
 		TOOL_HEMOSTAT,
 		TOOL_WIRECUTTER,
+		TOOL_IMPROVISED_HEMOSTAT,
 	)
 	for(var/obj/item/embedded as anything in embedded_objects)
 		if((embedded.tool_behaviour in retracting_behaviors) || embedded.embedding?.retract_limbs)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Bugfix that makes ghetto surgery tools actually work and removes !FUN! exploitable smelting for the stone pickaxe.
- Adds flags for improvised hemostat and retractor to their embed states, enabling additional steps of surgery.
- Adds the TOOL_SHOVEL to the shovel as was intended, it is now the saw replacement for surgery.
- Makes the stone pickaxe not equivalent to the iron pickaxe, updates the force to not be inherited.
- Removes an age-old bug to smelt the stone pickaxe into steel bars.
- Makes iron pickaxe wield able so it's not the odd one out.

Now tongs properly works as a clamping tool, a stake works as a retractor and a shovel works as a saw for all your foul mending in the wilds without boring miracles.

Stone pickaxes are no longer the solution to the riddle of steel.


## Testing Evidence
Tested that all were working as intended.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bugs bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
