### PR TITLE
Prevents overlapping miracles

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -25,6 +25,10 @@
 			target.adjustFireLoss(10)
 			target.fire_act(1,10)
 			return TRUE
+		if(target.has_status_effect(/datum/status_effect/buff/healing))
+			to_chat(user, span_warning("They are already under the effects of a healing aura!"))
+			revert_cast()
+			return FALSE
 		var/conditional_buff = FALSE
 		var/situational_bonus = 1
 		var/message_out


### PR DESCRIPTION
## About The Pull Request
To preface:

### MIRACLES ALREADY DO NOT STACK! THIS PR DOES NOT CHANGE THIS!

There can only be ONE miracle healing effect active on a mob at a time, and casting multiple at once only ever overrode the existing one -- including any patron-specific boons they might've been receiving.

This makes it a first-cast-first-serve approach and makes it clear that they do not overlap, and never have.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/c564a46e-4f26-448b-a145-d27712038d81)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Your Matthiosan 2x as effective miracle will not be overridden by Psydon's wet tissue version. At least, if you cast yours first.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
