### PR TITLE
Pan now scale to cooking instead of mace skill

### DIFF
--- a/code/modules/roguetown/roguejobs/cook/tools/pan.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/pan.dm
@@ -10,7 +10,7 @@
 	//dropshrink = 0.8
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
 	can_parry = TRUE
-	associated_skill = /datum/skill/combat/maces
+	associated_skill = /datum/skill/craft/cooking // This make pan a "viable" weapon for cook with high hit / parry chance. Won't carry them alone ofc.
 	has_inspect_verb = TRUE // For snowflake and allowing you to examine the pan's properties lmao
 	swingsound = list('sound/combat/wooshes/blunt/shovel_swing.ogg','sound/combat/wooshes/blunt/shovel_swing2.ogg')
 	drop_sound = 'sound/foley/dropsound/shovel_drop.ogg'


### PR DESCRIPTION
## About The Pull Request
Change the frying pan to scale to cooking skills, which chef and cooking roles have in abundance and can grind to legendary easily...

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="123" alt="dreamseeker_QToVVrCSMN" src="https://github.com/user-attachments/assets/589709aa-11aa-4bf1-8b56-974be2f61c14" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The League of Legend game design team and I have over 200+ years of collective game design experience. I think this will be good for the game.

Also it is funny. Moving it to cooking instead of maces stop MAA from wielding this as a meme weapon (it happened for 3 days and then they went back to real weapon) and gives cook a slightly improved fighting chance that is also hilarious.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
