### PR TITLE
Swapped Cleric Bucket helm for Abyssor Helm

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -127,7 +127,7 @@
 					head = /obj/item/clothing/head/roguetown/helmet/heavy/nochelm
 				if(/datum/patron/divine/abyssor)
 					cloak = /obj/item/clothing/cloak/templar/abyssor
-					head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
+					head = /obj/item/clothing/head/roguetown/helmet/heavy/abyssorgreathelm
 				if(/datum/patron/divine/dendor)
 					cloak = /obj/item/clothing/cloak/templar/dendor
 					head = /obj/item/clothing/head/roguetown/helmet/heavy/dendorhelm


### PR DESCRIPTION
Changed the Adventurer Cleric's Paladin helmet for Abyssor followers from bucket helm to Abyssor's great helm.

## About The Pull Request

ABYSSORITES REJOICE! RISE FROM THE TIDE AN UNLEASH THE FURY OF THE DEEP WITH YOUR TRUE DRIP!

## Testing Evidence

![AbyssorHelmProof](https://github.com/user-attachments/assets/15e9e724-58a4-4313-868b-11418aaa84e9)


## Why It's Good For The Game

THE TIDES SHALL NOT BE BOUND TO GENERIC LANDLUBBER CRUSADER TIN CANS! WE RISE FROM THE SEA AS HOLY WARRIORS! LET THE FOAMS RUN RED!
