### PR TITLE
Fix | Court Mage doors

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -38651,6 +38651,14 @@
 /obj/effect/landmark/start/mercenary,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"ojs" = (
+/obj/structure/mineral_door/wood{
+	icon_state = "wcv";
+	locked = 1;
+	lockid = "mage"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/magician)
 "oju" = (
 /obj/structure/mirror,
 /turf/open/floor/rogue/ruinedwood{
@@ -43873,6 +43881,8 @@
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/item/scrying,
+/obj/item/roguekey/manor,
+/obj/item/roguekey/manor,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "qcY" = (
@@ -519623,13 +519633,13 @@ iIg
 pvR
 iSm
 iSm
-gxt
+ojs
 iSm
 iSm
 iSm
 iSm
 iSm
-gxt
+ojs
 iSm
 iSm
 uTc


### PR DESCRIPTION
## About The Pull Request

Added the correct ID check for the court magicians quarters doors.

Also adds two manor keys so the magician associates they hire can also get into the keep itself.

## Testing Evidence

![dreamseeker_VxhX8bWJKi](https://github.com/user-attachments/assets/0100e950-90d5-4cac-b3ae-cdbdbd9b03dd)
![dreamseeker_VoyhUvJpfU](https://github.com/user-attachments/assets/a9ff8755-d8c6-45e5-80d2-577a1850aa08)

## Why It's Good For The Game

The damn key isn't being used anywhere, not even in their private room. This changes that.