### PR TITLE
Fixes Wise-Tree Sprite & Inverted Cross Sprite

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -117,42 +117,6 @@
 	var/datum/looping_sound/boneloop/soundloop
 	var/datum/vine_controller/controller
 
-/obj/structure/flora/tree/wise
-	name = "wise tree"
-	desc = "Dendor's favored. It seems to watch you with ancient awareness."
-	icon_state = "mystical"
-	var/activated = FALSE
-	var/cooldown = FALSE
-	var/retaliation_messages = list(
-		"LEAVE FOREST ALONE!",
-		"DENDOR PROTECTS!",
-		"NATURE'S WRATH!",
-		"BEGONE, INTERLOPER!"
-	)
-
-/obj/structure/flora/tree/wise/Initialize()
-	. = ..()
-	icon_state = "mystical"
-
-/obj/structure/flora/tree/wise/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	if(activated && !cooldown)
-		retaliate(user)
-
-/obj/structure/flora/tree/wise/proc/retaliate(mob/living/target)
-	if(cooldown || !istype(target) || !activated)
-		return
-
-	cooldown = TRUE
-	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 5 SECONDS)
-
-	var/message = pick(retaliation_messages)
-	say(span_danger("[message]"))
-
-	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, target))
-	target.throw_at(throw_target, 4, 2)
-	target.adjustBruteLoss(8)
-
 //grass
 /obj/structure/flora/grass
 	name = "grass"

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1035,8 +1035,7 @@
 /obj/structure/fluff/psycross/zizocross
 	name = "inverted cross"
 	desc = "An unholy symbol. Blasphemy for most, reverence for few."
-	icon_state = "zizoinvertedcross"
-	attacked_sound = list("sound/combat/hits/onmetal/metalimpact (1).ogg", "sound/combat/hits/onmetal/metalimpact (2).ogg")
+	icon_state = "invertedcross"
 	divine = FALSE
 
 /obj/structure/fluff/psycross/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -111,16 +111,43 @@
 	desc = "A blessed primordial tree, ancient beyond years. Said to be the very embodiment of the Tree Father himself—whose presence alone imbues druids with wild energies."
 	icon_state = "mystical"
 	max_integrity = 400
+	var/activated = FALSE
+	var/cooldown = FALSE
+	var/retaliation_messages = list(
+		"LEAVE FOREST ALONE!",
+		"DENDOR PROTECTS!",
+		"NATURE'S WRATH!",
+		"BEGONE, INTERLOPER!"
+	)
 
 /obj/structure/flora/roguetree/wise/Initialize()
 	. = ..()
 	icon_state = "mystical"
 
+/obj/structure/flora/roguetree/wise/attackby(obj/item/I, mob/user, params)
+	. = ..()
+	if(activated && !cooldown)
+		retaliate(user)
+
+
+/obj/structure/flora/roguetree/wise/proc/retaliate(mob/living/target)
+	if(cooldown || !istype(target) || !activated)
+		return
+
+	cooldown = TRUE
+	addtimer(VARSET_CALLBACK(src, cooldown, FALSE), 5 SECONDS)
+
+	var/message = pick(retaliation_messages)
+	say(span_danger("[message]"))
+
+	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, target))
+	target.throw_at(throw_target, 4, 2)
+	target.adjustBruteLoss(8)
+
 /obj/structure/flora/roguetree/wise/examine(mob/user)
 	. = ..()
 	SEND_SOUND(usr, sound(null))
 	playsound(user, 'sound/music/tree.ogg', 80)
-
 
 /obj/structure/flora/roguetree/burnt
 	name = "burnt tree"

--- a/code/modules/spells/roguetown/create_wise_tree.dm
+++ b/code/modules/spells/roguetown/create_wise_tree.dm
@@ -15,13 +15,13 @@
 	var/atom/target_atom = targets[1]
 	var/obj/structure/flora/target
 
-	if(istype(target_atom, /obj/structure/flora/tree) && !istype(target_atom, /obj/structure/flora/tree/wise) && !istype(target_atom, /obj/structure/flora/roguetree/stump))
+	if(istype(target_atom, /obj/structure/flora/tree) && !istype(target_atom, /obj/structure/flora/roguetree/wise) && !istype(target_atom, /obj/structure/flora/roguetree/stump))
 		target = target_atom
 	else if(istype(target_atom, /obj/structure/flora/newtree))
 		target = target_atom
 	else if(target_atom.loc && (get_dist(user, target_atom.loc) <= 1))
 		for(var/obj/structure/flora/tree/T in target_atom.loc)
-			if(!istype(T, /obj/structure/flora/tree/wise) && !istype(T, /obj/structure/flora/roguetree/stump))
+			if(!istype(T, /obj/structure/flora/roguetree/wise) && !istype(T, /obj/structure/flora/roguetree/stump))
 				target = T
 				break
 		if(!target)
@@ -47,7 +47,7 @@
 		return
 
 	var/turf/T = get_turf(target)
-	var/obj/structure/flora/tree/wise/new_wise_tree = new(T)
+	var/obj/structure/flora/roguetree/wise/new_wise_tree = new(T)
 	new_wise_tree.activated = TRUE
 	new_wise_tree.set_light(2, 2, 2, l_color = "#66FF99")
 


### PR DESCRIPTION
## About The Pull Request

Fixed the issue of the wise tree and inverted psy-cross (zizo) being missing. Was a minor bug. Also should fix the spawning on wise trees by the dendorite spell given via personal objective. 

## Testing Evidence

shrimple fix

## Why It's Good For The Game

unintended bug due to bad pathing on both.
