### PR TITLE
Added Tricorn to Loadout Options

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -32,6 +32,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Keffiyeh"
 	path = /obj/item/clothing/head/roguetown/roguehood/shalal
 
+/datum/loadout_item/tricorn
+	name = "Tricorn Hat"
+	path = /obj/item/clothing/head/roguetown/helmet/tricorn
+
 /datum/loadout_item/archercap
 	name = "Archer's cap"
 	path = /obj/item/clothing/head/roguetown/archercap


### PR DESCRIPTION
Added Tricorn to Loadout Options

## About The Pull Request

AVAST! All ye PIRATE BASTARDS rejoice! CHECK THIS DRIP ME HEARTIES! YAAAHAHAHAAAARRRR!

## Testing Evidence

![tricornProof](https://github.com/user-attachments/assets/e927134d-29f1-4f5a-86e5-287426979f19)


## Why It's Good For The Game

Fun hat that was left out of the loadout options. We have a lot of sea folk and pirate characters so they'll like it. Folk in the discord wanted it. We already have the rest of the sailor drip in there so why not.... Toootally not doing this because Tyr made a binding meme contract saying their life is in the hands of whoever makes this PR.
