### PR TITLE
Potter-Changes

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -8270,6 +8270,7 @@
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = -6
 	},
+/obj/item/reagent_containers/glass/bottle/claybottle/wine,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "cSN" = (
@@ -36649,12 +36650,8 @@
 	dir = 1;
 	icon_state = "longtable"
 	},
-/obj/item/paper,
-/obj/item/paper{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/natural/feather,
+/obj/item/natural/clay/glassbatch,
+/obj/item/natural/clay/glassbatch,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "myg" = (
@@ -48346,6 +48343,16 @@
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
+/obj/item/storage/roguebag/ash,
+/obj/item/natural/clay,
+/obj/item/natural/clay,
+/obj/item/natural/clay,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
+/obj/item/natural/stone,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "quQ" = (
@@ -56802,6 +56809,18 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"tmQ" = (
+/obj/structure/table/wood{
+	icon_state = "tablewood1"
+	},
+/obj/item/natural/feather,
+/obj/item/paper{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/roguestatue/glass,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "tmS" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/blocks,
@@ -64986,7 +65005,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
 "vVV" = (
-/obj/machinery/light/rogue/smelter,
+/obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "vVX" = (
@@ -277714,7 +277733,7 @@ exD
 exD
 exD
 ydb
-gXS
+dyE
 dyE
 mye
 uBc
@@ -278168,7 +278187,7 @@ exD
 mGM
 dyE
 dyE
-dyE
+gXS
 uBc
 cDX
 gyu
@@ -390713,7 +390732,7 @@ bGf
 bGf
 bGf
 vUD
-cMj
+tmQ
 oZe
 fQi
 fQi

--- a/code/game/objects/items/rogueitems/bags.dm
+++ b/code/game/objects/items/rogueitems/bags.dm
@@ -109,3 +109,20 @@
 	/obj/item/natural/worms/leech,
 	/obj/item/cooking/pan
 	)
+
+/obj/item/storage/roguebag/ash
+	populate_contents = list(
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+		/obj/item/ash,
+	/obj/item/ash
+	)

--- a/code/game/objects/items/rogueitems/ceramics.dm
+++ b/code/game/objects/items/rogueitems/ceramics.dm
@@ -15,9 +15,10 @@
 
 /obj/item/reagent_containers/glass/bottle/claybottle
 	name = "clay vessel"
-	desc = "A small ceramic bottle."
+	desc = "A ceramic bottle." //The sprite was anything but small
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claybottlecook"
+	volume = 65 // Larger than glass bottle
 	sellprice = 6
 	reagent_flags = OPENCONTAINER	//So it doesn't appear through
 

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -177,3 +177,31 @@
 /obj/item/reagent_containers/glass/bottle/rogue/beer/kgunplum
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer/kgunplum = 48)
 	desc = "A bottle with a Golden Swan cork-seal. A reddish-golden alcohol made from a fruit commonly found on the Kazengun-isles. A favourite of the commoners."
+
+		//////////////////////////
+		/// CLAY BOTTLES ///
+		//////////////////////////
+
+/obj/item/reagent_containers/glass/bottle/claybottle/wine
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer/wine = 65)
+	desc = "A clay bottle that contains a generic red-wine, likely from Raneshen. It has a red-clay cork-seal."
+
+/obj/item/reagent_containers/glass/bottle/claybottle/water
+	list_reagents = list(/datum/reagent/water = 65)
+	desc = "A clay bottle that with no markings."
+
+/obj/item/reagent_containers/glass/bottle/claybottle/beer
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 65)
+	desc = "A clay bottle that contains a generic housebrewed small-beer. It has an improvised corkseal made of hardened clay."
+
+/obj/item/reagent_containers/glass/bottle/claybottle/nred
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer/nred = 65)
+	desc = "A clay bottle with the City of Norwandine cork-seal. A red ale brewed to perfection in the lands of Hammerhold."
+
+/obj/item/reagent_containers/glass/bottle/claybottle/gronnmead
+	list_reagents = list(/datum/reagent/consumable/ethanol/gronnmead = 65)
+	desc = "A clay bottle with a Shieldmaiden Berewrey cork-seal. A deep red honey-wine, refined with the red berries native to Gronns highlands."
+
+/obj/item/reagent_containers/glass/bottle/claybottle/whitewine
+	list_reagents = list(/datum/reagent/consumable/ethanol/whitewine = 65)
+	desc = "A bottle with the Otavan Merchant Guild cork-seal. This one appears to be labelled as a sweet wine from the colder northern regions."

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -188,7 +188,7 @@
 
 /obj/item/reagent_containers/glass/bottle/claybottle/water
 	list_reagents = list(/datum/reagent/water = 65)
-	desc = "A clay bottle that with no markings."
+	desc = "A clay bottle with no markings."
 
 /obj/item/reagent_containers/glass/bottle/claybottle/beer
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 65)

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -199,9 +199,9 @@
 	desc = "A clay bottle with the City of Norwandine cork-seal. A red ale brewed to perfection in the lands of Hammerhold."
 
 /obj/item/reagent_containers/glass/bottle/claybottle/gronnmead
-	list_reagents = list(/datum/reagent/consumable/ethanol/gronnmead = 65)
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer/gronnmead = 65)
 	desc = "A clay bottle with a Shieldmaiden Berewrey cork-seal. A deep red honey-wine, refined with the red berries native to Gronns highlands."
 
 /obj/item/reagent_containers/glass/bottle/claybottle/whitewine
-	list_reagents = list(/datum/reagent/consumable/ethanol/whitewine = 65)
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer/whitewine = 65)
 	desc = "A bottle with the Otavan Merchant Guild cork-seal. This one appears to be labelled as a sweet wine from the colder northern regions."


### PR DESCRIPTION


## About The Pull Request

The Potter's house and craft needed some attention. 

This PR makes a minor fix to a specific bottle in ceramics, adds more starting material to get the Potter off the ground, and remaps their home slightly. This also adds some spawnable, though not complete list, of ceramic bottles with liquid.

The map change consists of prespawned ceramic, wine bottle. A glass statue, and changes their furnace to an oven, which is the structure that is used with their craft.

## Testing Evidence

Booted up local, tested. No issues.

## Why It's Good For The Game

The Potter role needed a bit of attention in a few minor ways. While they need MUCH more content, this is at least, in my opinion, a step in the right direction.

Puts them in line with other trades by giving them a slight boost to their starting materials.
