### PR TITLE
Cuts out excess crownstones, roles that should get crownstones now simply spawn with them

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -950,9 +950,8 @@
 /obj/structure/closet/crate/drawer/random{
 	pixel_y = 0
 	},
-/obj/item/scomstone/garrison,
 /obj/item/roguegem/diamond,
-/obj/item/scomstone/garrison,
+/obj/item/clothing/ring/active/nomag,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -8961,7 +8960,6 @@
 /obj/item/roguekey/manor,
 /obj/item/roguekey/sergeant,
 /obj/item/roguekey/sergeant,
-/obj/item/scomstone/bad/garrison,
 /obj/item/scomstone/bad/garrison,
 /obj/item/scomstone/bad/garrison,
 /obj/item/scomstone/bad/garrison,
@@ -44084,7 +44082,6 @@
 	pixel_y = -32
 	},
 /obj/item/rope/chain,
-/obj/item/scomstone/garrison,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "qUs" = (
@@ -46657,7 +46654,6 @@
 	pixel_y = -32
 	},
 /obj/item/scomstone/bad/garrison,
-/obj/item/scomstone/garrison,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "rWU" = (
@@ -55223,7 +55219,6 @@
 "vjF" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/scomstone/bad/garrison,
-/obj/item/scomstone/garrison,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "vjN" = (

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -8960,9 +8960,6 @@
 /obj/item/roguekey/manor,
 /obj/item/roguekey/sergeant,
 /obj/item/roguekey/sergeant,
-/obj/item/scomstone/bad/garrison,
-/obj/item/scomstone/bad/garrison,
-/obj/item/scomstone/bad/garrison,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -44082,6 +44079,9 @@
 	pixel_y = -32
 	},
 /obj/item/rope/chain,
+/obj/item/scomstone/bad/garrison,
+/obj/item/scomstone/bad/garrison,
+/obj/item/scomstone/bad/garrison,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
 "qUs" = (

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -44,7 +44,7 @@
 		head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/winterdress
 		pants = /obj/item/clothing/under/roguetown/tights/stockings/silk/random	//Added Silk Stockings for the female nobles
-		id = /obj/item/clothing/ring/silver
+		id = /obj/item/scomstone/garrison
 		shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	else if(should_wear_masc_clothes(H))
 		head = /obj/item/clothing/head/roguetown/nyle/consortcrown

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	beltl = /obj/item/storage/keyring/lord
 	l_hand = /obj/item/rogueweapon/lordscepter
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
-	id = /obj/item/clothing/ring/active/nomag
+	id = /obj/item/scomstone/garrison
 	if(should_wear_femme_clothes(H))
 		pants = /obj/item/clothing/under/roguetown/tights/black
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black


### PR DESCRIPTION
## About The Pull Request

- Removes the extra mapped in crownstones from the duke's bedroom, the knight captain's quarters, the marshal's quarters, and the sergeant's quarters.

- The duke and the consort now both spawn with crownstones.

- The anti-magic ring the duke previously spawned with can now be found in the duke's bedroom.

## Why It's Good For The Game

Cuts down on crownstone bloat. The dev who made the houndstones/crownstones, @Onutsio, has mentioned several times that they are intended to be in short supply and supposed to be limited to strictly garrison leadership roles.

![image](https://github.com/user-attachments/assets/f076b595-c11d-49d2-896e-c8ade1687e37)

Others have since come through and mapped in several spares and it's led to there being a total of 5 spare mapped in crown-stones to be freely handed out to whomever - which is pretty excessive. Half the garrison shouldn't be running around with instant access to call for back-up at all times. It's become far too commonplace for leadership roles to simply hand these extra crownstones out and that isn't how they were intended to be used.
 
All roles that are meant to get crownstones now simply spawn with them, and do not get any spares. If they lose them, they lose them - and that's that. An instant private scomline to the entire garrison should not be so easily replaceable.

There's still a few spare houndstones for leadership roles to distribute if they want to recruit extra infantry in-round, or if antagonists want to steal them to spy on the garrison's SCOMline chatter. I did not touch those; they're listen-only and a lot less problematic.
 
 ## Testing Evidence
 
 <details>

Booted up test server, spawned as duke & consort - both loadouts work fine.

![image](https://github.com/user-attachments/assets/27e0802e-0023-4770-b31a-f16003e695f0)

</details>
