### PR TITLE
Make base helmet hide hair/ears + Fullcoif hides snout

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -602,6 +602,7 @@
 	name = "helmet"
 	desc = "A helmet that doesn't get any more simple in design."
 	body_parts_covered = HEAD|HAIR|NOSE
+	flags_inv = HIDEHAIR|HIDEEARS
 	icon_state = "nasal"
 	sleevetype = null
 	sleeved = null

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -115,7 +115,7 @@
 /obj/item/clothing/neck/roguetown/chaincoif/full
 	name = "full chain coif"
 	icon_state = "fchaincoif"
-	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	resistance_flags = FIRE_PROOF
 	body_parts_covered = NECK|MOUTH|NOSE|HAIR|EARS|HEAD
 	adjustable = CAN_CADJUST


### PR DESCRIPTION
## About The Pull Request

Helmets (base) hide ears and hair. Children helms that override flags_inv and aren't already meant to hide hair won't be affected.
Full-face coif hides snout.

## Testing Evidence

Not extensively tested. But will work.

## Why It's Good For The Game

Helmet not hiding hair/ears made them look silly.  Same for the full-face coif.
