### PR TITLE
Adds loud messages for certain actions -- building twig platforms, destroying doors / windows / bars

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -259,6 +259,8 @@
 							if(X)
 								X.OnCrafted(user.dir, user)
 								X.add_fingerprint(user)
+								if(R.loud)
+									X.loud_message("Construction sounds can be heard")
 						else
 							var/atom/movable/I = new R.result (T)
 							I.CheckParts(parts, R)

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -23,6 +23,8 @@
 	var/wallcraft = FALSE
 	var/craftdiff = 1
 	var/sellprice = 0
+	/// Whether this recipe will transmit a message in a 7x7 column around the source.
+	var/loud = FALSE
 	//crafting diff, every diff removes 25% chance to craft
 /*
 /datum/crafting_recipe/example

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -290,7 +290,7 @@
 	attacked_sound = list("sound/combat/hits/onmetal/metalimpact (1).ogg", "sound/combat/hits/onmetal/metalimpact (2).ogg")
 
 /obj/structure/bars/obj_break(damage_flag)
-	loud_message("A sickening, metallic scrape of bars getting broken rings out", hearing_distance = 10)
+	loud_message("A sickening, metallic scrape of bars getting broken rings out", hearing_distance = 14)
 	. = ..()
 
 /obj/structure/bars/CanPass(atom/movable/mover, turf/target)

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -289,6 +289,10 @@
 	obj_flags = CAN_BE_HIT | BLOCK_Z_OUT_DOWN
 	attacked_sound = list("sound/combat/hits/onmetal/metalimpact (1).ogg", "sound/combat/hits/onmetal/metalimpact (2).ogg")
 
+/obj/structure/bars/obj_break(damage_flag)
+	loud_message("A sickening, metallic scrape of bars getting broken rings out", hearing_distance = 10)
+	. = ..()
+
 /obj/structure/bars/CanPass(atom/movable/mover, turf/target)
 	if(isobserver(mover))
 		return 1

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -687,6 +687,10 @@
 	icon_state = "wcv"
 
 
+/obj/structure/mineral_door/obj_break(damage_flag)
+	loud_message("A loud crash of door splinters echoes", hearing_distance = 10)
+	. = ..()
+
 /obj/structure/mineral_door/wood/pickaxe_door(mob/living/user, obj/item/I)
 	return
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -688,7 +688,7 @@
 
 
 /obj/structure/mineral_door/obj_break(damage_flag)
-	loud_message("A loud crash of door splinters echoes", hearing_distance = 10)
+	loud_message("A loud crash of door splinters echoes", hearing_distance = 14)
 	. = ..()
 
 /obj/structure/mineral_door/wood/pickaxe_door(mob/living/user, obj/item/I)

--- a/code/game/objects/structures/roguewindow.dm
+++ b/code/game/objects/structures/roguewindow.dm
@@ -223,6 +223,7 @@
 		attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
 		message_admins("Window broken. [ADMIN_JMP(src)]")
 		log_admin("Window broken at X:[src.x] Y:[src.y] Z:[src.z] in area: [get_area(src)]")
+		loud_message("A loud crash of a window getting broken rings out", hearing_distance = 10)
 		new /obj/item/natural/glass/shard (get_turf(src))
 		new /obj/effect/decal/cleanable/glass(get_turf(src))
 		climbable = TRUE

--- a/code/game/objects/structures/roguewindow.dm
+++ b/code/game/objects/structures/roguewindow.dm
@@ -223,7 +223,7 @@
 		attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
 		message_admins("Window broken. [ADMIN_JMP(src)]")
 		log_admin("Window broken at X:[src.x] Y:[src.y] Z:[src.z] in area: [get_area(src)]")
-		loud_message("A loud crash of a window getting broken rings out", hearing_distance = 10)
+		loud_message("A loud crash of a window getting broken rings out", hearing_distance = 14)
 		new /obj/item/natural/glass/shard (get_turf(src))
 		new /obj/effect/decal/cleanable/glass(get_turf(src))
 		climbable = TRUE

--- a/code/game/turfs/closed/wall/roguewalls.dm
+++ b/code/game/turfs/closed/wall/roguewalls.dm
@@ -45,6 +45,10 @@
 	climbdiff = 3
 	damage_deflection = 10
 
+/turf/closed/wall/mineral/rogue/stone/turf_destruction()
+	loud_message("Sound of a crumbling stone wall rings out", hearing_distance = 14)
+	. = ..()
+
 /turf/closed/wall/mineral/rogue/stone/window
 	name = "stone window"
 	desc = "A window with solid and sturdy stone frame."
@@ -88,6 +92,9 @@
 	climbdiff = 3
 	damage_deflection = 10
 
+/turf/closed/wall/mineral/rogue/craftstone/turf_destruction()
+	loud_message("Sound of heavy stone bricks crumbling apart rings out", hearing_distance = 14)
+	. = ..()
 
 /turf/closed/wall/mineral/rogue/stonebrick
 	name = "brick wall"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -248,7 +248,7 @@ GLOBAL_VAR_INIT(mobids, 1)
 	for(var/mob/living/L in listening)
 		var/strz
 		var/strdir
-		if(L.STAPER < 8 && !(L in viewers(world.view, src)))
+		if(L.STAPER <= 8 && !(L in viewers(world.view, src)))
 			to_chat(L, span_warning("You hear something... somewhere!"))
 			continue
 		if(L.z != src.z)
@@ -256,21 +256,22 @@ GLOBAL_VAR_INIT(mobids, 1)
 			if(L.z > src.z)
 				switch(zdiff)
 					if(1)
-						strz = "Below"
+						strz = "below"
 					if(2 to 999)
-						strz = "Far Below"
+						strz = "far below"
 			if(L.z < src.z)
 				switch(zdiff)
 					if(1)
-						strz = "Above"
+						strz = "above"
 					if(2 to 999)
-						strz = "Far Above"
+						strz = "far above"
 		if(directional)
 			var/dir = get_dir(L, src)
-			strdir = capitalize(dir2text(dir))
+			strdir = dir2text(dir)
 		//message + "from" + strz if we have it. If we do we add "and" + "strdir", otherwise only "strdir".
 		//If there's a z difference: "A rock can be heard falling" + "from" + "below/above/etc" + "and" + "northeast"
 		//No z difference: "A rock can be heard falling" + "from" + "northeast"
+		//No dir difference:"A rock can be heard falling" + "from" + "above"
 		var/fullmsg = span_warning("[message] from [strz ? "<b>[strz]</b>" : ""][strdir ? "[strz ? " and " : ""]<b>[strdir]</b>" : ""].")
 		to_chat(L, fullmsg)
 /**

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -219,6 +219,61 @@ GLOBAL_VAR_INIT(mobids, 1)
 		log_seen(src, null, hearers, (log_seen_msg ? log_seen_msg : message), log_seen)
 
 /**
+ * Show a message to all mobs in a vertical plane around the source atom. 
+ * Only use this for cases where the action being done is important enough to ignore z level / LOS.
+ * vars:
+ * * message is the message output. Keep in mind that its end will be appended with "Far Above / Above / Below / Far Below" & "North / East / West / South" etc
+ * * hearing_distance is the distance from the source that the message will be sent to.
+ * * directional will add an additional direction of the source of sound relative to the listener's position.
+ */
+
+/atom/proc/loud_message(message, hearing_distance = DEFAULT_MESSAGE_RANGE, directional = TRUE)
+	var/list/listening = get_hearers_in_view(hearing_distance, src)
+	for(var/_M in GLOB.player_list)
+		var/mob/M = _M
+		if(!M.client) //client is so that ghosts don't have to listen to mice
+			continue
+		if(!M)
+			continue
+		if(!M.client)
+			continue
+		if(get_dist(M, src) > hearing_distance) //they're out of range of normal hearing
+			if(M.client.prefs)
+				if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+					continue
+		if(!is_in_zweb(src.z,M.z))
+			continue
+		listening |= M
+	
+	for(var/mob/living/L in listening)
+		var/strz
+		var/strdir
+		if(L.STAPER < 8 && !(L in viewers(world.view, src)))
+			to_chat(L, span_warning("You hear something... somewhere!"))
+			continue
+		if(L.z != src.z)
+			var/zdiff = abs(L.z - src.z)
+			if(L.z > src.z)
+				switch(zdiff)
+					if(1)
+						strz = "Below"
+					if(2 to 999)
+						strz = "Far Below"
+			if(L.z < src.z)
+				switch(zdiff)
+					if(1)
+						strz = "Above"
+					if(2 to 999)
+						strz = "Far Above"
+		if(directional)
+			var/dir = get_dir(L, src)
+			strdir = capitalize(dir2text(dir))
+		//message + "from" + strz if we have it. If we do we add "and" + "strdir", otherwise only "strdir".
+		//If there's a z difference: "A rock can be heard falling" + "from" + "below/above/etc" + "and" + "northeast"
+		//No z difference: "A rock can be heard falling" + "from" + "northeast"
+		var/fullmsg = span_warning("[message] from [strz ? "<b>[strz]</b>" : ""][strdir ? "[strz ? " and " : ""]<b>[strdir]</b>" : ""].")
+		to_chat(L, fullmsg)
+/**
  * Show a message to all mobs in earshot of this one
  *
  * This would be for audible actions by the src mob

--- a/code/modules/roguetown/roguecrafting/turfs.dm
+++ b/code/modules/roguetown/roguecrafting/turfs.dm
@@ -292,6 +292,7 @@
 	verbage_simple = "assemble"
 	verbage = "assembles"
 	craftdiff = 0
+	loud = TRUE
 
 /datum/crafting_recipe/roguetown/turfs/twig/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))
@@ -309,6 +310,7 @@
 	verbage_simple = "assemble"
 	verbage = "assembles"
 	craftdiff = 1
+	loud = TRUE
 
 /datum/crafting_recipe/roguetown/turfs/twigplatform/TurfCheck(mob/user, turf/T)
 	if(isclosedturf(T))


### PR DESCRIPTION
## About The Pull Request
- Adds a new atom proc called "loud_message", which will transmit a chat message to anyone in a vertical space around the source, ignoring line of sight.
- Adds a loud message to:
   - Breaking windows
   - Breaking doors
   - Breaking bars
   - Breaking stone walls such as the ones around armory & keep dungeon
   - Building twig floors and platforms

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
If you build a twig platform from the top of the tree (two z levels above the knight):
![dreamseeker_ho6CDBUtGo](https://github.com/user-attachments/assets/697eacfc-ecb2-403e-b82f-53dd2810bc06)

The Knight will get this chat message:
![dreamseeker_0zeNocvg02](https://github.com/user-attachments/assets/37affc40-516b-45c8-98fa-59139abc4e10)

Other messages are formed like this: (ex. The listener is one z level above the broken window)
![dreamseeker_BfMiGoSMkA](https://github.com/user-attachments/assets/f07ae1f7-ea33-46bf-b57f-f5db06f46655)

(The listener is two or more z levels above the broken door)
![dreamseeker_8472i6EqSx](https://github.com/user-attachments/assets/034c034a-a7c5-42bf-a41d-34a92148a7b1)

If they have 8 PER or less, the listener will get this message instead:
![dreamseeker_nUnyNH17Jn](https://github.com/user-attachments/assets/2552cf96-a97f-420e-b550-92046d7f902e)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Consequence-free cheesing of broken doors / windows / skybridges by doing it out of look-up sight or out of range of our playsound limits was always, well, very parmesan. It was *apparently* getting used more frequently so measures had to be taken.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
