### PR TITLE
Battlemaster Customization Options

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -28,6 +28,7 @@
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)			
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
@@ -37,7 +38,7 @@
 			H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 			H.set_blindness(0)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-			var/weapons = list("Bastard Sword","Mace","Billhook","Battle Axe")
+			var/weapons = list("Bastard Sword","Mace","Billhook","Battle Axe","Short Sword & Heater Shield")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
 				if("Bastard Sword")
@@ -53,6 +54,28 @@
 				if("Battle Axe")
 					H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 					backr = /obj/item/rogueweapon/stoneaxe/battle
+				if("Short Sword & Heater Shield")
+					H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+					H.mind.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
+					backr = /obj/item/rogueweapon/shield/heater
+					beltr = /obj/item/rogueweapon/sword/iron/short
+			var/armors = list("Chainmaille Set","Iron Breastplate","Gambeson & Helmet")
+			var/armor_choice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+			switch(armor_choice)
+				if("Chainmaille Set")
+					shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+					pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+					neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
+					gloves = /obj/item/clothing/gloves/roguetown/chain/iron
+				if("Iron Breastplate")
+					armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
+					pants = /obj/item/clothing/under/roguetown/trou/leather
+					gloves = /obj/item/clothing/gloves/roguetown/angle
+				if("Gambeson & Helmet")
+					shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+					pants = /obj/item/clothing/under/roguetown/trou/leather
+					head = /obj/item/clothing/head/roguetown/helmet/kettle
+					gloves = /obj/item/clothing/gloves/roguetown/angle
 			H.change_stat("strength", 2)
 			H.change_stat("endurance", 1)
 			H.change_stat("constitution", 2)
@@ -60,11 +83,7 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
-			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 			shoes = /obj/item/clothing/shoes/roguetown/boots
-			neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
-			gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 			cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1)
 


### PR DESCRIPTION
## About The Pull Request

Adds a few options to the battlemaster class. Traditionally, fighter archetypes in DnD type settings are boring but offset this by being highly customizable. Our battlemaster is just some dork in chainmaille, so this aims to remedy this. Also does terrible powercreep to the subclass by giving it the 1 shield it used to have before the great adventurer resorting.

Adds:

1. Three options for armor instead of just one: players now can choose from the classic chain set, an iron breastplate set (**iron** breastplate, heavy leather gloves, normal leather pants) or a gambeson & kettle set perfect for the aspiring bog guard hopeful (kettle hat, gambeson, heavy leather gloves)
![image](https://github.com/user-attachments/assets/d451fdd6-50a9-41e6-aa7a-80d6f6c6ad6f)
2. A sword & board weapon option for weapon choice - Short Sword & Heater Shield. Gives the player an (iron!) short sword and a wooden heater shield, along with one extra point in shield to bring them to apprentice shield up from novice the other loadouts get. Straight stat buff from Bastard as a trade off for starting with what is perhaps the worst sword, as otherwise it'd just make way more sense to just take bastard and pick up a wood shield from the first goblin you leg-decap in a few swings. 
![image](https://github.com/user-attachments/assets/5300f424-0f8b-4265-9565-784863255faa)
3. A point of shield for all battlemasters regardless of weapon choice. They used to have this. They have it again. I'm not really sure what the shield skill even does or if it's functional. As I said above, people who take the heater & short weapon choice get a bonus point of shield, raising it to apprentice.
![image](https://github.com/user-attachments/assets/abcba89c-f8b9-4c8a-bf61-76413f1d9fcf)


## Testing Evidence

Ran it local, nothing blew up. 
![image](https://github.com/user-attachments/assets/1f4ac324-1985-4f6d-a7f5-de470afd1d4d)


## Why It's Good For The Game

~~i fucking HATE chainmaille it looks SO bad it's SO fucking loud I swear when you wear full chain it like blows out your speakers oh my FUCKING god please merge this i BEG you~~ A sword and shield adventurer dude is like THE classical fantasy guy and atm we don't have an option for that except for knight errant, and sometimes you don't want your tank to be a stuffy nobleman because it brings the vibe down. More customization is good, as is generally bringing the power level of adventurers down as well - they should be scrappy little dudes who get washed in 1v1s but with the power of friendship and a raid leader can take down even the baddest of baddies. I tried to keep all these additions very low power level, as you can see with the iron short sword (i really want that thing to get more love!) and the two other armor sets having pretty glaring weaknesses in the name of drip. If the point of shield is really a gamebreaker I'm willing to nix it and just let them have it only if they start heater, aside from that tho I think there's not much to take issue with here. 