### PR TITLE
Fix Fancy coat details

### DIFF
--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -135,6 +135,8 @@
 	desc = "A fancy tunic and coat combo. How elegant."
 	icon_state = "noblecoat"
 	sleevetype = "noblecoat"
+	detail_tag = "_detail"
+	detail_color = CLOTHING_AZURE
 	color = CLOTHING_WHITE
 	boobed = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Fancy Coat always had details but whoever made it forgot to put the detail tag in the code.
Now it can be recolored.

## Testing Evidence
![image](https://github.com/user-attachments/assets/84f6caef-067c-4b10-b323-1d9aebc50731)
![image](https://github.com/user-attachments/assets/542b3091-fbdf-4379-810b-7788e7ba1412)


