### PR TITLE
ports a combat fix from ratwood

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -233,6 +233,13 @@
 			move_delay = world.time + 10
 			to_chat(src, span_warning("I can't move!"))
 			return TRUE
+	if(mob.pulling && isliving(mob.pulling))
+		var/mob/living/L = mob.pulling
+		var/mob/living/M = mob
+		if(L.cmode && !L.resting && !L.incapacitated() && M.grab_state < GRAB_AGGRESSIVE)
+			move_delay = world.time + 10
+			to_chat(src, span_warning("[L] still has footing! I need a stronger grip!"))
+			return TRUE    
 
 /**
   * Allows mobs to ignore density and phase through objects


### PR DESCRIPTION
## About The Pull Request

https://github.com/Rotwood-Vale/Ratwood-Keep/pull/1642

ports this

## Testing Evidence
it works

## Why It's Good For The Game

You can no longer move around with a passive grab on someone if they're in combat mode, unless they are either: lying down, stunned, cuffed. Aggro grabs allow movement as normal.

this is good because a big combat meta rn is just grab and drag into wallkick and that's stupid. 2 people from RW said 'even we fixed this dogshit' so i went ahead and ported it.

Do not argue on this PR I will not read it I do not care what you think shut up forever
