### PR TITLE
Fixes blank grab intent clicks draining stamina with no delay

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -50,12 +50,13 @@
 			if(I.w_class < WEIGHT_CLASS_GIGANTIC)
 				item_skip = TRUE
 		if(!item_skip)
-			if(used_intent.releasedrain)
+			if(used_intent.releasedrain && !used_intent.type == INTENT_GRAB)
 				rogfat_add(ceil(used_intent.releasedrain * rmb_stam_penalty))
 			if(used_intent.type == INTENT_GRAB)
 				var/obj/AM = A
 				if(istype(AM) && !AM.anchored)
 					start_pulling(A) //add params to grab bodyparts based on loc
+					rogfat_add(ceil(used_intent.releasedrain * rmb_stam_penalty))
 					return
 			if(used_intent.type == INTENT_DISARM)
 				var/obj/AM = A


### PR DESCRIPTION
## About The Pull Request
It's dubious if this was ever intended by https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/2432 
If it was -- then this is a jak
If it wasn't -- then this is a fix
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled, loaded in. Was able to click on grab intent without stamcritting myself.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It now drains on successful grab connections, which may still not be preferable, but it'll do for the time being.
![dreamseeker_giQb7Ljz2s](https://github.com/user-attachments/assets/2cd17f66-33d8-4e2b-91a5-d3a663c9d2f4)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
