### PR TITLE
Fixes De-Rot Surgery Debuffs

### DIFF
--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -35,8 +35,12 @@
 	if(user.mind)
 		burndam -= (user.mind.get_skill_level(/datum/skill/misc/medicine) * 3)
 
-	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it.
-	target.apply_status_effect(/datum/status_effect/debuff/rotted)	//Perma debuff, needs cure - adds this on surgery.
+	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
+	if(target.stat == DEAD || was_zombie)											//Checks if the target is a dead rotted corpse.
+		var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
+		if(rot.amount >= 5 MINUTES)													//Fail-safe to make sure the dead person has at least rotted for ~5 min.					
+			target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it. (It's perma for zombies, NEEDS to be removed on de-zombify)
+			target.apply_status_effect(/datum/status_effect/debuff/rotted)			//Temp debuff, needs cure - adds this on surgery.
 
 	if(remove_rot(target = target, user = user, method = "surgery", damage = burndam,
 		success_message = "You burn away the rot inside of [target].",


### PR DESCRIPTION
## About The Pull Request

Reported issue where de-rot surgery was giving anyone, living or dead, the rot paralysis debuff. This makes it so it checks that the mob is dead OR is already a zombie, plus has 5 minutes worth of rot-time (7 min will zombify you) and then apply the debuff.

This way doing self-surgery or removing rot from non-dead people will no longer give the rot paralysis debuff.

## Testing Evidence

Didn't take a screenshot but tested on local. When doing self-surgery it did not apply the debuff to me.

When doing the surgery on a rotted corpse, it gave them rot paralysis as intended. Can't test this fully but was able to ensure it is at least looking to work as intended.

## Why It's Good For The Game

Unintended 'feature' of mine because I didn't think to include a check to avoid punishing living people who were being de-rotted.

I think players are punished enough if they're alive with limb-rot, we don't need to punish them extra like currently unintended.
