### PR TITLE
Fixes shield hit runtime by mob or non-item

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -51,7 +51,8 @@
 	var/mob/attacker
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
 		var/obj/item/I = hitby
-		attacker = I.thrownby
+		if(I && I?.thrownby)
+			attacker = I.thrownby
 	if(attack_type == PROJECTILE_ATTACK)
 		var/obj/projectile/P = hitby
 		attacker = P.firer

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -51,11 +51,12 @@
 	var/mob/attacker
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
 		var/obj/item/I = hitby
-		if(I && I?.thrownby)
+		if(I?.thrownby)
 			attacker = I.thrownby
 	if(attack_type == PROJECTILE_ATTACK)
 		var/obj/projectile/P = hitby
-		attacker = P.firer
+		if(P?.firer)
+			attacker = P.firer
 	if(attacker && istype(attacker))
 		if (!owner.can_see_cone(attacker))
 			return FALSE


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

![image](https://github.com/user-attachments/assets/1e75d076-ec5f-42fd-923d-39a08f256a1d)

Runtime was throwing when passed atom/movable that hit a shield wasn't an item. Like hitting someone with a thrown goblin. This tightens up the var access to prevent that runtime.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
It compiles. Theoretically it works!


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Since this is addressing a runtime, passing hits down to null/false shouldn't be any worse than the current alternative.