### PR TITLE
Remove stone mortar and pestle from alchemy lab recipes

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -1,6 +1,5 @@
 /datum/crafting_recipe/roguetown/alchemy
 	req_table = FALSE
-	tools = list(/obj/item/reagent_containers/glass/mortar, /obj/item/pestle)
 	verbage_simple = "mix"
 	skillcraft = /datum/skill/craft/alchemy
 	subtype_reqs = TRUE


### PR DESCRIPTION
## About The Pull Request
Remove stone mortar and pestle from alchemy lab recipes

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_4OXZk69Yzh](https://github.com/user-attachments/assets/30ea3e62-04cc-4a98-8100-9e87eafa017d)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It was always weird that you have to separately make mortar and pestle. Let's just assume the lab's fully equipped already.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
