### PR TITLE
Double efficiency of iron and steel javelin recipe

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -159,10 +159,11 @@
 	createditem_num = 4
 
 /datum/anvil_recipe/weapons/iron/javelin
-	name = "Iron Javelin (+1 Small Log)"
+	name = "2x Iron Javelin (+1 Small Log)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/ammo_casing/caseless/rogue/javelin
+	createditem_num = 2
 	craftdiff = 1
 
 /// STEEL WEAPONS
@@ -352,10 +353,11 @@
 	createditem_num = 4
 
 /datum/anvil_recipe/weapons/steel/javelin
-	name = "Steel Javelin (+1 Small Log)"
+	name = "2x Steel Javelin (+1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/ammo_casing/caseless/rogue/javelin/steel
+	createditem_num = 2
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/fishspear


### PR DESCRIPTION
## About The Pull Request
Double efficiency of iron and steel javelin recipe
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="182" alt="dreamseeker_gpiz4DQrT6" src="https://github.com/user-attachments/assets/f2bb3921-ba7e-4740-b103-20df66e68d1a" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Double efficiency of iron and steel javelin recipe. 

Since they're meant to be throwable projectile having them as expensive as a singular melee weapon is wild, five ingots to fill up a bag of five? Doubling the efficiency should make them see more use on classes that don't start with them.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
