### PR TITLE
Fixes resident spawn to catch court agents too

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -48,7 +48,7 @@
 
 	if(mapswitch == 0)
 		return
-	if(recipient.mind?.assigned_role == "Adventurer" || recipient.mind?.assigned_role == "Mercenary")
+	if(recipient.mind?.assigned_role == "Adventurer" || recipient.mind?.assigned_role == "Mercenary" || recipient.mind?.assigned_role == "Court Agent")
 		// Find tavern area for spawning
 		var/area/spawn_area
 		for(var/area/A in world)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Court agents weren't being caught by the resident apply_to_human or chain. Now they do.
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/c06a9580-9b7f-4212-b9c2-1b0dc68cc226)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Now I cannot meta that your resident adventurer is actually a court agent because you spawned outside of the tavern. Whatever good that would do me!