### PR TITLE
Delete range override on vigorous exchange

### DIFF
--- a/code/modules/spells/roguetown/acolyte/malum.dm
+++ b/code/modules/spells/roguetown/acolyte/malum.dm
@@ -4,7 +4,6 @@
 	releasedrain = 0
 	chargedrain = 0
 	chargetime = 0
-	range = 1
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	no_early_release = TRUE


### PR DESCRIPTION
## About The Pull Request
Delete range override on vigorous exchange

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Did not test

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yurke pointed out on discord it has a range of 1 and since LOS check was added that was respected and now you cannot stam max with the spell. 

this removes the override consistent with the LOS tweaks that removed most unnecesasry range override

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
