### PR TITLE
[NSFW] Hermaphrodites can finally fuck themselves. Includes consequences.

### DIFF
--- a/code/datums/sexcon/sex_actions/masturbate/masturbate_self_fuck.dm
+++ b/code/datums/sexcon/sex_actions/masturbate/masturbate_self_fuck.dm
@@ -1,0 +1,53 @@
+/datum/sex_action/masturbate_selfsex
+	name = "Fuck yourself"
+
+/datum/sex_action/masturbate_selfsex/shows_on_menu(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	if(user != target)
+		return FALSE
+	if(!user.getorganslot(ORGAN_SLOT_PENIS))
+		return FALSE
+	if(!user.getorganslot(ORGAN_SLOT_VAGINA))
+		return FALSE
+	return TRUE
+
+/datum/sex_action/masturbate_selfsex/can_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	if(user != target)
+		return FALSE
+	if(!get_location_accessible(user, BODY_ZONE_PRECISE_GROIN, TRUE))
+		return FALSE
+	if(!user.getorganslot(ORGAN_SLOT_PENIS))
+		return FALSE
+	if(!user.getorganslot(ORGAN_SLOT_VAGINA))
+		return FALSE
+	if(!user.sexcon.can_use_penis())
+		return
+	return TRUE
+
+/datum/sex_action/masturbate_selfsex/on_start(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	user.visible_message(span_warning("[user] pushes [user.p_their()] cock into [user.p_their()] own cunt!"))
+	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), 20, TRUE, ignore_walls = FALSE)
+
+/datum/sex_action/masturbate_selfsex/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fucks [user.p_their()] own cunt."))
+	playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE)
+
+	user.sexcon.perform_sex_action(user, 2, 0, TRUE)
+	if(user.sexcon.check_active_ejaculation())
+		user.visible_message(span_love("[user] cums into their own cunt!"))
+		user.sexcon.cum_into()
+		user.try_impregnate(target)
+		user.virginity = FALSE
+
+	if(user.sexcon.considered_limp())
+		user.sexcon.perform_sex_action(user, 1.2, 3, FALSE)
+	else
+		user.sexcon.perform_sex_action(target, 2.4, 7, FALSE)
+	target.sexcon.handle_passive_ejaculation()
+
+/datum/sex_action/masturbate_selfsex/on_finish(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	user.visible_message(span_warning("[user] pulls out of [user.p_them()]self."))
+
+/datum/sex_action/masturbate_selfsex/is_finished(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	if(user.sexcon.finished_check())
+		return TRUE
+	return FALSE

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -653,6 +653,7 @@
 #include "code\datums\sexcon\sex_actions\masturbate\masturbate_other_vagina_finger.dm"
 #include "code\datums\sexcon\sex_actions\masturbate\masturbate_penis.dm"
 #include "code\datums\sexcon\sex_actions\masturbate\masturbate_penis_over.dm"
+#include "code\datums\sexcon\sex_actions\masturbate\masturbate_self_fuck.dm"
 #include "code\datums\sexcon\sex_actions\masturbate\masturbate_vagina.dm"
 #include "code\datums\sexcon\sex_actions\masturbate\masturbate_vagina_finger.dm"
 #include "code\datums\sexcon\sex_actions\oral\blowjob.dm"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
- Added "masturbate_self_fuck.dm" to the game.
- Users of this sex action require a usable penis and a vagina.
- Users receive both the arousal of the top and the arousal of the bottom, making it a very pleasurable yet risky activity.
- Users who carelessly release inside of themselves may accidentally get themselves pregnant.

## Testing Evidence
![image](https://github.com/user-attachments/assets/440b460f-b8e0-4ac4-b61f-345a53908775)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
I can confirm it works. Booted up the game, no errors, spawned my character with the hen and her eggs, and proceeded to go fuck myself. It was fun, but the result of it certainly wasn't.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
This PR brings to light one of the most important issues facing hermaphrodite adventurers today; and that is accidental self-impregnation. A very real threat, and very dangerous for the health of communities affected.
One of the major leading causes for people to indulge in this activity seems to be hostile remarks such as "Aargh, Go fuck yeself!" taken as a command or request instead of an insult. Only YOU can help educate the kingdom of this threat.