### PR TITLE
Adding a div to close the footer on adv class menu

### DIFF
--- a/code/controllers/subsystem/rogue/role_class_handler/class_select_handler/class_select_handler.dm
+++ b/code/controllers/subsystem/rogue/role_class_handler/class_select_handler/class_select_handler.dm
@@ -265,6 +265,10 @@
 			<a class='mo_bottom_buttons' href='?src=\ref[src];show_combat_class=1'>[showing_combat_classes ? "Show Combat Classes" : "Show Pilgrim Classes"]</a>
 		</div>
 		"}
+	else
+		data += {"
+			</div>
+			"}
 
 	//Closing Tags
 	data += {"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Hunting the strange, "one option mission from the advanced class menu" bug. I found an open div at the end, which could be causing issues with 516's new HTML processing by not being logical.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

![image](https://github.com/user-attachments/assets/2c51b142-039d-4e49-9aec-76fd3644cd90)

Menu works fine in normal testing but the only way to see if this fixes the issue is to let it play, see if it continues to crop up.

## Why It's Good For The Game
 You gotta be able to pick all those classes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
