### PR TITLE
Decuples Anastasis cooldown and triples its devotion cost

### DIFF
--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -57,9 +57,9 @@
 	sound = 'sound/magic/revive.ogg'
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
-	charge_max = 2 MINUTES
+	charge_max = 20 MINUTES
 	miracle = TRUE
-	devotion_cost = 80
+	devotion_cost = 250
 	/// Amount of PQ gained for reviving people
 	var/revive_pq = PQ_GAIN_REVIVE
 


### PR DESCRIPTION
## About The Pull Request
- Cooldown 2 minutes -> 20 minutes
- Devotion cost 80 -> 250
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
uhhhhh I just kinda compiled 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
By request, as evidently an event antag facing off a conveyor belt of reviving victims wasn't fun.
The devotion cost is a token change at best, since you'd regain all 250 of it by passive regen.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
