### PR TITLE
Small Non-Armor Training Penalty

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -216,6 +216,9 @@
 			prob2defend = clamp(prob2defend, 5, 90)
 			if(HAS_TRAIT(user, TRAIT_HARDSHELL) && H.client)	//Dwarf-merc specific limitation w/ their armor on in pvp
 				prob2defend = clamp(prob2defend, 5, 70)
+			if(!H?.check_armor_skill())
+				prob2defend = clamp(prob2defend, 5, 75)			//Caps your max parry to 75 if using armor you're not trained in. Bad dexerity.
+				drained = drained + 5							//More stamina usage for not being trained in the armor you're using.
 
 			//Dual Wielding
 			var/attacker_dualw


### PR DESCRIPTION
## About The Pull Request

Wo-balance-salt-jak upon ye

Really simple PR. People kept saying "Well, if you wear armor you aren't trained for you fall over" - which wasn't true EXCEPT if you tried to dodge. So, parrying in armor you didn't have training for? No difference.

This makes it instead you have a capped parry % of 75, and you use extra stamina when parrying in the armor. Basically acting as a penalty but one you can honestly live with to a minor extent. You'll be less efficient than a trained person but still able to fight at least.

## Testing Evidence

I'll post some soon when I test this, getting this up first.

## Why It's Good For The Game

Basically does what most people seemed to THINK was the case anyway where you got penalized for wearing armor you aren't trained for. Does it in a less 'bullshit' way instead of just knocking you over to die.
