### PR TITLE
Fixes runtime in cure rot

### DIFF
--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -179,6 +179,7 @@
 	is_lethal = FALSE
 
 /obj/effect/proc_holder/spell/invoked/cure_rot/cast(list/targets, mob/living/user)
+	var/stinky = FALSE
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
 		if(target == user)
@@ -189,12 +190,19 @@
 		for(var/obj/structure/fluff/psycross/S in oview(5, user))
 			S.AOE_flash(user, range = 8)
 
+		var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
+		if(target.stat == DEAD || was_zombie)	//Checks if the target is a dead rotted corpse.
+			var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
+			if(rot && rot.amount && rot.amount >= 5 MINUTES)	//Fail-safe to make sure the dead person has at least rotted for ~5 min.
+				stinky = TRUE
+
 		if(remove_rot(target = target, user = user, method = "prayer",
 			success_message = "The rot leaves [target]'s body!",
 			fail_message = "Nothing happens.", lethal = is_lethal))
 			target.visible_message(span_notice("The rot leaves [target]'s body!"), span_green("I feel the rot leave my body!"))
 			target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it.
-			target.apply_status_effect(/datum/status_effect/debuff/rotted)	//Perma debuff, needs cure
+			if(stinky)
+				target.apply_status_effect(/datum/status_effect/debuff/rotted)	//Perma debuff, needs cure
 			return TRUE
 		else //Attempt failed, no rot
 			target.visible_message(span_warning("The rot fails to leave [target]'s body!"), span_warning("I feel no different..."))

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -32,19 +32,22 @@
 // calls the remove_rot which is shared with the pestra prayer to remove rot
 /datum/surgery_step/burn_rot/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	var/burndam = 20
+	var/stinky = FALSE
 	if(user.mind)
 		burndam -= (user.mind.get_skill_level(/datum/skill/misc/medicine) * 3)
 
 	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
 	if(target.stat == DEAD || was_zombie)											//Checks if the target is a dead rotted corpse.
 		var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
-		if(rot.amount >= 5 MINUTES)													//Fail-safe to make sure the dead person has at least rotted for ~5 min.					
-			target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it. (It's perma for zombies, NEEDS to be removed on de-zombify)
-			target.apply_status_effect(/datum/status_effect/debuff/rotted)			//Temp debuff, needs cure - adds this on surgery.
+		if(rot && rot.amount && rot.amount >= 5 MINUTES)	//Fail-safe to make sure the dead person has at least rotted for ~5 min.
+			stinky = TRUE				
 
 	if(remove_rot(target = target, user = user, method = "surgery", damage = burndam,
 		success_message = "You burn away the rot inside of [target].",
 		fail_message = "The surgery fails to remove the rot."))
+		target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it. (It's perma for zombies, NEEDS to be removed on de-zombify)
+		if(stinky)
+			target.apply_status_effect(/datum/status_effect/debuff/rotted)			//Temp debuff, needs cure - adds this on surgery.
 
 		display_results(user, target, span_notice("You burn away the rot inside of [target]."),
 		"[user] burns the rot within [target].",


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Rot.amount component fetch was returning null, which meant that the cure rot proc was hitting a runtime and not working. This tightens up the rot var access, preventing that runtime.

## Testing Evidence
![image](https://github.com/user-attachments/assets/e0dfe558-43f1-4aad-9f69-1107fae6344e)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Should obey the appropriate logic for the rotting debuff, but I'm not 100% sure on that.