### PR TITLE
Teeny Witch Hut fixes

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -2520,8 +2520,12 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
 "aYt" = (
-/obj/structure/fluff/walldeco/chains,
-/turf/open/floor/rogue/hexstone,
+/obj/effect/decal/cleanable/dirt/cobweb,
+/obj/item/natural/worms/leech,
+/obj/item/natural/worms/leech{
+	pixel_x = 5
+	},
+/turf/open/water/swamp,
 /area/rogue/under/town/basement)
 "aYx" = (
 /obj/structure/flora/roguegrass/bush,
@@ -6793,6 +6797,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/underdark)
+"cKO" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement)
 "cKU" = (
 /obj/structure/rack/rogue,
 /obj/machinery/light/rogue/wallfire/candle{
@@ -13251,7 +13262,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
 	},
-/turf/closed/wall/mineral/rogue/wooddark/window,
+/turf/closed,
 /area/rogue/indoors/town)
 "fiP" = (
 /obj/structure/closet/crate/drawer/random,
@@ -14207,6 +14218,10 @@
 "fCg" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
+	},
+/obj/structure/fluff/walldeco/chains{
+	pixel_x = 22;
+	pixel_y = 0
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
@@ -29185,10 +29200,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
 "lwq" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/rtfield)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/obj/structure/fermenting_barrel/water,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/under/town/basement)
 "lwu" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town/garrison)
@@ -43155,14 +43172,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "raa" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
+/obj/item/natural/worms/leech{
+	pixel_x = 5
 	},
-/obj/structure/fermenting_barrel/water,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/item/natural/worms/leech,
+/turf/open/water/swamp,
 /area/rogue/under/town/basement)
 "rag" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -51887,7 +51901,6 @@
 /area/rogue/under/town/basement)
 "uww" = (
 /obj/structure/rack/rogue/shelf/biggest,
-/obj/effect/decal/cleanable/dirt/cobweb,
 /obj/item/reagent_containers/glass/alchemical{
 	pixel_x = 7;
 	pixel_y = 8
@@ -226642,7 +226655,7 @@ pSg
 pSg
 pSg
 pSg
-lwq
+jiQ
 pWT
 qit
 qit
@@ -227088,12 +227101,12 @@ aFv
 qyR
 daQ
 daQ
-pWT
-qit
-qit
-qit
-qit
-qit
+pSg
+pSg
+pSg
+pSg
+pSg
+pSg
 pWT
 njB
 pWT
@@ -338733,13 +338746,13 @@ eGx
 eGx
 eGx
 eGx
-eGx
-eGx
-eGx
-eGx
-eGx
-eGx
-qwK
+cxA
+cxA
+cxA
+cxA
+cxA
+cxA
+cxA
 qwK
 qwK
 qwK
@@ -339185,13 +339198,13 @@ eGx
 eGx
 eGx
 eGx
-eGx
-eGx
-eGx
-eGx
-eGx
-eGx
-eGx
+cxA
+eXr
+eXr
+eXr
+eXr
+eXr
+cxA
 eGx
 qwK
 qwK
@@ -339637,13 +339650,13 @@ eGx
 eGx
 eGx
 eGx
-eGx
 cxA
 eXr
-eXr
+aYt
+raa
+bRr
 fAm
-fAm
-eGx
+cxA
 eGx
 eGx
 eGx
@@ -340091,9 +340104,9 @@ eGx
 eGx
 cxA
 eXr
-eXr
-bRr
-bRr
+lwq
+fCg
+cKO
 fAm
 cxA
 eGx
@@ -340544,8 +340557,8 @@ eGx
 cxA
 eXr
 uww
-fCg
-raa
+tUP
+mSN
 eXr
 cxA
 eGx
@@ -340996,7 +341009,7 @@ vvB
 cxA
 fAm
 fUP
-aYt
+tUP
 mSN
 eXr
 cxA
@@ -342349,7 +342362,7 @@ aBB
 aBB
 aBB
 aBB
-aBB
+cxA
 cxA
 cxA
 cxA
@@ -454006,7 +454019,7 @@ vBH
 iWF
 bAa
 pHH
-cxA
+vBH
 aBB
 aBB
 aBB


### PR DESCRIPTION
## About The Pull Request

- Discovered an extra dark wood window hidden beneath one of the reinforced windows and removed it. 
- Also noticed that the corner of the basement was showing from the outside.
- Made the basement one tile wider and looped the unpickable rock around it.

## Testing Evidence

![image](https://github.com/user-attachments/assets/d020ceba-418e-482e-a2fa-db28190f7b95)

## Why It's Good For The Game

No visual mistakes now that the map around the witch hut is bigger than it was in Dun_Manor. :]
