### PR TITLE
Remove Blindness from Spell Mage List.

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -30,7 +30,7 @@
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T0,
 					/obj/effect/proc_holder/spell/invoked/invisibility/miracle	= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/blindness/miracle		= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/blindness				= CLERIC_T2,
 					/obj/effect/proc_holder/spell/self/noc_spell_bundle			= CLERIC_T3,
 	)
 	confess_lines = list(

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -1,33 +1,28 @@
 // Noc Spells
+// Blindness is a cancerous spells and should not be available to everyone.
+// But I am not nuking it from Acolyte yet so it will be unavailable to mage.
+// I repathed it to avoid it becoming available to mages again.
 /obj/effect/proc_holder/spell/invoked/blindness
 	name = "Blindness"
 	desc = "Direct a mote of living darkness to temporarily blind another."
 	overlay_state = "blindness"
 	clothes_req = FALSE
 	releasedrain = 30
-	chargedrain = 5
-	chargetime = 5
+	chargedrain = 0
+	chargetime = 0
 	range = 7
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = 'sound/magic/churn.ogg'
 	spell_tier = 2 // Combat spell
-	invocation = "Obcaeco!"
-	invocation_type = "shout"
-	associated_skill = /datum/skill/magic/arcane
-	antimagic_allowed = TRUE
-	recharge_time = 15 SECONDS
-	cost = 3
-
-/obj/effect/proc_holder/spell/invoked/blindness/miracle
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
-	chargedrain = 0
-	chargetime = 0
 	invocation = "Noc blinds thee of thy sins!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	associated_skill = /datum/skill/magic/holy
 	devotion_cost = 15
+	recharge_time = 15 SECONDS
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	miracle = TRUE
+	cost = 3
 
 /obj/effect/proc_holder/spell/invoked/blindness/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))

--- a/code/modules/spells/spell_types/wizard/spell_list.dm
+++ b/code/modules/spells/spell_types/wizard/spell_list.dm
@@ -17,7 +17,6 @@ GLOBAL_LIST_INIT(learnable_spells, (list(/obj/effect/proc_holder/spell/invoked/p
 		/obj/effect/proc_holder/spell/targeted/touch/darkvision,
 		/obj/effect/proc_holder/spell/invoked/longstrider,
 		/obj/effect/proc_holder/spell/invoked/invisibility,
-		/obj/effect/proc_holder/spell/invoked/blindness,
 		/obj/effect/proc_holder/spell/invoked/projectile/acidsplash,
 		/obj/effect/proc_holder/spell/invoked/projectile/fireball/greater,
 //		/obj/effect/proc_holder/spell/invoked/frostbite,


### PR DESCRIPTION
## About The Pull Request
- Remove Blindness from the Mage Spelllist 
- Refactor it so that Miracle is the base spell so to avoid someone else adding it in as a spell later

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Spaned in as CM and Noc Acolyte
![NVIDIA_Overlay_gvKrurdqE1](https://github.com/user-attachments/assets/c0a22c9c-bcc9-4ab4-a29e-bacf7c1bb692)
![NVIDIA_Overlay_caKQOAiSja](https://github.com/user-attachments/assets/b02cd0ae-b6f1-450a-8c73-7f4de2ab8892)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Blindness is one of the few spells with zero telegraph besides an icon, and don't need a projectile to hit. In a 1v1, the fact you can see an incantation makes it less OP than before (thanksfully), but in a group fight slapping this spell just completely shutdown someone and get them killed. 

I've always disliked Blindness spells and any spell that I see as very hard to telegraph / counter so this remove it from the list of spells Mage can take. Noc Acolyte / Templar (?) can keep it for now so I don't take away their exclusive toy without giving them something back. 

I also leave Eyebite untouched due to it being an antag tool. For now.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
