### PR TITLE
hotfixes megarmach coat to be an actual codewise coat

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -432,7 +432,7 @@
 	max_integrity = 300
 	sellprice = 25
 
-/obj/item/clothing/suit/roguetown/armor/leather/heavy/raneshen
+/obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/raneshen
 	name = "megarmach scale coat"
 	desc = "A set of lightweight armor fashioned from the scales of the Ranesheni \'megarmach\', an armored reptilian creacher that ambushes prey by the riverside, and drags them deep into Abyssor's domain."
 	icon_state = "pangolin"

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -93,7 +93,7 @@
 			head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/raneshen
 			neck = /obj/item/clothing/neck/roguetown/leather
 			mask = /obj/item/clothing/mask/rogue/facemask/steel/paalloy
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/raneshen
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/raneshen
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/raneshen
 			wrists = /obj/item/clothing/wrists/roguetown/splintarms
 			gloves = /obj/item/clothing/gloves/roguetown/angle
@@ -149,7 +149,7 @@
 			head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/raneshen
 			neck = /obj/item/clothing/neck/roguetown/gorget/copper
 			mask = /obj/item/clothing/mask/rogue/facemask/copper
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/raneshen
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/raneshen
 			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/raneshen
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/copper
 			gloves = /obj/item/clothing/gloves/roguetown/angle


### PR DESCRIPTION
## About The Pull Request
I put the new armor underneath heavy/coat but for some reason made it a child of just heavy. Supposed to be a coat as per the name "megarmach scale coat"


## Testing Evidence

## Why It's Good For The Game
As above. Forgive my smooth brain for having two PR two hotfixes for such a simple thing.

