### PR TITLE
Bugfix | Merchantry Fix

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/luxury.dm
+++ b/code/modules/cargo/packsrogue/merchant/luxury.dm
@@ -35,6 +35,11 @@
 	/obj/item/reagent_containers/glass/cup/ceramic/fancy,
 	/obj/item/reagent_containers/glass/cup/ceramic/fancy)
 
+/datum/supply_pack/rogue/luxury/silverpsicross
+	name = "Silver Psycross"
+	cost = 200
+	contains = list(/obj/item/clothing/neck/roguetown/psicross/silverr)
+
 /datum/supply_pack/rogue/luxury/silverdagger
 	name = "Silver Dagger"
 	cost = 150
@@ -68,7 +73,7 @@
 
 /datum/supply_pack/rogue/luxury/talkstone
 	name = "Talkstone"
-	cost = 150
+	cost = 100
 	contains = list(/obj/item/clothing/neck/roguetown/talkstone)
 
 /datum/supply_pack/rogue/luxury/circlet

--- a/code/modules/cargo/packsrogue/merchant/luxury.dm
+++ b/code/modules/cargo/packsrogue/merchant/luxury.dm
@@ -38,7 +38,7 @@
 /datum/supply_pack/rogue/luxury/silverpsicross
 	name = "Silver Psycross"
 	cost = 200
-	contains = list(/obj/item/clothing/neck/roguetown/psicross/silverr)
+	contains = list(/obj/item/clothing/neck/roguetown/psicross/silver)
 
 /datum/supply_pack/rogue/luxury/silverdagger
 	name = "Silver Dagger"

--- a/code/modules/cargo/packsrogue/merchant/luxury.dm
+++ b/code/modules/cargo/packsrogue/merchant/luxury.dm
@@ -60,11 +60,6 @@
 	cost = 250
 	contains = list(/obj/item/listenstone)
 
-/datum/supply_pack/rogue/luxury/riddleofsteel
-	name = "Riddle of Steel"
-	cost = 500
-	contains = list(/obj/item/riddleofsteel)
-
 /datum/supply_pack/rogue/luxury/polishing_kit
 	name = "Polishing Kit"
 	no_name_quantity = TRUE

--- a/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
@@ -25,6 +25,11 @@
 	cost = 89
 	contains = list(/obj/item/roguegem/violet)
 
+/datum/supply_pack/rogue/gems/blortz
+	name = "Blortz"
+	cost = 100
+	contains = list(/obj/item/roguegem/blue)
+
 /datum/supply_pack/rogue/gems/ruby
 	name = "Rontz"
 	cost = 160

--- a/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
@@ -27,7 +27,7 @@
 
 /datum/supply_pack/rogue/gems/blortz
 	name = "Blortz"
-	cost = 100
+	cost = 130
 	contains = list(/obj/item/roguegem/blue)
 
 /datum/supply_pack/rogue/gems/ruby

--- a/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
@@ -40,7 +40,7 @@
 	cost = 190
 	contains = list(/obj/item/roguegem/diamond)
 
-/datum/supply_pack/rogue/luxury/riddleofsteel
+/datum/supply_pack/rogue/gems/riddleofsteel
 	name = "Riddle of Steel"
 	cost = 500
 	contains = list(/obj/item/riddleofsteel)

--- a/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
@@ -39,3 +39,9 @@
 	name = "Diamond"
 	cost = 190
 	contains = list(/obj/item/roguegem/diamond)
+
+/datum/supply_pack/rogue/luxury/riddleofsteel
+	name = "Riddle of Steel"
+	cost = 500
+	contains = list(/obj/item/riddleofsteel)
+

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -455,7 +455,7 @@
 	//dropshrink = 0.75
 	resistance_flags = FIRE_PROOF
 	allowed_race = CLOTHED_RACES_TYPES
-	sellprice = 98
+	sellprice = 70
 	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/neck/roguetown/horus


### PR DESCRIPTION
## About The Pull Request

Adds back the blortz gem, the silver psycross to luxury tab, and reduced the talkstone base price to 70 so it can be sold at the merchant for a 100.

Also moves the riddle of steel to the gems tab.

## Testing Evidence

<details>

![image](https://github.com/user-attachments/assets/72d7b070-b54a-4188-a7d6-18d99571e928)
![GnInNjEAcm](https://github.com/user-attachments/assets/38be745e-376d-40dd-82a9-9725dc84580c)
![image](https://github.com/user-attachments/assets/33e9f05d-87b7-4827-ac45-eea03b32ee03)
![So3osKQHbk](https://github.com/user-attachments/assets/914ca30f-190f-49f4-8f0e-1cddba26dd47)
![image](https://github.com/user-attachments/assets/5448d82f-8058-4f21-acbf-2665b02cb290)

</details>

## Why It's Good For The Game

I Hate Missing Things. Also hopefully incentivizes people to buy the talkstone now.
