### PR TITLE
Small Surgery Tweak

### DIFF
--- a/code/modules/surgery/surgery_tools_rogue.dm
+++ b/code/modules/surgery/surgery_tools_rogue.dm
@@ -68,6 +68,7 @@
 	parrysound = list('sound/combat/parry/bladed/bladedsmall (1).ogg','sound/combat/parry/bladed/bladedsmall (2).ogg','sound/combat/parry/bladed/bladedsmall (3).ogg')
 	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg','sound/combat/wooshes/bladed/wooshsmall (2).ogg','sound/combat/wooshes/bladed/wooshsmall (3).ogg')
 	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'
+	sharpness = IS_BLUNT
 	tool_behaviour = TOOL_HEMOSTAT
 	smeltresult = null
 
@@ -94,6 +95,7 @@
 	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'
 	wdefense = 3
 	wbalance = 1
+	sharpness = IS_BLUNT
 	w_class = WEIGHT_CLASS_NORMAL
 	thrown_bclass = BCLASS_BLUNT
 	tool_behaviour = TOOL_RETRACTOR
@@ -108,6 +110,7 @@
 	parrysound = list('sound/combat/parry/bladed/bladedsmall (1).ogg','sound/combat/parry/bladed/bladedsmall (2).ogg','sound/combat/parry/bladed/bladedsmall (3).ogg')
 	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg','sound/combat/wooshes/bladed/wooshsmall (2).ogg','sound/combat/wooshes/bladed/wooshsmall (3).ogg')
 	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'
+	sharpness = IS_BLUNT
 	tool_behaviour = TOOL_BONESETTER
 	smeltresult = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Small change to setting forceps, bone setter, and speculum to blunt so they wont be used to amputate, speeding up surgery on limbs, and making accidental decaps much less likely 

## Why It's Good For The Game

- No more accidental decaps/amputation when setting bones. 
- Speeds up surgery with no more pop ups asking to amputate for the bone setting and forcep steps.
- (Maybe a negative would like feedback) Scalpel will be needed in surgery rather then just using forcep to cut


## Proof of Testing (Required)

![image](https://github.com/user-attachments/assets/61377eb0-3274-47ab-8382-aa54cf8157e3)

Tested in a local host and Amputation still works along with bone fix and lux. 
