### PR TITLE
Lets helmet not hide hair/ears by default

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -602,7 +602,6 @@
 	name = "helmet"
 	desc = "A helmet that doesn't get any more simple in design."
 	body_parts_covered = HEAD|HAIR|NOSE
-	flags_inv = HIDEHAIR|HIDEEARS
 	icon_state = "nasal"
 	sleevetype = null
 	sleeved = null


### PR DESCRIPTION
## About The Pull Request

Was supposed to be done so in the previous PR.

## Testing Evidence

Tested.

## Why It's Good For The Game

Reverts to the status quo of no-hair/ear hiding on helms since MMB hides them, now.
