### PR TITLE
Increase apprentice post-spawn slot to 4

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -3,7 +3,7 @@
 	flag = MAGEAPPRENTICE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 3
+	total_positions = 4
 	spawn_positions = 4
 
 	allowed_races = RACES_ALL_KINDS


### PR DESCRIPTION
## About The Pull Request
Associates for some reason have 4 slots if 4 people queue up and fight for it at roundstart and 3 otherwise if it is late joined and filled. This was made 6 months ago. I don't understand the decision.

Also mage tower have more beds now + mage associates don't usually directly participate in combat outside of combat so it is a whatever roles. 

GIVE ME MY SLOT BACK. I want my RP...

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
none

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
i need that slot

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
