### PR TITLE
Reduce Parry Chance reduction per point of speed difference to 6%

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -503,7 +503,7 @@
 		prob2defend = prob2defend - (U.STASPD * 10)
 	if(I)
 		if(I.wbalance > 0 && U.STASPD > L.STASPD) //nme weapon is quick, so they get a bonus based on spddiff
-			prob2defend = prob2defend - ( I.wbalance * ((U.STASPD - L.STASPD) * 10) )
+			prob2defend = prob2defend - ( I.wbalance * ((U.STASPD - L.STASPD) * BASE_SWIFT_BALANCE_PARRY_DIFF) )
 		if(I.wbalance < 0 && L.STASPD > U.STASPD) //nme weapon is slow, so its easier to dodge if we're faster
 			prob2defend = prob2defend + ( I.wbalance * ((U.STASPD - L.STASPD) * 10) )
 		if(UH?.mind)

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -1,4 +1,6 @@
 #define BASE_PARRY_STAMINA_DRAIN 5 // Unmodified stamina drain for parry, now a var instead of setting on simplemobs
+#define BASE_SWIFT_BALANCE_PARRY_DIFF 6 // Percentage speed difference reduce parry chance by on swift balance weapon.
+
 /proc/accuracy_check(zone, mob/living/user, mob/living/target, associated_skill, datum/intent/used_intent, obj/item/I)
 	if(!zone)
 		return
@@ -196,7 +198,7 @@
 					attacker_skill = U.mind.get_skill_level(intenty.masteritem.associated_skill)
 					prob2defend -= (attacker_skill * 20)
 					if((intenty.masteritem.wbalance > 0) && (user.STASPD > src.STASPD)) //enemy weapon is quick, so get a bonus based on spddiff
-						prob2defend -= ( intenty.masteritem.wbalance * ((user.STASPD - src.STASPD) * 10) )
+						prob2defend -= ( intenty.masteritem.wbalance * ((user.STASPD - src.STASPD) * BASE_SWIFT_BALANCE_PARRY_DIFF) )
 				else
 					attacker_skill = U.mind.get_skill_level(/datum/skill/combat/unarmed)
 					prob2defend -= (attacker_skill * 20)


### PR DESCRIPTION
## About The Pull Request
Reduce Parry Chance reduction per point of speed difference to 6%
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiles.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
People keep complaining about swift nuking down parry chances so this is a compromise such that Dodge Build are still more powerful offensively without nuking their potential entirely. 

Dodge build tends to have shitty armor and crumble with a single stab that go pass their defenses.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
