### PR TITLE
Update interface.dm

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -148,7 +148,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 \tMMB (no intent) = Special Interaction
 \tSHIFT + LMB = Examine something
 \tSHIFT + RMB = Focus
-\tCTRL + LMB = TileAtomList
+\tALT + RMB = TileAtomList
 \tCTRL + RMB = Point at something
 </font>"}
 


### PR DESCRIPTION
Fixed TileAtomList's key shortcute being wrong.

## About The Pull Request
Fixed the instructions to give the proper key for TileAtomListing a square. 

## Why It's Good For The Game

I think players should be know what the correct key to search a stack is.

## Testing Evidence

[image](https://github.com/user-attachments/assets/6ecbd4cf-e5bb-47d6-8f93-ae32c0d1ec2e)