### PR TITLE
Adds helmet in-hands and on-belt sprites

### DIFF
--- a/code/game/objects/inhands_rogue.dm
+++ b/code/game/objects/inhands_rogue.dm
@@ -8,6 +8,8 @@
 	var/is_silver = FALSE
 	var/last_used = 0
 	var/toggle_state = null
+	var/icon_x_offset = 0
+	var/icon_y_offset = 0
 //#else
 //	var/force_reupdate_inhand = FALSE
 //#endif

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -309,13 +309,15 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	if(experimental_onhip)
 		if(slot_flags & ITEM_SLOT_BELT)
-			var/i = "onbelt"
-			var/list/prop = getonmobprop(i)
-			if(prop)
-				getmoboverlay(i,prop,behind=FALSE,mirrored=FALSE)
-				getmoboverlay(i,prop,behind=TRUE,mirrored=FALSE)
-				getmoboverlay(i,prop,behind=FALSE,mirrored=TRUE)
-				getmoboverlay(i,prop,behind=TRUE,mirrored=TRUE)
+			var/props2gen = list("onbelt", "onbeltr")
+			var/list/prop
+			for(var/i in props2gen)
+				prop = getonmobprop(i)
+				if(prop)
+					getmoboverlay(i,prop,behind=FALSE,mirrored=FALSE)
+					getmoboverlay(i,prop,behind=TRUE,mirrored=FALSE)
+					getmoboverlay(i,prop,behind=FALSE,mirrored=TRUE)
+					getmoboverlay(i,prop,behind=TRUE,mirrored=TRUE)
 
 	if(experimental_onback)
 		if(slot_flags & ITEM_SLOT_BACK)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -309,15 +309,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	if(experimental_onhip)
 		if(slot_flags & ITEM_SLOT_BELT)
-			var/props2gen = list("onbelt", "onbeltr")
-			var/list/prop
-			for(var/i in props2gen)
-				prop = getonmobprop(i)
-				if(prop)
-					getmoboverlay(i,prop,behind=FALSE,mirrored=FALSE)
-					getmoboverlay(i,prop,behind=TRUE,mirrored=FALSE)
-					getmoboverlay(i,prop,behind=FALSE,mirrored=TRUE)
-					getmoboverlay(i,prop,behind=TRUE,mirrored=TRUE)
+			var/i = "onbelt"
+			var/list/prop = getonmobprop(i)
+			if(prop)
+				getmoboverlay(i,prop,behind=FALSE,mirrored=FALSE)
+				getmoboverlay(i,prop,behind=TRUE,mirrored=FALSE)
+				getmoboverlay(i,prop,behind=FALSE,mirrored=TRUE)
+				getmoboverlay(i,prop,behind=TRUE,mirrored=TRUE)
 
 	if(experimental_onback)
 		if(slot_flags & ITEM_SLOT_BACK)

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -619,6 +619,21 @@
 	max_integrity = 200
 	grid_height = 64
 	grid_width = 64
+	experimental_onhip = TRUE
+
+/obj/item/clothing/head/roguetown/helmet/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("onbelt")
+				return list("shrink" = 0.45,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
+/obj/item/clothing/head/roguetown/helmet/equipped(mob/user, slot)
+	. = ..()
+	if(slot == SLOT_BELT_R)
+		to_chat(user, span_info("The helmet slips off of my right side. I should try latching it to my left."))
+		user.dropItemToGround(src)
+		playsound(user, drop_sound, 50)
+	
 
 /obj/item/clothing/head/roguetown/helmet/skullcap
 	name = "skull cap"
@@ -1212,6 +1227,12 @@
 	item_state = "psydonbarbute"
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
 
+/obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("onbelt")
+				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm
 	name = "psydonian armet"
 	desc = "An ornate helmet, whose visor has been bound shut with blacksteel chains. The Order of Saint Eora often decorates these armets with flowers - not only as a lucky charm gifted to them by fair maidens and family, but also as a vibrant reminder that 'happiness has to be fought for.'"
@@ -1219,6 +1240,12 @@
 	item_state = "psydonarmet"
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
 	adjustable = CAN_CADJUST
+
+/obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("onbelt")
+				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm/AdjustClothes(mob/user)
 	if(loc == user)

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -630,12 +630,6 @@
 			if("onbelt")
 				return list("shrink" = 0.42,"sx" = -3,"sy" = -8,"nx" = 6,"ny" = -8,"wx" = -1,"wy" = -8,"ex" = 3,"ey" = -8,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/clothing/head/roguetown/helmet/equipped(mob/user, slot)
-	. = ..()
-	/*if(slot == SLOT_BELT_R)
-		to_chat(user, span_info("The helmet slips off of my right side. I should try latching it to my left."))
-		user.dropItemToGround(src)
-		playsound(user, drop_sound, 50)*/
 	
 
 /obj/item/clothing/head/roguetown/helmet/skullcap

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -620,19 +620,22 @@
 	grid_height = 64
 	grid_width = 64
 	experimental_onhip = TRUE
+	experimental_inhand = TRUE
 
 /obj/item/clothing/head/roguetown/helmet/getonmobprop(tag)
 	if(tag)
 		switch(tag)
+			if("gen")
+				return list("shrink" = 0.5,"sx" = -5,"sy" = -3,"nx" = 0,"ny" = 0,"wx" = 0,"wy" = -3,"ex" = 2,"ey" = -3,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 8)
 			if("onbelt")
-				return list("shrink" = 0.45,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+				return list("shrink" = 0.42,"sx" = -3,"sy" = -8,"nx" = 6,"ny" = -8,"wx" = -1,"wy" = -8,"ex" = 3,"ey" = -8,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/equipped(mob/user, slot)
 	. = ..()
-	if(slot == SLOT_BELT_R)
+	/*if(slot == SLOT_BELT_R)
 		to_chat(user, span_info("The helmet slips off of my right side. I should try latching it to my left."))
 		user.dropItemToGround(src)
-		playsound(user, drop_sound, 50)
+		playsound(user, drop_sound, 50)*/
 	
 
 /obj/item/clothing/head/roguetown/helmet/skullcap
@@ -847,6 +850,14 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 	max_integrity = 300
+
+/obj/item/clothing/head/roguetown/helmet/otavan/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("gen")
+				return list("shrink" = 0.4,"sx" = -5,"sy" = -3,"nx" = 0,"ny" = 0,"wx" = 0,"wy" = -3,"ex" = 2,"ey" = -3,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 8)
+			if("onbelt")
+				return list("shrink" = 0.32,"sx" = -3,"sy" = -8,"nx" = 6,"ny" = -8,"wx" = -1,"wy" = -8,"ex" = 3,"ey" = -8,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/otavan/AdjustClothes(mob/user)
 	if(loc == user)
@@ -1230,8 +1241,10 @@
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute/getonmobprop(tag)
 	if(tag)
 		switch(tag)
+			if("gen")
+				return list("shrink" = 0.4,"sx" = -5,"sy" = -3,"nx" = 0,"ny" = 0,"wx" = 0,"wy" = -3,"ex" = 2,"ey" = -3,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 8)
 			if("onbelt")
-				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+				return list("shrink" = 0.32,"sx" = -3,"sy" = -8,"nx" = 6,"ny" = -8,"wx" = -1,"wy" = -8,"ex" = 3,"ey" = -8,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm
 	name = "psydonian armet"
@@ -1244,8 +1257,10 @@
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm/getonmobprop(tag)
 	if(tag)
 		switch(tag)
+			if("gen")
+				return list("shrink" = 0.4,"sx" = -5,"sy" = -3,"nx" = 0,"ny" = 0,"wx" = 0,"wy" = -3,"ex" = 2,"ey" = -3,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 8)
 			if("onbelt")
-				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+				return list("shrink" = 0.32,"sx" = -3,"sy" = -8,"nx" = 6,"ny" = -8,"wx" = -1,"wy" = -8,"ex" = 3,"ey" = -8,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm/AdjustClothes(mob/user)
 	if(loc == user)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -740,6 +740,12 @@ There are several things that need to be remembered:
 					onbelt_behind = mutable_appearance(beltr.getmoboverlay("onbelt",prop,behind=TRUE,mirrored=FALSE), layer=-BELT_BEHIND_LAYER)
 					onbelt_overlay = center_image(onbelt_overlay, beltr.inhand_x_dimension, beltr.inhand_y_dimension)
 					onbelt_behind = center_image(onbelt_behind, beltr.inhand_x_dimension, beltr.inhand_y_dimension)
+					if(beltr.icon_y_offset)
+						onbelt_behind.pixel_y += beltr.icon_y_offset
+						onbelt_overlay.pixel_y += beltr.icon_y_offset
+					if(beltr.icon_x_offset)
+						onbelt_overlay.pixel_x += beltr.icon_x_offset
+						onbelt_behind.pixel_x += beltr.icon_x_offset
 					if(ishuman(src))
 						var/mob/living/carbon/human/H = src
 						if(H.dna && H.dna.species)
@@ -795,6 +801,12 @@ There are several things that need to be remembered:
 					onbelt_behind = mutable_appearance(beltl.getmoboverlay("onbelt",prop,behind=TRUE,mirrored=TRUE), layer=-BELT_BEHIND_LAYER)
 					onbelt_overlay = center_image(onbelt_overlay, beltl.inhand_x_dimension, beltl.inhand_y_dimension)
 					onbelt_behind = center_image(onbelt_behind, beltl.inhand_x_dimension, beltl.inhand_y_dimension)
+					if(beltl.icon_y_offset)
+						onbelt_behind.pixel_y += beltl.icon_y_offset
+						onbelt_overlay.pixel_y += beltl.icon_y_offset
+					if(beltl.icon_x_offset)
+						onbelt_overlay.pixel_x += beltl.icon_x_offset
+						onbelt_behind.pixel_x += beltl.icon_x_offset
 					if(ishuman(src))
 						var/mob/living/carbon/human/H = src
 						if(H.dna && H.dna.species)

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -154,7 +154,12 @@
 
 			inhand_overlay = center_image(inhand_overlay, I.inhand_x_dimension, I.inhand_y_dimension)
 			behindhand_overlay = center_image(behindhand_overlay, I.inhand_x_dimension, I.inhand_y_dimension)
-
+			if(I.icon_y_offset)
+				behindhand_overlay.pixel_y += I.icon_y_offset
+				inhand_overlay.pixel_y += I.icon_y_offset
+			if(I.icon_x_offset)
+				behindhand_overlay.pixel_x += I.icon_x_offset
+				inhand_overlay.pixel_x += I.icon_x_offset
 			if(ishuman(src))
 				var/mob/living/carbon/human/H = src
 				if(H.dna && H.dna.species)

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/hats.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/hats.dm
@@ -9,6 +9,12 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
+/obj/item/clothing/head/roguetown/helmet/heavy/astratan/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("onbelt")
+				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
 /obj/item/clothing/head/roguetown/helmet/heavy/malum
 	name = "helm of malum"
 	desc = "Forged in a coal-black, this helmet carries a sigiled blade upon it's visor, ever reminding it's wearer of Malum's powerful gaze."
@@ -19,6 +25,12 @@
 	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
+
+/obj/item/clothing/head/roguetown/helmet/heavy/pestran/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("onbelt")
+				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/heavy/necran
 	name = "necran helmet"
@@ -31,6 +43,12 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
+/obj/item/clothing/head/roguetown/helmet/heavy/necran/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("onbelt")
+				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
 /obj/item/clothing/head/roguetown/helmet/heavy/pestran
 	name = "pestran helmet"
 	desc = "A hooded helmet worn by Her Templars, perfect for times of disease and for the heat of battle."
@@ -42,6 +60,12 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
+/obj/item/clothing/head/roguetown/helmet/heavy/pestran/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("onbelt")
+				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
 /obj/item/clothing/head/roguetown/helmet/heavy/eoran
 	name = "eoran helmet"
 	desc = "A visage of beauty, this helm made in soft pink and beige reminds one of the grace of Eora."
@@ -52,3 +76,9 @@
 	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
+
+/obj/item/clothing/head/roguetown/helmet/heavy/eoran/getonmobprop(tag)
+	if(tag)
+		switch(tag)
+			if("onbelt")
+				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/hats.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/hats.dm
@@ -9,11 +9,6 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
-/obj/item/clothing/head/roguetown/helmet/heavy/astratan/getonmobprop(tag)
-	if(tag)
-		switch(tag)
-			if("onbelt")
-				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/heavy/malum
 	name = "helm of malum"
@@ -26,11 +21,6 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
-/obj/item/clothing/head/roguetown/helmet/heavy/pestran/getonmobprop(tag)
-	if(tag)
-		switch(tag)
-			if("onbelt")
-				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/heavy/necran
 	name = "necran helmet"
@@ -43,12 +33,6 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
-/obj/item/clothing/head/roguetown/helmet/heavy/necran/getonmobprop(tag)
-	if(tag)
-		switch(tag)
-			if("onbelt")
-				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
-
 /obj/item/clothing/head/roguetown/helmet/heavy/pestran
 	name = "pestran helmet"
 	desc = "A hooded helmet worn by Her Templars, perfect for times of disease and for the heat of battle."
@@ -59,12 +43,6 @@
 	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
-
-/obj/item/clothing/head/roguetown/helmet/heavy/pestran/getonmobprop(tag)
-	if(tag)
-		switch(tag)
-			if("onbelt")
-				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/clothing/head/roguetown/helmet/heavy/eoran
 	name = "eoran helmet"
@@ -77,8 +55,3 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
-/obj/item/clothing/head/roguetown/helmet/heavy/eoran/getonmobprop(tag)
-	if(tag)
-		switch(tag)
-			if("onbelt")
-				return list("shrink" = 0.35,"sx" = 10,"sy" = -25,"nx" = 22,"ny" = -25,"wx" = 15,"wy" = -25,"ex" = 15,"ey" = -25,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 180,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 1,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)


### PR DESCRIPTION
## About The Pull Request
Added "onbelt" and "gen" sprite morphs to every helmet
![dreamseeker_niGg1snYFQ](https://github.com/user-attachments/assets/13428fc0-7398-4ed2-9200-a7f357aa9d22)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Above! I tested most of the helmets I could find and a few had their scaling adjusted to look less hyuge. 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No more floating / broken helmets when put on the belt slot. Knights can now look fancier when they take their helmet off.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
