### PR TITLE
Cave Troll, Stone Throw Fix

### DIFF
--- a/code/datums/actions/mobs/stone_throw.dm
+++ b/code/datums/actions/mobs/stone_throw.dm
@@ -3,7 +3,7 @@
 	button_icon = 'icons/effects/effects.dmi'
 	button_icon_state = "explosion"
 	desc = "Chucks a stone at someone"
-	cooldown_time = 15 SECONDS
+	cooldown_time = 20 SECONDS
 	var/cast_time	= 3 SECONDS
 	var/range = 8
 	var/def_zone = BODY_ZONE_CHEST

--- a/code/datums/actions/mobs/stone_throw.dm
+++ b/code/datums/actions/mobs/stone_throw.dm
@@ -1,0 +1,57 @@
+/datum/action/cooldown/mob_cooldown/stone_throw
+	name = "Stone Throw"
+	button_icon = 'icons/effects/effects.dmi'
+	button_icon_state = "explosion"
+	desc = "Chucks a stone at someone"
+	cooldown_time = 15 SECONDS
+	var/cast_time	= 3 SECONDS
+	var/range = 8
+	var/def_zone = BODY_ZONE_CHEST
+	var/rock_damage = 40
+
+/datum/action/cooldown/mob_cooldown/stone_throw/Activate(atom/target)
+	var/dist = get_dist(owner, target)
+	if(can_see(owner, target, range) && dist < range && dist > 1) //can see, in range and not adjacent
+		owner.visible_message(span_alert("[owner] reaches towards the ground, eyeing [target]."))
+		disable_cooldown_actions()
+		addtimer(CALLBACK(src, PROC_REF(prepare_stone), target), cast_time)
+		StartCooldown()
+	return TRUE
+
+/datum/action/cooldown/mob_cooldown/stone_throw/proc/prepare_stone(atom/target, mob/living/L)
+	owner.visible_message(span_alert("[owner] digs into the ground and grabs a massive rock!"))
+	playsound(owner, 'sound/items/dig_shovel.ogg', 100, TRUE)
+	sleep(20)
+	var/dist = get_dist(owner, target)
+	var/obj/effect/temp_visual/stone_throw/stone = new(owner.loc)
+	var/original_target_loc = target.loc
+	var/dx = (target.x - owner.x) * 32
+	var/dy = (target.y - owner.y) * 32
+	if(can_see(owner, target, range) && dist < range && dist > 1)
+		owner.visible_message(span_boldwarning("[owner] chucks a huge rock!"))
+		playsound(owner.loc, 'sound/combat/shieldraise.ogg', 100)
+		animate(stone, pixel_x = dx, pixel_y = dy, time = 4)
+		sleep(4) // Wait for the animation to complete
+		if(target && target.loc == original_target_loc)
+			stone.loc = target.loc
+			stone.pixel_x = 0
+			stone.pixel_y = 0
+			if(ismob(target))
+				var/mob/living/victim = target
+				def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_CHEST, BODY_ZONE_HEAD)
+				victim.apply_damage(rock_damage, BRUTE, def_zone, victim.run_armor_check(def_zone, "stab", damage = rock_damage))
+				victim.Paralyze(5)
+				to_chat(target, span_userdanger("You're hit by a big rock!"))
+				playsound(target, 'sound/foley/smash_rock.ogg', 100, TRUE)
+	else
+		owner.visible_message(span_alert("[owner] roars in frustration."))
+	return
+
+/obj/effect/temp_visual/stone_throw
+	icon = 'icons/roguetown/items/natural.dmi'
+	icon_state = "stonebig1"
+	name = "stone"
+	desc = "You should scram..."
+	layer = FLY_LAYER
+	plane = GAME_PLANE_UPPER
+	randomdir = FALSE

--- a/code/datums/ai/controllers/troll.dm
+++ b/code/datums/ai/controllers/troll.dm
@@ -27,7 +27,7 @@
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 
 
-/datum/ai_controller/troll/cave
+/datum/ai_controller/troll_cave
 	movement_delay = TROLL_MOVEMENT_SPEED
 
 	ai_movement = /datum/ai_movement/basic_avoidance
@@ -37,20 +37,21 @@
 
 	)
 
+	idle_behavior = /datum/idle_behavior/idle_random_walk
+
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/target_retaliate,
 		/datum/ai_planning_subtree/simple_find_target/closest,
 
-		/datum/ai_planning_subtree/basic_melee_attack_subtree/opportunistic, 
+		/datum/ai_planning_subtree/basic_melee_attack_subtree/opportunistic,
+		/datum/ai_planning_subtree/targeted_mob_ability/continue_planning,
+
 		/datum/ai_planning_subtree/basic_melee_attack_subtree,
-		/datum/ai_planning_subtree/targeted_mob_ability,
-		
 		/datum/ai_planning_subtree/simple_self_recovery,
 
-		/datum/ai_planning_subtree/find_dead_bodies,
+    	/datum/ai_planning_subtree/find_dead_bodies,
 		/datum/ai_planning_subtree/eat_dead_body,
 		/datum/ai_planning_subtree/find_food,
 		/datum/ai_planning_subtree/eat_food,
-	)
 
-	idle_behavior = /datum/idle_behavior/idle_random_walk
+	)

--- a/code/modules/mob/living/simple_animal/rogue/creacher/trolls/trollcave.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/trolls/trollcave.dm
@@ -1,11 +1,11 @@
-// Port from Vanderlin but I can't get their stone throw to work so I am leaving a note here instead
+// Port from Vanderlin with AP code for throwing the rock
 /mob/living/simple_animal/hostile/retaliate/rogue/troll/cave
 	name = "cave troll"
 	desc = "Dwarven tales of giants and trolls often contain these creatures, horrifying amalgamations of flesh and crystal who have long since abandoned Malum's ways."
 	icon = 'icons/roguetown/mob/monster/trolls/troll_cave.dmi'
 	health = CAVETROLL_HEALTH
 	maxHealth = CAVETROLL_HEALTH
-	ai_controller = /datum/ai_controller/troll/cave
+	ai_controller = /datum/ai_controller/troll_cave
 
 	botched_butcher_results = list (
 		/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 2,
@@ -33,3 +33,8 @@
 
 	defprob = 15
 
+/mob/living/simple_animal/hostile/retaliate/rogue/troll/cave/Initialize(mapload)
+	. = ..()
+	var/datum/action/cooldown/mob_cooldown/stone_throw/throwstone = new(src)
+	throwstone.Grant(src)
+	ai_controller.set_blackboard_key(BB_TARGETED_ACTION, throwstone)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -431,6 +431,7 @@
 #include "code\datums\actions\action_cooldown.dm"
 #include "code\datums\actions\mobs\dragon_leap.dm"
 #include "code\datums\actions\mobs\dragonbreath.dm"
+#include "code\datums\actions\mobs\stone_throw.dm"
 #include "code\datums\ai\_ai_behavior.dm"
 #include "code\datums\ai\_ai_controller.dm"
 #include "code\datums\ai\_ai_idle_behavior.dm"


### PR DESCRIPTION

## About The Pull Request

Gives the big scary cave troll their ability to throw rocks per the original port from Vanderlin. I'm not a coder so if this is bad feel free to close. Can be evaded by moving or by breaking vision with the troll before it throws it.

Adds stone_throw.dm and includes it in the .dme file.
Modifies trolls/cavetroll to grant them the ability.
Modifies controller/trolls to make cavetrolls have their own controller instead of inheriting the regular trolls. I wish I could explain why this was causing issues with granting the cavetroll abilities but I cannot, it just works™. Also changes the targeted_mob_ability to the appropriate "continue_planning" type path.


Does not map in any cave trolls.

This is good to go but I plan to modify their behavior in the future so they don't simply open with the ability or use it against skirmishers, but to make it a core aspect of their behavior.

## Testing Evidence

https://streamable.com/a02hna

## Why It's Good For The Game

Gives the cave troll their unique ability to differentiate them from the other trolls, not just by appearance and stats alone. Interesting threat for adventurers to deal with.
