### PR TITLE
Gives greatswords metal shafts

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -722,6 +722,7 @@
 	gripsprite = TRUE
 	wlength = WLENGTH_GREAT
 	w_class = WEIGHT_CLASS_BULKY
+	blade_dulling = DULLING_SHAFT_METAL
 	minstr = 9
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/swords
@@ -797,6 +798,7 @@
 	gripsprite = TRUE
 	wlength = WLENGTH_GREAT
 	w_class = WEIGHT_CLASS_BULKY
+	blade_dulling = DULLING_SHAFT_METAL
 	minstr = 8
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/swords

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -751,7 +751,6 @@
 	smeltresult = /obj/item/ingot/iron
 	smelt_bar_num = 3
 	max_blade_int = 200
-	blade_dulling = DULLING_SHAFT_METAL
 	wdefense = 4
 	force = 14
 	force_wielded = 35


### PR DESCRIPTION
## About The Pull Request

Gives greatswords (and the estoc) metal shafts, like other swords.

## Testing Evidence

eeeeeeeeee

![image](https://github.com/user-attachments/assets/91472458-d655-4344-af03-485469b316a0)

## Why It's Good For The Game

Greatswords didn't have a blade_dulling variable assigned, so they were just defaulting to wooden shafts. It seems like most other swords use metal shafts, so I would assume this is unintentional.