### PR TITLE
Oversight Fix | Mage associate keyring

### DIFF
--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -294,3 +294,6 @@
 
 /obj/item/storage/keyring/heir
 	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/heir, /obj/item/roguekey/garrison)
+
+/obj/item/storage/keyring/mageapprentice
+	keys = list(/obj/item/roguekey/manor, /obj/item/roguekey/tower)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -26,7 +26,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 	pants = /obj/item/clothing/under/roguetown/tights/random
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/storage/keyring/mage
+	beltr = /obj/item/storage/keyring/mageapprentice
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff
 	shoes = /obj/item/clothing/shoes/roguetown/gladiator // FANCY SANDALS


### PR DESCRIPTION
## About The Pull Request

Turns out my map pr did jack shit because they for some reason spawned with the COURT MAGOS special key. This fixes that.

## Testing Evidence

![image](https://github.com/user-attachments/assets/787711e1-34c3-4bac-bd3b-e17ca359ecd8)

## Why It's Good For The Game

The court magician room remains exclusive to them.
