### PR TITLE
Raise fire and lava damage, again, lower fireball CD to 15.

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -157,8 +157,8 @@
 			if("lava" in L.weather_immunities)
 				continue
 
-			if(L) //mobs turning into object corpses could get deleted here.
-				L.adjustFireLoss(40)
+			if(L)
+				L.adjustFireLoss(100)
 				L.adjust_fire_stacks(100)
 				L.IgniteMob()
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1868,7 +1868,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		var/burn_damage
 		var/firemodifier = H.fire_stacks / 50
 		if (H.on_fire)
-			burn_damage = min(5, H.fire_stacks * 2) // Minimum of 5 damage if you are on fire. Otherwise applies 2 per stack, up to 40.
+			burn_damage = 10 + H.fire_stacks * 3 // Minimum of 10 damage if you are on fire. Applies 3 additional per stack.
 		else
 			firemodifier = min(firemodifier, 0)
 			burn_damage = max(log(2-firemodifier,(H.bodytemperature-BODYTEMP_NORMAL))-5,0) // this can go below 5 at log 2.5

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -9,7 +9,7 @@
 	releasedrain = 30
 	chargedrain = 1
 	chargetime = 25
-	recharge_time = 20 SECONDS
+	recharge_time = 15 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
@@ -10,7 +10,7 @@
 	releasedrain = 50
 	chargedrain = 1
 	chargetime = 25
-	recharge_time = 20 SECONDS
+	recharge_time = 15 SECONDS
 	warnie = "spellwarning"
 	spell_tier = 4 // Highest tier AOE
 	invocation = "Maior Sphaera Ignis!"


### PR DESCRIPTION
## About The Pull Request
Felt like I overcorrected.
- Fire damage is now a minimum of 10 instead of 5. Each additional stack apply 3 instead of 2. Up to a maximum of 70 instead of maximum of 40.
- Lava now deals 100 instead of 40 on burn. You **can** still dramatically cross lava, but is much less likely to survive the act
- Fireball CD, which was raised to 20 seconds by Molly during April as Firestack were kinda cracked (but also unreliable back then), is lowered to 15. This applies to both Fireball and GFB.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Burned myself

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I felt like I overcorrected on fire so I am now increasing its lethality back up again.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
