### PR TITLE
Removes strength statcheck causing weapons to drop.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -246,6 +246,11 @@
 			effective = max(I.minstr / 2, 1)
 		if(effective > user.STASTR)
 			newforce = max(newforce*0.3, 1)
+			if(prob(33))
+				if(I.wielded)
+					to_chat(user, span_info("I am too weak to wield this weapon properly with both hands."))
+				else
+					to_chat(user, span_info("I am too weak to wield this weapon properly with one hand."))
 
 	switch(blade_dulling)
 		if(DULLING_CUT) //wooden that can't be attacked by clubs (trees, bushes, grass)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -102,15 +102,6 @@
 			if(src.mind?.has_antag_datum(/datum/antagonist/zombie) && (!src.handcuffed) && prob(50))
 				visible_message(span_warning("[src] spits out [mouth]."))
 				dropItemToGround(mouth, silent = FALSE)
-		if(held_items.len)
-			for(var/obj/item/I in held_items)
-				if(I.minstr)
-					var/effective = I.minstr
-					if(I.wielded)
-						effective = max(I.minstr / 2, 1)
-					if(effective > STASTR)
-						if(prob(effective))
-							dropItemToGround(I, silent = FALSE)
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0) //Temporary laziness thing. Will change to handles by species reee.
 	if(dna.species.space_move(src))


### PR DESCRIPTION
## About The Pull Request
If you lack the strength you will no longer randomly drop your weapons for moving.

## Testing Evidence
![image](https://github.com/user-attachments/assets/b25c8e61-8f73-4664-835d-4fe885f411fe)

## Why It's Good For The Game
Mostly a QoL update

Weapons already get a 70% damage penalty if you do not meet the requirements. We don't need something that annoys people by making them drop their items when they get slightly hungry and don't have a strap, or being forced to arbitrarily drop it mid combat because they got hungry.
