### PR TITLE
fixes bites and grab smashes not respecting armor

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -426,8 +426,10 @@
 
 /obj/item/grabbing/proc/smashlimb(atom/A, mob/living/user) //implies limb_grabbed and sublimb are things
 	var/mob/living/carbon/C = grabbed
-	var/armor_block = C.run_armor_check(limb_grabbed, d_type)
+	var/armor_block = C.run_armor_check(limb_grabbed, d_type, armor_penetration = BLUNT_DEFAULT_PENFACTOR)
 	var/damage = user.get_punch_dmg()
+	var/unarmed_skill = user.mind?.get_skill_level(/datum/skill/combat/unarmed)
+	damage *= (1 + (unarmed_skill / 10))	//1.X multiplier where X is the unarmed skill.
 	C.next_attack_msg.Cut()
 	if(C.apply_damage(damage, BRUTE, limb_grabbed, armor_block))
 		limb_grabbed.bodypart_attacked_by(BCLASS_BLUNT, damage, user, sublimb_grabbed, crit_message = TRUE)

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -499,6 +499,7 @@
 /obj/item/grabbing/bite
 	name = "bite"
 	icon_state = "bite"
+	d_type = "stab"
 	slot_flags = ITEM_SLOT_MOUTH
 	bleed_suppressing = 1
 	var/last_drink


### PR DESCRIPTION
## About The Pull Request
before
![dreamseeker_TEqaQhTLrG](https://github.com/user-attachments/assets/48060d37-e142-4dd9-b0f4-92871797d92b)

this was happening because it's blunt damage, and has no AP associated with it. (Biting is kind of a snowflaked own thing)
Meaning this is what's actually happening:
![dreamseeker_wwzBrcTDYy](https://github.com/user-attachments/assets/be44d76d-3f81-42f7-b335-514d9fba9ebd)

This PR changes bites to do explicitly stab damage, making it do this instead:
![dreamseeker_YVA0LKTAtj](https://github.com/user-attachments/assets/289b03a9-4f9c-4ed3-8060-861149d76f79)

AKA it properly respects armor now.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Above.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
armor-ignoring bites / smashes are not intended! Esp. not with blunt damage!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
