### PR TITLE
Reduces bog ambush mob quantity

### DIFF
--- a/modular_azurepeak/code/modules/mob/living/ambushes/mirespiders_ambush.dm
+++ b/modular_azurepeak/code/modules/mob/living/ambushes/mirespiders_ambush.dm
@@ -3,13 +3,13 @@
 
 /datum/ambush_config/mirespiders_ambush
 	mob_types = list(
-		/mob/living/simple_animal/hostile/retaliate/rogue/mirespider = 4,
+		/mob/living/simple_animal/hostile/retaliate/rogue/mirespider = 2,
 		/mob/living/simple_animal/hostile/rogue/mirespider_lurker = 1
 	)
 
 /datum/ambush_config/mirespiders_crawlers
 	mob_types = list(
-		/mob/living/simple_animal/hostile/retaliate/rogue/mirespider = 7,
+		/mob/living/simple_animal/hostile/retaliate/rogue/mirespider = 4,
 	)
 
 /datum/ambush_config/mirespiders_aragn


### PR DESCRIPTION
## About The Pull Request

Reduces by roughly half the quantity of mirespiders spawned by ambushes within the Bog. The maximum becomes four instead of seven. This does not touch the rarer special mirespider spawns.

## Testing Evidence

Untested - minor code changes (single digit swaps).

## Why It's Good For The Game

While ambushes provide an interesting challenge, too many mobs at a time. Being dead in the bog does not exactly provide any roleplay value, either. I personally believe a game is more fun if the match-ups are fairer. 

"You should team up to go in the Bog!" What about wretches? What about explorers, or anyone who wants to, y'know, interact with the round? 

"You should have moved around using stealth." is not a fix-all issue for when you do summon the ambushes. Mistakes happen.
