### PR TITLE
Rename cackleberry to egg, "powder" to flour, "powder" to "ozium"

### DIFF
--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -199,7 +199,7 @@
 	qdel(src)
 
 /obj/item/reagent_containers/powder/ozium
-	name = "powder"
+	name = "ozium"
 	desc = ""
 	icon = 'icons/roguetown/items/produce.dmi'
 	icon_state = "ozium"

--- a/modular/Neu_Farming/code/eggs.dm
+++ b/modular/Neu_Farming/code/eggs.dm
@@ -1,6 +1,6 @@
 /obj/item/reagent_containers/food/snacks/egg
 	icon = 'modular/Neu_Food/icons/food.dmi'
-	name = "cackleberry"
+	name = "egg"
 	desc = ""
 	icon_state = "egg"
 	dropshrink = 0.8

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -5,9 +5,6 @@
  *						*
  * * * * * * * * * * * **/
 
-// CONTAINMENT ZONE - marked for death
-/obj/item/reagent_containers/powder/flour/salt // salt being subtype of flour is terrible for so many reasons repath to  /obj/item/reagent_containers/powder/salt
-
 
 /*	........   Templates / Base items   ................ */
 /obj/item/reagent_containers // added vars used in neu cooking, might be used for other things too in the future. How it works is in each items attackby code.
@@ -321,9 +318,9 @@
  *								*
  * * * * * * * * * * * * * * * 	*/
 
-// -------------- POWDER (flour) -----------------
+// -------------- Flour -----------------
 /obj/item/reagent_containers/powder/flour
-	name = "powder"
+	name = "flour"
 	desc = "With this ambition, we build an empire."
 	gender = PLURAL
 	icon_state = "flour"
@@ -353,7 +350,7 @@
 	playsound(get_turf(user), 'modular/Neu_Food/sound/splishy.ogg', 100, TRUE, -1)
 	if(do_after(user, short_cooktime, target = src))
 		add_sleep_experience(user, /datum/skill/craft/cooking, user.STAINT)
-		name = "wet powder"
+		name = "wet flour"
 		desc = "Destined for greatness, at your hands."
 		R.reagents.remove_reagent(/datum/reagent/water, 10)
 		water_added = TRUE

--- a/modular/Neu_Food/code/cooked/NeuFood_snacks.dm
+++ b/modular/Neu_Food/code/cooked/NeuFood_snacks.dm
@@ -97,12 +97,12 @@
 	rotprocess = SHELFLIFE_EXTREME
 	eat_effect = /datum/status_effect/buff/foodbuff
 
-/*	.............   Fried Cackleberry   ................ */
+/*	.............   Fried egg   ................ */
 /obj/item/reagent_containers/food/snacks/rogue/friedegg
 	trash = null
 	list_reagents = list(/datum/reagent/consumable/nutriment = SNACK_DECENT)
-	tastes = list("fried cackleberry" = 1)
-	name = "fried cackleberry"
+	tastes = list("fried egg" = 1)
+	name = "fried egg"
 	desc = "A favorite dish among Astratans."
 	icon_state = "friedegg"
 	portable = FALSE

--- a/modular/Neu_Food/code/raw/NeuFood_dough.dm
+++ b/modular/Neu_Food/code/raw/NeuFood_dough.dm
@@ -155,7 +155,7 @@
 	if(istype(I, /obj/item/reagent_containers/food/snacks/egg))
 		if(isturf(loc)&& (found_table))
 			playsound(get_turf(user), 'sound/foley/dropsound/food_drop.ogg', 40, TRUE, -1)
-			to_chat(user, span_notice("Working cackleberry into the dough, shaping it into a cake..."))
+			to_chat(user, span_notice("Working egg into the dough, shaping it into a cake..."))
 			playsound(get_turf(user), 'modular/Neu_Food/sound/eggbreak.ogg', 100, TRUE, -1)
 			if(do_after(user,long_cooktime, target = src))
 				add_sleep_experience(user, /datum/skill/craft/cooking, user.STAINT)
@@ -459,8 +459,8 @@
 	foodtype = GRAIN | DAIRY
 
 /obj/item/reagent_containers/food/snacks/rogue/sandwich/egg
-	tastes = list("cheese" = 1,"cackleberry" = 1)
-	name = "cackleberry toast"
+	tastes = list("cheese" = 1,"egg" = 1)
+	name = "egg toast"
 	faretype = FARE_NEUTRAL
 	icon_state = "bread_egg"
 	foodtype = GRAIN | MEAT


### PR DESCRIPTION
## About The Pull Request
Rename cackleberry to egg, "powder" to flour, "powder" to "ozium"

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_rHYGjWNN1h](https://github.com/user-attachments/assets/d83b6345-f3de-4f38-9da1-1d98d40b3035)
![dreamseeker_lNHraz94qY](https://github.com/user-attachments/assets/3b8f7cac-3cd3-48b7-aa9c-c30530332e67)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Cackleberry is a late 19th century obscure word we've been calling them eggs since before and after what the fuck. 
Also "powder" should be flour.
Also "powder" should be ozium we have no reservation about naming moondust moondust so why ozium get a pass?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
