### PR TITLE
fixes heretic examines

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -790,7 +790,7 @@
 
 /// Returns patron-related examine text for the mob, if any. Can return null.
 /mob/living/proc/get_heretic_text(mob/examiner)
-	var/heretic_text
+	var/heretic_text = null
 	var/seer
 
 	if(HAS_TRAIT(src,TRAIT_DECEIVING_MEEKNESS))
@@ -822,7 +822,7 @@
 			if(HAS_TRAIT(examiner, TRAIT_DEPRAVED))
 				heretic_text += " She leads us to the greatest ends."
 	
-	return null
+	return heretic_text
 
 /// Same as get_heretic_text, but returns a simple symbol depending on the type of heretic!
 /mob/living/proc/get_heretic_symbol(mob/examiner)


### PR DESCRIPTION
## About The Pull Request
It always returned null. Oops.

Intended, and now-fixed functionality:
- Matthiosans (and only them) can tell other Matthiosans on examine
- Seers can tell everyone on examine

No other changes.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Zizite seer examining a Zizite
![dreamseeker_Yrx5tpc9Px](https://github.com/user-attachments/assets/73305622-2349-40be-8955-10f7bce4acd0)

Matthiosan examining a Matthiosan (No Seer virtue involved)
![dreamseeker_cAqaoWnAar](https://github.com/user-attachments/assets/cdbc1a65-b395-419f-8cc7-743411da880c)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This is how it was meant to work after the fsalute PR, but I forgot to remove a null when I intended to return the functionality.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
