### PR TITLE
Small fix for infinite flies loop on rotted bodies

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -65,6 +65,7 @@
 	var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
 	if (rot)
 		rot.amount = 0
+		rot.soundloop.stop()
 
 ///Cure bodyparts
 /proc/clean_body_parts(mob/living/carbon/target)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
There was funny logic where the flies soundloop on the rot datum would not stop if a corpse went over the 15 minute rot timer and never deadited (such as on church grounds). This puts a stop call in the clean rot proc, which should fix it.
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
Compiles!
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
BBZZZZZZZZZZZZZZTBBBBBBZZZZBBZBZBZBBBBBBBBBBBZZZZZZZT