### PR TITLE
Remove Roguemedium for votable rotation

### DIFF
--- a/code/game/gamemodes/roguetown/roguemedium.dm
+++ b/code/game/gamemodes/roguetown/roguemedium.dm
@@ -8,7 +8,7 @@
 	required_enemies = 0
 	recommended_enemies = 0
 	enemy_minimum_age = 0
-	votable = TRUE
+	votable = FALSE // Temporarily disabled until we have more antags variety + scale it properly
 	probability = 80
 
 	announce_span = "danger"


### PR DESCRIPTION
## About The Pull Request
Remove Roguemedium from votable rotation.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![NVIDIA_Overlay_sTDfjVPJ2l](https://github.com/user-attachments/assets/af00a9d6-6320-4d7e-9831-99ade5216f9f)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
People seems to have gotten **really really** tired of seeing the same non-stop werewolves + bandits every rounds. 

We don't have enough antag varieties to make it work yet. Let's just take Roguemedium off rotation until we add more minor antags + some kind of scaling.

Any feedback from anyone not named FreeStylalt will be ignored ty. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
