### PR TITLE
Fixes legendary butchering, fixes butchering certain creatures

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -419,7 +419,6 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		ssaddle = null
 	if(butcher_results || guaranteed_butcher_results)
 		var/list/butcher = list()
-
 		if(butcher_results)
 			if(user.mind.get_skill_level(/datum/skill/labor/butchering) == 0)
 				if(prob(70))
@@ -447,11 +446,11 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 				else
 					butcher = butcher_results
 			else
-				if(user.mind.get_skill_level(/datum/skill/labor/butchering) == 5)
+				if(user.mind.get_skill_level(/datum/skill/labor/butchering) >= 5)
 					butcher = perfect_butcher_results // only get the best results
 				else
 					butcher = butcher_results		// fallback incase skill doesn't get called
-
+		butcher ||= butcher_results // if the butcher value returns null, instead use default butcher_results
 		var/rotstuff = FALSE
 		var/datum/component/rot/simple/CR = GetComponent(/datum/component/rot/simple)
 		if(CR)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

- Fixes bug where butchering w/ legendary skill would always net you the normal butcher results.
- Fixes bug where butchering creatures that were missing their perfect or botched butchering lists would occasionally produce nothing. 
- The Mumblemancer's First PR . . . Please be nice if it somehow breaks :((

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
- It compiles. I butchered roughly 8 creatures at varying skill levels, including minotaurs, goats, saigas, ETC. AFAIK, all of it works perfectly fine. I used oldchat and didnt spot any runtimes.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
- Bugfixes.
- This _does_ make botched butchers on these creatures produce normal butchering results, however, this is not my problem. If the economy crashes because minos and dragons get butchered by 0 skill people.... IDK man add a botched butcher list to them. I can also do this LaterTM.
- Sutures will probably replace this soon W/ better overall butchery code to replace the if/elif tree. 