### PR TITLE
the fair warden's breaching axe

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -405,7 +405,7 @@
 
 /obj/attacked_by(obj/item/I, mob/living/user)
 	user.changeNext_move(CLICK_CD_MELEE)
-	var/newforce = get_complex_damage(I, user, blade_dulling)
+	var/newforce = (get_complex_damage(I, user, blade_dulling) * I.demolition_mod)
 	if(!newforce)
 		testing("dam33")
 		return 0

--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -70,6 +70,7 @@
 	max_blade_int = 100
 	minstr = 8
 	wdefense = 1
+	demolition_mod = 1.25
 	w_class = WEIGHT_CLASS_BULKY
 	wlength = WLENGTH_SHORT
 	pickup_sound = 'sound/foley/equip/rummaging-03.ogg'
@@ -374,6 +375,7 @@
 	associated_skill = /datum/skill/combat/axes
 	blade_dulling = DULLING_SHAFT_WOOD
 	wdefense = 6
+	demolition_mod = 1.5
 
 /obj/item/rogueweapon/greataxe/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -9,6 +9,8 @@
 
 	var/damtype = BRUTE
 	var/force = 0
+	//a modifier to an item's damage against structures
+	var/demolition_mod = 1
 
 	var/datum/armor/armor
 	var/last_peeled_limb


### PR DESCRIPTION
## About The Pull Request

axes now feature a demolition mod that allows them to break objects faster. this is mostly relevant to windows and doors, since you won't be hitting objs directly that often, though this technically makes it a stealth buff to woodcutter. i doubt they'll mind. no, it doesn't effect damage to armored pieces, since it only procs on direct attackbys on objs.

demolition_mod is a var that can be attached to any object so if there's other weapons or like unique things we'd like to make more betterer at breaking things its as simple as changing the value from 1 to something higher, or lower if you want to make it bad at breaking stuff.

## Testing Evidence

![image](https://github.com/user-attachments/assets/fa79bcf9-2b24-4332-aec4-4bed32adfcac)


## Why It's Good For The Game

its a cool tg feature that took no time at all to port
