### PR TITLE
Small smith/tailor map edits

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -3647,12 +3647,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "bpZ" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue,
+/obj/item/natural/bundle/curred_hide,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "bqi" = (
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -4861,12 +4859,12 @@
 	},
 /area/rogue/indoors/town)
 "bLQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/fluff/railing/wood,
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
 	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bLV" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/under/cave/licharena)
@@ -6866,10 +6864,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "czd" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "czf" = (
 /obj/structure/bars/pipe{
@@ -7367,6 +7366,15 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"cIm" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "cIt" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/cobble,
@@ -7512,12 +7520,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "cLL" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "cLP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -12369,15 +12374,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"ewR" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/clothing/cloak/apron/waist/brown,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
 "ewY" = (
 /obj/structure/bed/rogue/shit,
 /obj/structure/spider/stickyweb,
@@ -13347,11 +13343,15 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eOV" = (
-/obj/structure/fluff/walldeco/bsmith{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "eOW" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/blocks,
@@ -15012,6 +15012,12 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
+"fqO" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "fqS" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -15575,8 +15581,10 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
 "fBn" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "fBq" = (
 /obj/structure/rack/rogue,
@@ -15898,14 +15906,9 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fHN" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/dwarfin)
 "fHY" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/ruinedwood{
@@ -18664,11 +18667,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "gJU" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/fluff/walldeco/bsmith{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "gJY" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/carpet,
@@ -21623,6 +21626,19 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
+"hKr" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "hKs" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/cobblerock,
@@ -23963,15 +23979,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "iAy" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "iAD" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/carpet/red,
@@ -24214,8 +24227,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town)
 "iEJ" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "iEM" = (
 /obj/structure/lever{
@@ -26197,11 +26212,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "jpb" = (
-/obj/structure/fluff/walldeco/bsmith{
-	name = "DWARVEN KEEP"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "jpg" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -30161,9 +30177,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "kNF" = (
-/obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/obj/structure/fluff/walldeco/bsmith{
+	name = "DWARVEN KEEP"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "kNG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt,
@@ -30347,10 +30365,8 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement/keep)
 "kRP" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "kRS" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -30880,9 +30896,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1
-	},
+/obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "lcg" = (
@@ -34670,12 +34684,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
-"mys" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "myt" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/carpet/royalblack,
@@ -35345,11 +35353,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "mLF" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/item/clothing/cloak/apron/waist/brown,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "mLH" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -39192,11 +39203,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "oeq" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/turf/closed,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "oex" = (
 /obj/effect/spawner/lootdrop/roguetown,
 /obj/structure/closet/crate/chest,
@@ -41993,11 +42004,12 @@
 /turf/open/water/pond,
 /area/rogue/outdoors/woods)
 "pcr" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/cobble,
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "pct" = (
 /obj/random/spider,
@@ -42359,9 +42371,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "phE" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "phH" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -44119,10 +44133,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pMM" = (
-/obj/structure/rack/rogue,
-/obj/item/natural/bundle/curred_hide,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "pMW" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -46137,6 +46152,12 @@
 	dir = 1
 	},
 /area/rogue/under/cave/goblindungeon)
+"qxd" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "qxe" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble,
@@ -46185,10 +46206,13 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "qxR" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/dwarfin)
 "qxV" = (
 /obj/structure/fluff/railing/border{
@@ -47489,8 +47513,8 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/turf/closed,
+/area/rogue/indoors/town)
 "qUL" = (
 /obj/effect/decal/cobble/mossy{
 	dir = 8
@@ -48165,12 +48189,10 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "riJ" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "riX" = (
 /obj/effect/decal/cobbleedge{
@@ -51675,9 +51697,8 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
 "srE" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/rack/rogue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "srI" = (
@@ -51949,12 +51970,6 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town)
-"swo" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
 "swB" = (
 /obj/structure/mineral_door/bars{
@@ -53459,11 +53474,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/exposed/bath/vault)
 "tad" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/item/roguebin/water/gross,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "tae" = (
 /obj/structure/gate/bars/preopen{
 	gid = "outernorthgate";
@@ -55141,11 +55154,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "tGa" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "tGk" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/rtfield)
@@ -63040,14 +63053,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wqT" = (
-/obj/structure/fluff/railing/border{
+/obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/tile/brick,
+/turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
 "wqV" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -63211,19 +63220,6 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"wto" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "wtC" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -65004,9 +65000,14 @@
 	},
 /area/rogue/under/town/basement/keep)
 "xew" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "xeB" = (
 /obj/structure/flora/roguetree/burnt,
@@ -65631,13 +65632,10 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "xpv" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "xpH" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -146514,7 +146512,7 @@ iMR
 qOS
 cHC
 nvB
-kNF
+tad
 dlK
 urZ
 mMx
@@ -147858,7 +147856,7 @@ gKR
 gKR
 pcE
 ncG
-fBn
+kRP
 rPR
 iPN
 kxW
@@ -148315,8 +148313,8 @@ rPR
 rPR
 rPR
 kXy
-czd
-fBn
+tGa
+kRP
 kXy
 kXy
 xAN
@@ -149215,7 +149213,7 @@ rBY
 rBY
 rBY
 kXy
-iAy
+xew
 ncG
 rPR
 rPR
@@ -150119,12 +150117,12 @@ lrS
 rBY
 rBY
 kXy
-iEJ
+fHN
 ncG
-xew
-kXy
-czd
 srE
+kXy
+tGa
+oeq
 kXy
 kXy
 hAg
@@ -151928,7 +151926,7 @@ rPR
 rPR
 rPR
 rPR
-srE
+oeq
 kSG
 kXy
 xAN
@@ -152375,11 +152373,11 @@ kXy
 eYJ
 eYJ
 kXy
-cLL
+jpb
 epB
 eSw
 isH
-riJ
+pcr
 kXy
 kXy
 kXy
@@ -258139,11 +258137,11 @@ enA
 nJH
 sns
 lKo
-pMM
+bpZ
 kRg
-oeq
+qUB
 kRg
-ewR
+mLF
 lKo
 ruL
 kXi
@@ -258590,7 +258588,7 @@ phl
 fgh
 bMf
 sns
-swo
+wqT
 gyu
 iJD
 gyu
@@ -259050,7 +259048,7 @@ hRO
 sns
 euy
 cDX
-tGa
+pMM
 sns
 vOG
 lce
@@ -261317,7 +261315,7 @@ ykd
 xdU
 smL
 vaz
-bpZ
+bLQ
 sns
 sns
 sns
@@ -261769,7 +261767,7 @@ gfp
 hyu
 jWX
 xdU
-phE
+cLL
 sns
 sns
 sns
@@ -262221,7 +262219,7 @@ eyK
 eyK
 eyK
 cSf
-phE
+cLL
 sns
 sns
 sns
@@ -262673,7 +262671,7 @@ eyK
 eyK
 qFN
 vSs
-eOV
+gJU
 sns
 sns
 sns
@@ -263575,7 +263573,7 @@ vaz
 fTJ
 eyK
 eyK
-qUB
+xpv
 xHV
 smL
 eBq
@@ -264024,11 +264022,11 @@ jsB
 phl
 sns
 smL
-wto
+hKr
 eyK
-qxR
-gJU
-gJU
+qxd
+fqO
+fqO
 oED
 sns
 sns
@@ -264930,9 +264928,9 @@ sns
 smL
 ncq
 eyK
-mys
-kRP
-kRP
+iEJ
+fBn
+fBn
 oED
 sns
 sns
@@ -265383,7 +265381,7 @@ vaz
 fTJ
 eyK
 eyK
-qUB
+xpv
 xHV
 smL
 eBq
@@ -266289,7 +266287,7 @@ eyK
 eyK
 rdV
 vSs
-jpb
+kNF
 sns
 sns
 sns
@@ -266741,7 +266739,7 @@ eyK
 eyK
 eyK
 oGj
-phE
+cLL
 sns
 sns
 sns
@@ -267193,7 +267191,7 @@ gfp
 hyu
 jWX
 eCR
-phE
+cLL
 sns
 sns
 sns
@@ -267645,7 +267643,7 @@ eCR
 eCR
 smL
 vaz
-bpZ
+bLQ
 sns
 sns
 sns
@@ -374305,9 +374303,9 @@ bGf
 bGf
 kSK
 cDX
-bLQ
-wqT
-fHN
+iAy
+eOV
+cIm
 cDX
 kSK
 kSK
@@ -377477,7 +377475,7 @@ rYc
 bGf
 bGf
 lvw
-xpv
+qxR
 ftD
 qkp
 tIz
@@ -379284,7 +379282,7 @@ cnq
 jBr
 lir
 gPs
-tad
+phE
 cuO
 cuO
 cuO
@@ -379736,7 +379734,7 @@ wBe
 wNz
 jld
 gPs
-pcr
+czd
 eyK
 cuO
 eyK
@@ -380188,7 +380186,7 @@ gtl
 tRa
 lir
 gPs
-mLF
+riJ
 eyK
 eyK
 eyK
@@ -381997,7 +381995,7 @@ bGf
 bGf
 bGf
 lvw
-xpv
+qxR
 ftD
 qkp
 woA

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -4860,8 +4860,8 @@
 /area/rogue/indoors/town)
 "bLQ" = (
 /obj/structure/fluff/railing/wood,
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -6864,6 +6864,11 @@
 /obj/structure/fluff/walldeco/bsmith{
 	dir = 1
 	},
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk";
+	pixel_y = 0;
+	pixel_x = 32
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "czf" = (
@@ -7420,9 +7425,11 @@
 /area/rogue/outdoors/beach/forest)
 "cKw" = (
 /obj/effect/decal/cobbleedge{
-	dir = 8
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/dirt/ambush,
+/obj/machinery/light/rogue/lanternpost,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "cKE" = (
 /mob/living/carbon/human/species/dwarfskeleton/ambush,
@@ -7512,17 +7519,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
-"cLP" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
-	},
-/obj/machinery/light/rogue/lanternpost,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "cLQ" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /turf/open/floor/rogue/ruinedwood{
@@ -15583,7 +15579,9 @@
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/obj/machinery/light/rogue/lanternpost,
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "fBq" = (
@@ -29494,8 +29492,15 @@
 	},
 /area/rogue/indoors/town)
 "kzT" = (
-/obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/dirt/road,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
+	},
+/obj/machinery/light/rogue/lanternpost,
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "kAd" = (
 /turf/open/floor/rogue/ruinedwood,
@@ -46203,7 +46208,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/dirt/road,
+/turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "qxV" = (
 /obj/structure/fluff/railing/border{
@@ -46257,10 +46262,14 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/shelter/woods)
 "qzm" = (
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = 32
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble,
+/obj/effect/decal/cobbleedge{
+	dir = 8
+	},
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "qzo" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -51944,6 +51953,11 @@
 "svD" = (
 /obj/structure/fluff/walldeco/bsmith{
 	name = "DWARVEN KEEP"
+	},
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk";
+	pixel_y = 0;
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
@@ -254082,21 +254096,21 @@ qyR
 wyE
 qyR
 lNb
-qyR
 lGv
-qyR
-qyR
-qyR
-wyE
-qyR
+fpx
+fpx
+fpx
+fpx
+fpx
+fpx
 nea
-qyR
+wyE
 qyR
 tFL
 tVv
 ftH
 wNZ
-ftH
+qzm
 dzY
 sns
 sns
@@ -254533,18 +254547,18 @@ qyR
 qyR
 wyE
 fpx
-qHZ
+dQI
+kkc
 fpx
-qyR
-wyE
+gyu
+iJD
+cDX
+gyu
 fpx
 fpx
 fpx
 fpx
 fpx
-lGv
-qyR
-qyR
 oKW
 cne
 kac
@@ -254985,18 +254999,18 @@ pLh
 fpx
 fpx
 nJH
-dQI
-kkc
-kzT
+ins
+gyu
+gyu
+cDX
+ucq
+mwc
+lKo
 gyu
 iJD
-cDX
 gyu
-fpx
-fpx
-fpx
-fpx
-fpx
+cDX
+xpk
 enk
 vmk
 bUt
@@ -255437,18 +255451,18 @@ phl
 phl
 dQI
 sns
-ins
-gyu
-gyu
+sns
 cDX
-ucq
-mwc
+wKN
+mix
+kRg
+kRg
 lKo
-gyu
-iJD
+lZC
+fOM
+cNt
 gyu
 cDX
-xpk
 enk
 vmk
 bUt
@@ -255889,18 +255903,18 @@ jdu
 jYL
 sns
 sns
-sns
-cDX
-wKN
-mix
-kRg
-kRg
 lKo
-lZC
-fOM
-cNt
-gyu
-cDX
+lKo
+puQ
+hoD
+kRg
+kRg
+fsO
+kRg
+kRg
+iBM
+efX
+lKo
 enk
 vmk
 bUt
@@ -256342,17 +256356,17 @@ phl
 btK
 sns
 lKo
+aiE
+hTe
+gTD
+kRg
+lOl
 lKo
-puQ
-hoD
+bSA
 kRg
-kRg
-fsO
-kRg
-kRg
-iBM
-efX
-lKo
+kkB
+bPS
+iJD
 enk
 vmk
 bUt
@@ -256793,17 +256807,17 @@ vwU
 phl
 fpx
 sns
-lKo
-aiE
-hTe
-gTD
+iJD
+xtN
 kRg
-lOl
-lKo
-bSA
+arJ
 kRg
-kkB
-bPS
+nKO
+lKo
+tVf
+kRg
+iBM
+waZ
 iJD
 enk
 bUt
@@ -257245,18 +257259,18 @@ ocX
 wSP
 njB
 sns
-iJD
-xtN
+lKo
+hPz
 kRg
 arJ
 kRg
-nKO
+bKU
 lKo
-tVf
+vPv
 kRg
-iBM
-waZ
-iJD
+kRg
+eHy
+qLc
 enk
 bUt
 eNp
@@ -257698,17 +257712,17 @@ phl
 pWT
 sns
 lKo
-hPz
+xBd
 kRg
-arJ
+vGW
 kRg
-bKU
+qFN
 lKo
-vPv
+ruL
+kXi
 kRg
 kRg
-eHy
-qLc
+lKo
 enk
 bUt
 bUt
@@ -258149,18 +258163,18 @@ phl
 enA
 nJH
 sns
-lKo
-xBd
-kRg
-vGW
-kRg
-qFN
-lKo
-ruL
-kXi
-kRg
-kRg
-lKo
+fHN
+gyu
+iJD
+gyu
+fsO
+cDX
+cDX
+cDX
+hUC
+hUC
+gaP
+cDX
 oKW
 cne
 hYo
@@ -258601,18 +258615,18 @@ phl
 fgh
 bMf
 sns
-fHN
-gyu
-iJD
-gyu
-fsO
+cKw
+njB
+fpx
+pWT
+sns
+sns
+euy
 cDX
-cDX
-cDX
-hUC
-hUC
-gaP
-cDX
+kRP
+sns
+vOG
+lce
 pNm
 bVG
 fPZ
@@ -259059,14 +259073,14 @@ qPs
 njB
 hRO
 sns
-euy
-cDX
-kRP
+kzT
+njB
+sns
 sns
 vOG
-lce
+sns
 pWT
-pWT
+njB
 pWT
 fpx
 exD
@@ -259507,11 +259521,11 @@ wND
 sns
 vWX
 sns
-cKw
-cKw
+dQI
+dQI
 bVy
 sns
-cLP
+qxR
 jlj
 sns
 sns
@@ -260874,7 +260888,7 @@ klm
 hMe
 sns
 sns
-qzm
+sns
 nqN
 sns
 sns
@@ -263137,7 +263151,7 @@ eyK
 smL
 smL
 smL
-xhO
+sns
 sns
 sns
 eKH
@@ -265849,7 +265863,7 @@ eyK
 smL
 smL
 smL
-xhO
+sns
 sns
 sns
 eKH
@@ -268106,7 +268120,7 @@ wWs
 lGf
 aWT
 aWT
-lGf
+aWT
 wWs
 aWT
 aWT
@@ -369794,16 +369808,16 @@ mUl
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -370247,16 +370261,16 @@ bGf
 bGf
 bGf
 kSK
+cDX
+gyu
+gyu
+gyu
+gyu
+cDX
 kSK
 kSK
 kSK
 kSK
-kSK
-kSK
-kSK
-kSK
-kSK
-bGf
 bGf
 bGf
 kSK
@@ -370699,17 +370713,17 @@ phl
 bGf
 bGf
 kSK
-cDX
-gyu
-gyu
-gyu
-gyu
-cDX
+lKo
+nxt
+kRg
+aoW
+daV
+lKo
 kSK
 kSK
 kSK
 kSK
-bGf
+kSK
 bGf
 kSK
 kSK
@@ -371152,11 +371166,11 @@ bGf
 bGf
 kSK
 lKo
-nxt
-kRg
-aoW
-daV
-lKo
+bat
+xWU
+xWU
+fei
+cDX
 kSK
 kSK
 kSK
@@ -371603,12 +371617,12 @@ wSP
 bGf
 bGf
 kSK
+gKh
+kRg
+xWU
+xWU
+qRV
 lKo
-bat
-xWU
-xWU
-fei
-cDX
 kSK
 kSK
 kSK
@@ -372055,12 +372069,12 @@ wSP
 bGf
 bGf
 kSK
-gKh
-kRg
-xWU
-xWU
-qRV
 lKo
+kRg
+mJJ
+xWU
+kRg
+dpx
 kSK
 kSK
 kSK
@@ -372508,11 +372522,11 @@ bGf
 bGf
 kSK
 lKo
+vON
 kRg
-mJJ
-xWU
-kRg
-dpx
+mse
+ygp
+lKo
 kSK
 kSK
 kSK
@@ -372959,12 +372973,12 @@ phl
 bGf
 bGf
 kSK
-lKo
-vON
-kRg
-mse
-ygp
-lKo
+cDX
+gyu
+fsO
+gyu
+cDX
+cDX
 kSK
 kSK
 kSK
@@ -373412,11 +373426,11 @@ bGf
 bGf
 kSK
 cDX
-gyu
-fsO
-gyu
+wIv
+wIv
+wIv
 cDX
-cDX
+kSK
 kSK
 kSK
 kSK
@@ -373864,9 +373878,9 @@ bGf
 bGf
 kSK
 cDX
-wIv
-wIv
-wIv
+tGa
+riJ
+phE
 cDX
 kSK
 kSK
@@ -374314,18 +374328,18 @@ mTw
 wSP
 bGf
 bGf
-kSK
-cDX
-tGa
-riJ
-phE
-cDX
-kSK
-kSK
-kSK
-kSK
-kSK
-kSK
+bGf
+spC
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf
@@ -485507,13 +485521,13 @@ phl
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -488671,13 +488685,13 @@ kSK
 kSK
 bGf
 bGf
+bGf
 kSK
 kSK
 kSK
 kSK
 kSK
-kSK
-kSK
+bGf
 bGf
 bGf
 bGf
@@ -489576,11 +489590,11 @@ kSK
 bGf
 bGf
 bGf
-kSK
-kSK
-kSK
-kSK
-kSK
+bGf
+bGf
+bGf
+bGf
+bGf
 bGf
 bGf
 bGf

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -5018,6 +5018,14 @@
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
+"bPb" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "bPd" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/carpet,
@@ -11052,6 +11060,18 @@
 /obj/machinery/light/rogue/oven/east,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
+"dZP" = (
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/dwarfin)
 "dZV" = (
 /obj/structure/flora/roguetree/wise,
 /turf/open/floor/rogue/dirt,
@@ -15327,18 +15347,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/cave)
-"fvX" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/grown/log/tree/small{
-	pixel_y = 32
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/dwarfin)
 "fwa" = (
 /obj/item/natural/stone{
 	icon_state = "stone3"
@@ -23652,14 +23660,6 @@
 /obj/effect/landmark/start/sergeant,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
-"itS" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
 "iud" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered,
@@ -30739,6 +30739,14 @@
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"kZC" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "kZD" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -32353,7 +32361,7 @@
 /area/rogue/indoors)
 "lCu" = (
 /obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
+/obj/item/grown/log/tree/small{
 	pixel_y = 32
 	},
 /obj/item/natural/bundle/stick{
@@ -32736,12 +32744,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
-"lKE" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/indoors/town/dwarfin)
 "lKH" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/blocks,
@@ -38088,6 +38090,14 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
+"nGB" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "nGU" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/natural/cloth,
@@ -57481,14 +57491,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
-"usT" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
-/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
-/obj/item/reagent_containers/food/snacks/egg,
-/obj/item/reagent_containers/food/snacks/egg,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "usU" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -59398,6 +59400,12 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/orc,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
+"vcY" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/dwarfin)
 "vdf" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/transparent/openspace,
@@ -64467,14 +64475,6 @@
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
-"wRC" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "wRG" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/beach/forest)
@@ -371669,7 +371669,7 @@ bGf
 bGf
 kSK
 gKh
-itS
+bPb
 xWU
 xWU
 qRV
@@ -378005,7 +378005,7 @@ cDX
 uAr
 bGf
 lvw
-fvX
+lCu
 ftD
 qkp
 qnP
@@ -378460,7 +378460,7 @@ lvw
 fLv
 ftD
 xAu
-usT
+nGB
 kdM
 kSK
 bGf
@@ -379361,7 +379361,7 @@ jBr
 lir
 gPs
 qzP
-lKE
+vcY
 cuO
 cuO
 uLi
@@ -379813,7 +379813,7 @@ wNz
 jld
 gPs
 pcr
-wRC
+kZC
 cuO
 eyK
 eyK
@@ -381172,7 +381172,7 @@ lvw
 ven
 ftD
 eaE
-usT
+nGB
 kwO
 kSK
 bGf
@@ -381621,7 +381621,7 @@ rgo
 bGf
 bGf
 lvw
-lCu
+dZP
 ftD
 qkp
 tIz
@@ -493264,7 +493264,7 @@ auI
 wBe
 cDX
 uAr
-kSK
+bGf
 vaz
 lvw
 sJu
@@ -493716,7 +493716,7 @@ afK
 oMF
 cIz
 vvb
-kSK
+bGf
 lvw
 fPu
 sJu
@@ -494168,7 +494168,7 @@ afK
 qUu
 aoS
 cDX
-kSK
+bGf
 vaz
 lvw
 beI
@@ -494620,7 +494620,7 @@ cDX
 afK
 mjH
 afK
-kSK
+bGf
 kSK
 kSK
 kSK
@@ -495072,7 +495072,7 @@ sge
 wBe
 wBe
 afK
-kSK
+bGf
 kSK
 kSK
 kSK
@@ -495524,7 +495524,7 @@ afK
 qUu
 cMj
 vvb
-kSK
+bGf
 kSK
 kSK
 kSK
@@ -495976,7 +495976,7 @@ afK
 rYX
 nuY
 afK
-kSK
+bGf
 vaz
 lvw
 lfV
@@ -496428,7 +496428,7 @@ cDX
 afK
 afK
 cDX
-kSK
+bGf
 lvw
 vNu
 sJu

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -3647,11 +3647,9 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "bpZ" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/closed,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bqi" = (
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -4860,12 +4858,8 @@
 	},
 /area/rogue/indoors/town)
 "bLQ" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bLV" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/under/cave/licharena)
@@ -5014,6 +5008,13 @@
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
+"bPa" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "bPd" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/carpet,
@@ -6865,12 +6866,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "czd" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "czf" = (
 /obj/structure/bars/pipe{
 	pixel_x = -11
@@ -12692,6 +12694,12 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
+"eCk" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "eCo" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/pelt,
@@ -13340,11 +13348,14 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eOV" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/item/clothing/cloak/apron/waist/brown,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "eOW" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/blocks,
@@ -15569,7 +15580,7 @@
 /area/rogue/under/cave/mazedungeon)
 "fBn" = (
 /obj/structure/fluff/railing/border{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
@@ -17742,6 +17753,12 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"grG" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "grO" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cave/fishmandungeon)
@@ -18176,6 +18193,16 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"gAc" = (
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/dwarfin)
 "gAe" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -18654,11 +18681,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "gJU" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/turf/closed,
+/area/rogue/indoors/town)
 "gJY" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/carpet,
@@ -23953,9 +23980,14 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "iAy" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "iAD" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/carpet/red,
@@ -24198,15 +24230,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town)
 "iEJ" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
+/obj/structure/fluff/littlebanners/bluewhite{
+	pixel_y = -6
 	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iEM" = (
 /obj/structure/lever{
 	redstone_id = "merchroofshutt"
@@ -26187,12 +26215,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "jpb" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "jpg" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -30152,11 +30178,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "kNF" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "kNG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt,
@@ -30340,18 +30370,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement/keep)
 "kRP" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/item/roguebin/water/gross,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "kRS" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -30881,7 +30902,7 @@
 	pixel_x = -32
 	},
 /obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "lcg" = (
 /obj/structure/closet/crate/drawer,
@@ -33952,12 +33973,6 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/undeadmanor)
-"miR" = (
-/obj/structure/fluff/walldeco/bsmith{
-	name = "DWARVEN KEEP"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "miW" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -35340,13 +35355,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "mLF" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/rack/rogue,
+/obj/item/natural/bundle/curred_hide,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "mLH" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -36505,11 +36517,6 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
-"ngc" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "nge" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -39194,15 +39201,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "oeq" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "oex" = (
 /obj/effect/spawner/lootdrop/roguetown,
 /obj/structure/closet/crate/chest,
@@ -41999,11 +42002,9 @@
 /turf/open/water/pond,
 /area/rogue/outdoors/woods)
 "pcr" = (
-/obj/structure/fluff/walldeco/bsmith{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/dwarfin)
 "pct" = (
 /obj/random/spider,
 /turf/open/floor/rogue/dirt,
@@ -42364,11 +42365,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "phE" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "phH" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -44126,9 +44127,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pMM" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/wood,
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "pMW" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -45037,12 +45041,6 @@
 	dir = 4
 	},
 /area/rogue/outdoors/beach/forest)
-"qdB" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town)
 "qdC" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/cobble,
@@ -46197,13 +46195,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "qxR" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "qxV" = (
 /obj/structure/fluff/railing/border{
@@ -47195,10 +47191,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs/keep)
-"qNY" = (
-/obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
 "qOa" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -47479,6 +47471,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"qUk" = (
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "qUm" = (
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/pelt,
@@ -48184,10 +48183,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "riJ" = (
-/obj/structure/rack/rogue,
-/obj/item/natural/bundle/curred_hide,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "riX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -51691,11 +51691,10 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
 "srE" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "srI" = (
 /obj/machinery/light/roguestreet,
@@ -53470,14 +53469,18 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/exposed/bath/vault)
 "tad" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/clothing/cloak/apron/waist/brown,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/chest/neu,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "tae" = (
 /obj/structure/gate/bars/preopen{
 	gid = "outernorthgate";
@@ -55155,13 +55158,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "tGa" = (
-/obj/structure/fluff/railing/border{
+/obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/brick,
+/turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
 "tGk" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -62164,6 +62164,12 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"wbP" = (
+/obj/structure/fluff/walldeco/bsmith{
+	name = "DWARVEN KEEP"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "wbS" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/ruinedwood{
@@ -63057,11 +63063,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wqT" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/fluff/walldeco/bsmith{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "wqV" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
@@ -65004,10 +65010,13 @@
 	},
 /area/rogue/under/town/basement/keep)
 "xew" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/dwarfin)
 "xeB" = (
 /obj/structure/flora/roguetree/burnt,
@@ -65632,11 +65641,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "xpv" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/dwarfin)
 "xpH" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town/roofs/keep)
@@ -146512,7 +146521,7 @@ iMR
 qOS
 cHC
 nvB
-qNY
+kRP
 dlK
 urZ
 mMx
@@ -148313,7 +148322,7 @@ rPR
 rPR
 rPR
 vaz
-xew
+riJ
 fHN
 kXy
 kXy
@@ -149213,7 +149222,7 @@ rBY
 rBY
 rBY
 kXy
-iEJ
+gAc
 ncG
 rPR
 rPR
@@ -150117,12 +150126,12 @@ lrS
 rBY
 rBY
 kXy
-pMM
+pcr
 ncG
-ngc
+jpb
 vaz
-xew
-kNF
+riJ
+oeq
 kXy
 kXy
 hAg
@@ -151926,7 +151935,7 @@ rPR
 rPR
 rPR
 rPR
-kNF
+oeq
 kSG
 kXy
 xAN
@@ -152373,11 +152382,11 @@ kXy
 eYJ
 eYJ
 kXy
-srE
+qUk
 epB
 eSw
 isH
-mLF
+czd
 kXy
 kXy
 kXy
@@ -258137,11 +258146,11 @@ enA
 nJH
 sns
 lKo
-riJ
+mLF
 kRg
-bpZ
+gJU
 kRg
-tad
+eOV
 lKo
 ruL
 kXi
@@ -258588,7 +258597,7 @@ phl
 fgh
 bMf
 sns
-qdB
+tGa
 gyu
 iJD
 gyu
@@ -259048,9 +259057,9 @@ hRO
 sns
 euy
 cDX
-xpv
-sns
-vOG
+phE
+bLQ
+iEJ
 lce
 pWT
 pWT
@@ -261315,7 +261324,7 @@ ykd
 xdU
 smL
 vaz
-jpb
+pMM
 sns
 sns
 sns
@@ -261767,7 +261776,7 @@ gfp
 hyu
 jWX
 xdU
-iAy
+bpZ
 sns
 sns
 sns
@@ -262219,7 +262228,7 @@ eyK
 eyK
 eyK
 cSf
-iAy
+bpZ
 sns
 sns
 sns
@@ -262671,7 +262680,7 @@ eyK
 eyK
 qFN
 vSs
-pcr
+wqT
 sns
 sns
 sns
@@ -264022,9 +264031,9 @@ jsB
 phl
 sns
 smL
-kRP
+tad
 eyK
-wqT
+eCk
 lCu
 lCu
 oED
@@ -264928,9 +264937,9 @@ sns
 smL
 ncq
 eyK
-phE
 fBn
-fBn
+srE
+srE
 oED
 sns
 sns
@@ -266287,7 +266296,7 @@ eyK
 eyK
 rdV
 vSs
-miR
+wbP
 sns
 sns
 sns
@@ -266739,7 +266748,7 @@ eyK
 eyK
 eyK
 oGj
-iAy
+bpZ
 sns
 sns
 sns
@@ -267191,7 +267200,7 @@ gfp
 hyu
 jWX
 eCR
-iAy
+bpZ
 sns
 sns
 sns
@@ -267643,7 +267652,7 @@ eCR
 eCR
 smL
 vaz
-jpb
+pMM
 sns
 sns
 sns
@@ -374303,9 +374312,9 @@ bGf
 bGf
 kSK
 cDX
-czd
-oeq
-tGa
+bPa
+kNF
+iAy
 cDX
 kSK
 kSK
@@ -377475,7 +377484,7 @@ rYc
 bGf
 bGf
 lvw
-qxR
+xew
 ftD
 qkp
 tIz
@@ -379282,7 +379291,7 @@ cnq
 jBr
 lir
 gPs
-eOV
+grG
 cuO
 cuO
 cuO
@@ -379734,7 +379743,7 @@ wBe
 wNz
 jld
 gPs
-bLQ
+qxR
 eyK
 cuO
 eyK
@@ -380186,7 +380195,7 @@ gtl
 tRa
 lir
 gPs
-gJU
+xpv
 eyK
 eyK
 eyK
@@ -381995,7 +382004,7 @@ bGf
 bGf
 bGf
 lvw
-qxR
+xew
 ftD
 qkp
 woA

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -4571,6 +4571,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "bHv" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special,
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
@@ -54478,9 +54481,17 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
 "tqO" = (
-/obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/cape/guard,
+/obj/item/clothing/cloak/cape/guard,
+/obj/item/clothing/cloak/stabard/surcoat/guard,
+/obj/item/clothing/cloak/stabard/surcoat/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "tqT" = (
@@ -55661,20 +55672,6 @@
 "tMv" = (
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/garrison)
-"tMK" = (
-/obj/structure/closet/crate/roguecloset,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/stabard/guardhood,
-/obj/item/clothing/cloak/cape/guard,
-/obj/item/clothing/cloak/cape/guard,
-/obj/item/clothing/cloak/stabard/surcoat/guard,
-/obj/item/clothing/cloak/stabard/surcoat/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/stabard/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/obj/item/clothing/cloak/tabard/knight/guard,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/basement/keep)
 "tMN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -158349,7 +158346,7 @@ cxZ
 vtx
 vtx
 iad
-fFz
+tqO
 hof
 siF
 iad
@@ -158801,7 +158798,7 @@ bYC
 bYC
 bYC
 iad
-tqO
+fFz
 bHV
 xfz
 iad
@@ -161063,7 +161060,7 @@ iad
 iad
 bHV
 bHV
-tMK
+bHV
 iad
 bYC
 vrC

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -55661,6 +55661,20 @@
 "tMv" = (
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/garrison)
+"tMK" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/cape/guard,
+/obj/item/clothing/cloak/cape/guard,
+/obj/item/clothing/cloak/stabard/surcoat/guard,
+/obj/item/clothing/cloak/stabard/surcoat/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/obj/item/clothing/cloak/tabard/knight/guard,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "tMN" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -161049,7 +161063,7 @@ iad
 iad
 bHV
 bHV
-bHV
+tMK
 iad
 bYC
 vrC

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -3647,12 +3647,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "bpZ" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/wood,
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "bqi" = (
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -4553,10 +4553,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "bHf" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/stick,
-/obj/item/grown/log/tree/stick,
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
@@ -4824,8 +4823,6 @@
 	dir = 1;
 	icon_state = "largetable"
 	},
-/obj/item/clothing/cloak/apron/waist/brown,
-/obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "bKV" = (
@@ -4864,16 +4861,12 @@
 	},
 /area/rogue/indoors/town)
 "bLQ" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "bLV" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/under/cave/licharena)
@@ -6873,11 +6866,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "czd" = (
-/obj/structure/fluff/walldeco/bsmith{
+/obj/structure/stairs{
 	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "czf" = (
 /obj/structure/bars/pipe{
 	pixel_x = -11
@@ -7519,17 +7512,20 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "cLL" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "cLP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
 	icon_state = "cobbleedge-n"
+	},
+/obj/machinery/light/rogue/lanternpost,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_x = -32
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
@@ -12207,16 +12203,12 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
 "euy" = (
-/obj/machinery/light/rogue/lanternpost,
 /obj/effect/decal/cobbleedge{
 	dir = 10;
 	icon_state = "cobbleedge-n"
 	},
-/obj/structure/fluff/walldeco/customflag{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town)
 "euK" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -12377,6 +12369,15 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"ewR" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/clothing/cloak/apron/waist/brown,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "ewY" = (
 /obj/structure/bed/rogue/shit,
 /obj/structure/spider/stickyweb,
@@ -13346,11 +13347,11 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eOV" = (
-/obj/structure/stairs{
-	dir = 8
+/obj/structure/fluff/walldeco/bsmith{
+	dir = 1
 	},
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "eOW" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/blocks,
@@ -13555,11 +13556,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/physician)
 "eSw" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable"
-	},
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "eSA" = (
@@ -15574,12 +15575,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
 "fBn" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "fBq" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/potion_vitals,
@@ -15900,15 +15898,14 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fHN" = (
-/obj/structure/stairs{
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
 	},
-/turf/open/transparent/openspace,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "fHY" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/ruinedwood{
@@ -18667,8 +18664,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "gJU" = (
-/obj/structure/closet/crate/chest/old_crate,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "gJY" = (
 /obj/structure/bookcase/random/archive,
@@ -23579,14 +23578,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "isH" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/bucket/wooden{
-	pixel_x = 2;
-	pixel_y = 8
-	},
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "isS" = (
@@ -23966,8 +23963,14 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "iAy" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/turf/open/floor/rogue/blocks,
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "iAD" = (
 /mob/living/carbon/human/species/skeleton/npc,
@@ -24211,16 +24214,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town)
 "iEJ" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/turf/open/floor/rogue/blocks,
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "iEM" = (
 /obj/structure/lever{
@@ -26202,14 +26197,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "jpb" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/fluff/walldeco/bsmith{
+	name = "DWARVEN KEEP"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jpg" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -29369,7 +29361,6 @@
 	dir = 6;
 	icon_state = "largetable"
 	},
-/obj/item/grown/log/tree/small,
 /obj/item/flint,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
@@ -30170,11 +30161,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "kNF" = (
-/obj/structure/stairs{
-	dir = 4
-	},
-/turf/open/floor/rogue/blocks/green,
-/area/rogue/indoors/town/dwarfin)
+/obj/item/roguebin/water/gross,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "kNG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt,
@@ -30358,11 +30347,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement/keep)
 "kRP" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/area/rogue/indoors/town/dwarfin)
 "kRS" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -30891,6 +30880,9 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
 	},
+/obj/structure/fluff/railing/wood{
+	dir = 1
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "lcg" = (
@@ -31035,8 +31027,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "lfq" = (
-/obj/structure/rack/rogue,
 /obj/machinery/light/rogue/torchholder/c,
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "lfr" = (
@@ -32322,10 +32315,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
 "lCu" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/stick,
-/obj/item/grown/log/tree/stick,
+/obj/structure/rack/rogue/shelf,
+/obj/item/grown/log/tree/small{
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -34677,6 +34670,12 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/garrison)
+"mys" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "myt" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/carpet/royalblack,
@@ -35346,13 +35345,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "mLF" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
+/obj/structure/chair/wood/rogue/chair3{
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
@@ -39199,11 +39192,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "oeq" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Blacksmith"
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/turf/closed,
+/area/rogue/indoors/town)
 "oex" = (
 /obj/effect/spawner/lootdrop/roguetown,
 /obj/structure/closet/crate/chest,
@@ -42000,10 +41993,11 @@
 /turf/open/water/pond,
 /area/rogue/outdoors/woods)
 "pcr" = (
-/obj/machinery/anvil{
-	pixel_y = -5
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/blocks,
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "pct" = (
 /obj/random/spider,
@@ -42365,15 +42359,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "phE" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "phH" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -44131,9 +44119,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pMM" = (
-/obj/structure/fluff/walldeco/bsmith,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue,
+/obj/item/natural/bundle/curred_hide,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "pMW" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -46196,11 +46185,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "qxR" = (
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/structure/closet/crate/chest/old_crate,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "qxV" = (
 /obj/structure/fluff/railing/border{
@@ -47498,14 +47486,10 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town)
 "qUB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/railing/border{
+/obj/structure/stairs{
 	dir = 1
 	},
-/obj/structure/fluff/railing/border,
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "qUL" = (
 /obj/effect/decal/cobble/mossy{
@@ -48181,7 +48165,11 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "riJ" = (
-/obj/structure/roguemachine/scomm/l,
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "riX" = (
@@ -51687,9 +51675,11 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
 "srE" = (
-/obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/sewer)
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "srI" = (
 /obj/machinery/light/roguestreet,
 /turf/open/floor/rogue/dirt,
@@ -51959,6 +51949,12 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town)
+"swo" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
 "swB" = (
 /obj/structure/mineral_door/bars{
@@ -53463,9 +53459,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/exposed/bath/vault)
 "tad" = (
-/obj/machinery/light/rogue/torchholder/r,
-/obj/structure/fermenting_barrel/water,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "tae" = (
 /obj/structure/gate/bars/preopen{
@@ -55144,11 +55141,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "tGa" = (
-/obj/structure/fluff/littlebanners/bluewhite{
-	pixel_y = -6
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
 	},
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "tGk" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/rtfield)
@@ -63043,8 +63040,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wqT" = (
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "wqV" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
@@ -63207,6 +63211,19 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"wto" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "wtC" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -63943,14 +63960,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church/basement)
 "wIv" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
 /turf/open/floor/rogue/tile/brick,
-/area/rogue/outdoors/town/roofs)
+/area/rogue/indoors/town)
 "wIw" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobblerock,
@@ -64993,12 +65004,9 @@
 	},
 /area/rogue/under/town/basement/keep)
 "xew" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "xeB" = (
 /obj/structure/flora/roguetree/burnt,
@@ -65623,14 +65631,13 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "xpv" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
 	},
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 1
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
 	},
-/turf/open/transparent/openspace,
 /area/rogue/indoors/town/dwarfin)
 "xpH" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -66563,7 +66570,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
 "xHV" = (
-/turf/closed/wall/mineral/rogue/stone/moss,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/dwarfin)
 "xHW" = (
 /obj/structure/rack/rogue,
@@ -146507,7 +146514,7 @@ iMR
 qOS
 cHC
 nvB
-daP
+kNF
 dlK
 urZ
 mMx
@@ -146949,7 +146956,7 @@ kXy
 oHQ
 rPR
 rPR
-gJU
+mdN
 kXy
 ogs
 ogs
@@ -147406,8 +147413,8 @@ kXy
 kXy
 kXy
 ogs
-xAN
-srE
+pby
+jEk
 rkG
 cHC
 cHC
@@ -147851,15 +147858,15 @@ gKR
 gKR
 pcE
 ncG
-cGR
+fBn
 rPR
 iPN
 kxW
-vaz
+kXy
+kXy
 kXy
 kXy
 pby
-opX
 jEk
 hja
 cHC
@@ -148307,9 +148314,9 @@ rPR
 rPR
 rPR
 rPR
-eOV
 kXy
-kXy
+czd
+fBn
 kXy
 kXy
 xAN
@@ -148760,8 +148767,8 @@ lFM
 rPR
 rPR
 rPR
-riJ
-fen
+rPR
+rPR
 fen
 kXy
 dlK
@@ -149208,9 +149215,9 @@ rBY
 rBY
 rBY
 kXy
+iAy
 ncG
-ncG
-ncG
+rPR
 rPR
 rPR
 rPR
@@ -149662,11 +149669,11 @@ rBY
 ujo
 ncG
 ncG
-ncG
 rPR
-bpZ
-bLQ
-qxR
+rPR
+rPR
+rPR
+fen
 kXy
 dlK
 urZ
@@ -150112,12 +150119,12 @@ lrS
 rBY
 rBY
 kXy
+iEJ
 ncG
-ncG
-ncG
-kNF
+xew
 kXy
-kXy
+czd
+srE
 kXy
 kXy
 hAg
@@ -150566,12 +150573,12 @@ kXy
 kXy
 ncG
 rPR
-rPR
-vaz
+epB
 kXy
 kXy
 kXy
 kXy
+ogs
 xAN
 bkt
 mJd
@@ -151022,8 +151029,8 @@ kSG
 kXy
 kXy
 dlK
-kXy
-kXy
+ogs
+ogs
 xAN
 mJd
 ndO
@@ -151467,7 +151474,7 @@ mji
 ncG
 ncG
 ncG
-ncG
+rPR
 rPR
 rPR
 kSG
@@ -151921,8 +151928,8 @@ rPR
 rPR
 rPR
 rPR
-rPR
-tad
+srE
+kSG
 kXy
 xAN
 ldT
@@ -152368,11 +152375,11 @@ kXy
 eYJ
 eYJ
 kXy
-kXy
+cLL
 epB
 eSw
 isH
-mdN
+riJ
 kXy
 kXy
 kXy
@@ -258131,15 +258138,15 @@ phl
 enA
 nJH
 sns
-cDX
-gyu
-iJD
-gyu
-fsO
-cDX
+lKo
+pMM
+kRg
+oeq
+kRg
+ewR
 lKo
 ruL
-kRg
+kXi
 kRg
 kRg
 lKo
@@ -258582,13 +258589,13 @@ wSP
 phl
 fgh
 bMf
-btK
-btK
-btK
-iMX
-fpx
 sns
-sns
+swo
+gyu
+iJD
+gyu
+fsO
+cDX
 cDX
 cDX
 hUC
@@ -259034,7 +259041,7 @@ sns
 oXY
 dQI
 qok
-pWT
+sns
 fpx
 fpx
 qPs
@@ -259042,8 +259049,8 @@ njB
 hRO
 sns
 euy
-pWT
-sns
+cDX
+tGa
 sns
 vOG
 lce
@@ -259486,7 +259493,7 @@ sns
 qme
 sns
 wND
-bVy
+sns
 bVy
 sns
 cKw
@@ -260856,9 +260863,9 @@ klm
 hMe
 sns
 sns
-iaB
 qzm
 nqN
+sns
 sns
 sns
 sns
@@ -261309,9 +261316,9 @@ smL
 ykd
 xdU
 smL
-smL
 vaz
-iBJ
+bpZ
+sns
 sns
 sns
 sns
@@ -261758,11 +261765,11 @@ bhX
 sns
 smL
 lfq
-fTJ
 gfp
 hyu
 jWX
 xdU
+phE
 sns
 sns
 sns
@@ -262213,8 +262220,8 @@ kaR
 eyK
 eyK
 eyK
-eyK
 cSf
+phE
 sns
 sns
 sns
@@ -262664,9 +262671,9 @@ xdU
 fyu
 eyK
 eyK
-eyK
 qFN
 vSs
+eOV
 sns
 sns
 sns
@@ -263116,10 +263123,10 @@ smL
 uDM
 eyK
 eyK
-phE
-xHV
-xHV
-oeq
+smL
+smL
+smL
+iBJ
 sns
 sns
 eKH
@@ -263565,13 +263572,13 @@ myJ
 qou
 sns
 vaz
-iEJ
+fTJ
 eyK
 eyK
 qUB
 xHV
-pMM
-sns
+smL
+eBq
 sns
 sns
 eKH
@@ -264017,12 +264024,12 @@ jsB
 phl
 sns
 smL
-ncq
-wqT
+wto
 eyK
-eyK
+qxR
+gJU
+gJU
 oED
-sns
 sns
 sns
 sns
@@ -264470,12 +264477,12 @@ phl
 sns
 smL
 mfS
-wqT
-wqT
-wqT
+eyK
+eyK
+eyK
+eyK
 smL
-kRP
-sns
+xhO
 sns
 sns
 eKH
@@ -264922,11 +264929,11 @@ ezH
 sns
 smL
 ncq
-wqT
 eyK
-eyK
+mys
+kRP
+kRP
 oED
-sns
 sns
 sns
 sns
@@ -265373,13 +265380,13 @@ tbm
 jOX
 sns
 vaz
-iAy
+fTJ
 eyK
 eyK
-xpv
+qUB
+xHV
 smL
-czd
-sns
+eBq
 sns
 sns
 eKH
@@ -265828,10 +265835,10 @@ smL
 uDM
 eyK
 eyK
-fHN
 smL
 smL
-eBq
+smL
+iBJ
 sns
 sns
 eKH
@@ -266280,9 +266287,9 @@ eCR
 fyu
 eyK
 eyK
-eyK
 rdV
 vSs
+jpb
 sns
 sns
 sns
@@ -266733,8 +266740,8 @@ kaR
 eyK
 eyK
 eyK
-eyK
 oGj
+phE
 sns
 sns
 sns
@@ -267182,11 +267189,11 @@ exD
 ehB
 smL
 lfq
-fTJ
 gfp
-pcr
+hyu
 jWX
 eCR
+phE
 sns
 sns
 sns
@@ -267637,9 +267644,9 @@ smL
 eCR
 eCR
 smL
-smL
 vaz
-eBq
+bpZ
+sns
 sns
 sns
 eKH
@@ -268088,8 +268095,8 @@ wWs
 lGf
 aWT
 aWT
-fBn
-aWT
+lGf
+wWs
 aWT
 aWT
 sns
@@ -373845,11 +373852,11 @@ wSP
 bGf
 bGf
 kSK
-tGa
+cDX
 wIv
-tVe
-tVe
-wxQ
+wIv
+wIv
+cDX
 kSK
 kSK
 kSK
@@ -374296,18 +374303,18 @@ mTw
 wSP
 bGf
 bGf
-bGf
-spC
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+kSK
+cDX
+bLQ
+wqT
+fHN
+cDX
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -377019,7 +377026,7 @@ bGf
 bGf
 lvw
 kzB
-xew
+nhE
 kMZ
 vaz
 kwO
@@ -377470,7 +377477,7 @@ rYc
 bGf
 bGf
 lvw
-ftD
+xpv
 ftD
 qkp
 tIz
@@ -379277,7 +379284,7 @@ cnq
 jBr
 lir
 gPs
-eyK
+tad
 cuO
 cuO
 cuO
@@ -379729,13 +379736,13 @@ wBe
 wNz
 jld
 gPs
-eyK
+pcr
 eyK
 cuO
 eyK
 eyK
-mLF
-jpb
+jJV
+oEG
 bGf
 bGf
 bGf
@@ -380181,7 +380188,7 @@ gtl
 tRa
 lir
 gPs
-eyK
+mLF
 eyK
 eyK
 eyK
@@ -381538,7 +381545,7 @@ rgo
 bGf
 bGf
 lvw
-cLL
+lCu
 ftD
 qkp
 tIz
@@ -381990,7 +381997,7 @@ bGf
 bGf
 bGf
 lvw
-nhE
+xpv
 ftD
 qkp
 woA
@@ -382442,8 +382449,8 @@ bGf
 bGf
 bGf
 lvw
-qgD
-ftD
+kzB
+nhE
 bHf
 vaz
 kdM
@@ -489558,11 +489565,11 @@ kSK
 bGf
 bGf
 bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -494091,7 +494098,7 @@ lvw
 beI
 lvw
 kdM
-bGf
+kSK
 bGf
 bGf
 bGf
@@ -494543,7 +494550,7 @@ kSK
 kSK
 kSK
 kSK
-bGf
+kSK
 bGf
 bGf
 bGf
@@ -494990,12 +494997,12 @@ wBe
 wBe
 afK
 kSK
-bGf
-bGf
-bGf
-bGf
-bGf
-bGf
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -495447,7 +495454,7 @@ kSK
 kSK
 kSK
 kSK
-bGf
+kSK
 bGf
 bGf
 bGf
@@ -495899,7 +495906,7 @@ lvw
 lfV
 lvw
 kwO
-bGf
+kSK
 bGf
 bGf
 kSK

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -4859,11 +4859,10 @@
 	},
 /area/rogue/indoors/town)
 "bLQ" = (
-/obj/structure/fluff/railing/wood,
 /obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+	pixel_x = 32
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "bLV" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
@@ -260888,7 +260887,7 @@ klm
 hMe
 sns
 sns
-sns
+bLQ
 nqN
 sns
 sns
@@ -261342,7 +261341,7 @@ ykd
 xdU
 smL
 vaz
-bLQ
+oeq
 sns
 sns
 sns
@@ -267670,7 +267669,7 @@ eCR
 eCR
 smL
 vaz
-bLQ
+oeq
 sns
 sns
 sns
@@ -268120,7 +268119,7 @@ wWs
 lGf
 aWT
 aWT
-aWT
+lGf
 wWs
 aWT
 aWT

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -3647,9 +3647,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "bpZ" = (
-/obj/structure/rack/rogue,
-/obj/item/natural/bundle/curred_hide,
-/turf/open/floor/rogue/ruinedwood/herringbone,
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/closed,
 /area/rogue/indoors/town)
 "bqi" = (
 /obj/structure/chair/bench/ultimacouch,
@@ -4859,12 +4860,12 @@
 	},
 /area/rogue/indoors/town)
 "bLQ" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "bLV" = (
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/under/cave/licharena)
@@ -6864,12 +6865,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "czd" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "czf" = (
 /obj/structure/bars/pipe{
 	pixel_x = -11
@@ -7366,15 +7367,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"cIm" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
 "cIt" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/cobble,
@@ -7520,9 +7512,14 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "cLL" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/rack/rogue/shelf,
+/obj/item/grown/log/tree/small{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/dwarfin)
 "cLP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -13343,15 +13340,11 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eOV" = (
-/obj/structure/fluff/railing/border{
+/obj/structure/chair/wood/rogue/chair3{
 	dir = 4
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "eOW" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/blocks,
@@ -15012,12 +15005,6 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
-"fqO" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "fqS" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -15906,8 +15893,8 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fHN" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/blocks/stonered,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "fHY" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
@@ -18667,11 +18654,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "gJU" = (
-/obj/structure/fluff/walldeco/bsmith{
-	dir = 1
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "gJY" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/carpet,
@@ -21626,19 +21613,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
-"hKr" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
 "hKs" = (
 /obj/structure/mineral_door/swing_door,
 /turf/open/floor/rogue/cobblerock,
@@ -23979,12 +23953,9 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "iAy" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "iAD" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/carpet/red,
@@ -24227,10 +24198,14 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town)
 "iEJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/cobble,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "iEM" = (
 /obj/structure/lever{
@@ -26212,12 +26187,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "jpb" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/wood,
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "jpg" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -30177,11 +30152,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "kNF" = (
-/obj/structure/fluff/walldeco/bsmith{
-	name = "DWARVEN KEEP"
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "kNG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt,
@@ -30365,8 +30340,17 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement/keep)
 "kRP" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/closet/crate/chest/neu,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "kRS" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -32329,13 +32313,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
 "lCu" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/grown/log/tree/small{
-	pixel_y = 32
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "lCz" = (
 /obj/effect/decal/mossy{
@@ -33971,6 +33952,12 @@
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/undeadmanor)
+"miR" = (
+/obj/structure/fluff/walldeco/bsmith{
+	name = "DWARVEN KEEP"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "miW" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -35353,14 +35340,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "mLF" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
-	},
-/obj/item/clothing/cloak/apron/waist/brown,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "mLH" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -36519,6 +36505,11 @@
 	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town)
+"ngc" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "nge" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -39203,11 +39194,15 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "oeq" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "oex" = (
 /obj/effect/spawner/lootdrop/roguetown,
 /obj/structure/closet/crate/chest,
@@ -42004,13 +41999,11 @@
 /turf/open/water/pond,
 /area/rogue/outdoors/woods)
 "pcr" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/walldeco/bsmith{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "pct" = (
 /obj/random/spider,
 /turf/open/floor/rogue/dirt,
@@ -42371,8 +42364,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "phE" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
@@ -44133,11 +44126,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pMM" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town)
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/dwarfin)
 "pMW" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -45046,6 +45037,12 @@
 	dir = 4
 	},
 /area/rogue/outdoors/beach/forest)
+"qdB" = (
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town)
 "qdC" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/floor/rogue/cobble,
@@ -46152,12 +46149,6 @@
 	dir = 1
 	},
 /area/rogue/under/cave/goblindungeon)
-"qxd" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "qxe" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble,
@@ -47204,6 +47195,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/roofs/keep)
+"qNY" = (
+/obj/item/roguebin/water/gross,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "qOa" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -47513,8 +47508,8 @@
 /obj/structure/stairs{
 	dir = 1
 	},
-/turf/closed,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "qUL" = (
 /obj/effect/decal/cobble/mossy{
 	dir = 8
@@ -48189,11 +48184,10 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "riJ" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/rack/rogue,
+/obj/item/natural/bundle/curred_hide,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "riX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -51697,8 +51691,10 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
 "srE" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
 /obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "srI" = (
@@ -53474,9 +53470,14 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/exposed/bath/vault)
 "tad" = (
-/obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "largetable"
+	},
+/obj/item/clothing/cloak/apron/waist/brown,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "tae" = (
 /obj/structure/gate/bars/preopen{
 	gid = "outernorthgate";
@@ -55154,11 +55155,14 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "tGa" = (
-/obj/structure/stairs{
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/wood/rogue/chair3{
 	dir = 1
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "tGk" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/outdoors/rtfield)
@@ -63053,11 +63057,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wqT" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "wqV" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
@@ -65000,14 +65004,10 @@
 	},
 /area/rogue/under/town/basement/keep)
 "xew" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
+/obj/structure/stairs{
+	dir = 1
 	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks/stonered,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "xeB" = (
 /obj/structure/flora/roguetree/burnt,
@@ -65632,11 +65632,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
 "xpv" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/area/rogue/outdoors/town)
 "xpH" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town/roofs/keep)
@@ -146512,7 +146512,7 @@ iMR
 qOS
 cHC
 nvB
-tad
+qNY
 dlK
 urZ
 mMx
@@ -147856,7 +147856,7 @@ gKR
 gKR
 pcE
 ncG
-kRP
+fHN
 rPR
 iPN
 kxW
@@ -148312,9 +148312,9 @@ rPR
 rPR
 rPR
 rPR
-kXy
-tGa
-kRP
+vaz
+xew
+fHN
 kXy
 kXy
 xAN
@@ -149213,7 +149213,7 @@ rBY
 rBY
 rBY
 kXy
-xew
+iEJ
 ncG
 rPR
 rPR
@@ -150117,12 +150117,12 @@ lrS
 rBY
 rBY
 kXy
-fHN
+pMM
 ncG
-srE
-kXy
-tGa
-oeq
+ngc
+vaz
+xew
+kNF
 kXy
 kXy
 hAg
@@ -151926,7 +151926,7 @@ rPR
 rPR
 rPR
 rPR
-oeq
+kNF
 kSG
 kXy
 xAN
@@ -152373,11 +152373,11 @@ kXy
 eYJ
 eYJ
 kXy
-jpb
+srE
 epB
 eSw
 isH
-pcr
+mLF
 kXy
 kXy
 kXy
@@ -258137,11 +258137,11 @@ enA
 nJH
 sns
 lKo
+riJ
+kRg
 bpZ
 kRg
-qUB
-kRg
-mLF
+tad
 lKo
 ruL
 kXi
@@ -258588,7 +258588,7 @@ phl
 fgh
 bMf
 sns
-wqT
+qdB
 gyu
 iJD
 gyu
@@ -259048,7 +259048,7 @@ hRO
 sns
 euy
 cDX
-pMM
+xpv
 sns
 vOG
 lce
@@ -261315,7 +261315,7 @@ ykd
 xdU
 smL
 vaz
-bLQ
+jpb
 sns
 sns
 sns
@@ -261767,7 +261767,7 @@ gfp
 hyu
 jWX
 xdU
-cLL
+iAy
 sns
 sns
 sns
@@ -262219,7 +262219,7 @@ eyK
 eyK
 eyK
 cSf
-cLL
+iAy
 sns
 sns
 sns
@@ -262671,7 +262671,7 @@ eyK
 eyK
 qFN
 vSs
-gJU
+pcr
 sns
 sns
 sns
@@ -263573,7 +263573,7 @@ vaz
 fTJ
 eyK
 eyK
-xpv
+qUB
 xHV
 smL
 eBq
@@ -264022,11 +264022,11 @@ jsB
 phl
 sns
 smL
-hKr
+kRP
 eyK
-qxd
-fqO
-fqO
+wqT
+lCu
+lCu
 oED
 sns
 sns
@@ -264928,7 +264928,7 @@ sns
 smL
 ncq
 eyK
-iEJ
+phE
 fBn
 fBn
 oED
@@ -265381,7 +265381,7 @@ vaz
 fTJ
 eyK
 eyK
-xpv
+qUB
 xHV
 smL
 eBq
@@ -266287,7 +266287,7 @@ eyK
 eyK
 rdV
 vSs
-kNF
+miR
 sns
 sns
 sns
@@ -266739,7 +266739,7 @@ eyK
 eyK
 eyK
 oGj
-cLL
+iAy
 sns
 sns
 sns
@@ -267191,7 +267191,7 @@ gfp
 hyu
 jWX
 eCR
-cLL
+iAy
 sns
 sns
 sns
@@ -267643,7 +267643,7 @@ eCR
 eCR
 smL
 vaz
-bLQ
+jpb
 sns
 sns
 sns
@@ -374303,9 +374303,9 @@ bGf
 bGf
 kSK
 cDX
-iAy
-eOV
-cIm
+czd
+oeq
+tGa
 cDX
 kSK
 kSK
@@ -377927,7 +377927,7 @@ cDX
 uAr
 bGf
 lvw
-lCu
+cLL
 ftD
 qkp
 qnP
@@ -379282,7 +379282,7 @@ cnq
 jBr
 lir
 gPs
-phE
+eOV
 cuO
 cuO
 cuO
@@ -379734,7 +379734,7 @@ wBe
 wNz
 jld
 gPs
-czd
+bLQ
 eyK
 cuO
 eyK
@@ -380186,7 +380186,7 @@ gtl
 tRa
 lir
 gPs
-riJ
+gJU
 eyK
 eyK
 eyK
@@ -381543,7 +381543,7 @@ rgo
 bGf
 bGf
 lvw
-lCu
+cLL
 ftD
 qkp
 tIz

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -281220,7 +281220,7 @@ wWq
 akc
 gCd
 tjY
-tjY
+bpK
 gjo
 vxe
 vxe

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -3647,9 +3647,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "bpZ" = (
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/item/reagent_containers/glass/bucket/wooden,
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "bqi" = (
 /obj/structure/chair/bench/ultimacouch,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -4858,6 +4859,10 @@
 	},
 /area/rogue/indoors/town)
 "bLQ" = (
+/obj/structure/fluff/railing/wood,
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town)
 "bLV" = (
@@ -5008,13 +5013,6 @@
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/orcdungeon)
-"bPa" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/chair3,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
 "bPd" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/carpet,
@@ -5433,9 +5431,6 @@
 "bVG" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
 	},
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -6866,13 +6861,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "czd" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/coal,
-/obj/item/rogueore/iron,
-/obj/item/rogueore/iron,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/walldeco/bsmith{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "czf" = (
 /obj/structure/bars/pipe{
 	pixel_x = -11
@@ -7514,13 +7507,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
 "cLL" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/grown/log/tree/small{
-	pixel_y = 32
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "cLP" = (
 /obj/effect/decal/cobbleedge{
@@ -11715,6 +11705,19 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/woods)
+"elW" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	pixel_x = 12;
+	redstone_id = "weaponsmith_shutter"
+	},
+/obj/structure/table/wood{
+	dir = 4;
+	icon_state = "largetable";
+	pixel_x = 5
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "elZ" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = -32
@@ -12694,12 +12697,6 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woods)
-"eCk" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "eCo" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/pelt,
@@ -13348,14 +13345,15 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "eOV" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "largetable"
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
 	},
-/obj/item/clothing/cloak/apron/waist/brown,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/blocks/stonered,
+/area/rogue/indoors/town/dwarfin)
 "eOW" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/blocks,
@@ -15580,10 +15578,14 @@
 /area/rogue/under/cave/mazedungeon)
 "fBn" = (
 /obj/structure/fluff/railing/border{
-	dir = 6
+	dir = 8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/obj/machinery/light/rogue/lanternpost,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "fBq" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/potion_vitals,
@@ -15904,9 +15906,11 @@
 	},
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "fHN" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/effect/decal/cobbleedge{
+	dir = 4
+	},
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town)
 "fHY" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/ruinedwood{
@@ -17753,12 +17757,6 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
-"grG" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
 "grO" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/cave/fishmandungeon)
@@ -18193,16 +18191,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"gAc" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
-	},
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/blocks/stonered,
-/area/rogue/indoors/town/dwarfin)
 "gAe" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -18681,11 +18669,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
 "gJU" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
 	},
-/turf/closed,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "gJY" = (
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/carpet,
@@ -23980,14 +23968,18 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "iAy" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/chest/neu,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/iron,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/item/ingot/steel,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/dwarfin)
 "iAD" = (
 /mob/living/carbon/human/species/skeleton/npc,
 /turf/open/floor/carpet/red,
@@ -24230,11 +24222,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town)
 "iEJ" = (
-/obj/structure/fluff/littlebanners/bluewhite{
-	pixel_y = -6
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "iEM" = (
 /obj/structure/lever{
 	redstone_id = "merchroofshutt"
@@ -26215,9 +26207,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/goblindungeon)
 "jpb" = (
-/obj/item/reagent_containers/glass/bucket/wooden,
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/blocks/stonered/tiny,
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "jpg" = (
 /obj/structure/stairs/stone{
@@ -30179,14 +30172,10 @@
 /area/rogue/indoors/cave)
 "kNF" = (
 /obj/structure/fluff/railing/border{
-	dir = 4
+	dir = 10
 	},
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "kNG" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt,
@@ -30370,9 +30359,11 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/basement/keep)
 "kRP" = (
-/obj/item/roguebin/water/gross,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/town/sewer)
+/obj/structure/roguemachine/atm{
+	location_tag = "Steward Desk"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "kRS" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -30901,8 +30892,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
 	},
-/obj/structure/fluff/railing/wood,
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
 "lcg" = (
 /obj/structure/closet/crate/drawer,
@@ -32334,10 +32324,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
 "lCu" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/rack/rogue/shelf,
+/obj/item/grown/log/tree/small{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/dwarfin)
 "lCz" = (
 /obj/effect/decal/mossy{
@@ -33621,6 +33614,10 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/mazedungeon)
+"mcN" = (
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/blocks/stonered/tiny,
+/area/rogue/indoors/town/dwarfin)
 "mcR" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobblerock,
@@ -35355,10 +35352,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "mLF" = (
-/obj/structure/rack/rogue,
-/obj/item/natural/bundle/curred_hide,
-/turf/open/floor/rogue/ruinedwood/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "mLH" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -39201,11 +39199,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield)
 "oeq" = (
-/obj/machinery/light/rogue/torchholder/l{
-	dir = 8
-	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "oex" = (
 /obj/effect/spawner/lootdrop/roguetown,
 /obj/structure/closet/crate/chest,
@@ -42002,8 +41998,11 @@
 /turf/open/water/pond,
 /area/rogue/outdoors/woods)
 "pcr" = (
-/obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/blocks/stonered,
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "pct" = (
 /obj/random/spider,
@@ -42365,11 +42364,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "phE" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "phH" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -44127,12 +44129,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pMM" = (
-/obj/structure/fluff/railing/wood,
-/obj/structure/roguemachine/atm{
-	location_tag = "Steward Desk"
+/obj/structure/rack/rogue/shelf,
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/dwarfin)
 "pMW" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -46195,12 +46199,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
 "qxR" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/effect/decal/cobbleedge{
+	dir = 10;
+	icon_state = "cobbleedge-n"
 	},
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/dwarfin)
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "qxV" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -46312,6 +46316,12 @@
 "qzO" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave)
+"qzP" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "qzR" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -46637,18 +46647,14 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "qFN" = (
-/obj/structure/lever/wall{
-	dir = 4;
-	pixel_x = 12;
-	redstone_id = "weaponsmith_shutter"
-	},
+/obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable";
-	pixel_x = -5
+	dir = 1;
+	icon_state = "largetable"
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/dwarfin)
+/obj/item/clothing/cloak/apron/waist/brown,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "qFQ" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -47471,13 +47477,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"qUk" = (
-/obj/structure/rack/rogue,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
 "qUm" = (
 /obj/structure/bed/rogue,
 /obj/item/bedsheet/rogue/pelt,
@@ -48183,11 +48182,15 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "riJ" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks/stonered/tiny,
-/area/rogue/indoors/town/dwarfin)
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town)
 "riX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -51691,10 +51694,11 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
 "srE" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/rack/rogue,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "srI" = (
 /obj/machinery/light/roguestreet,
@@ -51937,6 +51941,12 @@
 "svv" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"svD" = (
+/obj/structure/fluff/walldeco/bsmith{
+	name = "DWARVEN KEEP"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town)
 "svH" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/cobble,
@@ -53469,17 +53479,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/exposed/bath/vault)
 "tad" = (
-/obj/structure/closet/crate/chest/neu,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/iron,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/item/ingot/steel,
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/blocks,
+/obj/structure/roguemachine/scomm,
+/turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/dwarfin)
 "tae" = (
 /obj/structure/gate/bars/preopen{
@@ -55158,10 +55159,11 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
 "tGa" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/closed/wall/mineral/rogue/wooddark,
+/obj/structure/chair/wood/rogue/chair3,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town)
 "tGk" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -60966,6 +60968,12 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
+"vGW" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/closed,
+/area/rogue/indoors/town)
 "vHd" = (
 /obj/effect/landmark/start/churchling,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -62164,12 +62172,6 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains/decap/stepbelow)
-"wbP" = (
-/obj/structure/fluff/walldeco/bsmith{
-	name = "DWARVEN KEEP"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
 "wbS" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/ruinedwood{
@@ -63063,11 +63065,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "wqT" = (
-/obj/structure/fluff/walldeco/bsmith{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town)
+/obj/item/roguebin/water/gross,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "wqV" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/ruinedwood,
@@ -65010,13 +65010,12 @@
 	},
 /area/rogue/under/town/basement/keep)
 "xew" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/obj/structure/closet/crate/chest/old_crate,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/coal,
+/obj/item/rogueore/iron,
+/obj/item/rogueore/iron,
+/turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin)
 "xeB" = (
 /obj/structure/flora/roguetree/burnt,
@@ -66208,6 +66207,11 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"xBd" = (
+/obj/structure/rack/rogue,
+/obj/item/natural/bundle/curred_hide,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "xBf" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town/roofs/keep)
@@ -146521,7 +146525,7 @@ iMR
 qOS
 cHC
 nvB
-kRP
+wqT
 dlK
 urZ
 mMx
@@ -147865,7 +147869,7 @@ gKR
 gKR
 pcE
 ncG
-fHN
+mcN
 rPR
 iPN
 kxW
@@ -148321,9 +148325,9 @@ rPR
 rPR
 rPR
 rPR
-vaz
-riJ
-fHN
+kXy
+cLL
+mcN
 kXy
 kXy
 xAN
@@ -149222,7 +149226,7 @@ rBY
 rBY
 rBY
 kXy
-gAc
+eOV
 ncG
 rPR
 rPR
@@ -150126,12 +150130,12 @@ lrS
 rBY
 rBY
 kXy
-pcr
+tad
 ncG
-jpb
-vaz
-riJ
-oeq
+bpZ
+kXy
+cLL
+gJU
 kXy
 kXy
 hAg
@@ -151935,7 +151939,7 @@ rPR
 rPR
 rPR
 rPR
-oeq
+gJU
 kSG
 kXy
 xAN
@@ -152382,11 +152386,11 @@ kXy
 eYJ
 eYJ
 kXy
-qUk
+srE
 epB
 eSw
 isH
-czd
+xew
 kXy
 kXy
 kXy
@@ -258146,11 +258150,11 @@ enA
 nJH
 sns
 lKo
-mLF
+xBd
 kRg
-gJU
+vGW
 kRg
-eOV
+qFN
 lKo
 ruL
 kXi
@@ -258597,7 +258601,7 @@ phl
 fgh
 bMf
 sns
-tGa
+fHN
 gyu
 iJD
 gyu
@@ -258612,7 +258616,7 @@ cDX
 pNm
 bVG
 fPZ
-bVG
+fBn
 dHe
 exD
 sns
@@ -259049,7 +259053,7 @@ oXY
 dQI
 qok
 sns
-fpx
+qxR
 fpx
 qPs
 njB
@@ -259057,9 +259061,9 @@ hRO
 sns
 euy
 cDX
-phE
-bLQ
-iEJ
+kRP
+sns
+vOG
 lce
 pWT
 pWT
@@ -259501,7 +259505,7 @@ qme
 sns
 wND
 sns
-bVy
+vWX
 sns
 cKw
 cKw
@@ -261324,7 +261328,7 @@ ykd
 xdU
 smL
 vaz
-pMM
+bLQ
 sns
 sns
 sns
@@ -261776,7 +261780,7 @@ gfp
 hyu
 jWX
 xdU
-bpZ
+oeq
 sns
 sns
 sns
@@ -262228,7 +262232,7 @@ eyK
 eyK
 eyK
 cSf
-bpZ
+oeq
 sns
 sns
 sns
@@ -262678,9 +262682,9 @@ xdU
 fyu
 eyK
 eyK
-qFN
+elW
 vSs
-wqT
+czd
 sns
 sns
 sns
@@ -263133,7 +263137,7 @@ eyK
 smL
 smL
 smL
-iBJ
+xhO
 sns
 sns
 eKH
@@ -264031,11 +264035,11 @@ jsB
 phl
 sns
 smL
-tad
+iAy
 eyK
-eCk
-lCu
-lCu
+kNF
+mLF
+mLF
 oED
 sns
 sns
@@ -264489,7 +264493,7 @@ eyK
 eyK
 eyK
 smL
-xhO
+iBJ
 sns
 sns
 eKH
@@ -264937,9 +264941,9 @@ sns
 smL
 ncq
 eyK
-fBn
-srE
-srE
+iEJ
+jpb
+jpb
 oED
 sns
 sns
@@ -265845,7 +265849,7 @@ eyK
 smL
 smL
 smL
-iBJ
+xhO
 sns
 sns
 eKH
@@ -266296,7 +266300,7 @@ eyK
 eyK
 rdV
 vSs
-wbP
+svD
 sns
 sns
 sns
@@ -266748,7 +266752,7 @@ eyK
 eyK
 eyK
 oGj
-bpZ
+oeq
 sns
 sns
 sns
@@ -267200,7 +267204,7 @@ gfp
 hyu
 jWX
 eCR
-bpZ
+oeq
 sns
 sns
 sns
@@ -267652,7 +267656,7 @@ eCR
 eCR
 smL
 vaz
-pMM
+bLQ
 sns
 sns
 sns
@@ -374312,9 +374316,9 @@ bGf
 bGf
 kSK
 cDX
-bPa
-kNF
-iAy
+tGa
+riJ
+phE
 cDX
 kSK
 kSK
@@ -377484,7 +377488,7 @@ rYc
 bGf
 bGf
 lvw
-xew
+pMM
 ftD
 qkp
 tIz
@@ -377936,7 +377940,7 @@ cDX
 uAr
 bGf
 lvw
-cLL
+lCu
 ftD
 qkp
 qnP
@@ -379291,7 +379295,7 @@ cnq
 jBr
 lir
 gPs
-grG
+qzP
 cuO
 cuO
 cuO
@@ -379743,7 +379747,7 @@ wBe
 wNz
 jld
 gPs
-qxR
+pcr
 eyK
 cuO
 eyK
@@ -381552,7 +381556,7 @@ rgo
 bGf
 bGf
 lvw
-cLL
+lCu
 ftD
 qkp
 tIz
@@ -382004,7 +382008,7 @@ bGf
 bGf
 bGf
 lvw
-xew
+pMM
 ftD
 qkp
 woA

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -4551,12 +4551,10 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "bHf" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
+/obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -4820,6 +4818,14 @@
 /obj/structure/table/wood{
 	dir = 1;
 	icon_state = "largetable"
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -4;
+	pixel_y = -6
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -15321,6 +15327,18 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/cave)
+"fvX" = (
+/obj/structure/rack/rogue/shelf,
+/obj/item/grown/log/tree/small{
+	pixel_y = 32
+	},
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
+/area/rogue/indoors/town/dwarfin)
 "fwa" = (
 /obj/item/natural/stone{
 	icon_state = "stone3"
@@ -23634,6 +23652,14 @@
 /obj/effect/landmark/start/sergeant,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
+"itS" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/indoors/town)
 "iud" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks/stonered,
@@ -30156,12 +30182,10 @@
 	},
 /area/rogue/indoors/town)
 "kMZ" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 1
-	},
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
+/obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -32329,7 +32353,10 @@
 /area/rogue/indoors)
 "lCu" = (
 /obj/structure/rack/rogue/shelf,
-/obj/item/grown/log/tree/small{
+/obj/item/natural/bundle/stick{
+	pixel_y = 32
+	},
+/obj/item/natural/bundle/stick{
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/ruinedwood{
@@ -32709,6 +32736,12 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/exposed/town/keep)
+"lKE" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/dwarfin)
 "lKH" = (
 /obj/structure/roguewindow/openclose/reinforced,
 /turf/open/floor/rogue/blocks,
@@ -36580,8 +36613,13 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = -4
+	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -43007,10 +43045,10 @@
 /turf/open/water/bath,
 /area/rogue/outdoors/beach/forest)
 "puG" = (
-/obj/structure/closet/crate/chest/neu,
 /obj/item/clothing/shoes/roguetown/boots/leather,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/machinery/light/rogue/wallfire/candle/r,
+/obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/dwarfin)
 "puH" = (
@@ -44133,10 +44171,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "pMM" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/natural/bundle/stick{
-	pixel_y = 32
-	},
+/obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
@@ -55305,6 +55340,7 @@
 /area/rogue/under/underdark)
 "tIz" = (
 /obj/machinery/light/rogue/hearth,
+/obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/dwarfin)
 "tID" = (
@@ -57445,6 +57481,14 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
+"usT" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/rogue/meat/sausage,
+/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+/obj/item/reagent_containers/food/snacks/egg,
+/obj/item/reagent_containers/food/snacks/egg,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "usU" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -64423,6 +64467,14 @@
 /obj/item/rogueore/coal,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
+"wRC" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/dwarfin)
 "wRG" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/beach/forest)
@@ -371617,7 +371669,7 @@ bGf
 bGf
 kSK
 gKh
-kRg
+itS
 xWU
 xWU
 qRV
@@ -377953,7 +378005,7 @@ cDX
 uAr
 bGf
 lvw
-lCu
+fvX
 ftD
 qkp
 qnP
@@ -378408,9 +378460,9 @@ lvw
 fLv
 ftD
 xAu
-vaz
+usT
 kdM
-uKC
+kSK
 bGf
 bGf
 bGf
@@ -378861,8 +378913,8 @@ lvw
 lvw
 oED
 kdM
-jJV
-oEG
+vaz
+uKC
 bGf
 bGf
 bGf
@@ -379309,7 +379361,7 @@ jBr
 lir
 gPs
 qzP
-cuO
+lKE
 cuO
 cuO
 uLi
@@ -379761,7 +379813,7 @@ wNz
 jld
 gPs
 pcr
-eyK
+wRC
 cuO
 eyK
 eyK
@@ -380213,7 +380265,7 @@ tRa
 lir
 gPs
 xpv
-eyK
+xpv
 eyK
 eyK
 bOs
@@ -380669,8 +380721,8 @@ lvw
 lvw
 ntz
 kwO
-iAJ
-oEG
+vaz
+cEQ
 bGf
 bGf
 kSK
@@ -381120,9 +381172,9 @@ lvw
 ven
 ftD
 eaE
-vaz
+usT
 kwO
-cEQ
+kSK
 bGf
 bGf
 kSK
@@ -492311,8 +492363,8 @@ bGf
 bGf
 lvw
 aSk
-uUh
-hed
+sJu
+xtn
 vaz
 kwO
 bGf
@@ -492765,7 +492817,7 @@ lvw
 xgK
 sJu
 sJu
-otT
+lmd
 lvw
 bGf
 bGf
@@ -493216,8 +493268,8 @@ kSK
 vaz
 lvw
 sJu
-sJu
-lmd
+uUh
+hed
 lvw
 bGf
 bGf
@@ -493668,7 +493720,7 @@ kSK
 lvw
 fPu
 sJu
-xtn
+otT
 vaz
 kdM
 bGf


### PR DESCRIPTION
## About The Pull Request

Some small mapping changes to the smithy/tailor shops. Adds queue space areas in front of the service desks.

## Testing Evidence

<details>

<summary>Screenshots:</summary>

Ground Floor:
![image](https://github.com/user-attachments/assets/6a656755-e36d-4791-aee8-4750db132412)

Basement: 
![image](https://github.com/user-attachments/assets/0ed57686-b64f-4334-abf7-e219e9a6d6a8)


</details>

## Why It's Good For The Game

There's lines now, which should mean less people clogging the roads in front of the smithy. Doesn't change the overall layout of either building **too** heavily.
