### PR TITLE
Map: Hermes and cheesemaker window

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -59862,7 +59862,7 @@
 	dir = 1
 	},
 /obj/structure/roguemachine/mail{
-	mailtag = "Streets (East)"
+	mailtag = "Fishing Village"
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -59858,11 +59858,16 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/magician)
 "vUz" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /obj/structure/roguemachine/mail{
 	mailtag = "Streets (East)"
 	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/rtfield)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "horzw"
+	},
+/area/rogue/outdoors/town)
 "vUB" = (
 /obj/structure/stairs{
 	dir = 1
@@ -158113,7 +158118,7 @@ jLU
 xWY
 bwv
 jLU
-wlf
+vUz
 hmG
 tXb
 jLU
@@ -242533,7 +242538,7 @@ iBS
 exD
 exD
 exD
-flT
+wFc
 sxy
 jHB
 keu
@@ -273374,7 +273379,7 @@ kBx
 iKD
 wxe
 blL
-vUz
+ebU
 ebU
 ebU
 ika


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Lowers fishing village hermes by 1 z-level so it is generally accessible.
![image](https://github.com/user-attachments/assets/651e9748-fa51-4d5f-b6ca-58f1140cf3db)


Adds a small barred window for the cheesemaker to do business out of.
![image](https://github.com/user-attachments/assets/33e369ca-83ab-4a68-a2da-22b8c9ff55ca)


## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/f4e1f2ca-2ffa-4972-977f-612a05fa5a5b)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Cheesemaker window was a request I saw, it helps them to do business out of their house a little easier.