### PR TITLE
Armor readability bugfixes

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -299,7 +299,10 @@
 //Turns a Body_parts_covered bitfield into a list of organ/limb names.
 //(I challenge you to find a use for this)
 //^ I did.
-/proc/body_parts_covered2organ_names(bpc, verbose = FALSE)
+//verbose = TRUE will include BOTH flags like "ARMS" and individual flags like "L ARM"
+//precise = TRUE will EXCLUDE combined flags like "ARMS" or "LEGS" and only include "L ARM" / "R ARM" etc
+//leaving both FALSE will include combined flags where appropriate.
+/proc/body_parts_covered2organ_names(bpc, verbose = FALSE, precise = FALSE)
 	var/list/covered_parts = list()
 
 	if(!bpc)
@@ -309,9 +312,9 @@
 		covered_parts |= list(READABLE_ZONE_HEAD)
 	if(bpc & NECK)
 		covered_parts |= list(READABLE_ZONE_NECK)
-	if(bpc & FACE && !verbose)
+	if(bpc & FACE && !precise)
 		covered_parts |= list(READABLE_ZONE_FACE)
-	else
+	if(verbose || precise || !(bpc & FACE))
 		if(bpc & MOUTH)
 			covered_parts |= list(READABLE_ZONE_MOUTH)
 		if(bpc & NOSE)
@@ -326,54 +329,34 @@
 	if(bpc & GROIN)
 		covered_parts |= list(READABLE_ZONE_GROIN)
 
-	if(bpc & ARMS && !verbose)
+	if(bpc & ARMS && !precise)
 		covered_parts |= list(READABLE_ZONE_ARMS)
-		if(verbose)
-			if(bpc & ARM_LEFT)
-				covered_parts |= list(READABLE_ZONE_L_ARM)
-			if(bpc & ARM_RIGHT)
-				covered_parts |= list(READABLE_ZONE_R_ARM)
-
-	else
+	if(verbose || precise || !(bpc & ARMS))
 		if(bpc & ARM_LEFT)
 			covered_parts |= list(READABLE_ZONE_L_ARM)
 		if(bpc & ARM_RIGHT)
 			covered_parts |= list(READABLE_ZONE_R_ARM)
 
-	if(bpc & HANDS && !verbose)
+	if(bpc & HANDS && !precise)
 		covered_parts |= list(READABLE_ZONE_HANDS)
-		if(verbose)
-			if(bpc & HAND_LEFT)
-				covered_parts |= list(READABLE_ZONE_L_HAND)
-			if(bpc & HAND_RIGHT)
-				covered_parts |= list(READABLE_ZONE_R_HAND)
-	else
+	if(verbose || precise || !(bpc & HANDS))
 		if(bpc & HAND_LEFT)
 			covered_parts |= list(READABLE_ZONE_L_HAND)
 		if(bpc & HAND_RIGHT)
 			covered_parts |= list(READABLE_ZONE_R_HAND)
 
-	if(bpc & LEGS && !verbose)
+	if(bpc & LEGS && !precise)
 		covered_parts |= list(READABLE_ZONE_LEGS)
-		if(verbose)
-			if(bpc & LEG_LEFT)
-				covered_parts |= list(READABLE_ZONE_L_LEG)
-			if(bpc & LEG_RIGHT)
-				covered_parts |= list(READABLE_ZONE_R_LEG)
-	else
+	if(verbose || precise || !(bpc & LEGS))
 		if(bpc & LEG_LEFT)
 			covered_parts |= list(READABLE_ZONE_L_LEG)
 		if(bpc & LEG_RIGHT)
 			covered_parts |= list(READABLE_ZONE_R_LEG)
 
-	if(bpc & FEET && !verbose)
+
+	if(bpc & FEET && !precise)
 		covered_parts |= list(READABLE_ZONE_FEET)
-		if(verbose)
-			if(bpc & FOOT_LEFT)
-				covered_parts |= list(READABLE_ZONE_L_FOOT)
-			if(bpc & FOOT_RIGHT)
-				covered_parts |= list(READABLE_ZONE_R_FOOT)
-	else
+	if(verbose || precise || !(bpc & FEET))
 		if(bpc & FOOT_LEFT)
 			covered_parts |= list(READABLE_ZONE_L_FOOT)
 		if(bpc & FOOT_RIGHT)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -469,10 +469,10 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 						inspec += "<b>[capitalize(zone)]</b> | "
 				else
 					var/list/zones = list()
-					//We have some part peeled, so we turn the printout into verbose mode and highlight the missing coverage.
-					for(var/zoneorg in body_parts_covered2organ_names(C.body_parts_covered, verbose = TRUE))
+					//We have some part peeled, so we turn the printout into precise mode and highlight the missing coverage.
+					for(var/zoneorg in body_parts_covered2organ_names(C.body_parts_covered, precise = TRUE))
 						zones += zoneorg
-					for(var/zonedyn in body_parts_covered2organ_names(C.body_parts_covered_dynamic, verbose = TRUE))
+					for(var/zonedyn in body_parts_covered2organ_names(C.body_parts_covered_dynamic, precise = TRUE))
 						inspec += "<b>[capitalize(zonedyn)]</b> | "
 						if(zonedyn in zones)
 							zones.Remove(zonedyn)
@@ -1344,7 +1344,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			if(peel_count >= peel_threshold)
 				body_parts_covered_dynamic &= ~coveragezone
 				playsound(src, 'sound/foley/peeled_coverage.ogg', 100)
-				var/list/peeledpart = body_parts_covered2organ_names(coveragezone, verbose = TRUE)
+				var/list/peeledpart = body_parts_covered2organ_names(coveragezone, precise = TRUE)
 				var/parttext
 				if(length(peeledpart))
 					parttext = peeledpart[1]	//There should really only be one bodypart that gets exposed here.

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -431,6 +431,8 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 //Sorry colorblind folks...
 /proc/colorgrade_rating(input, rating, elaborate = FALSE)
 	var/str
+	if(isnull(rating))
+		rating = 0
 	switch(rating)
 		if(0 to 9)
 			var/color = "#f81a1a"

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -305,9 +305,14 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 							else
 								coverage_exposed.Remove(coverageflag)
 			for(var/coverageflag in coverage)	//We go through the set up list and filter out redundancies. (ie Left Arm & Right Arm having identical stats to Arms)
+				to_chat(world, "checking the coverage flag of: [coverageflag]")
 				switch(coverageflag)
 					if(READABLE_ZONE_ARMS)
+						to_chat(world, "comparing L ARM: [coverage[READABLE_ZONE_L_ARM]] to R ARM: [coverage[READABLE_ZONE_R_ARM]]")
 						if(coverage[READABLE_ZONE_L_ARM] == coverage[READABLE_ZONE_R_ARM])
+							to_chat(world, "comparing blunt_max of L arm: [blunt_max[READABLE_ZONE_L_ARM]] to R arm: [blunt_max[READABLE_ZONE_R_ARM]]")
+							to_chat(world, "comparing slash_max of L arm: [slash_max[READABLE_ZONE_L_ARM]] to R arm: [slash_max[READABLE_ZONE_R_ARM]]")
+							to_chat(world, "comparing stab_max of L arm: [stab_max[READABLE_ZONE_L_ARM]] to R arm: [stab_max[READABLE_ZONE_R_ARM]]")
 							if((blunt_max[READABLE_ZONE_L_ARM] == blunt_max[READABLE_ZONE_R_ARM]) && (slash_max[READABLE_ZONE_L_ARM] == slash_max[READABLE_ZONE_R_ARM]) && (stab_max[READABLE_ZONE_L_ARM] == stab_max[READABLE_ZONE_R_ARM]))
 								coverage.Remove(READABLE_ZONE_L_ARM, READABLE_ZONE_R_ARM)
 							else

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -307,7 +307,6 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 			for(var/coverageflag in coverage)	//We go through the set up list and filter out redundancies. (ie Left Arm & Right Arm having identical stats to Arms)
 				switch(coverageflag)
 					if(READABLE_ZONE_ARMS)
-						to_chat(world, "comparing L ARM: [coverage[READABLE_ZONE_L_ARM]] to R ARM: [coverage[READABLE_ZONE_R_ARM]]")
 						if(coverage[READABLE_ZONE_L_ARM] == coverage[READABLE_ZONE_R_ARM])
 							if((blunt_max[READABLE_ZONE_L_ARM] == blunt_max[READABLE_ZONE_R_ARM]) && (slash_max[READABLE_ZONE_L_ARM] == slash_max[READABLE_ZONE_R_ARM]) && (stab_max[READABLE_ZONE_L_ARM] == stab_max[READABLE_ZONE_R_ARM]))
 								coverage.Remove(READABLE_ZONE_L_ARM, READABLE_ZONE_R_ARM)

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -305,14 +305,10 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 							else
 								coverage_exposed.Remove(coverageflag)
 			for(var/coverageflag in coverage)	//We go through the set up list and filter out redundancies. (ie Left Arm & Right Arm having identical stats to Arms)
-				to_chat(world, "checking the coverage flag of: [coverageflag]")
 				switch(coverageflag)
 					if(READABLE_ZONE_ARMS)
 						to_chat(world, "comparing L ARM: [coverage[READABLE_ZONE_L_ARM]] to R ARM: [coverage[READABLE_ZONE_R_ARM]]")
 						if(coverage[READABLE_ZONE_L_ARM] == coverage[READABLE_ZONE_R_ARM])
-							to_chat(world, "comparing blunt_max of L arm: [blunt_max[READABLE_ZONE_L_ARM]] to R arm: [blunt_max[READABLE_ZONE_R_ARM]]")
-							to_chat(world, "comparing slash_max of L arm: [slash_max[READABLE_ZONE_L_ARM]] to R arm: [slash_max[READABLE_ZONE_R_ARM]]")
-							to_chat(world, "comparing stab_max of L arm: [stab_max[READABLE_ZONE_L_ARM]] to R arm: [stab_max[READABLE_ZONE_R_ARM]]")
 							if((blunt_max[READABLE_ZONE_L_ARM] == blunt_max[READABLE_ZONE_R_ARM]) && (slash_max[READABLE_ZONE_L_ARM] == slash_max[READABLE_ZONE_R_ARM]) && (stab_max[READABLE_ZONE_L_ARM] == stab_max[READABLE_ZONE_R_ARM]))
 								coverage.Remove(READABLE_ZONE_L_ARM, READABLE_ZONE_R_ARM)
 							else


### PR DESCRIPTION
## About The Pull Request
If you've been using Assess, you may have noticed that occasionally, or perhaps frequently, you'd be met with something like this:
![image](https://github.com/user-attachments/assets/02bd2690-8e4b-47fa-917e-f075ecb35db1)

I'm not sure what goes wrong there as on my test servers it prints this out when trying to replicate the circumstances (clothes / stats and all):
![image](https://github.com/user-attachments/assets/22e04126-6328-4b5b-9d32-d087d0a16451)

However, I could only narrow it down to two things:
- a runtime (that I couldn't replicate)
- the value 0 getting treated as null somewhere in the chain.

Considering all Assess does is provide information without ever altering any of it, 

I figured this is a good enough bandaid, as a null value getting tossed around in the proc itself doesn't have any impact UNTIL it gets to the part that tries to convert numbers to letters, and null just so happens to not be a number.

In addition, this also fixed a few bugs that were present with examining armor after peels. They were fairly minor, but everything should be more readable now.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
assess a guy, hm yes everything is fine.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No more need to contact coders hopefully maybe
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
