### PR TITLE
Let chisel stab carve on signs

### DIFF
--- a/code/modules/roguetown/roguejobs/artificer/handsaw_chisel.dm
+++ b/code/modules/roguetown/roguejobs/artificer/handsaw_chisel.dm
@@ -34,6 +34,7 @@
 	throwforce = 2
 	possible_item_intents = list(/datum/intent/stab)
 	sharpness = IS_SHARP
+	wlength = WLENGTH_SHORT
 	dropshrink = 0.9
 	w_class = WEIGHT_CLASS_SMALL
 	wdefense = 0


### PR DESCRIPTION
## About The Pull Request

Makes the chisel `wlength_short`. Which shouldn't necessarily affect its performance in combat considering that it's not a combat tool.

Flipside is that it can carve on signs now.

## Testing Evidence

Tested.

## Why It's Good For The Game

Utility.
