### PR TITLE
Drip or Drown - updated apothecary starting clothes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
@@ -23,19 +23,21 @@
 
 /datum/outfit/job/roguetown/apothecary/pre_equip(mob/living/carbon/human/H)
 	..()
-	pants = /obj/item/clothing/under/roguetown/tights/black
-	shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/black
+	head = /obj/item/clothing/head/roguetown/roguehood/black
+	pants = /obj/item/clothing/under/roguetown/trou/apothecary
+	shirt = /obj/item/clothing/suit/roguetown/shirt/apothshirt
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/black
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/storage/belt/rogue/surgery_bag/full/physician
 	beltr = /obj/item/roguekey/physician
 	id = /obj/item/scomstone/bad
-	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
 		/obj/item/natural/worms/leech/cheele = 1,
 		/obj/item/recipe_book/alchemy = 1,
+		/obj/item/clothing/mask/rogue/physician = 1,
 	)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request

Since we already have named clothes in the game for this specific role, why don't make them wear it on the roundstart? Also, no more open ankles under robes, not the best idea to collect herbs from forest/garden when they are thorny and having your bare flesh open to them. Hood is a nice finishing move, along with plague mask in the bag to seal the drip, making apothecary a worthy apprentice to the physician by looks and skills.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Why It's Good For The Game

Drip = good.  Flashing out clothes that were only craftable before.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
