### PR TITLE
Adds Ear options to Half-Orcs

### DIFF
--- a/code/modules/client/customizer/customizers/organ/ears.dm
+++ b/code/modules/client/customizer/customizers/organ/ears.dm
@@ -88,6 +88,21 @@
 	customizer_choices = list(/datum/customizer_choice/organ/ears/goblin)
 	allows_disabling = FALSE
 
+/datum/customizer_choice/organ/ears/halforc
+	name = "Half-Orc Ears"
+	organ_type = /obj/item/organ/ears
+	sprite_accessories = list(
+		/datum/sprite_accessory/ears/goblin,
+		/datum/sprite_accessory/ears/goblin_alt,
+		/datum/sprite_accessory/ears/goblin_small,
+		/datum/sprite_accessory/ears/halforc,
+		/datum/sprite_accessory/ears/elf,
+		/datum/sprite_accessory/ears/elfw)
+
+/datum/customizer/organ/ears/halforc
+	customizer_choices = list(/datum/customizer_choice/organ/ears/halforc)
+	allows_disabling = FALSE
+
 /datum/customizer/organ/ears/demihuman
 	customizer_choices = list(/datum/customizer_choice/organ/ears/demihuman)
 	allows_disabling = TRUE

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -84,6 +84,7 @@
 		/datum/customizer/organ/breasts/human,
 		/datum/customizer/organ/vagina/human_anthro,
 		/datum/customizer/organ/horns/tusks,
+		/datum/customizer/organ/ears/halforc,
 		)
 	languages = list(
 		/datum/language/common,


### PR DESCRIPTION
## About The Pull Request
They now get an ear option in their Features tab.
At the moment, it's every goblin ear, their own unique half-orc ears, and two types of elf ears.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![7tKtQZjskF](https://github.com/user-attachments/assets/51045717-e3c8-4ed1-b627-3e622cf7a80a)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Half-Orc players can now RP as Hobgoblins, as a treat.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
