### PR TITLE
Gives the Executioner's Sword its own intents.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -529,8 +529,7 @@
 	name = "executioners sword"
 	desc = "A longsword with extra heft to its blade, reinforced."
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/rend, /datum/intent/sword/chop)
-	alt_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/bash)
+	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/exe, /datum/intent/rend, /datum/intent/axe/chop)
 	icon_state = "exe"
 	minstr = 12
 	slot_flags = ITEM_SLOT_BACK //Too big for hip

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -536,7 +536,8 @@
 
 /datum/intent/sword/thrust/exe
 	swingdelay = 4	//Slight delay to stab; big and heavy.
-	penfactor = 30	//Slightly better pen than base longsword, which is 20. It's a heavy blade so.
+	penfactor = BLUNT_DEFAULT_PENFACTOR //Flat tip? I don't know, man. This intent is won't penetrate anything but it damages armor more.
+	intent_intdamage_factor = 1.3 //This is basically like getting hit by a mace.
 
 /obj/item/rogueweapon/sword/long/exe/astrata
 	name = "\"Solar Judge\""


### PR DESCRIPTION


## About The Pull Request

The executioner's sword now has its unique thrust intent while gripped. Does 30AP instead of the usual 20AP but has a delay. This already existed but for some reason was removed from the sword at some point. Also has axe chop again while wielded.

Mordhau also just inherits from the longsword again.

## Testing Evidence

![image](https://github.com/user-attachments/assets/44601cd6-ebc9-42e1-9217-e8806ecf028f)
![image](https://github.com/user-attachments/assets/0b4c751c-1be9-4e5e-ac99-0ce0c9e8686d)

## Why It's Good For The Game
The sword is now a little more functionally different from the longsword instead of being longsword that requires 12 STR to use. While gripped, the sword has a slower thrust/chop but does more AP.

Also fixes a bit of a bug where the alt-grip/mordhau was using cut/thrust despite visually being held by the blade. Other swords don't do that.