### PR TITLE
Fix exploit in lottery machine

### DIFF
--- a/code/modules/roguetown/roguemachine/lottery.dm
+++ b/code/modules/roguetown/roguemachine/lottery.dm
@@ -150,6 +150,8 @@
 			return
 		if(!Adjacent(user))
 			return
+		if(src.stopgambling == 1) // double check because it's possible to have input field open before starting gambling
+			return
 		if((coin_amt*mod) > gamblingprice)
 			playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 			return


### PR DESCRIPTION
## About The Pull Request

Fixes a bug introduced in #339

## Testing Evidence

Currently this exploit exists and can be tested by doing the following steps.

1) Insert gold
2) Right click the machine to open the withdraw dialog
3) Keep it open and middle click to gamble
4) Withdraw money on when fail sound effect triggers

This adds an additional check before coins withdraw to see if gambling is currently underway.

## Why It's Good For The Game

Closes an exploit for infinite coins.