### PR TITLE
[FIX]: Fixes polishing tools being massive and infinite integrity exploit

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -87,6 +87,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	dropshrink = 0.8
 	var/uses = 12
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/polishing_cream/examine(mob/user)
 	. = ..()
@@ -120,6 +122,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	smeltresult = null
 	dropshrink = 0.8
+	grid_width = 32
+	grid_height = 32
 	var/roughness = 0 // 0  for a fine brush, 1 for a coarse brush
 
 /obj/item/armor_brush/attack_self(mob/user)
@@ -161,6 +165,8 @@
 			polished = 0
 			force -= 2
 			force_wielded -= 3
+			max_integrity -= 50
+			obj_integrity = min(obj_integrity, max_integrity)
 			var/datum/component/glint = GetComponent(/datum/component/metal_glint)
 			qdel(glint)
 		else if(polished >= 1 && polished <= 4)
@@ -172,6 +178,7 @@
 		polished = 4
 		remove_atom_colour(FIXED_COLOUR_PRIORITY)
 		add_atom_colour("#ffffff", FIXED_COLOUR_PRIORITY)
+		max_integrity += 50
 		obj_integrity += 50
 		force += 2
 		force_wielded += 3


### PR DESCRIPTION
## About The Pull Request
Fixes polishing tools occupying 4 inventory grids and also fixes an exploit that allowed polished tools to be infinitely applied +50 integrity. Now the code appropriately applies the temporary max integrity then removes it once the object is damaged.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![a](https://github.com/user-attachments/assets/0336fbea-b5d0-49bd-92ae-9bf0e9129841)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gubfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
