### PR TITLE
Bush + Drinking from River / Fountain QOL, Alcohol Hydration

### DIFF
--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -372,6 +372,8 @@
 					user.visible_message(span_notice("[user] finds [B] in [src]."))
 					return
 			user.visible_message(span_warning("[user] searches through [src]."))
+			if(looty.len && do_after(L, CLICK_CD_MELEE))
+				attack_hand(user)
 			if(!looty.len)
 				to_chat(user, span_warning("Picked clean... I should try later."))
 /obj/structure/flora/roguegrass/bush/update_icon()

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -372,7 +372,7 @@
 					user.visible_message(span_notice("[user] finds [B] in [src]."))
 					return
 			user.visible_message(span_warning("[user] searches through [src]."))
-			if(looty.len && do_after(L, CLICK_CD_MELEE))
+			if(looty.len)
 				attack_hand(user)
 			if(!looty.len)
 				to_chat(user, span_warning("Picked clean... I should try later."))

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -76,10 +76,11 @@
 		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 		user.visible_message(span_info("[user] starts to drink from [src]."))
 		if(do_after(L, 25, target = src))
-			var/list/waterl = list(/datum/reagent/water = 2)
+			var/list/waterl = list(/datum/reagent/water = 5)
 			var/datum/reagents/reagents = new()
 			reagents.add_reagent_list(waterl)
 			reagents.trans_to(L, reagents.total_volume, transfered_by = user, method = INGEST)
 			playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
+			onbite(user) // Auto repeat drinking
 		return
 	..()

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -237,11 +237,12 @@
 		user.visible_message(span_info("[user] starts to drink from [src]."))
 		if(do_after(L, 25, target = src))
 			var/list/waterl = list()
-			waterl[water_reagent] = 2
+			waterl[water_reagent] = 5
 			var/datum/reagents/reagents = new()
 			reagents.add_reagent_list(waterl)
 			reagents.trans_to(L, reagents.total_volume, transfered_by = user, method = INGEST)
 			playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
+			onbite(user) // Auto repeat drinking
 		return
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -13,6 +13,7 @@
 	nutriment_factor = 0
 	taste_description = "alcohol"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	hydration_factor = 10 // Moving hydration up a level
 	var/boozepwr = 25 //Higher numbers equal higher hardness, higher hardness equals more intense alcohol poisoning
 
 /*
@@ -76,7 +77,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	taste_description = "ale"
 	glass_name = "glass of beer"
 	glass_desc = ""
-	hydration_factor = 10
 
 /datum/reagent/consumable/ethanol/beer/cider
 	name = "Cider"


### PR DESCRIPTION
## About The Pull Request
Small stuffs
- Searching bush now autosearches until you find something. Taken from a Solaris PR.
- Drinking from a water turf / fountain will also automatically repeat drinking. Try to not drink from sewage automatically. Amount drank raised from 2 to 5 per bite.
- I made most non-beer alcohol dehydrating by accident. I have moved hydration factor up to the ethanol level as 10 - so ethanol is around 83% as hydrating as water per unit. No more thirsty at bar.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yeah
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
