### PR TITLE
Fixes yield runtime and calls update_mobility to fix clumsy hands

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1045,7 +1045,7 @@
 	
 	if(user != target)
 		var/reverse_message = "has been [what_done] by [ssource][postfix]"
-		target.log_message(reverse_message, LOG_ATTACK, color="orange", log_globally=FALSE)
+		target?.log_message(reverse_message, LOG_ATTACK, color="orange", log_globally=FALSE)
 
 /proc/log_seen(mob/user, atom/target, list/viewers, message, seen_type)
 	var/color

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1029,6 +1029,7 @@
 
 /mob/living/proc/end_submit()
 	surrendering = 0
+	update_mobility()
 
 
 /mob/proc/stop_attack(message = FALSE)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Fixes runtime where was we were trying to write attacklog onto NULL when someone yields.

Fixes clumsy hands that happen when standing up between the 30 second and 60 second yield debuffs by just calling update_mobility() after the 60 seconds' ends.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/5b867c06-099f-48d2-bd57-511bb5234529)


https://github.com/user-attachments/assets/d7743f3c-b450-4f1f-828c-4b7882e4d170


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
I YIELD!