### PR TITLE
Repath millstone, makes it placeable on table and an item

### DIFF
--- a/_maps/map_files/dun_manor/azure_forest.dmm
+++ b/_maps/map_files/dun_manor/azure_forest.dmm
@@ -2277,7 +2277,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -6400,7 +6400,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves)
 "ZQ" = (
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 12
 	},
 /obj/structure/table/wood,

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -4818,7 +4818,7 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/beach)
 "djr" = (
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /obj/structure/table/wood,
@@ -5983,7 +5983,7 @@
 /area/rogue/indoors/town/church)
 "dYe" = (
 /obj/structure/table/wood,
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 12
 	},
 /obj/item/reagent_containers/peppermill{
@@ -8970,7 +8970,7 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/tile,
@@ -11056,7 +11056,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -14203,7 +14203,7 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/tile,
@@ -14588,7 +14588,7 @@
 	dir = 9;
 	icon_state = "largetable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -16688,7 +16688,7 @@
 	dir = 1;
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /obj/machinery/light/rogue/wallfire/candle{
@@ -20219,7 +20219,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/blocks,
@@ -20520,7 +20520,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /obj/machinery/light/rogue/wallfire/candle{
@@ -23496,7 +23496,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -28651,7 +28651,7 @@
 	dir = 1;
 	icon_state = "longtable_mid"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/tile,
@@ -33148,7 +33148,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -33501,7 +33501,7 @@
 /area/rogue/indoors/town)
 "xvz" = (
 /obj/structure/table/wood,
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -34406,7 +34406,7 @@
 	dir = 10;
 	icon_state = "largetable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 12
 	},
 /turf/open/floor/rogue/blocks,

--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -3524,7 +3524,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "TT" = (
-/obj/structure/fluff/millstone,
+/obj/item/millstone,
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "TU" = (

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -2874,7 +2874,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/mazedungeon)
 "beg" = (
-/obj/structure/fluff/millstone,
+/obj/item/millstone,
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "beq" = (
@@ -5084,7 +5084,7 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 12
 	},
 /turf/open/floor/rogue/cobble,
@@ -6076,7 +6076,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
@@ -8323,7 +8323,7 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/tile,
@@ -9696,7 +9696,7 @@
 	},
 /area/rogue/indoors/town)
 "dOY" = (
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -12599,7 +12599,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/blocks,
@@ -22204,7 +22204,7 @@
 	dir = 1;
 	icon_state = "longtable_mid"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/tile,
@@ -24512,7 +24512,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -30127,7 +30127,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /obj/machinery/light/rogue/wallfire/candle{
@@ -41285,7 +41285,7 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/tile,
@@ -46471,7 +46471,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach/forest)
 "scY" = (
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_x = 3;
 	pixel_y = 7
 	},
@@ -47881,7 +47881,7 @@
 /area/rogue/indoors)
 "sAL" = (
 /obj/structure/table/wood,
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -50896,7 +50896,7 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "tMq" = (
-/obj/structure/fluff/millstone,
+/obj/item/millstone,
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
@@ -51423,7 +51423,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "tXp" = (
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 12
 	},
 /obj/structure/table/wood,
@@ -56986,7 +56986,7 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 12
 	},
 /turf/open/floor/rogue/hexstone,
@@ -57875,7 +57875,7 @@
 	dir = 9;
 	icon_state = "largetable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -59407,7 +59407,7 @@
 /obj/structure/table/wood{
 	icon_state = "largetable"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -59744,7 +59744,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/blocks/stonered,
@@ -60413,7 +60413,7 @@
 	dir = 1;
 	icon_state = "tablewood1"
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /obj/machinery/light/rogue/wallfire/candle{

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1431,7 +1431,7 @@
 	},
 /area/rogue/indoors)
 "azl" = (
-/obj/structure/fluff/millstone,
+/obj/item/millstone,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "azC" = (
@@ -8580,7 +8580,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
 "hVZ" = (
-/obj/structure/fluff/millstone,
+/obj/item/millstone,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield)
 "hWL" = (
@@ -11298,7 +11298,7 @@
 	},
 /area/rogue/indoors/town)
 "ldr" = (
-/obj/structure/fluff/millstone,
+/obj/item/millstone,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor)
 "lec" = (
@@ -16317,7 +16317,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/town/basement)
 "qLR" = (
-/obj/structure/fluff/millstone,
+/obj/item/millstone,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bog)
 "qMJ" = (
@@ -18066,7 +18066,7 @@
 	icon_state = "longtable_mid";
 	dir = 1
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/hexstone,
@@ -18878,7 +18878,7 @@
 	},
 /area/rogue/indoors/town/manor)
 "tAt" = (
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 7
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -20450,7 +20450,7 @@
 	icon_state = "largetable";
 	dir = 10
 	},
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 12
 	},
 /turf/open/floor/rogue/tile{

--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -563,7 +563,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors)
 "ut" = (
-/obj/structure/fluff/millstone{
+/obj/item/millstone{
 	pixel_y = 12
 	},
 /obj/structure/table/cooling,

--- a/code/modules/farming/crafting_recipes.dm
+++ b/code/modules/farming/crafting_recipes.dm
@@ -7,26 +7,6 @@
 	craftdiff = 0
 	time = 2 SECONDS
 
-/datum/crafting_recipe/roguetown/wheatflour
-	name = "flour (wheat)"
-	result = /obj/item/reagent_containers/powder/flour
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/wheat = 1)
-	structurecraft = /obj/structure/fluff/millstone
-	verbage_simple = "mill"
-	verbage = "mills"
-	craftdiff = -2
-	time = 3
-
-/datum/crafting_recipe/roguetown/oatflour
-	name = "flour (oat)"
-	result = /obj/item/reagent_containers/powder/flour
-	reqs = list(/obj/item/reagent_containers/food/snacks/grown/oat = 1)
-	structurecraft = /obj/structure/fluff/millstone
-	verbage_simple = "mill"
-	verbage = "mills"
-	craftdiff = -2
-	time = 3
-
 /datum/crafting_recipe/roguetown/structure/plough
 	name = "plough"
 	result = /obj/structure/plough

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -539,11 +539,10 @@
 
 /datum/crafting_recipe/roguetown/structure/millstone
 	name = "millstone"
-	result = /obj/structure/fluff/millstone
+	result = /obj/item/millstone
 	reqs = list(/obj/item/natural/stone = 3)
 	verbage = "assembles"
 	craftsound = null
-	wallcraft = TRUE
 	skillcraft = /datum/skill/craft/masonry
 
 /datum/crafting_recipe/roguetown/structure/lever

--- a/code/modules/roguetown/roguejobs/cook/tools/grinding.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/grinding.dm
@@ -1,16 +1,16 @@
 #define BASE_GRIND_TIME 2 SECONDS
-/obj/structure/fluff/millstone
+/obj/item/millstone // Previous structure path means it cannot be crafted on tables
 	name = "millstone"
 	desc = "A millstone used to grind grain into flour."
 	icon = 'icons/roguetown/misc/structure.dmi'
 	icon_state = "millstone"
-	density = TRUE
-	anchored = TRUE
+	density = FALSE
+	anchored = FALSE
 	blade_dulling = DULLING_BASH
 	max_integrity = 400
 	var/list/obj/item/to_grind = list()
 
-/obj/structure/fluff/millstone/attackby(obj/item/W, mob/living/user, params)
+/obj/item/millstone/attackby(obj/item/W, mob/living/user, params)
 	var/datum/skill/craft/cooking/cs = user?.mind?.get_skill_level(/datum/skill/craft/cooking)
 	var/scaled_grind_time = BASE_GRIND_TIME / get_cooktime_divisor(cs)
 	if(W.mill_result)


### PR DESCRIPTION
## About The Pull Request
- Turns millstone into an item and make it placeable and craftable on table, like how it is done everywhere on map
- Nukes the unused wheat + oat recipe for crafting from Ratwood, no one used them anyway and it is not sovlful (tm)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_cYna8yuBMO](https://github.com/user-attachments/assets/fad03944-cdc2-4d81-966f-20593c70da49)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Mapper put millstone on tables all of the time but when I am in game I cannot do it and have to take up space on the floor. Why???

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
