### PR TITLE
Typing indicator now remains visible more reliably

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -139,5 +139,3 @@
 
 /client/verb/disableInput()
 	set hidden = 1
-	if(isliving(mob))
-		mob.clear_typing_indicator()


### PR DESCRIPTION
## About The Pull Request
Any input used to disable it. I removed that bit of code. Hopefully that check wasn't added to cover up some  strange edge cases where it didn't go away. (It probably was)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_QhA8hKt5kj](https://github.com/user-attachments/assets/1d288eaa-6a52-4629-a201-95e5cf8f5a36)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Typebaits will no longer be as frequent, but bugged typing indicators might become more frequent.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
