### PR TITLE
Gives wicker baskets a crafting recipe

### DIFF
--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -826,3 +826,12 @@
 		to_chat(user, span_info("I need a dirt floor to do this."))
 		return FALSE
 	return TRUE
+
+/datum/crafting_recipe/roguetown/structure/wicker
+	name = "wicker basket"
+	result = /obj/structure/closet/crate/chest/wicker
+	reqs = list(/obj/item/grown/log/tree/stick = 4,
+				/obj/item/natural/fibers = 3)
+	verbage_simple = "weave"
+	verbage = "weaves"
+	craftdiff = 0


### PR DESCRIPTION
## About The Pull Request

Adds wicker baskets as a basic crafting recipe, requiring 4 sticks and 3 fibers to make. These are pretty much everywhere on the map as-is and have been requested before (https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/issues/2090) so I figured I might as well.

If these becoming craftable somehow turns into an issue I could tie them to a specific crafting skill and skill requirement and/or alter the recipe but they really shouldn't.

## Testing Evidence

Compiled, ran and functioned as intended.

![image](https://github.com/user-attachments/assets/fc87647e-57ff-4ffd-a91d-c91af3ae0d5d)
![image](https://github.com/user-attachments/assets/c74309dd-d148-45bd-874c-adb90166c0cf)
![image](https://github.com/user-attachments/assets/df363e76-0f01-4998-b99e-5e0b1ec58271)


## Why It's Good For The Game

Easy storage access for any class that doesn't have a dedicated home, feature has been requested before.
