### PR TITLE
Cops and Robbers: two new NPC types for mappers and event runners to play around with

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -315,6 +315,9 @@
 					var/mob/living/carbon/H = user
 					H.update_inv_wear_mask()
 
+/obj/item/clothing/mask/rogue/ragmask/red //predyed mask for NPCs
+	color = CLOTHING_RED
+
 /obj/item/clothing/mask/rogue/lordmask/naledi
 	name = "war scholar's mask"
 	item_state = "naledimask"

--- a/code/modules/mob/living/carbon/human/npc/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/highwayman.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	. = ..()
 	set_species(/datum/species/human/northern)
 	addtimer(CALLBACK(src, PROC_REF(after_creation)), 1 SECONDS)
-	is_silent = FALSE //they're talkin. is there a reason we turned this off?
+	is_silent = TRUE
 
 
 /mob/living/carbon/human/species/human/northern/highwayman/after_creation()

--- a/code/modules/mob/living/carbon/human/npc/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/highwayman.dm
@@ -1,0 +1,130 @@
+GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggrolines.txt"))
+
+/mob/living/carbon/human/species/human/northern/highwayman
+	aggressive=1
+	mode = AI_IDLE
+	faction = list("viking", "station")
+	ambushable = FALSE
+	dodgetime = 30
+	flee_in_pain = TRUE
+	stand_attempts = 6
+	possible_rmb_intents = list()
+	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
+
+
+/mob/living/carbon/human/species/human/northern/highwayman/ambush
+	aggressive=1
+
+	wander = TRUE
+
+/mob/living/carbon/human/species/human/northern/highwayman/retaliate(mob/living/L)
+	var/newtarg = target
+	.=..()
+	if(target)
+		aggressive=1
+		wander = TRUE
+		if(!is_silent && target != newtarg)
+			say(pick(GLOB.highwayman_aggro))
+			linepoint(target)
+
+/mob/living/carbon/human/species/human/northern/highwayman/should_target(mob/living/L)
+	if(L.stat != CONSCIOUS)
+		return FALSE
+	. = ..()
+
+/mob/living/carbon/human/species/human/northern/highwayman/Initialize()
+	. = ..()
+	set_species(/datum/species/human/northern)
+	addtimer(CALLBACK(src, PROC_REF(after_creation)), 1 SECONDS)
+	is_silent = FALSE //they're talkin. is there a reason we turned this off?
+
+
+/mob/living/carbon/human/species/human/northern/highwayman/after_creation()
+	..()
+	job = "Highwayman"
+	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_NOROGSTAM, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	equipOutfit(new /datum/outfit/job/roguetown/human/species/human/northern/highwayman)
+	var/obj/item/organ/eyes/organ_eyes = getorgan(/obj/item/organ/eyes)
+	if(organ_eyes)
+		organ_eyes.eye_color = pick("27becc", "35cc27", "000000")
+	update_hair()
+	update_body()
+
+/mob/living/carbon/human/species/human/northern/highwayman/npc_idle()
+	if(m_intent == MOVE_INTENT_SNEAK)
+		return
+	if(world.time < next_idle)
+		return
+	next_idle = world.time + rand(30, 70)
+	if((mobility_flags & MOBILITY_MOVE) && isturf(loc) && wander)
+		if(prob(20))
+			var/turf/T = get_step(loc,pick(GLOB.cardinals))
+			if(!istype(T, /turf/open/transparent/openspace))
+				Move(T)
+		else
+			face_atom(get_step(src,pick(GLOB.cardinals)))
+	if(!wander && prob(10))
+		face_atom(get_step(src,pick(GLOB.cardinals)))
+
+/mob/living/carbon/human/species/human/northern/highwayman/handle_combat()
+	if(mode == AI_HUNT)
+		if(prob(2)) // do not make this big or else they NEVER SHUT UP
+			emote("laugh")
+	. = ..()
+
+/datum/outfit/job/roguetown/human/species/human/northern/highwayman/pre_equip(mob/living/carbon/human/H)
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	if(prob(50))
+		mask = /obj/item/clothing/mask/rogue/ragmask/red
+	if(prob(50))
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
+	armor = /obj/item/clothing/suit/roguetown/armor/leather
+	if(prob(50))
+		armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
+	if(prob(50))
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	if(prob(50))
+		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	if(prob(50))
+		head = /obj/item/clothing/head/roguetown/helmet/leather
+	if(prob(30))
+		head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm
+	if(prob(50))
+		neck = /obj/item/clothing/neck/roguetown/coif
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	if(prob(50))
+		gloves = /obj/item/clothing/gloves/roguetown/angle
+	H.STASTR = rand(12,14) //GENDER EQUALITY!!
+	H.STASPD = 11
+	H.STACON = rand(10,12) //so their limbs no longer pop off like a skeleton
+	H.STAEND = 13
+	H.STAPER = 10
+	H.STAINT = 10
+	if(prob(50))
+		r_hand = /obj/item/rogueweapon/sword/iron/short
+	else
+		r_hand = /obj/item/rogueweapon/mace/cudgel
+	if(prob(20))
+		r_hand = /obj/item/rogueweapon/sword/falchion/militia
+	if(prob(20))
+		r_hand = /obj/item/rogueweapon/pick/militia
+	if(prob(25))	
+		l_hand = /obj/item/rogueweapon/shield/wood
+	if(prob(10))
+		l_hand = /obj/item/rogueweapon/shield/buckler
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	if(prob(30))
+		neck = /obj/item/clothing/neck/roguetown/leather
+	H.eye_color = "27becc"
+	H.hair_color = "61310f"
+	H.facial_hair_color = H.hair_color
+	if(H.gender == FEMALE)
+		H.hairstyle =  "Messy (Rogue)"
+	else
+		H.hairstyle = "Messy"
+		H.facial_hairstyle = "Beard (Manly)"

--- a/code/modules/mob/living/carbon/human/npc/militia.dm
+++ b/code/modules/mob/living/carbon/human/npc/militia.dm
@@ -17,6 +17,9 @@
 
 	wander = TRUE
 
+/mob/living/carbon/human/species/human/northern/militia/guard //variant that just stands around, if you want to place them as set dressing. will fight back vs hostile mobs
+	wander = FALSE
+
 /* /mob/living/carbon/human/species/human/northern/militia/retaliate(mob/living/L)
 	var/newtarg = target
 	.=..()

--- a/code/modules/mob/living/carbon/human/npc/militia.dm
+++ b/code/modules/mob/living/carbon/human/npc/militia.dm
@@ -1,0 +1,122 @@
+//GLOBAL_LIST_INIT(militia_aggro, world.file2list("strings/rt/militiaaggrolines.txt")) //this doesn't exit but feel free to make it
+
+/mob/living/carbon/human/species/human/northern/militia //weak peasant infantry. Neutral but can be given factions for events. 
+	aggressive=1
+	mode = AI_IDLE
+	faction = list("neutral")
+	ambushable = FALSE
+	dodgetime = 30
+	flee_in_pain = TRUE
+	stand_attempts = 6
+	possible_rmb_intents = list()
+	var/is_silent = TRUE /// Determines whether or not we will scream our funny lines at people.
+
+
+/mob/living/carbon/human/species/human/northern/militia/ambush
+	aggressive=1
+
+	wander = TRUE
+
+/* /mob/living/carbon/human/species/human/northern/militia/retaliate(mob/living/L)
+	var/newtarg = target
+	.=..()
+	if(target)
+		aggressive=1
+		wander = TRUE
+		if(!is_silent && target != newtarg)
+			say(pick(GLOB.militia_aggro))
+			linepoint(target) */
+
+/mob/living/carbon/human/species/human/northern/militia/should_target(mob/living/L)
+	if(L.stat != CONSCIOUS)
+		return FALSE
+	. = ..()
+
+/mob/living/carbon/human/species/human/northern/militia/Initialize()
+	. = ..()
+	set_species(/datum/species/human/northern)
+	addtimer(CALLBACK(src, PROC_REF(after_creation)), 1 SECONDS)
+	is_silent = TRUE
+
+
+/mob/living/carbon/human/species/human/northern/militia/after_creation()
+	..()
+	job = "Militia"
+	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_NOROGSTAM, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	equipOutfit(new /datum/outfit/job/roguetown/human/species/human/northern/militia)
+	var/obj/item/organ/eyes/organ_eyes = getorgan(/obj/item/organ/eyes)
+	if(organ_eyes)
+		organ_eyes.eye_color = pick("27becc", "35cc27", "000000")
+	update_hair()
+	update_body()
+
+/mob/living/carbon/human/species/human/northern/militia/npc_idle()
+	if(m_intent == MOVE_INTENT_SNEAK)
+		return
+	if(world.time < next_idle)
+		return
+	next_idle = world.time + rand(30, 70)
+	if((mobility_flags & MOBILITY_MOVE) && isturf(loc) && wander)
+		if(prob(20))
+			var/turf/T = get_step(loc,pick(GLOB.cardinals))
+			if(!istype(T, /turf/open/transparent/openspace))
+				Move(T)
+		else
+			face_atom(get_step(src,pick(GLOB.cardinals)))
+	if(!wander && prob(10))
+		face_atom(get_step(src,pick(GLOB.cardinals)))
+
+/* /mob/living/carbon/human/species/human/northern/militia/handle_combat()
+	if(mode == AI_HUNT)
+		if(prob(5)) // do not make this big or else they NEVER SHUT UP
+			emote("laugh")
+	. = ..() */
+
+/datum/outfit/job/roguetown/human/species/human/northern/militia/pre_equip(mob/living/carbon/human/H)
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
+	if(prob(50))
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/
+	if(prob(25))
+		armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	if(prob(50))
+		pants = /obj/item/clothing/under/roguetown/trou
+	if(prob(50))
+		head = /obj/item/clothing/head/roguetown/helmet/kettle
+	if(prob(30))
+		head = /obj/item/clothing/head/roguetown/helmet
+	if(prob(50))
+		neck = /obj/item/clothing/neck/roguetown/coif
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	if(prob(25))
+		gloves = /obj/item/clothing/gloves/roguetown/angle
+	H.STASTR = rand(10,11) //GENDER EQUALITY!!
+	H.STASPD = 10
+	H.STACON = rand(10,12) //so their limbs no longer pop off like a skeleton
+	H.STAEND = 10
+	H.STAPER = 10
+	H.STAINT = 10
+	if(prob(50))
+		r_hand = /obj/item/rogueweapon/spear
+	else
+		r_hand = /obj/item/rogueweapon/spear/militia
+
+	if(prob(20))
+		r_hand = /obj/item/rogueweapon/sword/falchion/militia
+	if(prob(20))
+		r_hand = /obj/item/rogueweapon/pick/militia
+	if(prob(75))	
+		l_hand = /obj/item/rogueweapon/shield/wood
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	H.eye_color = pick("27becc", "35cc27", "000000")
+	H.hair_color = pick ("4f4f4f", "61310f", "faf6b9")
+	H.facial_hair_color = H.hair_color
+	if(H.gender == FEMALE)
+		H.hairstyle = pick("Ponytail (Country)","Braid (Low)", "Braid (Short)", "Messy (Rogue)")
+	else
+		H.hairstyle = pick("Mohawk","Braid (Low)", "Braid (Short)", "Messy")
+		H.facial_hairstyle = pick("Beard (Viking)", "Beard (Long)", "Beard (Manly)")

--- a/code/modules/mob/living/carbon/human/npc/militia.dm
+++ b/code/modules/mob/living/carbon/human/npc/militia.dm
@@ -1,7 +1,7 @@
 //GLOBAL_LIST_INIT(militia_aggro, world.file2list("strings/rt/militiaaggrolines.txt")) //this doesn't exit but feel free to make it
 
-/mob/living/carbon/human/species/human/northern/militia //weak peasant infantry. Neutral but can be given factions for events. 
-	aggressive=1
+/mob/living/carbon/human/species/human/northern/militia //weak peasant infantry. Neutral but can be given factions for events. doesn't attack players. 
+	aggressive=1 //they attack things. INCLUDING SAIGAS (THIS MEANS THEY WILL AGGRO ON PEOPLES MOUNTS)
 	mode = AI_IDLE
 	faction = list("neutral")
 	ambushable = FALSE
@@ -13,13 +13,14 @@
 
 
 /mob/living/carbon/human/species/human/northern/militia/ambush
-	aggressive=1
 
 	wander = TRUE
 
-/mob/living/carbon/human/species/human/northern/militia/guard //variant that just stands around, if you want to place them as set dressing. will fight back vs hostile mobs
+/mob/living/carbon/human/species/human/northern/militia/guard //variant that doesn't wander, if you want to place them as set dressing. will aggro enemies and animals
 	wander = FALSE
 
+
+	
 /* /mob/living/carbon/human/species/human/northern/militia/retaliate(mob/living/L)
 	var/newtarg = target
 	.=..()
@@ -79,6 +80,7 @@
 	. = ..() */
 
 /datum/outfit/job/roguetown/human/species/human/northern/militia/pre_equip(mob/living/carbon/human/H)
+	cloak = /obj/item/clothing/cloak/stabard/guard
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 	if(prob(50))

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1564,6 +1564,8 @@
 #include "code\modules\mob\living\carbon\human\npc\drow.dm"
 #include "code\modules\mob\living\carbon\human\npc\dwarfskeleton.dm"
 #include "code\modules\mob\living\carbon\human\npc\goblin.dm"
+#include "code\modules\mob\living\carbon\human\npc\highwayman.dm"
+#include "code\modules\mob\living\carbon\human\npc\militia.dm"
 #include "code\modules\mob\living\carbon\human\npc\orc.dm"
 #include "code\modules\mob\living\carbon\human\npc\searaider.dm"
 #include "code\modules\mob\living\carbon\human\npc\skeleton.dm"

--- a/strings/rt/highwaymanaggrolines.txt
+++ b/strings/rt/highwaymanaggrolines.txt
@@ -1,0 +1,14 @@
+Never should have come here!
+Gonna cut your belly open like a blueblood's purse!
+Your coin or your life!
+Beware, stranger! Thou art being robbed!
+Tragedy befalls ye!
+Get 'em, boys!
+Let's hope this one is more fun than the last!
+Ground, NOW!
+Start running!
+Time to pay thine highway tax, sire!
+This one looks like they've got something good!
+Let's see if you put up a better fight than the last fool!
+Ahahahahaha!
+I'll make this quick!


### PR DESCRIPTION
## About The Pull Request

Adds two new types of NPC types - highwaymen and peasant militia. One is friendlier than the other. Doesn't place any ingame yet, but they can be spawned by admins running events or placed by mappers at a later date.

### Highwaymen
![image](https://github.com/user-attachments/assets/df9bd644-dfad-4010-ba0d-ffe0e23027cc)
Hark! Bandits! I wanted to create a new enemy type that had a power level between "goblin or skeleton you can stomp" and "medium armor axe man who removes thine limbs". Enter the bandit: an (easier) human enemy that wields mostly improvised weapons and clubs and wears leather armor. Intended to be a medium-low powered enemy that also provides a source of decent leather armor, something that in this world of the viking steel mill and 0 tailor players is hilariously harder to find than plate. They also come with fun little red masks! Who doesn't love that. Sometimes they'll have a little coin pouch on their hip to steal too. But that's okay, because you're the good guy. They also talk - apparently we disabled the sea raiders from talking, why is that? If that's not allowed let me know. I will be sad though I worked really hard copy pasting those skyrim bandit lines. 

### Peasant Militia
![image](https://github.com/user-attachments/assets/8144b291-3588-47a7-9098-9b35366420b0)
Oi what's all this then? A bunch of schmucks in the peasant levy for the admins to use in events. Whether being thrown at the lich/vampire lord/bandits as a narrative PvE beat or given a faction and thrown at the town to simulate WAR!! between some other ~~Estrucan~~ nation. It shouldn't be hard to throw a tabard on these guys too if you wanted to flavor them in any particular way. There's also a 'guard' variant that doesn't wander around if you want to throw them by gates/bridges/whatever for delicious background flavor when making up some visiting entourage or whatever.

## Testing Evidence
I spawned a ton of them and smashed them together several times. Everything works fine except we currently have a bug that makes NPCs bald and have white eyes - this effects sea raiders, too. Fixing this is important but outside the scope of this PR. In general, the peasant militia comes out on top of the highwaymen, who in turn can clear out goblins and such pretty easily themselves. 

It won't let me upload videos so here's some frame from the melee:
![image](https://github.com/user-attachments/assets/fccb29bc-33b6-4664-a6a1-a9b901010e63)
![image](https://github.com/user-attachments/assets/9ae59f30-7752-4429-bc43-02188f224070)
![image](https://github.com/user-attachments/assets/47da2e17-2061-4a89-b641-884734ebcbc3)

etc etc. 

## Why It's Good For The Game

More enemy variants are fun and good - it's really not hard to make these and I'm surprised we don't have more. At the moment we don't have any good low-powered humanoid enemy type that drops meaningful loot - we just have the vikings which are walking steel mills that are generally only killable by the sort of character who doesn't need that power boost, or goblins/skeletons/orks who all drop nothing of particular value while being moderate degrees of pushover to dangerous. 

If you are an event runner or mapper who wants a specific type of NPC to spawn in/place let me know here or on discord and I'll do my best to make it for you! I like having the stuff in-game line up with the unfolding lore and plotlines that organically pop up. 
