### PR TITLE
removes MAA tabard from the MAA skeleton NPC class.

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton.dm
@@ -114,8 +114,7 @@
 		else
 			r_hand = /obj/item/rogueweapon/knuckles/aknuckles
 		return
-	if(skeletonclass < 9) // Skeletal MAA Equal. Getting kinda up there in being dangerous.
-		cloak = /obj/item/clothing/cloak/stabard/surcoat/guard // Ooo Spooky Old Dead MAA
+	if(skeletonclass < 9) // Skeletal MAA Equal. Getting kinda up there in being dangerous. No guard tabard because it gets confusing for some people.
 		head = /obj/item/clothing/head/roguetown/helmet/heavy/aalloy
 		armor = /obj/item/clothing/suit/roguetown/armor/plate/half/aalloy
 		shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy


### PR DESCRIPTION
## About The Pull Request

Removes the MAA tabard that spawns using the duke's colors, on one of the skeleton NPC classes.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

People were giving a Sergeant grief over a "guard randomly attacking people" when it was actually just a skeleton.