### PR TITLE
Add floorkick + kick breaks passive grabs

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -268,9 +268,6 @@
 					return
 				if(A == src)
 					return
-				if(isliving(A))
-					if(!(mobility_flags & MOBILITY_STAND) && pulledby)
-						return
 				if(IsOffBalanced())
 					to_chat(src, span_warning("I haven't regained my balance yet."))
 					return

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1363,13 +1363,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return
 	if(user.rogfat >= user.maxrogfat)
 		return FALSE
-	if(!(user.mobility_flags & MOBILITY_STAND))
-		return FALSE
 	var/stander = TRUE
 	if(!(target.mobility_flags & MOBILITY_STAND))
 		stander = FALSE
 	if(!get_dist(user, target))
-		if(!stander && (user.mobility_flags & MOBILITY_STAND))
+		if(!stander)
 			target.lastattacker = user.real_name
 			target.lastattackerckey = user.ckey
 			if(target.mind)
@@ -1404,6 +1402,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		user.do_attack_animation(target, ATTACK_EFFECT_DISARM)
 		playsound(target, 'sound/combat/hits/kick/kick.ogg', 100, TRUE, -1)
+
+		if (target.pulling && target.grab_state < GRAB_AGGRESSIVE)
+			target.stop_pulling()
+			user.Immobilize(10)
 
 		var/turf/target_oldturf = target.loc
 		var/shove_dir = get_dir(user.loc, target_oldturf)


### PR DESCRIPTION
## About The Pull Request

You can now kick while on the floor. Works as normal.
All kicks now break passive grabs. Though aggressive grabs only result in the grabber keeping their grab and both being pushed by one tile. (Use this strategically to kick aggrograbbers off cliffs/onto tables/into walls if you can)
Kicking out of grab immobilises you for 1s, preventing *instant* escapes.

## Testing Evidence

Tested in local with two mobs. Remains to be seen how annoying it is in game.
![NVIDIA_Overlay_ntHqAK6GqJ](https://github.com/user-attachments/assets/e36d7829-1161-4765-baf7-cafdfda9c898)

## Why It's Good For The Game

Another counter to being constantly grappled. Might make grapplers more mindful of where and how they're grappling (or, if they can). Plus floor-kicks are right out of action movies, pretty cool.
