### PR TITLE
we got elden ring at home: fixes mt decap ambushes and uses it to add scary guys who want to kill you

### DIFF
--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -140,17 +140,23 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	name = "mt decapitation"
 	icon_state = "decap"
 	ambush_types = list(
-				/turf/open/floor/rogue/dirt)
+				/turf/open/floor/rogue/dirt,
+				/turf/open/floor/rogue/dirt/road,
+				/turf/open/floor/rogue/snow,
+				/turf/open/floor/rogue/grasscold,
+				/turf/open/floor/rogue/grass,
+				)
 	ambush_mobs = list(
-				/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 30,
-				/mob/living/carbon/human/species/skeleton/npc/ambush = 10,
-				/mob/living/carbon/human/species/goblin/npc/ambush/hell = 20)
+				new /datum/ambush_config/solo_treasure_hunter = 10,
+				new /datum/ambush_config/duo_treasure_hunter = 1
+				)
 	droning_sound = 'sound/music/area/decap.ogg'
 	droning_sound_dusk = null
 	droning_sound_night = null
 	first_time_text = "MOUNT DECAPITATION"
 	ambush_times = list("night","dawn","dusk","day")
 	converted_type = /area/rogue/indoors/shelter/mountains/decap
+
 /area/rogue/indoors/shelter/mountains/decap
 	icon_state = "decap"
 	droning_sound = 'sound/music/area/decap.ogg'
@@ -162,11 +168,16 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	name = "mt decapitation inner"
 	icon_state = "decap"
 	ambush_types = list(
-				/turf/open/floor/rogue/dirt)
+				/turf/open/floor/rogue/dirt,
+				/turf/open/floor/rogue/dirt/road,
+				/turf/open/floor/rogue/snow,
+				/turf/open/floor/rogue/grasscold,
+				/turf/open/floor/rogue/grass,
+				)
 	ambush_mobs = list(
-				/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 30,
-				/mob/living/carbon/human/species/skeleton/npc/ambush = 10,
-				/mob/living/carbon/human/species/goblin/npc/ambush/hell = 20)
+				new /datum/ambush_config/solo_treasure_hunter = 5,
+				new /datum/ambush_config/duo_treasure_hunter = 1
+				)
 	droning_sound = 'sound/music/area/decap_deeper.ogg'
 	droning_sound_dusk = null
 	droning_sound_night = null
@@ -178,10 +189,13 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	name = "mt decapitation gundu-zirak"
 	icon_state = "decap"
 	ambush_types = list(
-				/turf/open/floor/rogue/dirt)
+				/turf/open/floor/rogue/dirt,
+				/turf/open/floor/rogue/cobble,
+				)
 	ambush_mobs = list(
-				/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 30,
-				/mob/living/carbon/human/species/dwarfskeleton/ambush = 30)
+				new /datum/ambush_config/treasure_hunter_posse = 1,
+				/mob/living/carbon/human/species/dwarfskeleton/ambush = 30,
+				)
 	droning_sound = 'sound/music/area/prospector.ogg'
 	droning_sound_dusk = null
 	droning_sound_night = null

--- a/code/modules/mob/living/carbon/human/npc/mad_touched_treasure_hunters.dm
+++ b/code/modules/mob/living/carbon/human/npc/mad_touched_treasure_hunters.dm
@@ -1,0 +1,116 @@
+/* 
+*	based on pages from elden ring in terms of visual design, these guys are intended to be a speedbump to solo adventurers at mount decap
+*	deadly but small in numbers. come back with a party, chump
+*/
+
+/mob/living/carbon/human/species/human/northern/mad_touched_teasure_hunter
+	aggressive=1
+	mode = AI_IDLE
+	faction = list("viking", "station")
+	ambushable = FALSE
+	dodgetime = 15
+	flee_in_pain = FALSE
+	stand_attempts = 6
+	possible_rmb_intents = list()
+
+/mob/living/carbon/human/species/human/northern/mad_touched_teasure_hunter/ambush
+	aggressive=1
+	wander = TRUE
+
+/mob/living/carbon/human/species/human/northern/mad_touched_teasure_hunter/Initialize()
+	. = ..()
+	set_species(/datum/species/human/northern)
+	addtimer(CALLBACK(src, PROC_REF(after_creation)), 1 SECONDS)
+
+/mob/living/carbon/human/species/human/northern/mad_touched_teasure_hunter/after_creation()
+	..()
+	job = "Mad-touched Treasure Hunter"
+	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_NOROGSTAM, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	equipOutfit(new /datum/outfit/job/roguetown/human/species/human/northern/mad_touched_teasure_hunter)
+	var/obj/item/organ/eyes/organ_eyes = getorgan(/obj/item/organ/eyes)
+	if(organ_eyes)
+		organ_eyes.eye_color = pick("27becc", "35cc27", "000000")
+	update_hair()
+	update_body()
+	var/obj/item/bodypart/head/head = get_bodypart(BODY_ZONE_HEAD)
+	head.sellprice = 40
+
+/mob/living/carbon/human/species/human/northern/mad_touched_teasure_hunter/npc_idle()
+	if(m_intent == MOVE_INTENT_SNEAK)
+		return
+	if(world.time < next_idle)
+		return
+	next_idle = world.time + rand(30, 70)
+	if((mobility_flags & MOBILITY_MOVE) && isturf(loc) && wander)
+		if(prob(20))
+			var/turf/T = get_step(loc,pick(GLOB.cardinals))
+			if(!istype(T, /turf/open/transparent/openspace))
+				Move(T)
+		else
+			face_atom(get_step(src,pick(GLOB.cardinals)))
+	if(!wander && prob(10))
+		face_atom(get_step(src,pick(GLOB.cardinals)))
+
+/datum/outfit/job/roguetown/human/species/human/northern/mad_touched_teasure_hunter/pre_equip(mob/living/carbon/human/H)
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
+	mask = /obj/item/clothing/mask/rogue/facemask/steel/paalloy/mad_touched
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	if(prob(50))
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	head = /obj/item/clothing/head/roguetown/menacing/mad_touched_treasure_hunter
+	neck = /obj/item/clothing/neck/roguetown/coif
+	gloves = /obj/item/clothing/gloves/roguetown/angle
+	cloak = /obj/item/clothing/cloak/wickercloak
+	if(prob(50))
+		r_hand = /obj/item/rogueweapon/estoc
+	else
+		r_hand = /obj/item/rogueweapon/sword/rapier
+		l_hand = /obj/item/rogueweapon/shield/buckler
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	H.STASTR = rand(13,15)
+	H.STASPD = 15
+	H.STACON = rand(11,12)
+	H.STAEND = 13
+	H.STAPER = 10
+	H.STAINT = 14
+	H.eye_color = "27becc"
+	H.hair_color = "61310f"
+	H.facial_hair_color = H.hair_color
+	if(H.gender == FEMALE)
+		H.hairstyle =  "Messy (Rogue)"
+	else
+		H.hairstyle = "Messy"
+
+/obj/item/clothing/head/roguetown/menacing/mad_touched_treasure_hunter //its here so it doesnt wind up on some class' loadout.
+	name = "sack hood"
+	desc = "A ragged hood of thick jute fibres. The itchiness is unbearable."
+	sewrepair = TRUE
+	color = "#999999"
+	armor = ARMOR_HEAD_HELMET_BAD
+
+/obj/item/clothing/mask/rogue/facemask/steel/paalloy/mad_touched
+	name = "eerie ancient mask"
+
+/obj/item/clothing/mask/rogue/facemask/steel/paalloy/mad_touched/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+
+/datum/ambush_config/solo_treasure_hunter
+	mob_types = list(
+		/mob/living/carbon/human/species/human/northern/mad_touched_teasure_hunter/ambush = 1,
+	)
+
+/datum/ambush_config/duo_treasure_hunter
+	mob_types = list(
+		/mob/living/carbon/human/species/human/northern/mad_touched_teasure_hunter/ambush = 2,
+	)
+
+/datum/ambush_config/treasure_hunter_posse
+	mob_types = list(
+		/mob/living/carbon/human/species/human/northern/mad_touched_teasure_hunter/ambush = 3,
+	)

--- a/code/modules/mob/living/carbon/human/npc/mad_touched_treasure_hunters.dm
+++ b/code/modules/mob/living/carbon/human/npc/mad_touched_treasure_hunters.dm
@@ -29,6 +29,9 @@
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_NOROGSTAM, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 	equipOutfit(new /datum/outfit/job/roguetown/human/species/human/northern/mad_touched_teasure_hunter)
 	var/obj/item/organ/eyes/organ_eyes = getorgan(/obj/item/organ/eyes)
 	if(organ_eyes)
@@ -67,14 +70,14 @@
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	cloak = /obj/item/clothing/cloak/wickercloak
 	if(prob(50))
-		r_hand = /obj/item/rogueweapon/estoc
+		r_hand = /obj/item/rogueweapon/greatsword/paalloy
 	else
-		r_hand = /obj/item/rogueweapon/sword/rapier
-		l_hand = /obj/item/rogueweapon/shield/buckler
+		r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow //they're too stupid to use this but it makes the sprite look cool +  simplemobs are lame
+		l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	H.STASTR = rand(13,15)
-	H.STASPD = 15
-	H.STACON = rand(11,12)
+	H.STASTR = rand(14,16)
+	H.STASPD = 18 //you will regret telling me that bows are good for pve
+	H.STACON = rand(14,18)
 	H.STAEND = 13
 	H.STAPER = 10
 	H.STAINT = 14

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1729,6 +1729,7 @@
 #include "code\modules\mob\living\carbon\human\npc\dwarfskeleton.dm"
 #include "code\modules\mob\living\carbon\human\npc\goblin.dm"
 #include "code\modules\mob\living\carbon\human\npc\highwayman.dm"
+#include "code\modules\mob\living\carbon\human\npc\mad_touched_treasure_hunters.dm"
 #include "code\modules\mob\living\carbon\human\npc\militia.dm"
 #include "code\modules\mob\living\carbon\human\npc\orc.dm"
 #include "code\modules\mob\living\carbon\human\npc\searaider.dm"


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/ed6c8df7-26b3-4bbc-bad6-f1846e4a9d02)

did you know that mt decap had ambushes setup? me neither! that's because they could only proc on a single tile type that barely exists on that map in any capacity and barely ever existed anywhere on mt decap. whoops!

i fixed that by expanding the valid tiles to encompass most of mt decap. and added these crazy elden ring page dudes that will walk out of the treeline to gank you. they're like highwaymen if highwaymen could solo frag, but they spawn in low numbers, and are intended mostly to speedbump solo adventurers trying to run around and grab free shit on mt doom.

## Testing Evidence

i set up goofy shit like this and walked back and forth until i proc'd ambushes it was abysmal

![image](https://github.com/user-attachments/assets/24f2f139-9f8e-4669-9b9f-130ab65c73d3)


## Why It's Good For The Game
i fought these dudes in nightreign and remembered theyre real cool so i took a minute to add them to the game
![image](https://github.com/user-attachments/assets/df7c0c1b-19a2-4b9f-a992-3c401446c641)
