### PR TITLE
Change amount per gulp to 5 on default, use that for gulping, change …

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -2,6 +2,7 @@
 /obj/item/reagent_containers/glass
 	name = "glass"
 	amount_per_transfer_from_this = 10
+	var/amount_per_gulp = 5 // We need a separate amount for drinking
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)
 	volume = 50
 	reagent_flags = OPENCONTAINER|REFILLABLE
@@ -74,7 +75,7 @@
 					if (prob(25))
 						to_chat(human_user, span_red("I've got better manners than this..."))
 			to_chat(user, span_notice("I swallow a gulp of [src]."))
-		addtimer(CALLBACK(reagents, TYPE_PROC_REF(/datum/reagents, trans_to), M, min(amount_per_transfer_from_this,5), TRUE, TRUE, FALSE, user, FALSE, INGEST), 5)
+		addtimer(CALLBACK(reagents, TYPE_PROC_REF(/datum/reagents, trans_to), M, amount_per_gulp, TRUE, TRUE, FALSE, user, FALSE, INGEST), 5)
 		playsound(M.loc,pick(drinksounds), 100, TRUE)
 		return
 

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/roguetown/misc/alchemy.dmi'
 	icon_state = "vial_bottle"
 	amount_per_transfer_from_this = 9
+	amount_per_gulp = 9
 	possible_transfer_amounts = list(9)
 	volume = 27
 	fill_icon_thresholds = list(0, 33, 66, 100)


### PR DESCRIPTION
## About The Pull Request
When I refactored alchemical vial I deleted the code that make it gulp 9 units instead of 5 units per default. Refactor the code such that the default gulp volume is 1.7 ounce and otherwise it is 9 units (3 ounces) for vial

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
gvlp (I tested it)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gulp. Original design intention yada.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
