### PR TITLE
Conjure Weapon - No More Infinite Bladeworks

### DIFF
--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -25,7 +25,7 @@
 	attached_hand = null
 	action.UpdateButtonIcon()
 
-/obj/effect/proc_holder/spell/targeted/touch/cast(list/targets,mob/user = usr)
+/obj/effect/proc_holder/spell/targeted/touch/cast(list/targets, mob/user = usr)
 	if(!QDELETED(attached_hand))
 		remove_hand(TRUE)
 		to_chat(user, span_notice("[dropmessage]"))
@@ -48,7 +48,7 @@
 	if(!user.put_in_hands(attached_hand))
 		remove_hand(TRUE)
 		if (user.get_num_arms() <= 0)
-			to_chat(user, span_warning("I dont have any usable hands!"))
+			to_chat(user, span_warning("I don't have any usable hands!"))
 		else
 			to_chat(user, span_warning("My hands are full!"))
 		return FALSE

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
@@ -1,9 +1,6 @@
-#define CONJURE_DURATION 15 MINUTES
-
 /obj/effect/proc_holder/spell/invoked/conjure_weapon
 	name = "Conjure Weapon"
-	desc = "Conjure a weapon of your choice in your hand or on the ground.\n\
-	The weapon lasts for 15 minutes - but will refresh its duration infinitely when in the hand of an Arcyne user.\n\
+	desc = "Conjure a weapon of your choice in your hand. The weapon will be unsummoned should you conjure a new one or unbind the spell.\n\
 	At 12 int or above, conjure steel-tier weapons, otherwise conjure iron-tier weapons. Melee weapons only."
 	overlay_state = "conjure_weapon"
 	sound = list('sound/magic/whiteflame.ogg')
@@ -27,9 +24,11 @@
 	glow_color = GLOW_COLOR_METAL
 	glow_intensity = GLOW_INTENSITY_LOW
 
+	var/obj/item/rogueweapon/conjured_weapon = null
+
 	var/list/iron_weapons = list(
 		"Iron Short Sword" = /obj/item/rogueweapon/sword/iron/short,
-		"Iron Messer" = /obj/item/rogueweapon/sword/iron/messer,
+		"Iron Messer" = /obj/item/rogueweapon/sword/iron/messer/,
 		"Zweihander" = /obj/item/rogueweapon/greatsword/zwei,
 		"Cudgel" = /obj/item/rogueweapon/mace/cudgel,
 		"Iron Warhammer" = /obj/item/rogueweapon/mace/warhammer,
@@ -63,15 +62,27 @@
 	var/weapon_choice = input(user, "Choose a weapon", "Conjure Weapon") as anything in weapons
 	if(!weapon_choice)
 		return
+	if(src.conjured_weapon)
+		qdel(src.conjured_weapon)
+		src.conjured_weapon = null
 	weapon_choice = weapons[weapon_choice]
 
 	var/obj/item/rogueweapon/R = new weapon_choice(user.drop_location())
 	R.blade_dulling = DULLING_SHAFT_CONJURED
-	R.AddComponent(/datum/component/conjured_item, CONJURE_DURATION, TRUE, associated_skill)
+	R.filters += filter(type = "drop_shadow", x=0, y=0, size=1, offset = 2, color = GLOW_COLOR_ARCANE)
+	R.smeltresult = null
+	R.salvage_result = null
+	R.fiber_salvage = FALSE
 	user.put_in_hands(R)
+	src.conjured_weapon = R
 	return TRUE
 
 /obj/effect/proc_holder/spell/invoked/conjure_weapon/miracle
 	associated_skill = /datum/skill/magic/holy
 
-#undef CONJURE_DURATION
+/obj/effect/proc_holder/spell/invoked/conjure_weapon/Destroy()
+	if(src.conjured_weapon)
+		src.visible_message(span_warning("The [src]'s borders begin to shimmer and fade, before it vanishes entirely!"))
+		qdel(src.conjured_weapon)
+		src.conjured_weapon = null
+	return ..()

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
@@ -28,7 +28,7 @@
 
 	var/list/iron_weapons = list(
 		"Iron Short Sword" = /obj/item/rogueweapon/sword/iron/short,
-		"Iron Messer" = /obj/item/rogueweapon/sword/iron/messer/,
+		"Iron Messer" = /obj/item/rogueweapon/sword/iron/messer,
 		"Zweihander" = /obj/item/rogueweapon/greatsword/zwei,
 		"Cudgel" = /obj/item/rogueweapon/mace/cudgel,
 		"Iron Warhammer" = /obj/item/rogueweapon/mace/warhammer,

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
@@ -7,7 +7,7 @@
 
 	releasedrain = 60
 	chargedrain = 1
-	chargetime = 10 SECONDS // This is meant to make mid-combat summoning harder.
+	chargetime = 2 SECONDS
 	no_early_release = TRUE
 	recharge_time = 5 MINUTES // Not meant to be spammed or used as a mega support spell to outfit an entire party
 


### PR DESCRIPTION
## About The Pull Request

Changes Conjure Weapon to now be only capable of sustaining one weapon at a time and requiring the spell be known to sustain the weapon's existence. On summoning a new weapon, the former vanishes. On losing or forgetting the spell, the weapon vanishes. Furthermore, removes the timer altogether and lowers the cast time, as my changes leave no reason for the timer to continue existing and the lowered cast time will make the spell more useful should you find a break in combat (2-4 seconds, casting plus navigating menus) and need a weapon.

## Testing Evidence

I went around conjuring the weapon in different circumstances and despawning it in said different circumstances to see if it would break.

## Why It's Good For The Game

Currently both conjure weapon and conjure armor are odd spells. They're more useful to regular mages than they are to their spellblade counterparts as they don't typically start with decent arms and armor but can simply take these spells, get said arms and armor, and then use their spellbook to remove the spell and shift their points elsewhere. Meanwhile, spellblades are simply stuck with a spell that, while useful, is not as required due to starting with arms and armor.

This makes it so those classes getting conjure weapon is a tad more useful, especially since they can, for example, now use it to spawn in a dagger and put it in their bag without worrying that it's going to vanish because they had it in their bag when the 15 minute timer ended, preventing the refresh. It also makes it so mages aren't circumventing the economy as much, as they'll have to dedicate two of their spellpoints to having a weapon, as opposed to having a free resource. The removal of the timer also makes it less of a headache to check if the arbritary, rewinding, 15 minute timer is about to be up.

Lastly, this PR only changes conjure weapon for the time being for two reasons: the first is I don't want to completely change the conjurables only to find out there's a gamebreaking bug I missed; and the second is simply because as conjure armor works with multiple, individual pieces of armor and armor serving a different purpose than weapons (duh) I'll have change the spell more fundamentally than conjure weapon.