### PR TITLE
and kittysmooch taketh away - collapses lancer and footman squire into one class and adds a new one, the Skulduggerist.

### DIFF
--- a/_maps/templates/sewers.dm
+++ b/_maps/templates/sewers.dm
@@ -58,6 +58,7 @@
 		/obj/item/storage/bag/tray = 6,
 		/obj/item/mundane/puzzlebox/medium = 2,
 		/obj/item/mundane/puzzlebox/easy = 4,
+		/obj/item/book/granter/crafting_recipe/agricultural_society = 1,
 
 		//medical
 		/obj/item/needle = 4,

--- a/_maps/templates/smalldungeons.dm
+++ b/_maps/templates/smalldungeons.dm
@@ -72,6 +72,7 @@
 		/obj/item/mundane/puzzlebox/medium = 3,
 		/obj/item/mundane/puzzlebox/easy = 1,
 		/obj/item/mundane/puzzlebox/impossible = 2,
+		/obj/item/book/granter/crafting_recipe/agricultural_society = 1,
 
 		//medical
 		/obj/item/needle = 4,

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -147,6 +147,8 @@
 	name = "Agricultural Society and Its Future"
 	desc = "A hastily scrawled tome on the supposed dangers that growing food represents to the mortal races. \
 	Likely the mere ravings of a madman, but there's some interesting marginalia about offensive alchemy."
+	icon = 'icons/roguetown/items/books.dmi'
+	icon_state = "basic_book_0"
 	crafting_recipe_types = list(
 		/datum/crafting_recipe/roguetown/alchemy/bbomb
 	)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -143,6 +143,20 @@
 		user.mind.teach_crafting_recipe(crafting_recipe_type)
 		to_chat(user,span_notice("I learned how to make [initial(R.name)]."))
 
+/obj/item/book/granter/crafting_recipe/agricultural_society
+	name = "Agricultural Society and Its Future"
+	desc = "A hastily scrawled tome on the supposed dangers that growing food represents to the mortal races. \
+	Likely the mere ravings of a madman, but there's some interesting marginalia about offensive alchemy."
+	crafting_recipe_types = list(
+		/datum/crafting_recipe/roguetown/alchemy/bbomb
+	)
+	remarks = list(
+		"Agricultural society and its consequences have been a disaster for the mortal races...",
+		"The toil of the fields make life unfulfilling...",
+		"Wait, what's this part about saltpetre?",
+		"Those putrid curs will pay...",
+	)
+
 //! --BLACKSTONE SCROLLS-- !/
 /obj/item/book/granter/spell/blackstone/
     desc = "A scroll of potential known only to those that can decipher its secrets."

--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -1,4 +1,3 @@
-
 /obj/item/bomb
 	name = "bottle bomb"
 	desc = "A fiery explosion waiting to be coaxed from its glass prison."
@@ -9,12 +8,15 @@
 	throwforce = 0
 	slot_flags = ITEM_SLOT_HIP
 	throw_speed = 0.5
-	var/fuze = rand(30,60)
+	var/fuze = null //randomized on init
 	var/lit = FALSE
 	var/prob2fail = 5
 	grid_width = 32
 	grid_height = 64
 
+/obj/item/bomb/Initialize()
+	. = ..()
+	fuze = rand(40,60)
 
 /obj/item/bomb/spark_act()
 	light()

--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -9,9 +9,9 @@
 	throwforce = 0
 	slot_flags = ITEM_SLOT_HIP
 	throw_speed = 0.5
-	var/fuze = 50
+	var/fuze = rand(30,60)
 	var/lit = FALSE
-	var/prob2fail = 23
+	var/prob2fail = 5
 	grid_width = 32
 	grid_height = 64
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -42,6 +42,7 @@
 	H.mind.adjust_skillrank(/datum/skill/misc/medicine, 6, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 3, TRUE)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/roguetown/alchemy/bbomb)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
@@ -44,5 +44,6 @@
 	H.change_stat("endurance", 1)
 	H.change_stat("speed", 1)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+	H.mind.teach_crafting_recipe(/datum/crafting_recipe/roguetown/alchemy/bbomb)
 	H.mind.adjust_spellpoints(27) // Unlike Rogue Mage, who gets 6 but DExpert, this one don't have DExpert but have more spell points than anyone but the CM. 
 	wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -65,6 +65,7 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+		H.mind.teach_crafting_recipe(/datum/crafting_recipe/roguetown/alchemy/bbomb)
 		H.change_stat("strength", -1)
 		H.change_stat("constitution", -1)
 		H.change_stat("intelligence", 4)

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -16,7 +16,7 @@
 	outfit = /datum/outfit/job/roguetown/squire
 	display_order = JDO_SQUIRE
 	give_bank_account = TRUE
-	min_pq = -5 //squires aren't great but they can do some damage
+	min_pq = -5
 	max_pq = null
 	round_contrib_points = 2
 
@@ -29,7 +29,7 @@
 	beltl = /obj/item/storage/keyring/guardcastle
 	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
 	id = /obj/item/scomstone/bad/garrison
-	job_bitflag = BITFLAG_GARRISON		//Move this role to garrison section later. Shouldn't be under youngroles for transparancy they are garrison.
+	job_bitflag = BITFLAG_GARRISON
 
 /datum/job/roguetown/squire/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
@@ -47,16 +47,15 @@
 				index = H.real_name
 			S.name = "squire's tabard ([index])"
 
-/datum/advclass/squire/lancer
-	name = "Lancer Squire"
-	tutorial = "A hopeful for the next generation of knightly mounted lancers and infantry pike specialists, \
-	your training with polearms sets you apart from other squires."
-	outfit = /datum/outfit/job/roguetown/squire/lancer
+/datum/advclass/squire/knightly
+	name = "Knightly Squire"
+	tutorial = "Most squires pursue the same knightly skills as their mentors, from martial melee training to the equestrian arts. \
+	These young warriors are as ready for the infantry line as they are for the muster of cavalrie."
+	outfit = /datum/outfit/job/roguetown/squire/knightly
 		
 	category_tags = list(CTAG_SQUIRE)
 
-/datum/outfit/job/roguetown/squire/lancer/pre_equip(mob/living/carbon/human/H)
-	r_hand = /obj/item/rogueweapon/spear
+/datum/outfit/job/roguetown/squire/knightly/pre_equip(mob/living/carbon/human/H)
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
@@ -64,14 +63,14 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch,
-		/obj/item/clothing/neck/roguetown/chaincoif
+		/obj/item/clothing/neck/roguetown/chaincoif/iron,
 	)
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
@@ -87,52 +86,22 @@
 	ADD_TRAIT(H, TRAIT_SQUIRE_REPAIR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
-/datum/advclass/squire/footman
-	name = "Footman Squire"
-	tutorial = "Your training has been singularly focused on the intricacies of sword, a weapon whose versatility \
-	belies the difficulty of its use."
-	outfit = /datum/outfit/job/roguetown/squire/footman
-		
-	category_tags = list(CTAG_SQUIRE)
-
-/datum/outfit/job/roguetown/squire/footman/pre_equip(mob/living/carbon/human/H)
-	armor = /obj/item/clothing/suit/roguetown/armor/chainmail
-	gloves = /obj/item/clothing/gloves/roguetown/leather
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(
-		/obj/item/storage/belt/rogue/pouch,
-		/obj/item/clothing/neck/roguetown/chaincoif
-	)
-	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-		H.change_stat("strength", 1)
-		H.change_stat("perception", 1)
-		H.change_stat("constitution", 1)
-		H.change_stat("intelligence", 1)
-		H.change_stat("speed", 1)
-	ADD_TRAIT(H, TRAIT_SQUIRE_REPAIR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-
 	H.adjust_blindness(-3)
-	var/weapons = list("Iron Sword","Cudgel",)
+	var/weapons = list("Iron Sword","Cudgel","Spear")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
 		if("Iron Sword")
 			beltr = /obj/item/rogueweapon/sword/iron
+			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		if("Cudgel")	
 			beltr = /obj/item/rogueweapon/mace/cudgel
+			H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+
+		if("Spear")
+			r_hand = /obj/item/rogueweapon/spear
+			H.mind.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+
 
 /datum/advclass/squire/skirmisher
 	name = "Irregular Squire"
@@ -154,11 +123,11 @@
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger,
 		/obj/item/storage/belt/rogue/pouch,
-		/obj/item/clothing/neck/roguetown/chaincoif,
+		/obj/item/clothing/neck/roguetown/chaincoif/iron,
 		)
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
@@ -174,3 +143,48 @@
 		H.change_stat("speed", 2)
 	ADD_TRAIT(H, TRAIT_SQUIRE_REPAIR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+
+/datum/advclass/squire/skulduggerist
+	name = "Skulduggerist Squire"
+	tutorial = "An unusual path for squires that emphasizes subterfuge and trickery over open engagement. This \
+	controversial cast of squires often promote sideways into the ranks of frumentarii, spies, or secret constabulary."
+	outfit = /datum/outfit/job/roguetown/squire/skulduggerist
+		
+	category_tags = list(CTAG_SQUIRE)
+
+/datum/outfit/job/roguetown/squire/skulduggerist/pre_equip(mob/living/carbon/human/H)
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/light
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	backr = /obj/item/storage/backpack/rogue/backpack
+	backpack_contents = list(
+		/obj/item/storage/belt/rogue/pouch = 1,
+		/obj/item/clothing/neck/roguetown/coif = 1,
+		/obj/item/recipe_book/alchemy = 1,
+		/obj/item/net = 2,
+		/obj/item/restraints/legcuffs/beartrap = 2,
+		/obj/item/bomb = 2,
+		/obj/item/smokebomb = 2,
+		/obj/item/flint = 1,
+	)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/crafting, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
+		H.change_stat("perception", 1)
+		H.change_stat("constitution", 1)
+		H.change_stat("intelligence", 3)
+		H.mind.teach_crafting_recipe(/datum/crafting_recipe/roguetown/alchemy/bbomb)
+	ADD_TRAIT(H, TRAIT_SQUIRE_REPAIR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -156,7 +156,7 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
-	backr = /obj/item/storage/backpack/rogue/backpack
+	backl = /obj/item/storage/backpack/rogue/backpack
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch = 1,
 		/obj/item/clothing/neck/roguetown/coif = 1,

--- a/code/modules/jobs/job_types/roguetown/yeomen/artificer.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/artificer.dm
@@ -37,7 +37,8 @@
 		H.mind.adjust_skillrank(/datum/skill/craft/traps, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/ceramics, 3, TRUE)	//Just for basic pottery/glass stuff.
-
+		H.mind.teach_crafting_recipe(/datum/crafting_recipe/roguetown/alchemy/bbomb)
+		
 	head = /obj/item/clothing/head/roguetown/articap
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket
 	cloak = /obj/item/clothing/cloak/apron/waist/brown

--- a/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/apothecary.dm
@@ -51,6 +51,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/alchemy, 3, TRUE)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
+		H.mind.teach_crafting_recipe(/datum/crafting_recipe/roguetown/alchemy/bbomb)
 	H.change_stat("intelligence", 3)
 	H.change_stat("perception", 2)
 	ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -10,7 +10,13 @@
 	name = "bottle bomb"
 	category = "Table"
 	result = list(/obj/item/bomb)
-	reqs = list(/obj/item/reagent_containers/glass/bottle = 1, /obj/item/ash = 2, /obj/item/rogueore/coal = 1, /obj/item/natural/cloth = 1)
+	always_availible = FALSE
+	reqs = list(
+		/obj/item/reagent_containers/glass/bottle = 1,
+		/obj/item/ash = 2,
+		/obj/item/rogueore/coal = 1,
+		/obj/item/natural/cloth = 1,
+		)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/alchemy/ozium


### PR DESCRIPTION
## About The Pull Request

lancer and footman were rolled into a single class since they were already nearly identical. whichever loadout weapon you take is what you get a jman combat skill in.

adds a new squire class based around support, which receives no armor feat, no dexpert, and poor combat skills. instead it has this shit and the ability to craft bottle bombs:

![image](https://github.com/user-attachments/assets/4347c1cd-5422-48b4-a337-a8560427578b)

also makes some changes to bottle bombs:
- they only a 5% chance of being duds, or about 1 in 20.
- instead, they have a variable fuse between about 4 and 6 seconds. Good luck!
- the recipe to make them must be learned now, and is granted to classes that i assumed would know it. it can also be learned by anyone by finding a new book, Agricultural Society and Its Future.

## Testing Evidence

see above. for the bottle bombs i threw a bunch around they're kinda risky to use now because a short fuse is juuuuuust a little longer than the interaction CDs you gotta pass to throw it :3c

## Why It's Good For The Game

collapses class redundancy in favor of class variety, making a new class with a new niche. hopefully this doesn't go the way of irregular squire (the first garrison dexpert role) and portend a tide of people making bomb throwing knight classes or something goofy, but i think the playstyle here is niche enough that it wont. right?