### PR TITLE
itty bitty light tweak

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -136,6 +136,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon = 'icons/roguetown/items/lighting.dmi'
 	heat = 1000
 	spitoutmouth = FALSE
+	light_outer_range = 1
+	light_system = MOVABLE_LIGHT
+	light_color = "#f5a885"
+	light_on = FALSE
 
 	grid_width = 32
 	grid_height = 32
@@ -203,7 +207,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return
 
 	lit = TRUE
-//	name = "lit [name]"
+	set_light_on(TRUE)
+	name = "lit [name]"
 	attack_verb = list("burnt", "singed")
 	hitsound = list('sound/blank.ogg')
 	damtype = "fire"
@@ -247,6 +252,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	force = 0
 	icon_state = icon_off
 	item_state = icon_off
+	set_light_on(FALSE)
 	STOP_PROCESSING(SSobj, src)
 	ENABLE_BITFIELD(reagents.flags, NO_REACT)
 	lit = FALSE
@@ -555,8 +561,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/pipe/attack_self(mob/user)
 	var/turf/location = get_turf(user)
 	if(lit)
+		name = copytext(name,5,length(name)+1)
 		user.visible_message(span_notice("[user] puts out [src]."), span_notice("I put out [src]."))
 		lit = 0
+		set_light_on(FALSE)
 		icon_state = icon_off
 		item_state = icon_off
 		STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -124,7 +124,8 @@
 
 /obj/item/flashlight/flare/torch
 	name = "torch"
-	desc = "A stick with enough fiber wrapped around the end to burn for a decent amount of time. Mind the rain."
+	desc = "A stick with enough fiber wrapped around the end to burn for a decent amount of time. Mind it \
+	should you choose to ford across water."
 	w_class = WEIGHT_CLASS_NORMAL
 	light_outer_range = 7
 	force = 1

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -126,7 +126,7 @@
 	name = "torch"
 	desc = "A stick with enough fiber wrapped around the end to burn for a decent amount of time. Mind the rain."
 	w_class = WEIGHT_CLASS_NORMAL
-	light_outer_range = 5
+	light_outer_range = 7
 	force = 1
 	icon = 'icons/roguetown/items/lighting.dmi'
 	icon_state = "torch"
@@ -138,13 +138,14 @@
 	flags_1 = null
 	possible_item_intents = list(/datum/intent/use, /datum/intent/hit)
 	slot_flags = ITEM_SLOT_HIP
-	var/datum/looping_sound/torchloop/soundloop = null         //remove the = null to re-add the torch crackle sounds.
-	var/should_self_destruct = TRUE //added for torch burnout
+	//remove the = null to re-add the torch crackle sounds. (???? what the fuck)
+	var/datum/looping_sound/torchloop/soundloop = null
+	//added for torch burnout
+	var/should_self_destruct = TRUE
 	max_integrity = 40
 	fuel = 30 MINUTES
 	light_depth = 0
 	light_height = 0
-
 	grid_width = 32
 	grid_height = 32
 


### PR DESCRIPTION
## About The Pull Request

torches have their light range bumped to 7 instead of 5 and are now impervious to the rain. they are still extinguished by standing or falling in water and still have to be held to be used. this change gives them a purpose beyond a lamptern placeholder without displacing lamptern as a clear upgrade for most people.

zigs and pipes emit a small amount of light when lit and no longer lose parts of their name when extinguished.

## Testing Evidence

![image](https://github.com/user-attachments/assets/3f02a4bc-4320-4d55-9d33-12ea4d2b112a)

## Why It's Good For The Game

brightens up the game without sweeping balance changes and adds a little more verisimilitude

