### PR TITLE
Tweak Base Magic Resource Size to 1x1.

### DIFF
--- a/code/game/objects/items/rogueitems/magic/magic_resources.dm
+++ b/code/game/objects/items/rogueitems/magic/magic_resources.dm
@@ -3,9 +3,12 @@
 // Let me use another .dmi 
 // Since the enchanting / summoning system is not here yet, sellprice has been adjusted.
 /obj/item/magic
-    name = "magic resource"
-    desc = "You shouldn't be seeing this."
-    icon = 'icons/roguetown/items/magic_resources.dmi'
+	name = "magic resource"
+	desc = "You shouldn't be seeing this."
+	icon = 'icons/roguetown/items/magic_resources.dmi'
+	w_class = WEIGHT_CLASS_TINY
+	grid_width = 32
+	grid_height = 32
 
 // MELD
 /obj/item/magic/melded


### PR DESCRIPTION
## About The Pull Request
I forgot to set base size on the magical resources I ported from Vanderlin which was ported from RW yada so they were humongous.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![NVIDIA_Overlay_nBWM9FyDmV](https://github.com/user-attachments/assets/cdd1fa9a-ac83-4133-8ebd-1e23f597ee23)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Properly sized things for future summoning use

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
