### PR TITLE
Actions 1 - 6 Hotkeys. Atomized edition

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -26,7 +26,7 @@
 		return
 	if((istype(over_object, /atom/movable/screen/movable/action_button) && !istype(over_object, /atom/movable/screen/movable/action_button/hide_toggle)))
 		if(locked)
-//			to_chat(usr, span_warning("Action button \"[name]\" is locked, unlock it first."))
+			to_chat(usr, span_warning("Action button \"[name]\" is locked, unlock it first."))
 			return
 		var/atom/movable/screen/movable/action_button/B = over_object
 		var/list/actions = usr.actions
@@ -42,7 +42,7 @@
 /atom/movable/screen/movable/action_button/Click(location,control,params)
 	if (!can_use(usr))
 		return
-/*
+
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])
 		if(locked)
@@ -56,7 +56,7 @@
 		to_chat(usr, span_notice("Action button \"[name]\" [locked ? "" : "un"]locked."))
 		if(id && usr.client) //try to (un)remember position
 			usr.client.prefs.action_buttons_screen_locs["[name]_[id]"] = locked ? moved : null
-		return TRUE*/
+		return TRUE
 	if(usr.next_click > world.time)
 		return
 	usr.next_click = world.time + 1

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -310,3 +310,67 @@
 	var/mob/living/carbon/C = user.mob
 	C.cycle_rmb_intent()
 	return TRUE
+
+// ** Action Buttons **
+// I stopped at 6 because it is probably the maximum number you can comfortably reach on keyboard
+/datum/keybinding/carbon/actions
+	var/action_taken = 1
+/datum/keybinding/carbon/actions/down(client/user)
+	if(!iscarbon(user.mob))
+		return FALSE
+	var/mob/living/carbon/C = user.mob
+	var/list/datum/action/actions = C.actions
+	if(actions.len < action_taken) // Dodge a runtime
+		return FALSE
+	var/datum/action/action = actions[action_taken]
+	if(!action)
+		return FALSE
+	action.Trigger()
+
+/datum/keybinding/carbon/actions/action_1
+	hotkey_keys = list("Alt1")
+	name = "action_1"
+	full_name = "Action 1"
+	description = "Select the first action."
+	category = CATEGORY_CARBON
+	action_taken = 1
+
+/datum/keybinding/carbon/actions/action_2
+	hotkey_keys = list("Alt2")
+	name = "action_2"
+	full_name = "Action 2"
+	description = "Select the second action."
+	category = CATEGORY_CARBON
+	action_taken = 2
+
+/datum/keybinding/carbon/actions/action_3
+	hotkey_keys = list("Alt3")
+	name = "action_3"
+	full_name = "Action 3"
+	description = "Select the third action."
+	category = CATEGORY_CARBON
+	action_taken = 3
+
+/datum/keybinding/carbon/actions/action_4
+	hotkey_keys = list("Alt4")
+	name = "action_4"
+	full_name = "Action 4"
+	description = "Select the fourth action."
+	category = CATEGORY_CARBON
+	action_taken = 4
+
+/datum/keybinding/carbon/actions/action_5
+	hotkey_keys = list("Alt5")
+	name = "action_5"
+	full_name = "Action 5"
+	description = "Select the fifth action."
+	category = CATEGORY_CARBON
+	action_taken = 5
+
+/datum/keybinding/carbon/actions/action_6
+	hotkey_keys = list("Alt6")
+	name = "action_6"
+	full_name = "Action 6"
+	description = "Select the sixth action."
+	category = CATEGORY_CARBON
+	action_taken = 6


### PR DESCRIPTION
## About The Pull Request
Hotkeys changes from https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2267, atomized. 

- You get Alt1 to Alt6 as default hotkeys for action 1 to 6 on your hotkey bar - mainly for mage but also sergeant and knight etc. 
- I unlocked Ctrl key clicking to rearrange them which WILL affect the order you swap it at. It is a bit janky atm and it isn't documented, I blame it on SS13 interfaces. Documentation, soon. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![HsQ0GlleOd](https://github.com/user-attachments/assets/f7f6af87-9335-4871-be4a-0d33bbc71ea1)
![dreamseeker_mj015vo1FQ](https://github.com/user-attachments/assets/78b5c5e2-9d92-426e-bdf2-63fecc29d454)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes using these abilities easier.

Stuck to Alt 6 I think most reasonable poeple stick to alt 1 to alt 4 and alt 6 is farthest I can reach with a finger.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
