### PR TITLE
Graggarites aren't Gaggarites anymore.

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -158,13 +158,16 @@
 /obj/item/reagent_containers/food/snacks/organ/On_Consume(mob/living/eater)		//Graggarites looove eating organs, they loooove eating organs!
 	if(HAS_TRAIT(eater, TRAIT_ORGAN_EATER))
 		eat_effect = /datum/status_effect/buff/foodbuff
+		foodtype = RAW | MEAT
+	else
+		eat_effect = initial(eat_effect)
+		foodtype = initial(foodtype)
 	if(bitecount >= bitesize)
 		record_featured_stat(FEATURED_STATS_CRIMINALS, eater)
 		GLOB.azure_round_stats[STATS_ORGANS_EATEN]++
 		check_culling(eater)
 		SEND_SIGNAL(eater, COMSIG_ORGAN_CONSUMED, src.type)
 	. = ..()
-	eat_effect = initial(eat_effect)
 
 /obj/item/reagent_containers/food/snacks/organ/Destroy()
 	QDEL_NULL(organ_inside)


### PR DESCRIPTION
## About The Pull Request
They can eat organs without being grossed out. If a Graggarite eats an organ the GROSS flag is removed from the foodtype. If a non-Graggarite eats said organ, the initial foodtype flags are reapplied. It all works properly. Yummers.

## Testing Evidence
![image](https://github.com/user-attachments/assets/6c3d7d9e-2be0-4170-bd72-936097c3d877)
![image](https://github.com/user-attachments/assets/44e011b6-8af3-43d3-afaf-e658842a36e2)


## Why It's Good For The Game
SOVL and puke-prevention. They've got a taste for this kind of thing. Take more than one bite.

If anyone has a lighter-weight method of messing with the relevant flags, please give me an appropriate code comment or review. tysm!