### PR TITLE
Makes Horned Helmets Smelt & Require Iron Instead Of Steel

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -676,16 +676,17 @@
 
 /obj/item/clothing/head/roguetown/helmet/skullcap
 	name = "skull cap"
-	desc = "A helmet which covers the top of the head."
+	desc = "An iron helmet which covers the top of the head."
 	icon_state = "skullcap"
 	body_parts_covered = HEAD|HAIR
 	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/head/roguetown/helmet/horned
 	name = "horned cap"
-	desc = "A helmet with two horns poking out of the sides."
+	desc = "An iron helmet with two horns poking out of the sides."
 	icon_state = "hornedcap"
 	body_parts_covered = HEAD|HAIR
+	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/head/roguetown/helmet/winged
 	name = "winged cap"

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -133,6 +133,13 @@
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/leather)
 	created_item = /obj/item/clothing/suit/roguetown/armor/leather/studded/bikini
+
+/datum/anvil_recipe/armor/iron/helmethorned
+	name = "Horned Helmet"
+	req_bar = /obj/item/ingot/iron
+	created_item = /obj/item/clothing/head/roguetown/helmet/horned
+	craftdiff = 2
+	
 /*
 /datum/anvil_recipe/armor/helmetgoblin
 	name = "Goblin Helmet (+1 Iron)"
@@ -354,12 +361,6 @@
 	name = "Nasal Helmet"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/head/roguetown/helmet
-	craftdiff = 2
-
-/datum/anvil_recipe/armor/steel/helmethorned
-	name = "Horned Helmet"
-	req_bar = /obj/item/ingot/steel
-	created_item = /obj/item/clothing/head/roguetown/helmet/horned
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/helmetwinged


### PR DESCRIPTION
## About The Pull Request

Horned Helmets (made famous by the sea raider mobs we all know and loathe) are functionally identical to skullcaps (and nearly every other helmet but that's a different convo) except for the fact that they smelt into steel instead of iron. Several PRs have been made recently trying to address the very real 'steel is too common' issue, many of which remove the viking's horned helmets which damages their visual identity. My solution to this is making the helmets iron instead of steel, solving the steel availability issue while helping vikings maintain their visual identity. 

## Testing Evidence

![image](https://github.com/user-attachments/assets/2322998a-f08f-40ef-baec-77a3ce98fd00)
![image](https://github.com/user-attachments/assets/32fa8d7b-c34e-4c5a-bb5e-2ad1a4a62b6f)


## Why It's Good For The Game

Too much steel bad. Enemies maintaining visual identity good. Grrr..... 
