### PR TITLE
Steppesman Adjustments

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
@@ -7,7 +7,7 @@
 	category_tags = list(CTAG_MERCENARY)
 	traits_applied = list(TRAIT_OUTLANDER)
 	cmode_music = 'sound/music/combat_steppe.ogg'
-
+	horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled
 
 /datum/outfit/job/roguetown/mercenary/steppesman/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -25,7 +25,7 @@
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/whip)
+	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/whip, /obj/item/flashlight/flare/torch, /obj/item/rogueweapon/huntingknife/idagger/steel)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
@@ -44,7 +44,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
 	H.change_stat("perception", 3)
 	H.change_stat("endurance", 2)
 	H.change_stat("speed", 2)


### PR DESCRIPTION
## About The Pull Request

Steppesman got really left behind compared to other merc classes. Same stat-skills as others but less traits/no unique gear. Plus, showing such, **they didn't even have a toch.**

Does the following:
- Spawns them with a saiga, akin to Vaquero
- Tracking increased from 1 -> 2 (Gives them at least something unique to use.)
- Gives them a knife. Condoterio, Vaquero, and other mercs. Not a unique one, but lets them actually butcher and have a backup weapon instead of only a whip for melee.
- Gives them a torch. Possibly the most broken, powerful item of all time to give to them.... truly...
- Gives them a saiga on spawn.

## Testing Evidence

yeah need to test it, struggling due to byond hub down

## Why It's Good For The Game

Brings steppesman up to the other mercs. Other mercs still have better pants, armor, etc - but this tries to bring it MILDLY in line with similar classes by giving them a mount and at least a knife plus a torch.
