### PR TITLE
Add sellprice to fiber and cloth

### DIFF
--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -15,6 +15,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	spitoutmouth = FALSE
 	experimental_inhand = FALSE
+	sellprice = 2
 	bundletype = /obj/item/natural/bundle/fibers
 
 /obj/item/natural/fibers/attack_right(mob/user)
@@ -114,6 +115,7 @@
 	spitoutmouth = FALSE
 	experimental_inhand = FALSE
 	bundletype = /obj/item/natural/bundle/cloth
+	sellprice = 4
 	var/wet = 0
 	/// Effectiveness when used as a bandage, how much bloodloss we can staunch
 	var/bandage_effectiveness = 0.9


### PR DESCRIPTION
## About The Pull Request
Add a value of 2 to fiber, 4 to cloth.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_qWM6nIMKlU](https://github.com/user-attachments/assets/21d4c301-0623-4161-a94e-874a9add08e7)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- After 10,000 debate about stockpile this keep getting brought up that cloth / fiber has no value and is not exportable. Turns out it exportable by steward but it does in fact, have no value.

Value based on the normal export value (2.4 each for fibers and 4 for cloth before supply  / demand reduce)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
