### PR TITLE
Volf Helm adjustment

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -1429,7 +1429,7 @@
 	body_parts_covered = HEAD|HAIR|EARS
 	icon_state = "volfhead"
 	item_state = "volfhead"
-	armor = ARMOR_HEAD_CLOTHING
+	armor = ARMOR_HEAD_HELMET_BAD
 	max_integrity = 100
 	prevent_crits = list(BCLASS_BLUNT, BCLASS_TWIST)
 	anvilrepair = null


### PR DESCRIPTION
## About The Pull Request

Very simple change/buff/revert(?). All it does is up the armor on the wolf helm from ARMOR_HEAD_CLOTHING to ARMOR_HEAD_HELMET_BAD.

## Testing Evidence

I changed a single line of code.

## Why It's Good For The Game

Before the standardisation, the Volf Helm had the same stats as the Leather Helmet. Its description is: "A leather helmet fashioned from a volf's head." It's a leather helmet with a volf helm stitched on it. Further, codewise, it's a child of the leather helm and mechanics wise and its crafting recipe is found in leather_armor_recipes.dm, the filepath for **leather armor**. Not to mention, it takes more to craft than the leather helm.

It should have the same armor as the leather helm and the saiga head, thus the change. I can only imagine this was an oversight during the armor standardisation.