### PR TITLE
Adjust head size and price

### DIFF
--- a/code/game/objects/items/rogueitems/natural/heads.dm
+++ b/code/game/objects/items/rogueitems/natural/heads.dm
@@ -12,6 +12,7 @@
 	desc = "the head of a fearsome volf."
 	icon_state = "volfhead"
 	layer = 3.1
+	grid_height = 32
 	sellprice = 10
 
 /obj/item/natural/head/goat
@@ -19,6 +20,7 @@
 	desc = "the head of a simple goat."
 	icon_state = "goathead"
 	layer = 3.1
+	grid_height = 32
 	sellprice = 5
 
 /obj/item/natural/head/fox
@@ -26,6 +28,7 @@
 	desc = "the head of a majestic venard."
 	icon_state = "foxhead"
 	layer = 3.1
+	grid_height = 32
 	sellprice = 6
 
 /obj/item/natural/head/saiga
@@ -33,6 +36,7 @@
 	desc = "the head of a proud saiga."
 	icon_state = "saigahead"
 	layer = 3.1
+	grid_height = 32
 	sellprice = 12
 
 /obj/item/natural/head/direbear
@@ -40,23 +44,23 @@
 	desc = "the head of a terrifying direbear."
 	icon_state = "direbearhead"
 	layer = 3.1
-	sellprice = 16
+	sellprice = 20
 
 /obj/item/natural/head/mole
 	name = "mole head"
 	desc = "the head of a lesser mole."
 	icon_state = "molehead"
 	layer = 3.1
-	w_class = WEIGHT_CLASS_HUGE
-	twohands_required = TRUE
-	sellprice = 16
+	sellprice = 20
 
 /obj/item/natural/head/troll
 	name = "troll head"
 	desc = "the head of a giant troll."
 	icon_state = "trollhead"
 	layer = 3.1
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_NORMAL // We want them to be placeable in headhook
+	grid_height = 96
+	grid_width = 96
 	twohands_required = TRUE
 	sellprice = 110
 
@@ -76,8 +80,8 @@
 	desc = "the head of an unusually large rat."
 	icon_state = "roushead"
 	layer = 3.1
-	grid_height = 64
-	grid_width = 64
+	grid_height = 32
+	grid_width = 32
 	sellprice = 10
 
 /obj/item/natural/head/honeyspider
@@ -85,6 +89,6 @@
 	desc = "the head of a venomous honeyspider."
 	icon_state = "spiderhead"
 	layer = 3.1
-	grid_height = 64
-	grid_width = 64
+	grid_height = 32
+	grid_width = 32
 	sellprice = 10


### PR DESCRIPTION
## About The Pull Request
Adjust the size of heads and some prices based on feedback to encourage literal headhunting playstyle
- Troll Head can now be placed in headhook. They takes up 3x3 space
- Saiga, Volf, Goat Head is now 2x1.
- Direbear and Mole head is now 20 base sellprice. They are 2x2 as before.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_etCrJZsAIQ](https://github.com/user-attachments/assets/be571726-b3a4-4dd7-98dc-c6d2319a8d85)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Just want to make sure headhunting is profitable to engage in and headhooks are good tools to collect heads with, especially troll heads.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
