### PR TITLE
Minor Tracking Tweaks

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1773,7 +1773,7 @@
 				continue
 			if(see_invisible < M.invisibility)
 				continue
-			var/probby = (3 * STAPER) + (mind?.get_skill_level(/datum/skill/misc/tracking)) * 5
+			var/probby = (2 * STAPER) + (mind?.get_skill_level(/datum/skill/misc/tracking)) * 5
 			if(M.mob_timers[MT_INVISIBILITY] > world.time) // Check if the mob is affected by the invisibility spell
 				if(mind?.get_skill_level(/datum/skill/misc/tracking) <= SKILL_LEVEL_EXPERT)	//Master or Legendary from this point
 					continue
@@ -1782,17 +1782,17 @@
 				var/target_holy = M.mind?.get_skill_level(/datum/skill/magic/holy)
 				var/target_arcyne = M.mind?.get_skill_level(/datum/skill/magic/arcane)
 				var/chosen_skill = max(target_sneak, target_holy, target_arcyne)
-				probby -= chosen_skill * 10
+				probby -= chosen_skill * 5
 				if(M.STAPER > 10)
 					probby -= (M.STAPER) / 2
 			probby = (max(probby, 5))
 			if(prob(probby))
 				marked = TRUE
-				M.mob_timers[MT_INVISIBILITY] = world.time
-				M.update_sneak_invis()
-				to_chat(M, span_danger("[src] sees me! I'm found!"))
-				if(M.m_intent == MOVE_INTENT_SNEAK)
+				if(M.m_intent == MOVE_INTENT_SNEAK || M.mob_timers[MT_INVISIBILITY] > world.time)
 					emote("huh")
+					to_chat(M, span_danger("[src] sees me! I'm found!"))
+					M.update_sneak_invis()
+					M.mob_timers[MT_INVISIBILITY] = world.time
 					M.mob_timers[MT_FOUNDSNEAK] = world.time
 			else
 				if(M.m_intent == MOVE_INTENT_SNEAK || M.mob_timers[MT_INVISIBILITY] > world.time)


### PR DESCRIPTION
## About The Pull Request
- Makes the skillcheck of the person hiding equal to the tracker's tracking skill.
  - Previously the skill of the hider was doubled vs tracker's tracking skill, meaning if you had more sneak / holy / arcyne than the guy looking for you they'd pretty much always have ~5% chance to spot you.
  - Now Legendary Sneak will nullify Legendary Tracking 1:1
- You will no longer get "X sees me! I'm found!" message when you aren't
   - Sneaking
   - Invisible
- Consequently, if you have Legendary Tracking, you will have **at least** 2x your PER chance to spot anyone who is sneaking / invisible per attempt.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
ngl I kinda compiled since this is just numbers and moving a few things into an If statement
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fewer annoying messages, and finding invisible people is now actually possible rather than IMpossible at previously consistent 5% they were dealing with.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
