### PR TITLE
Add bun-bangs to halfelfs-tieflings

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -81,7 +81,8 @@
 		/datum/body_marking/flushed_cheeks,
 		/datum/body_marking/eyeliner,
 		/datum/body_marking/tonage,
-		
+		/datum/body_marking/bangs,
+		/datum/body_marking/bun,
 	)
 	languages = list(
 		/datum/language/common,

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/tiefling.dm
@@ -88,6 +88,8 @@
 		/datum/body_marking/flushed_cheeks,
 		/datum/body_marking/eyeliner,
 		/datum/body_marking/tonage,
+		/datum/body_marking/bangs,
+		/datum/body_marking/bun,
 	)
 	languages = list(
 		/datum/language/common,


### PR DESCRIPTION
## About The Pull Request

Adds bun n bangs to a few forgotten species.

## Testing Evidence
Yep.

## Why It's Good For The Game

Dwarves are the only species with sprite requirements. The rest (Volk included) can take in buns and bangs fine
