### PR TITLE
Path buckets correctly in mage tower. Add two wooden bowl, add millst…

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -9025,6 +9025,7 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
+/obj/item/millstone,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
 "dlT" = (
@@ -15087,6 +15088,9 @@
 	pixel_x = 9;
 	pixel_y = 9
 	},
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/magician)
 "frc" = (
@@ -22705,10 +22709,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/undeadmanor)
 "ibU" = (
-/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1
 	},
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "ica" = (
@@ -52847,8 +52851,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/woods)
 "sNq" = (
-/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/town/basement/keep)
 "sNs" = (


### PR DESCRIPTION
…one.

## About The Pull Request
Minor mapping tweak for mage tower, now that I don't play Associate regularly
- Buckets changed to the /wooden subtype so it can hold 33 ounces instead of 24. I hate that, I should repath that shit so the same mistake don't get made.
- Added 3 wooden bowls. Massive mage powercreep.
- Added a millstone

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gvlp Gvlp Gvlp I love properly sized bucket and millstone and having two bowls to share between 5 people.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
