### PR TITLE
Sins of the Father

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -3,8 +3,8 @@
 	flag = KNIGHT
 	department_flag = NOBLEMEN
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	allowed_races = RACES_NO_CONSTRUCT
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -3,8 +3,8 @@
 	flag = SQUIRE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)


### PR DESCRIPTION
## About The Pull Request

Pretty simple, this reduces knight slots by 1 and does the same with squires.

## Testing Evidence

Test server ran, blessed be.

## Why It's Good For The Game

Back in PR 21, knights were made into Royal Guard, who's purpose was to be a less geared heavy armor job with the point being written on the tin; to protect the royals. With it, gear was toned down and slots were increased. Flash forward to now, knights are back to being as big and hunky as they originally were and the slot count never changed, so we have 4 knights slots (if you include knight captain) which is truly really an unbalanced thing to fight against in any context. Let alone when the entire town gathers to for example, kill four moderately geared bandits on average. 

To wrap this up, I'll actually quote from the man who did PR 21.
"My intention was royal guard to not be knights, act as court guards"
