### PR TITLE
Fix int scaling breaking recharging by removing recharging variable

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -95,7 +95,6 @@
 		to_chat(rewarded, span_greentext("I feel a surge of mana flow into you!"))
 		for(var/obj/effect/proc_holder/spell/spell in rewarded.mind.spell_list)
 			spell.charge_counter = spell.charge_max
-			spell.recharging = FALSE
 			spell.update_icon()
 		rewarded.adjustBruteLoss(-25)
 		rewarded.adjustFireLoss(-25)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -347,7 +347,6 @@
 			L.mind.hasSoul = FALSE
 		for(var/obj/effect/proc_holder/spell/spell in L.mind.spell_list)
 			spell.charge_counter = spell.charge_max
-			spell.recharging = FALSE
 			spell.update_icon()
 
 /obj/projectile/magic/aoe

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -23,7 +23,6 @@
 		CRASH("Incorrect touch spell hand.")
 	//Start recharging.
 	attached_hand = null
-	recharging = TRUE
 	action.UpdateButtonIcon()
 
 /obj/effect/proc_holder/spell/targeted/touch/cast(list/targets,mob/user = usr)
@@ -35,7 +34,6 @@
 	for(var/mob/living/carbon/C in targets)
 		if(!attached_hand)
 			if(ChargeHand(C))
-				recharging = FALSE
 				return
 
 /obj/effect/proc_holder/spell/targeted/touch/charge_check(mob/user,silent = FALSE)


### PR DESCRIPTION
## About The Pull Request
Admins reported a bug that happened with Mage Overhaul 1 where spells would red out permanently. It turns out this is because of an edge case with charge_max being set *above* the current charge counter, on a fully charged spell, where recharging = false.

This removes the recharging variable and also moves the int scaling bloc outside of process to start_recharge() instead

(Funnily enough, you can just fix this by clicking on the spell anyway which start a recharge)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I replicated the issue once locally with Baotha's Blessings - when itr expired my Baotha's Blessings redded out. Haven't been able to replicate it with this fix.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fix this shitass code so I can add more bloats.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
