### PR TITLE
Make books + recipe books burn for 5 minutes

### DIFF
--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -5,7 +5,7 @@
 	slot_flags = ITEM_SLOT_HIP
 	var/base_icon_state = "basic_book"
 	unique = TRUE
-	firefuel = 2 MINUTES
+	firefuel = 5 MINUTES
 	dropshrink = 0.6
 	drop_sound = 'sound/foley/dropsound/book_drop.ogg'
 	force = 5

--- a/code/modules/crafting/recipe_books/recipe_book.dm
+++ b/code/modules/crafting/recipe_books/recipe_book.dm
@@ -5,6 +5,7 @@
 
 	grid_width = 32
 	grid_height = 32
+	firefuel = 5 MINUTES
 	var/list/types = list()
 	var/mob/current_reader
 	var/open

--- a/code/modules/crafting/recipe_books/recipe_books_list.dm
+++ b/code/modules/crafting/recipe_books/recipe_books_list.dm
@@ -60,6 +60,7 @@
 // This book should be widely given to everyone
 /obj/item/recipe_book/survival
 	name = "The Survival Handbook"
+	desc = "A book full of recipes and tips for surviving in the wild. Can be used as fuel in a pinch."
 	icon_state = "book6_0"
 	base_icon_state = "book6"
 


### PR DESCRIPTION
## About The Pull Request
Keep seeing people ditch their starter survival's handbook recipe book. Understandable. 

- Books now burn for 5 minutes (standard with fiber) instead of 2.
- Recipe books can also burn

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
compile, i tested it

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Burn books. raaaa

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
