### PR TITLE
Allows thrown items to hit mobs buckled to the pillory

### DIFF
--- a/modular/code/game/objects/pillory.dm
+++ b/modular/code/game/objects/pillory.dm
@@ -173,4 +173,11 @@
 		return null
 	return ..()
 
+/obj/structure/pillory/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum, damage_flag)
+	if(!has_buckled_mobs())
+		return ..()
+
+	var/mob/living/victim = pick(buckled_mobs)
+	return AM.throw_impact(victim, throwingdatum)
+
 #undef PILLORY_HEAD_OFFSET


### PR DESCRIPTION

## About The Pull Request

Redirects pillory's proc/hitby() at a buckled mob, if it is present. Otherwise calls parent, as usual.

## Testing Evidence

<details>
  <summary>It works and I'm _almost certain_ it won't break anything else.</summary>

https://github.com/user-attachments/assets/47f5d3d3-052d-4a6e-937d-3847403629f5

</details>

## Why It's Good For The Game

Sovl. 
Now we can actually throw stones at buckled criminals.
To be honest, I don't think anyone will use it at all. We rarely see pillories being used. But in case we do - this will probably be fun.