### PR TITLE
Bascinet

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1710,7 +1710,7 @@
 	emote_environment = 3
 	body_parts_covered = HEAD|HAIR|EARS
 	flags_inv = HIDEHAIR
-	block2add = FOV_BEHIND
+	block2add = null
 	smeltresult = /obj/item/ingot/steel
 
 /obj/item/clothing/head/roguetown/helmet/leather


### PR DESCRIPTION
## About The Pull Request

Unvisored bascinet blocks vision despite having identical stats and coverage to sallet which does not, besides visored bascinets flipped up do not cover vision either. If the other outcome is desirable (visored bascinets block vision even while flipped) then say so.

## Testing Evidence

![image](https://github.com/user-attachments/assets/d13139ef-ff7d-43ad-8408-cebf29d7e8b9)
![image](https://github.com/user-attachments/assets/c9f018f7-d469-4550-8920-abe030b09715)


## Why It's Good For The Game

Consistency.
