### PR TITLE
QOL refunds for Anastasis on cast failures

### DIFF
--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -69,14 +69,18 @@
 		testing("revived1")
 		var/mob/living/target = targets[1]
 		if(!target.mind)
+			revert_cast()
 			return FALSE
 		if(!target.mind.active)
 			to_chat(user, "Astrata is not done with [target], yet.")
+			revert_cast()
 			return FALSE
 		if(target == user)
+			revert_cast()
 			return FALSE
 		if(target.stat < DEAD)
 			to_chat(user, span_warning("Nothing happens."))
+			revert_cast()
 			return FALSE
 		if(GLOB.tod == "night")
 			to_chat(user, span_warning("Let there be light."))
@@ -92,6 +96,7 @@
 		target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 		if(!target.revive(full_heal = FALSE))
 			to_chat(user, span_warning("Nothing happens."))
+			revert_cast()
 			return FALSE
 		testing("revived2")
 		var/mob/living/carbon/spirit/underworld_spirit = target.get_spirit()


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Anastasis has some painful failures for casting on inactive minds, unlike lux which rejects and then allows you to go ahead with the next lux revive attempt. This fixes that.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

It compiles. All of the lines are before a return false, so that checks out.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Helps the church in dealing with the after-effect of slaughters, not have their resurrect eaten by an inactive mind. This was never the case before the ask to check if someone wants to respawn. But now, and especially with some of the other bugs spoken about in anastasis, this will help a little.
