### PR TITLE
Add word descriptor to show a weapon's force in game

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -115,9 +115,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	// non-clothing items
 	var/datum/dog_fashion/dog_fashion = null
 
-	//Tooltip vars
-	var/force_string //string form of an item's force. Edit this var only to set a custom force string
-	var/last_force_string_check = 0
 	var/tip_timer
 
 	var/trigger_guard = TRIGGER_GUARD_NONE
@@ -334,8 +331,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		new path(src)
 	actions_types = null
 
-	if(force_string)
-		item_flags |= FORCE_STRING_OVERRIDE
 
 	if(!hitsound)
 		if(damtype == "fire")
@@ -419,6 +414,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		var/list/inspec = list(span_notice("Properties of [src.name]"))
 		if(minstr)
 			inspec += "\n<b>MIN.STR:</b> [minstr]"
+		
+		if(force)
+			inspec += "\n<b>FORCE:</b> [get_force_string(force)]"
+		if(force_wielded && !wielded)
+			inspec += "\n<b>WIELDED FORCE:</b> [get_force_string(force_wielded)]"
 
 		if(wbalance)
 			inspec += "\n<b>BALANCE: </b>"
@@ -1052,38 +1052,25 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/on_juice()
 
-/obj/item/proc/set_force_string()
+/obj/item/proc/get_force_string(var/force)
 	switch(force)
-		if(0 to 4)
-			force_string = "very low"
-		if(4 to 7)
-			force_string = "low"
-		if(7 to 10)
-			force_string = "medium"
-		if(10 to 11)
-			force_string = "high"
-		if(11 to 20) //12 is the force of a toolbox
-			force_string = "robust"
-		if(20 to 25)
-			force_string = "very robust"
+		if(0 to 9)
+			return "Puny"
+		if(10 to 14)
+			return "Weak"
+		if(15 to 19)
+			return "Modest"
+		if(20 to 24)
+			return "Fine"
+		if(25 to 29)
+			return "Great"
+		if(30 to 35)
+			return "Grand"
 		else
-			force_string = "exceptionally robust"
-	last_force_string_check = force
-
-/obj/item/proc/openTip(location, control, params, user)
-	if(last_force_string_check != force && !(item_flags & FORCE_STRING_OVERRIDE))
-		set_force_string()
-	if(!(item_flags & FORCE_STRING_OVERRIDE))
-		openToolTip(user,src,params,title = name,content = "[desc]<br>[force ? "<b>Force:</b> [force_string]" : ""]",theme = "")
-	else
-		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string]",theme = "")
+			return "Mighty"
 
 /obj/item/MouseEntered(location, control, params)
 	. = ..()
-	if((item_flags & IN_INVENTORY || item_flags & IN_STORAGE) && usr.client.prefs.enable_tips && !QDELETED(src))
-		var/timedelay = usr.client.prefs.tip_delay/100
-		var/user = usr
-		tip_timer = addtimer(CALLBACK(src, PROC_REF(openTip), location, control, params, user), timedelay, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.
 
 /obj/item/MouseExited()
 	. = ..()

--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -13,7 +13,6 @@
 	throw_range = 7
 	grind_results = list(/datum/reagent/lye = 10)
 	var/cleanspeed = 35 //slower than mop
-	force_string = "robust... against germs"
 	var/uses = 100
 
 /obj/item/soap/ComponentInitialize()


### PR DESCRIPTION
## About The Pull Request
Add word descriptor to show a weapon's force in game

Also cleaned up unused old force string code

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_BMXPBGM9cQ](https://github.com/user-attachments/assets/10838373-bf5b-46c1-a55d-05a7341f3b53)
![dreamseeker_B9j0LWSM8R](https://github.com/user-attachments/assets/a9650a17-1181-4e04-9e0b-e413da41fb24)
![dreamseeker_3WNUcfftle](https://github.com/user-attachments/assets/cf327518-12d0-4574-b668-1988e46c1667)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Add word descriptor to show a weapon's force in game. Better transparency so people know roughly how good a weapon is without needing to code dive. Obscure it slightly behind words for immersion.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
