### PR TITLE
[BALANCEJAK :(] Restore Forlorn Hope Mercenary

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/forlorn.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/forlorn.dm
@@ -14,7 +14,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	neck = /obj/item/clothing/neck/roguetown/gorget/forlorncollar
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/volfplate
-	pants = /obj/item/clothing/under/roguetown/tights/black
+	pants = /obj/item/clothing/under/roguetown/trou/leather
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 	belt = /obj/item/storage/belt/rogue/leather
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
@@ -43,5 +43,6 @@
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 		H.change_stat("strength", 2)
 		H.change_stat("endurance", 3) // tuff boys
-		H.change_stat("constitution", 2) 
+		H.change_stat("constitution", 3) 
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

Gives FH Merc:

- +3 CON instead of +2

- CRIT RESISTANCE

- Leather Trousers

## Testing Evidence

Tested.

## Why It's Good For The Game

Woefully underpicked after nerfing. Considering other merc roles are way ahead of it (Grenzelhoftische being the last one that was on nigh-par), about time it gets its interesting bits back.

Powercreep I hear? Modestly. Combatting power-creep is often a wide-range effort than just focusing and gutting a singular role. This makes it viable until someone (maybe me later) comes by to rebalance mercenaries entirely (which means rebalancing a lot of other roles this might be expected to compete with)