### PR TITLE
Show integrity as number on weapons / armor.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -529,8 +529,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 		if(max_integrity)
 			inspec += "\n<b>DURABILITY:</b> "
-			var/meme = round(((obj_integrity / max_integrity) * 100), 1)
-			inspec += "[meme]%"
+			var/percent = round(((obj_integrity / max_integrity) * 100), 1)
+			inspec += "[percent]% ([obj_integrity])"
 
 		to_chat(usr, "[inspec.Join()]")
 


### PR DESCRIPTION
## About The Pull Request

- Show the actual number for integrity on weapon / armor

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

![dreamseeker_qVnxslgULE](https://github.com/user-attachments/assets/4e084921-61a0-4c07-957b-8e3d766d9103)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Codediver / Coder has a massive advantage in information when it comes to how much integrity an item have, and even coder / codediver have to onstantly dive to remember it. 

We already show durability as a percentage, might as well show the full number and let people be informed as to what gear is shit or good.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
