### PR TITLE
Roguelite / Extended Automatic 5 Minutes Vote. Vote refactor, Vote Verb.

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -241,7 +241,6 @@
 				if(M.votable)
 					votable_modes += M.config_tag
 		qdel(M)
-	votable_modes += "secret"
 
 /datum/controller/configuration/proc/LoadMOTD()
 	motd = file2text("[directory]/motd.txt")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -81,6 +81,7 @@ SUBSYSTEM_DEF(ticker)
 	var/list/cuckers = list()
 	var/cums = 0
 
+	var/gamemode_voted = FALSE
 	var/end_party = FALSE
 	var/last_lobby = 0
 	var/round_end = FALSE
@@ -191,6 +192,10 @@ SUBSYSTEM_DEF(ticker)
 				var/mob/dead/new_player/player = i
 				if(player.ready == PLAYER_READY_TO_PLAY)
 					++totalPlayersReady
+			
+			if(!gamemode_voted)
+				SSvote.initiate_vote("gamemode", "Psydon", timeLeft/2)
+				gamemode_voted = TRUE
 
 			if(start_immediately)
 				timeLeft = 0
@@ -445,7 +450,7 @@ SUBSYSTEM_DEF(ticker)
 
 	SSdbcore.SetRoundStart()
 
-	message_admins(span_notice("<B>Welcome to [station_name()], enjoy your stay!</B>"))
+	message_admins(span_notice("<B>Welcome to [station_name()], enjoy your stay! Gamemode: [mode.name] </B>"))
 
 	for(var/client/C in GLOB.clients)
 		if(C.mob)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(vote)
 	var/initiator = null
 	var/started_time = null
 	var/time_remaining = 0
+	var/custom_vote_period = 0
 	var/mode = null
 	var/question = null
 	var/list/choices = list()
@@ -18,7 +19,8 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/fire()	//called by master_controller
 	if(mode)
-		time_remaining = round((started_time + CONFIG_GET(number/vote_period) - world.time)/10)
+		var/vote_period = custom_vote_period || CONFIG_GET(number/vote_period)
+		time_remaining = round((started_time + vote_period - world.time)/10)
 
 		if(time_remaining < 0)
 			result()
@@ -37,6 +39,7 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/proc/reset()
 	initiator = null
 	time_remaining = 0
+	custom_vote_period = 0
 	mode = null
 	question = null
 	choices.Cut()
@@ -197,7 +200,7 @@ SUBSYSTEM_DEF(vote)
 				return vote
 	return 0
 
-/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key)
+/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, vote_period)
 	var/sound/vote_alert = new()
 	vote_alert.file = null
 	vote_alert.priority = 250
@@ -263,7 +266,12 @@ SUBSYSTEM_DEF(vote)
 		if(mode == "custom")
 			text += "\n[question]"
 		log_vote(text)
-		var/vp = CONFIG_GET(number/vote_period)
+		var/vp
+		if(vote_period)
+			vp = vote_period
+			custom_vote_period = vote_period
+		else
+			vp = CONFIG_GET(number/vote_period)
 		if(vote_alert.file)
 			for(var/mob/M in GLOB.player_list)
 				SEND_SOUND(M, vote_alert)
@@ -279,6 +287,16 @@ SUBSYSTEM_DEF(vote)
 //			generated_actions += V
 		return 1
 	return 0
+
+// Helper for sending an active vote to someone who has just logged in 
+/datum/controller/subsystem/vote/proc/send_vote(client/C)
+	if(!mode || !C)
+		return
+	var/text = "[capitalize(mode)] vote started by [initiator]."
+	if(mode == "custom")
+		text += "\n[question]"
+	var/remaining_time = time_remaining * 10
+	to_chat(C, "\n<font color='purple'><b>[text]</b>\nClick <a href='?src=[REF(src)]'>here</a> to place your vote.\nYou have [DisplayTimeText(remaining_time)] to vote.</font>")
 
 /datum/controller/subsystem/vote/proc/interface(client/C)
 	if(!C)
@@ -397,7 +415,6 @@ SUBSYSTEM_DEF(vote)
 /mob/verb/vote()
 	set category = "OOC"
 	set name = "Vote"
-	set hidden = 1
 	var/datum/browser/noclose/popup = new(src, "vote", "Voting Panel")
 	popup.set_window_options("can_close=0")
 	popup.set_content(SSvote.interface(client))

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -17,6 +17,7 @@
 /datum/game_mode/extended/announced
 	name = "extended"
 	config_tag = "extended"
+	votable = TRUE
 	false_report_weight = 0
 
 /datum/game_mode/extended/announced/send_intercept(report = 0)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -15,7 +15,7 @@
 /datum/game_mode
 	var/name = "invalid"
 	var/config_tag = null
-	var/votable = 1
+	var/votable = FALSE
 	var/probability = 0
 	var/false_report_weight = 0 //How often will this show up incorrectly in a centcom report?
 	var/report_type = "invalid" //gamemodes with the same report type will not show up in the command report together.

--- a/code/game/gamemodes/roguetown/chaosmode.dm
+++ b/code/game/gamemodes/roguetown/chaosmode.dm
@@ -522,7 +522,7 @@
 	required_enemies = 0
 	recommended_enemies = 0
 	enemy_minimum_age = 0
-	votable = 1
+	votable = FALSE
 	probability = 80
 
 	announce_span = "danger"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -259,8 +259,12 @@
 		to_chat(usr, span_warning("You do not have the rights to start a vote."))
 		return
 
-	var/type = input("What kind of vote?") as null|anything in list("End Round", "Custom")
+	var/list/allowed_modes = list("End Round", "Gamemode", "Custom")
+
+	var/type = input("What kind of vote?") as null|anything in allowed_modes
 	switch(type)
+		if("Gamemode")
+			type = "gamemode"
 		if("End Round")
 			type = "endround"
 		if("Custom")

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -71,6 +71,7 @@
 			postfix = "soon"
 		to_chat(src, "The game will start [postfix].")
 		if(client)
+			SSvote.send_vote(client)
 			var/usedkey = ckey(key)
 			/*if(usedkey in GLOB.anonymize)
 				usedkey = get_fake_key(usedkey)*/


### PR DESCRIPTION
## About The Pull Request
- At roundstart, start a 5 minutes vote for roguelite or extended round. (Custom period)
- Removed all round types except roguelite or extended from votable
- Added Vote verb back to OOC. dunno why it is missing.
- Hacky fix to send any active vote to a client that logged in. Works 90% of the time from what I see...I hate this system.
- Admin message at the start of a round tell them what gamemode it is. Helps with debug in case it breaks or something.

Admin can cancel the vote if they want to run something else custom by clicking "Vote" which opens the voting panel. If it somehow don't show up (Idk wtf is going on with this chat)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Proof it works (probably)
![dreamseeker_y0UWNsbb3g](https://github.com/user-attachments/assets/cbc7da75-e87f-4926-857b-53bf1d31e3bd)
Proof joining with a custom vote works (probably)
![dreamseeker_9CCfRdlasb](https://github.com/user-attachments/assets/9eebbb27-b37c-49f4-a6a5-3d5b80a86d31)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Let us have roguelite on regularly by letting players vote for the gamemode.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
