### PR TITLE
A few tweaks to the Polishing system, including shiny armor

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -91,8 +91,8 @@
 	desc = "I was once a squire in training, but failed to achieve knighthood. Though my dreams of glory were dashed, I retained my knowledge of equipment maintenance and repair, including how to polish arms and armor."
 	added_traits = list(TRAIT_SQUIRE_REPAIR)
 	added_stashed_items = list(
-		"Worker's Hammer" = /obj/item/rogueweapon/hammer/iron,
-		"Polishing Cream" = /obj/item/polishing_cream, 
+		"Hammer" = /obj/item/rogueweapon/hammer/iron,
+		"Polishing Cream" = /obj/item/polishing_cream,
 		"Fine Brush" = /obj/item/armor_brush
 	)
 	


### PR DESCRIPTION
## About The Pull Request
Tweaks Polishing in a few ways, please see the "Why it's good for the game" section for all the bullet points
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
To show how often the glint appears on worn armor
https://github.com/user-attachments/assets/57427372-5615-49f2-99f8-f9a3d381eed6
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Brush has been made 2 inventory grids tall: I originally made the size too small for a reusable tool, even the sprite went over the 1x1 inventory grid
- Polishing now lasts until the object has taken damage and its integrity 25% or less: This makes polishing more durable and not a 1-hit disappearing thing
- Polishing max integrity has been changed from a static +50 max integrity, to a +10% max integrity depending on the object's max integrity. This stops low max_integrity weapons like stone knives from obtaining a massive boost in their durability.
- Holding/wearing armor now makes glint effects appear on your character, this only applies to chest armor for now (since it covers most of the character), not helmets/bracers/gloves/boots, to avoid your character looking like a disco ball. It's rarer than turf glint to avoid the aforementioned disco ball effect.
- Renamed failed squire virtue hammer from "Worker's Hammer" to just "Hammer": this was a small thing, they're not a worker so it made no sense
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
