### PR TITLE
Azurian Disinflation Act - Stockpile Limit

### DIFF
--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -146,6 +146,19 @@
 				if(newtax < D.withdraw_price)
 					scom_announce("The withdraw price for [D.name] was decreased.")
 				D.withdraw_price = newtax
+	if(href_list["setlimit"])
+		var/datum/roguestock/D = locate(href_list["setlimit"]) in SStreasury.stockpile_datums
+		if(!D)
+			return
+		var/newlimit = input(usr, "Set a new limit for [D.name]", src, D.stockpile_limit) as null|num
+		if(newlimit)
+			if(!usr.canUseTopic(src, BE_CLOSE) || locked)
+				return
+			if(findtext(num2text(newlimit), "."))
+				return
+			newlimit = CLAMP(newlimit, 0, 999)
+			scom_announce("The stockpile limit for [D.name] was changed to [newlimit].")
+			D.stockpile_limit = newlimit
 	if(href_list["givemoney"])
 		var/X = locate(href_list["givemoney"])
 		if(!X)
@@ -300,6 +313,7 @@
 					contents += " [A.held_items[1] + A.held_items[2]]"
 					contents += " | SELL: <a href='?src=\ref[src];setbounty=\ref[A]'>[A.payout_price]m</a>"
 					contents += " / BUY: <a href='?src=\ref[src];setprice=\ref[A]'>[A.withdraw_price]m</a>"
+					contents += " / LIMIT: <a href='?src=\ref[src];setlimit=\ref[A]'>[A.stockpile_limit]</a>"
 					if(A.importexport_amt)
 						contents += " <a href='?src=\ref[src];import=\ref[A]'>\[IMP [A.importexport_amt] ([A.get_import_price()])\]</a> <a href='?src=\ref[src];export=\ref[A]'>\[EXP [A.importexport_amt] ([A.get_export_price()])\]</a> <BR>"
 			else
@@ -371,7 +385,7 @@
 
 	if(!canread)
 		contents = stars(contents)
-	var/datum/browser/popup = new(user, "VENDORTHING", "", 500, 800)
+	var/datum/browser/popup = new(user, "VENDORTHING", "", 700, 800)
 	popup.set_content(contents)
 	popup.open()
 

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
@@ -76,7 +76,7 @@
 	for(var/datum/roguestock/stockpile/R in SStreasury.stockpile_datums)
 		if(R.category != current_category)
 			continue
-		contents += "[R.name] - [R.payout_price] - [R.demand2word()]"
+		contents += "[R.name] - [R.payout_price] - ([R.held_items[stockpile_index]]/[R.stockpile_limit]) - [R.demand2word()]"
 		contents += "<BR>"
 
 	return contents

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
@@ -105,20 +105,25 @@
 		if(istype(I, /obj/item/natural/bundle))
 			var/obj/item/natural/bundle/B = I
 			if(B.stacktype == R.item_type)
+				var/nopay = R.held_items[stockpile_index] >= R.stockpile_limit // Check whether it is overflowed BEFORE nopaying them
 				R.held_items[stockpile_index] += B.amount
 				if(message == TRUE)
 					stock_announce("[B.amount] units of [R.name] has been stockpiled.")
 				qdel(B)
 				if(sound == TRUE)
 					playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)
-				var/amt = R.payout_price * B.amount
-				if(!SStreasury.give_money_account(amt, H, "+[amt] from [R.name] bounty") && message == TRUE)
-					say("No account found. Submit your fingers to a Meister for inspection.")
+				if(nopay)
+					say("Stockpile is full, no payment.")
+				else
+					var/amt = R.payout_price * B.amount
+					if(!SStreasury.give_money_account(amt, H, "+[amt] from [R.name] bounty") && message == TRUE)
+						say("No account found. Submit your fingers to a Meister for inspection.")
 			continue
 		else if(istype(I,R.item_type))
 			if(!R.check_item(I))
 				continue
 			var/amt = R.get_payout_price(I)
+			var/nopay = !R.transport_item && R.held_items[stockpile_index] >= R.stockpile_limit // Check whether it is overflowed BEFORE nopaying them
 			if(!R.transport_item)
 				R.held_items[stockpile_index] += 1 //stacked logs need to check for multiple
 				qdel(I)
@@ -140,7 +145,9 @@
 				if(sound == TRUE)
 					playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)
 					playsound(loc, 'sound/misc/disposalflush.ogg', 100, FALSE, -1)
-			if(amt)
+			if(nopay)
+				say("Stockpile is full, no payment.")
+			else if(amt)
 				if(!SStreasury.give_money_account(amt, H, "+[amt] from [R.name] bounty") && message == TRUE)
 					say("No account found. Submit your fingers to a Meister for inspection.")
 			return

--- a/code/modules/roguetown/roguestock/_roguestock.dm
+++ b/code/modules/roguetown/roguestock/_roguestock.dm
@@ -12,6 +12,8 @@
 	var/transport_item = FALSE
 	//SStreasury.queens_tax is used in getting import price
 	var/export_price = 1
+	// Limit for stockpile. Only accounted for if it is not transport_item
+	var/stockpile_limit = 100 // Limit beyond which the stockpile will just eat your things for free. Very high limit just to be safe you should define it directly.
 	//how many of the items are consumed/spawned when exporting/importing
 	var/importexport_amt = 10
 	var/import_only = FALSE //for importing crackers, etc

--- a/code/modules/roguetown/roguestock/stockpile_food.dm
+++ b/code/modules/roguetown/roguestock/stockpile_food.dm
@@ -8,6 +8,7 @@
 	export_price = 8
 	importexport_amt = 5
 	passive_generation = 3
+	stockpile_limit = 20
 	category = "Foodstuffs"
 
 /datum/roguestock/stockpile/grain
@@ -21,6 +22,7 @@
 	export_price = 3
 	importexport_amt = 10
 	passive_generation = 3
+	stockpile_limit = 50
 	category = "Foodstuffs"
 
 /datum/roguestock/stockpile/oat
@@ -34,6 +36,7 @@
 	export_price = 3
 	importexport_amt = 10
 	passive_generation = 3
+	stockpile_limit = 50
 	category = "Foodstuffs"
 
 /datum/roguestock/stockpile/garlick
@@ -47,6 +50,7 @@
 	export_price = 3
 	importexport_amt = 10
 	passive_generation = 3
+	stockpile_limit = 30
 	category = "Foodstuffs"
 
 /datum/roguestock/stockpile/apple
@@ -60,6 +64,7 @@
 	export_price = 5
 	importexport_amt = 5
 	passive_generation = 3
+	stockpile_limit = 30
 	category = "Foodstuffs"
 
 /datum/roguestock/stockpile/meat
@@ -72,6 +77,7 @@
 	transport_fee = 2
 	export_price = 8
 	importexport_amt = 5
+	stockpile_limit = 40
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -85,6 +91,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -98,6 +105,7 @@
 	transport_fee = 2
 	export_price = 8
 	importexport_amt = 5
+	stockpile_limit = 20
 	passive_generation = 1
 	category = "Foodstuffs"
 
@@ -111,6 +119,7 @@
 	transport_fee = 1
 	export_price = 5
 	importexport_amt = 5
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -124,6 +133,7 @@
 	transport_fee = 2
 	export_price = 5
 	importexport_amt = 5
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -137,6 +147,7 @@
 	transport_fee = 1
 	export_price = 5
 	importexport_amt = 5
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -150,6 +161,7 @@
 	transport_fee = 1
 	export_price = 2
 	importexport_amt = 5
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -163,6 +175,7 @@
 	transport_fee = 3
 	export_price = 13
 	importexport_amt = 5
+	stockpile_limit = 20
 	passive_generation = 1
 	category = "Foodstuffs"
 
@@ -176,6 +189,7 @@
 	transport_fee = 3
 	export_price = 5
 	importexport_amt = 5
+	stockpile_limit = 20
 	passive_generation = 1
 	category = "Foodstuffs"
 
@@ -189,6 +203,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 50 // Jackberries are used to mass produce raisins so higher limit
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -202,6 +217,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -215,6 +231,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -228,6 +245,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -241,6 +259,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -254,6 +273,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -267,6 +287,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -280,6 +301,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -293,5 +315,6 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 2
 	category = "Foodstuffs"

--- a/code/modules/roguetown/roguestock/stockpile_rawmat.dm
+++ b/code/modules/roguetown/roguestock/stockpile_rawmat.dm
@@ -8,6 +8,7 @@
 	transport_fee = 3
 	export_price = 5
 	importexport_amt = 10
+	stockpile_limit = 50
 	passive_generation = 5
 
 /datum/roguestock/stockpile/coal
@@ -20,6 +21,7 @@
 	transport_fee = 4
 	export_price = 6
 	importexport_amt = 10
+	stockpile_limit = 50
 	passive_generation = 2
 
 /datum/roguestock/stockpile/glass
@@ -32,6 +34,7 @@
 	transport_fee = 5
 	export_price = 5
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 3
 
 /datum/roguestock/stockpile/iron
@@ -44,6 +47,7 @@
 	transport_fee = 6
 	export_price = 8
 	importexport_amt = 10
+	stockpile_limit = 50
 	passive_generation = 2
 
 /datum/roguestock/stockpile/copper
@@ -56,6 +60,7 @@
 	transport_fee = 3
 	export_price = 5
 	importexport_amt = 10
+	stockpile_limit = 30
 	passive_generation = 2
 
 /datum/roguestock/stockpile/tin
@@ -68,6 +73,7 @@
 	transport_fee = 4
 	export_price = 5
 	importexport_amt = 10
+	stockpile_limit = 30
 	passive_generation = 2
 
 /datum/roguestock/stockpile/gold
@@ -79,6 +85,7 @@
 	withdraw_price = 75
 	transport_fee = 10
 	export_price = 75
+	stockpile_limit = 20
 	importexport_amt = 10
 
 /datum/roguestock/stockpile/silver
@@ -90,6 +97,7 @@
 	withdraw_price = 100
 	transport_fee = 10
 	export_price = 100
+	stockpile_limit = 20
 	importexport_amt = 10
 
 /datum/roguestock/stockpile/cloth
@@ -102,6 +110,7 @@
 	transport_fee = 2
 	export_price = 5
 	importexport_amt = 10
+	stockpile_limit = 60
 	passive_generation = 2
 
 /datum/roguestock/stockpile/fibers
@@ -114,6 +123,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
+	stockpile_limit = 60
 	passive_generation = 4
 
 /datum/roguestock/stockpile/silk
@@ -126,6 +136,7 @@
 	transport_fee = 1
 	export_price = 4
 	importexport_amt = 10
+	stockpile_limit = 20
 	passive_generation = 1
 
 //natural/hide/cured must be defined/populated in sstreasury before natural/hide, for istype stockpile check to work
@@ -139,6 +150,7 @@
 	transport_fee = 3
 	export_price = 7
 	importexport_amt = 10
+	stockpile_limit = 40
 	passive_generation = 3
 
 /datum/roguestock/stockpile/hide
@@ -151,6 +163,7 @@
 	transport_fee = 2
 	export_price = 12
 	importexport_amt = 5
+	stockpile_limit = 25
 	passive_generation = 2
 
 /datum/roguestock/stockpile/fur
@@ -163,4 +176,5 @@
 	transport_fee = 4
 	export_price = 15
 	importexport_amt = 5
+	stockpile_limit = 15
 	passive_generation = 1

--- a/code/modules/roguetown/roguestock/stockpile_rawmat.dm
+++ b/code/modules/roguetown/roguestock/stockpile_rawmat.dm
@@ -24,6 +24,19 @@
 	stockpile_limit = 50
 	passive_generation = 2
 
+/datum/roguestock/stockpile/stone
+	name = "Stone"
+	desc = "Stones. Used for construction"
+	item_type = /obj/item/natural/stone
+	held_items = list(10, 0)
+	payout_price = 0
+	withdraw_price = 1
+	transport_fee = 0
+	export_price = 1
+	importexport_amt = 10
+	stockpile_limit = 0
+	passive_generation = 10 // Free rocks!!
+
 /datum/roguestock/stockpile/glass
 	name = "Glass Batch"	//'Raw' glass
 	desc = "A mixture of finely ground materials that is used to make glass."


### PR DESCRIPTION
## About The Pull Request
- Adds stockpile limit to all stockpile items. Any additional item sold beyond the limit will NOT give you ANY money.
- You can check the stockpile limit in the feeding the stockpile tabs
- Steward can set the stockpile limit as they see fit.
- Default limit are very generous on purpose, so it mostly punishes people who flood the market with a single item. They are so generous they might as well not exist. 

Not really up for balancejakking. Might in the future add in an auto-export feature.
 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![NVIDIA_Overlay_jPTGqiYHcF](https://github.com/user-attachments/assets/a3c3ef5e-7cf2-43c2-b1d1-c193ea7544f9)
![NVIDIA_Overlay_UdxonGnoYA](https://github.com/user-attachments/assets/50d5551c-891d-4c96-9297-50c2463f06a2)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
A baby step solution to stop people from flooding the market with a single item completely.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
