### PR TITLE
Firestack, Some Spells Adjustment, Turf RR Removal

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -152,7 +152,7 @@
 
 //			L.adjustFireLoss(50)
 			if(L) //mobs turning into object corpses could get deleted here.
-				L.adjustFireLoss(10)
+				L.adjustFireLoss(40)
 				L.adjust_fire_stacks(100)
 				L.IgniteMob()
 

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -155,8 +155,6 @@
 				L.adjustFireLoss(10)
 				L.adjust_fire_stacks(100)
 				L.IgniteMob()
-				if(L.health <= 0)
-					L.dust(drop_items = TRUE)
 
 /turf/open/lava/onbite(mob/user)
 	if(isliving(user))

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -144,13 +144,9 @@
 				if(S && H && S.clothing_flags & LAVAPROTECT && H.clothing_flags & LAVAPROTECT)
 					return
 
-				if(C.health <= 0)
-					C.dust(drop_items = TRUE)
-
 			if("lava" in L.weather_immunities)
 				continue
 
-//			L.adjustFireLoss(50)
 			if(L) //mobs turning into object corpses could get deleted here.
 				L.adjustFireLoss(40)
 				L.adjust_fire_stacks(100)
@@ -211,8 +207,10 @@
 			var/obj/O = thing
 			if((O.resistance_flags & (ACID_PROOF|INDESTRUCTIBLE)) || O.throwing)
 				continue
+			O.obj_integrity -= O.max_integrity * 0.1
+			if(O.obj_integrity <= 0)
+				qdel(O)	
 			. = 1
-			qdel(O)
 
 		else if (isliving(thing))
 			. = 1
@@ -230,33 +228,16 @@
 				var/mob/living/live = buckle_check
 				if("lava" in live.weather_immunities)
 					continue
+			for(var/obj/item/clothing/C in L.contents)
+				if(C.resistance_flags & (ACID_PROOF|INDESTRUCTIBLE))
+					continue
+				C.obj_integrity -= C.max_integrity * 0.1
+				if(C.obj_integrity <= 0)
+					to_chat(L, span_danger("Your [C.name] is destroyed by the acid!"))
+					qdel(C)	
 
-			if(iscarbon(L))
-				var/mob/living/carbon/C = L
-//				var/obj/item/clothing/S = C.get_item_by_slot(SLOT_ARMOR)
-//				var/obj/item/clothing/H = C.get_item_by_slot(SLOT_HEAD)
-
-//				if(S && H && S.clothing_flags & LAVAPROTECT && H.clothing_flags & LAVAPROTECT)
-//					return
-				//make this acid
-				var/shouldupdate = FALSE
-				for(var/obj/item/bodypart/B in C.bodyparts)
-					if(!B.skeletonized && B.is_organic_limb())
-						B.skeletonize()
-						shouldupdate = TRUE
-				if(shouldupdate)
-					if(ishuman(C))
-						var/mob/living/carbon/human/H = C
-						H.underwear = "Nude"
-					C.unequip_everything()
-					C.update_body()
-//				C.dust(drop_items = TRUE)
-				continue
-
-//			if("lava" in L.weather_immunities)
-//				continue
-
-			L.dust(drop_items = TRUE)
+			L.adjustFireLoss(100)
+			to_chat(L, span_userdanger("THE ACID BURNS!"))
 
 /turf/open/lava/acid/onbite(mob/user)
 	if(isliving(user))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1856,9 +1856,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		var/burn_damage
 		var/firemodifier = H.fire_stacks / 50
 		if (H.on_fire)
-			burn_damage = 20
-			if(H.fire_stacks >= HUMAN_FIRE_STACK_ICON_NUM)
-				burn_damage = 200
+			burn_damage = min(5, H.fire_stacks * 2) // Minimum of 5 damage if you are on fire. Otherwise applies 2 per stack, up to 40.
 		else
 			firemodifier = min(firemodifier, 0)
 			burn_damage = max(log(2-firemodifier,(H.bodytemperature-BODYTEMP_NORMAL))-5,0) // this can go below 5 at log 2.5

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/snap_freeze.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/snap_freeze.dm
@@ -22,8 +22,8 @@
 	glow_color = GLOW_COLOR_ICE
 	glow_intensity = GLOW_INTENSITY_HIGH
 	ignore_los = FALSE
-	var/delay = 6
-	var/damage = 50 // less then fireball, more then lighting bolt
+	var/delay = 10
+	var/damage = 40 // less then fireball, more then lighting bolt
 	var/area_of_effect = 2
 
 /obj/effect/temp_visual/trapice

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -30,8 +30,9 @@
 	exp_light = 0
 	exp_flash = 0
 	exp_fire = 1
-	damage = 10
+	damage = 60
 	damage_type = BURN
+	npc_damage_mult = 2 // HAHAHA
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE
 	flag = "magic"

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
@@ -29,4 +29,6 @@
 	exp_light = 1
 	exp_flash = 2
 	exp_fire = 2
+	damage = 90 // This is gonna fucking HURT
+	npc_damage_mult = 2 // HAHAHA
 	flag = "magic"


### PR DESCRIPTION
## About The Pull Request
- Firestack no longer deal a flat 20 damage, and then 200 damage if above 5 stacks. Instead, it has a "curve" of dealing minimum 5 damage regardless of stack, and 2 per stack after. Up to 20 stacks.
- Fireball's damage is now frontloaded. Getting hit by one should hurt a lot - 60 damage on base fireball, 90 on GFB. They also have 2x NPC Damage Multiplier. They will demolish NPC in PVE now. Maybe people will run them?
- Snap Freeze's delay raised from 6 to 10 ticks and damage reduced to 40 from 50.
- Lava no longer round remove you. Torch you for 40 burn damage still and still set you on firestacks.
- Acid no longer RR you by skeletonizing you. Torch you for 100 burn damage per tick, and damage your items by 10% per tick so if you get yeeted into it your gears get melted if you don't leap out in time

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested. Burnt.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Firestacks being overtuned has been a consistent complaint. Thanks to Vexation pointing it out I found the root cause - It either deals 20 damage or nuke you entirely in 1 tick. Change the curves.
- Now fireball also match this curve and should be useful in PVE instead of being unreliable and cancerous - where it does nothing if you walk out in time and kill you entirely with no counterplay otherwise. GFB's reign of terror will be calmed down SLIGHTLY now. Probably.
- Snap Freeze has always been one of the most overtuned spell in the Mage's arsenal. Reliable, AOE CC and Damage. This make it so that it is theoretically possible to dodge it (still pretty hard) and reduce its damage slightly. (I know, I run it all the time if I plan to PVP)
- **HUGBOX:** Never liked Acid and Lava hard punishing you for a lagspike and utterly RRing you with no recourse, with Acid being even worse. So, I change it so that it is still punishing without instantly removing you with no resorts. This also means antags or fighters can use it waaaay more aggressively in fights around Acid / Lava without worrying about violating the RR on first contact rules. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
