### PR TITLE
Fixes Fur Crafting Issue

### DIFF
--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -2,6 +2,7 @@
 	tools = list(/obj/item/needle)
 	structurecraft = /obj/machinery/tanningrack
 	skillcraft = /datum/skill/craft/tanning
+	subtype_reqs = TRUE		//Makes it so fur-subtypes work. Basically if anything is just 'obj/item/natural/fur' - it'll take any fur. If it specifies 'natural/fur/direbear' - it will still require direbear.
 
 /datum/crafting_recipe/roguetown/leather/bedroll
 	name = "bedroll (2 leather, 1 rope)"

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -1,6 +1,7 @@
 /datum/crafting_recipe/roguetown/sewing
 	tools = list(/obj/item/needle)
 	skillcraft = /datum/skill/misc/sewing
+	subtype_reqs = TRUE		//For subtypes of fur
 
 /* craftdif of 0 */
 

--- a/code/modules/roguetown/roguecrafting/weaving.dm
+++ b/code/modules/roguetown/roguecrafting/weaving.dm
@@ -1,6 +1,7 @@
 /datum/crafting_recipe/roguetown/weaving
 	structurecraft = /obj/machinery/loom
 	skillcraft = /datum/skill/misc/sewing
+	subtype_reqs = TRUE		//For subtypes of fur
 
 /datum/crafting_recipe/roguetown/weaving/rags
 	name = "webbed shirt (1 silk)"


### PR DESCRIPTION
## About The Pull Request

Realized what the issue was and amended it. Leather and recipes had a sub_type checker set to false, it's set to true - should work fine given how everything is pathed.

Tl;dr - does this now:
- if you list the required leather as, say, cured - it NEEDS to be cured leather to craft.
- if you list the required leather as regular hide, you can use cured leather OR regular hide to make it.

Same way furs work now too. If it's listed as just fur, no specific? Any fur will be able to make it. If it's listed as fur but specifies direbear? Will need direbear to make. Etc.

## Testing Evidence

Hard to really prove via screenshots but did boot my test server up a few times. Tried making fur-lined boots and wolf helms to make sure this works without issue.

Also made sure to test things like, fur-lined boots (requires fur and *cured* leather to make) still required it. Added documentation in comments to how it works.

## Why It's Good For The Game

Bug.
