### PR TITLE
Minor Dungeon and Other Map Updates

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -3603,6 +3603,7 @@
 "buc" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/candle/skull/lit,
+/obj/item/rogueweapon/sword/long/blackflamb,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
 "bud" = (
@@ -5371,6 +5372,8 @@
 	},
 /obj/item/roguegem/diamond,
 /obj/structure/fluff/walldeco/bigpainting/lake,
+/obj/item/roguegem,
+/obj/item/clothing/ring/ruby,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
 "cdx" = (
@@ -6771,6 +6774,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
+"cGT" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/lamia,
+/turf/open/water/swamp/deep,
+/area/rogue/outdoors/bog)
 "cGZ" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -6889,9 +6896,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "cKn" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	locked = 1
-	},
+/obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/outdoors/beach/forest)
 "cKw" = (
@@ -7401,6 +7406,7 @@
 	locked = 1;
 	lockid = "lich"
 	},
+/obj/item/clothing/head/roguetown/helmet/blacksteel/bucket,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
 "cSL" = (
@@ -8802,6 +8808,10 @@
 /obj/item/roguekey/manor,
 /obj/item/roguekey/sergeant,
 /obj/item/roguekey/sergeant,
+/obj/item/scomstone/bad/garrison,
+/obj/item/scomstone/bad/garrison,
+/obj/item/scomstone/bad/garrison,
+/obj/item/scomstone/bad/garrison,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -8892,6 +8902,10 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/random,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
+"dwF" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/lamia,
+/turf/open/water/swamp,
+/area/rogue/outdoors/bog)
 "dwH" = (
 /obj/structure/closet/dirthole/grave,
 /obj/structure/fluff/walldeco/church/line{
@@ -12163,6 +12177,7 @@
 	locked = 1;
 	lockid = "lich"
 	},
+/obj/item/clothing/shoes/roguetown/boots/blacksteel/plateboots,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
 "eIY" = (
@@ -12715,6 +12730,15 @@
 /obj/structure/bars,
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves)
+"eVb" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/suit/roguetown/shirt/vampire,
+/obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/steward,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/manor)
 "eVh" = (
 /obj/structure/roguemachine/atm{
 	location_tag = "the Bathhouse";
@@ -17525,10 +17549,13 @@
 "gOQ" = (
 /obj/structure/closet/crate/roguecloset/lord,
 /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
-/obj/item/clothing/head/roguetown/helmet/heavy/frogmouth,
 /obj/item/rogueweapon/sword/long/judgement,
-/obj/item/clothing/gloves/roguetown/angle,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+/obj/item/clothing/gloves/roguetown/plate,
+/obj/item/clothing/wrists/roguetown/bracers,
+/obj/item/clothing/shoes/roguetown/boots/armor,
+/obj/item/clothing/under/roguetown/chainlegs,
+/obj/item/storage/belt/rogue/leather/steel/tasset,
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "gOR" = (
@@ -19068,6 +19095,34 @@
 "htN" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
+"htQ" = (
+/obj/item/bomb{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/bomb{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/bomb{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/bomb{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/bomb{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/bomb{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement/keep)
 "htV" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
@@ -23534,6 +23589,8 @@
 	lockid = "lich"
 	},
 /obj/item/roguegem/blue,
+/obj/item/roguegem/violet,
+/obj/item/clothing/ring/quartz,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
 "jdu" = (
@@ -29394,6 +29451,8 @@
 	lockid = "lich"
 	},
 /obj/item/storage/belt/rogue/pouch/coins/rich,
+/obj/item/storage/belt/rogue/pouch/coins/rich,
+/obj/item/storage/belt/rogue/pouch/coins/rich,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
 "ltk" = (
@@ -32139,6 +32198,7 @@
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/rope/chain,
 /obj/item/gwstrap,
+/obj/item/rogueweapon/mace/cudgel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "mCs" = (
@@ -33633,6 +33693,16 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"nhC" = (
+/obj/structure/closet/crate/chest/gold{
+	locked = 1;
+	lockid = "lich"
+	},
+/obj/item/book/granter/spell/blackstone/greaterfireball,
+/obj/item/book/granter/spell/blackstone/lightning,
+/obj/item/book/granter/spell/blackstone/acidsplash,
+/turf/open/floor/rogue/carpet/lord/left,
+/area/rogue/under/cave/licharena)
 "nhE" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -40335,6 +40405,9 @@
 	pixel_y = -32
 	},
 /obj/structure/closet/crate/roguecloset/dark,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
+/obj/item/clothing/suit/roguetown/shirt/vampire,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "pJJ" = (
@@ -47034,6 +47107,7 @@
 	lockid = "lich"
 	},
 /obj/item/clothing/suit/roguetown/armor/plate/blacksteel_full_plate,
+/obj/item/clothing/suit/roguetown/armor/plate/blacksteel_full_plate,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
 "snF" = (
@@ -48575,6 +48649,24 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"sTD" = (
+/obj/structure/closet/crate/chest/gold{
+	locked = 1;
+	lockid = "lich"
+	},
+/obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/item/ingot/gold,
+/obj/item/ingot/gold,
+/obj/item/ingot/silver,
+/obj/item/ingot/silver,
+/obj/item/ingot/silver,
+/obj/item/ingot/silver,
+/obj/item/ingot/gold,
+/obj/item/ingot/gold,
+/turf/open/floor/rogue/church,
+/area/rogue/under/cave/licharena)
 "sTI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -50418,6 +50510,10 @@
 	lockid = "lich"
 	},
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
+/obj/item/ingot/blacksteel,
+/obj/item/ingot/blacksteel,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
 "tGW" = (
@@ -50983,6 +51079,15 @@
 "tSv" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/beach)
+"tSx" = (
+/obj/structure/closet/crate/chest/gold{
+	locked = 1;
+	lockid = "lich"
+	},
+/obj/item/book/granter/spell/blackstone/skeleton,
+/obj/item/book/granter/spell/blackstone/bonechill,
+/turf/open/floor/rogue/carpet/lord/right,
+/area/rogue/under/cave/licharena)
 "tSy" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -51612,6 +51717,7 @@
 /obj/structure/closet/crate/roguecloset,
 /obj/item/scomstone,
 /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+/obj/item/clothing/mask/rogue/facemask/psydonmask,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/basement)
 "udO" = (
@@ -55802,6 +55908,10 @@
 	lockid = "lich"
 	},
 /obj/item/roguegem/green,
+/obj/item/clothing/ring/topaz,
+/obj/item/clothing/ring/topaz,
+/obj/item/roguegem/yellow,
+/obj/item/roguegem/yellow,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
 "vLv" = (
@@ -56527,6 +56637,7 @@
 "vYL" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/book/rogue/law,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "vYO" = (
@@ -57693,6 +57804,7 @@
 	locked = 1;
 	lockid = "lich"
 	},
+/obj/item/clothing/gloves/roguetown/blacksteel/plategloves,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena)
 "wve" = (
@@ -157751,7 +157863,7 @@ eWv
 dZz
 iad
 bYC
-wCC
+htQ
 wCC
 wCC
 wCC
@@ -180782,21 +180894,21 @@ eww
 vek
 vek
 vek
-nSO
+dqs
 dUd
-nSO
+dqs
 vek
-nSO
+dqs
 vek
-nSO
+dqs
 vek
 dUd
 vek
-nSO
+dqs
 vek
-nSO
+dqs
 vek
-nSO
+dqs
 oQk
 ujm
 ujm
@@ -182598,7 +182710,7 @@ vek
 vek
 vek
 iSG
-vek
+ict
 vek
 vek
 vek
@@ -183485,7 +183597,7 @@ ujm
 ujm
 ujm
 oQk
-tGU
+sTD
 cgR
 cgR
 wZZ
@@ -184841,7 +184953,7 @@ ujm
 ujm
 ujm
 oQk
-vNc
+nhC
 bqp
 vNc
 vNc
@@ -186649,7 +186761,7 @@ ujm
 ujm
 ujm
 oQk
-swK
+tSx
 swK
 swK
 swK
@@ -188926,7 +189038,7 @@ vek
 vek
 vek
 iSG
-vek
+ict
 vek
 vek
 vek
@@ -190726,21 +190838,21 @@ eww
 vek
 vek
 vek
-nSO
+dqs
 dUd
-nSO
+dqs
 vek
-nSO
+dqs
 vek
-nSO
+dqs
 vek
 dUd
 vek
-nSO
+dqs
 vek
-nSO
+dqs
 vek
-nSO
+dqs
 oQk
 ujm
 ujm
@@ -301060,7 +301172,7 @@ vhs
 epy
 qUs
 vhs
-vhs
+cGT
 vhs
 vhs
 vQH
@@ -303704,7 +303816,7 @@ hgc
 epy
 vhs
 vQH
-vhs
+cGT
 vhs
 vhs
 hgc
@@ -313227,7 +313339,7 @@ mrW
 mrW
 tYx
 czH
-vhs
+cGT
 vhs
 vQH
 vQH
@@ -314201,7 +314313,7 @@ qUs
 vhs
 vhs
 vhs
-vhs
+cGT
 vhs
 vhs
 vQH
@@ -323179,7 +323291,7 @@ tYx
 tYx
 tYx
 czH
-vhs
+cGT
 vhs
 vhs
 epy
@@ -327245,7 +327357,7 @@ vhs
 vhs
 vQH
 vhs
-czH
+dwF
 czH
 czH
 mrW
@@ -328634,7 +328746,7 @@ qUs
 qUs
 czH
 czH
-czH
+dwF
 tYx
 tYx
 tYx
@@ -386910,7 +387022,7 @@ uQS
 jyb
 uQS
 uQS
-aIh
+eVb
 vxe
 vmi
 vmi

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -103,6 +103,9 @@
 /obj/item/clothing/wrists/roguetown/bracers/leather,
 /obj/item/clothing/wrists/roguetown/bracers,
 /obj/item/clothing/wrists/roguetown/bracers,
+/obj/item/clothing/wrists/roguetown/bracers/leather/heavy,
+/obj/item/clothing/wrists/roguetown/bracers/leather/heavy,
+/obj/item/clothing/wrists/roguetown/bracers/leather/heavy,
 /turf/open/floor/rogue/carpet,
 /area/rogue)
 "ao" = (
@@ -116,6 +119,10 @@
 /obj/item/clothing/suit/roguetown/armor/leather,
 /obj/item/clothing/suit/roguetown/armor/leather,
 /obj/item/clothing/suit/roguetown/armor/leather,
+/obj/item/clothing/suit/roguetown/armor/leather/heavy,
+/obj/item/clothing/suit/roguetown/armor/leather/heavy,
+/obj/item/clothing/suit/roguetown/armor/leather/heavy/coat,
+/obj/item/clothing/suit/roguetown/armor/leather/heavy/coat,
 /turf/open/floor/rogue/carpet,
 /area/rogue)
 "ap" = (
@@ -127,6 +134,18 @@
 /obj/item/clothing/suit/roguetown/armor/plate,
 /obj/item/clothing/suit/roguetown/armor/plate,
 /obj/item/clothing/suit/roguetown/armor/plate,
+/obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+/obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+/obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+/obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+/obj/item/clothing/suit/roguetown/armor/plate/full/fluted,
+/obj/item/clothing/suit/roguetown/armor/plate/full/fluted,
+/obj/item/clothing/suit/roguetown/armor/plate/full/fluted,
+/obj/item/clothing/suit/roguetown/armor/plate/full/fluted,
+/obj/item/clothing/suit/roguetown/armor/plate/full,
+/obj/item/clothing/suit/roguetown/armor/plate/full,
+/obj/item/clothing/suit/roguetown/armor/plate/full,
+/obj/item/clothing/suit/roguetown/armor/plate/full,
 /turf/open/floor/rogue/carpet,
 /area/rogue)
 "aq" = (
@@ -138,6 +157,10 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy,
 /turf/open/floor/rogue/carpet,
 /area/rogue)
 "ar" = (
@@ -242,6 +265,8 @@
 	},
 /obj/item/clothing/head/roguetown/helmet/leather,
 /obj/item/clothing/head/roguetown/helmet/leather,
+/obj/item/clothing/head/roguetown/helmet/leather/advanced,
+/obj/item/clothing/head/roguetown/helmet/leather/advanced,
 /turf/open/floor/rogue/carpet,
 /area/rogue)
 "aC" = (
@@ -260,11 +285,10 @@
 	icon_state = "tablewood2";
 	dir = 10
 	},
-/obj/item/clothing/under/roguetown/trou,
-/obj/item/clothing/under/roguetown/trou,
-/obj/item/clothing/under/roguetown/trou,
-/obj/item/clothing/under/roguetown/trou,
-/obj/item/clothing/under/roguetown/trou,
+/obj/item/clothing/under/roguetown/heavy_leather_pants,
+/obj/item/clothing/under/roguetown/heavy_leather_pants,
+/obj/item/clothing/under/roguetown/heavy_leather_pants,
+/obj/item/clothing/under/roguetown/heavy_leather_pants,
 /turf/open/floor/rogue/carpet,
 /area/rogue)
 "aE" = (
@@ -347,6 +371,9 @@
 /obj/item/clothing/neck/roguetown/coif,
 /obj/item/clothing/neck/roguetown/coif,
 /obj/item/clothing/neck/roguetown/coif,
+/obj/item/clothing/neck/roguetown/leather,
+/obj/item/clothing/neck/roguetown/leather,
+/obj/item/clothing/neck/roguetown/leather,
 /turf/open/floor/rogue/carpet,
 /area/rogue)
 "aM" = (
@@ -1145,7 +1172,6 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "de" = (
-/obj/machinery/light/rogue/torchholder/c,
 /obj/effect/landmark/start/vampireknight,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
@@ -1792,6 +1818,11 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/banditcamp)
+"qG" = (
+/obj/structure/bars,
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors)
 "rr" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/herringbone,
@@ -1830,6 +1861,17 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue)
+"sP" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood2";
+	dir = 10
+	},
+/obj/item/rogueweapon/halberd/glaive,
+/obj/item/rogueweapon/halberd/glaive,
+/obj/item/rogueweapon/halberd/glaive,
+/obj/item/rogueweapon/halberd/glaive,
+/turf/open/floor/rogue/cobble,
+/area/rogue)
 "sQ" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -1837,6 +1879,20 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
+"sX" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors)
+"tx" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood2";
+	dir = 10
+	},
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/obj/item/gun/ballistic/revolver/grenadelauncher/sling,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors)
 "tN" = (
 /turf/closed,
 /area/rogue/under)
@@ -2086,6 +2142,22 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/banditcamp)
+"yR" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood2";
+	dir = 10
+	},
+/obj/projectile/bullet/reusable/sling_bullet/stone,
+/obj/projectile/bullet/reusable/sling_bullet/stone,
+/obj/projectile/bullet/sling_bullet,
+/obj/projectile/bullet/sling_bullet,
+/obj/projectile/bullet/sling_bullet,
+/obj/projectile/bullet/sling_bullet,
+/obj/projectile/bullet/sling_bullet,
+/obj/projectile/bullet/sling_bullet,
+/obj/projectile/bullet/sling_bullet,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors)
 "zk" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -2152,6 +2224,15 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/banditcamp)
+"AQ" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood2";
+	dir = 10
+	},
+/obj/item/storage/belt/rogue/surgery_bag/full,
+/obj/item/storage/belt/rogue/surgery_bag/full,
+/turf/open/floor/rogue/cobble,
+/area/rogue)
 "AT" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/herringbone,
@@ -2245,6 +2326,12 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow,
+/obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
 "Do" = (
@@ -2304,6 +2391,11 @@
 /obj/item/rogueweapon/huntingknife/idagger/silver,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
+"EO" = (
+/obj/structure/bars,
+/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors)
 "EP" = (
 /obj/effect/landmark/start/banditlate,
 /turf/open/floor/rogue/tile{
@@ -2449,6 +2541,11 @@
 	icon_state = "tablewood2";
 	dir = 10
 	},
+/obj/item/rogueweapon/sword/falx,
+/obj/item/rogueweapon/sword/falx,
+/obj/item/rogueweapon/sword/falx,
+/obj/item/rogueweapon/sword/falx,
+/obj/item/rogueweapon/sword/falx,
 /turf/open/floor/rogue/cobble,
 /area/rogue)
 "JA" = (
@@ -2599,6 +2696,10 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/banditcamp)
+"Pu" = (
+/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors)
 "PU" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -2794,6 +2895,17 @@
 /obj/item/quiver/bolts,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors)
+"Vl" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood2";
+	dir = 10
+	},
+/obj/item/rogueweapon/sword/gladius,
+/obj/item/rogueweapon/sword/gladius,
+/obj/item/rogueweapon/sword/gladius,
+/obj/item/rogueweapon/sword/gladius,
+/turf/open/floor/rogue/cobble,
+/area/rogue)
 "Vu" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/ruinedwood{
@@ -5227,7 +5339,7 @@ al
 vP
 aY
 lw
-lw
+sP
 lw
 jQ
 vP
@@ -5619,7 +5731,7 @@ bb
 lw
 Is
 lw
-Jp
+Vl
 vP
 bX
 kB
@@ -5877,7 +5989,7 @@ Ph
 lw
 lw
 lw
-lw
+AQ
 lw
 pE
 vP
@@ -6523,7 +6635,7 @@ Do
 Do
 Ph
 Ph
-Do
+yR
 bX
 bX
 bX
@@ -6653,7 +6765,7 @@ RH
 RH
 Ph
 Ph
-Do
+tx
 bX
 bX
 bX
@@ -10731,7 +10843,7 @@ WB
 Gz
 Tf
 cZ
-cZ
+sX
 dh
 WB
 WB
@@ -11120,7 +11232,7 @@ cD
 WB
 Gz
 Tf
-da
+EO
 cZ
 cZ
 dS
@@ -11250,7 +11362,7 @@ cb
 WB
 cP
 cO
-da
+qG
 dQ
 cZ
 da
@@ -11512,7 +11624,7 @@ cQ
 cN
 cN
 cZ
-cZ
+Pu
 WB
 dq
 dx


### PR DESCRIPTION
* Increases the reward yield for conquering and fighting the Lich boss, as it requires a large group of players to fight this unique mob, with a very high risk for a good quantity of players to get turned into lynch mob victims, nuggets, and BBQ'd by the Lich and his goons.
* Because I'm sinister and evil, a small handful lamia were placed around the terrorbog. Enjoy. Note, they are distant from one another.
* Adjustments made to the staff only area.
* Removed and replaced a few armor pieces in the lord's closet, they're not a frontliner but should still have access to something in case.
* Added a few pieces of clothes and other items to the marshal's and Hand's rooms. 
*Added a few houndstones to the sergeant's key closet, to hand out to an additionally hired members of the garrison, etc.
