### PR TITLE
lockpicks 1x1

### DIFF
--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -48,7 +48,7 @@
 	associated_skill = /datum/skill/misc/lockpicking	//Doesn't do anything, for tracking purposes only
 
 	grid_width = 32
-	grid_height = 64
+	grid_height = 32
 
 /obj/item/roguekey/lord
 	name = "master key"


### PR DESCRIPTION
## About The Pull Request

Makes lockpicks a 1x1 grid instead of 1x2

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

These things are as small as keys, it made no real sense. Even the lockpick ring is 1x1 like the keyring.
