### PR TITLE
Map Moat Fix

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -14871,7 +14871,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/mountains/decap)
 "fLp" = (
-/turf/open/water/river,
+/obj/structure/roguerock,
+/turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "fLv" = (
 /obj/structure/ladder,
@@ -21358,6 +21359,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/woods)
+"imY" = (
+/obj/structure/roguerock,
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "ina" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -54709,6 +54714,10 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
+"vpg" = (
+/obj/structure/roguerock,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "vps" = (
 /obj/structure/mirror{
 	pixel_x = -28;
@@ -122915,7 +122924,7 @@ miF
 fCP
 vFS
 vFS
-orc
+eMU
 orc
 orc
 ogs
@@ -123367,7 +123376,7 @@ miF
 eMU
 vFS
 vFS
-orc
+eMU
 orc
 ogs
 ogs
@@ -137830,12 +137839,12 @@ miF
 bhJ
 bhJ
 bVT
-bVT
+vFS
+vFS
+eMU
 daP
-orc
-orc
-orc
-uvk
+daP
+jcb
 ogs
 ogs
 ogs
@@ -138282,10 +138291,10 @@ qHj
 miF
 bhJ
 bhJ
-jcb
+vFS
+vFS
+eMU
 daP
-orc
-orc
 orc
 miF
 miF
@@ -138734,8 +138743,8 @@ qHj
 miF
 miF
 bhJ
-bhJ
-bhJ
+vFS
+vFS
 bhJ
 bhJ
 orc
@@ -139186,8 +139195,8 @@ miF
 miF
 miF
 bhJ
-bhJ
-bhJ
+vFS
+vFS
 bhJ
 bhJ
 bhJ
@@ -139638,8 +139647,8 @@ cxZ
 cxZ
 cxZ
 cxZ
-bhJ
-bhJ
+vFS
+cxZ
 bhJ
 bhJ
 orc
@@ -140091,8 +140100,8 @@ cxZ
 cxZ
 cxZ
 cxZ
-daP
-daP
+cxZ
+xCK
 bhJ
 orc
 bhJ
@@ -140530,9 +140539,9 @@ cxZ
 cxZ
 cxZ
 cxZ
-fLp
-fLp
-orc
+eMU
+eMU
+eMU
 bhJ
 bhJ
 bhJ
@@ -140544,8 +140553,8 @@ bhJ
 bhJ
 bhJ
 bhJ
-orc
-orc
+xCK
+xCK
 orc
 bhJ
 bhJ
@@ -140982,9 +140991,9 @@ cxZ
 cxZ
 cxZ
 cxZ
-fLp
-fLp
+eMU
 orc
+vpg
 bhJ
 bhJ
 bhJ
@@ -140997,7 +141006,7 @@ bhJ
 bhJ
 bhJ
 bhJ
-daP
+xCK
 bhJ
 bhJ
 bhJ
@@ -148659,9 +148668,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-tum
+ixP
 vFS
-bVT
+vFS
 bVT
 bVT
 bVT
@@ -149111,10 +149120,10 @@ tum
 tum
 tum
 tum
-tum
-eMU
+ixP
 vFS
-bVT
+vFS
+vFS
 bVT
 bVT
 bVT
@@ -149559,15 +149568,15 @@ tum
 tum
 tum
 tum
-tum
+htN
 htN
 htN
 tum
 ixP
-eMU
 vFS
-bVT
-bVT
+vFS
+vFS
+vFS
 bVT
 bVT
 ogl
@@ -150012,11 +150021,11 @@ htN
 htN
 htN
 htN
-htN
 tum
 tum
 ixP
-eMU
+ixP
+vFS
 vFS
 vFS
 vFS
@@ -150465,10 +150474,10 @@ htN
 tum
 tum
 tum
-tum
 ixP
 ixP
-eMU
+ixP
+vFS
 vFS
 vFS
 vFS
@@ -153632,7 +153641,7 @@ ogs
 miF
 miF
 ogs
-bVT
+vFS
 vFS
 vFS
 vFS
@@ -154084,7 +154093,7 @@ ogs
 miF
 qHj
 qHj
-qHj
+vFS
 vFS
 vFS
 vFS
@@ -154535,8 +154544,8 @@ ogs
 miF
 miF
 qHj
-qHj
-qHj
+nbg
+vFS
 vFS
 vFS
 vFS
@@ -154988,7 +154997,7 @@ miF
 miF
 qHj
 qHj
-qHj
+vFS
 vFS
 vFS
 bVT
@@ -155440,7 +155449,7 @@ miF
 qHj
 qHj
 qHj
-qHj
+vFS
 vFS
 vFS
 vFS
@@ -155892,7 +155901,7 @@ miF
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -156344,7 +156353,7 @@ qHj
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -156796,7 +156805,7 @@ qHj
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -157248,7 +157257,7 @@ qHj
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -157700,7 +157709,7 @@ qHj
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -158152,11 +158161,11 @@ qHj
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 eac
-vFS
+eMU
 ogs
 jcb
 orc
@@ -158604,10 +158613,10 @@ qHj
 qHj
 qHj
 ogs
-ogs
 vFS
 vFS
 vFS
+eMU
 eMU
 ogs
 uvk
@@ -159056,7 +159065,7 @@ miF
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 eMU
@@ -159508,7 +159517,7 @@ miF
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 ogs
@@ -159960,7 +159969,7 @@ miF
 miF
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 ogs
@@ -160412,7 +160421,7 @@ miF
 miF
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 ogs
@@ -160864,7 +160873,7 @@ miF
 miF
 miF
 ogs
-ogs
+vFS
 vFS
 vFS
 eMU
@@ -161316,7 +161325,7 @@ qHj
 miF
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -161768,7 +161777,7 @@ qHj
 miF
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -162220,7 +162229,7 @@ qHj
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -162672,7 +162681,7 @@ qHj
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -163124,7 +163133,7 @@ miF
 qHj
 qHj
 ogs
-ogs
+vFS
 vFS
 vFS
 vFS
@@ -164932,7 +164941,7 @@ miF
 qHj
 qHj
 ogs
-vFS
+bVT
 eMU
 eMU
 eMU
@@ -165388,7 +165397,7 @@ eMU
 eMU
 eMU
 eMU
-eMU
+imY
 ogs
 ogs
 ogs
@@ -169464,7 +169473,7 @@ ogs
 ogs
 ogs
 ogs
-xCK
+fLp
 xCK
 xCK
 xCK


### PR DESCRIPTION
## About The Pull Request

Fixes a mild oversight with the overhand over the moat near the keep. Rock wall no longer shows in the open space.

Plus added one unmerged commit here where I just linked the flowing waters. Nothing major besides you can now get washed to sea by the whole north moat instead of just half of it. (Still able to swim to the lip)

## Testing Evidence

Fixed the overhang
![image](https://github.com/user-attachments/assets/0461a778-3485-4736-96ab-21368896931f)
Linked moat
![image](https://github.com/user-attachments/assets/c6597c4f-fcbd-4925-a887-e3f869db893b)

## Why It's Good For The Game

Fix.
