### PR TITLE
Small Mindlink QOL & Fixes

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -177,6 +177,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(saymode && !saymode.handle_message(src, message, language))
 		return
 
+	message = treat_message(message) // unfortunately we still need this
+	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
+	if (sigreturn & COMPONENT_UPPERCASE_SPEECH)
+		message = uppertext(message)
+	if(!message)
+		return
+
 	if(!can_speak_vocal(message))
 //		visible_message("<b>[src]</b> makes a muffled noise.")
 		to_chat(src, span_warning("I can't talk."))
@@ -202,13 +209,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			succumbed = TRUE
 	else
 		src.log_talk(message, LOG_SAY, forced_by=forced)
-
-	message = treat_message(message) // unfortunately we still need this
-	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
-	if (sigreturn & COMPONENT_UPPERCASE_SPEECH)
-		message = uppertext(message)
-	if(!message)
-		return
 
 	if(src.client)
 		record_featured_stat(FEATURED_STATS_SPEAKERS, src)	//Yappin'

--- a/code/modules/spells/spell_types/wizard/utility/mindlink.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mindlink.dm
@@ -28,29 +28,44 @@
 		return
 	
 	var/list/possible_targets = list()
-	if(user.client)
-		possible_targets += user  // Always add self first
-		
-	if(user.mind?.known_people)  // Only check known_people if it exists
-		for(var/mob/living/L in GLOB.player_list)
-			if((L.client && L != user) && (L.real_name in user.mind.known_people))
-				possible_targets += L
-	
-	if(!length(possible_targets))
+	if(user.mind.known_people.len)
+		for(var/people in user.mind.known_people)
+			possible_targets += people
+	else
 		to_chat(user, span_warning("You have no known people to establish a mindlink with!"))
+		revert_cast()
 		return FALSE
 
-	var/mob/living/first_target = input(user, "Choose the first person to link", "Mindlink") as null|anything in possible_targets
-	if(!first_target)
-		return FALSE
-		
-	var/mob/living/second_target = input(user, "Choose the second person to link", "Mindlink") as null|anything in possible_targets
-	if(!second_target)
+	possible_targets = sortList(possible_targets)
+
+	if(user.client)
+		possible_targets = list(user.real_name) + possible_targets // Oohhhhhh this looks bad. But this is supposed to append ourselves at the start of the ordered list.
+	
+	var/first_target_name = input(user, "Choose the first person to link", "Mindlink") as null|anything in possible_targets
+
+	if(!first_target_name)
+		revert_cast()
 		return FALSE
 
-	if(first_target == second_target)
-		to_chat(user, span_warning("You cannot link someone to themselves!"))
+	var/mob/living/first_target
+
+	for(var/mob/living/carbon/human/HL in GLOB.human_list)
+		if(HL.real_name == first_target_name)
+			first_target = HL
+
+	possible_targets -= first_target_name
+	
+	var/second_target_name = input(user, "Choose the second person to link", "Mindlink") as null|anything in possible_targets
+
+	if(!second_target_name)
+		revert_cast()
 		return FALSE
+
+	var/mob/living/second_target
+
+	for(var/mob/living/carbon/human/HL in GLOB.human_list)
+		if(HL.real_name == second_target_name)
+			second_target = HL
 
 	user.visible_message(span_notice("[user] touches their temples and concentrates..."), span_notice("I establish a mental connection between [first_target] and [second_target]..."))
 	


### PR DESCRIPTION
## About The Pull Request

I found out Mindlink was grabbing the mob's visible name rather than their real name, making it so you couldn't mindlink with anyone currently hiding their face. It now lets you!

It will also now revert the cast if you cancel at any point during the initial casting. No more accidentally triggering the long cooldown on a miscast.

The list of targets is now sorted, too. It will still append you at the top of the list.

I dread the consequences, but I shuffled a bit of say.dm so that mute characters can still speak telepathically to others. Didn't make much sense not to be able to.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Telepathically spoke between two mute chars wearing hoods.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

We looooove cool spells.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
