### PR TITLE
Alchemy Tweaks

### DIFF
--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -165,6 +165,8 @@
 			if(initial(S1.id) == S.id)
 				. += S
 
+/mob/living/proc/has_subtypes_of_status_effect(effect) //				
+
 //////////////////////
 // STACKING EFFECTS //
 //////////////////////

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -163,9 +163,7 @@
 		var/datum/status_effect/S1 = effect
 		for(var/datum/status_effect/S in status_effects)
 			if(initial(S1.id) == S.id)
-				. += S
-
-/mob/living/proc/has_subtypes_of_status_effect(effect) //				
+				. += S	
 
 //////////////////////
 // STACKING EFFECTS //

--- a/code/modules/cargo/packsrogue/food.dm
+++ b/code/modules/cargo/packsrogue/food.dm
@@ -3,32 +3,6 @@
 	crate_name = "merchant guild's crate"
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
-/datum/supply_pack/rogue/food/healthpot
-	name = "Healing Potion"
-	cost = 80
-	contains = list(
-					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-				)
-
-//Only two since that's 4 uses total; two sips each. You only need one sip for cure.
-/datum/supply_pack/rogue/food/rotcure
-	name = "Rot Cure Potion"
-	cost = 300
-	contains = list(
-					/obj/item/reagent_containers/glass/bottle/rogue/rotcure,
-					/obj/item/reagent_containers/glass/bottle/rogue/rotcure,
-				)
-
-/datum/supply_pack/rogue/food/manapot
-	name = "Manna Potion"
-	cost = 80
-	contains = list(
-					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
-				)
 
 /datum/supply_pack/rogue/food/wineb
 	name = "Wine"

--- a/code/modules/cargo/packsrogue/merchant/merchant_potions.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_potions.dm
@@ -1,0 +1,132 @@
+// Merchant Potions. Merchant potions are meant to be relatively cost ineffective and set a CEILING for potion prices
+// Normal potion brewer can and should undercut these prices. However this gives merchants more things to sell to fulfill their role as "adventurer shop"
+// And hopefully generate demands for potions from other brewer who can offer it cheaper while improving access
+// Yes, they are meant to have access to the high tier stat buff potion but not the second tier health or mana potions or any of the poison.
+/datum/supply_pack/rogue/potions
+	group = "Potions"
+	crate_name = "merchant guild's crate"
+	crate_type = /obj/structure/closet/crate/chest/merchant
+
+//Only two since that's 4 uses total; two sips each. You only need one sip for cure.
+/datum/supply_pack/rogue/potions/rotcure
+	name = "Rot Cure Potion"
+	cost = 300
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/rogue/rotcure,
+					/obj/item/reagent_containers/glass/bottle/rogue/rotcure,
+				)
+
+/datum/supply_pack/rogue/potions/healthpot
+	name = "Healing Potion"
+	cost = 100
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+					/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+				)
+
+
+/datum/supply_pack/rogue/potions/manapot
+	name = "Mana Potion"
+	cost = 100
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
+					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
+					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
+					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
+					/obj/item/reagent_containers/glass/bottle/rogue/manapot,
+				)
+
+/datum/supply_pack/rogue/potions/stamina
+	name = "Stamina Potion"
+	cost = 100
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+					/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+					/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+					/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+					/obj/item/reagent_containers/glass/bottle/rogue/stampot,
+				)
+
+/datum/supply_pack/rogue/potions/antidote
+	name = "Poison Antidote"
+	cost = 100
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+				)
+
+/datum/supply_pack/rogue/potions/antidote
+	name = "Poison Antidote"
+	cost = 100
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
+				)
+
+// Stat potion are bought in packs of 2
+/datum/supply_pack/rogue/potions/strpot
+	name = "Strength Potion"
+	cost = 80
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/alchemical/strpot,
+					/obj/item/reagent_containers/glass/bottle/alchemical/strpot,
+				)
+
+// 25% discount due to it being more situational, even though duration is 2x as long
+/datum/supply_pack/rogue/potions/perpot
+	name = "Perception Potion"
+	cost = 60
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/alchemical/perpot,
+					/obj/item/reagent_containers/glass/bottle/alchemical/perpot,
+				)
+
+// 25% discount again, not as powerful as strength or speed.
+/datum/supply_pack/rogue/potions/endpot
+	name = "Endurance Potion"
+	cost = 60
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/alchemical/endpot,
+					/obj/item/reagent_containers/glass/bottle/alchemical/endpot,
+				)
+
+/datum/supply_pack/rogue/potions/endpot
+	name = "Constitution Potion"
+	cost = 60
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/alchemical/conpot,
+					/obj/item/reagent_containers/glass/bottle/alchemical/conpot,
+				)
+			
+/datum/supply_pack/rogue/potions/intpot
+	name = "Intelligence Potion"
+	cost = 60
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/alchemical/intpot,
+					/obj/item/reagent_containers/glass/bottle/alchemical/intpot,
+				)
+
+/datum/supply_pack/rogue/potions/spdpot
+	name = "Speed Potion"
+	cost = 80
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/alchemical/spdpot,
+					/obj/item/reagent_containers/glass/bottle/alchemical/spdpot,
+				)
+
+/datum/supply_pack/rogue/potions/lucpot
+	name = "Luck Potion"
+	cost = 60
+	contains = list(
+					/obj/item/reagent_containers/glass/bottle/alchemical/lucpot,
+					/obj/item/reagent_containers/glass/bottle/alchemical/lucpot,
+				)

--- a/code/modules/cargo/packsrogue/merchant/merchant_potions.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_potions.dm
@@ -61,17 +61,6 @@
 					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
 				)
 
-/datum/supply_pack/rogue/potions/antidote
-	name = "Poison Antidote"
-	cost = 100
-	contains = list(
-					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
-					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
-					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
-					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
-					/obj/item/reagent_containers/glass/bottle/rogue/antidote,
-				)
-
 // Stat potion are bought in packs of 2
 /datum/supply_pack/rogue/potions/strpot
 	name = "Strength Potion"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -81,6 +81,7 @@
 /datum/reagent/water/gross
 	taste_description = "something vile"
 	color = "#98934bc6"
+	harmful = TRUE
 
 /datum/reagent/water/gross/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
 	if(method == INGEST) // Make sure you DRANK the toxic water before giving damage

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -426,18 +426,6 @@
 	M.adjustToxLoss(3, 0)
 	return ..()
 
-/datum/reagent/toxin/killersice
-	name = "killersice"
-	description = "killersice"
-	reagent_state = LIQUID
-	color = "#FFFFFF"
-	metabolization_rate = 0.01
-	toxpwr = 0
-
-/datum/reagent/toxin/killersice/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(10, 0)
-	return ..()
-
 /datum/reagent/toxin/bad_food
 	name = "Bad Food"
 	description = "The result of some abomination of cookery, food so bad it's toxic."

--- a/code/modules/roguetown/roguecrafting/alchemy/cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/cauldron_recipes.dm
@@ -5,10 +5,10 @@
 	var/list/output_reagents = list() //list of paths of new reagents to create in the cauldron. Remember, 1 oz is 3 units! [reagent = amnt]
 	var/list/output_items = list() //List of paths for new items that should be created, [path = chance to be created]
 
-/datum/alch_cauldron_recipe/disease_cure
-	recipe_name = "Disease Cure"
+/datum/alch_cauldron_recipe/strong_antidote
+	recipe_name = "Strong Antidote"
 	smells_like = "purity"
-	output_reagents = list(/datum/reagent/medicine/diseasecure = 81)
+	output_reagents = list(/datum/reagent/medicine/strong_antidote = 81)
 
 /datum/alch_cauldron_recipe/antidote
 	recipe_name = "Antidote"

--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -89,7 +89,7 @@
 	icon_state = "seeddust"
 	major_pot = /datum/alch_cauldron_recipe/big_stamina_potion
 	med_pot = /datum/alch_cauldron_recipe/stamina_potion
-	minor_pot = /datum/alch_cauldron_recipe/disease_cure
+	minor_pot = /datum/alch_cauldron_recipe/strong_antidote
 
 /obj/item/alch/runedust
 	name = "raw essentia"
@@ -108,7 +108,7 @@
 /obj/item/alch/silverdust
 	name = "silver dust"
 	icon_state = "silverdust"
-	major_pot = /datum/alch_cauldron_recipe/disease_cure
+	major_pot = /datum/alch_cauldron_recipe/strong_antidote
 	med_pot = /datum/alch_cauldron_recipe/antidote
 	minor_pot = /datum/alch_cauldron_recipe/big_health_potion
 
@@ -179,7 +179,7 @@
 	grid_width = 32
 	grid_height = 64
 
-	major_pot = /datum/alch_cauldron_recipe/disease_cure
+	major_pot = /datum/alch_cauldron_recipe/strong_antidote
 	med_pot = /datum/alch_cauldron_recipe/health_potion
 	minor_pot = /datum/alch_cauldron_recipe/con_potion
 
@@ -211,7 +211,7 @@
 
 	major_pot = /datum/alch_cauldron_recipe/spd_potion
 	med_pot = /datum/alch_cauldron_recipe/big_mana_potion
-	minor_pot = /datum/alch_cauldron_recipe/disease_cure
+	minor_pot = /datum/alch_cauldron_recipe/strong_antidote
 
 /obj/item/alch/ozium
 	name = "alchemical ozium"
@@ -237,7 +237,7 @@
 	icon_state = "puresalt"
 
 	major_pot = /datum/alch_cauldron_recipe/antidote
-	med_pot = /datum/alch_cauldron_recipe/disease_cure
+	med_pot = /datum/alch_cauldron_recipe/strong_antidote
 	minor_pot = /datum/alch_cauldron_recipe/big_mana_potion
 
 /obj/item/alch/mineraldust

--- a/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
@@ -1,3 +1,14 @@
+/datum/status_effect/buff/alch/tick()
+	if(owner.status_effects)
+		for(var/datum/status_effect in owner.status_effects)
+			if(status_effect == src)
+				return
+			else if(istype(status_effect, /datum/status_effect/buff/alch))
+				owner.adjustToxLoss(2) // No Baothan exemption here
+				if(prob(10))
+					to_chat(owner, span_warning("My humor churns violently from the multiple potions in my body!"))
+				return
+
 /atom/movable/screen/alert/status_effect/buff/alch
 	desc = "Power rushes through your veins."
 	icon_state = "buff"

--- a/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
@@ -1,14 +1,3 @@
-/datum/status_effect/buff/alch/tick()
-	if(owner.status_effects)
-		for(var/datum/status_effect in owner.status_effects)
-			if(status_effect == src)
-				return
-			else if(istype(status_effect, /datum/status_effect/buff/alch))
-				owner.adjustToxLoss(2) // No Baothan exemption here
-				if(prob(10))
-					to_chat(owner, span_warning("My humor churns violently from the multiple potions in my body!"))
-				return
-
 /atom/movable/screen/alert/status_effect/buff/alch
 	desc = "Power rushes through your veins."
 	icon_state = "buff"

--- a/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/potionbuffs.dm
@@ -6,7 +6,7 @@
 	id = "strpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
 	effectedstats = list("strength" = 3)
-	duration = 930
+	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/strengthpot
 	name = "Strength"
@@ -16,7 +16,7 @@
 	id = "perpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
 	effectedstats = list("perception" = 3)
-	duration = 3000
+	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/perceptionpot
 	name = "Perception"
@@ -26,7 +26,7 @@
 	id = "intpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
 	effectedstats = list("intelligence" = 3)
-	duration = 3000
+	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/intelligencepot
 	name = "Intelligence"
@@ -36,7 +36,7 @@
 	id = "conpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
 	effectedstats = list("constitution" = 3)
-	duration = 930
+	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/constitutionpot
 	name = "Constitution"
@@ -46,7 +46,7 @@
 	id = "endpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
 	effectedstats = list("endurance" = 3)
-	duration = 930
+	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/endurancepot
 	name = "Endurance"
@@ -56,7 +56,7 @@
 	id = "spdpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/speedpot
 	effectedstats = list("speed" = 3)
-	duration = 930
+	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/speedpot
 	name = "Speed"
@@ -66,7 +66,7 @@
 	id = "forpot"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/alch/fortunepot
 	effectedstats = list("fortune" = 3)
-	duration = 3000
+	duration = 3 SECONDS
 
 /atom/movable/screen/alert/status_effect/buff/alch/fortunepot
 	name = "Fortune"

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -190,7 +190,7 @@
 	Roughly tested. At Metabolization Rate 1. 9 units sip (1/3 of a vial) last 20 seconds.
 	To make this somewhat equal to the old system, base metabolization rate is 0.1 - making it last 200 seconds - 600 seconds if you sip an entire vial.
 	This is 2x on weaker potions (Intelligence, Fortune). However, overdose threshold is now 30 units so you can only drink one vial at once.
-	And potion stacking is not possible without killing yourself.
+	And potion stacking is not possible without neutralizing itself.
 */
 /datum/reagent/buff
 	description = ""
@@ -203,6 +203,12 @@
 	M.Jitter(2)
 	if(!HAS_TRAIT(M, TRAIT_CRACKHEAD)) // Baothan get to stack more of one potion in their body, but not multiple
 		M.adjustToxLoss(3)
+
+/datum/reagent/buff/on_mob_life(mob/living/carbon/M)
+	for(var/datum/reagent/R in M.reagents.reagent_list)
+		if(istype(R, /datum/reagent/buff) && R != src)
+			holder.remove_reagent(R.type, 10)
+			// Rapidly purge stacking buffs
 
 /datum/reagent/buff/strength
 	name = "Strength"

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -182,52 +182,49 @@
 	..()
 	. = 1
 
-//Buff potions
+/* Buff potions
+	Previously, it would apply a status effect to the mob lasting for 93 / 300 seconds and remove everything
+	However it meant that putting it in an alchemical vial was a trap as it sipped 9 units instead of 5 units that is the required minimum.
+	And removed any excessive potion inside the body. This has been changed to apply a 3 seconds buff to the mob, but have much lower
+	metabolization rate, so that the duration of the buff depends on how long you last. 
+	Roughly tested. At Metabolization Rate 1. 9 units sip (1/3 of a vial) last 20 seconds.
+	To make this somewhat equal to the old system, base metabolization rate is 0.1 - making it last 200 seconds - 600 seconds if you sip an entire vial.
+	This is 2x on weaker potions (Intelligence, Fortune). However, overdose threshold is now 30 units so you can only drink one vial at once.
+	And potion stacking is not possible without killing yourself.
+*/
 /datum/reagent/buff
 	description = ""
 	reagent_state = LIQUID
-	metabolization_rate = REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM * 0.1
+	overdose_threshold = 30
 
 /datum/reagent/buff/strength
 	name = "Strength"
 	color = "#ff9000"
 	taste_description = "old meat"
 
-/datum/reagent/buff/strength/on_mob_add(mob/living/carbon/M)
-	testing("str pot in system")
-	if(M.has_status_effect(/datum/status_effect/buff/alch/strengthpot))
-		return ..()
-	if(M.reagents.has_reagent(/datum/reagent/buff/strength,4))
-		M.apply_status_effect(/datum/status_effect/buff/alch/strengthpot)
-		M.reagents.remove_reagent(/datum/reagent/buff/strength, M.reagents.get_reagent_amount(/datum/reagent/buff/strength))
+/datum/reagent/buff/strength/on_mob_life(mob/living/carbon/M)
+	M.apply_status_effect(/datum/status_effect/buff/alch/strengthpot)
 	return ..()
 
 /datum/reagent/buff/perception
 	name = "Perception"
 	color = "#ffff00"
 	taste_description = "cat piss"
+	metabolization_rate = REAGENTS_METABOLISM * 0.05
 
 /datum/reagent/buff/perception/on_mob_life(mob/living/carbon/M)
-	testing("per pot in system")
-	if(M.has_status_effect(/datum/status_effect/buff/alch/perceptionpot))
-		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/perception),4))
-		M.apply_status_effect(/datum/status_effect/buff/alch/perceptionpot)
-		M.reagents.remove_reagent(/datum/reagent/buff/perception, M.reagents.get_reagent_amount(/datum/reagent/buff/perception))
+	M.apply_status_effect(/datum/status_effect/buff/alch/perceptionpot)
 	return ..()
 
 /datum/reagent/buff/intelligence
 	name = "Intelligence"
 	color = "#438127"
 	taste_description = "bog water"
+	metabolization_rate = REAGENTS_METABOLISM * 0.05
 
 /datum/reagent/buff/intelligence/on_mob_life(mob/living/carbon/M)
-	testing("int pot in system")
-	if(M.has_status_effect(/datum/status_effect/buff/alch/intelligencepot))
-		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/intelligence),4))
-		M.apply_status_effect(/datum/status_effect/buff/alch/intelligencepot)
-		M.reagents.remove_reagent(/datum/reagent/buff/intelligence, M.reagents.get_reagent_amount(/datum/reagent/buff/intelligence))
+	M.apply_status_effect(/datum/status_effect/buff/alch/intelligencepot)
 	return ..()
 
 /datum/reagent/buff/constitution
@@ -236,26 +233,16 @@
 	taste_description = "bile"
 
 /datum/reagent/buff/constitution/on_mob_life(mob/living/carbon/M)
-	testing("con pot in system")
-	if(M.has_status_effect(/datum/status_effect/buff/alch/constitutionpot))
-		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/constitution),4))
-		M.apply_status_effect(/datum/status_effect/buff/alch/constitutionpot)
-		M.reagents.remove_reagent(/datum/reagent/buff/constitution, M.reagents.get_reagent_amount(/datum/reagent/buff/constitution))
+	M.apply_status_effect(/datum/status_effect/buff/alch/constitutionpot)
 	return ..()
 
 /datum/reagent/buff/endurance
 	name = "Endurance"
 	color = "#ffff00"
-	taste_description = "gote urine"
+	taste_description = "goat urine"
 
 /datum/reagent/buff/endurance/on_mob_life(mob/living/carbon/M)
-	testing("end pot in system")
-	if(M.has_status_effect(/datum/status_effect/buff/alch/endurancepot))
-		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/endurance),4))
-		M.apply_status_effect(/datum/status_effect/buff/alch/endurancepot)
-		M.reagents.remove_reagent(/datum/reagent/buff/endurance, M.reagents.get_reagent_amount(/datum/reagent/buff/endurance))
+	M.apply_status_effect(/datum/status_effect/buff/alch/endurancepot)
 	return ..()
 
 /datum/reagent/buff/speed
@@ -264,26 +251,17 @@
 	taste_description = "raw egg yolk"
 
 /datum/reagent/buff/speed/on_mob_life(mob/living/carbon/M)
-	testing("spd pot in system")
-	if(M.has_status_effect(/datum/status_effect/buff/alch/speedpot))
-		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/speed),4))
-		M.apply_status_effect(/datum/status_effect/buff/alch/speedpot)
-		M.reagents.remove_reagent(/datum/reagent/buff/speed, M.reagents.get_reagent_amount(/datum/reagent/buff/speed))
+	M.apply_status_effect(/datum/status_effect/buff/alch/speedpot)
 	return ..()
 
 /datum/reagent/buff/fortune
 	name = "Fortune"
 	color = "#ffff00"
 	taste_description = "pig urine"
+	metabolization_rate = REAGENTS_METABOLISM * 0.05
 
 /datum/reagent/buff/fortune/on_mob_life(mob/living/carbon/M)
-	testing("luck pot in system")
-	if(M.has_status_effect(/datum/status_effect/buff/alch/fortunepot))
-		return ..()
-	if(M.reagents.has_reagent((/datum/reagent/buff/fortune),4))
-		M.apply_status_effect(/datum/status_effect/buff/alch/fortunepot)
-		M.reagents.remove_reagent(/datum/reagent/buff/fortune, M.reagents.get_reagent_amount(/datum/reagent/buff/fortune))
+	M.apply_status_effect(/datum/status_effect/buff/alch/fortunepot)
 	return ..()
 
 

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -165,15 +165,15 @@
 	. = 1
 
 // About 3 time as potent as antidote
-/datum/reagent/medicine/diseasecure
-	name = "Disease Cure"
+/datum/reagent/medicine/strong_antidote
+	name = "Strong Antidote"
 	description = ""
 	reagent_state = LIQUID
 	color = "#004200"
 	taste_description = "dirt"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 
-/datum/reagent/medicine/diseasecure/on_mob_life(mob/living/carbon/M)
+/datum/reagent/medicine/strong_antidote/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.99)
 		M.adjustToxLoss(-12, 0)
 	for(var/datum/reagent/R in M.reagents.reagent_list)

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -198,6 +198,12 @@
 	metabolization_rate = REAGENTS_METABOLISM * 0.1
 	overdose_threshold = 30
 
+/datum/reagent/buff/overdose_process(mob/living/carbon/M)
+	. = ..()
+	M.Jitter(2)
+	if(!HAS_TRAIT(M, TRAIT_CRACKHEAD)) // Baothan get to stack more of one potion in their body, but not multiple
+		M.adjustToxLoss(3)
+
 /datum/reagent/buff/strength
 	name = "Strength"
 	color = "#ff9000"

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -140,31 +140,45 @@
 	..()
 	. = 1
 
+/** Design Note: Antidotes are meant to last as long as the poison, and purge them much quicker
+ Having a 1 to 1 antidote to poison where you have to tailor defense to an increasing amount of attack
+ is a bad idea, since that just means no one will use antidotes and the weapon win the race vs defense.
+ This means pre ingesting antidote when expecting poison is a viable strategy.
+ Previously, antidote did not have a dylovene-like effect and just purged toxin damage while poison will outlast them.
+**/
 /datum/reagent/medicine/antidote
 	name = "Poison Antidote"
 	description = ""
 	reagent_state = LIQUID
 	color = "#00ff00"
 	taste_description = "sickly sweet"
-	metabolization_rate = REAGENTS_METABOLISM
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/antidote/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.99)
 		M.adjustToxLoss(-4, 0)
+	for(var/datum/reagent/R in M.reagents.reagent_list)
+		if(R.harmful)
+			holder.remove_reagent(R.type, 1)
+
 	..()
 	. = 1
 
+// About 3 time as potent as antidote
 /datum/reagent/medicine/diseasecure
 	name = "Disease Cure"
 	description = ""
 	reagent_state = LIQUID
 	color = "#004200"
 	taste_description = "dirt"
-	metabolization_rate = REAGENTS_METABOLISM * 3
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/diseasecure/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.99)
-		M.adjustToxLoss(-16, 0)
+		M.adjustToxLoss(-12, 0)
+	for(var/datum/reagent/R in M.reagents.reagent_list)
+		if(R.harmful)
+			holder.remove_reagent(R, 3)
 	..()
 	. = 1
 

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -286,6 +286,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	color = "#47b2e0"
 	taste_description = "bitterness"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+	harmful = TRUE
 
 /datum/reagent/berrypoison/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.09)
@@ -305,6 +306,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	color = "#1a1616"
 	taste_description = "burning"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+	harmful = TRUE
 
 /datum/reagent/strongpoison/on_mob_life(mob/living/carbon/M)
 	testing("Someone was poisoned")
@@ -324,6 +326,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	color = "#2c1818"
 	taste_description = "sour meat"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+	harmful = TRUE
+
 
 /datum/reagent/organpoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
@@ -338,6 +342,8 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	color = "#083b1c"
 	taste_description = "breathlessness"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM * 3
+	harmful = TRUE
+
 
 /datum/reagent/stampoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
@@ -351,26 +357,26 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	color = "#041d0e"
 	taste_description = "frozen air"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM * 9
+	harmful = TRUE
+
 
 /datum/reagent/strongstampoison/on_mob_life(mob/living/carbon/M)
 	if(!HAS_TRAIT(M,TRAIT_NOROGSTAM))
 		M.rogstam_add(-180) //Rapidly leech stamina
 	return ..()
 
-
-/datum/reagent/killersice
+/datum/reagent/toxin/killersice
 	name = "Killer's Ice"
-	description = ""
+	description = "c8c9e9"
 	reagent_state = LIQUID
-	color = "#c8c9e9"
-	taste_description = "cold needles"
-	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+	color = "#FFFFFF"
+	metabolization_rate = 0.1
+	toxpwr = 0
+	harmful = TRUE
 
-/datum/reagent/killersice/on_mob_life(mob/living/carbon/M)
-	if(!HAS_TRAIT(M, TRAIT_NASTY_EATER) && !HAS_TRAIT(M, TRAIT_ORGAN_EATER))
-		M.adjustToxLoss(5)
+/datum/reagent/toxin/killersice/on_mob_life(mob/living/carbon/M)
+	M.adjustToxLoss(10, 0)
 	return ..()
-
 
 //Potion reactions
 /datum/chemical_reaction/alch/stronghealth
@@ -427,6 +433,7 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 	reagent_state = LIQUID
 	color = "#ffc400"
 	metabolization_rate = 0.5
+	harmful = TRUE
 
 /datum/reagent/toxin/fyritiusnectar/on_mob_life(mob/living/carbon/M)
 	if(volume > 0.49)

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -147,7 +147,7 @@
  Previously, antidote did not have a dylovene-like effect and just purged toxin damage while poison will outlast them.
 **/
 /datum/reagent/medicine/antidote
-	name = "Poison Antidote"
+	name = "Antidote"
 	description = ""
 	reagent_state = LIQUID
 	color = "#00ff00"

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -1,12 +1,12 @@
 
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot
-	list_reagents = list(/datum/reagent/medicine/healthpot = 45)
+	list_reagents = list(/datum/reagent/medicine/healthpot = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/healthpotnew
-	list_reagents = list(/datum/reagent/medicine/stronghealth = 45)
+	list_reagents = list(/datum/reagent/medicine/stronghealth = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/manapot
-	list_reagents = list(/datum/reagent/medicine/manapot = 45)
+	list_reagents = list(/datum/reagent/medicine/manapot = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/poison
 	list_reagents = list(/datum/reagent/toxin/killersice = 1)
@@ -16,19 +16,22 @@
 
 //vanderlin potion stuff//
 /obj/item/reagent_containers/glass/bottle/rogue/strongmanapot
-	list_reagents = list(/datum/reagent/medicine/strongmana = 45)
+	list_reagents = list(/datum/reagent/medicine/strongmana = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/stampot
-	list_reagents = list(/datum/reagent/medicine/stampot = 45)
+	list_reagents = list(/datum/reagent/medicine/stampot = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/strongstampot
-	list_reagents = list(/datum/reagent/medicine/strongstam = 45)
+	list_reagents = list(/datum/reagent/medicine/strongstam = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/antidote
-	list_reagents = list(/datum/reagent/medicine/antidote = 45)
+	list_reagents = list(/datum/reagent/medicine/antidote = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/diseasecure
-	list_reagents = list(/datum/reagent/medicine/diseasecure = 45)
+	list_reagents = list(/datum/reagent/medicine/diseasecure = 48)
+
+/obj/item/reagent_containers/glass/bottle/rogue/berrypoison
+	list_reagents = list(/datum/reagent/berrypoison = 15)
 
 /obj/item/reagent_containers/glass/bottle/rogue/strongpoison
 	list_reagents = list(/datum/reagent/strongpoison = 15)

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -27,8 +27,8 @@
 /obj/item/reagent_containers/glass/bottle/rogue/antidote
 	list_reagents = list(/datum/reagent/medicine/antidote = 48)
 
-/obj/item/reagent_containers/glass/bottle/rogue/diseasecure
-	list_reagents = list(/datum/reagent/medicine/diseasecure = 48)
+/obj/item/reagent_containers/glass/bottle/rogue/strong_antidote
+	list_reagents = list(/datum/reagent/medicine/strong_antidote = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/berrypoison
 	list_reagents = list(/datum/reagent/berrypoison = 15)

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -24,6 +24,12 @@
 /obj/item/reagent_containers/glass/bottle/rogue/strongstampot
 	list_reagents = list(/datum/reagent/medicine/strongstam = 45)
 
+/obj/item/reagent_containers/glass/bottle/rogue/antidote
+	list_reagents = list(/datum/reagent/medicine/antidote = 45)
+
+/obj/item/reagent_containers/glass/bottle/rogue/diseasecure
+	list_reagents = list(/datum/reagent/medicine/diseasecure = 45)
+
 /obj/item/reagent_containers/glass/bottle/rogue/strongpoison
 	list_reagents = list(/datum/reagent/strongpoison = 15)
 

--- a/code/modules/roguetown/roguemachine/merchant.dm
+++ b/code/modules/roguetown/roguemachine/merchant.dm
@@ -108,6 +108,7 @@
 #define UPGRADE_WARDROBE	(1<<4)
 #define UPGRADE_ALCOHOLS	(1<<5)
 #define UPGRADE_LIVESTOCK   (1<<6)
+#define UPGRADE_POTIONS     (1<<7)
 
 /obj/structure/roguemachine/merchantvend
 	name = "GOLDFACE"
@@ -220,6 +221,8 @@
 			options += "Purchase Alcohols License (50)"
 		if(!(upgrade_flags & UPGRADE_LIVESTOCK))
 			options += "Purchase Livestock License (50)"
+		if(!(upgrade_flags & UPGRADE_POTIONS))
+			options += "Purchase Potions License (50)"
 		var/select = input(usr, "Please select an option.", "", null) as null|anything in options
 		if(!select)
 			return
@@ -292,6 +295,16 @@
 				budget -= 50
 				upgrade_flags |= UPGRADE_LIVESTOCK
 				playsound(loc, 'sound/misc/gold_license.ogg', 100, FALSE, -1)
+			if("Purchase Potions License (50)")
+				if(upgrade_flags & UPGRADE_POTIONS)
+					return
+				if(budget < 50)
+					say("Ask again when you're serious.")
+					playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
+					return
+				budget -= 50
+				upgrade_flags |= UPGRADE_POTIONS
+				playsound(loc, 'sound/misc/gold_license.ogg', 100, FALSE, -1)
 	return attack_hand(usr)
 
 /obj/structure/roguemachine/merchantvend/attack_hand(mob/living/user)
@@ -332,6 +345,8 @@
 		unlocked_cats+="Alcohols"
 	if(upgrade_flags & UPGRADE_LIVESTOCK)
 		unlocked_cats+="Livestock"
+	if(upgrade_flags & UPGRADE_POTIONS)
+		unlocked_cats+="Potions"
 
 	if(current_cat == "1")
 		contents += "<center>"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1128,6 +1128,7 @@
 #include "code\modules\cargo\packsrogue\tools.dm"
 #include "code\modules\cargo\packsrogue\wardrobe.dm"
 #include "code\modules\cargo\packsrogue\weapons.dm"
+#include "code\modules\cargo\packsrogue\merchant\merchant_potions.dm"
 #include "code\modules\chatter\chatter.dm"
 #include "code\modules\client\asset_cache.dm"
 #include "code\modules\client\assets_rogue.dm"


### PR DESCRIPTION
## About The Pull Request
A series of tweaks to make some underused potions more used, make alchemy better for the end users, make normal gaming more worth it and powergaming less effective:

### Poison / Disease Cure Buffs
- Removed redundant define of killer's ice. Now it display properly as killer's ice instead of killersice. 
- Poison Antidote and Disease Cure now have 0.1 metabolization rate, instead of disease cure having 3x the metabolization rate and 4x the healing. Disease cure is now 3x as effective and *efficient* per volume, purging another asymmetrical cases of the stronger potion being faster acting but also arguably less effective. It is now a strict upgrade in every sense.
- Poison Antidote / Disease Cure has the dylovene effects common to charcoal / antitoxin on other server. It purges harmful reagents at the rate of 1 / 3 per purge.
- **Renamed Disease Cure to Strong Antidote**. There's no disease to be cured yet. It should be named for what it does - being an upgrade to strong antidote.
- **Renamed Poison Antidote to Antidote**. Consistent naming now.

This is meant to make antidote a **strong, actual counter** to poison, instead of it being something you apply after the fact and unable to actually neutralize the poison because the poison metabolizes way slower than the poison. If you are expecting to face doom poison / poison arrows, taking antidote is viable especially pre-fight as a type of prepping.

### Duration Scaling on Buff Potions & Anti-Powergaming Measure.
Instead of each potion removing 4 units and purging every unit of the same type of buff potion in your body to apply a fixed duration buff. (Alchemical Vial, which sips 9 units instead of 5 of normal bottle, were a massive trap to non-coders who is unaware of this as you waste 2x the volume). 

Buff potions were changed to last as long as you have them in your body, by applying a 3 seconds buff that is refreshed, while they now have a metabolization rate of 0.1 / 0.05:
- Buff potions now have an overdose threshold of 30 units - 10 ounces. You are immune if you are Baothan.
- Buff potions now have a duration scaling to the amount ingested, up to around 10 minutes at around 27 units or so. This is doubled on perception and intelligence.
- Drinking multiple buff potions at once will purge other potion types rapidly. Even if you are baothan.

### Merchantry Potions
- The potions merchant have has been spun out into a separate potions license
- Their health and mana pot is now sold in a pack of 5 for 100
- They sell stamina and poison antidote at the same cost 
- They sell Strength & Speed pot at base 80 per 2, and others at base 60 per 2

### Random Shit
- Execute the psychopath taking 1 ounce of sip from every bottles in Azuria. All non-poison bottles now start with **16** ounces of chemical instead of 15. AAHHHH garrison powercreep.


<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_WqjXHN86OU](https://github.com/user-attachments/assets/836f16a9-e075-4f13-8685-b6bfc6201e9c)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Makes poison & disease cure useful by making them actually counter, remove, and even pre-prep against poison. 
- Buff potions no longer have unintuitive noob trap, and is stronger in normal use (lasting on average 2x longer and being more convenient to have a longish-lasting buff for a whole fight) while nerfing the potential of stacking them HARD
- Merchants now provide potions and set a ceiling for potion price to create competition and alternative source of potions. As written in the design doc, it is 100% intended that a good potion brewer can and will undercut these prices. As our game is structured, there is no point for a merchant to hire an alchemist to brew **then** sell the potions, so it is one way to dump money for buffs

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
