### PR TITLE
Raw Materials Withdraw reduction + Stone 30 limit

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile_rawmat.dm
+++ b/code/modules/roguetown/roguestock/stockpile_rawmat.dm
@@ -4,7 +4,7 @@
 	item_type = /obj/item/grown/log/tree/small
 	held_items = list(2, 2)
 	payout_price = 3
-	withdraw_price = 5
+	withdraw_price = 3
 	transport_fee = 3
 	export_price = 5
 	importexport_amt = 10
@@ -17,7 +17,7 @@
 	item_type = /obj/item/rogueore/coal
 	held_items = list(5, 0)
 	payout_price = 4
-	withdraw_price = 6
+	withdraw_price = 4
 	transport_fee = 4
 	export_price = 6
 	importexport_amt = 10
@@ -29,12 +29,12 @@
 	desc = "Stones. Used for construction"
 	item_type = /obj/item/natural/stone
 	held_items = list(10, 0)
-	payout_price = 0
+	payout_price = 1
 	withdraw_price = 1
 	transport_fee = 0
 	export_price = 1
 	importexport_amt = 10
-	stockpile_limit = 0
+	stockpile_limit = 30 // Allow a small amount of stones to be sold for chiselling
 	passive_generation = 10 // Free rocks!!
 
 /datum/roguestock/stockpile/glass
@@ -43,7 +43,7 @@
 	item_type = /obj/item/natural/clay/glassbatch
 	held_items = list(5, 0)
 	payout_price = 4
-	withdraw_price = 7
+	withdraw_price = 4
 	transport_fee = 5
 	export_price = 5
 	importexport_amt = 10
@@ -56,7 +56,7 @@
 	item_type = /obj/item/rogueore/iron
 	held_items = list(6, 0)
 	payout_price = 5
-	withdraw_price = 8
+	withdraw_price = 5
 	transport_fee = 6
 	export_price = 8
 	importexport_amt = 10
@@ -69,7 +69,7 @@
 	item_type = /obj/item/rogueore/copper
 	held_items = list(6, 0)
 	payout_price = 3
-	withdraw_price = 5
+	withdraw_price = 3
 	transport_fee = 3
 	export_price = 5
 	importexport_amt = 10
@@ -82,7 +82,7 @@
 	item_type = /obj/item/rogueore/tin
 	held_items = list(6, 0)
 	payout_price = 4
-	withdraw_price = 5
+	withdraw_price = 4
 	transport_fee = 4
 	export_price = 5
 	importexport_amt = 10
@@ -95,7 +95,7 @@
 	item_type = /obj/item/rogueore/gold
 	held_items = list(0, 0)
 	payout_price = 50
-	withdraw_price = 75
+	withdraw_price = 50
 	transport_fee = 10
 	export_price = 75
 	stockpile_limit = 20
@@ -107,7 +107,7 @@
 	item_type = /obj/item/rogueore/silver
 	held_items = list(0, 0)
 	payout_price = 75
-	withdraw_price = 100
+	withdraw_price = 75
 	transport_fee = 10
 	export_price = 100
 	stockpile_limit = 20


### PR DESCRIPTION
## About The Pull Request
Follow up on my other economic PR to make stockpile actually used for WITHDRAWING MATERIALS.

- Remaining materials's withdraw price is lowered to match payout price, to cement stockpile's role as a way to exchange goods. The crown **do not** need to make more arbitrage profits. By default the price should favor stockpile as a way to feed materials the town need and withdraw materials producer need. 
- Stone's stockpile limit raised to 30 so there's a little bit of incentives to sell some stones instead of none to supply some building materials.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Because it is.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
