### PR TITLE
Gives iron and steel quarterstaff reinforced shaft + fix recipe

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -907,6 +907,7 @@
 	gripped_intents = list(/datum/intent/spear/bash/ranged/quarterstaff, /datum/intent/spear/thrust/quarterstaff/metal)
 	icon_state = "quarterstaff_iron"
 	max_integrity = 300
+	blade_dulling = DULLING_SHAFT_REINFORCED
 
 /obj/item/rogueweapon/woodstaff/quarterstaff/steel
 	name = "steel quarterstaff"
@@ -916,3 +917,4 @@
 	gripped_intents = list(/datum/intent/spear/bash/ranged/quarterstaff, /datum/intent/spear/thrust/quarterstaff/metal)
 	icon_state = "quarterstaff_steel"
 	max_integrity = 500
+	blade_dulling = DULLING_SHAFT_REINFORCED

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -295,14 +295,14 @@
 /datum/crafting_recipe/roguetown/quarterstaff_iron
 	name = "iron-reinforced quarterstaff"
 	result = list(/obj/item/rogueweapon/woodstaff/quarterstaff/iron)
-	reqs = list(/obj/item/rogueweapon/woodstaff/quarterstaff, /obj/item/ingot/iron = 1)
+	reqs = list(/obj/item/rogueweapon/woodstaff/quarterstaff = 1, /obj/item/ingot/iron = 1)
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/quarterstaff_steel
 	name = "steel-reinforced quarterstaff"
 	result = list(/obj/item/rogueweapon/woodstaff/quarterstaff/steel)
-	reqs = list(/obj/item/rogueweapon/woodstaff/quarterstaff, /obj/item/ingot/steel = 1)
+	reqs = list(/obj/item/rogueweapon/woodstaff/quarterstaff = 1, /obj/item/ingot/steel = 1)
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 3
 


### PR DESCRIPTION
## About The Pull Request
- Gives iron and steel quarterstaff reinforced shaft
- Fix their recipes not consuming the quarterstaff

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_jx2qWxlKqp](https://github.com/user-attachments/assets/60247e3f-1133-40d6-830c-135997989b96)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gives iron and steel quarterstaff reinforced shaft. It just make sense. It is literally reinforced. It is a better PVE (and maybe all around option) but most importantly it makes sense.

Fix their recipes not consuming the quarterstaff

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
