### PR TITLE
Adds a SCOM to the bathhouse. Fixes a typo.

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -32020,6 +32020,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
+"mIT" = (
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town/bath)
 "mIU" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/gold/pile,
@@ -32764,6 +32770,14 @@
 /obj/effect/landmark/start/vagrant,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"mYm" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cobble/mossy{
+	dir = 9
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mYq" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -32774,14 +32788,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"mYm" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/decal/cobble/mossy{
-	dir = 9
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "mYs" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -119519,7 +119525,7 @@ haH
 haH
 sBA
 eMv
-iBX
+mIT
 rqY
 eMv
 ckq

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/human/humen.dm
@@ -5,7 +5,7 @@
 	name = "Humen"
 	id = "humen"
 	desc = "<b>Humen</b><br>\
-	Humens (or \"Humans\") are the eldest of the Weeping God's creations. Noted for their\
+	Humens (or \"Humans\") are the eldest of the Weeping God's creations. Noted for their \
 	tenacity and overwhelming population, humens are the most commonly seen race across the lands, \
 	at a rate of about ten to one in regions such as Grenzelhoft. However, to the west \
 	the opposite is true. Humens come from a vast swathe of cultures and ethnicities, most of which \


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Adds a SCOM to the bathhouse to remove a dead zone in the main bathing area, at the request of a veteran bathmatron player. Doesn't impact any of the private rooms at all.

As a bonus, also fixes a typo I noticed while making a debug character. 


## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/1a9600f3-7cf6-404f-970d-97956e2b8555)
![image](https://github.com/user-attachments/assets/c9ecba06-80f3-4973-8bbe-fb3423135401)
![image](https://github.com/user-attachments/assets/84aef01d-6f0c-405a-9f04-40a741d76b03)
![image](https://github.com/user-attachments/assets/87176688-e67a-4aed-9c3d-d85a325c0c5a)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
SCOMs encourage town players to interact with each other by providing updates on the events in town. The bathhouse can be isolating as it's underground and a bit out of the way, this will alleviate that a bit. Players who do not wish to hear the SCOM in the bath can simply mute it. 