### PR TITLE
Virtue: Potter's Apprentice!

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -166,6 +166,15 @@
 						list(/datum/skill/craft/smelting, 2, 2)
 	)
 
+	/datum/virtue/utility/potter
+	name = "Potter's Apprentice"
+	desc = "In my youth, I trained under a skilled potter, learning how to shape clay and blow glass."
+	added_skills = list(list(/datum/skill/craft/crafting, 2, 2),
+						list(/datum/skill/craft/masonry, 2, 2),
+						list(/datum/skill/craft/carpentry, 2, 2),
+						list(/datum/skill/misc/ceramics, 2, 2),
+	)
+
 /datum/virtue/utility/hunter
 	name = "Hunter's Apprentice"
 	desc = "In my youth, I trained under a skilled hunter, learning how to butcher animals and work with leather/hide."


### PR DESCRIPTION
## About The Pull Request
Adds potter's apprentice, a virtue that gives round-start  +2 ceramics, crafting, masonry, and carpentry, up to apprentice for each!


## Testing Evidence
Lobby text:
![Screenshot 2025-06-18 044424](https://github.com/user-attachments/assets/1591c216-18e6-4c73-8e0a-beffdc0e2f02)
Round-start skills, relavent skills at the bottom:
![Screenshot 2025-06-18 045230](https://github.com/user-attachments/assets/18584347-1704-4334-9cde-2ea35bbf4ef2)


## Why It's Good For The Game

Mostly created as a gift to someone who wanted round-start ceramics as a hunter, since her character has been learning ceramics as well. I don't see this having any econ effects? I doubt apprentice ceramics is gonna be making you beaucoup bucks without some skill-grinding!
