### PR TITLE
Noc T3 -- Spell Bundle, Noc Miracle Adjustments

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -241,7 +241,7 @@
 	var/coord_col = "+[col-1]"
 	var/coord_col_offset = 4 + 2 * col
 
-	var/coord_row = "[row ? -row : "+0"]"
+	var/coord_row = "[row ? "+[row]" : "+0"]"
 
 	return "WEST[coord_col]:[coord_col_offset],SOUTH[coord_row]:3"
 

--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -107,13 +107,22 @@
 	if(!H || !H.mind || !patron)
 		return
 
-	var/list/spelllist = list(patron.extra_spell, /obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
 		var/newspell = new spell_type
 		H.mind.AddSpell(newspell)
 		LAZYADD(granted_spells, newspell)
+	if(length(patron.extra_spells))
+		for(var/spell_type in patron.extra_spells)
+			if(patron.extra_spells[spell_type] <= CLERIC_T1)
+				if(H.mind.has_spell(spell_type))
+					continue
+				else
+					var/newspell = new spell_type
+					H.mind.AddSpell(newspell)
+					LAZYADD(granted_spells, newspell)
 	level = CLERIC_T1
 	passive_devotion_gain = 0.25
 	passive_progression_gain = 0.25
@@ -123,7 +132,7 @@
 	if(!H || !H.mind || !patron)
 		return
 		
-	var/list/spelllist = list(patron.extra_spell, /obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0)
 	if(istype(patron,/datum/patron/divine))
 		spelllist += /obj/effect/proc_holder/spell/targeted/abrogation
 	for(var/spell_type in spelllist)
@@ -132,6 +141,15 @@
 		var/newspell = new spell_type
 		H.mind.AddSpell(newspell)
 		LAZYADD(granted_spells, newspell)
+	if(length(patron.extra_spells))
+		for(var/spell_type in patron.extra_spells)
+			if(patron.extra_spells[spell_type] <= CLERIC_T0)
+				if(H.mind.has_spell(spell_type))
+					continue
+				else
+					var/newspell = new spell_type
+					H.mind.AddSpell(newspell)
+					LAZYADD(granted_spells, newspell)
 	level = CLERIC_T0
 	max_devotion = CLERIC_REQ_1 //Max devotion limit - Paladins are stronger but cannot pray to gain all abilities beyond t1
 	max_progression = CLERIC_REQ_1
@@ -147,6 +165,15 @@
 		var/newspell = new spell_type
 		H.mind.AddSpell(newspell)
 		LAZYADD(granted_spells, newspell)
+	if(length(patron.extra_spells))
+		for(var/spell_type in patron.extra_spells)
+			if(patron.extra_spells[spell_type] <= CLERIC_T0)
+				if(H.mind.has_spell(spell_type))
+					continue
+				else
+					var/newspell = new spell_type
+					H.mind.AddSpell(newspell)
+					LAZYADD(granted_spells, newspell)
 	level = CLERIC_T0
 	max_devotion = CLERIC_REQ_1 //Max devotion limit - Churchlings only get diagnose and lesser miracle.
 	max_progression = CLERIC_REQ_0
@@ -155,13 +182,22 @@
 	if(!H || !H.mind || !patron)
 		return
 	granted_spells = list()
-	var/list/spelllist = list(patron.extra_spell, /obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
 		var/newspell = new spell_type
 		H.mind.AddSpell(newspell)
 		LAZYADD(granted_spells, newspell)
+	if(length(patron.extra_spells))
+		for(var/spell_type in patron.extra_spells)
+			if(patron.extra_spells[spell_type] <= CLERIC_T4)
+				if(H.mind.has_spell(spell_type))
+					continue
+				else
+					var/newspell = new spell_type
+					H.mind.AddSpell(newspell)
+					LAZYADD(granted_spells, newspell)
 	level = CLERIC_T4
 	passive_devotion_gain = 1
 	devotion = max_devotion
@@ -173,13 +209,22 @@
 		return
 
 	granted_spells = list()
-	var/list/spelllist = list(patron.extra_spell, /obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
+	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue
 		var/newspell = new spell_type
 		H.mind.AddSpell(newspell)
 		LAZYADD(granted_spells, newspell)
+	if(length(patron.extra_spells))
+		for(var/spell_type in patron.extra_spells)
+			if(patron.extra_spells[spell_type] <= CLERIC_T4)
+				if(H.mind.has_spell(spell_type))
+					continue
+				else
+					var/newspell = new spell_type
+					H.mind.AddSpell(newspell)
+					LAZYADD(granted_spells, newspell)
 	level = CLERIC_T4
 	passive_devotion_gain = 1
 	devotion = max_devotion

--- a/code/datums/gods/_patron.dm
+++ b/code/datums/gods/_patron.dm
@@ -34,8 +34,8 @@ GLOBAL_LIST_EMPTY(preference_patrons)
 	var/t3
 	/// Final tier spell
 	var/t4
-	/// For patrons with more spells than tiers. eg. Malum's Fire
-	var/extra_spell
+	/// For patrons with more spells than tiers. eg. Malum's Fire. Type as index, tier as value. (0-4)
+	var/list/extra_spells
 
 /datum/patron/proc/on_gain(mob/living/pious)
 	for(var/trait in mob_traits)

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -26,6 +26,7 @@
 	mob_traits = list(TRAIT_NIGHT_OWL, TRAIT_NOCSIGHT)
 	t1 = /obj/effect/proc_holder/spell/invoked/blindness/miracle
 	t2 = /obj/effect/proc_holder/spell/invoked/invisibility/miracle
+	t3 = /obj/effect/proc_holder/spell/self/noc_spell_bundle
 	confess_lines = list(
 		"NOC IS NIGHT!",
 		"NOC SEES ALL!",
@@ -42,7 +43,7 @@
 	t2 = /obj/effect/proc_holder/spell/targeted/shapeshift/dendor
 	t3 = /obj/effect/proc_holder/spell/targeted/conjure_glowshroom
 	t4 = /obj/effect/proc_holder/spell/self/howl/call_of_the_moon
-	extra_spell = /obj/effect/proc_holder/spell/invoked/spiderspeak
+	extra_spells = list(/obj/effect/proc_holder/spell/invoked/spiderspeak = 0)
 	confess_lines = list(
 		"DENDOR PROVIDES!",
 		"THE TREEFATHER BRINGS BOUNTY!",
@@ -88,7 +89,7 @@
 	t1 = /obj/effect/proc_holder/spell/invoked/avert
 	t2 = /obj/effect/proc_holder/spell/targeted/abrogation
 	t3 = /obj/effect/proc_holder/spell/targeted/churn
-	extra_spell = /obj/effect/proc_holder/spell/targeted/soulspeak
+	extra_spells = list(/obj/effect/proc_holder/spell/targeted/soulspeak = 0)
 	confess_lines = list(
 		"ALL SOULS FIND THEIR WAY TO NECRA!",
 		"THE UNDERMAIDEN IS OUR FINAL REPOSE!",
@@ -143,7 +144,7 @@
 	t2 = /obj/effect/proc_holder/spell/invoked/heatmetal
 	t3 = /obj/effect/proc_holder/spell/invoked/hammerfall
 	t4 = /obj/effect/proc_holder/spell/invoked/craftercovenant
-	extra_spell = /obj/effect/proc_holder/spell/invoked/malum_flame_rogue
+	extra_spells = list(/obj/effect/proc_holder/spell/invoked/malum_flame_rogue = 0)
 	confess_lines = list(
 		"MALUM IS MY MUSE!",
 		"TRUE VALUE IS IN THE TOIL!",

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -35,7 +35,8 @@
 		if(target.anti_magic_check(TRUE, TRUE))
 			return FALSE
 		target.visible_message(span_warning("[user] points at [target]'s eyes!"),span_warning("My eyes are covered in darkness!"))
-		target.blind_eyes(4)
+		var/strength = min(user.mind?.get_skill_level(associated_skill) * 4, 4)
+		target.blind_eyes(strength)
 		return TRUE
 	revert_cast()
 	return FALSE
@@ -74,10 +75,68 @@
 		if(target.anti_magic_check(TRUE, TRUE))
 			return FALSE
 		target.visible_message(span_warning("[target] starts to fade into thin air!"), span_notice("You start to become invisible!"))
+		var/dur = 5 * (user.mind?.get_skill_level(associated_skill))
 		animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
-		target.mob_timers[MT_INVISIBILITY] = world.time + 15 SECONDS
-		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), 15 SECONDS)
+		target.mob_timers[MT_INVISIBILITY] = world.time + dur SECONDS
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), dur SECONDS)
 		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), 15 SECONDS)
 		return TRUE
 	revert_cast()
 	return FALSE
+
+/obj/effect/proc_holder/spell/self/noc_spell_bundle
+	miracle = TRUE
+	devotion_cost = 200
+	chargetime = 0
+	chargedrain = 0
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	associated_skill = /datum/skill/magic/holy
+	var/list/utility_bundle = list(
+		/obj/effect/proc_holder/spell/invoked/diagnose/secular,
+		/obj/effect/proc_holder/spell/self/message,
+		/obj/effect/proc_holder/spell/invoked/leap,
+		/obj/effect/proc_holder/spell/targeted/touch/lesserknock,
+		/obj/effect/proc_holder/spell/invoked/mending,
+		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
+		/obj/effect/proc_holder/spell/invoked/aerosolize,
+		/obj/effect/proc_holder/spell/invoked/blink,
+		/obj/effect/proc_holder/spell/targeted/touch/darkvision,
+	)
+	var/list/offensive_bundle = list(
+		/obj/effect/proc_holder/spell/invoked/projectile/guided_bolt,
+		/obj/effect/proc_holder/spell/invoked/conjure_armor/miracle,
+		/obj/effect/proc_holder/spell/invoked/conjure_weapon/miracle
+	)
+	var/list/buff_bundle = list(
+		/obj/effect/proc_holder/spell/invoked/hawks_eyes,
+		/obj/effect/proc_holder/spell/invoked/giants_strength,
+		/obj/effect/proc_holder/spell/invoked/longstrider,
+		/obj/effect/proc_holder/spell/invoked/guidance,
+		/obj/effect/proc_holder/spell/invoked/haste,
+		/obj/effect/proc_holder/spell/invoked/fortitude,
+		/obj/effect/proc_holder/spell/invoked/forcewall/greater,
+	)
+/obj/effect/proc_holder/spell/self/noc_spell_bundle/cast(list/targets, mob/user)
+	. = ..()
+	var/choice = alert(user, "What type of spells has Noc blessed you with?", "CHOOSE BUNDLE", "Utility", "Offense", "Buffs")
+	switch(choice)
+		if("Utility")
+			add_spells(user, utility_bundle)
+		if("Offense")
+			add_spells(user, offensive_bundle)
+			ADD_TRAIT(user, TRAIT_MAGEARMOR, TRAIT_MIRACLE)
+		if("Buffs")
+			add_spells(user, buff_bundle)
+			ADD_TRAIT(user, TRAIT_MAGEARMOR, TRAIT_MIRACLE)
+		else
+			revert_cast()
+	user.mind?.RemoveSpell(src.type)
+
+
+/obj/effect/proc_holder/spell/self/noc_spell_bundle/proc/add_spells(mob/user, list/spells)
+	for(var/spell_type in spells)
+		if(user?.mind.has_spell(spell_type))
+			continue
+		else
+			var/newspell = new spell_type
+			user?.mind.AddSpell(newspell)

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_armor.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_armor.dm
@@ -57,34 +57,37 @@
 	var/obj/item/new_helmet = new helmet(target)
 	target.equip_to_slot_or_del(new_helmet, SLOT_HEAD)
 	// Passing all these vars are necessary to override the owner because equip_to_slot_or_del don't actually assign an owner on equip
-	new_helmet.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, /datum/skill/magic/arcane, GLOW_COLOR_ARCANE, target)
+	new_helmet.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill, GLOW_COLOR_ARCANE, target)
 	
 	var/obj/item/new_shirt = new shirt(target)
 	target.equip_to_slot_or_del(new_shirt, SLOT_SHIRT)
-	new_shirt.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, /datum/skill/magic/arcane, GLOW_COLOR_ARCANE, target)
+	new_shirt.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill, GLOW_COLOR_ARCANE, target)
 	
 	var/obj/item/new_wrists = new wrists(target)
 	target.equip_to_slot_or_del(new_wrists, SLOT_WRISTS)
-	new_wrists.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, /datum/skill/magic/arcane, GLOW_COLOR_ARCANE, target)
+	new_wrists.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill, GLOW_COLOR_ARCANE, target)
 
 	var/obj/item/new_gloves = new gloves(target)
 	target.equip_to_slot_or_del(new_gloves, SLOT_GLOVES)
-	new_gloves.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, /datum/skill/magic/arcane, GLOW_COLOR_ARCANE, target)
+	new_gloves.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill, GLOW_COLOR_ARCANE, target)
 
 	var/obj/item/new_neck = new neck(target)
 	target.equip_to_slot_or_del(new_neck, SLOT_NECK)
-	new_neck.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, /datum/skill/magic/arcane, GLOW_COLOR_ARCANE, target)
+	new_neck.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill, GLOW_COLOR_ARCANE, target)
 
 	var/obj/item/new_shoes = new shoes(target)
 	target.equip_to_slot_or_del(new_shoes, SLOT_SHOES)
-	new_shoes.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, /datum/skill/magic/arcane, GLOW_COLOR_ARCANE, target)
+	new_shoes.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill, GLOW_COLOR_ARCANE, target)
 
 	var/obj/item/new_armor = new armor(target)
 	target.equip_to_slot_or_del(new_armor, SLOT_ARMOR)
-	new_armor.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, /datum/skill/magic/arcane, GLOW_COLOR_ARCANE, target)
+	new_armor.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill, GLOW_COLOR_ARCANE, target)
 
 	var/obj/item/new_pants = new pants(target)
 	target.equip_to_slot_or_del(new_pants, SLOT_PANTS)
-	new_pants.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, /datum/skill/magic/arcane, GLOW_COLOR_ARCANE, target)
+	new_pants.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill, GLOW_COLOR_ARCANE, target)
+
+/obj/effect/proc_holder/spell/invoked/conjure_armor/miracle
+	associated_skill = /datum/skill/magic/holy
 
 #undef CONJURE_DURATION

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
@@ -67,9 +67,11 @@
 
 	var/obj/item/rogueweapon/R = new weapon_choice(user.drop_location())
 	R.blade_dulling = DULLING_SHAFT_CONJURED
-	R.AddComponent(/datum/component/conjured_item, CONJURE_DURATION)
+	R.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill)
 	user.put_in_hands(R)
 	return TRUE
 
+/obj/effect/proc_holder/spell/invoked/conjure_weapon/miracle
+	associated_skill = /datum/skill/magic/holy
 
 #undef CONJURE_DURATION


### PR DESCRIPTION
## About The Pull Request
Adds a T3 miracle for Nocites. Spell bundle.
![dreamseeker_6gjbPqxaeS](https://github.com/user-attachments/assets/24abbd8b-f2f7-41c4-9619-a5c31acdc2d8)

Utility:
![dreamseeker_rCYDmQ1Ysu](https://github.com/user-attachments/assets/a23def72-6a3e-4534-87f4-46d222200623)
(It's a bunch of minor 1-point spells.)
- Secular Diagnose
- Message
- Leap
- Lesser Knock
- Mending
- Fetch
- Aerosolize
- Blink
- Darkvision

Offense:
![dreamseeker_M5g0ifK21C](https://github.com/user-attachments/assets/5cf30d43-c91f-43e8-babb-b618a4c0c8d5)
- Guided Bolt
- Conjure Armor
- Conjure Weapon
- Mage Armor

Buffs:
![dreamseeker_wcnbCRXl5Q](https://github.com/user-attachments/assets/95662971-eb01-48f9-886e-96aac8f8cf08)
- Hawk's Eyes
- Giant's Strength
- Longstrider
- Guidance
- Haste
- Fortitude


Other changes:
- Invisibility is now Noc T1. Blindness is T2.
- Invisibility spell duration now scales with the user's associated skill.
- Blindness duration now also scales with the associated skill.

Code changes:
- Having too many spell buttons now overlaps upwards rather than downwards.
- Added compatibility for there being way more than 4-5 miracles per Patron.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Above!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Noc is the single Patron that felt justified to giving spells to, though I'm not particularly attached to this T3 idea.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
