### PR TITLE
Tightens up painflash logic

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -447,6 +447,7 @@
 
 /datum/status_effect/buff/healing/on_remove()
 	owner.remove_filter(MIRACLE_HEALING_FILTER)
+	owner.update_damage_hud()
 	
 /atom/movable/screen/alert/status_effect/buff/fortify
 	name = "Fortifying Miracle"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -937,7 +937,7 @@
 		clear_fullscreen("brute")*/
 
 	var/hurtdamage = ((get_complex_pain() / (STAEND * 10)) * 100) //what percent out of 100 to max pain
-	if(hurtdamage > 5)
+	if(hurtdamage > 5) //float
 		var/severity = 0
 		switch(hurtdamage)
 			if(5 to 20)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -937,7 +937,7 @@
 		clear_fullscreen("brute")*/
 
 	var/hurtdamage = ((get_complex_pain() / (STAEND * 10)) * 100) //what percent out of 100 to max pain
-	if(hurtdamage)
+	if(hurtdamage > 5)
 		var/severity = 0
 		switch(hurtdamage)
 			if(5 to 20)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -394,6 +394,8 @@
 		else
 			M.LAssailant = usr
 
+		M.update_damage_hud()
+
 		// Makes it so people who recently broke out of grabs cannot be grabbed again
 		if(TIMER_COOLDOWN_RUNNING(M, "broke_free") && M.stat == CONSCIOUS)
 			M.visible_message(span_warning("[M] slips from [src]'s grip."), \

--- a/code/modules/surgery/surgeries/healing.dm
+++ b/code/modules/surgery/surgeries/healing.dm
@@ -90,6 +90,7 @@
 	display_results(user, target, span_notice("[umsg]."),
 		"[tmsg].",
 		"[tmsg].")
+	target.update_damage_hud()
 	return TRUE
 
 /datum/surgery_step/heal/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)
@@ -103,6 +104,7 @@
 		urdamageamt_burn += round((target.getFireLoss()/(missinghpbonus*2)),0.1)
 
 	target.take_bodypart_damage(urdamageamt_brute, urdamageamt_burn)
+	target.update_damage_hud()
 	return TRUE
 
 /********************BRUTE STEPS********************/


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Some float logic in complex damage pain hud overlay meant that the flash wasn't properly going away when at full health. This helps the logic, and throws around some more places where that pain can go away.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->


https://github.com/user-attachments/assets/e817542c-d514-4b92-8ba4-e5b5967396de



## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Red flashbangs