### PR TITLE
Removes blade dulling from parry damage

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -333,7 +333,7 @@
 					else
 						flash_fullscreen("blackflash2")
 
-					var/dam2take = round((get_complex_damage(AB,user,used_weapon.blade_dulling)/2),1)
+					var/dam2take = round((get_complex_damage(AB,user,FALSE)/2),1)
 					if(dam2take)
 						if(dam2take > 0 && intenty.masteritem?.intdamage_factor)
 							dam2take = dam2take * intenty.masteritem?.intdamage_factor


### PR DESCRIPTION
## About The Pull Request
Two-fold reason:
- This fixes the rare (but impactful) instances where certain weapon vs weapon combos resulted in NO parry damage taken.
- Given the increased presence of damage multipliers vs integrity (and higher damfactors overall), it's best to not bog it down even more.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This makes parry damage be a consistent value that's half of the total boosted value (from STR + damfactor). This does not alter anything in relation to picking walls etc.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
