### PR TITLE
Tweak pain thresholds and make them use CON instead of END

### DIFF
--- a/code/datums/wounds/types/punctures.dm
+++ b/code/datums/wounds/types/punctures.dm
@@ -8,8 +8,6 @@
 	sewn_clotting_rate = 0.01
 	clotting_threshold = 0.2
 	sewn_clotting_threshold = 0.1
-	woundpain = 0
-	sewn_woundpain = 0
 	sew_threshold = 75
 	mob_overlay = "cut"
 	can_sew = TRUE

--- a/code/datums/wounds/types/slashes.dm
+++ b/code/datums/wounds/types/slashes.dm
@@ -8,8 +8,6 @@
 	sewn_clotting_rate = 0.02
 	clotting_threshold = 0.2
 	sewn_clotting_threshold = 0.1
-	woundpain = 0
-	sewn_woundpain = 0
 	sew_threshold = 50
 	mob_overlay = "cut"
 	can_sew = TRUE

--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -23,6 +23,7 @@
 	can_sew = FALSE
 	can_cauterize = FALSE
 	critical = TRUE
+	woundpain = 30 // it REALLY HURTS to have ruptured eardrums
 
 /datum/wound/facial/ears/can_apply_to_mob(mob/living/affected)
 	. = ..()
@@ -142,6 +143,7 @@
 		"The tongue is severed!",
 		"The tongue flies off in an arc!"
 	)
+	woundpain = 20
 	can_sew = FALSE
 	can_cauterize = FALSE
 	critical = TRUE
@@ -187,6 +189,7 @@
 		"The nose is mangled beyond recognition!",
 		"The nose is destroyed!",
 	)
+	woundpain = 10
 
 /datum/wound/facial/disfigurement/nose/on_mob_gain(mob/living/affected)
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -936,7 +936,7 @@
 	else
 		clear_fullscreen("brute")*/
 
-	var/hurtdamage = ((get_complex_pain() / (STAEND * 10)) * 100) //what percent out of 100 to max pain
+	var/hurtdamage = ((get_complex_pain() / (STACON * 10)) * 100) //what percent out of 100 to max pain
 	if(hurtdamage > 5) //float
 		var/severity = 0
 		switch(hurtdamage)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -293,7 +293,7 @@
 				monkey_attack(target)
 				if(flee_in_pain && (target.stat == CONSCIOUS))
 					var/paine = get_complex_pain()
-					if(paine >= ((STAEND * 10)*0.9))
+					if(paine >= ((STACON * 10)*0.9))
 //						mode = AI_FLEE
 						walk_away(src, target, 5, update_movespeed())
 				return TRUE

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -63,7 +63,7 @@
 	if(HAS_TRAIT(src, TRAIT_NOPAIN))
 		return
 	if(!stat)
-		var/pain_threshold = STAEND * 10
+		var/pain_threshold = STACON * 10
 		if(has_flaw(/datum/charflaw/masochist)) // Masochists handle pain better by about 1 endurance point
 			pain_threshold += 10
 		var/painpercent = get_complex_pain() / pain_threshold
@@ -71,7 +71,7 @@
 
 		if(world.time > mob_timers["painstun"])
 			mob_timers["painstun"] = world.time + 100
-			var/probby = 40 - (STAEND * 2)
+			var/probby = 40 - (STACON * 2)
 			probby = max(probby, 10)
 			if(lying || IsKnockdown())
 				if(prob(3) && (painpercent >= 80) )

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -142,16 +142,16 @@
 		add_stress(/datum/stressevent/sewertouched)
 
 /mob/living/carbon/proc/get_complex_pain()
-	var/amt = 0
+	. = 0
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
 		if(limb.status == BODYPART_ROBOTIC || limb.skeletonized)
 			continue
-		var/bodypart_pain = ((limb.brute_dam + limb.burn_dam) / limb.max_damage) * 100
+		var/bodypart_pain = ((limb.brute_dam + limb.burn_dam) / limb.max_damage) * limb.max_pain_damage
 		for(var/datum/wound/wound as anything in limb.wounds)
 			bodypart_pain += wound.woundpain
-		bodypart_pain = min(bodypart_pain, 100) //tops out at 100 per limb
-		amt += bodypart_pain
-	return amt
+		bodypart_pain = min(bodypart_pain, limb.max_pain_damage)
+		. += bodypart_pain
+	.
 
 ///////////////
 // BREATHING //

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -298,7 +298,7 @@
 	. = ..()
 	if(. && iscarbon(user))
 		var/mob/living/carbon/L = user
-		if(L.get_complex_pain() > (L.STAEND * 9))
+		if(L.get_complex_pain() > (L.STACON * 9))
 			L.setDir(2)
 			L.SetUnconscious(200)
 		else

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -86,8 +86,8 @@
 	//random painstun
 	if(!stat && !HAS_TRAIT(src, TRAIT_NOPAINSTUN))
 		if(world.time > mob_timers["painstun"] + 600)
-			if(getBruteLoss() + getFireLoss() >= (STAEND * 10))
-				var/probby = 53 - (STAEND * 2)
+			if(getBruteLoss() + getFireLoss() >= (STACON * 10))
+				var/probby = 53 - (STACON * 2)
 				if(!(mobility_flags & MOBILITY_STAND))
 					probby = probby - 20
 				if(prob(probby))

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -32,6 +32,7 @@
 	var/stamina_dam = 0
 	var/max_stamina_damage = 0
 	var/max_damage = 0
+	var/max_pain_damage = 100
 
 	var/cremation_progress = 0 //Gradually increases while burning when at full damage, destroys the limb when at 100
 
@@ -667,6 +668,7 @@
 /obj/item/bodypart/deconstruct(disassembled = TRUE)
 	drop_organs()
 	return ..()
+
 /obj/item/bodypart/chest
 	name = BODY_ZONE_CHEST
 	desc = ""
@@ -678,6 +680,7 @@
 	px_y = 0
 	stam_damage_coeff = 1
 	max_stamina_damage = 120
+	max_pain_damage = 150
 	var/obj/item/cavity_item
 	subtargets = list(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_STOMACH, BODY_ZONE_PRECISE_GROIN)
 	grabtargets = list(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_STOMACH, BODY_ZONE_PRECISE_GROIN)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -13,6 +13,7 @@
 	px_y = -8
 	stam_damage_coeff = 1
 	max_stamina_damage = 100
+	max_pain_damage = 125
 	dismember_wound = /datum/wound/dismemberment/head
 
 	var/mob/living/brain/brainmob = null //The current occupant.


### PR DESCRIPTION
This was done as part of my NPC AI improvements PR before it was moved from here to Ratwood. Basically:
- Makes special wounds more painful, because they're special.
- Makes pain checks use CON instead of END, because a lot of NPCs have insane amounts of END so it's not super easy to just make them OOS in combat.
- Increases the maximum pain level on the chest/head, so targeting chest/head on NPCs can more reliably put them in painstun/painflee.

This is part of bringing over/finishing/etc the NPC AI stuff I had planned for here and PR'd on Ratwood.