### PR TITLE
Removes evil-ass floating minecraft dirtblock on the Azure Coast

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -488235,7 +488235,7 @@ vMR
 vMR
 vMR
 vMR
-iYn
+vMR
 vMR
 vMR
 vMR


### PR DESCRIPTION
## About The Pull Request

Title (evil ass dirt block can be found at Z4: 157 344

## Testing Evidence

[https://i.imgur.com/Cyg33xO.png](https://i.imgur.com/Cyg33xO.png)

[https://i.imgur.com/sl9Iqjx.png](https://i.imgur.com/sl9Iqjx.png)

## Why It's Good For The Game

Prevents some poor soiler from dying when the Minecraft dirtblock falls on his head
