### PR TITLE
Buff stamina drain for dodge in PVE to 5.

### DIFF
--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -546,6 +546,7 @@
 	var/mob/living/carbon/human/UH
 	var/obj/item/I
 	var/drained = 10
+	var/drained_npc = 5
 	if(ishuman(src))
 		H = src
 	if(ishuman(user))
@@ -669,7 +670,9 @@
 
 		if(!dodge_status)
 			return FALSE
-		if(!H.rogfat_add(max(drained,5)))
+		if(!UH?.mind) // For NPC, reduce the drained to 5 stamina
+			drained = drained_npc
+		if(!H.rogfat_add(drained))
 			to_chat(src, span_warning("I'm too tired to dodge!"))
 			return FALSE
 	else //we are a non human


### PR DESCRIPTION
## About The Pull Request
Reduce stamina cost for dodging vs mindless mob to 5, from 10. Kinda a way to make it slightly more viable for PVE.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I tested it.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Dodge has always been viewed as an inferior option to parry given infinite parry HP (and now 4x EHP vs mobs). This should bring it somewhat in line. 

Probably still kinda bad but you know.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
