### PR TITLE
Grudgebearers and Black Oaks now spawn with torches

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
@@ -45,6 +45,7 @@
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/elven_plate
 				neck = /obj/item/clothing/neck/roguetown/chaincoif
 				beltl = /obj/item/rogueweapon/huntingknife/idagger/steel/special
+				beltr = /obj/item/flashlight/flare/torch
 				r_hand = /obj/item/rogueweapon/halberd/glaive
 				backr = /obj/item/gwstrap
 				backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor)
@@ -72,7 +73,7 @@
 				beltr = /obj/item/rogueweapon/huntingknife/idagger/silver/elvish
 				beltl = /obj/item/quiver/arrows
 				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-				backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/huntingknife/idagger/navaja)
+				backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/flashlight/flare/torch)
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 
 	//Shared minor skillblock from Wardens

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgebearer.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgebearer.dm
@@ -37,6 +37,7 @@
 				cloak = /obj/item/clothing/cloak/forrestercloak/snow
 				belt = /obj/item/storage/belt/rogue/leather/black
 				beltr = /obj/item/rogueweapon/mace
+				beltl = /obj/item/flashlight/flare/torch
 				backl = /obj/item/storage/backpack/rogue/backpack
 				shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 				gloves = /obj/item/clothing/gloves/roguetown/plate/dwarven
@@ -61,6 +62,7 @@
 				shoes = /obj/item/clothing/shoes/roguetown/boots/armor/dwarven
 				cloak = /obj/item/clothing/cloak/forrestercloak/snow
 				belt = /obj/item/storage/belt/rogue/leather/black
+				beltl = /obj/item/flashlight/flare/torch
 				backl = /obj/item/storage/backpack/rogue/satchel
 				shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
 				gloves = /obj/item/clothing/gloves/roguetown/plate/dwarven


### PR DESCRIPTION
## About The Pull Request
![dreamseeker_O3kSUAv0Qt](https://github.com/user-attachments/assets/d8102f82-3e81-4f99-8da3-9c9dd8fe4b01)
![dreamseeker_tH95Nx0ZAF](https://github.com/user-attachments/assets/caaf8816-3027-4872-a346-5d7d51031bd4)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
above
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Admittedly, Black Oaks need it slightly less, but this was an oversight, and long overdue.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
