### PR TITLE
Map Update | Smithy Privacy Shutters

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -33663,10 +33663,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/manor)
-"njq" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "njv" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
@@ -256100,7 +256096,7 @@ acE
 sBu
 kfC
 ass
-njq
+xdU
 kaR
 eyK
 eyK
@@ -256552,7 +256548,7 @@ puO
 phl
 sBu
 qfA
-njq
+xdU
 fyu
 eyK
 eyK
@@ -260168,7 +260164,7 @@ aWT
 aWT
 exD
 sns
-njq
+eCR
 fyu
 eyK
 eyK
@@ -260620,7 +260616,7 @@ pxc
 vAX
 exD
 ehB
-njq
+eCR
 kaR
 eyK
 eyK
@@ -261525,7 +261521,7 @@ tDA
 exD
 ehB
 vaz
-njq
+eCR
 oED
 smL
 smL


### PR DESCRIPTION
## About The Pull Request

Adds shutters to the smithy back windows. That's it. That's the PR.

## Testing Evidence

![image](https://github.com/user-attachments/assets/448190d2-a231-480b-94ee-e7d554ba7c21)

Simple change done in strongDMM, I ensured each shutter corresponds to each side levers.

## Why It's Good For The Game

Privacy gud. Also a request from a smith player.
