### PR TITLE
merges the two fun tabs

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -96,7 +96,7 @@ SUBSYSTEM_DEF(events)
 
 /client/proc/forceGamemode()
 	set name = "Open Gamemode Panel"
-	set category = "Fun"
+	set category = "-Fun-"
 	if(!holder ||!check_rights(R_FUN))
 		return
 	holder.forceGamemode(usr)


### PR DESCRIPTION
## About The Pull Request
![dreamseeker_hMUyw804YO](https://github.com/user-attachments/assets/3e765255-b2fe-44ce-9fa4-1fd82477ec2a)
![dreamseeker_mumD8CAAUJ](https://github.com/user-attachments/assets/e2a4ed5a-5d90-46f0-9341-52ae42ba032f)

The storyteller port came with a "Fun" tab but we actually use "-Fun-". So it just moves the single "Open Gamemode Panel" button over to the "-Fun-" tab.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![image](https://github.com/user-attachments/assets/3fde2b47-8aa0-4c1e-adbb-ef3860f87edd)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
-Someone- was annoyed by this, I'm sure.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
