### PR TITLE
Mimic

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -242,7 +242,6 @@
 	var/newcolor = input(src, "Choose your character's SECOND voice color:", "VIRTUE","#a0a0a0") as color|null
 	if(newcolor)
 		second_voice = sanitize_hexcolor(newcolor)
-		src.verbs -= /mob/living/carbon/human/proc/changevoice
 		return TRUE
 	else
 		return FALSE

--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -236,14 +236,16 @@
 	return TRUE
 
 /mob/living/carbon/human/proc/changevoice()
-	set name = "Change Second Voice (Can only use Once!)"
+	set name = "Change Voice"
 	set category = "Virtue"
 
-	var/newcolor = input(src, "Choose your character's SECOND voice color:", "VIRTUE","#a0a0a0") as color|null
+	var/newcolor = input(src, "Choose your character's voice color:", "VIRTUE","#a0a0a0") as color|null
 	if(newcolor)
-		second_voice = sanitize_hexcolor(newcolor)
+		voice_color = sanitize_hexcolor(newcolor)
+		to_chat(src, span_info("I've changed my voice perfectly."))
 		return TRUE
 	else
+		to_chat(src, span_info("I've decided to keep my voice for now."))
 		return FALSE
 
 /mob/living/carbon/human/proc/swapvoice()

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -272,13 +272,12 @@
 		REMOVE_TRAIT(recipient, TRAIT_UNSEEMLY, TRAIT_VIRTUE)
 
 /datum/virtue/utility/secondvoice
-	name = "Second Voice"
-	desc = "From performance, deception, or by a need to change yourself in uncanny ways, you've acquired a second, perfect voice. You may switch between them at any point."
-	custom_text = "Grants access to a new 'Virtue' tab. It will have the options for setting and changing your voice."
+	name = "Mimic"
+	desc = "From performance, deception, or by a need to change yourself in uncanny ways, you've warped your vocal chords into the ultimate mimicking tool. Just don't forget how your regular voice sounds..."
+	custom_text = "Grants access to a new 'Virtue' tab. It will have the options for changing your voice."
 
 /datum/virtue/utility/secondvoice/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.verbs += /mob/living/carbon/human/proc/changevoice
-	recipient.verbs += /mob/living/carbon/human/proc/swapvoice
 
 /datum/virtue/utility/keenears
 	name = "Keen Ears"


### PR DESCRIPTION
Replaces the Second Voice virtue with the Mimic virtue, allowing on-the-fly changing of your voice color. I am not a coder, I know nothing about BYOND, I am a chimpanzee doing her best to make a PR that isn't just balance changes ;w;

Test Screenshots:

![Screenshot 2025-04-22 191356](https://github.com/user-attachments/assets/878375c3-d061-49ab-b1eb-5408f828e171)

It's currently beyond my abilities as a coder to have the game record your voice color on roundstart and then have a second menu option to revert to your "default" voice; this is mostly a QoL change, but if someone could give me some advice I would either step back and let someone else PR it in or take a hand at trying myself.