### PR TITLE
(WIP) Ports Vanderlin aspirant changes (I don't know what I'm doing)

### DIFF
--- a/code/game/gamemodes/roguetown/roguetown.dm
+++ b/code/game/gamemodes/roguetown/roguetown.dm
@@ -257,7 +257,7 @@ var/global/list/roguegamemodes = list("Rebellion", "Vampires and Werewolves", "E
 /datum/game_mode/chaosmode/proc/pick_aspirants()
 	var/list/possible_jobs_aspirants = list("Prince", "Princess", "Knight Captain", "Steward", "Hand", "Knight")
 	var/list/possible_jobs_helpers = list("Knight Captain", "Prince", "Princess", "Hand",  "Steward", "Knight")
-	var/list/rolesneeded = list("Aspirant","Loyalist","Supporter")
+	var/list/rolesneeded = list("Aspirant", "Supporter")
 
 	antag_candidates = get_players_for_role(ROLE_ASPIRANT)
 	for(var/R in rolesneeded)


### PR DESCRIPTION
## About The Pull Request
In preparation for the new storyteller system and just because we desperately badly need more antagonist variety in general, this ports Vanderlin's new aspirant [system ](https://github.com/Monkestation/Vanderlin/pull/2050). The only problem is, I barely know how to code.
How this changes Aspirant:
- There are no more dedicated loyalists. The Keep should be doing this on it's own.
- The Aspirant and his buddies get to know who eachother are at all times.
- The Aspirant gets a simple boon at the start of the round, selectable from a handful of choices that I haven't messed with besides giving them slightly more flavorful names than "Knives" and "Swords", and removing the Gun option.

How this changes the original PR:
- Changes browser_input_list things to an input(things) list since that doesn't seem to work on our code?
- Removes the gun.
- Changes owner.special_items things to H.mind.special_items because that got that part to compile.

still working on figuring out how tf to replace all the SSmapping.retainer.aspirant things that lead back to Vanderlin's own different antagonist list with something that works for the one we have in game_mode.dm lol
this may be beyond my abilities with code atm but I thought I'd put it up in case anybody wanted to swipe the input changes to do the rest themselves or so I could get help
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
its not compiling yet lol
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
aspirant is fun
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
