### PR TITLE
Revert "Removes blade dulling from parry damage"

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -333,7 +333,7 @@
 					else
 						flash_fullscreen("blackflash2")
 
-					var/dam2take = round((get_complex_damage(AB,user,FALSE)/2),1)
+					var/dam2take = round((get_complex_damage(AB,user,used_weapon.blade_dulling)/2),1)
 					if(dam2take)
 						if(dam2take > 0 && intenty.masteritem?.intdamage_factor)
 							dam2take = dam2take * intenty.masteritem?.intdamage_factor


### PR DESCRIPTION
Reverts GeneralPantsuIsBadAtCoding/Azure-Peak#2241

this turned every weapon into a polearm fragility wise, which seems to have been overall a negative for combat
(which means the people talking about polearms feeling awful were very, very, right and should feel vindicated)

I'm not quite done with tweaking parry damage, but this is a stopgap for now that makes swords / axes etc immune to pve parry damage again