### PR TITLE
Crit Threshold & Limb Health Changes

### DIFF
--- a/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
+++ b/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
@@ -60,7 +60,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 40
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
 	sellprice = 30
@@ -77,7 +77,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 110
+	max_damage = 220
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30
@@ -112,7 +112,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 40
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
 	sellprice = 30
@@ -128,7 +128,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 110
+	max_damage = 220
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30
@@ -162,7 +162,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 20
+	max_damage = 40
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 300
 	sellprice = 30
@@ -178,7 +178,7 @@
 	status = BODYPART_ROBOTIC
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 110
+	max_damage = 220
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -673,7 +673,7 @@
 	name = BODY_ZONE_CHEST
 	desc = ""
 	icon_state = "default_human_chest"
-	max_damage = 200
+	max_damage = 300
 	body_zone = BODY_ZONE_CHEST
 	body_part = CHEST
 	px_x = 0
@@ -724,7 +724,7 @@
 	desc = ""
 	icon_state = "default_human_l_arm"
 	attack_verb = list("slapped", "punched")
-	max_damage = 100
+	max_damage = 200
 	max_stamina_damage = 50
 	body_zone = BODY_ZONE_L_ARM
 	body_part = ARM_LEFT
@@ -781,7 +781,7 @@
 	desc = ""
 	icon_state = "default_human_r_arm"
 	attack_verb = list("slapped", "punched")
-	max_damage = 100
+	max_damage = 200
 	body_zone = BODY_ZONE_R_ARM
 	body_part = ARM_RIGHT
 	aux_zone = BODY_ZONE_PRECISE_R_HAND
@@ -838,7 +838,7 @@
 	desc = ""
 	icon_state = "default_human_l_leg"
 	attack_verb = list("kicked", "stomped")
-	max_damage = 100
+	max_damage = 200
 	body_zone = BODY_ZONE_L_LEG
 	body_part = LEG_LEFT
 	body_damage_coeff = 1
@@ -888,7 +888,7 @@
 	// alternative spellings of 'pokey' are availible
 	icon_state = "default_human_r_leg"
 	attack_verb = list("kicked", "stomped")
-	max_damage = 100
+	max_damage = 200
 	body_zone = BODY_ZONE_R_LEG
 	body_part = LEG_RIGHT
 	body_damage_coeff = 1

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -125,8 +125,7 @@
 		if(human_owner.checkcritarmor(zone_precise, bclass))
 			return FALSE
 		if(owner.mind && (get_damage() <= (max_damage * 0.9))) //No crits unless the damage is maxed out.
-			if(owner.mobility_flags & MOBILITY_STAND && !owner.buckled) //Unless they're buckled or lying down.
-				do_crit = FALSE
+			do_crit = FALSE // We used to check if they are buckled or lying down but being grounded is a big enough advantage.
 	if(user)
 		if(user.goodluck(2))
 			dam += 10

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -124,7 +124,7 @@
 		var/mob/living/carbon/human/human_owner = owner
 		if(human_owner.checkcritarmor(zone_precise, bclass))
 			return FALSE
-		if(owner.mind && get_damage() < max_damage/2) //No crits except if it hits a damage threshold on players.
+		if(owner.mind && (get_damage() < max_damage)) //No crits unless the damage is maxed out.
 			if(owner.mobility_flags & MOBILITY_STAND && !owner.buckled) //Unless they're buckled or lying down.
 				do_crit = FALSE
 	if(user)

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -124,7 +124,7 @@
 		var/mob/living/carbon/human/human_owner = owner
 		if(human_owner.checkcritarmor(zone_precise, bclass))
 			return FALSE
-		if(owner.mind && (get_damage() < max_damage)) //No crits unless the damage is maxed out.
+		if(owner.mind && (get_damage() <= (max_damage * 0.9))) //No crits unless the damage is maxed out.
 			if(owner.mobility_flags & MOBILITY_STAND && !owner.buckled) //Unless they're buckled or lying down.
 				do_crit = FALSE
 	if(user)


### PR DESCRIPTION
## About The Pull Request
This PR tries to addresses that armor full coverage is 1000% necessary on AP to survive because you will get critted within 1 - 2 hits if you are unarmored.
- Instead of crit threshold applying at half max limb damage, you now need to hit 90% damage before you can crit a place
- Chest max health increased to 300 from 200. Limb base health increased from 100 to 200.
- Prosthetic limbs health doubled to match above

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="624" alt="dreamseeker_bjdZnNwylz" src="https://github.com/user-attachments/assets/c4000f35-56ba-44b9-ba16-d6be691b2e0a" />
<img width="413" alt="dreamseeker_HU0JNjThrj" src="https://github.com/user-attachments/assets/0cd0271f-8f65-45b9-a10a-0ec0bba54d39" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
People are far too fragile and full armor coverage is 200% necessary to survive in this game. Longer, less insta delimb / crit fight are more enjoyable than  2 hits into delimb / crit, despite what all the armorjakking / hema / realism / lifeweb jakking people on discord tell you otherwise (they like to play armored roles too). 

This should make it more palatable to reduce armor coverage and availability in the future because people will survive having no armor a bit longer, and is indirectly a Constitution / Towner buff because they can get pecked by a chicken a few time before getting arteried. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
