### PR TITLE
Fixes Vagabond Spawn and RTField miszone in new buildings

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -2637,6 +2637,10 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"aTP" = (
+/obj/effect/landmark/start/orphan,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/beach)
 "aTQ" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
@@ -3420,7 +3424,7 @@
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "bgY" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -3976,11 +3980,6 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
-"brV" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
 "brW" = (
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
@@ -5399,9 +5398,6 @@
 	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
-"bQj" = (
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/outdoors/rtfield)
 "bQF" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -7465,9 +7461,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "cCY" = (
-/obj/structure/mineral_door/wood/towner/generic,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/rtfield)
+/obj/effect/landmark/start/orphan,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/town)
 "cDa" = (
 /obj/structure/bars/pipe,
 /turf/open/floor/rogue/metal/barograte/open,
@@ -7647,14 +7643,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"cGA" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "cGC" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble,
@@ -10370,14 +10358,6 @@
 /obj/item/cooking/platter/gold,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/shelter/mountains/decap)
-"dEj" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "dEw" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -11246,10 +11226,6 @@
 "dUU" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave)
-"dUV" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
 "dUW" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobblerock,
@@ -13734,8 +13710,9 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town)
 "eLb" = (
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/outdoors/rtfield)
+/obj/effect/landmark/start/orphan,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/town)
 "eLe" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -17489,7 +17466,7 @@
 "fYx" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "fZc" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
@@ -17947,14 +17924,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
-"ghB" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "ghJ" = (
 /mob/living/carbon/human/species/goblin/npc/hell,
 /turf/open/floor/rogue/grasscold,
@@ -18399,6 +18368,11 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
+"gpG" = (
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/orphan,
+/turf/open/floor/rogue/woodturned,
+/area/rogue/outdoors/town)
 "gpR" = (
 /obj/structure/closet/crate/chest,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
@@ -19116,12 +19090,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"gAF" = (
-/obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "gAH" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/rogue/hexstone,
@@ -21233,14 +21201,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark)
-"hjR" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "hjS" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -24153,13 +24113,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "ijl" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
+/obj/effect/landmark/start/orphan,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town)
 "ijo" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -26043,14 +25999,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
-"iNX" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "iOk" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -27263,11 +27211,6 @@
 /obj/item/clothing/head/roguetown/articap,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"jil" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "jim" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = -32
@@ -28055,9 +27998,6 @@
 /obj/item/rope,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"jya" = (
-/turf/closed/wall/mineral/rogue/decowood/vert,
-/area/rogue/outdoors/rtfield)
 "jyb" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -28958,10 +28898,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/under/cave/dukecourt)
-"jPf" = (
-/obj/structure/mineral_door/wood/towner/generic,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/rtfield)
 "jPl" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
@@ -30372,12 +30308,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark)
-"koY" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "kpa" = (
 /obj/structure/mirror,
 /obj/structure/chair/stool/rogue,
@@ -31471,7 +31401,7 @@
 /obj/item/seeds/berryrogue,
 /obj/item/seeds/berryrogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "kIh" = (
 /obj/structure/roguemachine/scomm,
 /turf/open/floor/rogue/dirt/road,
@@ -33376,7 +33306,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "lqH" = (
 /obj/structure/floordoor{
 	redstone_id = "entryduke"
@@ -36178,7 +36108,7 @@
 /obj/item/reagent_containers/glass/bottle,
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "mqv" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/naturalstone,
@@ -36379,9 +36309,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/bogcaves/sunkencity)
 "mtZ" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/obj/structure/flora/roguegrass,
+/obj/effect/landmark/start/orphan,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "mub" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/mannequin/male/female,
@@ -37716,11 +37647,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
 "mTe" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/obj/effect/landmark/start/orphan,
+/turf/open/floor/rogue/dirt,
+/area/rogue/outdoors/town)
 "mTr" = (
 /obj/structure/fermenting_barrel/water,
 /turf/open/floor/rogue/tile/masonic{
@@ -41991,7 +41920,7 @@
 	dir = 6
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "osb" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor5-old"
@@ -42905,9 +42834,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/shelter/woods)
-"oGW" = (
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
 "oGY" = (
 /obj/item/paper{
 	pixel_x = 2;
@@ -43877,7 +43803,7 @@
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "oXt" = (
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/cave/orcdungeon)
@@ -44094,7 +44020,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "pbd" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -44495,7 +44421,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "phq" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -46109,7 +46035,7 @@
 /obj/machinery/light/rogue/oven/east,
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "pJe" = (
 /obj/effect/spawner/lootdrop/roguetown,
 /obj/structure/closet/crate/chest,
@@ -46962,7 +46888,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "pXd" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -48531,14 +48457,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/roofs)
-"qxE" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "qxL" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/hexstone,
@@ -51503,14 +51421,6 @@
 	icon_state = "weird1"
 	},
 /area/rogue/indoors/town/church/chapel)
-"rAp" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
 "rAA" = (
 /obj/structure/table/church{
 	icon_state = "churchtable_mid_alt"
@@ -52322,12 +52232,6 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/random,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
-"rPo" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "rPA" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	icon_state = "iron_corner"
@@ -56375,12 +56279,6 @@
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/physician)
-"tgM" = (
-/obj/machinery/light/rogue/oven/south,
-/obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
 "tgQ" = (
 /obj/structure/roguemachine/mail/l,
 /turf/open/floor/rogue/wood/herringbone,
@@ -57345,14 +57243,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor)
-"txo" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/outdoors/rtfield)
 "txq" = (
 /obj/machinery/light/rogue/torchholder/c{
 	dir = 1
@@ -58644,9 +58534,6 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
-"tSB" = (
-/turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
 "tSE" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -59309,13 +59196,6 @@
 /obj/item/reagent_containers/glass/mortar,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
-"udG" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
 "udK" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 2;
@@ -59842,7 +59722,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "ulD" = (
 /obj/structure/bars/pipe{
 	dir = 4
@@ -61289,7 +61169,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "uMT" = (
 /obj/item/grown/log/tree/stick,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -63597,7 +63477,7 @@
 "vBc" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "vBd" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 8
@@ -64278,7 +64158,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "vMi" = (
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
 /turf/open/floor/rogue/cobble/mossy,
@@ -68095,7 +67975,7 @@
 	locked = 1
 	},
 /turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/rtfield)
+/area/rogue/indoors/town)
 "wZr" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
 /turf/open/water/bath,
@@ -69020,10 +68900,6 @@
 /obj/structure/bookcase/random/archive,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"xoW" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/rtfield)
 "xpc" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
@@ -71175,10 +71051,6 @@
 /obj/structure/mineral_door/wood/donjon/stone/broken,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"yeK" = (
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/outdoors/rtfield)
 "yeZ" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/cobblerock,
@@ -71502,6 +71374,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"yjS" = (
+/obj/effect/landmark/start/orphan,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/tavern)
 "yjX" = (
 /obj/structure/spacevine,
 /obj/structure/flora/roguegrass/maneater/real,
@@ -163200,7 +163076,7 @@ miF
 bhJ
 bhJ
 bhJ
-svv
+aTP
 kDS
 uEY
 pCG
@@ -247206,7 +247082,7 @@ fpx
 fpx
 aFv
 aFv
-aFv
+mTe
 aFv
 aFv
 aFv
@@ -250391,7 +250267,7 @@ sns
 saG
 dJN
 dJN
-rbu
+yjS
 taS
 nmH
 pvg
@@ -257605,7 +257481,7 @@ lGv
 fpx
 fpx
 fpx
-fpx
+cCY
 fpx
 fpx
 nea
@@ -258040,7 +257916,7 @@ uBc
 cDX
 cDX
 cDX
-qyR
+eLb
 jrV
 sns
 sns
@@ -258459,7 +258335,7 @@ iMd
 iMd
 iMd
 iMd
-fpx
+cCY
 fpx
 fpx
 fpx
@@ -258986,7 +258862,7 @@ okN
 rbu
 rbu
 rbu
-rbu
+yjS
 uBc
 aoF
 dra
@@ -260829,7 +260705,7 @@ kRg
 kRg
 kRg
 giW
-suk
+gpG
 suk
 mbo
 aHO
@@ -265704,12 +265580,12 @@ fpx
 exD
 exD
 exD
-sPF
-jya
-bQj
-bQj
-bQj
-sPF
+cDX
+uBc
+phl
+phl
+phl
+cDX
 kIh
 fpx
 fpx
@@ -266156,12 +266032,12 @@ fpx
 exD
 exD
 exD
-jya
-brV
-rAp
+uBc
+iIc
+vGe
 pJd
 bgS
-jya
+uBc
 aFv
 njB
 pWT
@@ -266608,12 +266484,12 @@ exD
 exD
 exD
 exD
-jya
-sPF
+uBc
+cDX
 vMd
 ulx
 pWZ
-jya
+uBc
 oOv
 aFv
 nlW
@@ -267060,12 +266936,12 @@ exD
 exD
 exD
 exD
-jya
-txo
-cGA
-qxE
-ijl
-jya
+uBc
+qps
+ucT
+sRx
+xBZ
+uBc
 aFv
 ftO
 ohA
@@ -267512,12 +267388,12 @@ exD
 exD
 exD
 exD
-sPF
-jil
-dEj
-jil
-jil
-jya
+cDX
+sYZ
+hut
+sYZ
+sYZ
+uBc
 aFv
 pWT
 pWT
@@ -267964,12 +267840,12 @@ exD
 exD
 exD
 exD
-sPF
-sPF
-iNX
-tSB
-mTe
-koY
+cDX
+cDX
+ncY
+cMj
+nHx
+flT
 pWT
 aZo
 daQ
@@ -268004,7 +267880,7 @@ puO
 puO
 puO
 phl
-sns
+ijl
 smL
 mfS
 eyK
@@ -268417,11 +268293,11 @@ exD
 exD
 exD
 ehB
-jPf
-gAF
-tSB
+fXC
+gpg
+cMj
 phn
-koY
+flT
 njB
 daQ
 cOj
@@ -268512,7 +268388,7 @@ aZo
 lKo
 lKO
 lKo
-fpx
+cCY
 fpx
 sns
 uLv
@@ -268869,11 +268745,11 @@ exD
 exD
 exD
 crS
-koY
-hjR
-dUV
+flT
+bUr
+bIp
 paZ
-koY
+flT
 daQ
 daQ
 rYO
@@ -269321,11 +269197,11 @@ exD
 exD
 exD
 exD
-sPF
-jya
-jya
-jya
-sPF
+cDX
+uBc
+uBc
+uBc
+cDX
 daQ
 daQ
 wMX
@@ -271567,11 +271443,11 @@ lKo
 lKO
 lKo
 qfA
-sPF
-jya
+cDX
+uBc
 wZq
-jya
-sPF
+uBc
+cDX
 qfA
 sBN
 jKh
@@ -272019,11 +271895,11 @@ cDX
 gyu
 cDX
 qfA
-jya
-rPo
-jil
+uBc
+evD
+sYZ
 kIa
-jya
+uBc
 cKe
 sBN
 fpx
@@ -272471,11 +272347,11 @@ lKo
 pqo
 lKo
 qfA
-jya
-sPF
-ghB
+uBc
+cDX
+keu
 mqt
-xoW
+vUD
 cKe
 sBN
 fpx
@@ -272923,11 +272799,11 @@ lKo
 lKO
 lKo
 qfA
-jya
-txo
-cGA
+uBc
+qps
+ucT
 vBc
-jya
+uBc
 cKe
 sBN
 fpx
@@ -273375,13 +273251,13 @@ cDX
 gyu
 cDX
 mIz
-sPF
-yeK
-dEj
-oGW
-sPF
-jya
-sPF
+cDX
+cZN
+hut
+dra
+cDX
+uBc
+cDX
 kIh
 exD
 exD
@@ -273827,13 +273703,13 @@ lKo
 pqo
 lKo
 qfA
-eLb
-eLb
+guo
+guo
 lqG
-oGW
-oGW
-mtZ
-jya
+dra
+dra
+saX
+uBc
 exD
 exD
 exD
@@ -274279,13 +274155,13 @@ lKo
 lKO
 lKo
 qfA
-eLb
-tgM
-udG
-oGW
-oGW
-oGW
-cCY
+guo
+kLa
+pJJ
+dra
+dra
+dra
+cyz
 exD
 exD
 exD
@@ -274731,13 +274607,13 @@ cDX
 gyu
 cDX
 pGx
-eLb
-eLb
+guo
+guo
 orV
 fYx
 uMO
 oXr
-jya
+uBc
 exD
 exD
 exD
@@ -275184,12 +275060,12 @@ pqo
 lKo
 jQH
 jQH
-sPF
-jya
-jya
-jya
-jya
-sPF
+cDX
+uBc
+uBc
+uBc
+uBc
+cDX
 tHo
 exD
 exD
@@ -275655,7 +275531,7 @@ fpx
 fpx
 bge
 aFv
-aFv
+mTe
 wMX
 gZB
 njB
@@ -293715,7 +293591,7 @@ cDX
 gyu
 cDX
 kkv
-aFv
+mTe
 kkv
 kkv
 kkv
@@ -294263,7 +294139,7 @@ daQ
 daQ
 pWT
 pWT
-njB
+mtZ
 tEe
 pWT
 jiQ


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
![image](https://github.com/user-attachments/assets/26e2865d-4be7-4a89-9b4a-996c5aa0d6b6)
These two buildings were RTfield, they're indoors/town now like the rest of the buildings.

Vagabond / "orphan" had all its landmarks removed (in #2578 I think). This spreads 13 landmarks around for vagabonds on round spawn. Where do you go? It's a gamble! Probably in a muddy alley way somewhere. 
## Testing Evidence
![image](https://github.com/user-attachments/assets/8f79ba0f-6abc-472f-8b34-e11a72d1cce8)
Landmark works just fine.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
A bum spawned in the squire room, mon dieu