### PR TITLE
Port Ratwood #2698 Infinite Fuel Fix + Great Furnace Exploit fix + No refuel check

### DIFF
--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -148,8 +148,11 @@
 							break
 					return
 	if(W.firefuel)
+		if(W.smeltresult) // For things with actual smelt results - functionally no differences
+			if(alert(usr, "Fuel [src] with [W]?", "ROGUETOWN", "Fuel", "Smelt") != "Fuel")
+				return TRUE
 		if(alert(usr, "Fuel [src] with [W]?", "ROGUETOWN", "Yes", "No") != "Yes")
-			return TRUE //returns true if the answer is no, we don't want to feed it
+			return TRUE
 		if(!W)
 			return
 		if(user.get_active_held_item() != W)

--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -148,8 +148,16 @@
 							break
 					return
 	if(W.firefuel)
-		if (alert(usr, "Fuel the [src] with [W]?", "ROGUETOWN", "Fuel", "Smelt") != "Fuel")
+		if(alert(usr, "Fuel [src] with [W]?", "ROGUETOWN", "Yes", "No") != "Yes")
 			return TRUE //returns true if the answer is no, we don't want to feed it
+		if(!W)
+			return
+		if(user.get_active_held_item() != W)
+			to_chat(user, span_warning("That item is no longer in my hand..."))
+			return
+
+		user.dropItemToGround(W)
+
 		if(initial(fueluse))
 			if(fueluse > initial(fueluse) - 5 SECONDS)
 				to_chat(user, "<span class='warning'>[src] is fully fueled.</span>")

--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -8,6 +8,7 @@
 	var/datum/looping_sound/soundloop = null // = /datum/looping_sound/fireloop
 	pass_flags = LETPASSTHROW
 	flags_1 = NODECONSTRUCT_1
+	var/no_refuel = FALSE // For special holder that don't actually refuel
 	var/cookonme = FALSE
 	var/crossfire = TRUE
 	var/can_damage = FALSE
@@ -147,7 +148,7 @@
 						else
 							break
 					return
-	if(W.firefuel)
+	if(W.firefuel && !no_refuel)
 		if(W.smeltresult) // For things with actual smelt results - functionally no differences
 			if(alert(usr, "Fuel [src] with [W]?", "ROGUETOWN", "Fuel", "Smelt") != "Fuel")
 				return TRUE

--- a/code/game/objects/lighting/lantern_post.dm
+++ b/code/game/objects/lighting/lantern_post.dm
@@ -7,6 +7,7 @@
 	density = FALSE
 	var/obj/item/flashlight/flare/torch/torchy
 	fueluse = 0 //we use the torch's fuel
+	no_refuel = TRUE
 	soundloop = null
 	crossfire = FALSE
 	plane = GAME_PLANE_UPPER

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -13,6 +13,7 @@
 	dir = SOUTH
 	crossfire = TRUE
 	fueluse = 0
+	no_refuel = TRUE
 
 /obj/machinery/light/rogue/firebowl/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSTABLE))
@@ -106,6 +107,7 @@
 	bulb_colour = "#ffa35c"
 	density = FALSE
 	fueluse = 0
+	no_refuel = TRUE
 	crossfire = FALSE
 	cookonme = TRUE
 
@@ -175,6 +177,7 @@
 	density = FALSE
 	var/obj/item/flashlight/flare/torch/torchy
 	fueluse = FALSE //we use the torch's fuel
+	no_refuel = TRUE
 	soundloop = null
 	crossfire = FALSE
 	plane = GAME_PLANE_UPPER
@@ -310,6 +313,7 @@
 	pixel_y = -10
 	layer = 2.0
 	fueluse = 0
+	no_refuel = TRUE
 	soundloop = null
 	crossfire = FALSE
 	obj_flags = CAN_BE_HIT | BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -55,6 +55,11 @@
 		if(!(..())) //False/null if using the item as fuel. If true, we want to try smelt it so go onto next segment.
 			return
 	if(W.smeltresult)
+		if(!W)
+			return
+		if(user.get_active_held_item() != W)
+			to_chat(user, span_warning("That item is no longer in my hand..."))
+			return
 		if(ore.len < maxore)
 			user.dropItemToGround(W)
 			W.forceMove(src)


### PR DESCRIPTION
## About The Pull Request
- Port Ratwood #2698 Infinite Fuel Fix.
- Also changes the alert text to "Yes" or "No" instead of Fuel / Smelt, because Smelt gives you the idea that you will smelt it instead of fueling it when it is a cancel. This is applicable to items without smeltresult.
- Item are also dropped and fed to the furnace when smelted. This prevents a 4x coal exploit doable by spam clicking the Great Furnace.
- Add a check to prevent fueling torch holders etc. that cannot be fueled.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_VG5MBJSV8N](https://github.com/user-attachments/assets/bd49fb71-eede-4262-9be5-eeba1191b765)
![dreamseeker_Q0Gh0kkI2X](https://github.com/user-attachments/assets/0ce4db41-d333-4a5e-b05b-4cee3fad630d)



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
bug & exploits bad

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
