### PR TITLE
Invisible Glazed Clay Statue Fix

### DIFF
--- a/code/game/objects/items/rogueitems/ceramics.dm
+++ b/code/game/objects/items/rogueitems/ceramics.dm
@@ -91,7 +91,7 @@
 	name = "ceramic statue"
 	desc = "A ceramic statue, shining in its eligance!"
 	icon = 'icons/roguetown/items/cooking.dmi'
-	icon_state = "claystatuecook1"
+	icon_state = "claystatuecooked1"
 	smeltresult = null	//No resource return
 	sellprice = 15		//Iron is worth 20, so these gotta be a little cheaper
 

--- a/code/game/objects/items/rogueitems/ceramics.dm
+++ b/code/game/objects/items/rogueitems/ceramics.dm
@@ -97,7 +97,7 @@
 
 /obj/item/roguestatue/clay/Initialize()
 	. = ..()
-	icon_state = "claystatuecook[pick(1,2)]"
+	icon_state = "claystatuecooked[pick(1,2)]"
 
 /obj/item/roguestatue/glass
 	name = "glass statue"


### PR DESCRIPTION
## About The Pull Request

The glazed clay statue was invisible. This fixes that! 

## Testing Evidence

![clayProof](https://github.com/user-attachments/assets/fd3c1e69-9f7c-488e-bc51-a6a68abc6cfd)

Wow! Such glaze! 

## Why It's Good For The Game

It did make a funny invisible party trick, but it's probably best to let the room décor piece be room décor. 