### PR TITLE
Fixes inert glands being -too- hard to get

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -102,6 +102,17 @@
 	craftdiff = 5
 	verbage_simple = "mix"
 
+/datum/crafting_recipe/roguetown/alchemy/revival_potion_spider
+	name = "Revival potion"
+	category = "Table"
+	result = list(/obj/item/reagent_containers/glass/bottle/revival = 1)
+	reqs = list(/obj/item/reagent_containers/food/snacks/eoran_aril/auric = 1,
+	 			/obj/item/alch/viscera = 2,
+				/obj/item/reagent_containers/glass/bottle/alchemical,
+				/obj/item/reagent_containers/spidervenom_inert = 3)
+	craftdiff = 5
+	verbage_simple = "mix"
+
 /// bottle craft
 
 /datum/crafting_recipe/roguetown/alchemy/glassbottles

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/mirespiders.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/mirespiders.dm
@@ -243,12 +243,13 @@
 						/obj/item/natural/hide = 1,
 						/obj/item/natural/silk = 1, 
 						/obj/item/alch/viscera = 1,
+						/obj/item/reagent_containers/spidervenom_inert = 1, 
 						/obj/item/natural/head/mirespider_paralytic = 1)
 	perfect_butcher_results = list(/obj/item/reagent_containers/food/snacks/rogue/meat/spider = 2,
 						/obj/item/natural/hide = 1,
 						/obj/item/natural/silk = 1, 
 						/obj/item/alch/viscera = 1, 
-						/obj/item/reagent_containers/spidervenom_inert = 1, 
+						/obj/item/reagent_containers/spidervenom_inert = 2, 
 						/obj/item/natural/head/mirespider_paralytic = 1)
 
 	health = MIRESPIDER_ARAGN_HEALTH


### PR DESCRIPTION
## About The Pull Request
These were never meant to be rare drops.
Undoes these being rare drops from when butchery was reworked.
- Also adds an alternative recipe for revival potions that just takes more glands since the arils themselves are already pretty hard to get, and hunting mire spiders is dangerous enough as is. Trolls are a little bit too finite and hard to get from ambushes.

## Testing Evidence
Reuses working code.
