### PR TITLE
Refactor & Redo gesture required. Readd to projectile / offensive spells, prevent selection

### DIFF
--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -75,6 +75,7 @@
 	var/projectile_amount = 1	//Projectiles per cast.
 	var/current_amount = 0	//How many projectiles left.
 	var/projectiles_per_fire = 1		//Projectiles per fire. Probably not a good thing to use unless you override ready_projectile().
+	gesture_required = TRUE // All projectiles are offensive and should be locked to not handcuff
 
 /obj/effect/proc_holder/spell/invoked/projectile/proc/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)
 	return

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -681,6 +681,11 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			return FALSE
 		if(nonabstract_req && (isbrain(user)))
 			return FALSE
+
+	if(ishuman(user)) // Make the button red out and unselectable
+		var/mob/living/carbon/human/H = user
+		if(H.handcuffed && gesture_required)
+			return FALSE
 	
 	if((invocation_type == "whisper" || invocation_type == "shout") && isliving(user))
 		var/mob/living/living_user = user

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/aerosolize.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/aerosolize.dm
@@ -18,6 +18,7 @@
 	invocation_type = "shout"
 	glow_color = GLOW_COLOR_ARCANE
 	glow_intensity = GLOW_INTENSITY_LOW
+	gesture_required = TRUE // Spell w/ offensive potential, but don't matter cuz you have no hands. Still, consistency
 	cost = 1
 
 	xp_gain = TRUE

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/ensnare.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/ensnare.dm
@@ -17,6 +17,7 @@
 	spell_tier = 3
 	invocation = "Impedio!"
 	invocation_type = "shout"
+	gesture_required = TRUE // Offensive spell
 	glow_color = GLOW_COLOR_DISPLACEMENT
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 	overlay_state = "ensnare"

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
@@ -20,6 +20,7 @@
 	invocation_type = "shout"
 	glow_color = GLOW_COLOR_DISPLACEMENT
 	glow_intensity = GLOW_INTENSITY_MEDIUM
+	gesture_required = TRUE // Offensive spell. Don't blast guards while chained.
 	var/stun_amt = 5
 	var/maxthrow = 3
 	var/sparkle_path = /obj/effect/temp_visual/gravpush

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/frostbite.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/frostbite.dm
@@ -21,6 +21,7 @@
 	glow_color = GLOW_COLOR_ICE
 	glow_intensity = GLOW_INTENSITY_LOW
 	cost = 1
+	gesture_required = TRUE // Offensive spell
 
 	xp_gain = TRUE
 	miracle = FALSE

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
@@ -19,6 +19,7 @@
 	invocation_type = "shout"
 	glow_color = GLOW_COLOR_DISPLACEMENT
 	glow_intensity = GLOW_INTENSITY_MEDIUM
+	gesture_required = TRUE
 	range = 7
 	var/delay = 3
 	var/damage = 0 // damage based off your str 

--- a/code/modules/spells/spell_types/wizard/misc/magicians_brick.dm
+++ b/code/modules/spells/spell_types/wizard/misc/magicians_brick.dm
@@ -22,6 +22,8 @@
 	glow_color = GLOW_COLOR_ARCANE
 	glow_intensity = GLOW_INTENSITY_LOW
 
+	gesture_required = TRUE // Don't really matter
+
 /obj/effect/proc_holder/spell/self/magicians_brick/cast(list/targets, mob/living/user = usr)
 	var/obj/item/rogueweapon/R = new /obj/item/rogueweapon/magicbrick(user.drop_location())
 	R.AddComponent(/datum/component/conjured_item, CONJURE_DURATION)

--- a/code/modules/spells/spell_types/wizard/misc/shadowstep.dm
+++ b/code/modules/spells/spell_types/wizard/misc/shadowstep.dm
@@ -12,6 +12,7 @@
 	chargetime = 0 SECONDS
 	recharge_time = 30 SECONDS
 	hide_charge_effect = TRUE
+	gesture_required = TRUE // Mobility spell
 	spell_tier = 2
 	// This is super telegraphed so it shouldn't need any whisper. It can stay silent as a unique.
 	var/area_of_effect = 1


### PR DESCRIPTION
## About The Pull Request
When I added the gesture required call it was added to all projectiles. However, I didn't do the check properly which means you can select the projectile, charging just fizzled out. But there were way around. Chains just prevented you from charging the spell reliably but you can get around it. 

This should prevent all of such edge cases:
- Added gesture required to the invoked spells that should have it: Aerosolize, Ensnare, Magicians Brick, Gravity, Frostbite, Repulse, Shadowstep. Following the rules of if it has direct offensive / mobiltiy potential it cannot be cast while cuffed. 
- Readded the check to all projectile spells. Some no-delay projectiles can still be fired and from what I heard, with spamming inputs you can still bypass it on projectiles requiring charge time
- Redid the check so that spells are unselectable if it fails, instead of being selectable and then fizzling out unreliably.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_GkWd2A5YP1](https://github.com/user-attachments/assets/ef5f7bdc-1efc-466c-a573-fe036d96cdf3)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
If a mage let you put chains on, it should be over for their most direct way of restricting it. 

Look I main a [redacted] mage and I think it is important for fighting them to be fair.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
