### PR TITLE
Insane zweihander buff

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -761,6 +761,7 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 3
 	max_blade_int = 300
+	force_wielded = 35
 
 /obj/item/rogueweapon/greatsword/psygsword
 	name = "Apocrypha"

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -761,6 +761,7 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 3
 	max_blade_int = 300
+	force = 14
 	force_wielded = 35
 
 /obj/item/rogueweapon/greatsword/psygsword


### PR DESCRIPTION
## About The Pull Request

Raises steel zweihander damage so that it's no longer objectively weaker than its iron counterpart.

## Why It's Good For The Game

The steel zwei does less damage than the iron one for some reason, this PR makes them do the same amount of force damage. Steel weapons are supposed to be an upgrade to iron - this feels like an oversight. 

## Testing Evidence

It's two lines.