### PR TITLE
Simple Belt nerf

### DIFF
--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -77,17 +77,20 @@
 	icon_state = "rope"
 	item_state = "rope"
 	color = "#b9a286"
+	component_type = /datum/component/storage/concrete/roguetown/belt/cloth
 
 /obj/item/storage/belt/rogue/leather/cloth
 	name = "cloth sash"
 	desc = ""
 	icon_state = "cloth"
+	component_type = /datum/component/storage/concrete/roguetown/belt/cloth
 
 /obj/item/storage/belt/rogue/leather/cloth/lady
 	color = "#575160"
 
 /obj/item/storage/belt/rogue/leather/cloth/bandit
 	color = "#ff0000"
+	component_type = /datum/component/storage/concrete/roguetown/belt //bandits are clever at making space I guess
 
 /obj/item/storage/belt/rogue/pouch
 	name = "pouch"

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -90,7 +90,7 @@
 
 /obj/item/storage/belt/rogue/leather/cloth/bandit
 	color = "#ff0000"
-	component_type = /datum/component/storage/concrete/roguetown/belt //bandits are clever at making space I guess
+	component_type = /datum/component/storage/concrete/roguetown/belt
 
 /obj/item/storage/belt/rogue/pouch
 	name = "pouch"


### PR DESCRIPTION
## About The Pull Request
Adds preexisting storage component meant for cloth belts to cloth and rope belts, nerfing their storage
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It's already there bro
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Returns old consistency pre-grid storage where shitty belts had shitty storage
I didn't actually consider who has or hasn't a cool belt (except bandits) , I just think a couple pieces of twine shouldn't hold 2 swords and 3 knives
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
