### PR TITLE
gravity delay

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_aoe/blade_burst.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/blade_burst.dm
@@ -23,7 +23,7 @@
 	glow_intensity = GLOW_INTENSITY_HIGH
 	gesture_required = TRUE
 	ignore_los = FALSE
-	var/delay = 14
+	var/delay = 12
 	var/damage = 125 //if you get hit by this it's your fault
 	var/area_of_effect = 1
 
@@ -31,7 +31,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "trap"
 	light_outer_range = 2
-	duration = 14
+	duration = 12
 	layer = MASSIVE_OBJ_LAYER
 
 /obj/effect/temp_visual/blade_burst

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
@@ -21,7 +21,7 @@
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 	gesture_required = TRUE
 	range = 7
-	var/delay = 3
+	var/delay = 7
 	var/damage = 0 // damage based off your str 
 	var/area_of_effect = 0
 
@@ -36,8 +36,13 @@
 			
 
 	for(var/turf/affected_turf in view(area_of_effect, T))
-		new /obj/effect/temp_visual/gravity(affected_turf)
+	
+		new /obj/effect/temp_visual/gravity_trap(affected_turf)
+	
 		playsound(T, 'sound/magic/gravity.ogg', 80, TRUE, soundping = FALSE)
+
+		sleep(delay)
+		new /obj/effect/temp_visual/gravity(affected_turf)
 		for(var/mob/living/L in affected_turf.contents) 
 			if(L.anti_magic_check())
 				visible_message(span_warning("The gravity fades away around you [L] "))  //antimagic needs some testing
@@ -65,3 +70,13 @@
 	layer = MASSIVE_OBJ_LAYER
 	light_outer_range = 2
 	light_color = COLOR_PALE_PURPLE_GRAY
+
+/obj/effect/temp_visual/gravity_trap
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "hierophant_blast"
+	dir = NORTH
+	name = "rippling arcyne energy"
+	desc = "Get out of the way!"
+	randomdir = FALSE
+	duration = 7 SECONDS
+	layer = MASSIVE_OBJ_LAYER

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
@@ -47,7 +47,7 @@
 			if(L.anti_magic_check())
 				visible_message(span_warning("The gravity fades away around you [L] "))  //antimagic needs some testing
 				playsound(get_turf(L), 'sound/magic/magic_nulled.ogg', 100)
-				return 
+				return TRUE
 
 			if(L.STASTR <= 15)
 				L.adjustBruteLoss(60)
@@ -59,7 +59,7 @@
 				to_chat(L, "<span class='userdanger'>You're magically weighed down, and your strength resist!</span>")
 			
 			
-
+	return TRUE
 /obj/effect/temp_visual/gravity
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "hierophant_squares"

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
@@ -21,7 +21,7 @@
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 	gesture_required = TRUE
 	range = 7
-	var/delay = 7
+	var/delay = 5
 	var/damage = 0 // damage based off your str 
 	var/area_of_effect = 0
 
@@ -50,7 +50,7 @@
 				return 
 
 			if(L.STASTR <= 15)
-				L.adjustBruteLoss(30)
+				L.adjustBruteLoss(60)
 				L.Knockdown(5)
 				to_chat(L, "<span class='userdanger'>You're magically weighed down, losing your footing!</span>")
 			else
@@ -78,5 +78,5 @@
 	name = "rippling arcyne energy"
 	desc = "Get out of the way!"
 	randomdir = FALSE
-	duration = 7 SECONDS
+	duration = 5 SECONDS
 	layer = MASSIVE_OBJ_LAYER


### PR DESCRIPTION
1 year ago I. dente. Unleashed the biggest evil azure peak has ever seen. gravity.

I'm tired of people (rightfully) bitching about it, it was fun. this pr gives gravity a small delay, about half as long as blade burst.
will ppl still typebait you with this? maybe. idk. but it's now way harder to hit moving ppl.  (also doubling the damage up to 60 as it's now harder 2 hit.)

this also speeds up bladeburst slightly as the speed it was at was pre-debloat and pre-awesome serverbox. shit runs way better now. still very slow. 

