### PR TITLE
Two Bugs, Helmets on Hips stopping drinking and Alchemy Mortar Drop

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -320,10 +320,10 @@
 
 //Outdated but still in use apparently. This should at least be a human proc.
 //Daily reminder to murder this - Remie.
-/mob/living/proc/get_equipped_items(include_pockets = FALSE)
+/mob/living/proc/get_equipped_items(include_pockets = FALSE, include_beltslots = TRUE)
 	return
 
-/mob/living/carbon/get_equipped_items(include_pockets = FALSE)
+/mob/living/carbon/get_equipped_items(include_pockets = FALSE, include_beltslots = TRUE)
 	var/list/items = list()
 	if(back)
 		items += back
@@ -335,14 +335,15 @@
 		items += wear_neck
 	return items
 
-/mob/living/carbon/human/get_equipped_items(include_pockets = FALSE)
+/mob/living/carbon/human/get_equipped_items(include_pockets = FALSE, include_beltslots = TRUE)
 	var/list/items = ..()
 	if(belt)
 		items += belt
-	if(beltr)
-		items += beltr
-	if(beltl)
-		items += beltl
+	if(include_beltslots) //prototype arg defined as true for legacy
+		if(beltr)
+			items += beltr
+		if(beltl)
+			items += beltl
 	if(backr)
 		items += backr
 	if(backl)

--- a/code/modules/roguetown/roguecrafting/alchemy/mortarpestle.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/mortarpestle.dm
@@ -38,8 +38,6 @@
 		to_chat(user, "<span class='notice'>I remove [to_grind] from the mortar.</span>")
 		if(!user.put_in_hands(to_grind))
 			to_chat(user, span_warning("My hands are full! I drop [to_grind] on the ground"))
-			to_grind = null
-			return
 		to_grind = null
 		return
 	to_chat(user, "<span class='notice'>It's empty.</span>")

--- a/code/modules/roguetown/roguecrafting/alchemy/mortarpestle.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/mortarpestle.dm
@@ -38,6 +38,7 @@
 		to_chat(user, "<span class='notice'>I remove [to_grind] from the mortar.</span>")
 		if(!user.put_in_hands(to_grind))
 			to_chat(user, span_warning("My hands are full! I drop [to_grind] on the ground"))
+			to_grind = null
 			return
 		to_grind = null
 		return

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -115,7 +115,7 @@
 			for(var/obj/item/grabbing/grab in carbon_victim.grabbedby)
 				if(grab.sublimb_grabbed == location)
 					return TRUE
-		for(var/obj/item/equipped_item in carbon_victim.get_equipped_items(include_pockets = FALSE))
+		for(var/obj/item/equipped_item in carbon_victim.get_equipped_items(include_pockets = FALSE, include_beltslots = FALSE))
 			if(zone2covered(location, equipped_item.body_parts_covered))
 				return FALSE
 		if(ishuman(carbon_victim))


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Having a helmet on hip blocks your mouth, you can't drink. Overloads the call to treat beltslots more or less as pockets, defaults the condition to TRUE for cooperation with other function calls.

Alchemy mortars were not nulling their obj ref when emptying with full hands, causing remote fetches. Fixes that.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/d6672e2b-c16b-4d60-aad3-d5e1b3da4aa0)

![image](https://github.com/user-attachments/assets/360d4a67-f54f-4595-92dc-9cc1724c38a4)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Two for one deal