### PR TITLE
a very HEARTFELT PR

### DIFF
--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -2,7 +2,6 @@
 	name = "Lord of Heartfelt"
 	greet_text = "You are the Lord of Heartfelt, ruler of a once-prosperous barony now in ruin. Guided by your Magos, you journey to the Peak, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
 	outfit = /datum/outfit/job/roguetown/heartfelt/lord
-	allowed_sexes = list(MALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	grant_lit_torch = TRUE
 	show_wanderer_examine = FALSE
@@ -211,7 +210,7 @@
 	name = "Magos of Heartfelt"
 	greet_text = "You are the Magos of Heartfelt, renowned for your arcane knowledge yet unable to foresee the tragedy that befell your home. Drawn by a guiding star to the Peak, you seek answers and perhaps a new purpose in the wake of destruction."
 	outfit = /datum/outfit/job/roguetown/heartfelt/magos
-	allowed_races = RACES_ALL_KINDS
+	allowed_races = RACES_NO_CONSTRUCT
 	grant_lit_torch = TRUE
 	show_wanderer_examine = FALSE
 
@@ -271,7 +270,7 @@
 	name = "Prior of Heartfelt"
 	greet_text = "The Prior of Heartfelt, you were destined for ascension within the Church, but fate intervened with the barony's downfall, delaying it indefinitely. Still guided by the blessings of Astrata, you journey to the Peak, determined to offer what aid and solace you can."
 	outfit = /datum/outfit/job/roguetown/heartfelt/prior
-	allowed_races = RACES_ALL_KINDS
+	allowed_races = RACES_NO_CONSTRUCT
 	grant_lit_torch = TRUE
 	show_wanderer_examine = FALSE
 

--- a/code/datums/migrants/migrant_waves/heartfelt wave.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt wave.dm
@@ -46,9 +46,65 @@
 	name = "The Court of Heartfelt"
 	shared_wave_type = /datum/migrant_wave/heartfelt
 	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_four
 	roles = list(
 		/datum/migrant_role/heartfelt/lord = 1,
 		/datum/migrant_role/heartfelt/knight = 1,
 		/datum/migrant_role/heartfelt/hand = 1,
 	)
 	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+
+/datum/migrant_wave/heartfelt_down_four
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_five
+	roles = list(
+		/datum/migrant_role/heartfelt/lord = 1,
+		/datum/migrant_role/heartfelt/lady = 1,
+		/datum/migrant_role/heartfelt/knight = 1,
+	)
+	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+
+/datum/migrant_wave/heartfelt_down_five
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_six
+	roles = list(
+		/datum/migrant_role/heartfelt/lord = 1,
+		/datum/migrant_role/heartfelt/hand = 1,
+	)
+	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Now, in the end, it is only the Lord and their trusty Hand left on their lonesome..."
+
+/datum/migrant_wave/heartfelt_down_six
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_seven
+	roles = list(
+		/datum/migrant_role/heartfelt/lord = 1,
+		/datum/migrant_role/heartfelt/knight = 1,
+	)
+	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Now, in the end, it is only the Lord and their trusty knight left on their lonesome..."
+
+
+/datum/migrant_wave/heartfelt_down_seven
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_eight
+	roles = list(
+		/datum/migrant_role/heartfelt/lord = 1,
+		/datum/migrant_role/heartfelt/lady = 1,
+	)
+	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Now, in the end, it is only the Lord and their love left on their lonesome..."
+
+/datum/migrant_wave/heartfelt_down_eight
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	roles = list(
+		/datum/migrant_role/heartfelt/lord = 1,
+	)
+	greet_text = "Fleeing disaster, you have came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. It was all for naught - in the end, only you are left, bereft of your family and men. How the mighty have fallen..."


### PR DESCRIPTION
## About The Pull Request

I was picking away at making a new migrant wave and decided to take a look at the Heartfelt and why they never get played. Before, the fewest Heartfelt that could spawn was 3, and they HAD to be the Lord, Knight and Hand; now, the game will attempt to spawn another combination failing that (lord/LADY/hand), then attempt to spawn pairs: Lord and Hand, Lord and Knight, Lord and Lady - eventually allowing a singular Lord to spawn. This might be controversial, but I think having a lone survivor is compelling and they make an excellent antagonism target. As well, more people will likely begin to play Heartfelt in greater numbers if you allow fewer; I believe the barrier to entry has a stifling effect, and enabling more Lord and Lady spawns together may be more appealing to many.

This also prevents Constructs from being the Magos and Prior, as they already cannot be court magicians/apprentices or most churchoids, and removes the gender lock on Lords as it was checking (I think?) for body type, not gender, and we like to gender-unlock roles anyways. I left the Lady's as it is, you know, the Lady. It would be a little weird to have a beefcake Lady of Heartfelt. Extremely funny, but maybe too much.

Eventually I would like to just improve the system so you can queue as whichever you want instead of it opening specific roles, but revamping the whole fucking shitty migrant system is beyond my abilities right now, I'm probably going to commission it and I just want to play a femboy Lord, smh.

## Testing Evidence

On a locally hosted version the Heartfelt roll successfully cycles through the different combinations and a lone Lord spawn *as a feminine body type character* was possible. By the way, it looks like the on-mob Heartfelt armor sprite is broken, and I don't know why. 

## Why It's Good For The Game

Lady lords good...................
