### PR TITLE
Remove global ambush CD. Make ambush CD per mob every 5 minutes.

### DIFF
--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -1,5 +1,5 @@
 GLOBAL_VAR_INIT(ambush_chance_pct, 20) // Please don't raise this over 100 admins :')
-GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 3 MINUTES) // Cooldown for each individual mob being considered for an ambush
+GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 5 MINUTES) // Cooldown for each individual mob being considered for an ambush
 
 /mob/living/proc/ambushable()
 	if(stat)

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -1,11 +1,7 @@
 GLOBAL_VAR_INIT(ambush_chance_pct, 20) // Please don't raise this over 100 admins :')
-GLOBAL_VAR_INIT(ambush_global_cooldown, 3 MINUTES) // Cooldown for the game spawning ambushes on anyone
-GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 15 SECONDS) // Cooldown for each individual mob being considered for an ambush
+GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 3 MINUTES) // Cooldown for each individual mob being considered for an ambush
 
 /mob/living/proc/ambushable()
-	if(mob_timers["ambushlast"])
-		if(world.time < mob_timers["ambushlast"] + GLOB.ambush_global_cooldown)
-			return FALSE
 	if(stat)
 		return FALSE
 	return ambushable


### PR DESCRIPTION
## About The Pull Request
As per title.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Was always kinda weird you can just get no ambush despite deliberately triggering it because someone else somewhere in the world triggered an ambush in the last 3 minutes. 

Now this make ambush slightly more farmable if you are hungry for a fight and also no longer dependent on a weird global CD.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
