### PR TITLE
Adds a swing delay to warhammer pick

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -436,7 +436,7 @@
 	animname = "stab"
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
 	misscost = 1
-	swingdelay = 14
+	swingdelay = 15
 	penfactor = 80
 	damfactor = 0.9
 	item_d_type = "stab"

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -433,10 +433,10 @@
 	icon_state = "inpick"
 	blade_class = BCLASS_PICK
 	attack_verb = list("picks", "impales")
+	animname = "stab"
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
-	chargetime = 14
 	misscost = 1
-	no_early_release = TRUE
+	swingdelay = 14
 	penfactor = 80
 	damfactor = 0.9
 	item_d_type = "stab"


### PR DESCRIPTION
## About The Pull Request
Now it's (almost) the same as every other pick, except the swing delay is slightly longer.
It no longer has a chargetime, only a swingdelay.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
booted it up and had at it
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It was out of line of every other pick for a while and the way it was differentiated (chargetime) didn't seem to work out.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
