### PR TITLE
MAA Helmet Selection

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -88,7 +88,6 @@
 
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord		//Bit worse shirt protection than the archer
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale			//Makes up for worse shirt protection with kinda better armor protection
-	head = /obj/item/clothing/head/roguetown/helmet/sallet				//Better protection than kettle archer has
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	neck = /obj/item/clothing/neck/roguetown/gorget
 
@@ -111,6 +110,18 @@
 			backl = /obj/item/gwstrap
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/keyring/guardcastle)
 	H.verbs |= /mob/proc/haltyell
+
+	var/helmets = list(
+	"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+	"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+	"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
+	"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+	"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+	"None"
+	)
+	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+	if(helmchoice != "None")
+		head = helmets[helmchoice]
 
 // Ranged weapons and daggers on the side - lighter armor, but fleet!
 /datum/advclass/manorguard/skirmisher
@@ -147,7 +158,6 @@
 
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord			// Cant wear chainmail anymoooree
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded		//Helps against arrows; makes sense for a ranged-type role.
-	head = /obj/item/clothing/head/roguetown/helmet/kettle
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 
@@ -168,6 +178,18 @@
 
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/keyring/guardcastle)
 	H.verbs |= /mob/proc/haltyell
+
+	var/helmets = list(
+	"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+	"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+	"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
+	"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+	"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+	"None"
+	)
+	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+	if(helmchoice != "None")
+		head = helmets[helmchoice]
 
 /datum/advclass/manorguard/cavalry
 	name = "Cavalryman"
@@ -206,7 +228,6 @@
 
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord		//Bit worse shirt protection than the archer -- as foot soldier.
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale			//Makes up for worse shirt protection with kinda better armor protection
-	head = /obj/item/clothing/head/roguetown/helmet/winged				//Same as the sallet, but fleet!
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	neck = /obj/item/clothing/neck/roguetown/gorget
 
@@ -224,3 +245,15 @@
 	
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/keyring/guardcastle)
 	H.verbs |= /mob/proc/haltyell
+
+	var/helmets = list(
+	"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+	"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+	"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
+	"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+	"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+	"None"
+	)
+	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+	if(helmchoice != "None")
+		head = helmets[helmchoice]


### PR DESCRIPTION
## About The Pull Request

MAA can now select helmets on spawn, similar to knights.

## Testing Evidence

![image](https://github.com/user-attachments/assets/e2af67bb-17a6-4ea3-ba5f-0064ae7d2522)

## Why It's Good For The Game

Most of these helmets are near-identical in terms of protection and already available in the armory anyways. With the armory size reduction, this means MAA who latejoin won't risk of losing out on their favorite-looking helm.