### PR TITLE
Add the forester virtue

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -253,6 +253,7 @@
 /datum/virtue/utility/forester
 	name = "Forester"
 	desc = "The forest is your home, or at least, it used to be. You always long to return and roam free once again, and you have not forgotten your knowledge on how to be self sufficient."
+	added_stashed_items = list("Trusty hoe" = /obj/item/rogueweapon/hoe)
 	added_skills = list(list(/datum/skill/craft/cooking, 2, 2),
 						list(/datum/skill/misc/athletics, 2, 2),
 						list(/datum/skill/labor/farming, 2, 2),

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -250,6 +250,16 @@
 	added_stashed_items = list("Bag of Food" = /obj/item/storage/roguebag/food)
 	added_skills = list(list(/datum/skill/craft/cooking, 3, 6))
 
+/datum/virtue/utility/forester
+	name = "Forester"
+	desc = "The forest is your home, or at least, it used to be. You always long to return and roam free once again, and you have not forgotten your knowledge on how to be self sufficient."
+	added_skills = list(list(/datum/skill/craft/cooking, 2, 2),
+						list(/datum/skill/misc/athletics, 2, 2),
+						list(/datum/skill/labor/farming, 2, 2),
+						list(/datum/skill/labor/fishing, 2, 2),
+						list(/datum/skill/labor/lumberjacking, 2, 2)
+	)
+
 /datum/virtue/utility/mining
 	name = "Miner's Apprentice"
 	desc = "The dark shafts, the damp smells of ichor and the laboring hours are no stranger to me. I keep my pickaxe and lamptern close, and have been taught how to mine well."


### PR DESCRIPTION
## About The Pull Request

**Gets up to apprentice level in**

- Cooking
- Lumberjacking
- Athletics
- Farming
- Fishing

## Testing Evidence

Mage associate with the new skills. Cooking mastery to test if it works with personal granary. 
![image](https://github.com/user-attachments/assets/6a5ce957-a961-4b8a-9dcf-ef67d8894dcc)

## Why It's Good For The Game

There's no apprentice style trait for these skills. This should let more people pick a food producing focus without making it their entire job or having to hinge solely on the Innkeep. But it's mainly interesting for.
- Adventurers (Ability to be self sufficient)
- Hermits (Witches, druids and whatnot)
- Servants (Being very poor, servants often have to farm if they wish to run the kitchen specifically, but they start with no farming skill)
- Followers of Abyssor & Dendor.
- Mercenaries who want to cook for their guild.
