### PR TITLE
Inquisitor Confession & Confession Paper Minor Rework

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -178,7 +178,10 @@
 	if(H == src)
 		to_chat(src, span_warning("I already torture myself."))
 		return
-	if (!H.restrained())
+	if(H.stat == DEAD)
+		to_chat(src, span_warning("[H] is dead already..."))
+		return
+	if(!H.restrained())
 		to_chat(src, span_warning ("My victim needs to be restrained in order to do this!"))
 		return
 	if(!istype(S, /obj/item/clothing/neck/roguetown/psicross/silver))
@@ -191,23 +194,22 @@
 	if(!H.stat)
 		SEND_SIGNAL(src, COMSIG_TORTURE_PERFORMED, H)
 		var/static/list/torture_lines = list(
-			"CONFESS!",
+			"CONFESS YOUR WRONGDOINGS!",
 			"TELL ME YOUR SECRETS!",
-			"SPEAK!",
+			"SPEAK THE TRUTH!",
 			"YOU WILL SPEAK!",
 			"TELL ME!",
+			"THE PAIN HAS ONLY BEGUN, CONFESS!",
 		)
-
-		src.visible_message(span_warning("[src] shoves the silver psycross in [H]'s face!"))
 		say(pick(torture_lines), spans = list("torture"))
 		H.emote("agony", forced = TRUE)
+		H.confession_time("antag", src)
 		H.add_stress(/datum/stressevent/tortured)
 
 		if(!(do_mob(src, H, 10 SECONDS)))
 			return
 
 		src.visible_message(span_warning("[src]'s silver psycross abruptly catches flame, burning away in an instant!"))
-		H.confess_sins("antag")
 		qdel(S)
 		return
 	to_chat(src, span_warning("This one is not in a ready state to be questioned..."))
@@ -254,30 +256,169 @@
 			return
 
 		src.visible_message(span_warning("[src]'s silver psycross abruptly catches flame, burning away in an instant!"))
-		H.confess_sins("patron")
+		H.confession_time("patron", src)
 		H.add_stress(/datum/stressevent/tortured)
 		qdel(S)
 		return
 	to_chat(src, span_warning("This one is not in a ready state to be questioned..."))
 
-/mob/living/carbon/human/proc/confess_sins(confession_type = "antag")
-	var/static/list/innocent_lines = list(
-		"I AM NO SINNER!",
-		"I'M INNOCENT!",
-		"I HAVE NOTHING TO CONFESS!",
-		"I AM FAITHFUL!",
-	)
-	var/list/confessions = list()
-	switch(confession_type)
-		if("patron")
-			if(length(patron?.confess_lines))
-				confessions += patron.confess_lines
-		if("antag")
-			for(var/datum/antagonist/antag in mind?.antag_datums)
-				if(!length(antag.confess_lines))
-					continue
-				confessions += antag.confess_lines
-	if(length(confessions))
-		say(pick(confessions), spans = list("torture"))
+/mob/living/carbon/human/proc/confession_time(confession_type = "antag", mob/living/carbon/human/user)
+	var/timerid = addtimer(CALLBACK(src, PROC_REF(confess_sins), confession_type, FALSE, user), 10 SECONDS, TIMER_STOPPABLE)
+	var/static/list/options = list("RESIST!!", "CONFESS!!")
+	var/responsey = input(src, "Resist torture?", "TEST OF PAIN", options)
+
+	if(SStimer.timer_id_dict[timerid])
+		deltimer(timerid)
+	else
+		to_chat(src, span_warning("Too late..."))
 		return
-	say(pick(innocent_lines), spans = list("torture"))
+	if(responsey == "RESIST!!")
+		confess_sins(confession_type, resist=TRUE, interrogator=user)
+	else
+		confess_sins(confession_type, resist=FALSE, interrogator=user)
+
+/mob/living/carbon/human/proc/confess_sins(confession_type = "antag", resist, mob/living/carbon/human/interrogator, torture=TRUE, obj/item/paper/confession/confession_paper, false_result)
+	if(stat == DEAD)
+		return
+	var/static/list/innocent_lines = list(
+		"I DON'T KNOW!",
+		"STOP THIS MADNESS!!",
+		"I DON'T DESERVE THIS!",
+		"THE PAIN!",
+		"I HAVE NOTHING TO SAY...!",
+		"WHY ME?!",
+		"I'M INNOCENT!",
+		"I AM NO SINNER!",
+	)
+	var/resist_chance = 0
+	if(resist)
+		to_chat(src, span_boldwarning("I attempt to resist the torture!"))
+		resist_chance = (STAINT + STAEND) + 10
+
+		if(confession_type == "antag")									// Inherant bonus to resist if you are an antag/heretic.
+			resist_chance += 25
+		if(istype(buckled, /obj/structure/fluff/walldeco/chains))		// If the victim is on hanging chains, apply a resist penalty
+			resist_chance -= 10
+		var/mob/living/carbon/human/H
+		if(H.has_status_effect(/datum/status_effect/buff/drunk))		// Loose lips sink ships.
+			resist_chance -= 10
+		if(H.has_status_effect(/datum/status_effect/debuff/revived))	//Weakened body and mind
+			resist_chance -= 5
+		if(H.has_status_effect(/datum/status_effect/debuff/devitalised))	//Weakened soul and mind
+			resist_chance -= 10
+		if(HAS_TRAIT(H, TRAIT_DECEIVING_MEEKNESS))						// Guraded bonus given you hide your faith better than others.
+			resist_chance += 15
+		if(HAS_TRAIT(H, TRAIT_CRITICAL_WEAKNESS))						// Negative for being bully-bait.
+			resist_chance -= 15
+		var/painpercent = (H.get_complex_pain() / (H.STAEND * 10)) * 100
+		if(painpercent < 100)											// If beaten/badly wounded, penalty.
+			resist_chance -= 15
+
+	if(!prob(resist_chance))
+		var/list/confessions = list()
+		var/antag_type = null
+		switch(confession_type)
+			if("antag")
+				if(!false_result)
+					for(var/datum/antagonist/antag in mind?.antag_datums)
+						if(!length(antag.confess_lines))
+							continue
+						confessions += antag.confess_lines
+						antag_type = antag.name
+						break // Only need one antag type
+			if("patron")
+				if(ispath(false_result, /datum/patron))
+					var/datum/patron/fake_patron = new false_result()
+					if(length(fake_patron.confess_lines))
+						confessions += fake_patron.confess_lines
+						antag_type = fake_patron.name
+				else
+					if(length(patron?.confess_lines))
+						confessions += patron.confess_lines
+						antag_type = patron.name
+
+		if(torture && interrogator && confession_type == "patron")
+			var/datum/patron/interrogator_patron = interrogator.patron
+			var/datum/patron/victim_patron = patron
+			switch(interrogator_patron.associated_faith.type)
+				if(/datum/patron/old_god)
+					if(victim_patron.type == /datum/patron/divine)
+						interrogator.add_stress(/datum/stressevent/tortured)
+					else if(victim_patron.type == /datum/patron/inhumen)
+						interrogator.add_stress(/datum/stressevent/tortured)
+						
+
+		if(length(confessions))
+			if(torture) // Only scream your confession if it's due to torture.
+				say(pick(confessions), spans = list("torture"), forced = TRUE)
+			else
+				say(pick(confessions), forced = TRUE)
+			if(has_confessed) // This is to check if the victim has already confessed, if so just inform the torturer and return. This is so that the Inquisitor cannot get infinite confession points and get all of the things upon getting thier first heretic.
+				visible_message(span_warning("[name] has already signed a confession!"), "I have already signed a confession!")
+				return
+			var/obj/item/paper/confession/held_confession
+			if(istype(confession_paper))
+				held_confession = confession_paper
+			else if(interrogator?.is_holding_item_of_type(/obj/item/paper/confession)) // This code is to process gettin a signed confession through torture.
+				held_confession = interrogator.is_holding_item_of_type(/obj/item/paper/confession)
+			if(held_confession && !held_confession.signed) // Check to see if the confession is already signed.
+				// held_confession.bad_type = "AN EVILDOER" // In case new antags are added with confession lines but have yet to be added here.
+				//this is no longer reliable as all patrons have confess lines now
+				switch(antag_type)
+					if("Bandit")
+						held_confession.bad_type = "AN OUTLAW OF THE THIEF-LORD"
+						held_confession.antag = antag_type
+					if("Verewolf")
+						held_confession.bad_type = "A BEARER OF DENDOR'S CURSE"
+						held_confession.antag = antag_type
+					if("Lesser Verewolf")
+						held_confession.bad_type = "A BEARER OF DENDOR'S CURSE"
+						held_confession.antag = antag_type
+					if("Vampire")
+						held_confession.bad_type = "A SCION OF KAINE"
+						held_confession.antag = antag_type
+					if("Lesser Vampire")
+						held_confession.bad_type = "A SCION OF KAINE"
+						held_confession.antag = antag_type
+					if("Vampire Lord")
+						held_confession.bad_type = "THE BLOOD-LORD OF VANDERLIN"
+						held_confession.antag = antag_type
+					if("Vampire Spawn")
+						held_confession.bad_type = "AN UNDERLING OF THE BLOOD-LORD"
+						held_confession.antag = antag_type
+					if("Maniac")
+						held_confession.bad_type = "A MANIAC DELUDED BY MADNESS"
+						held_confession.antag = antag_type
+					if("Matthios")
+						held_confession.bad_type = "A FOLLOWER OF THE THIEF-LORD"
+						held_confession.antag = "worshiper of " + antag_type
+					if("Zizo")
+						held_confession.bad_type = "A FOLLOWER OF THE FORBIDDEN ONE"
+						held_confession.antag = "worshiper of " + antag_type
+					if("Graggar")
+						held_confession.bad_type = "A FOLLOWER OF THE DARK SUN"
+						held_confession.antag = "worshiper of " + antag_type
+					if("Godless")
+						held_confession.bad_type = "A DAMNED ANTI-THEIST"
+						held_confession.antag = "worshiper of nothing"
+					if("Baotha")
+						held_confession.bad_type = "A FOLLOWER OF THE REMORSELESS RUINER"
+						held_confession.antag = "worshiper of " + antag_type
+					if("Peasant Rebel")
+						return // Inquisitors don't care about peasant revolts targeting the King
+					else
+						return // good job you tortured an innocent person
+				has_confessed = TRUE
+				held_confession.signed = real_name
+				held_confession.info = "THE GUILTY PARTY ADMITS THEIR SINFUL NATURE AS <font color='red'>[held_confession.bad_type]</font>. THEY WILL SERVE ANY PUNISHMENT OR SERVICE AS REQUIRED BY THE ORDER OF THE PSYCROSS UNDER PENALTY OF DEATH.<br/><br/>SIGNED,<br/><font color='red'><i>[held_confession.signed]</i></font>"
+				held_confession.update_icon_state()
+			return
+		else
+			if(torture) // Only scream your confession if it's due to torture.
+				say(pick(innocent_lines), spans = list("torture"), forced = TRUE)
+			else
+				say(pick(innocent_lines), forced = TRUE)
+			return
+	to_chat(src, span_good("I resist the torture!"))
+	say(pick(innocent_lines), spans = list("torture"), forced = TRUE)
+	return

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -116,6 +116,8 @@
 	var/is_legacy = FALSE
 	var/received_resident_key = FALSE
 
+	var/has_confessed = FALSE // Used to track if they have confessed it was written onto a confession paper
+
 	possible_rmb_intents = list(/datum/rmb_intent/feint,\
 	/datum/rmb_intent/aimed,\
 	/datum/rmb_intent/strong,\

--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -225,44 +225,109 @@
 /obj/item/paper/confession
 	name = "confession"
 	icon_state = "confession"
+	var/base_icon_state = "confession"
 	info = "THE GUILTY PARTY ADMITS THEIR SIN AND THE WEAKENING OF PSYDON'S HOLY FLOCK. THEY WILL REPENT AND SUBMIT TO ANY PUNISHMENT THE CLERGY DEEMS APPROPRIATE, OR BE RELEASED IMMEDIATELY. LET THIS RECORD OF THEIR SIN WEIGH ON THE ANGEL GABRIEL'S JUDGEMENT AT THE MANY-SPIKED GATES OF HEAVEN.<br/><br/>SIGNED,"
-	var/signed = FALSE
-	textper = 150
+	var/signed = null
+	var/antag = null // The literal name of the antag, like 'Bandit' or 'worshiper of Zizo'
+	var/bad_type = null // The type of the antag, like 'OUTLAW OF THE THIEF-LORD'
+	textper = 108
+	maxlen = 2000
+	var/confession_type = "antag" //for voluntary confessions
+
+
+/obj/item/paper/confession/examine(mob/user)
+	. = ..()
+	. += span_info("Left click with a feather to sign, right click to change confession type.")
+
+/obj/item/paper/confession/attackby(atom/A, mob/living/user, params)
+	if(signed)
+		return
+	if(istype(A, /obj/item/natural/feather))
+		attempt_confession(user)
+		return TRUE
+	return ..()
 
 /obj/item/paper/confession/update_icon_state()
+	. = ..()
 	if(mailer)
 		icon_state = "paper_prep"
-		name = "letter"
 		throw_range = 7
 		return
-	name = initial(name)
 	throw_range = initial(throw_range)
-	if(signed)
-		icon_state = "confessionsigned"
-		return
-	icon_state = "confession"
+	icon_state = "[base_icon_state][signed ? "signed" : ""]"
+	return
 
-/obj/item/paper/confession/attack(mob/living/carbon/human/M, mob/user)
-	if(signed)
-		return ..()
-	if(!M.get_bleed_rate())
-		to_chat(user, span_warning("No. The sinner must be bleeding."))
+/obj/item/paper/confession/proc/attempt_confession(mob/living/carbon/human/M, mob/user)
+	if(!ishuman(M))
 		return
-	if(!M.stat)
-		to_chat(user, span_info("I courteously offer the confession to [M]."))
-		if(alert(M, "Sign the confession with your blood?", "CONFESSION OF SIN", "Yes", "No") != "Yes")
+	var/input = alert(M, "Sign the confession of your true nature?", "CONFESSION OF [confession_type == "antag" ? "VILLAINY" : "FAITH"]", "Yes", "Lie", "No")
+	if(M.stat >= UNCONSCIOUS)
+		return
+	if(!M.CanReach(src))
+		return
+	if(signed)
+		return
+	if(input == "Yes")
+		playsound(src, 'sound/items/write.ogg', 50, FALSE, ignore_walls = FALSE)
+		M.visible_message(span_info("[M] has agreed to confess their true [confession_type == "antag" ? "villainy" : "faith"]."), span_info("I agree to confess my true nature."), vision_distance = COMBAT_MESSAGE_RANGE)
+		M.confess_sins(confession_type, resist=FALSE, interrogator=user, torture=FALSE, confession_paper = src, false_result = TRUE)
+	else if(input == "Lie")
+		var/fake = TRUE
+		if(confession_type == "patron")
+			var/list/divine_gods = list()
+			for(var/datum/patron/path as anything in GLOB.patrons_by_faith[/datum/faith/divine] + GLOB.patrons_by_faith[/datum/faith/old_god])
+				if(!path.name)
+					continue
+				var/pref_name = path.name ? path.name : path.name
+				divine_gods[pref_name] = path
+			if(length(divine_gods)) // sanity check
+				var/fake_patron = input(M, "Who will you pretend your patron is?", "DECEPTION") as null|anything in divine_gods
+				if(!fake)
+					fake_patron = pick(divine_gods)
+				fake = divine_gods[fake_patron]
+		if(M.stat >= UNCONSCIOUS)
 			return
-		if(M.stat)
+		if(!M.CanReach(src))
 			return
 		if(signed)
 			return
-		if(M.has_flaw(/datum/charflaw/addiction/godfearing))
-			M.add_stress(/datum/stressevent/confessedgood)
-		else
-			M.add_stress(/datum/stressevent/confessed)
-		M.add_stress(/datum/stressevent/confessed)
-		signed = M.real_name
-		info = "THE GUILTY PARTY ADMITS THEIR SIN AND THE WEAKENING OF PSYDON'S HOLY FLOCK. THEY WILL REPENT AND SUBMIT TO ANY PUNISHMENT THE CLERGY DEEMS APPROPRIATE, OR BE RELEASED IMMEDIATELY. LET THIS RECORD OF THEIR SIN WEIGH ON THE ANGEL GABRIEL'S JUDGEMENT AT THE MANY-SPIKED GATES OF HEAVEN.<br/><br/>SIGNED,<br/><font color='red'>[signed]</font>"
+		playsound(src, 'sound/items/write.ogg', 50, FALSE, ignore_walls = FALSE)
+		M.visible_message(span_info("[M] has agreed to confess their true [confession_type == "antag" ? "villainy" : "faith"]."), span_info("I agree to confess my true nature."), vision_distance = COMBAT_MESSAGE_RANGE)
+		M.confess_sins(confession_type, resist=FALSE, interrogator=user, torture=FALSE, confession_paper = src, false_result = fake)
+	else
+		M.visible_message(span_boldwarning("[M] refused to sign the confession!"), span_boldwarning("I refused to sign the confession!"), vision_distance = COMBAT_MESSAGE_RANGE)
+	return
+
+/obj/item/paper/confession/read(mob/user)
+	if(!user.client || !user.hud_used)
+		return
+	if(!user.hud_used.reads)
+		return
+	if(!user.can_read(src))
+		if(info)
+			user.mind.adjust_skillrank(/datum/skill/misc/reading, 2, FALSE)
+		return
+	/*font-size: 125%;*/
+	if(in_range(user, src) || isobserver(user))
+		user.hud_used.reads.icon_state = "scroll"
+		user.hud_used.reads.show()
+		var/dat = {"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
+					<html><head><style type=\"text/css\">
+					body { background-image:url('book.png');background-repeat: repeat; }</style>
+					</head><body scroll=yes>"}
+		dat += "[info]<br>"
+		dat += "<a href='byond://?src=[REF(src)];close=1' style='position:absolute;right:50px'>Close</a>"
+		dat += "</body></html>"
+		user << browse(dat, "window=reading;size=460x300;can_close=0;can_minimize=0;can_maximize=0;can_resize=0;titlebar=0")
+		onclose(user, "reading", src)
+	else
+		return "<span class='warning'>I'm too far away to read it.</span>"
+
+/obj/item/paper/confession/rmb_self(mob/user)
+	return TRUE
+
+/obj/item/paper/confession/attack_right(mob/user)
+	return TRUE
 
 /obj/item/paper/scroll/sell_price_changes
 	name = "updated purchasing prices"


### PR DESCRIPTION
## About The Pull Request

Redoes a tad how confessions work in-line with prior code from Stonekeep/Vanderlin with changes.

Examples of changes are:
- You can now resist confessions, with various modifiers atop of your end/int that will effect the outcome of resisting.
- Confession papers now can be used and read akin to normal papers with a slight refactor

## Testing Evidence

Hard to do, thus drafting for now for review. Needs multiple people really to be able to test this fully.

## Why It's Good For The Game

Basically adds more roleplay element and ability to actually resist confession once captured to appear innocent depending on modifiers you have. 
