### PR TITLE
Revert Malum Dream XP Half Discount.

### DIFF
--- a/code/datums/skills/_skill.dm
+++ b/code/datums/skills/_skill.dm
@@ -13,17 +13,12 @@
 /datum/skill/proc/get_skill_speed_modifier(level)
 	return
 
-/datum/skill/proc/get_dream_cost_for_level(level, mob/living/user)
+/datum/skill/proc/get_dream_cost_for_level(level)
 	if(length(specific_dream_costs) >= level)
 		return specific_dream_costs[level]
 	var/cost = FLOOR(dream_cost_base + (dream_cost_per_level * (level - 1)), 1)
 	if(level == SKILL_LEVEL_LEGENDARY)
 		cost += dream_legendary_extra_cost
-	
-	// Malum worshippers (with TRAIT_FORGEBLESSED) spend fewer dream points on craft skills
-	if(user && HAS_TRAIT(user, TRAIT_FORGEBLESSED) && (istype(src, /datum/skill/craft) || (istype(src, /datum/skill/misc/sewing))))
-		cost = max(1, FLOOR(cost * 0.5, 1)) // 50% reduction, minimum cost of 1
-	
 	return cost
 
 /datum/skill/proc/skill_level_effect(level, datum/mind/mind)

--- a/code/datums/sleep_adv/sleep_adv.dm
+++ b/code/datums/sleep_adv/sleep_adv.dm
@@ -193,7 +193,7 @@
 /datum/sleep_adv/proc/get_skill_cost(skill_type)
 	var/datum/skill/skill = GetSkillRef(skill_type)
 	var/next_level = get_next_level_for_skill(skill_type)
-	return skill.get_dream_cost_for_level(next_level, mind.current)
+	return skill.get_dream_cost_for_level(next_level)
 
 /datum/sleep_adv/proc/get_special_cost()
 	return 3
@@ -207,11 +207,6 @@
 	var/dream_text = skill.get_random_dream()
 	if(dream_text)
 		to_chat(mind.current, span_notice(dream_text))
-	
-	// Notify player if they're benefiting from Malum's blessing for craft skills or sewing
-	if(HAS_TRAIT(mind.current, TRAIT_FORGEBLESSED) && (istype(skill, /datum/skill/craft) || istype(skill, /datum/skill/misc/sewing)))
-		to_chat(mind.current, span_notice("Malum's blessing reduces the dream point cost of your crafting training."))
-	
 	sleep_adv_points -= get_skill_cost(skill_type)
 	adjust_sleep_xp(skill_type, -get_requried_sleep_xp_for_skill(skill_type, 1))
 	mind.adjust_skillrank(skill_type, 1, FALSE)


### PR DESCRIPTION
## About The Pull Request
Reverts: https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/1711

Which gave Malumite 50% discount on learning any crafting skills

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I've come to the belief this trait is actually a really bad idea over the past two months and I believe it play a large part in people stealing the smith and other's job easily. 

Dedicated crafters start with Expert or above in their crafting skills. They seldomly stray to take other jobs and can reach Legendary in two night. This buff primarily benefits people stealing jobs from crafters instead and powerful gamers.

It should go. In the future maybe we can replace it with something that helps dedicated crafters. Like item quality boost.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
