### PR TITLE
Court agent appears in the Actors tab (as Adventurer)

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -224,6 +224,8 @@ SUBSYSTEM_DEF(migrants)
 		GLOB.character_ckey_list[character.real_name] = character.ckey
 		if(!character.mind.special_role)
 			GLOB.actors_list[character.mobid] = "[character.real_name] as [rank]<BR>"
+		if(character.mind.special_role == "Court Agent")
+			GLOB.actors_list[character.mobid] = "[character.real_name] as Adventurer<BR>"
 		log_character("[character.ckey] ([fakekey]) - [character.real_name] - [rank]")
 	if(GLOB.respawncounts[character.ckey])
 		var/AN = GLOB.respawncounts[character.ckey]


### PR DESCRIPTION


## About The Pull Request

Court agent appears in the actors tab as "Name as Adventurer".

## Testing Evidence

![image](https://github.com/user-attachments/assets/9a4cf38c-ccc7-43cc-933c-618385814013)

## Why It's Good For The Game

Seems like an oversight that this isn't already the case. Either way it makes it easier to tell when a character you want to RP with is on.
