### PR TITLE
Small skill oversight fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -372,6 +372,7 @@
 		
 		if("Greataxe + Sling")
 			H.mind.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 			r_hand = /obj/item/rogueweapon/greataxe/steel
 			backl = /obj/item/gwstrap
 			beltr = /obj/item/quiver/sling/iron

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -372,7 +372,7 @@
 		
 		if("Greataxe + Sling")
 			H.mind.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
+			H.mind.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
 			r_hand = /obj/item/rogueweapon/greataxe/steel
 			backl = /obj/item/gwstrap
 			beltr = /obj/item/quiver/sling/iron


### PR DESCRIPTION
## About The Pull Request

In the https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2168 PR
Royal champions receive a greataxe + slings option.
However, they have no axe skills and are not given any from the selection.
This resolves that issue.

## Testing Evidence

I didn't. It should be fine though!

## Why It's Good For The Game

Now they won't suck with axes despite supposed to be very good at it?
