### PR TITLE
GAGGAR GRANDEST SHAFT

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -417,6 +417,7 @@
 	name = "vicious greataxe"
 	desc = "A greataxe who's edge thrums with the motive force, violence, oh, sweet violence!"
 	icon_state = "graggargaxe"
+	blade_dulling = DULLING_SHAFT_GRAND
 	force = 20
 	force_wielded = 40
 	icon = 'icons/roguetown/weapons/64.dmi'


### PR DESCRIPTION
## About The Pull Request

Literally just gives the vicious axe (Graggar weapon) the grand shaft, like the other ritual weapons have. 



## Testing Evidence

![proof](https://github.com/user-attachments/assets/db3822dd-a143-4fa6-b748-2264d9d59bbd)



## Why It's Good For The Game

I've noticed these breaking a lot faster than most of the ritual weapons, and it's clearly an oversight. This will ensure that it's in-line with the other ritual weapons, given it's the ARMOR that is balanced to be 'worse' than the others-- Not the weapon.
