### PR TITLE
[Fix] Gives Beggars Thieves' Cant Back

### DIFF
--- a/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/beggar.dm
+++ b/modular_azurepeak/code/modules/jobs/job_types/roguetown/vagabond/beggar.dm
@@ -54,5 +54,7 @@
 		H.change_stat("intelligence", -4)
 		H.change_stat("constitution", -3)
 		H.change_stat("endurance", -3)
+		H.grant_language(/datum/language/thievescant)
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_NASTY_EATER, TRAIT_GENERIC)
+		


### PR DESCRIPTION
wrong beggar had it

## About The Pull Request
Gives Beggars Thieves' Cant. There were supposed to have it but it was put in the wrong beggar.dm. Requested by funky. 

## Testing Evidence

![image](https://github.com/user-attachments/assets/5835a629-b6a5-4e0a-b118-a5da9340727a)

## Why It's Good For The Game

i thieves cant think of a reason