### PR TITLE
Ports schism and influence changes from Vanderlin

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1091,10 +1091,13 @@ SUBSYSTEM_DEF(gamemode)
 			lowest = initialized_storyteller
 	if(!highest)
 		return
-	if(storytellers_with_influence[highest] > 1.25)
-		highest.bonus_points -= 1.25
 
-	lowest.bonus_points += 1.25
+	var/adjustment = min(2.5, 1 + (0.3 * FLOOR(max(0, highest.times_chosen - 5) / 5, 1)))
+
+	if(storytellers_with_influence[highest] > adjustment)
+		highest.bonus_points -= adjustment
+
+	lowest.bonus_points += adjustment
 
 	set_storyteller(highest.type)
 

--- a/code/datums/storytellers/_base.dm
+++ b/code/datums/storytellers/_base.dm
@@ -1,7 +1,7 @@
 /// Standard follower modifier for storytellers, ie. how many points they get for each follower
 #define STANDARD_FOLLOWER_MODIFIER 20
-/// Special follower modifier for Astrata, who is a default patron
-#define ASTRATA_FOLLOWER_MODIFIER STANDARD_FOLLOWER_MODIFIER - 2
+/// Lower follower modifier for special storytellers such as Astrata, who is a default patron
+#define LOWER_FOLLOWER_MODIFIER STANDARD_FOLLOWER_MODIFIER - 2
 
 ///The storyteller datum. He operates with the SSgamemode data to run events
 /datum/storyteller

--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -47,6 +47,7 @@
 	desc = "Astrata will provide a balanced and varied experience. Consider this the default experience."
 	weight = 6
 	always_votable = TRUE
+	follower_modifier = LOWER_FOLLOWER_MODIFIER
 	color_theme = "#FFD700"
 
 	influence_factors = list(
@@ -63,6 +64,7 @@
 	welcome_text = "The veil between realms shimmers in your presence."
 	weight = 4
 	always_votable = TRUE
+	follower_modifier = LOWER_FOLLOWER_MODIFIER
 	color_theme = "#F0F0F0"
 
 	tag_multipliers = list(
@@ -296,6 +298,7 @@
 	welcome_text = "You will kneel."
 	weight = 4
 	always_votable = TRUE
+	follower_modifier = LOWER_FOLLOWER_MODIFIER
 	color_theme = "#CC4444"
 
 	tag_multipliers = list(

--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -64,7 +64,6 @@
 	welcome_text = "The veil between realms shimmers in your presence."
 	weight = 4
 	always_votable = TRUE
-	follower_modifier = LOWER_FOLLOWER_MODIFIER
 	color_theme = "#F0F0F0"
 
 	tag_multipliers = list(
@@ -298,7 +297,6 @@
 	welcome_text = "You will kneel."
 	weight = 4
 	always_votable = TRUE
-	follower_modifier = LOWER_FOLLOWER_MODIFIER
 	color_theme = "#CC4444"
 
 	tag_multipliers = list(

--- a/code/modules/events/god_intervention/schism.dm
+++ b/code/modules/events/god_intervention/schism.dm
@@ -94,7 +94,6 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 			if(supporter)
 				to_chat(supporter, span_userdanger("NEVER DEFY ME AGAIN!"))
 				supporter.electrocute_act(5, astrata)
-				// supporter.add_curse(/datum/curse/astrata) This should IDEALLY give a curse. But we have no god-themed curses. YET.
 
 		cleanup_schism()
 

--- a/code/modules/events/god_intervention/schism.dm
+++ b/code/modules/events/god_intervention/schism.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	var/list/supporters_astrata = list()
 	var/list/supporters_challenger = list()
 	var/list/neutrals = list()
+	var/halfway_passed = FALSE
 
 /datum/tennite_schism/New(datum/patron/challenger)
 	. = ..()
@@ -23,7 +24,7 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	if(!challenger)
 		return
 
-	priority_announce("[challenger.name] challenges Astrata's leadeship! The outcome of this conflict will be decided in less than 2 daes by a sheer number of their supporters. [challenger.name] promises great rewards to the faithful if victorious, while Astrata swears revenge to any who dare to defy her. Choose your side, or stand aside...", "Schism within the Ten", 'sound/magic/marked.ogg')
+	priority_announce("[challenger.name] challenges Astrata's leadership! The outcome of this conflict will be decided in less than 2 daes by a sheer number of their alive supporters. [challenger.name] promises great rewards to the faithful if victorious, while Astrata swears revenge to any who dare to defy her. Choose your side, or stand aside...", "Schism within the Ten", 'sound/magic/marked.ogg')
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
 		setup_mob(H)
 
@@ -36,7 +37,7 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 
 	var/mob/living/carbon/human/H = spawned
 	var/datum/patron/challenger = challenger_god?.resolve()
-	if(!challenger)
+	if(!challenger || !H)
 		return
 
 	to_chat(H, span_notice("There is an active schism within the Ten! [challenger.name] has challenged Astrata's leadership!"))
@@ -72,13 +73,19 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 
 	if(astrata_count >= challenger_count)
 		priority_announce("Astrata's light prevails over the challenge of [challenger.name]! The Sun Queen confirms her status as a true heir of Psydon!", "Astrata is VICTORIOUS!", 'sound/magic/ahh2.ogg')
-		adjust_storyteller_influence("Astrata", 300)
+		adjust_storyteller_influence("Astrata", 200)
+		adjust_storyteller_influence(challenger.name, -50)
 
 		for(var/datum/weakref/supporter_ref in supporters_astrata)
 			var/mob/living/carbon/human/supporter = supporter_ref.resolve()
 			if(supporter && supporter.patron == astrata)
-				to_chat(supporter, span_notice("Astrata's light prevails! Your steadfast devotion is rewarded with many triumphs."))
-				supporter.adjust_triumphs(3)
+				for(var/obj/effect/proc_holder/spell/self/choose_schism_side/spell in supporter.mind.spell_list)
+					if(spell.chose_early)
+						to_chat(supporter, span_notice("Astrata's light prevails! Your steadfast devotion is rewarded with many triumphs."))
+						supporter.adjust_triumphs(3)
+					else
+						to_chat(supporter, span_notice("Astrata's light prevails, but your late support goes unrewarded."))
+					break
 			else if(supporter)
 				to_chat(supporter, span_notice("Astrata's light prevails over the challenge of [challenger.name]! The Sun Queen expected no less than your total support."))
 
@@ -87,81 +94,105 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 			if(supporter)
 				to_chat(supporter, span_userdanger("NEVER DEFY ME AGAIN!"))
 				supporter.electrocute_act(5, astrata)
+				// supporter.add_curse(/datum/curse/astrata) This should IDEALLY give a curse. But we have no god-themed curses. YET.
+
+		cleanup_schism()
 
 	else if(challenger_count > astrata_count)
 		priority_announce("[challenger.name]'s challenge succeeds against Astrata's tyranny! The Sun Queen is grudgingly forced to share power with [challenger.name]...", "[challenger.name] RULES!", 'sound/magic/inspire_02.ogg')
-		adjust_storyteller_influence(challenger.name, 300)
+		adjust_storyteller_influence(challenger.name, 200)
+		adjust_storyteller_influence("Astrata", -50)
 
 		for(var/datum/weakref/supporter_ref in supporters_challenger)
 			var/mob/living/carbon/human/supporter = supporter_ref.resolve()
 			if(supporter && supporter.patron == challenger)
-				to_chat(supporter, span_notice("[challenger.name]'s challenge succeeds! Your persistent faith is rewarded with triumphs."))
-				supporter.adjust_triumphs(2)
+				for(var/obj/effect/proc_holder/spell/self/choose_schism_side/spell in supporter.mind.spell_list)
+					if(spell.chose_early)
+						to_chat(supporter, span_notice("[challenger.name]'s challenge succeeds! Your persistent faith is rewarded with triumphs."))
+						supporter.adjust_triumphs(2)
+					else
+						to_chat(supporter, span_notice("[challenger.name] succeeds, but your late support goes unrewarded."))
+					break
 			else if(supporter)
-				to_chat(supporter, span_notice("[challenger.name]'s challenge succeeds against Astrata's tyranny! Your support is rewarded with a triumph."))
-				supporter.adjust_triumphs(1)
-
-		var/mob/living/carbon/human/selected_priest = null
-		var/was_supporter = FALSE
-		var/was_clergy = FALSE
-
-		// First try to find a challenger supporter who is also clergy
-		for(var/datum/weakref/supporter_ref in supporters_challenger)
-			var/mob/living/carbon/human/human_mob = supporter_ref.resolve()
-			if(human_mob && human_mob.stat != DEAD && human_mob.client && (human_mob.mind?.assigned_role in GLOB.church_positions) && human_mob.patron == challenger)
-				selected_priest = human_mob
-				was_supporter = TRUE
-				break
-
-		// If no supporter found, fall back to any clergy member who has the challenger as his patron
-		if(!selected_priest)
-			for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
-				if(human_mob.stat != DEAD && human_mob.client && (human_mob.mind?.assigned_role in GLOB.church_positions) && human_mob.patron == challenger)
-					selected_priest = human_mob
-					was_clergy = TRUE
+				for(var/obj/effect/proc_holder/spell/self/choose_schism_side/spell in supporter.mind.spell_list)
+					if(spell.chose_early)
+						to_chat(supporter, span_notice("[challenger.name]'s challenge succeeds against Astrata's tyranny! Your support is rewarded with a triumph."))
+						supporter.adjust_triumphs(1)
+					else
+						to_chat(supporter, span_notice("[challenger.name]'s challenge succeeds, but your late support goes unrewarded."))
 					break
-
-		// As a last resort, pick someone who has the challenger as his patron, is nonheretical species, is adult and is not a noble, garrison or a migrant
-		if(!selected_priest)
-			for(var/datum/weakref/supporter_ref in supporters_challenger)
-				var/mob/living/carbon/human/human_mob = supporter_ref.resolve()
-				if(human_mob && human_mob.stat != DEAD && human_mob.client && human_mob.patron == challenger && !human_mob.is_noble() && !(human_mob.mind?.assigned_role in GLOB.garrison_positions) && !(human_mob.mind?.assigned_role in GLOB.allmig_positions))
-					selected_priest = human_mob
-					was_supporter = TRUE
-					break
-
-		// Promote the selected priest if we found one
-		if(selected_priest)
-			var/male
-			if(selected_priest.gender == FEMALE)
-				selected_priest.job = "Vice Priestess"
-				selected_priest.advjob = "Vice Priestess"
-				male = FALSE
-			else
-				selected_priest.job = "Vice Priest"
-				selected_priest.advjob = "Vice Priest"
-				male = TRUE
-			selected_priest.migrant_type = null
-			if(!was_clergy)
-				selected_priest.verbs |= /mob/living/carbon/human/proc/devotionreport
-				selected_priest.verbs |= /mob/living/carbon/human/proc/clericpray
-			selected_priest.verbs |= /mob/living/carbon/human/proc/churchexcommunicate
-			//selected_priest.verbs |= /mob/living/carbon/human/proc/churchcurse	- Add this back seperate later in a seperate PR. Good feature, PR too big tho.
-			selected_priest.verbs |= /mob/living/carbon/human/proc/churchannouncement
-
-			if(was_supporter)
-				to_chat(selected_priest, span_green("[challenger.name] smiles upon you! Your faithful support during the schism has been rewarded with the position of a [male ? "Vice Priest" : "Vice Priestess"]!"))
-			else
-				to_chat(selected_priest, span_green("Though you did not openly support [challenger.name] during the schism, you have been chosen to serve as a [male ? "Vice Priest" : "Vice Priestess"]!"))
-
-			priority_announce("[challenger.name] has selected [selected_priest.real_name] as a [male ? "Vice Priest" : "Vice Priestess"]! Power sharing begins!", "[male ? "Vice Priest" : "Vice Priestess"] rises")
-
 		for(var/datum/weakref/supporter_ref in supporters_astrata)
 			var/mob/living/carbon/human/supporter = supporter_ref.resolve()
 			if(supporter)
 				to_chat(supporter, span_userdanger("INCOMPETENT IMBECILES!"))
 				supporter.electrocute_act(5, astrata)
 
+		if(GLOB.todoverride == null)
+			addtimer(CALLBACK(src, PROC_REF(astrata_scorn)), 15 SECONDS)
+
+		addtimer(CALLBACK(src, PROC_REF(select_and_announce_vice_priest), challenger), 30 SECONDS)
+
+/datum/tennite_schism/proc/astrata_scorn()
+		priority_announce("You don't deserve my holy light, you ungrateful swines!", "Astrata's Scorn", 'sound/magic/fireball.ogg')
+		GLOB.todoverride = "night"
+		settod()
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(reset_tod_override)), 20 MINUTES)
+
+/datum/tennite_schism/proc/select_and_announce_vice_priest(datum/patron/challenger)
+	var/mob/living/carbon/human/selected_priest = null
+	var/was_supporter = FALSE
+
+	// First try to find a challenger supporter who is also clergy
+	for(var/datum/weakref/supporter_ref in supporters_challenger)
+		var/mob/living/carbon/human/human_mob = supporter_ref.resolve()
+		if(human_mob && human_mob.stat != DEAD && human_mob.client && (human_mob.mind?.assigned_role in GLOB.church_positions) && human_mob.patron == challenger)
+			selected_priest = human_mob
+			was_supporter = TRUE
+			break
+
+	// If no supporter found, fall back to any clergy member who has the challenger as his patron
+	if(!selected_priest)
+		for(var/mob/living/carbon/human/human_mob in GLOB.player_list)
+			if(human_mob.stat != DEAD && human_mob.client && (human_mob.mind?.assigned_role in GLOB.church_positions) && human_mob.patron == challenger)
+				selected_priest = human_mob
+				break
+
+	// Promote the selected priest if we found one
+	if(selected_priest)
+		var/male
+		if(selected_priest.gender == FEMALE)
+			selected_priest.job = "Vice Priestess"
+			selected_priest.advjob = "Vice Priestess"
+			male = FALSE
+		else
+			selected_priest.job = "Vice Priest"
+			selected_priest.advjob = "Vice Priest"
+			male = TRUE
+		selected_priest.migrant_type = null
+		var/datum/devotion/D = selected_priest.devotion
+		if(D)
+			D.passive_devotion_gain = 1
+			D.passive_progression_gain = 1
+			START_PROCESSING(SSobj, D)
+		selected_priest.verbs |= /mob/living/carbon/human/proc/devotionreport
+		selected_priest.verbs |= /mob/living/carbon/human/proc/clericpray
+		selected_priest.verbs |= /mob/living/carbon/human/proc/churchexcommunicate
+		//selected_priest.verbs |= /mob/living/carbon/human/proc/churchcurse	- Add this back seperate later in a seperate PR. Good feature, PR too big tho.
+		selected_priest.verbs |= /mob/living/carbon/human/proc/churchannouncement
+
+		priority_announce("[challenger.name] has selected [selected_priest.real_name] as a new [male ? "Vice Priest" : "Vice Priestess"]! Power sharing begins!", "[male ? "Vice Priest" : "Vice Priestess"] rises", 'sound/magic/inspire_02.ogg')
+
+		if(was_supporter)
+			to_chat(selected_priest, span_green("[challenger.name] smiles upon you! Your faithful support during the schism has been rewarded with the position of a [male ? "Vice Priest" : "Vice Priestess"]!"))
+		else
+			to_chat(selected_priest, span_green("Though you did not openly support [challenger.name] during the schism, you have been chosen to serve as a [male ? "Vice Priest" : "Vice Priestess"]!"))
+
+		if(D)
+			to_chat(selected_priest, span_notice("You have gained a passive devotion gain and powers to announce, excommunicate or curse!"))
+
+	cleanup_schism()
+
+/datum/tennite_schism/proc/cleanup_schism()
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
 		if(!H.mind)
 			continue
@@ -195,6 +226,8 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	else if(challenger_count > astrata_count)
 		priority_announce("[challenger.name] is leading in the schism! Astrata will soon be forced to yield...", "Schism Rages On", 'sound/magic/marked.ogg')
 
+	halfway_passed = TRUE
+
 /datum/tennite_schism/proc/change_side(mob/living/carbon/human/user, new_side)
 	supporters_astrata -= WEAKREF(user)
 	supporters_challenger -= WEAKREF(user)
@@ -217,6 +250,7 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	name = "Choose your side"
 	overlay_state = "limb_attach"
 	recharge_time = 20 SECONDS
+	var/chose_early = FALSE
 	var/uses_remaining = 2
 
 /obj/effect/proc_holder/spell/self/choose_schism_side/cast(mob/living/carbon/human/user)
@@ -236,8 +270,6 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	options["Neutral"] = "neutral"
 	if(challenger)
 		options["[challenger.name]"] = "challenger"
-
-
 	var/choice = input(user, "Choose your allegiance in the schism, you can change your side [uses_remaining] more time\s", "Choose your side") as null|anything in options
 	if(!choice || !current_schism)
 		return
@@ -258,6 +290,9 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	uses_remaining--
 	current_schism.change_side(user, options[choice])
 
+	if(!current_schism.halfway_passed)
+		chose_early = TRUE
+
 	if(uses_remaining <= 0)
 		if(action)
 			action.UpdateButtonIcon()
@@ -268,11 +303,11 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	name = "Schism within the Ten"
 	track = EVENT_TRACK_INTERVENTION
 	typepath = /datum/round_event/schism_within_ten
-	weight = 1
-	max_occurrences = 1	//Re-enabled since we have more interventions.
+	weight = 0.2
+	max_occurrences = 1
 	min_players = 60
-	earliest_start = 30 MINUTES
-	allowed_storytellers = list(/datum/storyteller/noc, /datum/storyteller/ravox, /datum/storyteller/necra, /datum/storyteller/xylix, /datum/storyteller/pestra, /datum/storyteller/abyssor, /datum/storyteller/dendor, /datum/storyteller/eora, /datum/storyteller/malum)
+	earliest_start = 20 MINUTES
+	allowed_storytellers = list(/datum/storyteller/noc, /datum/storyteller/ravox, /datum/storyteller/necra, /datum/storyteller/xylix, /datum/storyteller/pestra, /datum/storyteller/abyssor, /datum/storyteller/dendor, /datum/storyteller/malum)
 	//Once more 'generic' god interventions are in, add to Psydon as well.
 
 /datum/round_event_control/schism_within_ten/canSpawnEvent(players_amt, gamemode, fake_check)
@@ -293,23 +328,9 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 	if(!alternative_events)
 		return FALSE
 
-	var/datum/patron/astrata = GLOB.patronlist[/datum/patron/divine/astrata]
-	if(!astrata)
+	var/datum/patron/challenger = find_strongest_challenger()
+	if(!challenger)
 		return FALSE
-
-	var/astrata_followers = GLOB.patron_follower_counts["Astrata"] || 0
-	var/astrata_influence = get_storyteller_influence("Astrata") || 0
-
-	for(var/type in subtypesof(/datum/patron/divine) - /datum/patron/divine/astrata)
-		var/datum/patron/divine/god = GLOB.patronlist[type]
-		if(!god)
-			continue
-
-		var/god_followers = GLOB.patron_follower_counts[god.name] || 0
-		var/god_influence = get_storyteller_influence(god.name) || 0
-
-		if(god_followers > astrata_followers && god_influence > astrata_influence)
-			return TRUE
 
 	return FALSE
 
@@ -356,19 +377,33 @@ GLOBAL_LIST_EMPTY(tennite_schisms)
 		return FALSE
 	return istype(human_mob.patron, /datum/patron/divine)
 
+/// Resets day cycle override to null
+/proc/reset_tod_override()
+	GLOB.todoverride = null
+
 /// Finds strongest divine pantheon to challenge Astrata
 /proc/find_strongest_challenger()
 	var/datum/patron/strongest_challenger
-	var/most_followers = 0
+	var/highest_influence = 0
+	var/astrata_influence = get_storyteller_influence("Astrata") || 0
 
-	for(var/type in subtypesof(/datum/patron/divine) - /datum/patron/divine/astrata)
+	for(var/type in subtypesof(/datum/patron/divine) - list(/datum/patron/divine/astrata, /datum/patron/divine/eora))
 		var/datum/patron/divine/god = GLOB.patronlist[type]
 		if(!god)
 			continue
 
-		var/current_followers = GLOB.patron_follower_counts[god.name] || 0
-		if(current_followers > most_followers)
-			most_followers = current_followers
+		var/has_clergy = FALSE
+		for(var/mob/living/carbon/human/H in GLOB.player_list)
+			if(H.stat != DEAD && H.client && H.patron == god && (H.mind?.assigned_role in GLOB.church_positions))
+				has_clergy = TRUE
+				break
+
+		if(!has_clergy)
+			continue
+
+		var/god_influence = get_storyteller_influence(god.name) || 0
+		if(god_influence > highest_influence && god_influence > astrata_influence)
+			highest_influence = god_influence
 			strongest_challenger = god
 
 	return strongest_challenger


### PR DESCRIPTION
## About The Pull Request

Ports [schism and influence changes from Vanderlin by Arkatos1](https://github.com/Monkestation/Vanderlin/pull/2261)

- Lowers event weight very considerably, should happen much less often now
- Challenger is now decided by influence, not number of followers
- Challenger must have atleast 1 clergy of their faith present
- No triumph rewards for those who a choose side after the half point announcement
- Loser deity also loses a bit of their influence
- **_Unlike in original PR, Astrata's followers will not get cursed. We lack god-themed curses._**
- If Challenger wins, Astrata will throw a tantrum and hides the Sun for a while
- Vice Priest can now only be chosen from the clergy and also gets a passive devotion gain
- Eora will now not trigger the schism

Influences

- Penalty from a repeated storyteller reigns is now slowly growing from 1 to a maximum of 2,5
- ~~Adds a small follower penalty to Noc and Zizo, as they are often forced patrons~~ As we have no forced patrons, that penalty is no longer applied.

## Testing Evidence

I tested it *as much as possible* on my local instance. However, not all code can be tested without other players present. 

## Why It's Good For The Game

Meaningful schism. 