### PR TITLE
quick fix 4 da spooky mask

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/mad_touched_treasure_hunters.dm
+++ b/code/modules/mob/living/carbon/human/npc/mad_touched_treasure_hunters.dm
@@ -102,9 +102,10 @@
 /obj/item/clothing/mask/rogue/facemask/steel/paalloy/mad_touched
 	name = "eerie ancient mask"
 
-/obj/item/clothing/mask/rogue/facemask/steel/paalloy/mad_touched/Initialize()
+/obj/item/clothing/mask/rogue/facemask/steel/paalloy/mad_touched/equipped(mob/user, slot)
 	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+	if(slot == SLOT_WEAR_MASK)
+		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
 /datum/ambush_config/solo_treasure_hunter
 	mob_types = list(


### PR DESCRIPTION
## About The Pull Request

fixes the cursed mask that mad-touched treasure hunters drop to only curse upon equipping in the mask slot

expanded mechanics for this and refinement of the treasure hunters themselves comes in another pr but i wanted this out so admins dont have to wrench it from ppls hands

## Testing Evidence

![image](https://github.com/user-attachments/assets/25e93e87-2dce-46ca-90a4-9c8585ef2e50)

## Why It's Good For The Game

bugfix