### PR TITLE
Cavalryman Saiga

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -172,7 +172,7 @@
 
 /datum/advclass/manorguard/cavalry
 	name = "Cavalryman"
-	tutorial = "You are a professional soldier of the realm, specializing in the steady beat of hoof falls. Lighter and more expendable then the knights, you charge with lance in hand. Beast sold seperately."
+	tutorial = "You are a professional soldier of the realm, specializing in the steady beat of hoof falls. Lighter and more expendable then the knights, you charge with lance in hand."
 	outfit = /datum/outfit/job/roguetown/manorguard/cavalry
 	horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled //Since knights start with the Buck
 

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -174,6 +174,7 @@
 	name = "Cavalryman"
 	tutorial = "You are a professional soldier of the realm, specializing in the steady beat of hoof falls. Lighter and more expendable then the knights, you charge with lance in hand. Beast sold seperately."
 	outfit = /datum/outfit/job/roguetown/manorguard/cavalry
+	horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled //Since knights start with the Buck
 
 	category_tags = list(CTAG_MENATARMS)
 


### PR DESCRIPTION
## About The Pull Request

Gives Cavalryman loadout for Man-At-Arms a mount (Saiga Doe).

## Testing Evidence

![image](https://github.com/user-attachments/assets/c44080c3-72cd-49e2-8b21-ad5e7eb4def4)
![image](https://github.com/user-attachments/assets/846fef26-29e7-4357-a359-4e3817381db7)

## Why It's Good For The Game

It has no real benefit over playing a footman and doesn't even live up to a fantasy of being mounted watchman, so now it might even be picked.
