### PR TITLE
Changes Custom Music Threshold from 4 to 3

### DIFF
--- a/code/datums/skills/misc.dm
+++ b/code/datums/skills/misc.dm
@@ -72,7 +72,7 @@
 
 /datum/skill/misc/music
 	name = "Music"
-	desc = "Increases the effects of your music on reducing stresses per level. At Level 4 or above, allows you to play a custom song."
+	desc = "Increases the effects of your music on reducing stresses per level. At Level 3 or above, allows you to play a custom song."
 	dreams = list(
 		"...offstage, anxiety grips you, sweat beading on your brow. But onstage, you are as still as a winter night, your voice steady and clear. Curiosity pulls your audience in as you begin to sing...",
 		"...you raise your hands to the strings and draw the crowds attention unto yourself. The music comes easily out of you, and your lyre is like a second voice...",

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -81,7 +81,7 @@
 				groupplaying = FALSE
 		if(!groupplaying)
 			var/list/options = song_list.Copy()
-			if(user.mind && user.mind.get_skill_level(/datum/skill/misc/music) >= 4)
+			if(user.mind && user.mind.get_skill_level(/datum/skill/misc/music) >= 3)
 				options["Upload New Song"] = "upload"
 			
 			var/choice = input(user, "Which song?", "Music", name) as null|anything in options


### PR DESCRIPTION
Lets people with the Performer virtue play custom music right out the gate, mainly. Also affects bathmaids. Not a lot to it, I just think that letting more people play their own music is good for flavor. You don't have to be an expert in music to make a song; in fact, even an amateur can make something beautiful. I feel like Journeyman is a pretty good middle point to start being able to import custom music.