### PR TITLE
User-made announces will log, now

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -8,16 +8,20 @@
 		announcement += "<h1 class='alert'>[title]</h1>"
 	announcement += "<br><span class='alert'>[STRIP_HTML_SIMPLE(text, MAX_MESSAGE_LEN)]</span>"
 
+	if (sender)
+		sender.log_talk(text, LOG_SAY, tag="priority announcement")
+		message_admins("[ADMIN_LOOKUPFLW(sender)] has made a priority announcement.")
+
 	var/s = sound(sound)
 	for(var/mob/M in GLOB.player_list)
-		if(!M.can_hear())
+		if (!M.can_hear())
 			return
-		if(receiver && !(istype(M, receiver) || (sender && M == sender)))
+		if (receiver && !(istype(M, receiver) || (sender && M == sender)))
 			return
 
 		to_chat(M, announcement)
-		if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
-			if(!sound)
+		if (M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
+			if (!sound)
 				return
 			M.playsound_local(M, s, 100)
 

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -20,18 +20,16 @@ SUBSYSTEM_DEF(communications)
 	if(is_silicon)
 		if(user.job)
 			var/used_title = user.get_role_title()
-			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Decrees", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
+			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Decrees", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), sender = user)
 			silicon_message_cooldown = world.time + 5 SECONDS
 	else
 		if(user.job)
 			var/used_title = user.get_role_title()
-			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Speaks", 'sound/misc/bell.ogg', "Captain")
+			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Speaks", 'sound/misc/bell.ogg', sender = user)
 			nonsilicon_message_cooldown = world.time + 5 SECONDS
 		else
-			priority_announce(html_decode(user.treat_message(input)), "Someone Speaks", 'sound/misc/bell.ogg', "Captain")
+			priority_announce(html_decode(user.treat_message(input)), "Someone Speaks", 'sound/misc/bell.ogg', sender = user)
 			nonsilicon_message_cooldown = world.time + 5 SECONDS
-	user.log_talk(input, LOG_SAY, tag="priority announcement")
-	message_admins("[ADMIN_LOOKUPFLW(user)] has made a priority announcement.")
 
 #undef COMMUNICATION_COOLDOWN
 #undef COMMUNICATION_COOLDOWN_AI

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -188,7 +188,7 @@
 	for(var/name in GLOB.outlawed_players)
 		if(user.real_name == name)
 			GLOB.outlawed_players -= user.real_name
-			priority_announce("[user.real_name] has completed their penance. Justice has been served in the eyes of Ravox.", "PENANCE", 'sound/misc/bell.ogg', "Captain")
+			priority_announce("[user.real_name] has completed their penance. Justice has been served in the eyes of Ravox.", "PENANCE", 'sound/misc/bell.ogg')
 	playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 5, TRUE)
 	if(QDELETED(src))
 		return

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -168,7 +168,7 @@
 		if(!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
 			to_chat(src, span_warning("I need to do this from the chapel."))
 			return FALSE
-		priority_announce("[inputty]", title = "The Priest Speaks", sound = 'sound/misc/bell.ogg')
+		priority_announce("[inputty]", title = "The Priest Speaks", sound = 'sound/misc/bell.ogg', sender = src)
 
 /obj/effect/proc_holder/spell/self/convertrole/templar
 	name = "Recruit Templar"

--- a/code/modules/jobs/job_types/roguetown/goblin/chieftain.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/chieftain.dm
@@ -46,33 +46,6 @@
 		if(!istype(get_area(src), /area/rogue/indoors/shelter/mountains/decap))
 			to_chat(src, span_warning("I need to do this from the Goblin Kingdom."))
 			return FALSE
-		priority_announce("[inputty]", title = "The Goblin King Squeals", sound = 'sound/misc/dun.ogg')
-/*
-/mob/living/carbon/human/proc/goblinopenslot()
-	set name = "Open Slot"
-	set category = "Goblin King"
-	if(stat)
-		return
-	var/datum/job/cookjob = SSjob.GetJob("Goblin Cook")
-	var/datum/job/guardjob = SSjob.GetJob("Goblin Guard")
-	var/datum/job/smithjob = SSjob.GetJob("Goblin Smith")
-	var/list/souloptions = list("Goblin Cook", "Goblin Guard", "Goblin Smith")
-	var/pickedsoul = input("Which worker shall join kingdom?", "Available workers") as null|anything in souloptions
-	if(!istype(get_area(src), /area/rogue/indoors/shelter/mountains/decap))
-		to_chat(src, span_warning("I need to do this from the Goblin Kingdom."))
-		return FALSE
-	if(!pickedsoul)
-		return
-	switch(pickedsoul)
-		if("Goblin Cook")
-			cookjob.total_positions += 1
-			priority_announce("Goblin Cook shall join our Kingdom", title = "The Goblin King Hires", sound = 'sound/misc/dun.ogg')
-		if("Goblin Guard")
-			guardjob.total_positions += 1
-			priority_announce("Goblin Guard shall join our Kingdom", title = "The Goblin King Hires", sound = 'sound/misc/dun.ogg')
-		if("Goblin Smith")
-			smithjob.total_positions += 1
-			priority_announce("Goblin Smith shall join our Kingdom", title = "The Goblin King Hires", sound = 'sound/misc/dun.ogg')
-*/
+		priority_announce("[inputty]", title = "The Goblin King Squeals", sound = 'sound/misc/dun.ogg', sender = src)
 
 

--- a/code/modules/jobs/job_types/roguetown/yeomen/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/villagechief.dm
@@ -39,7 +39,7 @@ GLOBAL_VAR_INIT(last_elder_announce, -50000) // Inits variable for later
 		visible_message(span_warning("[src] takes a deep breath, preparing to make an announcement.."))
 		if(do_after(src, 15 SECONDS, target = src)) // Reduced to 15 seconds from 30 on the original Herald PR. 15 is well enough time for sm1 to shove you.
 			say(announcementinput)
-			priority_announce("[announcementinput]", "The Elder Decrees", 'sound/misc/bell.ogg')
+			priority_announce("[announcementinput]", "The Elder Decrees", 'sound/misc/bell.ogg', sender = src)
 			GLOB.last_elder_announce = world.time
 		else
 			to_chat(src, span_warning("Your announcement was interrupted!"))


### PR DESCRIPTION
## About The Pull Request

For staff. Announces made by players log with name + text to game.log

## Testing Evidence

Not really but this should work.

## Why It's Good For The Game

Good for logging. Only duke announcements were being logged.
