### PR TITLE
Adds a variable to exclude certain Antagonists from counting towards the gamemode's Antag count

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -642,7 +642,16 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if (M.stat != DEAD)
 			current_players[CURRENT_LIVING_PLAYERS].Add(M)
 			if (M.mind && (M.mind.special_role || M.mind.antag_datums?.len > 0))
-				current_players[CURRENT_LIVING_ANTAGS].Add(M)
+				// AZURE PEAK ADDITION START: Check if player has any antags that use an antag slot
+				var/counts_as_antag = FALSE
+				for(var/datum/antagonist/A in M.mind.antag_datums || list())
+					if(A.uses_antag_slot)
+						counts_as_antag = TRUE
+						break
+				if(counts_as_antag)
+					current_players[CURRENT_LIVING_ANTAGS].Add(M)
+				// AZURE PEAK ADDITION END
+				// current_players[CURRENT_LIVING_ANTAGS].Add(M) // AZURE PEAK: Commented out original code
 		else
 			if (istype(M,/mob/dead/observer))
 				var/mob/dead/observer/O = M

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/antag_hud_type
 	var/antag_hud_name
 	var/list/confess_lines
+	var/uses_antag_slot = TRUE // AZURE PEAK: Whether this antag type counts toward the antag limit
 
 	//Antag panel properties
 	var/show_in_antagpanel = TRUE	//This will hide adding this antag type in antag panel, use only for internal subtypes that shouldn't be added directly but still show if possessed by mind

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -7,6 +7,7 @@
 	antag_hud_name = "zombie"
 	show_in_roundend = FALSE
 	rogue_enabled = TRUE
+	uses_antag_slot = FALSE  // Prevents zombie/deadite from taking up antag slots
 	/// SET TO FALSE IF WE DON'T TURN INTO ROTMEN WHEN REMOVED
 	var/become_rotman = FALSE
 	var/zombie_start


### PR DESCRIPTION
## About The Pull Request
Requested by staff, adds a variable that excludes certain antags from counting towards the gamemode's living antags so that they don't limit new ones from appearing, this was applied to deadites in this PR. It still counts the player as a living antag if they have an antag type that doesn't have this variable set to true, so a Deadite Vampire will count as a living antag.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Can't seem to force dynamic gamemode locally, please trust/Test Merge
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Make sure "antagonists" like Deadites don't actually stop other antag types from potentially spawning
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
