### PR TITLE
Farm Tools & Brew

### DIFF
--- a/code/datums/skills/craft.dm
+++ b/code/datums/skills/craft.dm
@@ -66,7 +66,7 @@
 
 /datum/skill/craft/traps
 	name = "Trapmaking"
-	desc = "Determines whether you can craft mantraps. That's it."
+	desc = "Determines whether you can craft mantraps and if you can spot and disable traps."
 	dreams = list(
 		"...you spin a quiet silver wire across a hallway, lying in wait for your prey. The monstrous pale volf approaches. This time, you are prepared...",
 		"...the gleam of the trap's sharp teeth catches the dim light as you conceal it beneath layers of brush and foliage. To the untrained eye, it's nothing more than a harmless patch of grass - but you know better..."
@@ -74,7 +74,7 @@
 
 /datum/skill/craft/cooking
 	name = "Cooking"
-	desc = "Increases cooking & ingredients preparation speed. -25% if none, 0% if Novice, +50% per level after."
+	desc = "Increases cooking & ingredients preparation speed. -25% if none, 0% if Novice, +50% per level after. At Journeyman you can ferment crops in a barrel."
 	dreams = list(
 		"...over a crackling campfire, a slab of fresh meat sizzles as it cooks, its scent filling the air. The simplest meals are often the most difficult to perfect...",
 		"...your knife bears down onto a wheel of cheese, and you cut away at the imperfections that lie on its skin. Next would be the eggs and the dough, and they'll roll together into a wonderful meal...",

--- a/code/modules/farming/fermenting_barrel.dm
+++ b/code/modules/farming/fermenting_barrel.dm
@@ -37,6 +37,9 @@
 	return TRUE
 
 /obj/structure/fermenting_barrel/attackby(obj/item/I, mob/user, params)
+	if(user.mind.get_skill_level(/datum/skill/craft/cooking) <= 3)
+		to_chat(user, span_notice("I am not knowledgable enough to brew."))
+		return FALSE
 	if(istype(I,/obj/item/reagent_containers/food/snacks/grown))
 		if(try_ferment(I, user))
 			return TRUE

--- a/code/modules/farming/plough.dm
+++ b/code/modules/farming/plough.dm
@@ -10,6 +10,10 @@
 	facepull = FALSE
 	drag_slowdown = 2
 
+/obj/structure/plough/examine(mob/user)
+	. = ..()
+	. += span_notice("TILTS any dirt/grass tile it's dragged over - requires user to drag it while having SNEAK active.")
+
 /obj/structure/plough/Moved(oldLoc, movement_dir)
 	. = ..()
 	if(pulledby && pulledby.m_intent == MOVE_INTENT_SNEAK)

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -27,6 +27,10 @@
 	misscost = 0
 	no_attack = TRUE
 
+/obj/item/rogueweapon/thresher/examine(mob/user)
+	. = ..()
+	. += span_notice("Use on STRIKE intent to break up produce for seeds. THRESH on stalks to beat out grains.")
+
 /obj/item/rogueweapon/thresher/getonmobprop(tag)
 	. = ..()
 	if(tag)
@@ -76,6 +80,10 @@
 	slot_flags = ITEM_SLOT_HIP
 	max_blade_int = 50
 	smeltresult = /obj/item/ingot/iron
+
+/obj/item/rogueweapon/sickle/examine(mob/user)
+	. = ..()
+	. += span_notice("Use on any plant to instantly harvest it. HERBS turn to fiber when attacked.")
 
 /obj/item/rogueweapon/sickle/getonmobprop(tag)
 	. = ..()
@@ -136,6 +144,10 @@
 	max_integrity = 100
 	hoe_damage = 25
 	work_time = 15 SECONDS
+
+/obj/item/rogueweapon/hoe/examine(mob/user)
+	. = ..()
+	. += span_notice("TILT intent allows you to make new plots for plants. Using it (on any intent) on a plot that already has something planted removes WEEDS.")
 
 /obj/item/rogueweapon/hoe/getonmobprop(tag)
 	. = ..()
@@ -282,6 +294,10 @@
 	slot_flags = ITEM_SLOT_BACK
 	drop_sound = 'sound/foley/dropsound/wooden_drop.ogg'
 	smeltresult = /obj/item/ingot/iron
+
+/obj/item/rogueweapon/pitchfork/examine(mob/user)
+	. = ..()
+	. += span_notice("Use RIGHT CLICK to flip compost in the bin. While wielded SCOOP intent allows you to pick up large amount (19) stalks.")
 
 /obj/item/rogueweapon/pitchfork/getonmobprop(tag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds descriptions to farm tools in the ways on how to actually use them (some were very obscure like plough).
Fermenting barrels now require lvl 3 cooking (Journeyman) to ferment anything in.
Updated cooking and trapmaking descriptions.

## Testing Evidence

![image](https://github.com/user-attachments/assets/76ff28b5-a550-46a7-8852-8ae2c6678625)

![image](https://github.com/user-attachments/assets/f51fca1b-490b-4570-889b-cab2ea8834f6)

## Why It's Good For The Game

The tools are obscure in some of their uses so some clarifications for new players is probably a good idea since it's not all too intuitive.
With how much I buffed fermentation in barrels it did lead to tapsters being out of the job pretty much since even little amounts of produce could fully satisfy the demand of alcoholics. This way you have to either grind it out or take a virtue to be able to do it.
