### PR TITLE
Regency Mechanic. Also Coronation touches

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -20,11 +20,15 @@ SUBSYSTEM_DEF(communications)
 	if(is_silicon)
 		if(user.job)
 			var/used_title = user.get_role_title()
+			if(SSticker.regentmob == user)
+				used_title = "[used_title]" + " Regent"
 			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Decrees", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
 			silicon_message_cooldown = world.time + 5 SECONDS
 	else
 		if(user.job)
 			var/used_title = user.get_role_title()
+			if(SSticker.regentmob == user)
+				used_title = "[used_title]" + " Regent"
 			priority_announce(html_decode(user.treat_message(input)), "The [used_title] Speaks", 'sound/misc/bell.ogg', "Captain")
 			nonsilicon_message_cooldown = world.time + 5 SECONDS
 		else

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -66,6 +66,8 @@ SUBSYSTEM_DEF(ticker)
 	var/list/royals_readied = list()
 	var/rulertype = "Grand Duke" // reports whether king or queen rules
 	var/rulermob = null // reports what the ruling mob is.
+	var/regentmob = null // keeps track of regent mob
+	var/regentday = -1 // to prevent regent shuffling
 	var/failedstarts = 0
 	var/list/manualmodes = list()
 

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -92,6 +92,9 @@
 	set category = "Priest"
 	if(!mind)
 		return
+	if(world.time < 30 MINUTES)
+		to_chat(src, span_warning("It is a bad omen to coronate so early in the week."))
+		return FALSE
 	if(!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
 		to_chat(src, span_warning("I need to do this in the chapel."))
 		return FALSE
@@ -124,10 +127,15 @@
 		else
 			SSticker.rulertype = "Grand Duke"
 		SSticker.rulermob = HU
+		SSticker.regentmob = null
 		var/dispjob = mind.assigned_role
 		removeomen(OMEN_NOLORD)
 		say("By the authority of the gods, I pronounce you Ruler of all Azuria!")
 		priority_announce("[real_name] the [dispjob] has named [HU.real_name] the inheritor of AZURE PEAK!", title = "Long Live [HU.real_name]!", sound = 'sound/misc/bell.ogg')
+		var/datum/job/roguetown/nomoredukes = SSjob.GetJob("Grand Duke")
+		if(nomoredukes?.total_positions == 1)
+			nomoredukes.total_positions = 0 //We got what we got now.
+
 
 /mob/living/carbon/human/proc/churchexcommunicate()
 	set name = "Curse"

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -63,12 +63,17 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		else
 			SSticker.rulertype = "Grand Duke"
 		to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is [SSticker.rulertype] of Azure Peak.</span></span></b>")
+		SSticker.regentmob = null //Time for regent to give up the position.
 		if(STATION_TIME_PASSED() <= 10 MINUTES) //Late to the party? Stuck with default colors, sorry!
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
 
 /datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/roguetown/crown/serpcrown
+	if(SSroguemachine.crown == null || (QDELETED(SSroguemachine.crown)))
+		SSroguemachine.crown = null
+		head = /obj/item/clothing/head/roguetown/crown/serpcrown
+	else
+		to_chat(H, span_warning("My crown must be yet in the realm. I shall search it out."))
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	cloak = /obj/item/clothing/cloak/lordcloak
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -64,6 +64,8 @@
 		on_examine_face(user)
 		var/used_name = name
 		var/used_title = get_role_title()
+		if(SSticker.regentmob == user)
+			used_title = "[used_title]" + " Regent"
 		var/display_as_wanderer = FALSE
 		var/is_returning = FALSE
 		if(observer_privilege)

--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -60,9 +60,9 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 	var/nocrown
 	if(!istype(H.head, /obj/item/clothing/head/roguetown/crown/serpcrown))
 		nocrown = TRUE
-	var/notlord
-	if(SSticker.rulermob != H)
-		notlord = TRUE
+	var/notlord = TRUE
+	if(SSticker.rulermob == H || SSticker.regentmob == H)
+		notlord = FALSE
 
 	if(mode)
 		if(findtext(message, "nevermind"))
@@ -143,7 +143,7 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 	switch(mode)
 		if(0)
 			if(findtext(message, "secrets of the throat"))
-				say("My commands are: Make Decree, Make Announcement, Set Taxes, Declare Outlaw, Summon Crown, Summon Key, Make Law, Remove Law, Purge Laws, Purge Decrees, Nevermind")
+				say("My commands are: Make Decree, Make Announcement, Set Taxes, Declare Outlaw, Summon Crown, Summon Key, Make Law, Remove Law, Purge Laws, Purge Decrees, Become Regent, Nevermind")
 				playsound(src, 'sound/misc/machinelong.ogg', 100, FALSE, -1)
 			if(findtext(message, "make announcement"))
 				if(nocrown)
@@ -245,6 +245,34 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 				playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
 				give_tax_popup(H)
 				return
+			if(findtext(message, "become regent"))
+				if(nocrown)
+					say("You need the crown.")
+					playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
+					return
+				if(SSticker.rulermob != null)
+					say("The true lord is already present in the realm.")
+					playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
+					return
+				if(!(HAS_TRAIT(H, TRAIT_NOBLE)))
+					say("You have not the noble blood to be regent.")
+					playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
+					return
+				if(HAS_TRAIT(H, TRAIT_OUTLANDER))
+					say("You are too estranged from this realm to be regent.")
+					playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
+					return
+				if(SSticker.regentday == GLOB.dayspassed)
+					say("A regent has already been declared this dae!")
+					playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
+					return
+				if(SSticker.regentmob == H)
+					say("You are already the regent!")
+					playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
+					return
+				become_regent(H)
+				return
+
 		if(1)
 			make_announcement(H, raw_message)
 			mode = 0
@@ -355,3 +383,8 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 /proc/purge_decrees()
 	GLOB.lord_decrees = list()
 	priority_announce("All of the land's prior decrees have been purged!", "DECREES PURGED", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
+
+/proc/become_regent(mob/living/carbon/human/H)
+	priority_announce("[H.name], the [H.get_role_title()], sits as the regent of the realm.", "A New Regent Resides", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
+	SSticker.regentmob = H
+	SSticker.regentday = GLOB.dayspassed


### PR DESCRIPTION
## About The Pull Request
* Fixes ghost crown that spawns on Duke's head when he joins while the crown still exists somewhere else.
* Sets Priest coronation timer limit to prevent it from happening prior to 30 minutes into the round. Also makes it close open Duke jobslot, if viable.
* Regency mechanic. Noble non-foreigner that is in possession of the crown can sit on the throne and declare "BECOME REGENT", identifying them as the lord for purposes of laws, outlawing, taxes, and so on.
Beware, there can only be one shuffling of regent per day. And if the Duke comes home, you are immediately relieved of your duty.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/0ad19723-cb65-4988-8c56-41d25b68bde1)

## Why It's Good For The Game
There was a bad situation where the keep was victimized after a minute-one duke round leaving, and the priest exploited the keep's ask for coronation to make some seriously upsetting power plays - basically exploiting the OOC duck of the duke player. this was fundamentally unhealthy for the round, especially with taxes now being a *thing* to be considered with the merchant / steward and economy changes, tightening. So having these things tied up behind a Priest role that may likely turn their role's obligations on its head and be OOCly combative is unhealthy - it incentivizes far-traveling and rejoining AS the duke, which is nonsense.

This allows the keep to maintain their own house, while still relying on the priest for coronation and legitimacy for the installation of a true new ruler.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Having suffered through the dysgenics that happens when a Priest chooses to exploit the obligation of their slot for strife's sake, for just fabricating complete trash upon the remnant of the keep that are trying to cope with a minute-1 gone duke: regency is a tough ask, but I think it's necessary. I know you get this all the time, but I'm probably outta here if this one doesn't get merged, or, the problem doesn't get fixed somehow. It was that bad. I feel very strongly about this one.