### PR TITLE
Literally swaps the falx for a bastard sword for the Berserker wretch class

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -454,7 +454,7 @@
 			beltr = /obj/item/rogueweapon/mace/goden/steel
 		if ("Sword")
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-			beltr = /obj/item/rogueweapon/sword/falx
+			beltr = /obj/item/rogueweapon/sword/long
 	H.change_stat("strength", 3)
 	H.change_stat("endurance", 1)
 	H.change_stat("constitution", 2)


### PR DESCRIPTION
## About The Pull Request

Just gives the berserker class a bastard sword instead of a falx. Reason? It's more versatile in comparison, plus barbarians with a big-ass sword sounds cooler than the falx. 

## Testing Evidence

It works. Compiled with no errors. Literally a single line change.

## Why It's Good For The Game

Honestly it's a lot more versatile and thematic. Versatility-wise it offers both peel and the mechanic of mordhauing, which I think is INCREDIBLE and fitting for brutal as hell warriors. And honestly I believe barbarians using large-ass bastard swords sound way more in-line.
