### PR TITLE
Bardiche no chargetime on cut 1.2 damfactor

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -48,15 +48,12 @@
 	damfactor = 1
 
 /datum/intent/spear/cut/bardiche
-    damfactor = 1.0
-    chargetime = 1
+    damfactor = 1.2
+    chargetime = 0
 
 /datum/intent/spear/cut/glaive
 	damfactor = 1.2
 	chargetime = 0
-
-/datum/intent/spear/cut/bardiche/scythe
-	reach = 2
 
 /datum/intent/spear/cast
 	name = "cast"
@@ -625,7 +622,7 @@
 	name = "summer scythe"
 	desc = "Summer's verdancy runs through the head of this scythe. All the more to sow."
 	icon_state = "dendorscythe"
-	gripped_intents = list(/datum/intent/spear/thrust/eaglebeak, /datum/intent/spear/cut/bardiche/scythe, /datum/intent/axe/chop/scythe, SPEAR_BASH)
+	gripped_intents = list(/datum/intent/spear/thrust/eaglebeak, /datum/intent/spear/cut/bardiche, /datum/intent/axe/chop/scythe, SPEAR_BASH)
 
 /obj/item/rogueweapon/halberd/psyhalberd
 	name = "Stigmata"


### PR DESCRIPTION
## About The Pull Request
Rebel gave the Cavalryman class Bardiche instead of Glaive (good) but Bardiche always felt awkward to use because of its poor thrust that is not competitive vs the BIS Billhook / Halberd that stab through armor. 

It also has 1 charge time on its cut making it much harder to use in practice compared to say, Zweihander.

This remove the charge time on the cut and give it 1.2 dam factor for 36 damage per cut, compared to Zwei's base 35 damage and 38.5 damage per cut at 1.1 dam factor. Both have no penetration and zwei is probably still the better weapon but at least Bardiche should be good for the thing it is thematically good at now.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiles

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Give Bardiche a bit of a niche amongst polearm with no delay 2 range cut.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
