### PR TITLE
Gives Unarmed Barbarians Strong Bite Back

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -167,6 +167,7 @@
 				if ("MY BARE HANDS!!!")
 					H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+					ADD_TRAIT(H, TRAIT_STRONGBITE, TRAIT_GENERIC)
 			H.change_stat("strength", 3)
 			H.change_stat("endurance", 1)
 			H.change_stat("constitution", 2)


### PR DESCRIPTION
## About The Pull Request

Before the adventurer class refactor, barbarian had a subclass called 'Ravager' which was an unarmed focused fighter that had strong bite. They lost this trait in the sorting around of classes. This PR gives it back.

## Testing Evidence

![image](https://github.com/user-attachments/assets/f027982e-4da5-4ce9-85db-05ca5bb6e0e9)


## Why It's Good For The Game

I believe this was just an oversight. Bite is a nice tool for the unarmed, unarmored barbarian to have but ultimately isn't that much stronger than swift punching some dude's helmet into his skull. Lets my shark barbarian have her core funny gimmick back. 

https://github.com/user-attachments/assets/54bb921e-b8b4-48d8-aafc-7462509ce1d6
