### PR TITLE
Update | Removes Rockhill mentions from items.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -663,7 +663,7 @@
 
 /obj/item/rogueweapon/halberd/psyhalberd
 	name = "Stigmata"
-	desc = "Christened in the Siege of Rockhill, these silver-tipped poleaxes - wielded by a lonesome contingent of Saint Eora's paladins - kept the horrors at bay for forty daes-and-nites. Long-since-recovered from the rubble, this relic now serve as a bulwark for the defenseless."
+	desc = "Christened in the Siege of Lirvas, these silver-tipped poleaxes - wielded by a lonesome contingent of Saint Eora's paladins - kept the horrors at bay for forty daes-and-nites. Long-since-recovered from the rubble, this relic now serve as a bulwark for the defenseless."
 	icon_state = "psyhalberd"
 
 /obj/item/rogueweapon/halberd/psyhalberd/ComponentInitialize()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2138,7 +2138,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	quality = DRINK_NICE
 
 /datum/reagent/consumable/ethanol/beer/rtoper
-	name = "Rockhill Toper"
+	name = "Lirvas Toper"
 	boozepwr = 40
 	taste_description = "overwhelming tartness"
 	color = "#e0a400"

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -144,7 +144,7 @@
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/rtoper
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer/rtoper = 48)
-	desc = "A bottle with the Rockhill-crest cork-seal. An especially tart cider from the kingdom of Rockhill. Myths say the brewers let the barrels age in the bog, which results in that especially stong flavour."
+	desc = "A bottle with the Lirvas-crest cork-seal. An especially tart cider from the petty kingdom of Lirvas. Myths say the brewers let the barrels age in the bog, which results in that especially stong flavour."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/nred
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer/nred = 48)


### PR DESCRIPTION
## About The Pull Request

Title.

Eventually all the ancestries should be nuked and replaced with skin color names too.

## Testing Evidence

![dreamseeker_MGcfRCQMYr](https://github.com/user-attachments/assets/4cd2d3c5-58bc-42f6-af42-ad257d88ab20)

## Why It's Good For The Game

Rockhill doesn't exist according to our official map, so I swapped it with the Kingdom of Lirvas:

![image](https://github.com/user-attachments/assets/aa160f56-5c18-4ccd-914c-6164a8e00000)
