### PR TITLE
Witch House Teeny Fix

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -15162,7 +15162,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
 	},
-/turf/closed,
+/turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "fiP" = (
 /obj/structure/closet/crate/drawer/random,
@@ -23986,6 +23986,7 @@
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 1
 	},
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town)
 "ifN" = (


### PR DESCRIPTION
## About The Pull Request

One of the front windows of the house opens out to void space. Had to patch it up with flooring just like the other window.
A bucket is also missing in the witch's house, which is essential for their work.

## Testing Evidence

![image](https://github.com/user-attachments/assets/b188de90-97c1-4608-a1f6-0a53ca5d56c0)

## Why It's Good For The Game

Visual Fix, imagine opening a window to the shadow realm 
