### PR TITLE
Adds the new Fox tails to the Fox Species

### DIFF
--- a/code/modules/client/customizer/customizers/organ/tail.dm
+++ b/code/modules/client/customizer/customizers/organ/tail.dm
@@ -16,8 +16,10 @@
 	organ_type = /obj/item/organ/tail/vulpkanin
 	sprite_accessories = list(
 	/datum/sprite_accessory/tail/fox,
+	/datum/sprite_accessory/tail/fox2,
 	/datum/sprite_accessory/tail/eevee,
-	/datum/sprite_accessory/tail/fennec
+	/datum/sprite_accessory/tail/fennec,
+	/datum/sprite_accessory/tail/tamamo_kitsune
 	)
 
 /datum/customizer/organ/tail/lupian


### PR DESCRIPTION
## About The Pull Request

Adds the new Fox tails to the Fox Species.

Foxy creatures known for their cleverness and mischief. In ancient history they were Dendor's original champions, but as His madness grew the connect became frey and forgotten, leaving them to their own devices. Or, at least, that's what they say.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

![image](https://github.com/user-attachments/assets/ea75d2ad-9a47-4452-ac39-0c8534d99e96)![image](https://github.com/user-attachments/assets/64529286-784d-4177-bff9-4c996d6489af)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

The fox tails weren't given to the fox species.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
