### PR TITLE
Small Lich Tweak - 2 lives, better combat stats, 8 spellpoints

### DIFF
--- a/code/modules/antagonists/roguetown/villain/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich.dm
@@ -122,7 +122,7 @@
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 5, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 3, TRUE)
-	H.mind.adjust_spellpoints(5)
+	H.mind.adjust_spellpoints(8)
 
 	// Give it decent combat stats to make up for loss of 2 extra lives
 	H.change_stat("strength", 3)

--- a/code/modules/antagonists/roguetown/villain/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich.dm
@@ -110,9 +110,9 @@
 
 	H.mind.adjust_skillrank(/datum/skill/misc/reading, 6, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 5, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 5, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/magic/arcane, 6, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/riding, 4, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
@@ -124,11 +124,12 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 3, TRUE)
 	H.mind.adjust_spellpoints(5)
 
-	H.change_stat("strength", -1)
+	// Give it decent combat stats to make up for loss of 2 extra lives
+	H.change_stat("strength", 3)
 	H.change_stat("intelligence", 5)
 	H.change_stat("constitution", 5)
-	H.change_stat("endurance", -1)
-	H.change_stat("speed", -1)
+	H.change_stat("perception", 3)
+	H.change_stat("speed", 1)
 
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/bonechill)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_undead)
@@ -154,11 +155,11 @@
 /datum/outfit/job/roguetown/lich/post_equip(mob/living/carbon/human/H)
 	..()
 	var/datum/antagonist/lich/lichman = H.mind.has_antag_datum(/datum/antagonist/lich)
-	for(var/i in 1 to 3)
-		var/obj/item/phylactery/new_phylactery = new(H.loc)
-		lichman.phylacteries += new_phylactery
-		new_phylactery.possessor = lichman
-		H.equip_to_slot_or_del(new_phylactery,SLOT_IN_BACKPACK, TRUE)
+	// One phylactery instead of 3 so that they don't need to get chased down non-stop.
+	var/obj/item/phylactery/new_phylactery = new(H.loc)
+	lichman.phylacteries += new_phylactery
+	new_phylactery.possessor = lichman
+	H.equip_to_slot_or_del(new_phylactery,SLOT_IN_BACKPACK, TRUE)
 
 /datum/antagonist/lich/proc/consume_phylactery(timer = 10 SECONDS)
 	if(phylacteries.len == 0)


### PR DESCRIPTION
## About The Pull Request
- Cut down Lich to only having 2 lives instead of 4 (by reducing the amount of phylactery they get from 3 to 1)
- Give Lich much better combat stats - 3 strength instead of -1, +1 speed instead of -1, +3 perception. Get +1 Endurance (barely matter) instead of -1.
- Polearms go to Expert now. They had a lot of time to practice with their poles.
- Arcane is always 6. I mean, they're a Lich. (It barely affect anything)
- Gave them 8 spellpoints base

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
People complain about Lich round because you have to kill them **four** times which dominate an entire round. This allow them to keep their sovlful phylactery but now you only have to chase them once. It may make Lich much more bearable as an antag in regular rotation in the future. 

In exchange, they get significant stat buff to not get bent instantly in melee.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
