### PR TITLE
Makes alchemical vial small, repath to reduce repeated code

### DIFF
--- a/_maps/map_files/dun_manor/azure_coast.dmm
+++ b/_maps/map_files/dun_manor/azure_coast.dmm
@@ -6913,36 +6913,36 @@
 "TC" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = -5
 	},

--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -13973,51 +13973,51 @@
 /area/rogue/indoors/town/manor)
 "jTM" = (
 /obj/structure/rack/rogue/shelf/biggest,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0;
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 6;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 5;
 	pixel_y = 0
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 6;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -5;
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -6;
 	pixel_y = -2
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = -6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = 5
 	},
@@ -15234,51 +15234,51 @@
 "kNu" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/machinery/light/rogue/wallfire/candle/r,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0;
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 6;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 5;
 	pixel_y = 0
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 6;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -5;
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -6;
 	pixel_y = -2
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = -6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = 5
 	},
@@ -26238,36 +26238,36 @@
 "srN" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 0;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = -5
 	},

--- a/_maps/map_files/dun_manor/smalldecap.dmm
+++ b/_maps/map_files/dun_manor/smalldecap.dmm
@@ -2170,7 +2170,7 @@
 "BH" = (
 /obj/item/ingot/gold,
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/alchemical/conpot{
+/obj/item/reagent_containers/glass/bottle/alchemical/conpot{
 	pixel_x = -10;
 	pixel_y = 11
 	},
@@ -3269,7 +3269,7 @@
 "QD" = (
 /obj/item/roguestatue/gold,
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/alchemical/conpot{
+/obj/item/reagent_containers/glass/bottle/alchemical/conpot{
 	pixel_x = -9;
 	pixel_y = 2
 	},
@@ -3668,11 +3668,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblinfort)
 "VW" = (
-/obj/item/reagent_containers/glass/alchemical/lucpot{
+/obj/item/reagent_containers/glass/bottle/alchemical/lucpot{
 	pixel_x = -9;
 	pixel_y = 9
 	},
-/obj/item/reagent_containers/glass/alchemical/strpot{
+/obj/item/reagent_containers/glass/bottle/alchemical/strpot{
 	pixel_x = 9;
 	pixel_y = 1
 	},

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -11584,7 +11584,7 @@
 "evP" = (
 /obj/item/ingot/gold,
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/alchemical/conpot{
+/obj/item/reagent_containers/glass/bottle/alchemical/conpot{
 	pixel_x = -10;
 	pixel_y = 11
 	},
@@ -15201,11 +15201,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fNY" = (
-/obj/item/reagent_containers/glass/alchemical/lucpot{
+/obj/item/reagent_containers/glass/bottle/alchemical/lucpot{
 	pixel_x = -9;
 	pixel_y = 9
 	},
-/obj/item/reagent_containers/glass/alchemical/strpot{
+/obj/item/reagent_containers/glass/bottle/alchemical/strpot{
 	pixel_x = 9;
 	pixel_y = 1
 	},
@@ -17869,32 +17869,32 @@
 "gQd" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical,
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = -5
 	},
@@ -26334,48 +26334,48 @@
 "kaC" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/machinery/light/rogue/wallfire/candle/r,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 6;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 6;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -5;
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -6;
 	pixel_y = -2
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = -6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = 5
 	},
@@ -27935,48 +27935,48 @@
 /area/rogue/outdoors/mountains/decap)
 "kGd" = (
 /obj/structure/rack/rogue/shelf/biggest,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 6;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 6;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -5;
 	pixel_y = -8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -6;
 	pixel_y = -2
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = -6
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = -1
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -11;
 	pixel_y = 5
 	},
@@ -35830,7 +35830,7 @@
 "nMP" = (
 /obj/item/roguestatue/gold,
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/alchemical/conpot{
+/obj/item/reagent_containers/glass/bottle/alchemical/conpot{
 	pixel_x = -9;
 	pixel_y = 2
 	},
@@ -44852,32 +44852,32 @@
 /area/rogue/indoors/town/church/chapel)
 "rla" = (
 /obj/structure/rack/rogue/shelf/biggest,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical,
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = -5
 	},
@@ -53265,32 +53265,32 @@
 /area/rogue/under/cave/skeletoncrypt)
 "uww" = (
 /obj/structure/rack/rogue/shelf/biggest,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical,
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = -5
 	},
@@ -61141,7 +61141,7 @@
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "xyr" = (
 /obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/glass/alchemical/spdpot,
+/obj/item/reagent_containers/glass/bottle/alchemical/spdpot,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap)
 "xyC" = (

--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -624,32 +624,32 @@
 "wF" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/decal/cleanable/dirt/cobweb,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = 7;
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical,
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical,
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_y = -5
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7
 	},
-/obj/item/reagent_containers/glass/alchemical{
+/obj/item/reagent_containers/glass/bottle/alchemical{
 	pixel_x = -7;
 	pixel_y = -5
 	},

--- a/code/game/objects/effects/spawners/roguemapgen.dm
+++ b/code/game/objects/effects/spawners/roguemapgen.dm
@@ -144,11 +144,11 @@
 /obj/effect/spawner/lootdrop/potion_stats
 	icon_state = "lootstatpot"
 	spawned = list(
-		/obj/item/reagent_containers/glass/alchemical/strpot = 10,
-		/obj/item/reagent_containers/glass/alchemical/perpot = 10,
-		/obj/item/reagent_containers/glass/alchemical/endpot = 10,
-		/obj/item/reagent_containers/glass/alchemical/conpot = 10,
-		/obj/item/reagent_containers/glass/alchemical/intpot = 10,
-		/obj/item/reagent_containers/glass/alchemical/spdpot = 10,
-		/obj/item/reagent_containers/glass/alchemical/lucpot = 10
+		/obj/item/reagent_containers/glass/bottle/alchemical/strpot = 10,
+		/obj/item/reagent_containers/glass/bottle/alchemical/perpot = 10,
+		/obj/item/reagent_containers/glass/bottle/alchemical/endpot = 10,
+		/obj/item/reagent_containers/glass/bottle/alchemical/conpot = 10,
+		/obj/item/reagent_containers/glass/bottle/alchemical/intpot = 10,
+		/obj/item/reagent_containers/glass/bottle/alchemical/spdpot = 10,
+		/obj/item/reagent_containers/glass/bottle/alchemical/lucpot = 10
 	)

--- a/code/modules/cargo/packsrogue/tools.dm
+++ b/code/modules/cargo/packsrogue/tools.dm
@@ -214,14 +214,14 @@
 /datum/supply_pack/rogue/tools/alch_bottle
 	name = "Alchemy Bottle"
 	cost = 1
-	contains = list(/obj/item/reagent_containers/glass/alchemical,)
+	contains = list(/obj/item/reagent_containers/glass/bottle/alchemical,)
 
 /datum/supply_pack/rogue/tools/alch_bottles
 	name = "Bulk Alchemy Bottles" //Buy 8 now get 1 free!
 	cost = 8
-	contains = list(/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,
-	/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,
-	/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical,/obj/item/reagent_containers/glass/alchemical)
+	contains = list(/obj/item/reagent_containers/glass/bottle/alchemical,/obj/item/reagent_containers/glass/bottle/alchemical,/obj/item/reagent_containers/glass/bottle/alchemical,
+	/obj/item/reagent_containers/glass/bottle/alchemical,/obj/item/reagent_containers/glass/bottle/alchemical,/obj/item/reagent_containers/glass/bottle/alchemical,
+	/obj/item/reagent_containers/glass/bottle/alchemical,/obj/item/reagent_containers/glass/bottle/alchemical,/obj/item/reagent_containers/glass/bottle/alchemical)
 	
 
 /datum/supply_pack/rogue/tools/gwstrap

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -198,13 +198,13 @@
 			head = /obj/item/clothing/head/roguetown/bucklehat
 			gloves = /obj/item/clothing/gloves/roguetown/angle
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1)
-			beltl = pick(/obj/item/reagent_containers/glass/alchemical/strpot, 
-						/obj/item/reagent_containers/glass/alchemical/conpot, 
-						/obj/item/reagent_containers/glass/alchemical/endpot,
-						/obj/item/reagent_containers/glass/alchemical/spdpot,
-						/obj/item/reagent_containers/glass/alchemical/perpot,
-						/obj/item/reagent_containers/glass/alchemical/intpot,
-						/obj/item/reagent_containers/glass/alchemical/lucpot)
+			beltl = pick(/obj/item/reagent_containers/glass/bottle/alchemical/strpot, 
+						/obj/item/reagent_containers/glass/bottle/alchemical/conpot, 
+						/obj/item/reagent_containers/glass/bottle/alchemical/endpot,
+						/obj/item/reagent_containers/glass/bottle/alchemical/spdpot,
+						/obj/item/reagent_containers/glass/bottle/alchemical/perpot,
+						/obj/item/reagent_containers/glass/bottle/alchemical/intpot,
+						/obj/item/reagent_containers/glass/bottle/alchemical/lucpot)
 
 		if("Flagellant")
 			to_chat(H, span_warning("You are a pacifistic warrior who embraces suffering, believing pain is the path to enlightenment. You take the suffering of others upon yourself."))

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -62,7 +62,7 @@
 
 /datum/crafting_recipe/roguetown/alchemy/glassbottles
 	name = "alchemy bottles"
-	result = list(/obj/item/reagent_containers/glass/alchemical, /obj/item/reagent_containers/glass/alchemical, /obj/item/reagent_containers/glass/alchemical, /obj/item/reagent_containers/glass/alchemical, /obj/item/reagent_containers/glass/alchemical, /obj/item/reagent_containers/glass/alchemical)
+	result = list(/obj/item/reagent_containers/glass/bottle/alchemical, /obj/item/reagent_containers/glass/bottle/alchemical, /obj/item/reagent_containers/glass/bottle/alchemical, /obj/item/reagent_containers/glass/bottle/alchemical, /obj/item/reagent_containers/glass/bottle/alchemical, /obj/item/reagent_containers/glass/bottle/alchemical)
 	reqs = list(/obj/item/natural/stone = 1, /obj/item/natural/dirtclod = 1)
 	craftdiff = 1
 	verbage_simple = "forge"

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
@@ -1,4 +1,4 @@
-/obj/item/reagent_containers/glass/alchemical
+/obj/item/reagent_containers/glass/bottle/alchemical
 	name = "alchemical vial"
 	desc = "A cute bottle, conviniently holding 3 swigs of a fluid."
 	icon = 'icons/roguetown/misc/alchemy.dmi'
@@ -7,136 +7,16 @@
 	possible_transfer_amounts = list(9)
 	volume = 27
 	fill_icon_thresholds = list(0, 33, 66, 100)
-	dropshrink = 0.8
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH
 	obj_flags = CAN_BE_HIT
-	spillable = FALSE
-	var/closed = TRUE //Put a cork in it!
-	reagent_flags = TRANSPARENT
-	w_class = WEIGHT_CLASS_SMALL
-	drinksounds = list('sound/items/drink_bottle (1).ogg','sound/items/drink_bottle (2).ogg')
-	fillsounds = list('sound/items/fillcup.ogg')
-	poursounds = list('sound/items/fillbottle.ogg')
+	w_class = WEIGHT_CLASS_TINY
 	experimental_onhip = FALSE
 	experimental_inhand = FALSE
+	grid_height = 32 // Takes 1x1 area
 	sellprice = 1
 
-
-/*
-	The next two functions are copies from ..(), but edited to give the max per transfer.
-	so if your child has a per-transfer of 100, its putting all 100 in that thing. Be careful...
-*/
-/obj/item/reagent_containers/glass/alchemical/attack(mob/M, mob/user, obj/target)
-	testing("a1")
-	if(istype(M))
-		if(user.used_intent.type == INTENT_GENERIC)
-			return ..()
-		else
-			if(!spillable)
-				return
-			if(!reagents || !reagents.total_volume)
-				to_chat(user, "<span class='warning'>[src] is empty!</span>")
-				return
-			if(user.used_intent.type == INTENT_SPLASH)
-				var/R
-				M.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [M]!</span>", \
-								"<span class='danger'>[user] splashes the contents of [src] onto you!</span>")
-				if(reagents)
-					for(var/datum/reagent/A in reagents.reagent_list)
-						R += "[A] ([num2text(A.volume)]),"
-
-				if(isturf(target) && reagents.reagent_list.len && thrownby)
-					log_combat(thrownby, target, "splashed (thrown) [english_list(reagents.reagent_list)]")
-					message_admins("[ADMIN_LOOKUPFLW(thrownby)] splashed (thrown) [english_list(reagents.reagent_list)] on [target] at [ADMIN_VERBOSEJMP(target)].")
-				reagents.reaction(M, TOUCH)
-				log_combat(user, M, "splashed", R)
-				reagents.clear_reagents()
-				return
-			else if(user.used_intent.type == INTENT_POUR)
-				if(!canconsume(M, user))
-					return
-				if(M != user)
-					M.visible_message("<span class='danger'>[user] attempts to feed [M] something.</span>", \
-								"<span class='danger'>[user] attempts to feed you something.</span>")
-					if(!do_mob(user, M))
-						return
-					if(!reagents || !reagents.total_volume)
-						return // The drink might be empty after the delay, such as by spam-feeding
-					M.visible_message("<span class='danger'>[user] feeds [M] something.</span>", \
-								"<span class='danger'>[user] feeds you something.</span>")
-					log_combat(user, M, "fed", reagents.log_list())
-				else
-					to_chat(user, "<span class='notice'>I swallow a gulp of [src].</span>")
-				addtimer(CALLBACK(reagents, TYPE_PROC_REF(/datum/reagents, trans_to), M, amount_per_transfer_from_this, TRUE, TRUE, FALSE, user, FALSE, INGEST), 5)
-				playsound(M.loc,pick(drinksounds), 100, TRUE)
-				return
-
-/obj/item/reagent_containers/glass/alchemical/attack_obj(obj/target, mob/living/user)
-	if(user.used_intent.type == INTENT_GENERIC)
-		return ..()
-	testing("attackobj1")
-	if(!spillable)
-		return
-	if(target.is_refillable() && (user.used_intent.type == INTENT_POUR)) //Something like a glass. Player probably wants to transfer TO it.
-		testing("attackobj2")
-		if(!reagents.total_volume)
-			to_chat(user, "<span class='warning'>[src] is empty!</span>")
-			return
-		if(target.reagents.holder_full())
-			to_chat(user, "<span class='warning'>[target] is full.</span>")
-			return
-		user.visible_message("<span class='notice'>[user] pours [src] into [target].</span>", \
-						"<span class='notice'>I pour [src] into [target].</span>")
-		if(user.m_intent != MOVE_INTENT_SNEAK)
-			if(poursounds)
-				playsound(user.loc,pick(poursounds), 100, TRUE)
-		for(var/i in 1 to 10)
-			if(do_after(user, 8, target = target))
-				if(!reagents.total_volume)
-					break
-				if(target.reagents.holder_full())
-					break
-				if(!reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user))
-					reagents.reaction(target, TOUCH, amount_per_transfer_from_this)
-			else
-				break
-		return
-	if(target.is_drainable() && (user.used_intent.type == /datum/intent/fill)) //A dispenser. Transfer FROM it TO us.
-		testing("attackobj3")
-		if(!target.reagents.total_volume)
-			to_chat(user, "<span class='warning'>[target] is empty!</span>")
-			return
-		if(reagents.holder_full())
-			to_chat(user, "<span class='warning'>[src] is full.</span>")
-			return
-		if(user.m_intent != MOVE_INTENT_SNEAK)
-			if(fillsounds)
-				playsound(user.loc,pick(fillsounds), 100, TRUE)
-		user.visible_message("<span class='notice'>[user] fills [src] with [target].</span>", \
-							"<span class='notice'>I fill [src] with [target].</span>")
-		for(var/i in 1 to 10)
-			if(do_after(user, 8, target = target))
-				if(reagents.holder_full())
-					break
-				if(!target.reagents.total_volume)
-					break
-				target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user)
-			else
-				break
-		return
-
-/*
-	This ends the copy-edited code.
-*/
-/obj/item/reagent_containers/glass/alchemical/attackby(obj/item/I, mob/user, params)
-	if(reagents.total_volume)
-		return
-	if(closed)
-		return
-	else
-		return ..()
-
-/obj/item/reagent_containers/glass/alchemical/update_icon(dont_fill=FALSE)
+// Shitty copy paste override until bottle code refactored
+/obj/item/reagent_containers/glass/bottle/alchemical/update_icon(dont_fill=FALSE)
 	if(!fill_icon_thresholds || dont_fill)
 		return
 
@@ -158,21 +38,3 @@
 
 	if(closed)
 		add_overlay("vial_cork")
-/obj/item/reagent_containers/glass/alchemical/rmb_self(mob/user)
-	. = ..()
-	closed = !closed
-	user.changeNext_move(CLICK_CD_RAPID)
-	if(closed)
-		reagent_flags = TRANSPARENT
-		reagents.flags = reagent_flags
-		to_chat(user, span_notice("You carefully press the cork back into the mouth of [src]."))
-		spillable = FALSE
-		desc = initial(desc)
-	else
-		reagent_flags = OPENCONTAINER
-		reagents.flags = reagent_flags
-		to_chat(user, span_notice("You thumb off the cork from [src]."))
-		playsound(user.loc,'sound/items/uncork.ogg', 100, TRUE)
-		spillable = TRUE
-		desc += "The cork appears to be off."
-	update_icon()

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -33,25 +33,25 @@
 /obj/item/reagent_containers/glass/bottle/rogue/strongstampoison
 	list_reagents = list(/datum/reagent/strongstampoison = 15)
 
-/obj/item/reagent_containers/glass/alchemical/strpot
+/obj/item/reagent_containers/glass/bottle/alchemical/strpot
 	list_reagents = list(/datum/reagent/buff/strength = 27)
 
-/obj/item/reagent_containers/glass/alchemical/perpot
+/obj/item/reagent_containers/glass/bottle/alchemical/perpot
 	list_reagents = list(/datum/reagent/buff/perception = 27)
 
-/obj/item/reagent_containers/glass/alchemical/endpot
+/obj/item/reagent_containers/glass/bottle/alchemical/endpot
 	list_reagents = list(/datum/reagent/buff/endurance = 27)
 
-/obj/item/reagent_containers/glass/alchemical/conpot
+/obj/item/reagent_containers/glass/bottle/alchemical/conpot
 	list_reagents = list(/datum/reagent/buff/constitution = 27)
 
-/obj/item/reagent_containers/glass/alchemical/intpot
+/obj/item/reagent_containers/glass/bottle/alchemical/intpot
 	list_reagents = list(/datum/reagent/buff/intelligence = 27)
 
-/obj/item/reagent_containers/glass/alchemical/spdpot
+/obj/item/reagent_containers/glass/bottle/alchemical/spdpot
 	list_reagents = list(/datum/reagent/buff/speed = 27)
 
-/obj/item/reagent_containers/glass/alchemical/lucpot
+/obj/item/reagent_containers/glass/bottle/alchemical/lucpot
 	list_reagents = list(/datum/reagent/buff/fortune = 27)
 
 //////////////////////////

--- a/modular_azurepeak/code/modules/alchemy/alchemy_recipes.dm
+++ b/modular_azurepeak/code/modules/alchemy/alchemy_recipes.dm
@@ -1,6 +1,6 @@
 /datum/crafting_recipe/roguetown/alchemy/paralytic_venom
 	name = "paralytic venom activation"
-	result = list(/obj/item/reagent_containers/glass/alchemical/spidervenom_paralytic = 1)
-	reqs = list(/obj/item/reagent_containers/spidervenom_inert = 2, /obj/item/reagent_containers/powder/moondust, /obj/item/reagent_containers/glass/alchemical)
+	result = list(/obj/item/reagent_containers/glass/bottle/alchemical/spidervenom_paralytic = 1)
+	reqs = list(/obj/item/reagent_containers/spidervenom_inert = 2, /obj/item/reagent_containers/powder/moondust, /obj/item/reagent_containers/glass/bottle/alchemical)
 	craftdiff = 5
 	verbage_simple = "mix"

--- a/modular_azurepeak/code/modules/reagents/reagent_containers/spider_venom.dm
+++ b/modular_azurepeak/code/modules/reagents/reagent_containers/spider_venom.dm
@@ -27,7 +27,7 @@
 	metabolization_rate = 0.01
 	var/venom_resistance
 
-/obj/item/reagent_containers/glass/alchemical/spidervenom_paralytic
+/obj/item/reagent_containers/glass/bottle/alchemical/spidervenom_paralytic
 	list_reagents = list(/datum/reagent/toxin/spidervenom_paralytic = 1)
 	desc = "An ominous vial, filled with venom of the deadly Aragn spider. Feels hot to the touch."
 


### PR DESCRIPTION
## About The Pull Request
Alchemical vial is now 1x1.

Repathed it and deleted most unnecessary copy pasted code from bottle. Might conflict with map. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="277" alt="dreamseeker_GuKmVTWllu" src="https://github.com/user-attachments/assets/0c241f11-0273-48c0-9742-aecb3e69ca64" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Alchemical Vial - except for the fact they cannot be thrown, are strictly inferior to the 16 ounces glass bottles. They are neat for selling things from cauldrons because cauldron brew in 9 / 27 ounces, but every gamer rebottle them instead. This give them a niche as they hold 9 ounces each and stop triggering my inner optimizer.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
