### PR TITLE
[JAK] Small Armor Peel

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1335,9 +1335,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/coveragezone = attackzone2coveragezone(bodypart)
 	if(!(body_parts_inherent & coveragezone))
 		if(!last_peeled_limb || coveragezone == last_peeled_limb)
+			if(peel_display_count == null) // This should never happen. Alas.
+				peel_display_count = 0
 			if(divisor >= peel_threshold)
 				peel_count += divisor ? (peel_threshold / divisor ) : 1
-			else if(divisor < peel_threshold)
+			else
 				peel_count++
 			if(peel_count >= peel_threshold)
 				body_parts_covered_dynamic &= ~coveragezone
@@ -1349,13 +1351,15 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				visible_message("<font color = '#f5f5f5'><b>[parttext ? parttext : "Coverage"]</font></b> gets peeled off of [src]!")
 				reset_peel(success = TRUE)
 			else
-				visible_message(span_info("Peel strikes [src]! <b>[ROUND_UP(peel_count)]</b>!"))
+				peel_display_count++
+				visible_message(span_info("Peel strikes [src]! <b>[peel_display_count]</b>!"))
 		else
 			last_peeled_limb = coveragezone
 			reset_peel()
 	else
 		last_peeled_limb = coveragezone
 		reset_peel()
+
 
 /obj/item/proc/repair_coverage()
 	body_parts_covered_dynamic = body_parts_covered
@@ -1365,6 +1369,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(peel_count > 0 && !success)
 		visible_message(span_info("Peel count lost on [src]!"))
 	peel_count = 0
+	peel_display_count = 0
 
 /obj/item/proc/attackzone2coveragezone(location)
 	switch(location)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1335,10 +1335,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/coveragezone = attackzone2coveragezone(bodypart)
 	if(!(body_parts_inherent & coveragezone))
 		if(!last_peeled_limb || coveragezone == last_peeled_limb)
-			if(peel_display_count == null) // This should never happen. Alas.
-				peel_display_count = 0
+			if(peel_hits == null) // This should never happen. Alas.
+				peel_hits = 0
 			if(divisor >= peel_threshold)
-				peel_count += divisor ? (peel_threshold / divisor ) : 1
+				peel_hits++
+				peel_count = (peel_hits * peel_threshold) / divisor
 			else
 				peel_count++
 			if(peel_count >= peel_threshold)
@@ -1351,8 +1352,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				visible_message("<font color = '#f5f5f5'><b>[parttext ? parttext : "Coverage"]</font></b> gets peeled off of [src]!")
 				reset_peel(success = TRUE)
 			else
-				peel_display_count++
-				visible_message(span_info("Peel strikes [src]! <b>[peel_display_count]</b>!"))
+				visible_message(span_info("Peel strikes [src]! <b>[peel_hits]</b>!"))
 		else
 			last_peeled_limb = coveragezone
 			reset_peel()
@@ -1369,7 +1369,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(peel_count > 0 && !success)
 		visible_message(span_info("Peel count lost on [src]!"))
 	peel_count = 0
-	peel_display_count = 0
+	peel_hits = 0
 
 /obj/item/proc/attackzone2coveragezone(location)
 	switch(location)

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -67,6 +67,10 @@
 	peel_divisor = 3
 	reach = 2
 
+/datum/intent/sword/peel/small
+	name = "swift sword armor peel"
+	peel_divisor = 6
+
 /datum/intent/sword/chop
 	name = "chop"
 	icon_state = "inchop"
@@ -444,7 +448,7 @@
 	wbalance = WBALANCE_SWIFT
 	icon_state = "tabi"
 	icon = 'icons/roguetown/weapons/64.dmi'
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/chop)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/peel/small, /datum/intent/sword/chop)
 	alt_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
 	gripped_intents = null
 	parrysound = list('sound/combat/parry/bladed/bladedthin (1).ogg', 'sound/combat/parry/bladed/bladedthin (2).ogg', 'sound/combat/parry/bladed/bladedthin (3).ogg')
@@ -670,7 +674,7 @@
 	name = "sabre"
 	desc = "A very popular backsword made for cavalrymen that originated in Naledi and spread its influence further north, reaching Aavnr as a \"Szablya\" and notoriously cementing itself as the preferred weapon of the Potentate's Hussars."
 	icon_state = "saber"
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust/sabre, /datum/intent/sword/peel, /datum/intent/sword/strike)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust/sabre, /datum/intent/sword/peel/small, /datum/intent/sword/strike)
 	gripped_intents = null
 	parrysound = list('sound/combat/parry/bladed/bladedthin (1).ogg', 'sound/combat/parry/bladed/bladedthin (2).ogg', 'sound/combat/parry/bladed/bladedthin (3).ogg')
 	swingsound = BLADEWOOSH_SMALL
@@ -697,7 +701,7 @@
 	desc = "A sickle-shaped sword of Naledi origin that owes its design to a type of battle axe its ancient settlers once used - it represents a symbol of power and conquest. This one in particular is made of blued steel."
 	icon_state = "nockhopesh"
 	force = 25	//Base is 22
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/chop/falx, /datum/intent/sword/peel)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/chop/falx, /datum/intent/sword/peel/small)
 	max_integrity = 200
 
 /obj/item/rogueweapon/sword/sabre/alloy
@@ -742,7 +746,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	dropshrink = 0.75
-	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier, /datum/intent/sword/peel)
+	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier, /datum/intent/sword/peel/small)
 	gripped_intents = null
 	parrysound = list(
 		'sound/combat/parry/bladed/bladedthin (1).ogg',
@@ -879,7 +883,7 @@
 	desc = "The mariner's special: A short, broad sabre with a slightly curved blade optimized for slashing."
 	icon_state = "cutlass"
 	force = 23
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/chop, /datum/intent/sword/peel)
+	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/chop, /datum/intent/sword/peel/small)
 	gripped_intents = null
 	wdefense = 6
 	wbalance = WBALANCE_SWIFT

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -13,7 +13,7 @@
 	var/datum/armor/armor
 	var/last_peeled_limb
 	var/peel_count = 0
-	var/peel_display_count = 0 //This is probably not the best way to track it but I'm not great at math, lads
+	var/peel_hits = 0 // This should always be an integer. Tracks actual hits by peel on obj. Used to calculate peel_count in items.dm.
 	var/peel_threshold = 3
 	var/obj_integrity	//defaults to max_integrity
 	var/max_integrity = 500

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -13,6 +13,7 @@
 	var/datum/armor/armor
 	var/last_peeled_limb
 	var/peel_count = 0
+	var/peel_display_count = 0 //This is probably not the best way to track it but I'm not great at math, lads
 	var/peel_threshold = 3
 	var/obj_integrity	//defaults to max_integrity
 	var/max_integrity = 500


### PR DESCRIPTION
## About The Pull Request

Swords with WBALANCE_SWIFT now have a weaker version of Peel intent. 

- Swift weapons require 6 hits.
- Normal weapons require 4 hits.
- Heavy weapons require 3 hits.

Also changes the way the peel counter works because it didn't actually work for values above 4. Not a user facing change.

## Testing Evidence

![image](https://github.com/user-attachments/assets/0ad8c1d2-81aa-4856-8214-382ef20384a9)

## Why It's Good For The Game

After speaking with a couple people about what to do with rapiers/sabres practically ignoring armor, I had the _thought_ of floating removing it but I don't want to completely cuck the people who enjoy dueling swords. They're fun and cool looking and I think peel just needs a minor tweak.

Instead of making rapiers/sabres easier to parry and take away their unique trait, I want to see if allowing that to stay as is and instead making it harder to ignore the armor a person has on improves the situation. The fact that swift weapons can't be reliably parried unless you are also someone that would benefit from a swift weapon means it's _probably_ a good idea that these swords not nullify armor as easily as their heavier counterparts.

**TL;DR: If a weapon is hard to parry, it should be hard for it to ignore armor.**
