### PR TITLE
Great Weapon Strap Refactor [Ready]

### DIFF
--- a/modular_azurepeak/code/game/objects/items/gwstrap.dm
+++ b/modular_azurepeak/code/game/objects/items/gwstrap.dm
@@ -24,8 +24,8 @@
 	var/atom/movable/weps = null
 	sewrepair = TRUE
 
-/obj/item/gwstrap/attackby(obj/A, mob/living/carbon/user, params)
-	if(istype(A, /obj/item/rogueweapon/spear) || istype(A, /obj/item/rogueweapon/eaglebeak) || istype(A, /obj/item/rogueweapon/halberd) || istype(A, /obj/item/rogueweapon/estoc) || istype(A, /obj/item/rogueweapon/greatsword))
+/obj/item/gwstrap/attackby(obj/item/A, mob/living/carbon/user, params)
+	if(istype(A, /obj/item/rogueweapon) && A.w_class >= WEIGHT_CLASS_BULKY)
 		if(weps == null)
 			for(var/obj/item/gwstrap/I in user.get_equipped_items(TRUE))
 				to_chat(loc, span_warning("I work the latches of my strap to holster [A]."))

--- a/modular_azurepeak/code/game/objects/items/gwstrap.dm
+++ b/modular_azurepeak/code/game/objects/items/gwstrap.dm
@@ -36,6 +36,7 @@
 					getonmobprop("onback")
 					LAZYSET(I.onprop, "onback", getonmobprop("onback"))
 					user.update_inv_back()
+					name = "greatweapon strap ([A.name])"
 		else
 			to_chat(loc, span_warning("The holster already holds a weapon!"))
 		return
@@ -47,6 +48,7 @@
 			to_chat(loc, span_warning("I work the latches of my strap to unholster [weps]."))
 			if(do_after(user, 50, target = user))
 				user.put_in_active_hand(weps, user.active_hand_index)
+				name = "greatweapon strap"
 				weps = null
 				update_icon()
 				user.update_inv_back()
@@ -93,6 +95,7 @@
 
 /obj/item/gwstrap/proc/on_drop(datum/source, mob/user)
 	if(weps != null)
+		name = "greatweapon strap"
 		var/atom/movable/I = weps
 		weps = null
 		update_icon()


### PR DESCRIPTION
## About The Pull Request
Due to the gw straps not working with the axes from my other PR I looked at the code and sighed.

TL;DR of what this does: 
-Great weapon straps can hold a greater variety of options and the repeated OR checks they had was cleaned up.
-Great weapon straps will also show the name of the weapon they're carrying in parenthesis.

![gwstrap1](https://github.com/user-attachments/assets/5aeb6461-554b-451d-a731-78efab4387a7)


Longer read:

I noticed that the code for how they handled things was a list of repeated OR checks for several weapons.
This PR refactors it to now contain any object which is a subtype of rogueweapon AND has the weight class of WEIGHT_CLASS_BULKY.
To summarize what WEIGHT_CLASS_BULKY does, is it disallows the weapon from being able to fit into containers. Essentially, any weapon which will **not** fit into your bag will now fit onto a great weapon strap.
This means that you can now fit **more** (as in variety, not quantity) weapons or even a few _not_ weapons into the great weapon strap.

As an example of a **benefit**: the peasant warflail, which had fit neither upon one's back nor belt, will now have a manner in which it can be carried without being in your hands. This follows suit for any other weapon which may have been lost within the oversight of weapons made.

As an example of a **side-effect**: Standard stone/iron/steel axes or shields can now fit into a great weapon strap. _Though I don't think this matters too greatly._ It **is** a result of it.

My alternative go-about for a solution is to add in another var onto the rogueweapon object which allows great weapon strap compatability. **I avoided going this route upon the assumption of working with what I have instead of adding anew.**

## Testing Evidence

![weapontesting](https://github.com/user-attachments/assets/bf7f0075-4a4b-44a3-9979-2f8f25f0acdf)


## Why It's Good For The Game

Increases the options which fit into a great weapon strap as well as future-proofing to a mild degree without having to add onto an unnecessarily long OR check for the item.
