### PR TITLE
Adds crownstone functionality into the crown

### DIFF
--- a/code/controllers/subsystem/rogue/roguemachine.dm
+++ b/code/controllers/subsystem/rogue/roguemachine.dm
@@ -11,7 +11,7 @@ PROCESSING_SUBSYSTEM_DEF(roguemachine)
 	var/hermailermaster
 	var/list/death_queue = list()
 	var/last_death_report
-	var/obj/item/crown
+	var/obj/item/clothing/head/roguetown/crown/serpcrown/crown
 	var/obj/item/key
 
 /datum/controller/subsystem/processing/roguemachine/fire(resumed = 0)

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -527,29 +527,6 @@
 /obj/item/clothing/head/roguetown/headband/red
 	color = CLOTHING_RED
 
-/obj/item/clothing/head/roguetown/crown/serpcrown
-	name = "crown of azure peak"
-	desc = ""
-	icon_state = "serpcrown"
-	//dropshrink = 0
-	dynamic_hair_suffix = null
-	sellprice = 200
-	resistance_flags = FIRE_PROOF | ACID_PROOF
-	anvilrepair = /datum/skill/craft/armorsmithing
-	visual_replacement = /obj/item/clothing/head/roguetown/crown/fakecrown
-
-/obj/item/clothing/head/roguetown/crown/serpcrown/Initialize()
-	. = ..()
-	if(SSroguemachine.crown)
-		qdel(src)
-	else
-		SSroguemachine.crown = src
-
-/obj/item/clothing/head/roguetown/crown/serpcrown/proc/anti_stall()
-	src.visible_message(span_warning("The Crown of Azure Peak crumbles to dust, the ashes spiriting away in the direction of the Keep."))
-	SSroguemachine.crown = null //Do not harddel.
-	qdel(src) //Anti-stall
-
 /obj/item/clothing/head/roguetown/crown/fakecrown
 	name = "fake crown"
 	desc = "You shouldn't be seeing this."

--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -274,6 +274,7 @@
 			for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
 				if(S.garrisonline)
 					S.repeat_message(raw_message, src, usedcolor, message_language)
+			SSroguemachine.crown?.repeat_message(raw_message, src, usedcolor, message_language)
 			return
 		for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
 			if(!S.calling)
@@ -282,6 +283,7 @@
 			S.repeat_message(raw_message, src, usedcolor, message_language)
 		for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
 			S.repeat_message(raw_message, src, usedcolor, message_language)//make the listenstone hear scom
+		SSroguemachine.crown?.repeat_message(raw_message, src, usedcolor, message_language)
 
 /obj/structure/roguemachine/scomm/proc/dictate_laws()
 	if(dictating)
@@ -351,6 +353,7 @@
 			S.repeat_message(input_text, src, usedcolor)
 		for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)//make the listenstone hear scomstone
 			S.repeat_message(input_text, src, usedcolor)
+		SSroguemachine.crown?.repeat_message(input_text, src, usedcolor)
 
 /obj/item/scomstone/MiddleClick(mob/user)
 	if(.)
@@ -733,6 +736,7 @@
 				S.repeat_message(input_text, src, usedcolor)
 			for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
 				S.repeat_message(input_text, src, usedcolor)
+			SSroguemachine.crown?.repeat_message(input_text, src, usedcolor)
 		if(garrisonline)
 			input_text = "<big><span style='color: [GARRISON_SCOM_COLOR]'>[input_text]</span></big>" //Prettying up for Garrison line
 			for(var/obj/item/scomstone/bad/garrison/S in SSroguemachine.scomm_machines)
@@ -742,6 +746,7 @@
 			for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
 				if(S.garrisonline)
 					S.repeat_message(input_text, src, usedcolor)
+			SSroguemachine.crown?.repeat_message(input_text, src, usedcolor)
 
 /obj/item/scomstone/garrison/attack_self(mob/living/user)
 	if(.)

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
@@ -1,6 +1,9 @@
+#define GARRISON_CROWN_COLOR "#C2A245"
+
 /obj/item/clothing/head/roguetown/crown/serpcrown
-	name = "crown of azure peak"
-	desc = ""
+	name = "\the Crown of Azure Peak"
+	article = "the"
+	desc = "Heavy is the head that wears this."
 	icon_state = "serpcrown"
 	//dropshrink = 0
 	dynamic_hair_suffix = null
@@ -47,7 +50,7 @@
 			for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
 				S.repeat_message(input_text, src, usedcolor)
 		if(garrisonline)
-			input_text = "<big><span style='color: [GARRISON_SCOM_COLOR]'>[input_text]</span></big>" // Prettying up for Garrison line
+			input_text = "<big><span style='color: [GARRISON_CROWN_COLOR]'>[input_text]</span></big>" // Prettying up for Garrison line
 			for(var/obj/item/scomstone/bad/garrison/S in SSroguemachine.scomm_machines)
 				S.repeat_message(input_text, src, usedcolor)
 			for(var/obj/item/scomstone/garrison/S in SSroguemachine.scomm_machines)

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
@@ -1,7 +1,7 @@
 #define GARRISON_CROWN_COLOR "#C2A245"
 
 /obj/item/clothing/head/roguetown/crown/serpcrown
-	name = "Crown of Azure Peak"
+	name = "Crown of Azuria"
 	article = "the"
 	desc = "Heavy is the head that wears this."
 	icon_state = "serpcrown"
@@ -14,7 +14,7 @@
 	var/listening = TRUE
 	var/speaking = TRUE
 	var/garrisonline = TRUE
-	var/messagereceivedsound = 'sound/misc/garrisonscom.ogg'
+	var/messagereceivedsound = 'sound/misc/scom.ogg'
 	var/hearrange = 0 // Only hearable by wearer
 	flags_1 = HEAR_1
 
@@ -34,7 +34,7 @@
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/attack_right(mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_MELEE)
-	var/input_text = input(user, "Enter your royal decree:", "Crown Decree")
+	var/input_text = input(user, "Enter your ducal message:", "Crown SCOM")
 	if(input_text)
 		var/usedcolor = user.voice_color
 		if(user.voicecolor_override)
@@ -102,35 +102,3 @@
 		I.send_speech(message, hearrange, I, , spans, message_language=language)
 	else
 		send_speech(message, hearrange, src, , spans, message_language=language)
-
-/obj/item/clothing/head/roguetown/crown/serpcrown/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode, original_message)
-	if(speaker.loc != loc && !ismob(loc))
-		return
-	if(!ishuman(speaker))
-		return
-	if(!listening)
-		return
-	var/mob/living/carbon/human/H = speaker
-	var/usedcolor = H.voice_color
-	if(H.voicecolor_override)
-		usedcolor = H.voicecolor_override
-	if(raw_message)
-		if(length(raw_message) > 100)
-			raw_message = "<small>[raw_message]</small>"
-		if(garrisonline)
-			raw_message = "<span style='color: [GARRISON_SCOM_COLOR]'>[raw_message]</span>" // Prettying up for Garrison line
-			for(var/obj/item/scomstone/garrison/S in SSroguemachine.scomm_machines)
-				S.repeat_message(raw_message, src, usedcolor, message_language)
-			for(var/obj/item/scomstone/bad/garrison/S in SSroguemachine.scomm_machines)
-				S.repeat_message(raw_message, src, usedcolor, message_language)
-			for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
-				if(S.garrisonline)
-					S.repeat_message(raw_message, src, usedcolor, message_language)
-			return
-		for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
-			if(!S.calling)
-				S.repeat_message(raw_message, src, usedcolor, message_language)
-		for(var/obj/item/scomstone/S in SSroguemachine.scomm_machines)
-			S.repeat_message(raw_message, src, usedcolor, message_language)
-		for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
-			S.repeat_message(raw_message, src, usedcolor, message_language)

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
@@ -1,7 +1,7 @@
 #define GARRISON_CROWN_COLOR "#C2A245"
 
 /obj/item/clothing/head/roguetown/crown/serpcrown
-	name = "\the Crown of Azure Peak"
+	name = "Crown of Azure Peak"
 	article = "the"
 	desc = "Heavy is the head that wears this."
 	icon_state = "serpcrown"

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
@@ -1,0 +1,133 @@
+/obj/item/clothing/head/roguetown/crown/serpcrown
+	name = "crown of azure peak"
+	desc = ""
+	icon_state = "serpcrown"
+	//dropshrink = 0
+	dynamic_hair_suffix = null
+	sellprice = 200
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	anvilrepair = /datum/skill/craft/armorsmithing
+	visual_replacement = /obj/item/clothing/head/roguetown/crown/fakecrown
+	var/listening = TRUE
+	var/speaking = TRUE
+	var/garrisonline = TRUE
+	var/messagereceivedsound = 'sound/misc/garrisonscom.ogg'
+	var/hearrange = 0 // Only hearable by wearer
+	flags_1 = HEAR_1
+
+/obj/item/clothing/head/roguetown/crown/serpcrown/Initialize()
+	. = ..()
+	if(SSroguemachine.crown)
+		qdel(src)
+	else
+		SSroguemachine.crown = src
+		SSroguemachine.scomm_machines += src
+
+/obj/item/clothing/head/roguetown/crown/serpcrown/proc/anti_stall()
+	src.visible_message(span_warning("The Crown of Azure Peak crumbles to dust, the ashes spiriting away in the direction of the Keep."))
+	SSroguemachine.scomm_machines -= src
+	SSroguemachine.crown = null //Do not harddel.
+	qdel(src) //Anti-stall
+
+/obj/item/clothing/head/roguetown/crown/serpcrown/attack_right(mob/living/carbon/human/user)
+	user.changeNext_move(CLICK_CD_MELEE)
+	var/input_text = input(user, "Enter your royal decree:", "Crown Decree")
+	if(input_text)
+		var/usedcolor = user.voice_color
+		if(user.voicecolor_override)
+			usedcolor = user.voicecolor_override
+		user.whisper(input_text)
+		if(length(input_text) > 100)
+			input_text = "<small>[input_text]</small>"
+		if(!garrisonline)
+			for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
+				S.repeat_message(input_text, src, usedcolor)
+			for(var/obj/item/scomstone/S in SSroguemachine.scomm_machines)
+				S.repeat_message(input_text, src, usedcolor)
+			for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
+				S.repeat_message(input_text, src, usedcolor)
+		if(garrisonline)
+			input_text = "<big><span style='color: [GARRISON_SCOM_COLOR]'>[input_text]</span></big>" // Prettying up for Garrison line
+			for(var/obj/item/scomstone/bad/garrison/S in SSroguemachine.scomm_machines)
+				S.repeat_message(input_text, src, usedcolor)
+			for(var/obj/item/scomstone/garrison/S in SSroguemachine.scomm_machines)
+				S.repeat_message(input_text, src, usedcolor)
+			for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
+				if(S.garrisonline)
+					S.repeat_message(input_text, src, usedcolor)
+
+/obj/item/clothing/head/roguetown/crown/serpcrown/attack_self(mob/living/user)
+	if(.)
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+	garrisonline = !garrisonline
+	to_chat(user, span_info("I [garrisonline ? "connect the crown to the garrison SCOMline" : "connect the crown to the general SCOMline"]"))
+
+/obj/item/clothing/head/roguetown/crown/serpcrown/MiddleClick(mob/user)
+	if(.)
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	playsound(loc, 'sound/misc/beep.ogg', 100, FALSE, -1)
+	listening = !listening
+	speaking = !speaking
+	to_chat(user, span_info("I [speaking ? "unmute" : "mute"] the crown's SCOM capabilities."))
+	update_icon()
+
+/obj/item/clothing/head/roguetown/crown/serpcrown/proc/repeat_message(message, atom/A, tcolor, message_language)
+	if(A == src)
+		return
+	if(!ismob(loc))
+		return
+	if(tcolor)
+		voicecolor_override = tcolor
+	if(speaking && message)
+		playsound(loc, messagereceivedsound, 100, TRUE, -1)
+		say(message, language = message_language)
+	voicecolor_override = null
+
+/obj/item/clothing/head/roguetown/crown/serpcrown/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+	if(!can_speak())
+		return
+	if(message == "" || !message)
+		return
+	spans |= speech_span
+	if(!language)
+		language = get_default_language()
+	if(istype(loc, /obj/item))
+		var/obj/item/I = loc
+		I.send_speech(message, hearrange, I, , spans, message_language=language)
+	else
+		send_speech(message, hearrange, src, , spans, message_language=language)
+
+/obj/item/clothing/head/roguetown/crown/serpcrown/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode, original_message)
+	if(speaker.loc != loc && !ismob(loc))
+		return
+	if(!ishuman(speaker))
+		return
+	if(!listening)
+		return
+	var/mob/living/carbon/human/H = speaker
+	var/usedcolor = H.voice_color
+	if(H.voicecolor_override)
+		usedcolor = H.voicecolor_override
+	if(raw_message)
+		if(length(raw_message) > 100)
+			raw_message = "<small>[raw_message]</small>"
+		if(garrisonline)
+			raw_message = "<span style='color: [GARRISON_SCOM_COLOR]'>[raw_message]</span>" // Prettying up for Garrison line
+			for(var/obj/item/scomstone/garrison/S in SSroguemachine.scomm_machines)
+				S.repeat_message(raw_message, src, usedcolor, message_language)
+			for(var/obj/item/scomstone/bad/garrison/S in SSroguemachine.scomm_machines)
+				S.repeat_message(raw_message, src, usedcolor, message_language)
+			for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
+				if(S.garrisonline)
+					S.repeat_message(raw_message, src, usedcolor, message_language)
+			return
+		for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
+			if(!S.calling)
+				S.repeat_message(raw_message, src, usedcolor, message_language)
+		for(var/obj/item/scomstone/S in SSroguemachine.scomm_machines)
+			S.repeat_message(raw_message, src, usedcolor, message_language)
+		for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
+			S.repeat_message(raw_message, src, usedcolor, message_language)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2079,6 +2079,7 @@
 #include "modular_azurepeak\code\game\objects\weapons\axes.dm"
 #include "modular_azurepeak\code\modules\alchemy\alchemy_recipes.dm"
 #include "modular_azurepeak\code\modules\clothing\rogueclothes\cloaks.dm"
+#include "modular_azurepeak\code\modules\clothing\rogueclothes\crown.dm"
 #include "modular_azurepeak\code\modules\clothing\rogueclothes\hats.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\beggar.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\courier.dm"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

This PR modularizes the crown of azure peak, setting it in its own new file. And then we slap all of the snowflake SCOM guts into it (Claude helped me do this). Effectively turning the crown into its own crownstone.

We do a safe navigation check off of SSRoguemachine to see if the crown exists on each access, which plays nice with the titan crown recovery logic that could lead to the crown being repeatedly deleted and initialized.

Generally it behaves as everything else does. Inhand use switches from main scom to garriscom. Middle click mute. Right click while wearing to speak into it.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
Here we are speaking on the crown. The garrison line comes through large and golden, but is normal on the main line.
![image](https://github.com/user-attachments/assets/c08d8638-316c-4a8c-8539-2358d7bd045f)

Other SCOMs seemed ok after far travel deleted the crown.
![image](https://github.com/user-attachments/assets/ca0f2bd9-f4eb-4e4c-9f8b-a2d9123f369f)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Regent RP, particularly the heirs, really struggle to hold the keep together if they are not in the loop. And there are no crownstones to spare on the map. So this gives those regents, what have you, an easy crownstone to have - it's the crown.