### PR TITLE
(wip) expands slapcrafting to a big chunk of existing craft menu recipes

### DIFF
--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -19,6 +19,50 @@
 	sellprice = 2
 	bundletype = /obj/item/natural/bundle/fibers
 
+/obj/item/natural/fibers/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/stonehoe,
+		/datum/crafting_recipe/roguetown/woodhammer,
+		/datum/crafting_recipe/roguetown/tneedle,
+		/datum/crafting_recipe/roguetown/recurvepartial,
+		/datum/crafting_recipe/roguetown/longbowpartial,
+		/datum/crafting_recipe/roguetown/wickercloak,
+		/datum/crafting_recipe/roguetown/torch,
+		/datum/crafting_recipe/roguetown/woodhammer,
+		/datum/crafting_recipe/roguetown/stonehoe,
+		/datum/crafting_recipe/roguetown/stonesword,
+		/datum/crafting_recipe/roguetown/woodsword,
+		/datum/crafting_recipe/roguetown/bag,
+		/datum/crafting_recipe/roguetown/bagx5,
+		/datum/crafting_recipe/roguetown/rod,
+		/datum/crafting_recipe/roguetown/pearlcross,
+		/datum/crafting_recipe/roguetown/bpearlcross,
+		/datum/crafting_recipe/roguetown/shellnecklace,
+		/datum/crafting_recipe/roguetown/shellbracelet,
+		/datum/crafting_recipe/roguetown/abyssoramulet,
+		/datum/crafting_recipe/roguetown/broom,
+		/datum/crafting_recipe/roguetown/woodcross,
+		/datum/crafting_recipe/roguetown/mantrap,
+		/datum/crafting_recipe/roguetown/tribalrags,
+		/datum/crafting_recipe/roguetown/skullmask,
+		/datum/crafting_recipe/roguetown/bonespear,
+		/datum/crafting_recipe/roguetown/boneaxe,
+		/datum/crafting_recipe/roguetown/goodluckcharm,
+		/datum/crafting_recipe/roguetown/bouquet_rosa,
+		/datum/crafting_recipe/roguetown/bouquet_salvia,
+		/datum/crafting_recipe/roguetown/bouquet_matricaria,
+		/datum/crafting_recipe/roguetown/bouquet_calendula,
+		/datum/crafting_recipe/roguetown/flowercrown_rosa,
+		/datum/crafting_recipe/roguetown/flowercrown_salvia,
+		/datum/crafting_recipe/roguetown/slingpouchcraft,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /obj/item/natural/fibers/attack_right(mob/user)
 	if(user.get_active_held_item())
 		return
@@ -124,6 +168,21 @@
 	var/wet = 0
 	/// Effectiveness when used as a bandage, how much bloodloss we can staunch
 	var/bandage_effectiveness = 0.9
+
+/obj/item/natural/cloth/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/longbowpartial,
+		/datum/crafting_recipe/roguetown/bag,
+		/datum/crafting_recipe/roguetown/bagx5,
+		/datum/crafting_recipe/roguetown/book_crafting_kit,
+		/datum/crafting_recipe/roguetown/slingpouchcraft,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
 
 /obj/item/natural/cloth/attack_right(mob/user)
 	if(user.get_active_held_item())
@@ -246,6 +305,18 @@
 	embedding = list("embedded_unsafe_removal_time" = 20, "embedded_pain_chance" = 10, "embedded_pain_multiplier" = 1, "embed_chance" = 35, "embedded_fall_chance" = 0)
 	resistance_flags = FLAMMABLE
 	max_integrity = 20
+
+/obj/item/natural/thorn/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/tneedle,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /obj/item/natural/thorn/attack_self(mob/living/user)
 	user.visible_message(span_warning("[user] snaps [src]."))
 	playsound(user,'sound/items/seedextract.ogg', 100, FALSE)
@@ -445,7 +516,7 @@
 
 /obj/item/natural/bowstring
 	name = "fibre bowstring"
-	desc = "A tough and durable length of woven plant fiber, prepared to launch many an arrow."
+	desc = "Wax-fed fibrous thread has been spun and dressed into a continuous loop."
 	icon_state = "fibers"
 	possible_item_intents = list(/datum/intent/use)
 	force = 0
@@ -460,6 +531,19 @@
 	w_class = WEIGHT_CLASS_TINY
 	spitoutmouth = FALSE
 	experimental_inhand = FALSE
+
+/obj/item/natural/bowstring/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/bow,
+		/datum/crafting_recipe/roguetown/recurvebow,
+		/datum/crafting_recipe/roguetown/longbow,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
 
 /obj/item/natural/bundle/worms
 	name = "worms"

--- a/code/game/objects/items/rogueitems/natural/dirtclod.dm
+++ b/code/game/objects/items/rogueitems/natural/dirtclod.dm
@@ -43,6 +43,14 @@
 /obj/item/natural/dirtclod/Initialize()
 	icon_state = "clod[rand(1,2)]"
 	..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/wickercloak,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
 
 /obj/structure/fluff/clodpile
 	name = "dirt pile"

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -144,6 +144,28 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 	sharpening_factor = 0.1
 	spark_chance = 35
 
+/obj/item/natural/stone/Initialize()
+	. = ..()
+	stone_lore()
+
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/stoneaxe,
+		/datum/crafting_recipe/roguetown/stonehammer,
+		/datum/crafting_recipe/roguetown/stonepick,
+		/datum/crafting_recipe/roguetown/stonehoe,
+		/datum/crafting_recipe/roguetown/stonetongs,
+		/datum/crafting_recipe/roguetown/stoneknife,
+		/datum/crafting_recipe/roguetown/stonespear,
+		/datum/crafting_recipe/roguetown/stonesword,
+		/datum/crafting_recipe/roguetown/pot,
+		/datum/crafting_recipe/roguetown/net,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /obj/item/natural/whetstone
 	name = "whetstone"
 	icon_state = "whetstone"
@@ -159,9 +181,27 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 	sharpening_factor = 0.4
 	spark_chance = 80
 
-/obj/item/natural/stone/Initialize()
+/obj/item/natural/whetstoneInitialize()
 	. = ..()
-	stone_lore()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/reinforcedshaft,
+		/datum/crafting_recipe/roguetown/peasantry/thresher/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/shovel/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/hoe/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/pitchfork/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/goedendag,
+		/datum/crafting_recipe/roguetown/peasantry/scythe,
+		/datum/crafting_recipe/roguetown/peasantry/warflail,
+		/datum/crafting_recipe/roguetown/peasantry/warpick,
+		/datum/crafting_recipe/roguetown/peasantry/warpick_steel,
+		/datum/crafting_recipe/roguetown/peasantry/maciejowski_knife,
+		/datum/crafting_recipe/roguetown/peasantry/maciejowski_messer,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
 
 /*
 	This right here is stone lore,

--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -72,6 +72,61 @@
 	smeltresult = /obj/item/rogueore/coal
 	lumber_amount = 0
 
+/obj/item/grown/log/tree/small/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/stoneaxe,
+		/datum/crafting_recipe/roguetown/stonehammer,
+		/datum/crafting_recipe/roguetown/stonepick,
+		/datum/crafting_recipe/roguetown/stonehoe,
+		/datum/crafting_recipe/roguetown/woodspade,
+		/datum/crafting_recipe/roguetown/woodhammer,
+		/datum/crafting_recipe/roguetown/stonesword,
+		/datum/crafting_recipe/roguetown/woodclub,
+		/datum/crafting_recipe/roguetown/fishingcage,
+		/datum/crafting_recipe/roguetown/rod,
+		/datum/crafting_recipe/roguetown/bowpartial,
+		/datum/crafting_recipe/roguetown/recurvepartial,
+		/datum/crafting_recipe/roguetown/longbowpartial,
+		/datum/crafting_recipe/roguetown/billhook,
+		/datum/crafting_recipe/roguetown/goedendag,
+		/datum/crafting_recipe/roguetown/woodsword,
+		/datum/crafting_recipe/roguetown/woodshield,
+		/datum/crafting_recipe/roguetown/spoon,
+		/datum/crafting_recipe/roguetown/fork,
+		/datum/crafting_recipe/roguetown/platter,
+		/datum/crafting_recipe/roguetown/rollingpin,
+		/datum/crafting_recipe/roguetown/woodbucket,
+		/datum/crafting_recipe/roguetown/woodcup,
+		/datum/crafting_recipe/roguetown/woodtray,
+		/datum/crafting_recipe/roguetown/woodbowl,
+		/datum/crafting_recipe/roguetown/pipe,
+		/datum/crafting_recipe/roguetown/mantrap,
+		/datum/crafting_recipe/roguetown/paperscroll,
+		/datum/crafting_recipe/roguetown/boneaxe,
+		/datum/crafting_recipe/roguetown/prosthetic/woodleftarm,
+		/datum/crafting_recipe/roguetown/prosthetic/woodrightarm,
+		/datum/crafting_recipe/roguetown/prosthetic/woodleftleft,
+		/datum/crafting_recipe/roguetown/prosthetic/woodrightleg,
+		/datum/crafting_recipe/roguetown/tarot_deck,
+		/datum/crafting_recipe/roguetown/heatershield,
+		/datum/crafting_recipe/roguetown/woodshaft,
+		/datum/crafting_recipe/roguetown/peasantry/thresher/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/shovel/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/hoe/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/pitchfork/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/peasantwarflail,
+		/datum/crafting_recipe/roguetown/peasantry/waraxe,
+		/datum/crafting_recipe/roguetown/peasantry/warspear_hoe,
+		/datum/crafting_recipe/roguetown/peasantry/warspear_pitchfork,
+		/datum/crafting_recipe/roguetown/peasantry/scythe,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /obj/item/grown/log/tree/small/attackby(obj/item/I, mob/living/user, params)
 	if(item_flags & IN_STORAGE)
 		return
@@ -104,17 +159,40 @@
 	smeltresult = /obj/item/rogueore/coal
 	lumber_amount = 0
 
+/obj/item/grown/log/tree/bowpartial/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/bow,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /obj/item/grown/log/tree/bowpartial/recurve
 	name = "recurve bowstave"
 	desc = "An incomplete recurve bow, waiting to be strung."
 	icon = 'icons/roguetown/items/64x.dmi'
 	icon_state = "recurve_bowstave"
 
+/obj/item/grown/log/tree/bowpartial/recurve/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/recurvebow,
+		)
+
 /obj/item/grown/log/tree/bowpartial/longbow
 	name = "long bowstave"
 	desc = "An incomplete longbow, waiting to be strung."
 	icon = 'icons/roguetown/items/64x.dmi'
 	icon_state = "long_bowstave"
+
+/obj/item/grown/log/tree/bowpartial/longbow/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/longbow,
+		)
 
 /obj/item/grown/log/tree/stick
 	name = "stick"
@@ -153,6 +231,28 @@
 /obj/item/grown/log/tree/stick/Initialize()
 	icon_state = "stick[rand(1,2)]"
 	..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/fishingcage,
+		/datum/crafting_recipe/roguetown/woodspade,
+		/datum/crafting_recipe/roguetown/stonetongs,
+		/datum/crafting_recipe/roguetown/stoneknife,
+		/datum/crafting_recipe/roguetown/broom,
+		/datum/crafting_recipe/roguetown/woodcross,
+		/datum/crafting_recipe/roguetown/dye_brush,
+		/datum/crafting_recipe/roguetown/peasantry/thresher,
+		/datum/crafting_recipe/roguetown/peasantry/shovel,
+		/datum/crafting_recipe/roguetown/peasantry/hoe,
+		/datum/crafting_recipe/roguetown/peasantry/pitchfork,
+		/datum/crafting_recipe/roguetown/wickercloak,
+		/datum/crafting_recipe/roguetown/torch,
+		/datum/crafting_recipe/roguetown/stonearrow,
+		/datum/crafting_recipe/roguetown/stonearrow_five,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
 
 /obj/item/grown/log/tree/stick/attack_self(mob/living/user)
 	user.visible_message(span_warning("[user] snaps [src]."))

--- a/code/game/objects/items/rogueitems/ropechainbola.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola.dm
@@ -20,6 +20,31 @@
 	grid_width = 32
 	grid_height = 64
 
+/obj/item/rope/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/ropebelt,
+		/datum/crafting_recipe/roguetown/net,
+		/datum/crafting_recipe/roguetown/billhook,
+		/datum/crafting_recipe/roguetown/goedendag,
+		/datum/crafting_recipe/roguetown/rucksack,
+		/datum/crafting_recipe/roguetown/peasantry/thresher/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/shovel/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/hoe/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/pitchfork/whetstone,
+		/datum/crafting_recipe/roguetown/peasantry/peasantwarflail,
+		/datum/crafting_recipe/roguetown/peasantry/goedendag,
+		/datum/crafting_recipe/roguetown/peasantry/waraxe,
+		/datum/crafting_recipe/roguetown/peasantry/warspear_hoe,
+		/datum/crafting_recipe/roguetown/peasantry/warspear_pitchfork,
+		/datum/crafting_recipe/roguetown/peasantry/scythe,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /datum/intent/tie
 	name = "tie"
 	chargetime = 0

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -281,7 +281,7 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleaf
 	seed = /obj/item/seeds/sweetleaf
 	name = "swampweed"
-	desc = "A 'foggy' pipe weed."
+	desc = "A pipeweed with pungent odor and a sparkling surface."
 	icon_state = "swampweed"
 	filling_color = "#008000"
 	bitesize_mod = 1
@@ -294,7 +294,7 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweed
 	seed = /obj/item/seeds/pipeweed
 	name = "westleach leaf"
-	desc = "A generic kind of pipe weed."
+	desc = "A pipeweed prized for its rich flavor."
 	icon_state = "westleach"
 	filling_color = "#008000"
 	bitesize_mod = 1
@@ -308,7 +308,7 @@
 /obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry
 	seed = null
 	name = "westleach leaf"
-	desc = "A dried leaf."
+	desc = "A dried pipeweed, ready to smoke."
 	icon_state = "westleachd"
 	dry = TRUE
 	pipe_reagents = list(/datum/reagent/drug/nicotine = 30)
@@ -316,16 +316,38 @@
 	list_reagents = list(/datum/reagent/drug/nicotine = 5, /datum/reagent/consumable/nutriment = 1)
 	grind_results = list(/datum/reagent/drug/nicotine = 10)
 
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/sigdry,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry
 	seed = null
 	name = "swampweed"
-	desc = "It's dried."
+	desc = "A prepared pipeweed prized for its foggy effects."
 	icon_state = "swampweedd"
 	dry = TRUE
 	pipe_reagents = list(/datum/reagent/drug/space_drugs = 30)
 	list_reagents = list(/datum/reagent/drug/space_drugs = 2,/datum/reagent/consumable/nutriment = 1)
 	grind_results = list(/datum/reagent/drug/space_drugs = 5)
 	eat_effect = /datum/status_effect/debuff/badmeal
+
+/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/sigsweet,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
 
 /obj/item/reagent_containers/food/snacks/grown/onion/rogue
 	name = "onion"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -117,6 +117,16 @@
 	pixel_x = rand(-9, 9)
 	update_icon_state()
 	updateinfolinks()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/sigsweet,
+		/datum/crafting_recipe/roguetown/sigdry,
+		/datum/crafting_recipe/roguetown/rocknutdry,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
 
 /obj/item/paper/update_icon_state()
 	if(mailer)

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -158,6 +158,17 @@
 	volume = 1
 	sellprice = 0
 
+/obj/item/reagent_containers/powder/rocknut/Initialize()
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/rocknutdry,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /datum/reagent/floure
 	name = "flour"
 	description = ""

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -5,8 +5,10 @@
 /datum/crafting_recipe/roguetown/tneedle
 	name = "sewing needle"
 	result = /obj/item/needle/thorn
-	reqs = list(/obj/item/natural/thorn = 1,
-				/obj/item/natural/fibers = 1)
+	reqs = list(
+		/obj/item/natural/thorn = 1,
+		/obj/item/natural/fibers = 1,
+		)
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/cloth
@@ -22,12 +24,12 @@
 /datum/crafting_recipe/roguetown/cloth5x
 	name = "cloth 5x (10 fibers)"
 	result = list(
-				/obj/item/natural/cloth,
-				/obj/item/natural/cloth,
-				/obj/item/natural/cloth,
-				/obj/item/natural/cloth,
-				/obj/item/natural/cloth,
-				)
+		/obj/item/natural/cloth,
+		/obj/item/natural/cloth,
+		/obj/item/natural/cloth,
+		/obj/item/natural/cloth,
+		/obj/item/natural/cloth,
+		)
 	reqs = list(/obj/item/natural/fibers = 10)
 	tools = list(/obj/item/needle)
 	skillcraft = /datum/skill/misc/sewing
@@ -78,8 +80,10 @@
 	name = "net"
 	result = /obj/item/net
 	craftdiff = 2
-	reqs = list(/obj/item/rope = 2,
-				/obj/item/natural/stone = 3)
+	reqs = list(
+		/obj/item/rope = 2,
+		/obj/item/natural/stone = 3,
+		)
 	verbage_simple = "braid"
 	verbage = "braids"
 
@@ -101,7 +105,10 @@
 /datum/crafting_recipe/roguetown/bow
 	name = "wooden bow"
 	result = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
-	reqs = list(/obj/item/natural/bowstring = 1, /obj/item/grown/log/tree/bowpartial = 1)
+	reqs = list(
+		/obj/item/natural/bowstring = 1,
+		/obj/item/grown/log/tree/bowpartial = 1,
+		)
 	verbage_simple = "string together"
 	verbage = "strings together"
 	craftdiff = 2
@@ -114,7 +121,7 @@
 		/obj/item/natural/bone = 2,
 		/obj/item/reagent_containers/food/snacks/tallow = 1,
 		/obj/item/natural/fibers = 2,
-	)
+		)
 	tools = /obj/item/rogueweapon/huntingknife
 	verbage_simple = "carve"
 	verbage = "carves"
@@ -139,7 +146,7 @@
 		/obj/item/natural/cloth = 1,
 		/obj/item/reagent_containers/food/snacks/tallow = 1,
 		/obj/item/natural/fibers = 2,
-	)
+		)
 	tools = /obj/item/rogueweapon/huntingknife
 	verbage_simple = "carve"
 	verbage = "carves"
@@ -295,7 +302,10 @@
 /datum/crafting_recipe/roguetown/quarterstaff_iron
 	name = "iron-reinforced quarterstaff"
 	result = list(/obj/item/rogueweapon/woodstaff/quarterstaff/iron)
-	reqs = list(/obj/item/rogueweapon/woodstaff/quarterstaff = 1, /obj/item/ingot/iron = 1)
+	reqs = list(
+		/obj/item/rogueweapon/woodstaff/quarterstaff = 1,
+		/obj/item/ingot/iron = 1,
+		)
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 2
 
@@ -602,8 +612,10 @@
 /datum/crafting_recipe/roguetown/rod
 	name = "fishing rod"
 	result = /obj/item/fishingrod/crafted
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-		/obj/item/natural/fibers = 2)
+	reqs = list(
+		/obj/item/grown/log/tree/small = 1,
+		/obj/item/natural/fibers = 2,
+		)
 
 
 /obj/item/fishingrod/crafted
@@ -612,23 +624,29 @@
 /datum/crafting_recipe/roguetown/fishingcage
 	name = "fishing cage"
 	result = /obj/item/fishingcage
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-		/obj/item/grown/log/tree/stick = 2)
+	reqs = list(
+		/obj/item/grown/log/tree/small = 1,
+		/obj/item/grown/log/tree/stick = 2,
+		)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/woodspade
 	name = "wood spade"
 	result = /obj/item/rogueweapon/shovel/small
-	reqs = list(/obj/item/grown/log/tree/small = 1,
-			/obj/item/grown/log/tree/stick = 1)
+	reqs = list(
+		/obj/item/grown/log/tree/small = 1,
+		/obj/item/grown/log/tree/stick = 1,
+		)
 /obj/item/rogueweapon/shovel/small/crafted
 	sellprice = 5
 
 /datum/crafting_recipe/roguetown/pearlcross
 	name = "amulet (pearls)"
 	result = /obj/item/clothing/neck/roguetown/psicross/pearl
-	reqs = list(/obj/item/natural/fibers = 1,
-			/obj/item/pearl = 3)
+	reqs = list(
+		/obj/item/natural/fibers = 1,
+		/obj/item/pearl = 3,
+		)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/bpearlcross
@@ -920,13 +938,15 @@
 /datum/crafting_recipe/roguetown/candle/eora
 	name = "eora's candle (x3)"
 	result = list(
-				/obj/item/candle/eora,
-				/obj/item/candle/eora,
-				/obj/item/candle/eora,
-				)
-	reqs = list(/obj/item/reagent_containers/food/snacks/tallow = 1,
-				/obj/item/alch/rosa = 1,
-				/datum/reagent/water/blessed = 25)
+		/obj/item/candle/eora,
+		/obj/item/candle/eora,
+		/obj/item/candle/eora,
+		)
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/tallow = 1,
+		/obj/item/alch/rosa = 1,
+		/datum/reagent/water/blessed = 25,
+		)
 
 /datum/crafting_recipe/roguetown/slingcraft
 	name = "sling"
@@ -939,7 +959,10 @@
 /datum/crafting_recipe/roguetown/slingpouchcraft
 	name = "sling bullet pouch"
 	result = /obj/item/quiver/sling/
-	reqs = list(/obj/item/natural/fibers = 1, /obj/item/natural/cloth = 1)
+	reqs = list(
+		/obj/item/natural/fibers = 1,
+		/obj/item/natural/cloth = 1,
+		)
 	verbage_simple = "craft"
 	verbage = "crafts"
 	craftdiff = 0
@@ -947,9 +970,9 @@
 /datum/crafting_recipe/roguetown/stonebullets
 	name = "stone sling bullets (x2)"
 	result = list(
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				)
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		)
 	reqs = list(/obj/item/natural/stone = 1)
 	verbage_simple = "smooth"
 	verbage = "smooths"
@@ -958,17 +981,17 @@
 /datum/crafting_recipe/roguetown/stonebullets10x
 	name = "stone sling bullets (x10)"
 	result = list(
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
-				)
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		/obj/item/ammo_casing/caseless/rogue/sling_bullet/stone,
+		)
 	reqs = list(/obj/item/natural/stone = 5)
 	verbage_simple = "smooth"
 	verbage = "smooths"
@@ -979,7 +1002,7 @@
     result = /obj/item/hair_dye_cream
     reqs = list(
         /obj/item/reagent_containers/glass/bowl = 1,
-        /obj/item/reagent_containers/food/snacks/grown/berries/rogue = 3
+        /obj/item/reagent_containers/food/snacks/grown/berries/rogue = 3,
     )
 
 // DIE
@@ -1077,53 +1100,67 @@
 
 /datum/crafting_recipe/roguetown/peasantry/thresher
 	name = "Thresher (+1 Iron Ingot)"
-	reqs = list(/obj/item/grown/log/tree/stick = 1, 
-				/obj/item/ingot/iron = 1)
+	reqs = list(
+				/obj/item/grown/log/tree/stick = 1, 
+				/obj/item/ingot/iron = 1,
+				)
 	result = /obj/item/rogueweapon/thresher
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/peasantry/thresher/whetstone
 	name = "Thresher (+4 Whetstones, +1 Log, +1 Rope)"
-	reqs = list(/obj/item/grown/log/tree/small = 1, 
+	reqs = list(
+				/obj/item/grown/log/tree/small = 1, 
 				/obj/item/natural/whetstone = 4,
-				/obj/item/rope = 1)
+				/obj/item/rope = 1,
+				)
 	result = /obj/item/rogueweapon/thresher
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/peasantry/shovel
 	name = "Shovel (+1 Iron Ingot, +2 Sticks)"
-	reqs = list(/obj/item/grown/log/tree/stick = 2, 
-				/obj/item/ingot/iron = 1)
+	reqs = list(
+				/obj/item/grown/log/tree/stick = 2, 
+				/obj/item/ingot/iron = 1,
+				)
 	result = /obj/item/rogueweapon/shovel
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/peasantry/shovel/whetstone
 	name = "Shovel (+3 Whetstones, +2 Logs, +1 Rope)"
-	reqs = list(/obj/item/grown/log/tree/small = 2, 
-				/obj/item/natural/whetstone = 3,
-				/obj/item/rope = 1)
+	reqs = list(
+		/obj/item/grown/log/tree/small = 2, 
+		/obj/item/natural/whetstone = 3,
+		/obj/item/rope = 1,
+		)
 	result = /obj/item/rogueweapon/shovel
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/peasantry/hoe
 	name = "Hoe (+1 Iron Ingot, +2 Sticks)"
-	reqs = list(/obj/item/grown/log/tree/stick = 2, 
-				/obj/item/ingot/iron = 1)
+	reqs = list(
+		/obj/item/grown/log/tree/stick = 2, 
+		/obj/item/ingot/iron = 1,
+		)
 	result = /obj/item/rogueweapon/hoe
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/peasantry/hoe/whetstone
 	name = "Shovel (+3 Whetstones, +2 Logs, +1 Rope)"
-	reqs = list(/obj/item/grown/log/tree/small = 2, 
-				/obj/item/natural/whetstone = 3,
-				/obj/item/rope = 1)
+	reqs = list(
+		/obj/item/grown/log/tree/small = 2, 
+		/obj/item/natural/whetstone = 3,
+		/obj/item/rope = 1,
+		)
 	result = /obj/item/rogueweapon/hoe
 	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/peasantry/pitchfork
 	name = "Pitchfork (+1 Iron Ingot, +2 Sticks)"
-	reqs = list(/obj/item/grown/log/tree/stick = 2, 
-				/obj/item/ingot/iron = 1)
+	reqs = list(
+		/obj/item/grown/log/tree/stick = 2, 
+		/obj/item/ingot/iron = 1,
+		)
 	result = /obj/item/rogueweapon/pitchfork
 	craftdiff = 0
 

--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -168,6 +168,23 @@
 	smeltresult = /obj/item/ingot/iron
 	sellprice = 25
 
+/obj/item/ingot/iron/Initialize(mapload, smelt_quality)
+	. = ..()
+	var/static/list/slapcraft_recipe_list = list(
+		/datum/crafting_recipe/roguetown/structure/plough,
+		/datum/crafting_recipe/roguetown/peasantry/thresher,
+		/datum/crafting_recipe/roguetown/peasantry/shovel,
+		/datum/crafting_recipe/roguetown/peasantry/hoe,
+		/datum/crafting_recipe/roguetown/peasantry/pitchfork,
+		/datum/crafting_recipe/roguetown/quarterstaff_iron,
+		/datum/crafting_recipe/roguetown/mantrap,
+		)
+
+	AddElement(
+		/datum/element/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+		)
+
 /obj/item/ingot/copper
 	name = "copper bar"
 	desc = "This bar causes a gentle tingling sensation when touched."


### PR DESCRIPTION
## About The Pull Request

![slapcraft the planet](https://github.com/user-attachments/assets/b0216b40-e5e3-440b-8fec-1c00d72f1897)

enables slapcrafting for a significant chunk of our existing crafting menu recipes, including radial support with icon display of the finished products.

some known issues:
- does not currently tell you what crafting items you're missing per recipe
- some items with preexisting onclick interactions don't like to work, like fibers
- single ingredient craft recipes don't play nicely with the slapcrafting component yet
- radial menus need rogue gfx

## Testing Evidence

![image](https://github.com/user-attachments/assets/ac6da648-ea4f-49a4-b24e-bb31d1d4c167)


## Why It's Good For The Game

you can finally craft a zig by slapping paper with dried leafs this shit kicks ass
