### PR TITLE
Fix feather renaming

### DIFF
--- a/code/game/objects/items/rogueitems/natural/feather.dm
+++ b/code/game/objects/items/rogueitems/natural/feather.dm
@@ -33,7 +33,7 @@
 			if(oldname == input)
 				to_chat(user, span_notice("I changed \the [O.name] to... well... \the [O.name]."))
 			else
-				O.name = "[input] ([oldname])"
+				O.name = "[input] ([initial(O.name)])"
 				to_chat(user, span_notice("\The [oldname] has been successfully been renamed to \the [input]."))
 				O.renamedByPlayer = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Uses the initial name of a weapon instead of the renamed renamed renamed name when feather rename..

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="415" alt="dreamseeker_Z6pFMV2GBA" src="https://github.com/user-attachments/assets/34733547-c6f2-493a-979e-43e00901e88a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It is a bug and prevent cursed weapon with extremely long name

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
