### PR TITLE
Puts in failure return for churnwealthy if user.z != target.z

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -190,6 +190,11 @@
 /obj/effect/proc_holder/spell/invoked/churnwealthy/cast(list/targets, mob/living/user)
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/target = targets[1]
+
+		if(user.z != target.z) //Stopping no-interaction snipes
+			to_chat(user, "<font color='yellow'>The Free-God compels me to face [target] on level ground before I transact.</font>")
+			revert_cast()
+			return
 		var/mammonsonperson = get_mammons_in_atom(target)
 		var/mammonsinbank = SStreasury.bank_accounts[target]
 		var/totalvalue = mammonsinbank + mammonsonperson
@@ -197,6 +202,7 @@
 			totalvalue += 101 // We're ALWAYS going to do a medium level smite minimum to nobles.
 		if(totalvalue <=10)
 			to_chat(user, "<font color='yellow'>[target] one has no wealth to hold against them.</font>")
+			revert_cast()
 			return
 		if(totalvalue <=30)
 			user.say("Wealth becomes woe!")


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Churn the wealthy is a powerful spell, but it's used by doofuses to no-esc snipe the nobility and then run off thinking they effected something productive to their victim's round. This enforces at least some manner of visibility to use the spell, same z-level, so maybe the Iconoclasts will attempt some token interaction on this HRP server before they press their nuke button.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

![image](https://github.com/user-attachments/assets/173fdf3b-049a-40fa-964f-c8d984f9a4b0)

![image](https://github.com/user-attachments/assets/a375772a-d979-454f-9806-a6b6b8f6b843)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Has the salt not convinced you? 

So that we don't have a thousand "I can't resist the temptation" moments, and a thousand slaps on the wrist. Let's solve this with code and not have to worry about it again.
