### PR TITLE
mapper wrongs activist

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -15552,7 +15552,7 @@
 	locked = 1;
 	lockid = "baroness"
 	},
-/obj/item/roguegem,
+/obj/item/roguegem/ruby,
 /obj/item/book/granter/spell/blackstone/frostbolt,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -29281,7 +29281,7 @@
 /area/rogue/indoors/town)
 "kBL" = (
 /obj/structure/table/vtable,
-/obj/item/roguegem{
+/obj/item/roguegem/ruby{
 	pixel_y = 10
 	},
 /obj/item/roguegem/blue,
@@ -41330,8 +41330,8 @@
 	},
 /area/rogue/indoors/town/manor)
 "oYo" = (
-/obj/item/roguegem,
-/obj/item/roguegem,
+/obj/item/roguegem/ruby,
+/obj/item/roguegem/ruby,
 /obj/item/roguegem/violet,
 /obj/item/roguegem/yellow,
 /obj/item/roguegem/green,
@@ -58880,7 +58880,7 @@
 	},
 /obj/item/roguegem/diamond,
 /obj/structure/fluff/walldeco/bigpainting/lake,
-/obj/item/roguegem,
+/obj/item/roguegem/ruby,
 /obj/item/clothing/ring/ruby,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)


### PR DESCRIPTION
## About The Pull Request

rontzes are no longer the base gemtype to help prevent funky behavior when calling them up. this ensures that all rontz on dun world are the new, proper typepath

## Testing Evidence

it just works

## Why It's Good For The Game

they shouldn't have been the base gem item in the first place arguably, now they're properly childed alongside their siblings, gay sex, etc
