### PR TITLE
[FIX]: Fixes any potential duplication bug with reusable projectiles

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -98,12 +98,7 @@
 	visible_message(span_danger("[src] is hit by \a [P]!"), null, null, COMBAT_MESSAGE_RANGE)
 	if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
 		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armor_penetration)
-	//AZURE PEAK ADDITION START: Make sure reusable projectiles don't disappear on hit
-	if(istype(P, /obj/projectile/bullet/reusable))
-		var/obj/projectile/bullet/reusable/R = P
-		if(!R.dropped)
-			R.handle_drop()
-	//AZURE PEAK ADDITION END
+	P.handle_drop() //AZURE PEAK: Make sure reusable projectiles don't disappear on hit
 
 /obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
 	user.do_attack_animation(src)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -98,7 +98,12 @@
 	visible_message(span_danger("[src] is hit by \a [P]!"), null, null, COMBAT_MESSAGE_RANGE)
 	if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
 		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armor_penetration)
-	P.handle_drop() //AZURE PEAK: Make sure reusable projectiles don't disappear on hit
+	//AZURE PEAK ADDITION START: Make sure reusable projectiles don't disappear on hit
+	if(istype(P, /obj/projectile/bullet/reusable))
+		var/obj/projectile/bullet/reusable/R = P
+		if(!R.dropped)
+			R.handle_drop()
+	//AZURE PEAK ADDITION END
 
 /obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
 	user.do_attack_animation(src)

--- a/code/modules/projectiles/projectile/reusable/_reusable.dm
+++ b/code/modules/projectiles/projectile/reusable/_reusable.dm
@@ -3,11 +3,15 @@
 	desc = ""
 	ammo_type = /obj/item/ammo_casing/caseless
 	impact_effect_type = null
+	var/has_dropped = FALSE  //Flag to track if we've already dropped the ammo
 
 /obj/projectile/bullet/reusable/handle_drop()
-	if(dropped)
-		dropped.forceMove(get_turf(dropped))
-	else
+	if(has_dropped)  //If we've already dropped an ammo, do nothing
+		return
+	has_dropped = TRUE  //Mark as dropped
+	if(dropped)  //If it exists, move it to the turf
+		dropped.forceMove(get_turf(src))
+	else  //Otherwise create it
 		var/turf/T = get_turf(src)
 		dropped = new ammo_type(T)
 


### PR DESCRIPTION
## About The Pull Request
Thanks to https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2176 an interesting bug came to surface: when arrows failed the CheckExit() check of objects such as chairs, benches (or anything that stops any atom from exiting the object from a specific direction), said arrows would jitter in place until they reached their max distance of movement, triggering their own on_range() which then called handle_drop(). But since they also called Bump(), the code that I added recently was triggered. Effectively this duplicated the arrows.
Instead of fixing the arrows not being able to exit chairs (as it might be an intended feature) I decided to fix the origin of the issue directly by making sure handle_drop() sets a flag to true for a single projectile, stopping it from dropping multiple reusable projectiles at once.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Bug:

https://github.com/user-attachments/assets/1ba3ddb8-d2ba-4b21-ba53-d0d8f0e230f5

Fix:

https://github.com/user-attachments/assets/42d77d7d-6301-4373-b218-2bf5b110c9e4


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugfix.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
