### PR TITLE
Dragon and Direbear Sprite Location Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/creacher/direbear.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/direbear.dm
@@ -4,6 +4,7 @@
 	icon_state = "direbear"
 	icon_living = "direbear"
 	icon_dead = "direbear_dead"
+	pixel_x = -16
 	base_intents = list(/datum/intent/simple/bite/bear)
 	botched_butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 1, 
 									/obj/item/natural/hide = 1, 

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/dragon.dm
@@ -4,6 +4,8 @@
 	icon_state = "dragon"
 	icon_living = "dragon"
 	icon_dead = "dragon_dead"
+	pixel_x = -32
+	pixel_y = -16
 	footstep_type = FOOTSTEP_MOB_HEAVY
 	gender = MALE
 	emote_hear = null


### PR DESCRIPTION
## About The Pull Request

A quick fix that adjusts the sprite location for dragons and direbears relative to where they actually are.

## Testing Evidence

![Capture](https://github.com/user-attachments/assets/ae84a0e1-dca4-4ec3-9e43-73b1c48a1a52)

Pink glitter decal shows their actual position in the world space. Tested in game locally, looks and feels **much** better.

## Why It's Good For The Game

Makes fighting the respective mobs less weird and janky, the dragon being a particularly bad offender.
