### PR TITLE
Advanced Lessons in Unga - Barbarian Loadout Expansion

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -135,6 +135,7 @@
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
@@ -145,15 +146,24 @@
 			ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 			H.cmode_music = 'sound/music/combat_gronn.ogg'
 			H.set_blindness(0)
-			var/weapons = list("Katar","Battle Axe","MY BARE HANDS!!!")
+			var/weapons = list("Katar","Axe","Sword","Club","Spear","MY BARE HANDS!!!")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
 				if ("Katar")
 					H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 					beltr = /obj/item/rogueweapon/katar
-				if("Battle Axe")
+				if("Axe")
 					H.mind.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)
-					beltr = /obj/item/rogueweapon/stoneaxe/battle
+					beltr = /obj/item/rogueweapon/stoneaxe/boneaxe
+				if("Sword")
+					H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+					beltr = /obj/item/rogueweapon/sword/short
+				if("Club")
+					H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+					beltr = /obj/item/rogueweapon/mace/woodclub
+				if("Spear")
+					H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+					r_hand = /obj/item/rogueweapon/spear/bonespear
 				if ("MY BARE HANDS!!!")
 					H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/a40a7432-5393-4312-843b-c46dc3a6a639)

Expands barbarian weapon selection to allow them access to a wider array of weapons to better facilitate roleplaying more types of half-naked dude who beats stuff to death. Gives barbarians two points in polearms, up to three if they elect to start with a spear. Gives the barbarian starting weapons a refit, making them both more in-line with the class identity as well as gently depowering them - notably, the battle axe is now a stone axe. 


## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
Spawned as each of the weapon subtypes and verified that they started with the correct skills and loadout.
![image](https://github.com/user-attachments/assets/9e7693c8-42e5-482f-9ddd-059930efc253)
![image](https://github.com/user-attachments/assets/370f7404-d021-49ee-a461-2cf17f9148be)

## Why It's Good For The Game

More customization is always good as it facilitates better roleplay when mechanics and character identity line up. 

The general design direction by the maintainers seems to be 'make adventurers weaker' so this aims to help in that direction, removing a steel best-in-class weapon from a non battlemaster/duelist adventurer (who seem to be the only two who have a rightful claim to such a thing). 

The weapons selected in this loadout aim to be in line with what a barbarian would use, and also synergize well with barbarian's combat identity of 'grab that guy and bonk him'. (Hence the inclusion of a short sword) Since most of the barbarian's power comes from their grappling and strength damage bonus, a slightly weaker weapon for the first half hour of play shouldn't be too insurmountable a hill to climb. Trust nothing but your fists, baby. 