### PR TITLE
Pocket Additions to Tabards (And some minor stuff)

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -33,6 +33,18 @@
 	var/picked
 	var/overarmor = TRUE
 
+/obj/item/clothing/cloak/tabard/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete/roguetown/cloak)
+
+/obj/item/clothing/cloak/tabard/dropped(mob/living/carbon/human/user)
+	..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	if(STR)
+		var/list/things = STR.contents()
+		for(var/obj/item/I in things)
+			STR.remove_from_storage(I, get_turf(src))
+
 /obj/item/clothing/cloak/abyssortabard
 	name = "abyssorite tabard"
 	desc = "A tabard worn by Abyssorite devouts."
@@ -46,6 +58,18 @@
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
 	flags_inv = HIDECROTCH|HIDEBOOB
 	var/overarmor = TRUE
+
+/obj/item/clothing/cloak/abyssortabard/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete/roguetown/cloak)
+
+/obj/item/clothing/cloak/abyssortabard/dropped(mob/living/carbon/human/user)
+	..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	if(STR)
+		var/list/things = STR.contents()
+		for(var/obj/item/I in things)
+			STR.remove_from_storage(I, get_turf(src))
 
 /obj/item/clothing/cloak/abyssortabard/MiddleClick(mob/user)
 	overarmor = !overarmor
@@ -71,6 +95,19 @@
 	flags_inv = HIDECROTCH|HIDEBOOB
 	var/open_wear = FALSE
 	var/overarmor = TRUE
+
+/obj/item/clothing/cloak/psydontabard/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete/roguetown/cloak)
+
+/obj/item/clothing/cloak/psydontabard/dropped(mob/living/carbon/human/user)
+	..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	if(STR)
+		var/list/things = STR.contents()
+		for(var/obj/item/I in things)
+			STR.remove_from_storage(I, get_turf(src))
+
 
 /obj/item/clothing/cloak/psydontabard/alt
 	name = "opened psydonian tabard"

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -419,6 +419,18 @@
 	var/picked
 	var/overarmor = TRUE
 
+/obj/item/clothing/cloak/stabard/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete/roguetown/cloak)
+
+/obj/item/clothing/cloak/stabard/dropped(mob/living/carbon/human/user)
+	..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	if(STR)
+		var/list/things = STR.contents()
+		for(var/obj/item/I in things)
+			STR.remove_from_storage(I, get_turf(src))
+
 /obj/item/clothing/cloak/stabard/MiddleClick(mob/user) 
 	overarmor = !overarmor
 	to_chat(user, span_info("I [overarmor ? "wear the tabard over my armor" : "wear the tabard under my armor"]."))
@@ -1180,6 +1192,18 @@
 
 /obj/item/clothing/cloak/templar
 	var/overarmor = TRUE
+
+/obj/item/clothing/cloak/templar/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete/roguetown/cloak)
+
+/obj/item/clothing/cloak/templar/dropped(mob/living/carbon/human/user)
+	..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	if(STR)
+		var/list/things = STR.contents()
+		for(var/obj/item/I in things)
+			STR.remove_from_storage(I, get_turf(src))
 
 /obj/item/clothing/cloak/templar/psydon
 	name = "psydon tabard"

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -277,6 +277,7 @@
 	icon_state = "furlinedanklets"
 	item_state = "furlinedanklets"
 	sewrepair = TRUE
+	is_barefood = TRUE
 	armor = list("blunt" = 30, "slash" = 10, "stab" = 20, "piercing" = 0, "fire" = 0, "acid" = 0)
 	is_barefoot = TRUE
 	salvage_amount = 1

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -277,7 +277,7 @@
 	icon_state = "furlinedanklets"
 	item_state = "furlinedanklets"
 	sewrepair = TRUE
-	is_barefood = TRUE
+	is_barefoot = TRUE
 	armor = list("blunt" = 30, "slash" = 10, "stab" = 20, "piercing" = 0, "fire" = 0, "acid" = 0)
 	is_barefoot = TRUE
 	salvage_amount = 1

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -240,13 +240,6 @@
 	created_item = /obj/item/rogueweapon/estoc
 	craftdiff = 4
 
-/datum/anvil_recipe/weapons/buckler
-	name = "Buckler (+1 Steel)"
-	req_bar = /obj/item/ingot/steel
-	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel)
-	created_item = /obj/item/rogueweapon/greatsword/grenz
-	craftdiff = 4
-
 /datum/anvil_recipe/weapons/steel/axe
 	name = "Axe (+1 Stick)"
 	req_bar = /obj/item/ingot/steel

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -329,7 +329,47 @@ GLOBAL_LIST_EMPTY(loadout_items)
 /datum/loadout_item/cloth_blindfold
 	name = "Cloth Blindfold"
 	path = /obj/item/clothing/mask/rogue/blindfold
-	
+
+/datum/loadout_item/psicross
+	name = "Psydonian Cross"
+	path = /obj/item/clothing/neck/roguetown/psicross
+
+/datum/loadout_item/psicross/astrata
+	name = "Amulet of Astrata"
+	path = /obj/item/clothing/neck/roguetown/psicross/astrata
+
+/datum/loadout_item/psicross/noc
+	name = "Amulet of Noc"
+	path = /obj/item/clothing/neck/roguetown/psicross/noc
+
+/datum/loadout_item/psicross/abyssor
+	name = "Amulet of Abyssor"
+	path = /obj/item/clothing/neck/roguetown/psicross/abyssor
+
+/datum/loadout_item/psicross/dendor
+	name = "Amulet of Dendor"
+	path = /obj/item/clothing/neck/roguetown/psicross/dendor
+
+/datum/loadout_item/psicross/necra
+	name = "Amulet of Necra"
+	path = /obj/item/clothing/neck/roguetown/psicross/necra
+
+/datum/loadout_item/psicross/pestra
+	name = "Amulet of Pestra"
+	path = /obj/item/clothing/neck/roguetown/psicross/pestra
+
+/datum/loadout_item/psicross/ravox
+	name = "Amulet of Ravox"
+	path = /obj/item/clothing/neck/roguetown/psicross/ravox
+
+/datum/loadout_item/psicross/malum
+	name = "Amulet of Malum"
+	path = /obj/item/clothing/neck/roguetown/psicross/malum
+
+/datum/loadout_item/psicross/eora
+	name = "Amulet of Eora"
+	path = /obj/item/clothing/neck/roguetown/psicross/eora
+
 //Donator Section
 //All these items are stored in the donator_fluff.dm in the azure modular folder for simplicity.
 //All should be subtypes of existing weapons/clothes/armor/gear, whatever, to avoid balance issues I guess. Idk, I'm not your boss.


### PR DESCRIPTION
## About The Pull Request
The tailors within azure peak have learned how to sew pockets onto tabards and other such clothing! 
-Tabards/surcoats/stabards now have pockets.
Means that you do not have to compromise your drip for that extra smidge of storage.
-Added psicrosses to loadout!
Represent your faith without having to be a templar or an acolyte.
-Some minor fixes (removal of a defunct anvil recipe and making some footwraps inline with each other)


## Testing Evidence

![storageclothing1](https://github.com/user-attachments/assets/7e6d74a2-e0b9-4c82-a10b-f3d16dfe6372)
![storageclothing2](https://github.com/user-attachments/assets/b5530111-2775-4255-bf6f-a8bfe981f231)
![storageclothing3](https://github.com/user-attachments/assets/9cfad8ed-0897-4d84-b932-913bc7020b79)
![psicross](https://github.com/user-attachments/assets/0157fa44-ce51-47db-91df-1ee4baf92ffb)
![psicross2](https://github.com/user-attachments/assets/f4cd2659-d1af-4440-9394-fc447896e59d)


## Why It's Good For The Game

Less need to compromise style and storage. Anyone who decided to give up a cloak for their colors would lose out on that tiny bit of pocket space for storing their hardtack and flask of red. I believe they should have some
Otherwise, loadout psicrosses are there for people who wish to represent their faith without needing to find or be given one. For those who carry their faith with them but not the devout virtue.

If there is any other small changes that wish to be seen in with this, do leave a comment with such thoughts.