### PR TITLE
Cauldron requires a pot instead of iron bars 

### DIFF
--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -718,7 +718,7 @@
 /datum/crafting_recipe/roguetown/structure/cauldronalchemy
 	name = "alchemy cauldron"
 	result = /obj/machinery/light/rogue/cauldron
-	reqs = list(/obj/item/ingot/iron = 3)
+	reqs = list(/obj/item/reagent_containers/glass/bucket/pot = 1)
 	verbage_simple = "assemble"
 	verbage = "assembles"
 	skillcraft = /datum/skill/craft/alchemy


### PR DESCRIPTION
## About The Pull Request
Building a cauldron requires a pot instead of iron bars
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Might do this to see if a stone pot works but it should be fine regardless
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It already takes most of an hour to set up an alchemy stand from scratch if you plan to make anything more complex than basic bitch health pots, and iron bars are uniquely annoying to source, especially with the PR up to remove all the mob iron. A cauldron is just a stationary pot anyhow.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Given that potions require actual skills now, there's no reason to worry about things like random adventurers making health potion anywhere they want.
