### PR TITLE
Adds a DoNotRevive prompt for dead being revived + ZZ'd people can't be revived

### DIFF
--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -27,9 +27,12 @@
 	if(target.stat < DEAD)
 		to_chat(user, "They're not dead!")
 		return FALSE
+	if(target.mind && !target.mind.active)
+		to_chat(user, "[target]'s heart is inert. Maybe it will respond later?")
+		return FALSE
 
 /datum/surgery_step/infuse_lux/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
-	display_results(user, target, span_notice("I begin to revive [target]..."),
+	display_results(user, target, span_notice("I begin to revive [target]... will their heart respond?"),
 		span_notice("[user] begins to work lux into [target]'s heart."),
 		span_notice("[user] begins to work lux into [target]'s heart."))
 	return TRUE
@@ -38,9 +41,15 @@
 	var/revive_pq = PQ_GAIN_REVIVE
 	if(target.mob_biotypes & MOB_UNDEAD)
 		display_results(user, target, span_notice("You cannot infuse life into the undead! The rot must be cured first."),
-		"[user] works the lux into [target]'s innards.",
-		"[user] works the lux into [target]'s innards.")
+			"[user] works the lux into [target]'s innards.",
+			"[user] works the lux into [target]'s innards.")
 		return FALSE
+	if (target.mind)
+		if(alert(target, "Are you ready to face the world, once more?", "Revival", "I must go on", "Let me rest") != "I must go on")
+			display_results(user, target, span_notice("[target]'s heart refuses the lux. They're only in sweet dreams, now."),
+				"[user] works the lux into [target]'s innards, but nothing happens.",
+				"[user] works the lux into [target]'s innards, but nothing happens.")
+			return FALSE
 	target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 	if(!target.revive(full_heal = FALSE))
 		display_results(user, target, span_notice("The lux refuses to meld with [target]'s heart. Their damage must be too severe still."),


### PR DESCRIPTION
## About The Pull Request

When someone uses lux to revive you, you get a prompt.
Logged out people can't be revived.

## Testing Evidence

![NVIDIA_Overlay_2ZwdTNiUg4](https://github.com/user-attachments/assets/5fb812fe-2fa9-438d-b1a3-d597931d0e7c)


## Why It's Good For The Game

Some people just want to stay dead.
