### PR TITLE
Quick Donator Item fix | The tale of how I accidentally ripped my sleeves and made myself naked.

### DIFF
--- a/modular_azurepeak/code/game/objects/items/donator_fluff_items.dm
+++ b/modular_azurepeak/code/game/objects/items/donator_fluff_items.dm
@@ -37,6 +37,7 @@
 	sleeved = 'modular_azurepeak/icons/clothing/onmob/donor_sleeves_armor.dmi'
 	flags_inv = HIDEBOOB
 	color = null
+	nodismemsleeves = TRUE // prevents sleeves from being torn
 
 //Bat's donator item - custom harp sprite
 /obj/item/rogue/instrument/harp/handcarved


### PR DESCRIPTION
## About The Pull Request
Simple fix, removes the ability to rip my donator items sleeves.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Booted up a test server, furiously pressed MMB, failed to tear sleeves.

Below is an oversized image of what I was attempting to do but failed to. Also included is some subway surfers gameplay to keep the contributors entertained.
![flat,750x,075,f-pad,750x1000,f8f8f8](https://github.com/user-attachments/assets/881c5486-16e7-4b56-89a3-2842deac1ae0) ![subway-surfers-icegif-5](https://github.com/user-attachments/assets/997db9a4-10e3-4eff-99df-41948becdea7)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
If I rip a sleeve on my item it makes the sprite invisible and that's bad :^(
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
