### PR TITLE
Add spellsinger hats and robes as Level 6 recipe to sewing

### DIFF
--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -1056,3 +1056,23 @@
 	reqs = list(/obj/item/natural/cloth = 1,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/sewing/spellsingerrobes
+	name = "spellsinger robes (4 fibers, 6 cloth, 1 silk)"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/spellcasterrobe)
+	reqs = list(/obj/item/natural/cloth = 6,
+	            /obj/item/natural/fibers = 4,
+				/obj/item/natural/silk = 1)
+	tools = list(/obj/item/needle)
+	craftdiff = 6
+	sellprice = 30
+
+/datum/crafting_recipe/roguetown/sewing/spellsingerhat
+	name = "spellsinger hat (1 fibers, 1 cloth, 2 silk)"
+	result = list(/obj/item/clothing/head/roguetown/spellcasterhat)
+	reqs = list(/obj/item/natural/cloth = 1,
+	            /obj/item/natural/fibers = 1,
+				/obj/item/natural/silk = 2)
+	tools = list(/obj/item/needle)
+	craftdiff = 6
+	sellprice = 20


### PR DESCRIPTION
## About The Pull Request
Add spellsinger hats and robes as Level 6 recipe to sewing
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="121" alt="dreamseeker_xtWcy2X6vw" src="https://github.com/user-attachments/assets/5ed8b26f-33a2-4cdb-bccc-c2c100d62529" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Add spellsinger hats and robes as Level 6 recipe to sewing
Felinid said that is OK and Level 6 should gate it from being easily craftable. Plus it is whimsical and good and practical mage drip.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
