### PR TITLE
NPC Jump Stamina Adjustment + New Decap Ambush + Buckler

### DIFF
--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -147,6 +147,10 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 				/turf/open/floor/rogue/grass,
 				)
 	ambush_mobs = list(
+				new /datum/ambush_config/pair_of_direbear = 10,
+				new /datum/ambush_config/trio_of_highwaymen = 10,
+				new /datum/ambush_config/singular_minotaur = 10,
+				new /datum/ambush_config/duo_minotaur = 5,
 				new /datum/ambush_config/solo_treasure_hunter = 10,
 				new /datum/ambush_config/duo_treasure_hunter = 1
 				)
@@ -175,6 +179,10 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 				/turf/open/floor/rogue/grass,
 				)
 	ambush_mobs = list(
+				new /datum/ambush_config/pair_of_direbear = 10,
+				new /datum/ambush_config/trio_of_highwaymen = 10,
+				new /datum/ambush_config/singular_minotaur = 10,
+				new /datum/ambush_config/duo_minotaur = 5,
 				new /datum/ambush_config/solo_treasure_hunter = 5,
 				new /datum/ambush_config/duo_treasure_hunter = 1
 				)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -43,8 +43,8 @@
 	var/npc_jump_chance = 5
 	/// If the NPC's target is more than this many tiles away, they will try to leap ahead on their path.
 	var/npc_jump_distance = 4
-	/// When above this amount of stamina, the NPC will not attempt to jump.
-	var/npc_max_jump_stamina = 80
+	/// When above this amount of stamina (Stamina is stamina damage), the NPC will not attempt to jump.
+	var/npc_max_jump_stamina = 50
 
 /mob/living/carbon/human/proc/IsStandingStill()
 	return doing || resisting || pickpocketing
@@ -199,6 +199,7 @@
 	if(next_move > world.time) // Jumped too recently!
 		return FALSE
 	if(stamina > npc_max_jump_stamina)
+		NPC_THINK("Too little stamina to jump, skipping! My current stamina is [stamina], max is [npc_max_jump_stamina].")
 		return FALSE
 	var/turf/our_turf = get_turf(src)
 	if(our_turf.Distance_cardinal(get_turf(target), src) <= npc_jump_distance)

--- a/code/modules/mob/living/carbon/human/npc/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/highwayman.dm
@@ -118,7 +118,7 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	if(prob(25))	
 		l_hand = /obj/item/rogueweapon/shield/wood
 	if(prob(10))
-		l_hand = /obj/item/rogueweapon/shield/buckler
+		l_hand = /obj/item/rogueweapon/shield/buckler/palloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	if(prob(30))
 		neck = /obj/item/clothing/neck/roguetown/leather

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -128,7 +128,7 @@
 	var/max_energy = 1000
 	var/max_stamina = 100
 	var/energy = 1000
-	var/stamina = 0
+	var/stamina = 0 // Stamina. In reality this is stamina damage and the higher it is the worse it is.
 
 	var/last_fatigued = 0
 	var/last_ps = 0

--- a/modular_azurepeak/code/modules/mob/living/ambushes/mount_decap_ambush.dm
+++ b/modular_azurepeak/code/modules/mob/living/ambushes/mount_decap_ambush.dm
@@ -1,0 +1,19 @@
+/datum/ambush_config/pair_of_direbear
+	mob_types = list(
+		/mob/living/simple_animal/hostile/retaliate/rogue/direbear = 2
+	)
+
+/datum/ambush_config/trio_of_highwaymen
+	mob_types = list(
+		/mob/living/simple_animal/hostile/retaliate/rogue/highwayman = 3
+	)
+
+/datum/ambush_config/singular_minotaur
+	mob_types = list(
+		/mob/living/simple_animal/hostile/retaliate/rogue/minotaur = 1
+	)
+
+/datum/ambush_config/duo_minotaur
+	mob_types = list(
+		/mob/living/simple_animal/hostile/retaliate/rogue/minotaur = 2
+	)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2349,6 +2349,7 @@
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\vagabond.dm"
 #include "modular_azurepeak\code\modules\jobs\job_types\roguetown\vagabond\wanted.dm"
 #include "modular_azurepeak\code\modules\mob\living\ambushes\mirespiders_ambush.dm"
+#include "modular_azurepeak\code\modules\mob\living\ambushes\mount_decap_ambush.dm"
 #include "modular_azurepeak\code\modules\mob\living\simple_animal\rogue\creacher\abyssal_monsters.dm"
 #include "modular_azurepeak\code\modules\mob\living\simple_animal\rogue\creacher\dragon.dm"
 #include "modular_azurepeak\code\modules\mob\living\simple_animal\rogue\creacher\gethsmane.dm"


### PR DESCRIPTION
## About The Pull Request
- NPC will now only leap when they have 50% stamina bar or above, instead of 20% or above. Less likely to stamcrit themselves leaping now.
- Added new ambushes to Mount Decap: Trio of highwaymen, solo minotaur, duo minotaur, and a pair of direbear.
- Replaced buckler on highwayman with the new ancient buckler made by Kittysmooch, so they stop dropping really good gears.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes NPC more difficult :tm: in a fair way and less prone to stamcritting themselves.
Make Mount Decap actually you know, dangerous?
Make highwamyen less easy to farm for BIS buckler.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
