### PR TITLE
Power in Faith (And Pugilism) - Addition of the "Expert Pugilist" trait, alongside some minor rebalancing, to most "Monk" classes.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -9,19 +9,17 @@
 /datum/outfit/job/roguetown/disciple/pre_equip(mob/living/carbon/human/H)
 	..()
 	neck = /obj/item/clothing/neck/roguetown/psicross/silver
-	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	gloves = /obj/item/clothing/gloves/roguetown/chain/psydon
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
-	belt = /obj/item/storage/belt/rogue/leather/black
-	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	id = /obj/item/clothing/ring/silver
 	backl = /obj/item/storage/backpack/rogue/satchel
 	mask = /obj/item/clothing/mask/rogue/facemask/psydonmask
 	head = /obj/item/clothing/head/roguetown/roguehood/psydon
-	var/classes = list("Otavan Monk", "Naledi-Trained Scholar")
+	var/classes = list("Otavan Disciple", "Naledi-Trained Scholar")
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 	switch(classchoice)
-		if("Otavan Monk")
+		if("Otavan Disciple")
 			H.set_blindness(0)
 			brute_equip(H)
 		if("Naledi-Trained Scholar")
@@ -37,8 +35,8 @@
 
 /datum/outfit/job/roguetown/disciple/proc/brute_equip(mob/living/carbon/human/H)
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1)
-	gloves = /obj/item/clothing/gloves/roguetown/chain/psydon
-	armor = /obj/item/clothing/suit/roguetown/armor/skin_armor/monk_skin
+	belt = /obj/item/storage/belt/rogue/leather/rope
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	cloak = /obj/item/clothing/cloak/psydontabard/alt
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 5, TRUE)
@@ -50,9 +48,10 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.change_stat("strength", 3)
-		H.change_stat("endurance", 4)
-		H.change_stat("constitution", 4)
+		H.change_stat("endurance", 3)
+		H.change_stat("constitution", 3)
 		H.change_stat("intelligence", -2)
+		ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
@@ -63,6 +62,9 @@
 /datum/outfit/job/roguetown/disciple/proc/naledi_equip(mob/living/carbon/human/H)
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1)
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	belt = /obj/item/storage/belt/rogue/leather/black
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	cloak = /obj/item/clothing/cloak/psydontabard/alt
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
@@ -85,6 +87,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/forcewall)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/summonrogueweapon/bladeofpsydon)
+		ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -51,7 +51,7 @@
 		H.change_stat("endurance", 3)
 		H.change_stat("constitution", 3)
 		H.change_stat("intelligence", -2)
-		H.change_stat("speed", -2)
+		H.change_stat("speed", -1)
 		ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -51,6 +51,7 @@
 		H.change_stat("endurance", 3)
 		H.change_stat("constitution", 3)
 		H.change_stat("intelligence", -2)
+		H.change_stat("speed", -2)
 		ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -36,6 +36,7 @@
 /datum/outfit/job/roguetown/disciple/proc/brute_equip(mob/living/carbon/human/H)
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1)
 	belt = /obj/item/storage/belt/rogue/leather/rope
+	pants = /obj/item/clothing/under/roguetown/tights/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	cloak = /obj/item/clothing/cloak/psydontabard/alt
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -85,7 +85,7 @@
 			H.change_stat("strength", 2)
 			H.change_stat("endurance", 2)
 			H.change_stat("constitution", 2)
-			H.change_stat("speed", 2)
+			H.change_stat("speed", 1)
 
 		if("Paladin")
 			to_chat(H, span_warning("A holy warrior. Where others of the clergy may have spent their free time studying scriptures, you have instead honed your skills with a blade."))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -35,6 +35,7 @@
 			H.set_blindness(0)
 			to_chat(H, span_warning("You are a wandering acolyte, versed in both miracles and martial arts. You forego the heavy armor paladins wear in favor of a more nimble approach to combat, utilizing your fists."))
 			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/priest
+			pants = /obj/item/clothing/under/roguetown/tights/black
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			backl = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -34,19 +34,17 @@
 		if("Monk")
 			H.set_blindness(0)
 			to_chat(H, span_warning("You are a wandering acolyte, versed in both miracles and martial arts. You forego the heavy armor paladins wear in favor of a more nimble approach to combat, utilizing your fists."))
-			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-			wrists = /obj/item/clothing/wrists/roguetown/bracers
-			gloves = /obj/item/clothing/gloves/roguetown/chain
-			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-			shoes = /obj/item/clothing/shoes/roguetown/boots
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/priest
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
+			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			backl = /obj/item/storage/backpack/rogue/satchel
-			belt = /obj/item/storage/belt/rogue/leather
+			belt = /obj/item/storage/belt/rogue/rope
 			beltr = /obj/item/flashlight/flare/torch/lantern
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1)
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
 			C.grant_spells_templar(H)
-			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
@@ -54,15 +52,7 @@
 			H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-			var/weapons = list("Katar","Knuckle Dusters","MY BARE HANDS!!!")
-			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-			switch(weapon_choice)
-				if("Katar")
-					backpack_contents += list(/obj/item/rogueweapon/katar = 1)
-				if("Knuckle Dusters")
-					backpack_contents += list(/obj/item/rogueweapon/knuckles = 1)
-				if("MY BARE HANDS!!!")
-					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 			switch(H.patron?.type)
 				if(/datum/patron/old_god)
 					cloak = /obj/item/clothing/cloak/psydontabard
@@ -93,10 +83,9 @@
 					head = /obj/item/clothing/head/roguetown/roguehood
 			H.cmode_music = 'sound/music/combat_holy.ogg'
 			H.change_stat("strength", 2)
-			H.change_stat("endurance", 1)
+			H.change_stat("endurance", 2)
+			H.change_stat("constitution", 2)
 			H.change_stat("speed", 2)
-			H.change_stat("perception", -1)
-			H.change_stat("intelligence", -1)
 
 		if("Paladin")
 			to_chat(H, span_warning("A holy warrior. Where others of the clergy may have spent their free time studying scriptures, you have instead honed your skills with a blade."))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -38,7 +38,7 @@
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
 			backl = /obj/item/storage/backpack/rogue/satchel
-			belt = /obj/item/storage/belt/rogue/rope
+			belt = /obj/item/storage/belt/rogue/leather/rope
 			beltr = /obj/item/flashlight/flare/torch/lantern
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -97,6 +97,7 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltr = /obj/item/storage/keyring/churchie
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	gloves = /obj/item/clothing/gloves/roguetown/angle
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
@@ -123,7 +124,7 @@
 		H.change_stat("strength", 3)
 		H.change_stat("constitution", 2)
 		H.change_stat("endurance", 2)
-		H.change_stat("speed", 1)
+		H.change_stat("speed", 2)
 
 		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -93,6 +93,7 @@
 			neck = pick(psicross_options) // Random psicross, as cleric.
 			cloak = /obj/item/clothing/cloak/templar/xylix
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/priest
+	pants = /obj/item/clothing/under/roguetown/tights/black
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	beltr = /obj/item/storage/keyring/churchie

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -1,4 +1,4 @@
-//shield flail or longsword, tief can be this with red cross test
+//shield flail or longsword, tief can be this with red cross
 
 /datum/job/roguetown/templar
 	title = "Templar"
@@ -25,9 +25,6 @@
 /datum/outfit/job/roguetown/templar
 	has_loadout = TRUE
 	allowed_patrons = ALL_DIVINE_PATRONS
-	belt = /obj/item/storage/belt/rogue/leather/black
-	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
-	beltr = /obj/item/storage/keyring/churchie
 	id = /obj/item/clothing/ring/silver
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(/obj/item/ritechalk)
@@ -95,8 +92,10 @@
 			)
 			neck = pick(psicross_options) // Random psicross, as cleric.
 			cloak = /obj/item/clothing/cloak/templar/xylix
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/priest
+	belt = /obj/item/storage/belt/rogue/leather/rope
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
+	beltr = /obj/item/storage/keyring/churchie
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	if(H.mind)
@@ -122,12 +121,12 @@
 			H.mind.adjust_skillrank(/datum/skill/craft/smelting, 1, TRUE)
 		H.cmode_music = 'sound/music/combat_holy.ogg'
 		H.change_stat("strength", 3)
+		H.change_stat("constitution", 2)
 		H.change_stat("endurance", 2)
-		H.change_stat("speed", 2)
-		H.change_stat("perception", -1)
+		H.change_stat("speed", 1)
 
 		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
@@ -136,7 +135,7 @@
 
 /datum/outfit/job/roguetown/templar/monk/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-	var/weapons = list("Katar")
+	var/weapons = list("Katar","Knuckle Dusters")
 	switch(H.patron?.type)
 		if(/datum/patron/divine/eora)
 			weapons += "Close Caress"
@@ -147,6 +146,8 @@
 	switch(weapon_choice)
 		if("Katar")
 			H.put_in_hands(new /obj/item/rogueweapon/katar(H), TRUE)
+		if("Knuckle Dusters")
+			H.put_in_hands(new /obj/item/rogueweapon/knuckles(H), TRUE)
 		if("Close Caress")
 			H.put_in_hands(new /obj/item/rogueweapon/knuckles/eora(H), TRUE)
 		if("Barotrauma")
@@ -209,6 +210,9 @@
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+	belt = /obj/item/storage/belt/rogue/leather/black
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
+	beltr = /obj/item/storage/keyring/churchie
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	armor = /obj/item/clothing/suit/roguetown/armor/plate	///Half-Plate not fullplate
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -1,4 +1,4 @@
-//shield flail or longsword, tief can be this with red cross
+//shield flail or longsword, tief can be this with red cross test
 
 /datum/job/roguetown/templar
 	title = "Templar"

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -128,7 +128,7 @@
 
 		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
-
+		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_spells_templar(H)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -115,6 +115,7 @@
 			H.mind.AddSpell(new/obj/effect/proc_holder/spell/invoked/projectile/repel)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shadowstep)
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
 
 			head = /obj/item/clothing/head/roguetown/roguehood/pontifex


### PR DESCRIPTION
## About The Pull Request
Hello!

This is the third _(and final_) part of a recent rework to the _"pugilism"_ playstyle, spearheaded by Onutiso and myself. Her previous contributions include [overhauling the _"Civilized Barbarian"_ trait, adding unarmed damage multipliers to gloves](https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2017), and [fixing the long-broken unarmed parrying mechanics](https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2011). Seeing as these changes have been successfully merged for a couple weeks without any serious issues or bugs cropping up, we _should_ be in the clear to cap off this rework with one last pull request.

As the title mentions, this pull request will be adding the _"Expert Pugilist"_ trait - which gives you a higher critical hit chance _(and no targeting restrictions)_ with unarmed attacks - to all "Monk"-type classes that don't already have it.

In addition, I'll also be tweaking the equipment and statistics of most "Monk"-type classes. This is to better emphasize their niche of being well-conditioned pugilists, who've _(mostly)_ forsaken weapons and armor in favor of miracles and unarmed combat.

Every change will be listed below. If you have any concerns with certain choices, please don't hesitate to let me know (either in the comments or by pinging me in #dev-general). Hopefully, these changes _should_ seem fairly reasonable.

...

**MONK, ADVENTURER**
- Removed the option for spawning with _katars_ or _knuckledusters_.
- Removed the _chain gauntlets_ and _hardened leather pants_.
- Replaced the _steel bracers_ with _heavy leather bracers_.
- Replaced the _padded gambeson_ with _undervestments_.
- Replaced the _leather boots_ with _sandals_.
- Replaced the _leather belt_ with a _rope belt_.
- Added the _"Expert Pugilism / Civilized Barbarian"_ trait.
- Increased the Wrestling skill to Expert.
- Changed the statblock from..
**(+II STR, +I END,  0 CON, +II SPD, -I PER, -I INT)** .. to .. **(+II STR, +II END, +II CON, +I SPD, 0 PER, 0 INT)**.

Inspired by the original Monk archetypes from **Roguetown 1E** and **Stonekeep**, this subclass has been redesigned to function as a specialized _(and pugilist-centric)_ alternative to the Barbarian. They're the _"Floyd Merryweather"_ to the Barbarian's _"Mike Tyson"_, essentially - physically well-rounded and good at supporting others, but lacking the sheer versatility and resilience of their counterpart.

...

**MONK, TEMPLAR**
- Removed the _hardened leather pants_.
- Replaced the _heavy leather coat_ with _undervestments_.
- Replaced the _leather belt_ with a _rope belt_.
- Added the _"Expert Pugilism / Civilized Barbarian"_ trait.
- Added the _heavy leather gloves_.
- Added the option to select _knuckledusters_ as a starting weapon.
- Changed the statblock from..
**(+III STR, +II END, 0 CON, +II SPD, -I PER, 0 INT)** .. to .. **(+III STR, +II END, +II CON, +II SPD, 0 PER, 0 INT)**.

This serves as a direct upgrade to the _adventuring_ Monk. Relatively same design philosophy: they're physically impressive and adept in unarmed combat, but still rely on good positioning and dodging to avoid being dismembered-or-mangled on the spot. They get better armor, in the form of steel bracers and heavy leather gloves, alongside an improved statblock. Most appealingly, they're able to rock proper unarmed-type weapons from the get-go.

...

**DISCIPLE, ORTHODOXIST - 'OTAVAN' SUBCLASS**
- Removed the _hardened leather pants_.
- Removed the _monkskin_ slotblocker.
- Replaced the _leather belt_ with a _rope belt_.
- Added the _"Expert Pugilism / Civilized Barbarian"_ trait.
- Changed the statblock from..
**(+III STR, +IV END, +IV CON, 0 SPD, 0 PER, -II INT)** .. to .. **(+III STR, +III END, +III CON, -I SPD, 0 PER, -II INT)**.

Similar philosophy to how the Templar!Monk is handled. Instead of the _adventuring_ Monk serving as the baseline, however, it's the _adventuring_ Barbarian instead. The slotblocker has been removed, in conjunction with **-I END / -I CON / -I SPD**. They're about as tough as a non-antagonist role _should_ get, without immediate access to armor or weapons. Functions as the heavyweight, non-dodging counterpart to the _"Naledian-Trained Scholar"_ subclass.

...

- Added the _"Expert Pugilism / Civilized Barbarian"_ trait to the following subclasses..

**DISCIPLE, ORTHODOXIST - 'NALEDIAN' SUBCLASS**
**NALEDIAN, MERCENARY - 'PONTIFEX' SUBCLASS**

...

## Why It's Good For The Game
Monks have been in a strange spot for the past couple months. Some _"Monk"_-type classes are remarkably frail and have to exclusively rely on armor-and-weapons to fight, while others are a bit _too_ overtuned in terms of equipment and statblocks. This pull request will hopefully make them a lot more cohesive in terms of balancing, and - most importantly - allow people to better act out their fantasies of staring in a Steven Seagal flick.