### PR TITLE
Fixes simple mobs not dealing parry / armor damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -14,7 +14,7 @@
 	return (armorval/max(organnum, 1))
 
 
-/mob/living/carbon/human/proc/checkarmor(def_zone, d_type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor)
+/mob/living/carbon/human/proc/checkarmor(def_zone, d_type, damage, armor_penetration, blade_dulling, peeldivisor, intdamfactor = 1)
 	if(!d_type)
 		return 0
 	if(isbodypart(def_zone))
@@ -328,7 +328,7 @@
 		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(dam_zone))
 		if(!affecting)
 			affecting = get_bodypart(BODY_ZONE_CHEST)
-		var/ap = (M.d_type == "blunt") ? BLUNT_DEFAULT_PENFACTOR : M.a_intent.penfactor
+		var/ap = (M.d_type == "blunt") ? BLUNT_DEFAULT_PENFACTOR : M.armor_penetration
 		var/armor = run_armor_check(affecting, M.d_type, armor_penetration = ap, damage = damage)
 		next_attack_msg.Cut()
 

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -352,7 +352,7 @@
 							var/mob/living/simple_animal/SM = user
 							dam2take = rand(SM.melee_damage_lower, SM.melee_damage_upper)
 							dam2take *= (SM.STASTR / 10)
-							dam2take *= 0.4
+							dam2take *= 0.25
 							switch(used_weapon.blade_dulling)
 								if(DULLING_SHAFT_CONJURED)
 									dam2take *= 1.3
@@ -692,7 +692,7 @@
 						var/mob/living/simple_animal/SM = user
 						dam2take = rand(SM.melee_damage_lower, SM.melee_damage_upper)
 						dam2take *= (SM.STASTR / 10)
-						dam2take *= 0.4
+						dam2take *= 0.25
 						switch(IS.blade_dulling)
 							if(DULLING_SHAFT_CONJURED)
 								dam2take *= 1.3

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -347,7 +347,34 @@
 							if(higher_intfactor > 1)	//Make sure to keep your weapon and intent intfactors consistent to avoid problems here!
 								used_intfactor = higher_intfactor
 							dam2take *= used_intfactor
-						used_weapon.take_damage(max(dam2take,1), BRUTE, used_weapon.d_type)
+					else	//This is normally handled in get_complex_damage, but it doesn't support simple mobs... at all, so we do a clunky mini-version of it.
+						if(istype(user, /mob/living/simple_animal))
+							var/mob/living/simple_animal/SM = user
+							dam2take = rand(SM.melee_damage_lower, SM.melee_damage_upper)
+							dam2take *= (SM.STASTR / 10)
+							dam2take *= 0.5
+							switch(used_weapon.blade_dulling)
+								if(DULLING_SHAFT_CONJURED)
+									dam2take *= 1.3
+								if(DULLING_SHAFT_METAL)
+									switch(SM.d_type)
+										if("slash")
+											dam2take *= 0.5
+										if("blunt")
+											dam2take *= 1.5
+								if(DULLING_SHAFT_WOOD)
+									switch(SM.d_type)
+										if("slash")
+											dam2take *= 1.5
+										if("blunt")
+											dam2take *= 0.5
+								if(DULLING_SHAFT_REINFORCED)
+									switch(SM.d_type)
+										if("slash")
+											dam2take *= 0.75
+										if("stab")
+											dam2take *= 1.5
+					used_weapon.take_damage(max(dam2take,1), BRUTE, used_weapon.d_type)
 					return TRUE
 				else
 					return FALSE

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -352,7 +352,7 @@
 							var/mob/living/simple_animal/SM = user
 							dam2take = rand(SM.melee_damage_lower, SM.melee_damage_upper)
 							dam2take *= (SM.STASTR / 10)
-							dam2take *= 0.5
+							dam2take *= 0.4
 							switch(used_weapon.blade_dulling)
 								if(DULLING_SHAFT_CONJURED)
 									dam2take *= 1.3
@@ -687,6 +687,33 @@
 					if(higher_intfactor > 1)	//Make sure to keep your weapon and intent intfactors consistent to avoid problems here!
 						used_intfactor = higher_intfactor
 					dam2take *= used_intfactor
+				else
+					if(istype(user, /mob/living/simple_animal))
+						var/mob/living/simple_animal/SM = user
+						dam2take = rand(SM.melee_damage_lower, SM.melee_damage_upper)
+						dam2take *= (SM.STASTR / 10)
+						dam2take *= 0.4
+						switch(IS.blade_dulling)
+							if(DULLING_SHAFT_CONJURED)
+								dam2take *= 1.3
+							if(DULLING_SHAFT_METAL)
+								switch(SM.d_type)
+									if("slash")
+										dam2take *= 0.5
+									if("blunt")
+										dam2take *= 1.5
+							if(DULLING_SHAFT_WOOD)
+								switch(SM.d_type)
+									if("slash")
+										dam2take *= 1.5
+									if("blunt")
+										dam2take *= 0.5
+							if(DULLING_SHAFT_REINFORCED)
+								switch(SM.d_type)
+									if("slash")
+										dam2take *= 0.75
+									if("stab")
+										dam2take *= 1.5
 				IS.take_damage(max(dam2take,1), BRUTE, IU.d_type)
 
 			user.visible_message(span_warning("<b>[user]</b> clips [src]'s weapon!"))


### PR DESCRIPTION
## About The Pull Request
To armor or parries / weapon clips. I've no idea how long it's been like this, and this miiiight make dungeon crawling more costly.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Booted up and tested this extensively with a wolf. The new code shouldn't apply if the attacker isn't a simple_animal.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It might not be. It was reported as a bug that armor wasn't taking damage from simple mobs. I caused this very recently, then I dug further and found out parries didn't work either.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
