### PR TITLE
Makes stilted helm not adjustable

### DIFF
--- a/code/modules/clothing/adjustable_component.dm
+++ b/code/modules/clothing/adjustable_component.dm
@@ -43,6 +43,8 @@
 	var/obj/item/clothing/C = parent
 	if(!ishuman(C.loc))
 		return
+	if(C.adjustable != CAN_CADJUST)
+		return
 	var/mob/living/carbon/human/H = C.loc
 	if(toggled_open)	//We're open, so we'll close
 		toggle_closed(C)

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -962,7 +962,7 @@
 		desc = "A darksteel froggemund. Called forth from the edge of what should be known. In Her name."
 		flags_inv = HIDEFACE|HIDESNOUT|HIDEEARS 
 		body_parts_covered = HEAD|EARS|HAIR
-		adjustable = FALSE
+		adjustable = CANT_CADJUST
 	else
 		icon_state = "zizobarbute"
 		name = "darksteel barbute"


### PR DESCRIPTION
## About The Pull Request

Stilted helm can't be adjusted anymore- as intended.

NUFC: makes the component check for `adjustable`. 

## Testing Evidence

Tested with the stilted helm. Should not be causing user-facing changes on any other helm.

## Why It's Good For The Game

Consistency. Intent n code-wise
