### PR TITLE
Oversight Fix | Naledi + Kazengun Ancestry languages

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -113,6 +113,10 @@
 		foreign.grant_language(/datum/language/etruscan)
 	if(foreign.skin_tone == SKIN_COLOR_GRONN)
 		foreign.grant_language(/datum/language/gronnic)
+	if(foreign.skin_tone == SKIN_COLOR_NALEDI)
+		foreign.grant_language(/datum/language/celestial)
+	if(foreign.skin_tone == SKIN_COLOR_KAZENGUN)
+		foreign.grant_language(/datum/language/kazengunese)
 
 /datum/species/demihuman/get_random_features()
 	var/list/returned = MANDATORY_FEATURE_LIST

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -86,6 +86,10 @@
 		foreign.grant_language(/datum/language/etruscan)
 	if(foreign.skin_tone == SKIN_COLOR_GRONN)
 		foreign.grant_language(/datum/language/gronnic)
+	if(foreign.skin_tone == SKIN_COLOR_NALEDI)
+		foreign.grant_language(/datum/language/celestial)
+	if(foreign.skin_tone == SKIN_COLOR_KAZENGUN)
+		foreign.grant_language(/datum/language/kazengunese)
 
 /datum/species/human/northern/get_skin_list()
 	return list(


### PR DESCRIPTION
## About The Pull Request

Added sama'glos to those born from Naledi, and Kazengunese to those from Kazengun. Works on humen and half-kin (duh).

Ideally in the future another coder will split ancestry from skin colors, but for now, here's how we roll.

## Testing Evidence

![dreamseeker_ZMZFB1xCce](https://github.com/user-attachments/assets/e9272ed6-8855-4d03-8e5c-f133457f476c)
![dreamseeker_tg3ZhqPc1P](https://github.com/user-attachments/assets/8222110a-5abe-4e10-844c-099f4d24966c)
![bXhjn8kDrz](https://github.com/user-attachments/assets/f7842748-70a9-4f49-a5d7-fc65e9c1ee37)
![dreamseeker_WyLmoCUZvr](https://github.com/user-attachments/assets/b882300f-3a8f-4dd2-8abc-614bba20e676)

## Why It's Good For The Game

Not being able to speak your own native tongue is sad, bro