### PR TITLE
Snowflake Dismember Prevention for very strong weapons

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -75,8 +75,8 @@
 						return TRUE
 
 //This proc returns obj/item/clothing, the armor that has "soaked" the crit. Using it for dismemberment check
-/mob/living/carbon/human/proc/checkcritarmorreference(def_zone, d_type)
-	if(!d_type)
+/mob/living/carbon/human/proc/checkcritarmorreference(def_zone, bclass)
+	if(!bclass)
 		return null
 	var/obj/item/clothing/best_armor = null
 	if(isbodypart(def_zone))
@@ -90,7 +90,7 @@
 			var/obj/item/clothing/C = bp
 			if(zone2covered(def_zone, C.body_parts_covered_dynamic))
 				if(C.obj_integrity > 1)
-					if(d_type in C.prevent_crits)
+					if(bclass in C.prevent_crits)
 						if(!best_armor)
 							best_armor = C
 						else if (round(((best_armor.obj_integrity / best_armor.max_integrity) * 100), 1) < round(((C.obj_integrity / C.max_integrity) * 100), 1)) //We want the armor with highest % integrity 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -73,6 +73,29 @@
 				if(C.obj_integrity > 1)
 					if(d_type in C.prevent_crits)
 						return TRUE
+
+//This proc returns obj/item/clothing, the armor that has "soaked" the crit. Using it for dismemberment check
+/mob/living/carbon/human/proc/checkcritarmorreference(def_zone, d_type)
+	if(!d_type)
+		return null
+	var/obj/item/clothing/best_armor = null
+	if(isbodypart(def_zone))
+		var/obj/item/bodypart/CBP = def_zone
+		def_zone = CBP.body_zone
+	var/list/body_parts = list(head, wear_mask, wear_wrists, wear_shirt, wear_neck, cloak, wear_armor, wear_pants, backr, backl, gloves, shoes, belt, s_store, glasses, ears, wear_ring)
+	for(var/bp in body_parts)
+		if(!bp)
+			continue
+		if(bp && istype(bp , /obj/item/clothing))
+			var/obj/item/clothing/C = bp
+			if(zone2covered(def_zone, C.body_parts_covered_dynamic))
+				if(C.obj_integrity > 1)
+					if(d_type in C.prevent_crits)
+						if(!best_armor)
+							best_armor = C
+						else if (round(((best_armor.obj_integrity / best_armor.max_integrity) * 100), 1) < round(((C.obj_integrity / C.max_integrity) * 100), 1)) //We want the armor with highest % integrity 
+							best_armor = C
+	return best_armor
 /*
 /mob/proc/checkwornweight()
 	return 0

--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -44,6 +44,7 @@
 			var/int_percent = round(((checked_armor.obj_integrity / checked_armor.max_integrity) * 100), 1) //lifted from examine
 			if(int_percent > 80 && !HAS_TRAIT(H, TRAIT_CRITICAL_WEAKNESS) && !HAS_TRAIT(H, TRAIT_EASYDISMEMBER))
 				to_chat(H, span_warning("My [checked_armor.name] just saved me from losing my [src.name]!"))
+				checked_armor.obj_integrity -= checked_armor.max_integrity / 2 //Armor sundered
 				return FALSE
 
 	var/obj/item/bodypart/affecting = C.get_bodypart(BODY_ZONE_CHEST)

--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -37,6 +37,15 @@
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
 		return FALSE
 
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		var/obj/item/clothing/checked_armor = H.checkcritarmorreference(src.body_zone, bclass)
+		if(checked_armor && checked_armor.max_integrity != 0)
+			var/int_percent = round(((checked_armor.obj_integrity / checked_armor.max_integrity) * 100), 1) //lifted from examine
+			if(int_percent > 80 && !HAS_TRAIT(H, TRAIT_CRITICAL_WEAKNESS) && !HAS_TRAIT(H, TRAIT_EASYDISMEMBER))
+				to_chat(H, span_warning("My [checked_armor.name] just saved me from losing my [src.name]!"))
+				return FALSE
+
 	var/obj/item/bodypart/affecting = C.get_bodypart(BODY_ZONE_CHEST)
 	if(affecting && dismember_wound)
 		affecting.add_wound(dismember_wound)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Werewolf one taps your leg. A tale as old as time. What if your armor let you have at least one bop?

/datum/species/proc/spec_attacked_by() rolls for dismemberment on each hit where there is NOT "no damage", meaning that werewolf claw overpenetration memetically one-taps your leg. This PR puts in a little check so that if the armor on that limb is better than 80%, the dismemberment is prevented IF, ONLY IF, the damage type is prevented by the crit protection on that armor. This represents your armor being in good enough integrity to withstand a severing blow.

Expensive loop fishes for the armor piece on the limb with the most integrity, so maybe your scale will save you from one and then your chausses will save you from the next. Nifty

## Testing Evidence

![image](https://github.com/user-attachments/assets/c98619f0-c8d2-40d0-9f89-2c4f66743cb1)


https://github.com/user-attachments/assets/1d3155d5-d8d1-4102-8998-b482e8fa8a88



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Integrity % is at 80, so that you can examine your armor and see if "It's Damaged" (unsafe) or "It's a little damaged" or better (safe). Can be adjusted of course. There are scant few armor overpenetration issues as it is, so really this is maybe overtuning to just deal with werewolves instead of nerfing claws. Who can say for sure.
