### PR TITLE
Gold Ore perma enchant. Mending no longer visible message

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -33,7 +33,7 @@
 				I.obj_integrity = I.max_integrity
 				I.obj_fix()
 		else
-			user.visible_message(span_info("[I] appears to be in perfect condition."))
+			to_chat(user, span_info("[I] appears to be in perfect condition."))
 			revert_cast()
 	else
 		to_chat(user, span_warning("There is no item here!"))


### PR DESCRIPTION
## About The Pull Request
Suggestion by Alinar on discord. This is a ghetto enchant system until we port over something permanent from Vanderlin / Ratwood

- Enchant Weapon now can be made permanent (Read: 200 minutes duration) if the caster is holding a piece of gold ore (raw gold) in their hand. Should be sufficiently expensive but something people want to pursue now. 
- Mending no longer send a visible message to everyone if it is in perfect condition.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_GZh1VPtTRM](https://github.com/user-attachments/assets/c9a56c87-73a9-4b29-9fae-c3ecedf29525)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Make enchant weapons useful for other people if they can pay the price needed to improve their weapons to a mage with the spell. Yeah, this is not the full on enchantment system but it will do as a substitute until I / some crazy coder do it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
