### PR TITLE
Replaces knight errant's belt

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -90,7 +90,7 @@
 			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 			wrists = /obj/item/clothing/wrists/roguetown/bracers
 			shoes = /obj/item/clothing/shoes/roguetown/boots/armor
-			belt = /obj/item/storage/belt/rogue/leather/plaquegold
+			belt = /obj/item/storage/belt/rogue/leather/steel/tasset
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/flashlight/flare/torch/lantern
 			backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/recipe_book/survival = 1)


### PR DESCRIPTION
## About The Pull Request

Replaces knight errant's belt with a steel tasset belt instead of a gold belt.

## Testing Evidence

It's a single line change.

## Why It's Good For The Game

- Matches their armor a lot better and just looks nicer overall.
- Can't be immediately traded to the merchant roundstart for a ton of extra mammon for free.
- More in line with gear that actual knights have access to. Why does knight errant spawn with a special belt that is normally reserved for the duke and the marshal?
