### PR TITLE
Auto Export + Stockpile / Economy Tweaks

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -215,17 +215,14 @@ SUBSYSTEM_DEF(treasury)
 			give_money_account(how_much, welfare_dependant, "Noble Estate")
 
 /datum/controller/subsystem/treasury/proc/do_export(var/datum/roguestock/D)
-	if((D.held_items[1] + D.held_items[2]) < D.importexport_amt)
+	if((D.held_items[1] < D.importexport_amt))
 		return FALSE
 	var/amt = D.get_export_price()
 
-	// Try to export everything from town stockpile
+	// You should only export from town stockpiles, not from remote. Remote is meant
+	// To fulfill local economic shortfall and not to make $$ for the steward.
 	if(D.held_items[1] >= D.importexport_amt)
 		D.held_items[1] -= D.importexport_amt
-	// If not possible, first pull form town stockpile, then bog stockpile
-	else
-		D.held_items[2] -= (D.importexport_amt - D.held_items[1])
-		D.held_items[1] = 0
 
 	SStreasury.treasury_value += amt
 	SStreasury.total_export += amt

--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -208,6 +208,20 @@
 		compact = !compact
 	if(href_list["changecat"])
 		current_category = href_list["changecat"]
+	if(href_list["changeautoexport"])
+		if(!usr.canUseTopic(src, BE_CLOSE) || locked)
+			return
+		var/new_autoexport = input(usr, "Set a new autoexport percentage between 0 and 100", src, SStreasury.autoexport_percentage * 100) as null|num
+		if(!new_autoexport && new_autoexport != 0)
+			return
+		if(findtext(num2text(new_autoexport), "."))
+			return
+		if(new_autoexport < 0 || new_autoexport > 100)
+			to_chat(usr, span_warning("Invalid autoexport percentage. Must be between 0 and 100."))
+			return
+		new_autoexport = round(new_autoexport)
+		SStreasury.autoexport_percentage = new_autoexport * 0.01
+	
 	return attack_hand(usr)
 
 /obj/structure/roguemachine/steward/proc/do_import(datum/roguestock/D,number)
@@ -291,6 +305,8 @@
 				contents += "Treasury: [SStreasury.treasury_value]m"
 				contents += " / Lord's Tax: [SStreasury.tax_value*100]%"
 				contents += " / Guild's Tax: [SStreasury.queens_tax*100]%</center><BR>"
+				contents += "<center>Auto Export Stockpile Above: "
+				contents += "<a href='?src=\ref[src];changeautoexport=1'>[SStreasury.autoexport_percentage * 100]%</a></center><BR>"
 				var/selection = "<center>Categories: "
 				for(var/category in categories)
 					if(category == current_category)

--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -85,25 +85,9 @@
 		var/datum/roguestock/D = locate(href_list["export"]) in SStreasury.stockpile_datums
 		if(!D)
 			return
-		if((D.held_items[1] + D.held_items[2]) < D.importexport_amt)
+		if(!SStreasury.do_export(D))
 			say("Insufficient stock.")
 			return
-		var/amt = D.get_export_price()
-
-		// Try to export everything from town stockpile
-		if(D.held_items[1] >= D.importexport_amt)
-			D.held_items[1] -= D.importexport_amt
-		// If not possible, first pull form town stockpile, then bog stockpile
-		else
-			D.held_items[2] -= (D.importexport_amt - D.held_items[1])
-			D.held_items[1] = 0
-
-		SStreasury.treasury_value += amt
-		SStreasury.total_export += amt
-		SStreasury.log_to_steward("+[amt] exported [D.name]")
-		if(amt >= 100) //Only announce big spending.
-			scom_announce("Azure Peak exports [D.name] for [amt] mammon.")
-		D.lower_demand()
 	if(href_list["togglewithdraw"])
 		var/datum/roguestock/D = locate(href_list["togglewithdraw"]) in SStreasury.stockpile_datums
 		if(!D)

--- a/code/modules/roguetown/roguestock/stockpile_food.dm
+++ b/code/modules/roguetown/roguestock/stockpile_food.dm
@@ -13,7 +13,7 @@
 	export_price = 8
 	importexport_amt = 5
 	passive_generation = 3
-	stockpile_limit = 30
+	stockpile_limit = 25
 	category = "Foodstuffs"
 
 /datum/roguestock/stockpile/grain
@@ -55,7 +55,7 @@
 	export_price = 3
 	importexport_amt = 10
 	passive_generation = 3
-	stockpile_limit = 30
+	stockpile_limit = 50
 	category = "Foodstuffs"
 
 /datum/roguestock/stockpile/apple
@@ -69,7 +69,7 @@
 	export_price = 5
 	importexport_amt = 5
 	passive_generation = 3
-	stockpile_limit = 30
+	stockpile_limit = 50
 	category = "Foodstuffs"
 
 /datum/roguestock/stockpile/meat
@@ -81,8 +81,8 @@
 	withdraw_price = 4
 	transport_fee = 2
 	export_price = 8
-	importexport_amt = 5
-	stockpile_limit = 40
+	importexport_amt = 10
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -96,7 +96,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -110,7 +110,7 @@
 	transport_fee = 2
 	export_price = 8
 	importexport_amt = 5
-	stockpile_limit = 30
+	stockpile_limit = 25
 	passive_generation = 1
 	category = "Foodstuffs"
 
@@ -124,7 +124,7 @@
 	transport_fee = 1
 	export_price = 5
 	importexport_amt = 5
-	stockpile_limit = 30
+	stockpile_limit = 25
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -138,7 +138,7 @@
 	transport_fee = 2
 	export_price = 5
 	importexport_amt = 5
-	stockpile_limit = 30
+	stockpile_limit = 25
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -152,7 +152,7 @@
 	transport_fee = 1
 	export_price = 5
 	importexport_amt = 5
-	stockpile_limit = 30
+	stockpile_limit = 25
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -166,7 +166,7 @@
 	transport_fee = 1
 	export_price = 2
 	importexport_amt = 5
-	stockpile_limit = 30
+	stockpile_limit = 25
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -180,7 +180,7 @@
 	transport_fee = 3
 	export_price = 13
 	importexport_amt = 5
-	stockpile_limit = 30
+	stockpile_limit = 25
 	passive_generation = 1
 	category = "Foodstuffs"
 
@@ -194,7 +194,7 @@
 	transport_fee = 2
 	export_price = 5
 	importexport_amt = 5
-	stockpile_limit = 30
+	stockpile_limit = 25
 	passive_generation = 1
 	category = "Foodstuffs"
 
@@ -222,7 +222,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -236,7 +236,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -250,7 +250,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -264,7 +264,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -278,7 +278,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -292,7 +292,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -306,7 +306,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -320,7 +320,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -334,7 +334,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -348,7 +348,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"
 
@@ -362,6 +362,6 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 	category = "Foodstuffs"

--- a/code/modules/roguetown/roguestock/stockpile_rawmat.dm
+++ b/code/modules/roguetown/roguestock/stockpile_rawmat.dm
@@ -34,7 +34,7 @@
 	transport_fee = 0
 	export_price = 1
 	importexport_amt = 10
-	stockpile_limit = 30 // Allow a small amount of stones to be sold for chiselling
+	stockpile_limit = 50 // Allow a small amount of stones to be sold for chiselling
 	passive_generation = 10 // Free rocks!!
 
 /datum/roguestock/stockpile/glass
@@ -46,8 +46,8 @@
 	withdraw_price = 4
 	transport_fee = 5
 	export_price = 5
-	importexport_amt = 10
-	stockpile_limit = 20
+	importexport_amt = 5
+	stockpile_limit = 25
 	passive_generation = 3
 
 /datum/roguestock/stockpile/iron
@@ -73,7 +73,7 @@
 	transport_fee = 3
 	export_price = 5
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 
 /datum/roguestock/stockpile/tin
@@ -86,7 +86,7 @@
 	transport_fee = 4
 	export_price = 5
 	importexport_amt = 10
-	stockpile_limit = 30
+	stockpile_limit = 50
 	passive_generation = 2
 
 /datum/roguestock/stockpile/gold
@@ -98,7 +98,7 @@
 	withdraw_price = 50
 	transport_fee = 10
 	export_price = 75
-	stockpile_limit = 20
+	stockpile_limit = 50
 	importexport_amt = 10
 
 /datum/roguestock/stockpile/silver
@@ -110,8 +110,8 @@
 	withdraw_price = 75
 	transport_fee = 10
 	export_price = 100
-	stockpile_limit = 20
-	importexport_amt = 10
+	stockpile_limit = 25
+	importexport_amt = 5
 
 /datum/roguestock/stockpile/cloth
 	name = "Cloth"
@@ -123,7 +123,7 @@
 	transport_fee = 2
 	export_price = 5
 	importexport_amt = 10
-	stockpile_limit = 60
+	stockpile_limit = 100
 	passive_generation = 2
 
 /datum/roguestock/stockpile/fibers
@@ -136,7 +136,7 @@
 	transport_fee = 1
 	export_price = 3
 	importexport_amt = 10
-	stockpile_limit = 60
+	stockpile_limit = 50
 	passive_generation = 4
 
 /datum/roguestock/stockpile/silk
@@ -148,8 +148,8 @@
 	withdraw_price = 2
 	transport_fee = 1
 	export_price = 4
-	importexport_amt = 10
-	stockpile_limit = 20
+	importexport_amt = 5
+	stockpile_limit = 25
 	passive_generation = 1
 
 //natural/hide/cured must be defined/populated in sstreasury before natural/hide, for istype stockpile check to work
@@ -163,7 +163,7 @@
 	transport_fee = 3
 	export_price = 7
 	importexport_amt = 10
-	stockpile_limit = 40
+	stockpile_limit = 50
 	passive_generation = 3
 
 /datum/roguestock/stockpile/hide
@@ -189,5 +189,5 @@
 	transport_fee = 4
 	export_price = 15
 	importexport_amt = 5
-	stockpile_limit = 15
+	stockpile_limit = 25
 	passive_generation = 1


### PR DESCRIPTION
## About The Pull Request
To address feedbacks from stewards about stockpile being tedious I am putting in the feature I wanted to code but took out of the first iteration of nuking the vault. 

- An autoexport mechanic has been added. Steward can set the percentage it is at in Stockpile tab. At roundstart, the stockpile will attempt to auto export every goods at or above 60% of the stockpile limit (exporting by the import / export amount) to generate mammons. Steward can set this to between 0% to 100% (thus attempting to export everything or only thing that are above the limit). I considered setting it to 200% or so but decided to "noobproof" this from bad stewards who don't export surplus and give the towner no job to do
- Auto Export **Do Not Export** if it is not profitable. So it is possible for towner to still crash the demand if they flood it with 20,000 hides or something.
- To reduce the amount of free $ Keep gets, remote stockpile no longer count for export. The amount of passively generated goods amounted to an additional 200 - 500 mammons per tick which run counter to the design intent. Remote generation is there to help smooth over the economy especially on lowpop.
- Queen's Tax (Basically, money sink that are applied to merchant + steward on import and export) has been reduced to 10% from 15%, improving the profit margin for both ends significantly. This is a slight merchant + steward buff for the intended new way to earn money. Yeah, I might be reinflating the economy again. But tweaking the economy to have more $ in a **dynamic, player-driven** way is imo better.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![NVIDIA_Overlay_eAu3PdINy0](https://github.com/user-attachments/assets/cf0e3c41-6010-4a7b-adc4-f1b9c3e1f04f)
![NVIDIA_Overlay_60vZ0P3L7m](https://github.com/user-attachments/assets/bc8d526c-1a9e-4b35-b58a-3d7ed6aebb28)
![NVIDIA_Overlay_3zJwaEvNkM](https://github.com/user-attachments/assets/3bf9e037-0f9c-401d-a059-d00477894ca4)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
See my manifesto above. 

Letting merchant earn a bit more on both end is good because they're still underappreciated. Stewards get less micromanagement but also much less free money.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
