### PR TITLE
Self Service:tm:, +1 Templar Slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -12,8 +12,8 @@
 	min_pq = 3 //Deus vult, but only according to the proper escalation rules
 	max_pq = null
 	round_contrib_points = 2
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 4
+	spawn_positions = 4
 	advclass_cat_rolls = list(CTAG_TEMPLAR = 20)
 	display_order = JDO_TEMPLAR
 


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/5fcee781-030a-47cb-b8c2-8cbe82823577)

![image](https://github.com/user-attachments/assets/d8a942cc-037b-457d-8e21-4f64bcbaa636)


I promise I'm working on things that are actually good too! I promise!

## Testing Evidence

Single line balance change (flay me)

## Why It's Good For The Game

(Okay but, really, this is just a very popular role that is very low slotted despite not being incredibly strong. Now that Orthos are still stronger than Templars, and that the garrison has 12+ combat roles, I dont think 1 more templar slot will really be that big of a deal. I guess this is TECHNICALLY a balance pr since +1 church combat role)
