### PR TITLE
Rebalances personal granary

### DIFF
--- a/code/game/objects/items/rogueitems/bags.dm
+++ b/code/game/objects/items/rogueitems/bags.dm
@@ -94,11 +94,18 @@
 
 /obj/item/storage/roguebag/food
 	populate_contents = list(
-	/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-	/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-	/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-	/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
-	/obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
+	/obj/item/reagent_containers/food/snacks/rogue/bread,
 	/obj/item/reagent_containers/food/snacks/grown/apple,
-	/obj/item/reagent_containers/glass/bottle/waterskin/milk
+	/obj/item/reagent_containers/glass/bottle/waterskin/milk,
+	/obj/item/fishingrod,
+	/obj/item/natural/worms/grubs,
+	/obj/item/natural/worms/grubs,
+	/obj/item/natural/worms/grubs,
+	/obj/item/natural/worms,
+	/obj/item/natural/worms,
+	/obj/item/natural/worms,
+	/obj/item/natural/worms/leech,
+	/obj/item/natural/worms/leech,
+	/obj/item/natural/worms/leech,
+	/obj/item/cooking/pan
 	)

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -249,9 +249,10 @@
 
 /datum/virtue/utility/granary
 	name = "Personal Granary"
-	desc = "You've worked in or around the kitchens enough to steal away a sack of supplies that no one would surely miss, just in case. You've picked up on some cooking tips in your spare time, as well."
+	desc = "You've worked in or around the docks enough to steal away a sack of supplies that no one would surely miss, just in case. You've picked up on some cooking and fishing tips in your spare time, as well."
 	added_stashed_items = list("Bag of Food" = /obj/item/storage/roguebag/food)
-	added_skills = list(list(/datum/skill/craft/cooking, 3, 6))
+	added_skills = list(list(/datum/skill/craft/cooking, 3, 6),
+						list(/datum/skill/labor/fishing, 2, 6))
 
 /datum/virtue/utility/forester
 	name = "Forester"

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -248,7 +248,7 @@
 	added_skills = list(list(/datum/skill/misc/lockpicking, 3, 6))
 
 /datum/virtue/utility/granary
-	name = "Personal Granary"
+	name = "Cunning Provisioner"
 	desc = "You've worked in or around the docks enough to steal away a sack of supplies that no one would surely miss, just in case. You've picked up on some cooking and fishing tips in your spare time, as well."
 	added_stashed_items = list("Bag of Food" = /obj/item/storage/roguebag/food)
 	added_skills = list(list(/datum/skill/craft/cooking, 3, 6),


### PR DESCRIPTION
## About The Pull Request

- Grants 1 bread instead of hardtack & copiette.
- Fishing rod
- 9 bait items
- frying pan
- 2 fishing levels up to legendary

## Testing Evidence

![image](https://github.com/user-attachments/assets/071e0746-8325-4f00-9b1d-138a9e938ae0)

## Why It's Good For The Game

Shifts the focus of the virtue towards food gathering and cooking. You can make cheesebread pretty easily with the supplies. Pots are easy to make, but pans are not. So now you can get set up with a little kitchen more easily out in the woods.

Main goal is to make it so that adventurers take this actually sit down somewhere to cook up some butchered meats or gathered fish instead of just living a whole round off their own granary bag. 