### PR TITLE
fixes grenzlehoft zweihander

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -45,7 +45,7 @@
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
 				if("Zweihander")
-					r_hand = /obj/item/rogueweapon/greatsword/zwei
+					r_hand = /obj/item/rogueweapon/greatsword/grenz
 				if("Kriegmesser & Buckler") // Buckler cuz they have no shield skill.
 					r_hand = /obj/item/rogueweapon/sword/long/kriegmesser
 					l_hand = /obj/item/rogueweapon/shield/buckler


### PR DESCRIPTION
Changes the spawn gear back to a steel zwei. That's all.

Assumedly changed to iron by mistake, noteably the path on these suck so I get it.