### PR TITLE
Give Ceramics to Artificer's Apprentice!

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -166,6 +166,15 @@
 						list(/datum/skill/craft/smelting, 2, 2)
 	)
 
+	/datum/virtue/utility/potter
+	name = "Potter's Apprentice"
+	desc = "In my youth, I trained under a skilled potter, learning how to shape clay and blow glass."
+	added_skills = list(list(/datum/skill/craft/crafting, 2, 2),
+						list(/datum/skill/craft/masonry, 2, 2),
+						list(/datum/skill/craft/carpentry, 2, 2),
+						list(/datum/skill/misc/ceramics, 2, 2),
+	)
+
 /datum/virtue/utility/hunter
 	name = "Hunter's Apprentice"
 	desc = "In my youth, I trained under a skilled hunter, learning how to butcher animals and work with leather/hide."

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -166,15 +166,6 @@
 						list(/datum/skill/craft/smelting, 2, 2)
 	)
 
-	/datum/virtue/utility/potter
-	name = "Potter's Apprentice"
-	desc = "In my youth, I trained under a skilled potter, learning how to shape clay and blow glass."
-	added_skills = list(list(/datum/skill/craft/crafting, 2, 2),
-						list(/datum/skill/craft/masonry, 2, 2),
-						list(/datum/skill/craft/carpentry, 2, 2),
-						list(/datum/skill/misc/ceramics, 2, 2),
-	)
-
 /datum/virtue/utility/hunter
 	name = "Hunter's Apprentice"
 	desc = "In my youth, I trained under a skilled hunter, learning how to butcher animals and work with leather/hide."
@@ -193,7 +184,8 @@
 						list(/datum/skill/craft/carpentry, 2, 2),
 						list(/datum/skill/craft/masonry, 2, 2),
 						list(/datum/skill/craft/engineering, 2, 2),
-						list(/datum/skill/craft/smelting, 2, 2)
+						list(/datum/skill/craft/smelting, 2, 2),
+						list(/datum/skill/misc/ceramics, 2, 2)
 	)
 	added_stashed_items = list(
 		"Hammer" = /obj/item/rogueweapon/hammer/wood,


### PR DESCRIPTION
## About The Pull Request

One line change that gives artificer's apprentice +2 ceramics! Round two of my first PR lol

## Testing Evidence

Lobby Text:
![Screenshot 2025-06-18 054600](https://github.com/user-attachments/assets/b759f25f-2293-4201-a6b0-1ea401cf66c2)

## Why It's Good For The Game

Added for a friend who wanted round-start ceramics! Really doubt this'll affect much since the potter subclass gets +5 ceramics, which means you'd have to grind to get close to that even with this change.
