### PR TITLE
(Staff Tool) LOOC Muting & Banning

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -6,6 +6,7 @@
 #define MUTE_PRAY		(1<<2)
 #define MUTE_ADMINHELP	(1<<3)
 #define MUTE_DEADCHAT	(1<<4)
+#define MUTE_LOOC		(1<<5)
 #define MUTE_ALL		(~0)
 
 //Some constants for DB_Ban

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -137,6 +137,7 @@
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_PRAY]'><font color='[(muted & MUTE_PRAY)?"red":"blue"]'>PRAY</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ADMINHELP]'><font color='[(muted & MUTE_ADMINHELP)?"red":"blue"]'>ADMINHELP</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_DEADCHAT]'><font color='[(muted & MUTE_DEADCHAT)?"red":"blue"]'>DEADCHAT</font></a> | "
+		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>LOOC</font></a>\]"
 		body += "(<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ALL]'><font color='[(muted & MUTE_ALL)?"red":"blue"]'>toggle all</font></a>)"
 
 	body += "<br><br>"

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -240,7 +240,7 @@
 							"Garrison" = GLOB.garrison_positions,
 							"Church" = GLOB.church_positions,
 							"Mercenaries" = GLOB.mercenary_positions,
-							"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC"))
+							"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC", "LOOC"))
 		for(var/department in headless_job_lists)
 			output += "<div class='column'><label class='rolegroup [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			break_counter = 0

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -235,6 +235,9 @@
 		if(MUTE_OOC)
 			mute_string = "OOC"
 			feedback_string = "OOC"
+		if(MUTE_LOOC)
+			mute_string = "LOOC"
+			feedback_string = "LOOC"
 		if(MUTE_PRAY)
 			mute_string = "pray"
 			feedback_string = "Pray"

--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -34,6 +34,13 @@
 		to_chat(usr, "<span class='danger'> Speech is currently admin-disabled.</span>")
 		return
 
+	if(prefs.muted & MUTE_LOOC)
+		to_chat(src, "<span class='danger'>I cannot use LOOC (temp muted).</span>")
+		return
+
+	if(is_banned_from(ckey, "LOOC"))
+		to_chat(src, "<span class='danger'>I cannot use LOOC (perma muted).</span>")
+
 	if(!mob)
 		return
 
@@ -63,10 +70,17 @@
 	else
 		prefix = "LOOC (WP)"
 
+
+	var/list/mobs = list()
+	var/muted = prefs.muted
 	for(var/mob/M in range(7,src))
+		var/added_text
 		var/client/C = M.client
 		if(!M.client)
 			continue
+		mobs += C
+		if(C in GLOB.admins)
+			added_text += " ([mob.ckey]) <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>\[MUTE\]</font></a>"
 		if(isobserver(M))
 			continue //Also handled later.
 		if(C.prefs.chat_toggles & CHAT_OOC)
@@ -74,5 +88,5 @@
 				var/turf/speakturf = get_turf(M)
 				var/turf/sourceturf = get_turf(usr)
 				if((speakturf in get_hear(7, sourceturf)) || wp == 1)
-					to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>")
+					to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
 	to_chat(usr, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>")

--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -89,9 +89,4 @@
 				var/turf/sourceturf = get_turf(usr)
 				if((speakturf in get_hear(7, sourceturf)) || wp == 1)
 					to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
-	for(var/client/C in GLOB.admins)
-		if(CHAT_GHOSTEARS)
-			if(C in mobs)
-				continue
-			to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name] ([mob.ckey]) <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>MUTE</font></a>:</EM> <span class='message'>[msg]</span></b></font>")
 	to_chat(usr, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>")

--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -89,4 +89,9 @@
 				var/turf/sourceturf = get_turf(usr)
 				if((speakturf in get_hear(7, sourceturf)) || wp == 1)
 					to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+	for(var/client/C in GLOB.admins)
+		if(CHAT_GHOSTEARS)
+			if(C in mobs)
+				continue
+			to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name] ([mob.ckey]) <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>MUTE</font></a>:</EM> <span class='message'>[msg]</span></b></font>")
 	to_chat(usr, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>")


### PR DESCRIPTION
## About The Pull Request

was taking a time away prs but staff wanted a way to mute and ban players from looc which apparently had broke prior. this adds the ability back to mute LOOC, which is just a round-long thing or until unmuted, or ban LOOC akin to how they can ban OOC usage.

staff want to police the dogshit looc abuse, so here - ported some of vanderlin's tweaks from https://github.com/Monkestation/Vanderlin/pull/393 + mild changes to get it working here properly since we use a mildly different ban system.

i did leave out the part where admins anywhere can see looc just to avoid flashbanging them with vile shit + left out the 'dead and unconcious players can't looc' only because i've seen it used properly to ask to rr or requesting rr or going  'sorry wasn't in my body' - so it stays cus i see use and hope staff police it is all.

**please test merge this before full merger to ensure it works fully; can only test so much locally.**

## Testing Evidence

yep
![image](https://github.com/user-attachments/assets/3316c526-cf9d-4ed4-965a-68f3aac0f03c)

## Why It's Good For The Game

looc salt begone, back to f13 with you
