### PR TITLE
Tweak + fix for squire needle repair

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -93,8 +93,7 @@
 			var/repairskill = (user.mind.get_skill_level(/datum/skill/misc/sewing) + user.mind.get_skill_level(/datum/skill/craft/tanning)) * 5
 			var/sewtime = max(5, (60 - skill))
 			if(HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR))
-				skill = max(30, skill) // Squire can't fail a repair
-				sewtime = min(skill, 30) // Squire have half sewing time minimum
+				skill = skill < 30 ? 30 : skill // Make sure they can't fail but let them suffer sewtime
 			if(!do_after(user, sewtime, target = I))
 				return
 			if(prob(max(0, 60 - (skill * 2)))) //The more knowlegeable we are the less chance we damage the object


### PR DESCRIPTION
## About The Pull Request
Fixed up the code where if you have more than 30 skills it get turned into 30 (like if you took hunter's apprentice as squire), sutures pointed this out. 
also removed the sewing time boost, suffer if you're not skilled.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_t5QqSq5GO1](https://github.com/user-attachments/assets/afc48ce7-69a5-4eb2-8b75-b3d25dc6c215)
(this is with to chat code added)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Taking hunter's apprentice is worth it on squire.
debuff repair speed of squire a tiny bit (it doesn't matter) if they don't have the skills

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
