### PR TITLE
Hoardmaster fixes

### DIFF
--- a/code/modules/cargo/packsrogue/Sawbones.dm
+++ b/code/modules/cargo/packsrogue/Sawbones.dm
@@ -170,7 +170,7 @@
 	contains = list(/obj/item/reagent_containers/glass/bottle/alchemical/strpot)
 
 /datum/supply_pack/rogue/Sawbones/spdpot
-	name = "Strength Potion"
+	name = "Speed Potion"
 	cost = 10
 	contains = list(/obj/item/reagent_containers/glass/bottle/alchemical/spdpot)
 
@@ -193,3 +193,4 @@
 	name = "Poison Antidote"
 	cost = 10
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/strong_antidote)
+	

--- a/code/modules/cargo/packsrogue/Things.dm
+++ b/code/modules/cargo/packsrogue/Things.dm
@@ -88,3 +88,8 @@
 	name = "Dragonscale Necklace"
 	cost = 900
 	contains = list(/obj/item/clothing/neck/roguetown/blkknight)
+
+/datum/supply_pack/rogue/Things/smokebomb
+	name = "Smoke Bomb"
+	cost = 30
+	contains = list(/obj/item/smokebomb)


### PR DESCRIPTION
## About The Pull Request

- Fixes Speed potions being incorrectly labelled as Strength potions in Sawbones Hoardmaster shop.

- Adds smoke bombs as an escape tool in the 'general' Hoardmaster shop. I meant to do this in the last hoardmaster PR but it slipped my mind, sorry.

## Testing Evidence

It's like 4 lines, man. It compiles.

## Why It's Good For The Game

Stupid typo fix. Also adds smoke bombs 4 bandits in their shop, which are a decent escape tool for getting away from 1v5 situations.