### PR TITLE
Baothan miracle fixes & tweaks

### DIFF
--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -409,7 +409,6 @@
 	reagent_state = LIQUID
 	color = "#ff6207"
 	overdose_threshold = 20
-	addiction_threshold = 15
 	metabolization_rate = 0.5
 
 /obj/item/reagent_containers/powder/herozium

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -409,6 +409,7 @@
 	reagent_state = LIQUID
 	color = "#ff6207"
 	overdose_threshold = 20
+	addiction_threshold = 15
 	metabolization_rate = 0.5
 
 /obj/item/reagent_containers/powder/herozium

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -26,7 +26,7 @@
 		target.apply_status_effect(/datum/status_effect/buff/druqks)
 		ADD_TRAIT(target, TRAIT_CRACKHEAD, TRAIT_GENERIC)		//Gets the trait temorarily, basically will just stop any active/upcoming ODs.
 		target.visible_message("<span class='info'>[target]'s eyes appear to gloss over!</span>", "<span class='notice'>I feel.. at ease.</span>")
-		addtimer(CALLBACK(src, PROC_REF(remove_buff), target), wait = 2 MINUTES)	//Should be long enough to prevent an overdose. If not, maybe up to 20 or so.
+		addtimer(CALLBACK(src, PROC_REF(remove_buff), target), wait = 2 MINUTES)	//Should be long enough to prevent an overdose.
 
 /obj/effect/proc_holder/spell/invoked/baothablessings/proc/remove_buff(mob/living/carbon/target)
 	REMOVE_TRAIT(target, TRAIT_CRACKHEAD, TRAIT_GENERIC)							
@@ -56,7 +56,7 @@
 	damage = 1
 	poisontype = /datum/reagent/herozium
 	poisonfeel = "burning" //Would make sense for your eyes or nose to burn, I guess.
-	poisonamount = 7 //Decent bit of high, second dose would cause flat-out overdose.
+	poisonamount = 7 //Decent bit of high, three doses would be just above the overdose threshold if applied fast enough.
 
 /obj/projectile/magic/blowingdust/on_hit(target, mob/living/M)
 	. = ..()

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -26,7 +26,7 @@
 		target.apply_status_effect(/datum/status_effect/buff/druqks)
 		ADD_TRAIT(target, TRAIT_CRACKHEAD, TRAIT_GENERIC)		//Gets the trait temorarily, basically will just stop any active/upcoming ODs.
 		target.visible_message("<span class='info'>[target]'s eyes appear to gloss over!</span>", "<span class='notice'>I feel.. at ease.</span>")
-		addtimer(CALLBACK(src, PROC_REF(remove_buff), target), wait = 15 SECONDS)	//Should be long enough to prevent an overdose. If not, maybe up to 20 or so.
+		addtimer(CALLBACK(src, PROC_REF(remove_buff), target), wait = 2 MINUTES)	//Should be long enough to prevent an overdose. If not, maybe up to 20 or so.
 
 /obj/effect/proc_holder/spell/invoked/baothablessings/proc/remove_buff(mob/living/carbon/target)
 	REMOVE_TRAIT(target, TRAIT_CRACKHEAD, TRAIT_GENERIC)							
@@ -52,7 +52,11 @@
 /obj/projectile/magic/blowingdust
 	name = "unholy dust"
 	icon_state = "spark"
-	nodamage = TRUE	//No effect because it's drugs.
+	nodamage = FALSE
+	damage = 1
+	poisontype = /datum/reagent/herozium
+	poisonfeel = "burning" //Would make sense for your eyes or nose to burn, I guess.
+	poisonamount = 7 //Decent bit of high, second dose would cause flat-out overdose.
 
 /obj/projectile/magic/blowingdust/on_hit(target, mob/living/M)
 	. = ..()
@@ -61,9 +65,6 @@
 	if(target)
 		to_chat(target, span_warning("Gah! Something.. got in my - eyes.."))
 		M.blur_eyes(2)
-		poisontype = /datum/reagent/ozium
-		poisonfeel = "burning" //Would make sense for your eyes or nose to burn, I guess.
-		poisonamount = 7 //Decent bit of high, second dose would cause flat-out overdose.
 
 //Numbing Pleasure - T3, removes all pain from self for a period of time. (Similar to Ravox's without any blood-clotting and better pain suppression + good mood buff.)
 /obj/effect/proc_holder/spell/invoked/painkiller


### PR DESCRIPTION
## About The Pull Request
- The blessing now lasts 2 minutes. (By request)
- Fixed the "blowing dust" not doing anything. It was because you need to deal at least 1 damage to apply poison reagents.
- Changed the poison reagent to herozium.
- It gives -5 SPD, but +3 END among other things.
- It has an actual OD threshold.

Consequences:
- If you keep spamming a guy you will OD them and they'll die of suffocation. Emphasis on spamming a guy. It takes like 4 hits to start overdose, but if you keep at it it'll get pretty lethal.
- It does a thing!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Booted it up and shot a guy until he died of oxy damage.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Le spell le work? As le intended? (I think)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
