### PR TITLE
Add custom colour to FT/Paperwork

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -457,6 +457,17 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 	t = replacetext(t, "!", "$a")
 
+	// Parse colour
+	if(!barebones)
+		var/regex/hexgex = regex(@"(?<=-=)(.{6})", "g")
+		while(hexgex.Find(t))
+			var/endblock = findtext(t, "=-", hexgex.index)
+			if(!endblock)
+				break
+			t = replacetext(t, "=-", "</font>", hexgex.index, endblock+2)
+			var/c_code = sanitize_hexcolor(hexgex.match)
+			t = replacetext(t, "-=[hexgex.match]", "<font color='[c_code]'>", hexgex.index-2, endblock+2)
+
 	// Parse hr and small
 
 	if(!limited)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1629,7 +1629,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					dat += "^text^ : Increases the <font size = \"4\">size</font> of the text.<br>"
 					dat += "((text)) : Decreases the <font size = \"1\">size</font> of the text.<br>"
 					dat += "* item : An unordered list item.<br>"
-					dat += "--- : Adds a horizontal rule.<br><br>"
+					dat += "--- : Adds a horizontal rule.<br>"
+					dat += "-=FFFFFFtext=- : Adds a specific <font color = '#FFFFFF'>colour</font> to text.<br><br>"
 					dat += "Minimum Flavortext: <b>[MINIMUM_FLAVOR_TEXT]</b> characters.<br>"
 					dat += "Minimum OOC Notes: <b>[MINIMUM_OOC_NOTES]</b> characters."
 					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 350)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -336,7 +336,8 @@
 		((text)) : Decreases the <font size = \"1\">size</font> of the text.<br>
 		* item : An unordered list item.<br>
 		&nbsp;&nbsp;* item: An unordered list child item.<br>
-		--- : Adds a horizontal rule.
+		--- : Adds a horizontal rule.<br>
+		-=FFFFFFtext=- : Adds a specific <font color = '#FFFFFF'>colour</font> to text.
 	</BODY></HTML>"}, "window=paper_help")
 
 


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin.

`-=FFFFFFtext=-` to do so. `FFFFFF` is of course where your colour code of choice goes. Works with all other formattings, does work on paper.

## Testing Evidence

![NVIDIA_Overlay_qIL6JGSAgQ](https://github.com/user-attachments/assets/29fe993e-f52b-4d4e-bf42-ef162f4d016a)
![NVIDIA_Overlay_TBkINQoAPD](https://github.com/user-attachments/assets/3e7f1b7e-b3cc-4386-8c6b-6762fb4f9894)
Example shows using this with nesting as well as other formatting option and multi-line.

## Why It's Good For The Game

More customisation in paper and FTs are good. These colours are not restricted - and *can* be a bit painfully if asked to.
Sanitised, and does not have a decent chance in malicious HTML/XML code injection.
