### PR TITLE
Adds mid-mousebutton interaction for helmets to hide hair+ears

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -159,6 +159,7 @@
 #define HIDEEYES		(1<<6)	// Whether eyes and glasses are hidden
 #define HIDEFACE		(1<<7)	// Whether we appear as unknown.
 #define HIDEHAIR		(1<<8)
+#define HIDE_HEADTOP	(HIDEEARS | HIDEHAIR)
 #define HIDEFACIALHAIR	(1<<9)
 #define HIDENECK		(1<<10)
 #define HIDEBOOB		(1<<11)

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -620,6 +620,15 @@
 	experimental_onhip = TRUE
 	experimental_inhand = TRUE
 
+/obj/item/clothing/head/roguetown/helmet/MiddleClick(mob/user)
+	if(!ishuman(user))
+		return
+	if(flags_inv & HIDE_HEADTOP)
+		flags_inv &= ~HIDE_HEADTOP
+	else
+		flags_inv |= HIDE_HEADTOP
+	user.update_inv_head()
+
 /obj/item/clothing/head/roguetown/helmet/getonmobprop(tag)
 	if(tag)
 		switch(tag)


### PR DESCRIPTION
## About The Pull Request

Puts this up to a middlemousebutton interaction to toggle hair/ears hiding.
Helms with existing MMB interactions aren't affected and also can't have their hair/ears toggled.

## Testing Evidence

Tested.

## Why It's Good For The Game

Choices.
Future MMB interactions for any helm can override the same interaction. If asked, can switch this to something obscure like alt+click or smth.
