### PR TITLE
Proofreading and Description Pass #5: Wanderlust

### DIFF
--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -262,7 +262,7 @@
 
 /obj/item/rogue/instrument/flute
 	name = "flute"
-	desc = "A slender flute carefully carved from a smooth wood piece."
+	desc = "A row of slender hollow tubes of varying lengths that produce a light airy sound when blown across."
 	icon_state = "flute"
 	song_list = list("Half-Dragon's Ten Mammon" = 'sound/music/instruments/flute (1).ogg',
 	"'The Local Favorite'" = 'sound/music/instruments/flute (2).ogg',

--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -120,7 +120,7 @@
 /obj/item/natural/bone
 	name = "bone"
 	icon_state = "bone"
-	desc = "The meatless remains of the dead. Whether it came from an animal or a person it all looks the same now."
+	desc = "The meatless remains of the dead. Whether it came from an animal or a person, it all looks the same now."
 	blade_dulling = 0
 	max_integrity = 20
 	static_debris = null

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -78,7 +78,7 @@
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust, /datum/intent/dagger/chop)
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH
 	name = "hunting knife"
-	desc = "This survival knife might be able to get you through the wild."
+	desc = "A hunter's prized possession. Keep it sharp, and it might last you through the wild."
 	icon_state = "huntingknife"
 	icon = 'icons/roguetown/weapons/32.dmi'
 	item_state = "bone_dagger"

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -589,7 +589,7 @@
 	possible_item_intents = list(SPEAR_THRUST, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
 	gripped_intents = list(SPEAR_THRUST, /datum/intent/spear/cut/halberd, /datum/intent/sword/chop, SPEAR_BASH)
 	name = "halberd"
-	desc = "A steel halberd, the pinnacle of all cumulative melee weapon knowledge to some, but commonly seen in a guardsman's hands none-the-less. The reinforcements along the shaft provide greater durability."
+	desc = "A steel halberd, the pinnacle of all cumulative melee weapon knowledge. The only downside is the cost, so it's rarely seen outside of the guardsmans' hands. The reinforcements along the shaft provide greater durability."
 	icon_state = "halberd"
 	icon = 'icons/roguetown/weapons/64.dmi'
 	pixel_y = -16

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -9,7 +9,7 @@
  */
 /obj/structure/bed
 	name = "bed"
-	desc = ""
+	desc = "A soft warm bed complete with sheets and pillows."
 	icon_state = "bed"
 	icon = 'icons/obj/objects.dmi'
 	anchored = TRUE

--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -245,7 +245,7 @@
 
 /obj/structure/chair/stool/rogue
 	name = "stool"
-	desc = ""
+	desc = "Three stubby legs nailed to the underside of a small round seat. Stable, if simple."
 	icon_state = "barstool"
 	icon = 'icons/roguetown/misc/structure.dmi'
 	item_chair = /obj/item/chair/stool/bar/rogue
@@ -256,6 +256,7 @@
 
 /obj/item/chair/stool/bar/rogue
 	name = "stool"
+	desc = "Three stubby legs nailed to the underside of a small round seat. Stable, if simple."
 	icon_state = "baritem"
 	icon = 'icons/roguetown/misc/structure.dmi'
 	origin_type = /obj/structure/chair/stool/rogue
@@ -296,6 +297,8 @@
 		rotcomp.HandRot(rotcomp,user,ROTATION_CLOCKWISE)
 
 /obj/structure/bed/rogue/shit
+	name = "straw bed"
+	desc = "A rough bed of straw. It's scratchy, and probably hides lots of bugs, but at least it's dry and warm."
 	icon_state = "shitbed"
 	sleepy = 1
 

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -788,7 +788,7 @@
 		to_chat(user, span_warning("The door doesn't lock from this side."))
 
 /obj/structure/mineral_door/wood/donjon
-	desc = "dungeon door"
+	desc = "A solid metal door with a slot to peek through."
 	icon_state = "donjondir"
 	base_state = "donjon"
 	keylock = TRUE

--- a/code/game/objects/structures/walldeco.dm
+++ b/code/game/objects/structures/walldeco.dm
@@ -27,7 +27,7 @@
 
 /obj/structure/fluff/walldeco/wantedposter
 	name = "bandit notice"
-	desc = ""
+	desc = "A place for posters displaying the faces of roving bandits. Let's see if there are any this week..."
 	icon_state = "wanted1"
 	layer = BELOW_MOB_LAYER
 	pixel_y = 32
@@ -204,7 +204,7 @@
 
 /obj/structure/fluff/walldeco/customflag
 	name = "Azure Peak flag"
-	desc = ""
+	desc = "A banner flutters in the breeze in the proud heraldic colors of the Duchy."
 	icon_state = "wallflag"
 
 /obj/structure/fluff/walldeco/customflag/Initialize()

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -2,6 +2,7 @@
 
 /turf/closed/mineral //wall piece
 	name = "rock"
+	desc = "Lichens and moss cling to the jagged contours of the rock face. It is slick with moisture and exudes the heavy odors of dirt, minerals, and petrichor."
 	icon = 'icons/turf/mining.dmi'
 	icon_state = "rock"
 	var/smooth_icon = 'icons/turf/smoothrocks.dmi'
@@ -190,7 +191,7 @@
 /turf/closed/mineral/random/rogue
 //	layer = ABOVE_MOB_LAYER
 	name = "rock"
-	desc = ""
+	desc = "Lichens and moss cling to the jagged contours of the rock face. It is slick with moisture and exudes the heavy odors of dirt, minerals, and petrichor."
 	icon = 'icons/turf/roguewall.dmi'
 	icon_state = "minrandbad"
 	smooth = SMOOTH_TRUE | SMOOTH_MORE
@@ -219,7 +220,7 @@
 /turf/closed/mineral/rogue
 //	layer = ABOVE_MOB_LAYER
 	name = "rock"
-	desc = ""
+	desc = "Lichens and moss cling to the jagged contours of the rock face. It is slick with moisture and exudes the heavy odors of dirt, minerals, and petrichor."
 	icon = 'icons/turf/roguewall.dmi'
 	icon_state = "rockyash"
 	smooth = SMOOTH_TRUE | SMOOTH_MORE
@@ -293,7 +294,7 @@
 
 /turf/closed/mineral/rogue/bedrock
 	name = "rock"
-	desc = "seems barren, and nigh indestructable"
+	desc = "Seems barren and nigh-indestructable"
 	icon_state = "rockyashbed"
 //	smooth_icon = 'icons/turf/walls/hardrock.dmi'
 	max_integrity = 10000000

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -75,7 +75,7 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 	name = "gambeson"
-	desc = "A large shirt meant to be used below armor."
+	desc = "A large shirt meant to be worn below armor."
 	icon_state = "gambeson"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|VITALS
 	armor = list("blunt" = 60, "slash" = 40, "piercing" = 50, "stab" = 30, "fire" = 0, "acid" = 0)
@@ -91,14 +91,14 @@
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/light
 	name = "light gambeson"
-	desc = "A barely padded gambeson, typically worn by the peasantry as cheap yet fashionable armor for the whole body. May stop an arrow."
+	desc = "A thin barely-padded gambeson, typically worn by the peasantry as cheap yet fashionable armor for the whole body. May stop an arrow."
 	armor = list("blunt" = 40, "slash" = 30, "stab" = 20, "piercing" = 40, "fire" = 0, "acid" = 0)
 	prevent_crits = null // It won't help, like, at all.
 	sellprice = 10
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 	name = "padded gambeson"
-	desc = "A gambeson with additional padding layers, hardened to make it more durable. Typically used as a layer under plate armor, it still cannot compare to proper armor. Will probably stop a crossbow bolt."
+	desc = "A gambeson with additional padding layers, hardened to make it more durable. It still does not compare to leather or metal, but it will probably stop a crossbow bolt, so it's typically worn to complement proper armor."
 	icon_state = "gambesonp"
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_CHOP)
 	armor = list("blunt" = 80, "slash" = 50, "stab" = 50, "piercing" = 80, "fire" = 0, "acid" = 0)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -97,6 +97,7 @@
 
 /obj/effect/decal/remains/crow
 	name = "zad remains"
+	desc = "Nevermore..."
 	gender = PLURAL
 	icon_state = "crow1"
 	icon = 'icons/roguetown/mob/monster/crow.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/roguetown/crow.dm
+++ b/code/modules/mob/living/simple_animal/hostile/roguetown/crow.dm
@@ -1,6 +1,6 @@
 /obj/item/reagent_containers/food/snacks/crow
 	name = "zad"
-	desc = "Pesky bird."
+	desc = "A black bird commonly associated with Necra. They were once trained for use in carrying messages around and respected for their cleverness, but are nowadays considered no better than vermin."
 	icon_state = "crow"
 	icon = 'icons/roguetown/mob/monster/crow.dmi'
 	list_reagents = list(/datum/reagent/consumable/nutriment = 4)
@@ -20,7 +20,7 @@
 
 /obj/item/reagent_containers/food/snacks/rogue/friedcrow
 	name = "fried zad"
-	desc = ""
+	desc = "It took some work to pluck off all the feathers, but in the end you prevailed. The result is a surprisingly crispy, if bland, morsel."
 	icon = 'icons/roguetown/items/food.dmi'
 	icon_state = "fcrow"
 	bitesize = 2

--- a/code/modules/mob/living/simple_animal/hostile/roguetown/smallrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/roguetown/smallrat.dm
@@ -1,6 +1,6 @@
 /obj/item/reagent_containers/food/snacks/smallrat
 	name = "rat"
-	desc = ""
+	desc = "A scurrying rodent often found in sewers and pantries."
 	icon_state = "srat"
 	icon = 'icons/roguetown/mob/monster/rat.dmi'
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5)

--- a/code/modules/mob/living/simple_animal/hostile/roguetown/werewolf/werewolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/roguetown/werewolf/werewolf.dm
@@ -1,7 +1,7 @@
 
 /mob/living/simple_animal/hostile/rogue/werewolf
 	name = "WEREWOLF"
-	desc = ""
+	desc = "THE HOWL OF A MAD GOD SHAKES YOUR BONES! FLESH SHORN INTO VISCERA SPRAYS THE WALLS! RIP AND TEAR!"
 	icon = 'icons/roguetown/mob/monster/werewolf.dmi'
 	icon_state = "wwolf_m"
 	icon_living = "wwolf_m"

--- a/code/modules/mob/living/simple_animal/rogue/creacher/volf.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/volf.dm
@@ -3,6 +3,7 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf
 	icon = 'icons/roguetown/mob/monster/vol.dmi'
 	name = "volf"
+	desc = "A snarling beast of mangy fur and yellowed teeth. Volves are known to attack hapless travelers in the deep forests when prey is scarce."
 	icon_state = "vv"
 	icon_living = "vv"
 	icon_dead = "vvd"
@@ -75,6 +76,7 @@
 
 /obj/effect/decal/remains/wolf
 	name = "remains"
+	desc = "Whether by starvation, disease, inter-pack conflict, or an unlucky kick from a saiga, this volf has died."
 	gender = PLURAL
 	icon_state = "bones"
 	icon = 'icons/roguetown/mob/monster/vol.dmi'

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 	poursounds = list('sound/items/fillbottle.ogg')
 	experimental_onhip = TRUE
 	debris = list(/obj/item/natural/glass/shard = 1)
-	var/desc_uncorked = "An open bottle, hopefully a cork is close by."
+	var/desc_uncorked = "An open bottle. Hopefully the cork is nearby."
 	var/fancy		// for bottles with custom descriptors that you don't want to change when bottle manipulated
 
 /obj/item/reagent_containers/glass/bottle/update_icon(dont_fill=FALSE)
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 		spillable = TRUE
 		GLOB.weather_act_upon_list |= src
 		if(!fancy)
-			desc = "An open bottle, hopefully a cork is close by."
+			desc = "An open bottle. Hopefully a cork is nearby."
 	update_icon()
 
 /obj/item/reagent_containers/glass/bottle/Initialize()

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
@@ -1,6 +1,6 @@
 /obj/item/reagent_containers/glass/bottle/alchemical
 	name = "alchemical vial"
-	desc = "A cute bottle that can hold three swigs of a fluid, which is useful for both miserly business practices and preventing accidental overdosing."
+	desc = "A cute bottle that can hold three swigs of liquid, which is useful for both miserly business practices and preventing accidental overdosing. This one lacks a cork."
 	icon = 'icons/roguetown/misc/alchemy.dmi'
 	icon_state = "vial_bottle"
 	amount_per_transfer_from_this = 9


### PR DESCRIPTION
## About The Pull Request

This PR adds more flavorful descriptions to many things. Unlike the previous ones which more or less followed a specific theme, this one aimed for a more scattered approach; rather than diving through the code, I wandered around in-game and took notes of whatever I stumbled across for a more natural and organic process.

- Random weapons
- Rock walls
- Random furniture
- Bandit posters
- Zads, rats, volves, and the dreaded werewolf!
- Minor proofreading

Unfortunately for me, I learned that descriptions don't seem to work for mobs. Hopefully such a day comes when they can be read in-game.

## Testing Evidence
![dreammaker_gq9K1TdYNF](https://github.com/user-attachments/assets/830ad6e1-6bcf-40ac-a8cb-72e2455dd045)
![dreamseeker_nD2sM6TLLJ](https://github.com/user-attachments/assets/55ac97c1-a0f4-46c4-bf52-0a0657085554)
![dreamseeker_xRW5NLqJeO](https://github.com/user-attachments/assets/2a25b1b1-6eec-47d7-a278-fcb5930c9a0c)
![dreamseeker_rrO6BGRMWd](https://github.com/user-attachments/assets/f27635ad-3f7b-478e-9e50-2fe6e2e066af)
![dreamseeker_Pra8UO6O2n](https://github.com/user-attachments/assets/14f61a7f-a771-4e5e-a114-c7622ec0cfb2)
![dreamseeker_u8Ko0xgk78](https://github.com/user-attachments/assets/370c400e-2311-4d93-ad23-eebc2365658d)
![dreamseeker_HzV21gmZSh](https://github.com/user-attachments/assets/8db01276-11b6-4f4b-8ec4-a172bb0747d0)

Quality Control Notes:

- The rock wall flavor text was applied to all mineral walls for consistency and to avoid giving away the ones that have ores.
- The uncorked alchemical vial description was adjusted to account for the lack of a cork.

## Why It's Good For The Game

Flavor text and description further expands on the world and makes it feel more alive.