### PR TITLE
Use drop location for staff and fix it disappearing in hand (inside mob)

### DIFF
--- a/modular_azurepeak/code/game/objects/items/magic_staffs.dm
+++ b/modular_azurepeak/code/game/objects/items/magic_staffs.dm
@@ -93,7 +93,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/toper(loc)
+			new /obj/item/rogueweapon/woodstaff/toper(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else
@@ -104,7 +104,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/amethyst(loc)
+			new /obj/item/rogueweapon/woodstaff/amethyst(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else
@@ -115,7 +115,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/emerald(loc)
+			new /obj/item/rogueweapon/woodstaff/emerald(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else
@@ -126,7 +126,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/sapphire(loc)
+			new /obj/item/rogueweapon/woodstaff/sapphire(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else
@@ -137,7 +137,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/quartz(loc)
+			new /obj/item/rogueweapon/woodstaff/quartz(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else
@@ -148,7 +148,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/quartz(loc)
+			new /obj/item/rogueweapon/woodstaff/quartz(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else
@@ -159,7 +159,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/diamond(loc)
+			new /obj/item/rogueweapon/woodstaff/diamond(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else
@@ -170,7 +170,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/ruby(loc)
+			new /obj/item/rogueweapon/woodstaff/ruby(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else
@@ -181,7 +181,7 @@
 			playsound(loc, 'modular_azurepeak/sound/spellbooks/crystal.ogg', 100, TRUE)
 			user.visible_message(span_warning("[user] slots [user.p_their()] [arcyne_focus] into the staff!"), \
 				span_notice("I empower the staff with an arcyne-focus!"))
-			new /obj/item/rogueweapon/woodstaff/riddle_of_steel(loc)
+			new /obj/item/rogueweapon/woodstaff/riddle_of_steel(drop_location())
 			qdel(arcyne_focus)
 			qdel(src)
 		else


### PR DESCRIPTION
## About The Pull Request
Use drop location for staff and fix it disappearing in hand (inside mob)

Sutures pointed out that the staff might be inside mob content and it turn out because it is calling for (loc) that means if you add a gem to your staff in your hand it get moved inside you.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="134" alt="dreamseeker_Mxo14z6CWj" src="https://github.com/user-attachments/assets/f4cae6aa-b49d-4ff3-a146-29255d8bd6af" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
there is no longer an amethyst staff inside you

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
