### PR TITLE
quiver dump + MAA recurve

### DIFF
--- a/code/modules/clothing/rogueclothes/quiver.dm
+++ b/code/modules/clothing/rogueclothes/quiver.dm
@@ -39,6 +39,20 @@
 		else
 			return FALSE
 
+/obj/item/quiver/attack_self(mob/living/user)
+	..()
+
+	if (!arrows.len)
+		return
+	to_chat(user, span_warning("I begin to take out the arrows from [src], one by one..."))
+	for(var/obj/item/ammo_casing/caseless/rogue/arrow in arrows)
+		if(!do_after(user, 0.5 SECONDS))
+			return
+		arrow.forceMove(user.loc)
+		arrows -= arrow
+
+	update_icon()
+
 /obj/item/quiver/attackby(obj/A, loc, params)
 	if(A.type in subtypesof(/obj/item/ammo_casing/caseless/rogue))
 		if(A.type in subtypesof(/obj/item/ammo_casing/caseless/rogue/javelin))

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -161,7 +161,7 @@
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 		if("Bow") // They can head down to the armory to sideshift into one of the other bows.
 			beltr = /obj/item/quiver/arrows
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
+			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 		if("Sling")
 			beltr = /obj/item/quiver/sling/iron
 			r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling // Both are belt slots and it's not worth setting where the cugel goes for everyone else, sad.


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. Use quiver in hand to dump out arrows.
MAA gets their recurve because I accidentally gave them selfbows instead when pulling their longbows.

## Testing Evidence

Tested.

## Why It's Good For The Game

issue fix + easy way to dump out arrows is good when you're replacing your quiver stash
