### PR TITLE
Nuke defdrain and set base parry stamina drain to 5

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/zizoconstruct.dm
+++ b/code/modules/mob/living/carbon/human/npc/zizoconstruct.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(zizoconstruct_aggro, world.file2list("strings/rt/zconstructaggr
 	H.STAPER = 8
 	H.STAINT = 1
 
-/obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct //I have no unarmed and I must parry. More interesting than defdrain/prob and gives construct PC a fun item to loot and use
+/obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct //I have no unarmed and I must parry. More interesting than defprob and gives construct PC a fun item to loot and use
 	name = "construct knuckles"
 	desc = "A vicous pair of bronze knuckles designed specifically for constructs. There is a terrifying, hollow spike in the center of the grip. There doesn't seem to be a way to wield it without impaling yourself."
 	wdefense = 11

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -135,7 +135,6 @@
 	var/surrendering = 0
 
 	var/defprob = 50 //base chance to defend against this mob's attacks, for simple mob combat
-	var/defdrain = 5
 	var/encumbrance = 0
 
 	var/eyesclosed = 0

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -1,3 +1,4 @@
+#define BASE_PARRY_STAMINA_DRAIN 5 // Unmodified stamina drain for parry, now a var instead of setting on simplemobs
 /proc/accuracy_check(zone, mob/living/user, mob/living/target, associated_skill, datum/intent/used_intent, obj/item/I)
 	if(!zone)
 		return
@@ -140,7 +141,7 @@
 			last_parry = world.time
 			if(intenty && !intenty.canparry)
 				return FALSE
-			var/drained = user.defdrain
+			var/drained = BASE_PARRY_STAMINA_DRAIN
 			var/weapon_parry = FALSE
 			var/offhand_defense = 0
 			var/mainhand_defense = 0

--- a/code/modules/mob/living/simple_animal/hostile/deepone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/deepone.dm
@@ -31,7 +31,6 @@
 	canparry = TRUE
 	d_intent = INTENT_DODGE
 	defprob = 50
-	defdrain = 20
 	speak_emote = list("burbles")
 	faction = list("deepone")
 	footstep_type = FOOTSTEP_MOB_BAREFOOT

--- a/code/modules/mob/living/simple_animal/hostile/roguetown/haunt.dm
+++ b/code/modules/mob/living/simple_animal/hostile/roguetown/haunt.dm
@@ -40,7 +40,6 @@
 	faction = list("undead")
 	footstep_type = null
 	defprob = 50 //decently skilled
-	defdrain = 20
 	canparry = TRUE
 	retreat_health = null
 	var/obj/structure/bonepile/slavepile

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -30,7 +30,6 @@
 	canparry = TRUE
 	d_intent = INTENT_PARRY
 	defprob = 50
-	defdrain = 20
 	speak_emote = list("grunts")
 	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone,	/obj/item/skull)
 	faction = list("undead")

--- a/code/modules/mob/living/simple_animal/rogue/creacher/bigrat.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/bigrat.dm
@@ -54,7 +54,6 @@
 	STASPD = 10
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	attack_same = 1
 	retreat_health = 0.3
 	aggressive = 1

--- a/code/modules/mob/living/simple_animal/rogue/creacher/cat.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/cat.dm
@@ -40,7 +40,6 @@
 	faction = list("rogueanimal")
 	deaggroprob = 15
 	defprob = 30
-	defdrain = 10
 	dodgetime = 10
 	del_on_deaggro = 99 SECONDS
 	

--- a/code/modules/mob/living/simple_animal/rogue/creacher/demon.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/demon.dm
@@ -40,7 +40,6 @@
 	faction = list("undead")
 	footstep_type = null
 	defprob = 50 //decently skilled
-	defdrain = 20
 	canparry = TRUE
 	retreat_health = null
 	var/obj/structure/bonepile/slavepile

--- a/code/modules/mob/living/simple_animal/rogue/creacher/direbear.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/direbear.dm
@@ -49,7 +49,6 @@
 	simple_detect_bonus = 40	//No sneaking by our boy..
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	del_on_deaggro = 2 MINUTES
 	retreat_health = 0.3
 	food = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/dragger.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/dragger.dm
@@ -40,7 +40,6 @@
 	faction = list("undead")
 	footstep_type = null
 	defprob = 50 //decently skilled
-	defdrain = 20
 	canparry = TRUE
 	retreat_health = null
 

--- a/code/modules/mob/living/simple_animal/rogue/creacher/fox.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/fox.dm
@@ -58,7 +58,6 @@
 	simple_detect_bonus = 20
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	del_on_deaggro = 44 SECONDS
 	retreat_health = 0.3
 	food = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/headless.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/headless.dm
@@ -42,7 +42,6 @@
 	STASPD = 10
 	deaggroprob = 0
 	defprob = 10
-	defdrain = 5
 	del_on_deaggro = 999 SECONDS
 	retreat_health = 0.1
 	food = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/honeyspider.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/honeyspider.dm
@@ -41,7 +41,6 @@
 	STASPD = 10
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	attack_same = 0
 	retreat_health = 0.3
 	attack_sound = list('sound/vo/mobs/spider/attack (1).ogg','sound/vo/mobs/spider/attack (2).ogg','sound/vo/mobs/spider/attack (3).ogg','sound/vo/mobs/spider/attack (4).ogg')

--- a/code/modules/mob/living/simple_animal/rogue/creacher/lamia.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/lamia.dm
@@ -41,7 +41,6 @@
 	STASPD = 12
 	deaggroprob = 0
 	defprob = 35
-	defdrain = 5
 	del_on_deaggro = 999 SECONDS
 	retreat_health = 0.1
 	food = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/mole.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mole.dm
@@ -50,7 +50,6 @@
 	STASPD = 13
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	del_on_deaggro = 44 SECONDS
 	retreat_health = 0.3
 	food = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/mossback.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mossback.dm
@@ -37,7 +37,6 @@
 	pooptype = null
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	del_on_deaggro = 10 SECONDS
 	retreat_health = 0
 	food = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/troll.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/troll.dm
@@ -47,7 +47,6 @@
 	minimum_distance = 0
 	deaggroprob = 0
 	defprob = 20
-	defdrain = 15
 	del_on_deaggro = 99 SECONDS
 	retreat_health = 0
 	food = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/trollbog.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/trollbog.dm
@@ -49,7 +49,6 @@
 	minimum_distance = 0
 	deaggroprob = 0
 	defprob = 30
-	defdrain = 13
 	del_on_deaggro = 99 SECONDS
 	retreat_health = 0
 	food = 0

--- a/code/modules/mob/living/simple_animal/rogue/creacher/volf.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/volf.dm
@@ -55,7 +55,6 @@
 	simple_detect_bonus = 20
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	del_on_deaggro = 44 SECONDS
 	retreat_health = 0.3
 	food = 0

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -41,7 +41,6 @@
 	STASPD = 13
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	del_on_deaggro = 9999 SECONDS
 	retreat_health = 0.3
 	food = 0

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/minotaur.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/minotaur.dm
@@ -42,7 +42,6 @@
 
 	deaggroprob = 0
 	defprob = 40
-	defdrain = 10
 	retreat_health = 0
 	food = 0
 	attack_sound = list('sound/combat/wooshes/blunt/wooshhuge (1).ogg','sound/combat/wooshes/blunt/wooshhuge (2).ogg','sound/combat/wooshes/blunt/wooshhuge (3).ogg')

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/mirespiders.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/mirespiders.dm
@@ -36,7 +36,6 @@
     STASPD = 13
     footstep_type = FOOTSTEP_MOB_BAREFOOT
     defprob = 40
-    defdrain = 5
     retreat_health = 0
     food = 0
 

--- a/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/orc.dm
+++ b/modular_hearthstone/code/modules/mob/living/simple_animal/rogue/orc.dm
@@ -31,7 +31,6 @@
 	canparry = TRUE
 	d_intent = INTENT_PARRY
 	defprob = 50
-	defdrain = 20
 	speak_emote = list("grunts")
 	speak = list("WAAAGH!", "KRUSH AND KILL!", "Never should have come here!", "Slaughter them all!", "Kill everything!", "Hahaha! Die!")
 	loot = list(/obj/effect/mob_spawn/human/orc/corpse/savageorc,


### PR DESCRIPTION
## About The Pull Request
- Remove the defdrain variable, which is defined on living mobs and defined how much stamina is drained on parry.
- This variable was set to FUCKING 20 ON SIMPLEMOBS ORC AND SKELETONS, harder than trolls
- Combined with previously bugged attack rate, it means a single mob can stunklock you and drain stam in seconds from parry, nevermind two.
- Now all parry drain 5, consistent for both PVP and PVE

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_MiMmPA3hmi](https://github.com/user-attachments/assets/2dce4c6e-a636-43b6-8942-33116e67a68c)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
There's far better leverage for making mobs harder to fight like giving them harder hitting weapons. 
Stunlocking them with a non transparent stamina drain mechanics, especially with skeletons (a trash mob) having 20 drain (!!!), is unfair.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
