### PR TITLE
QOL changes for Xylix-adjacent folk - Adds Jester outfit to Sewing, allows Jester hat to be MMB'd to show ears, adds Loadout Jester outfit

### DIFF
--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -352,6 +352,15 @@
 	GLOB.lordcolor -= src
 	return ..()
 
+/obj/item/clothing/head/roguetown/jester/MiddleClick(mob/user)
+	if(!ishuman(user))
+		return
+	if(flags_inv & HIDE_HEADTOP)
+		flags_inv &= ~HIDE_HEADTOP
+	else
+		flags_inv |= HIDE_HEADTOP
+	user.update_inv_head()
+
 /obj/item/clothing/head/roguetown/strawhat
 	name = "straw hat"
 	desc = "It's scratchy and rustic, but at least it keeps the sun off your head while you toil in the fields."

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -401,6 +401,29 @@
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
+/datum/crafting_recipe/roguetown/sewing/jesterchest
+	name = "jester's tunick (1 fibers, 3 cloth)"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/jester)
+	reqs = list(/obj/item/natural/cloth = 3,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/sewing/jesterhead
+	name = "jester's hat (1 fibers, 2 cloth, 1 set of jingle bells)"
+	result = list(/obj/item/clothing/head/roguetown/jester)
+	reqs = list(/obj/item/natural/cloth = 2,
+				/obj/item/natural/fibers = 1,
+				/obj/item/jingle_bells = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/sewing/jestershoes
+	name = "jester's shoes (1 fibers, 2 cloth, 1 set of jingle bells)"
+	result = list(/obj/item/clothing/shoes/roguetown/jester)
+	reqs = list(/obj/item/natural/cloth = 2,
+				/obj/item/natural/fibers = 1,
+				/obj/item/jingle_bells = 1)
+	craftdiff = 3
+
 /datum/crafting_recipe/roguetown/sewing/bardress
 	name = "bar dress (1 fibers, 3 cloth)"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/dress)

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -441,6 +441,18 @@ GLOBAL_LIST_EMPTY(loadout_items)
     name = "Noble's Chaperon"
     path = /obj/item/clothing/head/roguetown/chaperon/noble
 
+/datum/loadout_item/jesterhat
+    name = "Jester's Hat"
+    path = /obj/item/clothing/head/roguetown/jester
+
+/datum/loadout_item/jestertunick
+    name = "Jester's Tunick"
+    path = /obj/item/clothing/suit/roguetown/shirt/jester
+
+/datum/loadout_item/jestershoes
+    name = "Jester's Shoes"
+    path = /obj/item/clothing/shoes/roguetown/jester
+
 //Donator Section
 //All these items are stored in the donator_fluff.dm in the azure modular folder for simplicity.
 //All should be subtypes of existing weapons/clothes/armor/gear, whatever, to avoid balance issues I guess. Idk, I'm not your boss.

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -27,6 +27,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Farkle Dice Container"
 	path = /obj/item/storage/pill_bottle/dice/farkle
 
+/datum/loadout_item/tarot_deck
+	name = "Tarot Deck"
+	path = /datum/crafting_recipe/roguetown/survival/tarot_deck
+
 //HATS
 /datum/loadout_item/shalal
 	name = "Keffiyeh"


### PR DESCRIPTION
## About The Pull Request
Does as the title says. Adds a few neat little things.

- Jester outfit can now be sewn, The tunic is a difficulty 3 and requires 3 cloth and 1 fiber. The Hat and Shoes can be made with 2 cloth, 1 fiber, and the Jingle Bells.

- Jester outfits have been added to the loadout as well for peak Xylix fashion. Z-level jumping and comedy sold separately.

- You can now MMB the Jester hat to show and hide your ears instead of them automatically being hidden.

- A little side addition to the loadout while I was at it, the TAROT CARDS. They're fun.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles and works on my machine :^)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Allows for replacement outfits should the jester accidentally lose their clothing, lets people be goofy, adds soul.

Also adds more use for jingle bells because they currently are used for one whole thing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
