### PR TITLE
Click cooldown QoL

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -29,21 +29,28 @@
 		adj += S.nextmove_adjust()
 	if(!hand)
 		var/check_move = world.time + ((num + adj)*mod)
-		if((check_move >= next_move) || override)
+		if(override)
 			next_move = check_move
+		else
+			if(world.time >= next_move)
+				next_move = check_move
 		hud_used?.cdmid?.mark_dirty()
 		return
 	if(hand == 1)
 		var/check_move = world.time + ((num + adj)*mod)
-		if((check_move >= next_lmove) || override)
+		if(override)
 			next_lmove = check_move
-		next_lmove = world.time + ((num + adj)*mod)
+		else
+			if(world.time >= next_lmove)
+				next_lmove = check_move
 		hud_used?.cdleft?.mark_dirty()
 	else
 		var/check_move = world.time + ((num + adj)*mod)
-		if((check_move >= next_rmove) || override)
+		if(override)
 			next_rmove = check_move
-		next_rmove = world.time + ((num + adj)*mod)
+		else
+			if(world.time >= next_rmove)
+				next_rmove = check_move
 		hud_used?.cdright?.mark_dirty()
 
 /*

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -750,6 +750,7 @@
 			viewing.show_message(span_notice("[M] tucks [I] [insert_preposition]to [parent]."), MSG_VISUAL)
 		else
 			viewing.show_message(span_notice("[M] tucks something [insert_preposition]to [parent]."), MSG_VISUAL)
+	M.changeNext_move(CLICK_CD_RAPID, null, override = TRUE)
 
 /datum/component/storage/proc/update_icon()
 	if(isobj(parent))

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -191,6 +191,7 @@
 	if(!isitem(O) || !click_gather || SEND_SIGNAL(O, COMSIG_CONTAINS_STORAGE))
 		return FALSE
 	. = COMPONENT_NO_ATTACK
+	M.changeNext_move(CLICK_CD_RAPID, null, TRUE)
 	if(locked)
 //		to_chat(M, span_warning("[parent] seems to be locked!"))
 		return FALSE
@@ -856,6 +857,7 @@
 	var/atom/A = parent
 	if(!attack_hand_interact)
 		return
+	user.changeNext_move(CLICK_CD_RAPID, null, TRUE)
 	if(user.active_storage == src && A.loc == user) //if you're already looking inside the storage item
 		user.active_storage.close(user)
 		close(user)
@@ -920,7 +922,7 @@
 	if(locked)
 		to_chat(user, span_warning("[parent] seems to be locked!"))
 		return
-
+	user.changeNext_move(CLICK_CD_RAPID, null, TRUE)
 	var/atom/A = parent
 	if(!quickdraw)
 		A.add_fingerprint(user)

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -11,6 +11,7 @@
 	if(!cmode)	//We just toggled it off.
 		addtimer(CALLBACK(src, PROC_REF(purge_bait)), 30 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 
+// Rclick override to allow for behaviour that is targetless. It's pretty snowflakey, but covers most bases.
 /mob/living/carbon/human/RightClickOn(atom/A, params)
 	if(rmb_intent && !rmb_intent.adjacency && !istype(A, /obj/item/clothing) && cmode && !istype(src, /mob/living/carbon/human/species/skeleton) && !istype(A, /obj/item/quiver) && !istype(A, /obj/item/storage))
 		var/held = get_active_held_item()
@@ -19,6 +20,7 @@
 			if(I.associated_skill)
 				rmb_intent.special_attack(src, A)
 	else
+		changeNext_move(CLICK_CD_RANGE, null, override = TRUE)
 		. = ..()
 
 /datum/rmb_intent/proc/special_attack(mob/living/user, atom/target)


### PR DESCRIPTION
## About The Pull Request
- Interactions with storage spaces now has a short click cd
- Same applies for some (though not all) non-combat interactions
- Clickcd overrides now properly override, though this comes with some quirky caveats.

I'm not sure whether doing a dissected approach like this is better than just slapping a shorter cd to the baseline procs and dealing with any issues that arise. Either way, worth a TM.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/a86ed283-7b0f-4bbd-8b4c-810587a3db33


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
it's very annoying to click about your inventory but nothing happens
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
