### PR TITLE
Mercenary Fixes

### DIFF
--- a/code/modules/clothing/rogueclothes/quiver.dm
+++ b/code/modules/clothing/rogueclothes/quiver.dm
@@ -148,7 +148,6 @@
 	desc = ""
 	icon_state = "javelinbag0"
 	item_state = "javelinbag"
-	slot_flags = ITEM_SLOT_BACK
 	max_storage = 4
 
 /obj/item/quiver/javelin/attack_turf(turf/T, mob/living/user)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
@@ -34,7 +34,7 @@
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/labor/mining, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
@@ -46,6 +46,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/traps, 1, TRUE)		//May help with dungeon stuff future; plus has use in dark areas.
 		H.mind.adjust_skillrank(/datum/skill/craft/smelting, 2, TRUE)	//Accompanies mining; they know how to smelt, not make armor though.
 		H.change_stat("fortune", 1)
 		H.change_stat("strength", 1)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
@@ -38,15 +38,14 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)	//Gets this for bomb making.
 		H.mind.adjust_skillrank(/datum/skill/craft/engineering, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/craft/traps, 1, TRUE)		//May help with dungeon stuff future; plus has use in dark areas.
 		H.mind.adjust_skillrank(/datum/skill/craft/smelting, 2, TRUE)	//Accompanies mining; they know how to smelt, not make armor though.
 		H.change_stat("fortune", 1)
 		H.change_stat("strength", 1)


### PR DESCRIPTION
## About The Pull Request

was only going to do LOOC change but this was a simple fast pr and i got cum in my mailbox about the steppesman issue so fuck it fixed it

- javelin bags can now fit on hip, which they didn't originally because fear of 4 bags of them, but honestly on testing it was such a non-issue just let them have it. fixes steppesman not spawning with it cus not fitting on hip.
- underdweller lost it's 4 wrestling (accidently gave it 4 instead of 3), as reported as being a bit 'too overtuned' by an underdweller main, instead tossed them an extra climbing skill since they'll be using it to get tf out of cave areas semi-often. it's equal to garrison skill level anyway on some of their roles so it's plenty fair.

## Testing Evidence

yeah it works

## Why It's Good For The Game

1. i made javelins not fit on belt cus they were originally really strong then got really weak but now are decent - no longer fear the chad with 4 javelin bags on every back/hip slot.
2. underdweller adjustmentjak cus asked for and it's fair, i realized i fucked up the wrestling skill my bad g
