### PR TITLE
Don't attempt to show hover over text for qdel'd turf/mob/atoms

### DIFF
--- a/code/_onclick/hud/mouseover.dm
+++ b/code/_onclick/hud/mouseover.dm
@@ -32,6 +32,8 @@
 
 /atom/proc/handle_mouseover(location, control, params)
 	var/mob/p = usr
+	if(QDELETED(src))
+		return FALSE
 	if(p.client)
 		if(!p.client.mouseovertext)
 			p.client.genmouseobj()
@@ -84,6 +86,8 @@
 
 /turf/handle_mouseover(location,control,params)
 	var/mob/p = usr
+	if(QDELETED(src))
+		return FALSE
 	if(p.client)
 		if(!p.client.mouseovertext)
 			p.client.genmouseobj()
@@ -107,6 +111,8 @@
 
 /turf/open/handle_mouseover(location, control, params)
 	var/mob/p = usr
+	if(QDELETED(src))
+		return FALSE
 	if(p.client)
 		if(!p.client.mouseovertext)
 			p.client.genmouseobj()
@@ -125,6 +131,8 @@
 
 /mob/handle_mouseover(location,control,params)
 	var/mob/p = usr
+	if(QDELETED(src))
+		return FALSE
 	if(p.client)
 		if(!p.client.mouseovertext)
 			p.client.genmouseobj()


### PR DESCRIPTION
## About The Pull Request

This PR fixes #2306

## Testing Evidence

I have debugged the original issue by tracing what is attempted to be drawn over the screen when hovering the cursor over an object, and found that even after it has been collected, it'll attempt to render the position of a QDEL'd item.

I've recorded a video of this bug in action, and the fix being shown working by logging in chat.
```dm
/atom/proc/handle_mouseover(location, control, params)
	var/mob/p = usr
	if(QDELETED(src))
		to_chat(p, span_notice("attempted to render deleted object [name]"))
		return FALSE
	...
```

https://github.com/user-attachments/assets/3d8d5900-76bd-4d68-b884-a34053b95874

By using the same checks when collecting items as for hovering, it'll avoid rendering hover over items that'll be invalid as the object no longer exists on the server, but still exists on the client due to ping latency.

## Why It's Good For The Game

Fixes a bug that mostly affects high ping users.

Fixes #2306