### PR TITLE
Refactors devotion

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -111,6 +111,12 @@
 					holder.mind.AddSpell(newspell)
 					LAZYADD(granted_spells, newspell)
 
+
+//The main proc that distributes all the needed devotion tweaks to the given class.
+//cleric_tier 		- The cleric tier that the holder will get spells of immediately.
+//passive_gain 		- Passive devotion gain, if any, will begin processing this datum.
+//devotion_limit	- The CLERIC_REQ max_devotion and max_progression will be set to. Devotee overrides this with its own value!
+//start_maxed		- Whether this class starts out with all devotion maxed. Mostly used by Acolytes & Priests to spawn with everything.
 /datum/devotion/proc/grant_miracles(mob/living/carbon/human/H, cleric_tier = CLERIC_T0, passive_gain = 0, devotion_limit, start_maxed = FALSE)
 	if(!H || !H.mind || !patron)
 		return

--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -11,6 +11,10 @@
 #define CLERIC_REQ_3 500
 #define CLERIC_REQ_4 750
 
+#define CLERIC_REGEN_DEVOTEE 0.15
+#define CLERIC_REGEN_MINOR 0.25
+#define CLERIC_REGEN_MAJOR 1
+
 // Cleric Holder Datums
 
 /datum/devotion
@@ -76,160 +80,54 @@
 	if(!prog_amt) // no point in the rest if it's just an expenditure
 		return TRUE
 	progression = clamp(progression + prog_amt, 0, max_progression)
-	var/obj/effect/spell_unlocked
 	switch(level)
 		if(CLERIC_T0)
 			if(progression >= CLERIC_REQ_1)
-				spell_unlocked = patron.t1
 				level = CLERIC_T1
 		if(CLERIC_T1)
 			if(progression >= CLERIC_REQ_2)
-				spell_unlocked = patron.t2
 				level = CLERIC_T2
 		if(CLERIC_T2)
 			if(progression >= CLERIC_REQ_3)
-				spell_unlocked = patron.t3
 				level = CLERIC_T3
 		if(CLERIC_T3)
 			if(progression >= CLERIC_REQ_4)
-				spell_unlocked = patron.t4
 				level = CLERIC_T4
-	if(!spell_unlocked || !holder?.mind || holder.mind.has_spell(spell_unlocked, specific = FALSE))
-		return TRUE
-	spell_unlocked = new spell_unlocked
-	if(!silent)
-		to_chat(holder, span_boldnotice("I have unlocked a new spell: [spell_unlocked]"))
-	holder.mind.AddSpell(spell_unlocked)
-	LAZYADD(granted_spells, spell_unlocked)
+	if(!holder?.mind)
+		return FALSE
+	try_add_spells(silent = silent)
 	return TRUE
 
-/datum/devotion/proc/grant_spells(mob/living/carbon/human/H)
-	if(!H || !H.mind || !patron)
-		return
-
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1)
-	for(var/spell_type in spelllist)
-		if(!spell_type || H.mind.has_spell(spell_type))
-			continue
-		var/newspell = new spell_type
-		H.mind.AddSpell(newspell)
-		LAZYADD(granted_spells, newspell)
-	if(length(patron.extra_spells))
-		for(var/spell_type in patron.extra_spells)
-			if(patron.extra_spells[spell_type] <= CLERIC_T1)
-				if(H.mind.has_spell(spell_type))
+/datum/devotion/proc/try_add_spells(silent = FALSE)
+	if(length(patron.miracles))
+		for(var/spell_type in patron.miracles)
+			if(patron.miracles[spell_type] <= level)
+				if(holder.mind.has_spell(spell_type))
 					continue
 				else
 					var/newspell = new spell_type
-					H.mind.AddSpell(newspell)
+					if(!silent)
+						to_chat(holder, span_boldnotice("I have unlocked a new spell: [newspell]"))
+					holder.mind.AddSpell(newspell)
 					LAZYADD(granted_spells, newspell)
-	level = CLERIC_T1
-	passive_devotion_gain = 0.25
-	passive_progression_gain = 0.25
-	update_devotion(50, 50, silent = TRUE)
 
-/datum/devotion/proc/grant_spells_templar(mob/living/carbon/human/H)
+/datum/devotion/proc/grant_miracles(mob/living/carbon/human/H, cleric_tier = CLERIC_T0, passive_gain = 0, devotion_limit, start_maxed = FALSE)
 	if(!H || !H.mind || !patron)
 		return
-		
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0)
-	if(istype(patron,/datum/patron/divine))
-		spelllist += /obj/effect/proc_holder/spell/targeted/abrogation
-	for(var/spell_type in spelllist)
-		if(!spell_type || H.mind.has_spell(spell_type))
-			continue
-		var/newspell = new spell_type
-		H.mind.AddSpell(newspell)
-		LAZYADD(granted_spells, newspell)
-	if(length(patron.extra_spells))
-		for(var/spell_type in patron.extra_spells)
-			if(patron.extra_spells[spell_type] <= CLERIC_T0)
-				if(H.mind.has_spell(spell_type))
-					continue
-				else
-					var/newspell = new spell_type
-					H.mind.AddSpell(newspell)
-					LAZYADD(granted_spells, newspell)
-	level = CLERIC_T0
-	max_devotion = CLERIC_REQ_1 //Max devotion limit - Paladins are stronger but cannot pray to gain all abilities beyond t1
-	max_progression = CLERIC_REQ_1
-
-/datum/devotion/proc/grant_spells_churchling(mob/living/carbon/human/H)
-	if(!H || !H.mind || !patron)
-		return
-
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, /obj/effect/proc_holder/spell/invoked/lesser_heal, /obj/effect/proc_holder/spell/invoked/diagnose) //This would have caused jank.
-	for(var/spell_type in spelllist)
-		if(!spell_type || H.mind.has_spell(spell_type))
-			continue
-		var/newspell = new spell_type
-		H.mind.AddSpell(newspell)
-		LAZYADD(granted_spells, newspell)
-	if(length(patron.extra_spells))
-		for(var/spell_type in patron.extra_spells)
-			if(patron.extra_spells[spell_type] <= CLERIC_T0)
-				if(H.mind.has_spell(spell_type))
-					continue
-				else
-					var/newspell = new spell_type
-					H.mind.AddSpell(newspell)
-					LAZYADD(granted_spells, newspell)
-	level = CLERIC_T0
-	max_devotion = CLERIC_REQ_1 //Max devotion limit - Churchlings only get diagnose and lesser miracle.
-	max_progression = CLERIC_REQ_0
-
-/datum/devotion/proc/grant_spells_priest(mob/living/carbon/human/H)
-	if(!H || !H.mind || !patron)
-		return
-	granted_spells = list()
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
-	for(var/spell_type in spelllist)
-		if(!spell_type || H.mind.has_spell(spell_type))
-			continue
-		var/newspell = new spell_type
-		H.mind.AddSpell(newspell)
-		LAZYADD(granted_spells, newspell)
-	if(length(patron.extra_spells))
-		for(var/spell_type in patron.extra_spells)
-			if(patron.extra_spells[spell_type] <= CLERIC_T4)
-				if(H.mind.has_spell(spell_type))
-					continue
-				else
-					var/newspell = new spell_type
-					H.mind.AddSpell(newspell)
-					LAZYADD(granted_spells, newspell)
-	level = CLERIC_T4
-	passive_devotion_gain = 1
-	devotion = max_devotion
-	update_devotion(300, CLERIC_REQ_4, silent = TRUE)
-	START_PROCESSING(SSobj, src)
-
-/datum/devotion/proc/grant_spells_monk(mob/living/carbon/human/H) //added to give acolytes passive regen like priests
-	if(!H || !H.mind || !patron)
-		return
-
-	granted_spells = list()
-	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0, patron.t1, patron.t2, patron.t3, patron.t4)
-	for(var/spell_type in spelllist)
-		if(!spell_type || H.mind.has_spell(spell_type))
-			continue
-		var/newspell = new spell_type
-		H.mind.AddSpell(newspell)
-		LAZYADD(granted_spells, newspell)
-	if(length(patron.extra_spells))
-		for(var/spell_type in patron.extra_spells)
-			if(patron.extra_spells[spell_type] <= CLERIC_T4)
-				if(H.mind.has_spell(spell_type))
-					continue
-				else
-					var/newspell = new spell_type
-					H.mind.AddSpell(newspell)
-					LAZYADD(granted_spells, newspell)
-	level = CLERIC_T4
-	passive_devotion_gain = 1
-	devotion = max_devotion
-	update_devotion(300, CLERIC_REQ_4, silent = TRUE)
-	START_PROCESSING(SSobj, src)
+	level = cleric_tier
+	if(devotion_limit) //Upper devotion limit - Limits gain to that tier's miracles. Mostly used by Templars / Paladins.
+		max_devotion = devotion_limit
+		max_progression = devotion_limit
+	if(passive_gain)
+		passive_devotion_gain = passive_gain
+		passive_progression_gain = passive_gain
+		START_PROCESSING(SSobj, src)
+	if(start_maxed)		//Mainly for Acolytes & Priests
+		devotion = max_devotion
+		update_devotion(max_devotion, CLERIC_REQ_4, silent = TRUE)
+	else
+		update_devotion(50, 50, silent = TRUE)
+	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 
 // Debug verb
 /mob/living/carbon/human/proc/devotionchange()

--- a/code/datums/gods/_patron.dm
+++ b/code/datums/gods/_patron.dm
@@ -24,18 +24,8 @@ GLOBAL_LIST_EMPTY(preference_patrons)
 	var/list/confess_lines
 	/// Some patrons have related traits, why not?
 	var/list/mob_traits
-	/// Tier 0 spell
-	var/t0
-	/// Tier 1 spell
-	var/t1
-	/// Tier 2 spell
-	var/t2
-	/// Tier 3 spell
-	var/t3
-	/// Final tier spell
-	var/t4
-	/// For patrons with more spells than tiers. eg. Malum's Fire. Type as index, tier as value. (0-4)
-	var/list/extra_spells
+	/// Assoc list of miracles it grants. Type = Cleric_Tier
+	var/list/miracles = list()
 
 /datum/patron/proc/on_gain(mob/living/pious)
 	for(var/trait in mob_traits)

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -1,7 +1,6 @@
 /datum/patron/divine
 	name = null
 	associated_faith = /datum/faith/divine
-	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 
 /datum/patron/divine/astrata
 	name = "Astrata"
@@ -9,9 +8,12 @@
 	desc = "The she-form of the Twinned Gods, the combined amalgam of single-bodied Astrata and Noc that opens her eyes at glorious Dae. Men bask under the gift of the Sun. A single form begets two Gods that shift at Dusk and Dawn but always endures, even at night."
 	worshippers = "The Noble Hearted, Zealots and Farmers"
 	mob_traits = list(TRAIT_APRICITY)
-	t1 = /obj/effect/proc_holder/spell/invoked/sacred_flame_rogue
-	t2 = /obj/effect/proc_holder/spell/invoked/heal
-	t3 = /obj/effect/proc_holder/spell/invoked/revive
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/sacred_flame_rogue	= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/heal					= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/revive				= CLERIC_T3,
+	)
 	confess_lines = list(
 		"ASTRATA IS MY LIGHT!",
 		"ASTRATA BRINGS LAW!",
@@ -24,9 +26,12 @@
 	desc = "The he-form of the Twinned Gods, the combined amalgam of single-bodied Noc and Astrata that opens his eyes during pondorous Night. He gifted man knowledge of divinity and magicks. A single form begets two Gods that shift at Dusk and Dawn but always endures, even at dae."
 	worshippers = "Wizards and Scholars"
 	mob_traits = list(TRAIT_NIGHT_OWL, TRAIT_NOCSIGHT)
-	t1 = /obj/effect/proc_holder/spell/invoked/invisibility/miracle
-	t2 = /obj/effect/proc_holder/spell/invoked/blindness/miracle
-	t3 = /obj/effect/proc_holder/spell/self/noc_spell_bundle
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/invisibility/miracle	= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/blindness/miracle		= CLERIC_T2,
+					/obj/effect/proc_holder/spell/self/noc_spell_bundle			= CLERIC_T3,
+	)
 	confess_lines = list(
 		"NOC IS NIGHT!",
 		"NOC SEES ALL!",
@@ -39,11 +44,14 @@
 	desc = "The God of Wilds, born from Abyssor's feverish dreams. Spilt forth life from the oceans to land in a wild craze. The Father of Ground-Lyfe. Treefather."
 	worshippers = "Druids, Beasts, Madmen"
 	mob_traits = list(TRAIT_KNEESTINGER_IMMUNITY, TRAIT_LEECHIMMUNE)
-	t1 = /obj/effect/proc_holder/spell/targeted/blesscrop
-	t2 = /obj/effect/proc_holder/spell/targeted/shapeshift/dendor
-	t3 = /obj/effect/proc_holder/spell/targeted/conjure_glowshroom
-	t4 = /obj/effect/proc_holder/spell/self/howl/call_of_the_moon
-	extra_spells = list(/obj/effect/proc_holder/spell/invoked/spiderspeak = CLERIC_T0)
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/spiderspeak 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/targeted/blesscrop			= CLERIC_T1,
+					/obj/effect/proc_holder/spell/targeted/shapeshift/dendor	= CLERIC_T2,
+					/obj/effect/proc_holder/spell/targeted/conjure_glowshroom	= CLERIC_T3,
+					/obj/effect/proc_holder/spell/self/howl/call_of_the_moon	= CLERIC_T4,
+	)
 	confess_lines = list(
 		"DENDOR PROVIDES!",
 		"THE TREEFATHER BRINGS BOUNTY!",
@@ -56,9 +64,12 @@
 	desc = "The strongest of the Ten; when awakened, the world flooded for a thousand daes and a thousand nights before he was put to slumber. Resting fitfully did Dendor split from his skull like a gaping wound. Communes rarely with his followers, only offering glimpses in dreams. Gifted primordial Man water. "
 	worshippers = "Men of the Sea, Primitive Aquatics"
 	mob_traits = list(TRAIT_ABYSSOR_SWIM, TRAIT_SEA_DRINKER)
-	t1 = /obj/effect/proc_holder/spell/invoked/abyssor_bends
-	t2 = /obj/effect/proc_holder/spell/invoked/abyssheal
-	t3 = /obj/effect/proc_holder/spell/invoked/call_mossback
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/abyssor_bends			= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/abyssheal				= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/call_mossback			= CLERIC_T3,
+	)
 	confess_lines = list(
 		"ABYSSOR COMMANDS THE WAVES!",
 		"THE OCEAN'S FURY IS ABYSSOR'S WILL!",
@@ -71,9 +82,12 @@
 	desc = "Stalwart warrior, glorious justicier; legends say he came down to the Basin to repel the vile hordes of demons with his own hands, and that he seeks warriors for his divine army among mortals."
 	worshippers = "Warriors, Sellswords & those who seek Justice"
 	mob_traits = list(TRAIT_SHARPER_BLADES, TRAIT_JUSTICARSIGHT)
-	t1 = /obj/effect/proc_holder/spell/self/divine_strike
-	t2 = /obj/effect/proc_holder/spell/self/call_to_arms
-	t3 = /obj/effect/proc_holder/spell/invoked/persistence
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/self/divine_strike			= CLERIC_T1,
+					/obj/effect/proc_holder/spell/self/call_to_arms				= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/persistence			= CLERIC_T3,
+	)
 	confess_lines = list(
 		"RAVOX IS JUSTICE!",
 		"THROUGH STRIFE, GRACE!",
@@ -86,10 +100,13 @@
 	desc = "Veiled Lady of the underworld, equally feared and respected by mortals. She taught mortals the inevitability of death and cares for them as they reach the afterlife."
 	worshippers = "The Dead, Mourners, Gravekeepers"
 	mob_traits = list(TRAIT_SOUL_EXAMINE, TRAIT_NOSTINK)	//No stink is generic but they deal with dead bodies so.. makes sense, I suppose?
-	t1 = /obj/effect/proc_holder/spell/invoked/avert
-	t2 = /obj/effect/proc_holder/spell/targeted/abrogation
-	t3 = /obj/effect/proc_holder/spell/targeted/churn
-	extra_spells = list(/obj/effect/proc_holder/spell/targeted/soulspeak = CLERIC_T0)
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/targeted/soulspeak 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/avert					= CLERIC_T1,
+					/obj/effect/proc_holder/spell/targeted/abrogation			= CLERIC_T2,
+					/obj/effect/proc_holder/spell/targeted/churn				= CLERIC_T3,
+	)
 	confess_lines = list(
 		"ALL SOULS FIND THEIR WAY TO NECRA!",
 		"THE UNDERMAIDEN IS OUR FINAL REPOSE!",
@@ -102,8 +119,11 @@
 	desc = "The Laughing God, both famous and infamous for his sway over the forces of luck. Xylix is known for the inspiration of many a bards lyric. Speaks through his gift to man; the Tarot deck."
 	worshippers = "Gamblers, Bards, Artists, and the Silver-Tongued"
 	mob_traits = list(TRAIT_XYLIX)
-	t1 = /obj/effect/proc_holder/spell/invoked/wheel
-	t2 = /obj/effect/proc_holder/spell/invoked/mockery
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/wheel					= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/mockery				= CLERIC_T2,
+	)
 	confess_lines = list(
 		"ASTRATA IS MY LIGHT!",
 		"NOC IS NIGHT!",
@@ -123,11 +143,13 @@
 	desc = "Goddess that blessed many a saint with healing hands, Pestra taught man the arts of medicine and its benefits."
 	worshippers = "The Sick, Phyicians, Apothecaries"
 	mob_traits = list(TRAIT_EMPATH, TRAIT_ROT_EATER)
-	t0 = /obj/effect/proc_holder/spell/invoked/diagnose
-	t1 = /obj/effect/proc_holder/spell/invoked/lesser_heal
-	t2 = /obj/effect/proc_holder/spell/invoked/heal
-	t3 = /obj/effect/proc_holder/spell/invoked/attach_bodypart
-	t4 = /obj/effect/proc_holder/spell/invoked/cure_rot
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/diagnose				= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/heal					= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/attach_bodypart		= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/cure_rot				= CLERIC_T3,
+	)
 	confess_lines = list(
 		"PESTRA SOOTHES ALL ILLS!",
 		"DECAY IS A CONTINUATION OF LIFE!",
@@ -140,11 +162,14 @@
 	desc = "Opinionless god of the crafts. He teaches that great works for killing or saving are great works, either way. The well-oiled guillotine and the well-sharpened axe are tools, and there is no good and evil to their craft."
 	worshippers = "Smiths, Miners, Engineers"
 	mob_traits = list(TRAIT_FORGEBLESSED, TRAIT_BETTER_SLEEP)
-	t1 = /obj/effect/proc_holder/spell/invoked/vigorousexchange
-	t2 = /obj/effect/proc_holder/spell/invoked/heatmetal
-	t3 = /obj/effect/proc_holder/spell/invoked/hammerfall
-	t4 = /obj/effect/proc_holder/spell/invoked/craftercovenant
-	extra_spells = list(/obj/effect/proc_holder/spell/invoked/malum_flame_rogue = CLERIC_T0)
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/malum_flame_rogue 	= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/vigorousexchange		= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/heatmetal				= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/hammerfall			= CLERIC_T3,
+					/obj/effect/proc_holder/spell/invoked/craftercovenant		= CLERIC_T4,
+	)
 	confess_lines = list(
 		"MALUM IS MY MUSE!",
 		"TRUE VALUE IS IN THE TOIL!",
@@ -159,9 +184,11 @@
 	desc = "Baotha's fairer half, made from blind, unconditional love. She is without a shred of hate in her heart and taught mankind that true love that even transcends Necra's grasp."
 	worshippers = "Lovers, the romantically inclined, and Doting Grandparents"
 	mob_traits = list(TRAIT_EMPATH, TRAIT_EXTEROCEPTION)
-	t1 = /obj/effect/proc_holder/spell/invoked/bud
-	t2 = /obj/effect/proc_holder/spell/invoked/eoracurse
-	t3 = null
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/bud					= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/eoracurse				= CLERIC_T2,
+	)
 	confess_lines = list(
 		"EORA BRINGS US TOGETHER!",
 		"HER BEAUTY IS EVEN IN THIS TORMENT!",

--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -2,7 +2,6 @@
 	name = null
 	associated_faith = /datum/faith/inhumen
 	undead_hater = FALSE
-	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
 	confess_lines = list(
 		"PSYDON IS THE DEMIURGE!",
 		"THE TEN ARE WORTHLESS COWARDS!",
@@ -15,9 +14,12 @@
 	desc = "A once-mortal snow elf turned god. Her hubris in thinking she could harvest lux from the planet itself led to the elimination of her entire race. Her works are still used to this dae in some cases."
 	worshippers = "Necromancers, Researchers, Warlocks, and the Undead"
 	mob_traits = list(TRAIT_CABAL)
-	t1 = /obj/effect/proc_holder/spell/invoked/projectile/profane/miracle
-	t2 = /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/miracle
-	t3 = /obj/effect/proc_holder/spell/invoked/rituos/miracle
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/projectile/profane/miracle 	= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/raise_lesser_undead/miracle 	= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/rituos/miracle 				= CLERIC_T3
+	)
 	confess_lines = list(
 		"PRAISE ZIZO!",
 		"LONG LIVE ZIZO!",
@@ -30,9 +32,12 @@
 	desc = "Slave orc turned deity, said by the Holy Ecclesial to have been blessed by Ravox himself. He took his blessings to wage a bloody war against his once-captors, and then continued his conquest in his own name. Some Graggarites might care for honor, however many do not- what matters are results, and victory at a reasonable cost."
 	worshippers = "Prisoners, Slaves, Militants, and the Cruel"
 	mob_traits = list(TRAIT_HORDE, TRAIT_ORGAN_EATER)
-	t1 = /obj/effect/proc_holder/spell/self/call_to_slaughter
-	t2 = /obj/effect/proc_holder/spell/invoked/projectile/blood_net
-	t3 = /obj/effect/proc_holder/spell/invoked/revel_in_slaughter
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/self/call_to_slaughter 				= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/projectile/blood_net 			= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/revel_in_slaughter 			= CLERIC_T3,
+	)
 	confess_lines = list(
 		"GRAGGAR IS THE BEAST I WORSHIP!",
 		"THROUGH VIOLENCE, DIVINITY!",
@@ -45,10 +50,13 @@
 	desc = "The Man who stole fire from the sun and used it in his pursuit of immortality; exchanging the knowledge of how to make fire with the lessers for safety in doing so. He guides those who live in the dark, away from the flame of civilization; and those who believe in his cause bring the wealth of the undeserving in the light to the deserving in the dark."
 	worshippers = "Highwaymen, Alchemists, Downtrodden Peasants, and Merchants"
 	mob_traits = list(TRAIT_COMMIE, TRAIT_MATTHIOS_EYES)
-	t0 = /obj/effect/proc_holder/spell/invoked/appraise
-	t1 = /obj/effect/proc_holder/spell/invoked/transact
-	t2 = /obj/effect/proc_holder/spell/invoked/equalize
-	t3 = /obj/effect/proc_holder/spell/invoked/churnwealthy
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/appraise						= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/transact						= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/equalize						= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/churnwealthy					= CLERIC_T3,
+	)
 	confess_lines = list(
 		"MATTHIOS STEALS FROM THE WORTHLESS!",
 		"MATTHIOS IS JUSTICE!",
@@ -61,9 +69,12 @@
 	desc = "The twin sister of Eora, fallen to disgrace. She brings comfort to those who can't find it elsewhere but the bottom of a bottle; and she tempts those who have lost much into her fold through offers of relief and pleasure, yet they soon find themselves unable to escape her grasp. Seen as a scorned lover by many, and followed by such."
 	worshippers = "Widows, Gamblers, Addicts, and Scorned Lovers"
 	mob_traits = list(TRAIT_DEPRAVED, TRAIT_CRACKHEAD)
-	t1 = /obj/effect/proc_holder/spell/invoked/baothablessings
-	t2 = /obj/effect/proc_holder/spell/invoked/projectile/blowingdust
-	t3 = /obj/effect/proc_holder/spell/invoked/painkiller
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 					= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/baothablessings				= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/projectile/blowingdust		= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/painkiller					= CLERIC_T3,
+	)
 	confess_lines = list(
 		"BAOTHA DEMANDS PLEASURE!",
 		"LIVE, LAUGH, LOVE!",

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -4,7 +4,9 @@
 	desc = "The true God of everything, Psydon is maximally good - He created humen in his image to live in Psydonia, and defended the Azure Basin by sending the COMET SYON to defeat the rampaging archdemon."
 	worshippers = "Fanatics and Nostalgists"
 	associated_faith = /datum/faith/old_god
-	t0 = /obj/effect/proc_holder/spell/invoked/lesser_heal
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
+	)
 	confess_lines = list(
 		"THERE IS ONLY ONE TRUE GOD!",
 		"PSYDON YET LIVES! PSYDON YET ENDURES!",

--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -306,5 +306,4 @@
 		H.change_stat("endurance", 1)
 		H.change_stat("speed", -1)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells_priest(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -30,8 +30,7 @@
 		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells_templar(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 
 /datum/outfit/job/roguetown/disciple/proc/brute_equip(mob/living/carbon/human/H)
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
@@ -51,8 +51,7 @@
 
 		H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
-		C.grant_spells_templar(H)
-		H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+		C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 
 
 /datum/outfit/job/roguetown/psydoniantemplar/choose_loadout(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/Iconoclast.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/Iconoclast.dm
@@ -48,5 +48,4 @@
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC) // We are going to be the lord's first heavy armor unarmed class
 	ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells_monk(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -44,7 +44,7 @@
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1)
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
-			C.grant_spells_templar(H)
+			C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
@@ -154,7 +154,7 @@
 					head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
 			H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
-			C.grant_spells_templar(H)
+			C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 			var/weapons = list("Bastard Sword","Mace","Flail")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
@@ -187,7 +187,7 @@
 			beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/special
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
-			C.grant_spells_templar(H)
+			C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 			backpack_contents = list(/obj/item/flashlight/flare/torch = 1)
 			H.mind.adjust_skillrank(/datum/skill/misc/music, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
@@ -308,9 +308,7 @@
 					cloak = /obj/item/clothing/suit/roguetown/shirt/robe //placeholder, anyone who doesn't have cool patron drip sprites just gets generic robes
 					head = /obj/item/clothing/head/roguetown/roguehood
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
-			C.grant_spells(H)
-			START_PROCESSING(SSobj, C)
-
+			C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR)	//Minor regen, can level up to T4.
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
 			neck = /obj/item/clothing/neck/roguetown/psicross
@@ -351,5 +349,3 @@
 			/obj/item/clothing/neck/roguetown/psicross/eora
 			)
 			neck = pick(psicross_options)
-
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
@@ -82,8 +82,7 @@
 
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR)	//Minor regen, can level up to T4.
 
 /obj/item/clothing/cloak/stabard/crusader
 	name = "surcoat of the golden order"

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -305,9 +305,7 @@
 	beltl = /obj/item/roguekey/inhumen
 	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/ritechalk = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
-	START_PROCESSING(SSobj, C)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR)	//Minor regen, can level up to T4.
 	wretch_select_bounty(H)
 
 /datum/advclass/wretch/necromancer

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -75,5 +75,4 @@
 	ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells_priest(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -161,5 +161,4 @@
 			ADD_TRAIT(H, TRAIT_WATERBREATHING, TRAIT_GENERIC)
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells_monk(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -70,8 +70,7 @@
 		H.change_stat("endurance", 1)
 		H.change_stat("speed", -1)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron) // This creates the cleric holder used for devotion spells
-	C.grant_spells_priest(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.
 
 	H.verbs |= /mob/living/carbon/human/proc/coronate_lord
 	H.verbs |= /mob/living/carbon/human/proc/churchexcommunicate

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -132,8 +132,7 @@
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells_templar(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 
 /datum/outfit/job/roguetown/templar/monk/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
@@ -252,8 +251,7 @@
 
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells_templar(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 
 /datum/outfit/job/roguetown/templar/crusader/choose_loadout(mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -170,8 +170,7 @@
 			backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife)
 			
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
-			C.grant_spells_monk(H)
-			H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+			C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.
 			H.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/lesser_heal)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
@@ -49,5 +49,4 @@
 	H.change_stat("speed", 2)
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_spells_churchling(H)
-	H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.

--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/excommunicado.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/excommunicado.dm
@@ -35,7 +35,5 @@
 		H.change_stat("endurance", -1)
 
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
-		C.grant_spells(H)
-		START_PROCESSING(SSobj, C)
-		H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
+		C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR)	//Minor regen, can level up to T4.
 		GLOB.excommunicated_players += H.real_name // john roguetown, you are EXCOMMUNICADO.

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -26,17 +26,13 @@
 	if (!recipient.devotion)
 		// only give non-devotionists orison... and t0 for some reason (this is probably a bad idea)
 		var/datum/devotion/new_faith = new /datum/devotion(recipient, recipient.patron)
-		var/datum/patron/our_patron = new_faith.patron
-		new_faith.max_devotion = CLERIC_REQ_1 - 20
-		new_faith.max_progression = CLERIC_REQ_1 - 20
-		recipient.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 		recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/orison)
 		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE))
-			recipient.mind?.AddSpell(new our_patron.t0)
+			new_faith.grant_miracles(recipient, cleric_tier = CLERIC_T0, passive_gain = FALSE, devotion_limit = (CLERIC_REQ_1 - 20))	//Capped to T0 miracles.
 	else
 		// for devotionists, bump up their maximum 1 tier and give them a TINY amount of passive devo gain
 		var/datum/devotion/our_faith = recipient.devotion
-		our_faith.passive_devotion_gain += 0.15
+		our_faith.passive_devotion_gain += CLERIC_REGEN_DEVOTEE
 		switch (our_faith.max_devotion)
 			if (CLERIC_REQ_0)
 				our_faith.max_devotion = CLERIC_REQ_1


### PR DESCRIPTION
## About The Pull Request
For players:
- You shouldn't notice any changes! Except:
- Matthiosans now get Lesser Miracle where applicable (same as every other Patron).

For coders:
- Miracles are now an all-inclusive assoc list tied to the expected cleric tier as a value rather than hardcoded T0/T1 etc.
   - Positives: Tiers can have any amount of miracles now.
   - Negatives: Orision and lesser miracle are now included in every miracles list.
- Added defines for passive devotion gain values.
- Everything is now tied to a single `grant_miracles` proc that has everything we may need (hopefully) in the parameters.
- When adding a miracle-user class you only need to init the devotion and call that proc. No need to start processing or add the verbs or anything else. grant_miracles handles all of that now.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested:
- Priests / Acolytes
- Non-Combat class w/ Devotee
- Combat class w/ Devotee

Everything worked as expected.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This is mostly a backend refactor because dealing with this was just getting annoying and cumbersome. We already had multiple patrons have more than just 5 miracles, this just allows that to be the norm.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
