### PR TITLE
Removes roundstart plate from Heretic

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -42,6 +42,7 @@
 	if (istype (H.patron, /datum/patron/inhumen/zizo))
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
 		ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
+	head = /obj/item/clothing/head/roguetown/helmet/bascinet
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half
@@ -50,7 +51,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	shoes = /obj/item/clothing/shoes/roguetown/boots
-	cloak = /obj/item/clothing/cloak/cape
+	cloak = /obj/item/clothing/cloak/cape/crusader
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/shield/tower/metal
 	belt = /obj/item/storage/belt/rogue/leather


### PR DESCRIPTION
## About The Pull Request

Removes the full set of plate heretic gets considering for 1 that is deserter niche for 2 they can just summon it anyway.

## Testing Evidence

![image](https://github.com/user-attachments/assets/c29c6453-f680-4d2e-850f-e878a3d4a0a6)

## Why It's Good For The Game

Heretic is most played wretch by far - to me it's mostly because it's full plate on spawn + miracles for 1 level worse skills than deserter who doesn't get benefit of that. You can still have your full plate if you smith OR if you simply summon it but no more handouts.
