### PR TITLE
Adds dostrip overload for bandit coins, ashes them on non-bandit strip

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -512,6 +512,14 @@
 		qdel(src)
 	..()
 
+/obj/item/mattcoin/doStrip(mob/stripper, mob/owner)
+	if(!(stripper?.mind.has_antag_datum(/datum/antagonist/bandit))) //You're not a bandit, you can't strip the bandit coin
+		to_chat(stripper, "[src] turns to ash in my hands!")
+		playsound(stripper.loc, 'sound/items/firesnuff.ogg', 100, FALSE, -1)
+		qdel(src)
+		return FALSE
+	. = ..()
+
 /obj/item/mattcoin/attack_right(mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	var/input_text = input(user, "Enter your message:", "Message")


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Admin request. This solution allows fellow Matthiosites out in the world have and cherish their bandit coin if they are given one. But prevents (in one way) the coin from falling into the hands of a town-aligned Matthiosite.

## Testing Evidence

https://github.com/user-attachments/assets/92157508-fd7c-47f0-a567-05d6bb3e6de4


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
hmm