### PR TITLE
Ceramic Tweaks

### DIFF
--- a/code/game/objects/items/rogueitems/ceramics.dm
+++ b/code/game/objects/items/rogueitems/ceramics.dm
@@ -59,7 +59,7 @@
 /obj/item/natural/clay/claycup
 	name = "unglazed clay flask"
 	icon = 'icons/roguetown/items/cooking.dmi'
-	icon_state = "claycuperaw"
+	icon_state = "claycupraw"
 	desc = "A small flask fashioned from clay. Still needs to be glazed to be useful."
 	cooked_type = /obj/item/reagent_containers/glass/cup/claycup
 
@@ -67,7 +67,7 @@
 	name = "clay flask"
 	desc = "A small ceramic flask."
 	icon = 'icons/roguetown/items/cooking.dmi'
-	icon_state = "claybottlecook"
+	icon_state = "claycupcook"
 	sellprice = 3
 	reagent_flags = OPENCONTAINER	//So it doesn't appear through
 


### PR DESCRIPTION
Fixes clay cup so it isn't invisible and swaps its cooked version to use the right sprite.

## About The Pull Request

- The raw clay cup was invisible on craft. It is now visible.
- The glazed clay cup used the wrong sprite. It now uses the correct sprite.

## Testing Evidence

![TheHarvest](https://github.com/user-attachments/assets/f9ca34af-4204-4b1a-8014-a7a766e80536)
[Forgot to get a screenshot so just pretend this is it and take my word for it]

## Why It's Good For The Game

More fucky stuff has been made unfucky. Bugfixes ahoy!
