### PR TITLE
Further Baotha Miracle Tweaks

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -469,6 +469,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 // common trait sources
 #define TRAIT_GENERIC "generic"
 #define TRAIT_VIRTUE "virtue"
+#define TRAIT_MIRACLE "miracle"
 #define UNCONSCIOUS_BLIND "unconscious_blind"
 #define EYE_DAMAGE "eye_damage"
 #define GENETIC_MUTATION "genetic"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -236,7 +236,7 @@
 	id = "druqks"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/vitae
 	effectedstats = list("fortune" = 2)
-	duration = 1 MINUTE
+	duration = 1 MINUTES
 
 /datum/status_effect/buff/vitae/on_apply()
 	. = ..()

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -50,7 +50,7 @@
 	id = "druqks"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/druqks
 	effectedstats = list("intelligence" = 5,"speed" = 3,"fortune" = -5)
-	duration = 10 SECONDS
+	duration = 2 MINUTES
 
 /datum/status_effect/buff/druqks/on_apply()
 	. = ..()

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -236,7 +236,7 @@
 	id = "druqks"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/vitae
 	effectedstats = list("fortune" = 2)
-	duration = 10 SECONDS
+	duration = 1 MINUTE
 
 /datum/status_effect/buff/vitae/on_apply()
 	. = ..()

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -20,16 +20,13 @@
 /obj/effect/proc_holder/spell/invoked/baothablessings/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
 		var/mob/living/carbon/target = targets[1]
-		if(istype(target.patron, /datum/patron/inhumen/baotha))
-			to_chat(user, span_warning("They already possess Baotha's blessings.."))
-			return FALSE										//This stops us from accidently removing another Baothan's anti-overdose trait.
 		target.apply_status_effect(/datum/status_effect/buff/druqks)
-		ADD_TRAIT(target, TRAIT_CRACKHEAD, TRAIT_GENERIC)		//Gets the trait temorarily, basically will just stop any active/upcoming ODs.
+		ADD_TRAIT(target, TRAIT_CRACKHEAD, TRAIT_MIRACLE)		//Gets the trait temorarily, basically will just stop any active/upcoming ODs.
 		target.visible_message("<span class='info'>[target]'s eyes appear to gloss over!</span>", "<span class='notice'>I feel.. at ease.</span>")
 		addtimer(CALLBACK(src, PROC_REF(remove_buff), target), wait = 2 MINUTES)	//Should be long enough to prevent an overdose.
 
 /obj/effect/proc_holder/spell/invoked/baothablessings/proc/remove_buff(mob/living/carbon/target)
-	REMOVE_TRAIT(target, TRAIT_CRACKHEAD, TRAIT_GENERIC)							
+	REMOVE_TRAIT(target, TRAIT_CRACKHEAD, TRAIT_MIRACLE)							
 	to_chat(target, span_warning("I see everything clearly once more.."))
 	target.visible_message("[target]'s eyes appear to return to normal.")
 
@@ -47,7 +44,8 @@
 	chargedrain = 0
 	chargetime = 15
 	charge_max = 10 SECONDS
-	invocation = "Have a taste of the maiden's pure-bliss!"
+	invocation_type = "whisper"
+	invocation = "Have a taste of the maiden's pure-bliss..."
 
 /obj/projectile/magic/blowingdust
 	name = "unholy dust"
@@ -56,7 +54,7 @@
 	damage = 1
 	poisontype = /datum/reagent/herozium
 	poisonfeel = "burning" //Would make sense for your eyes or nose to burn, I guess.
-	poisonamount = 7 //Decent bit of high, three doses would be just above the overdose threshold if applied fast enough.
+	poisonamount = 8 //Decent bit of high, three doses would be just above the overdose threshold if applied fast enough.
 
 /obj/projectile/magic/blowingdust/on_hit(target, mob/living/M)
 	. = ..()

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -78,7 +78,7 @@
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
-	charge_max = 20 SECONDS
+	charge_max = 90 SECONDS
 	miracle = TRUE
 	devotion_cost = 75
 
@@ -91,7 +91,7 @@
 			return FALSE	//No, you don't get to feel good. You're a undead mob. Feel bad.
 		target.visible_message(span_info("[target] begins to twitch as warmth radiates from them!"), span_notice("The pain from my wounds fade, every new one being a mere, pleasent warmth!"))
 		phy.pain_mod *= 0.5	//Literally halves your pain modifier.
-		addtimer(VARSET_CALLBACK(phy, pain_mod, phy.pain_mod /= 0.5), 20 SECONDS)	//Adds back the 0.5 of pain, basically setting it back to 1.
+		addtimer(VARSET_CALLBACK(phy, pain_mod, phy.pain_mod /= 0.5), 1 MINUTES)	//Adds back the 0.5 of pain, basically setting it back to 1.
 		target.apply_status_effect(/datum/status_effect/buff/vitae)					//Basically lowers fortune by 2 but +3 speed, it's powerful. Drugs cus Baotha.
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request
- Baotha's Blessing status effect has been extended to the same duration as the trait. -- 2 Minutes.
- Baotha's Blessing can be cast on Baothans. They will not lose their trait after. We have code for specifically these types of situations.
- Enrapturing Powder's invocation is now whispered, and "poisons" for an extra unit.
   - This means the OD can actually be reached in 3-4 shots in a row (at ~24-32 units for a 20 OD threshold).
- Numbing pleasure also now lasts for as long as the painkiller -- 1 minute.
   - Consequently, the CD was set to 90 seconds.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_trGV8NINVV](https://github.com/user-attachments/assets/778cf2e9-711e-4de3-99ec-3173b34f8ad0)

Checking my traits after self-casting Baotha's Blessing:
![dreamseeker_sW0qpfOWhd](https://github.com/user-attachments/assets/13160205-74be-44fc-8e5f-35c63100574f)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
By request, and topping off the quirks I forgot about in the [previous PR](https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2153)
Of course, this might be tipping it over the edge, so keep an eye out for abusive behaviour from the hedonists -- they can really do some nasty stuff with drugs and status effects, now.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
