### PR TITLE
safer access for two little runtimes

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -200,7 +200,7 @@
 	if(mob_light)
 		qdel(mob_light)
 	if(mob_charge_effect)
-		mastermob.vis_contents -= mob_charge_effect
+		mastermob?.vis_contents -= mob_charge_effect
 
 
 /datum/intent/use

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -49,8 +49,10 @@
 /obj/item/rogueweapon/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the projectile", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, args)
 	var/mob/attacker
+	var/obj/item/I
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
-		var/obj/item/I = hitby
+		if(istype(hitby, /obj/item)) // can't trust mob -> item assignments
+			I = hitby
 		if(I?.thrownby)
 			attacker = I.thrownby
 	if(attack_type == PROJECTILE_ATTACK)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Stricter typecasting for atom/movable throwing to obj/item, apparently if it's a mob it will still go in the square hole.

Something about a door trying to mouse up, I don't know. Everything else in that proc is safe navigation. What did the ancestors know that we don't.
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
Compiles.
## Why It's Good For The Game
Thought I fixed em
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
