### PR TITLE
Unarmed Tweaks

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -356,3 +356,5 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 
 //Weapon values
 #define BLUNT_DEFAULT_PENFACTOR		-100
+
+#define UNARMED_DAMAGE_DEFAULT		12

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -459,7 +459,7 @@
 	misscost = 5
 	releasedrain = 2	//Lowered for intent stam usage.
 	swingdelay = 0
-	clickcd = CLICK_CD_FAST
+	clickcd = 10
 	rmb_ranged = TRUE
 	candodge = TRUE
 	canparry = TRUE
@@ -467,6 +467,7 @@
 	miss_text = "swing a fist at the air"
 	miss_sound = "punchwoosh"
 	item_d_type = "blunt"
+	intent_intdamage_factor = 0.5
 
 /datum/intent/unarmed/punch/rmb_ranged(atom/target, mob/user)
 	if(ismob(target))

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -123,6 +123,9 @@
 			for(var/part in int.target_parts)
 				str +="|[bodyzone2readablezone(part)]|"
 			inspec += str
+	if(intent_intdamage_factor != 1)
+		var/percstr = abs(intent_intdamage_factor - 1) * 100
+		inspec += "\nThis intent deals [percstr]% [intent_intdamage_factor > 1 ? "more" : "less"] damage to integrity."
 	inspec += "<br>----------------------"
 
 	to_chat(user, "[inspec.Join()]")
@@ -456,6 +459,7 @@
 	misscost = 5
 	releasedrain = 2	//Lowered for intent stam usage.
 	swingdelay = 0
+	clickcd = CLICK_CD_FAST
 	rmb_ranged = TRUE
 	candodge = TRUE
 	canparry = TRUE

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -361,7 +361,7 @@
 	penfactor = BLUNT_DEFAULT_PENFACTOR
 	damfactor = 1.1
 	clickcd = CLICK_CD_MELEE
-	swingdelay = 10
+	swingdelay = 8
 	intent_intdamage_factor = 1.8
 	icon_state = "insmash"
 	item_d_type = "blunt"

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -238,7 +238,7 @@
 	icon_state = "incut"
 	attack_verb = list("cuts", "slashes")
 	animname = "cut"
-	blade_class = BCLASS_CHOP
+	blade_class = BCLASS_CUT
 	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
 	penfactor = 0
 	chargetime = 0
@@ -274,7 +274,7 @@
 	desc = "A gift from a creature of the sea. The claw is sharpened to a wicked edge."
 	icon_state = "abyssorclaw"
 	force = 27	//Its thrust will be able to pen 80 stab armor if the wielder has 17 STR. (With softcap)
-	max_integrity = 150
+	max_integrity = 120
 
 
 /obj/item/rogueweapon/knuckles
@@ -301,7 +301,7 @@
 	smeltresult = /obj/item/ingot/steel
 	grid_width = 64
 	grid_height = 32
-	intdamage_factor = 1.45
+	intdamage_factor = 1.2
 
 /obj/item/rogueweapon/knuckles/getonmobprop(tag)
 	. = ..()
@@ -347,7 +347,7 @@
 	chargetime = 0
 	penfactor = BLUNT_DEFAULT_PENFACTOR
 	clickcd = 8
-	damfactor = 1
+	damfactor = 1.1
 	swingdelay = 0
 	icon_state = "inpunch"
 	item_d_type = "blunt"
@@ -359,9 +359,10 @@
 	attack_verb = list("smashes")
 	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
 	penfactor = BLUNT_DEFAULT_PENFACTOR
-	damfactor = 1.3
-	clickcd = 10
-	swingdelay = 6
+	damfactor = 1.1
+	clickcd = CLICK_CD_MELEE
+	swingdelay = 10
+	intent_intdamage_factor = 1.8
 	icon_state = "insmash"
 	item_d_type = "blunt"
 
@@ -371,6 +372,7 @@
 	icon_state = "aknuckle"
 	force = 12
 	max_integrity = 150
+	wdefense = 5
 	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
 

--- a/code/modules/clothing/rogueclothes/gloves.dm
+++ b/code/modules/clothing/rogueclothes/gloves.dm
@@ -29,6 +29,7 @@
 	anvilrepair = null
 	sewrepair = TRUE
 	salvage_result = /obj/item/natural/hide/cured
+	unarmed_bonus = 1.1
 
 /obj/item/clothing/gloves/roguetown/leather/black
 	color = CLOTHING_BLACK
@@ -99,6 +100,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
+	unarmed_bonus = 1.15
 
 /obj/item/clothing/gloves/roguetown/chain/aalloy
 	name = "decrepit chain gauntlets"

--- a/code/modules/clothing/rogueclothes/gloves.dm
+++ b/code/modules/clothing/rogueclothes/gloves.dm
@@ -11,6 +11,9 @@
 	max_heat_protection_temperature = 361
 	experimental_inhand = FALSE
 
+	/// Unarmed damage multiplier (for pure fists / wrestling only)
+	var/unarmed_bonus = 1
+
 /obj/item/clothing/gloves/roguetown/leather
 	name = "leather gloves"
 	desc = ""
@@ -164,6 +167,7 @@
 
 	grid_width = 64
 	grid_height = 32
+	unarmed_bonus = 1.2
 
 /obj/item/clothing/gloves/roguetown/plate/aalloy
 	name = "decrepit plate gauntlets"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -111,7 +111,7 @@
 		return TRUE
 
 /mob/living/carbon/human/get_punch_dmg()
-	var/damage = 12
+	var/damage = STASTR
 
 	var/used_str = STASTR
 
@@ -125,16 +125,13 @@
 	if(used_str <= 9)
 		damage = max(damage - (damage * ((10 - used_str) * 0.1)), 1)
 
-	if(istype(G, /obj/item/clothing/gloves/roguetown/plate))
-		damage = (damage * 1.20)
-	if(istype(G, /obj/item/clothing/gloves/roguetown/chain))
-		damage = (damage * 1.15)
-	if(istype(G, /obj/item/clothing/gloves/roguetown/leather))
-		damage = (damage * 1.10) 
+	if(istype(G, /obj/item/clothing/gloves/roguetown))
+		var/obj/item/clothing/gloves/roguetown/GL = G
+		damage = (damage * GL.unarmed_bonus)
 
 	if(mind)
 		if(mind.has_antag_datum(/datum/antagonist/werewolf))
-			return 30
+			return 50
 
 	return damage
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -111,7 +111,12 @@
 		return TRUE
 
 /mob/living/carbon/human/get_punch_dmg()
-	var/damage = STASTR
+
+	var/damage
+	if(STASTR > UNARMED_DAMAGE_DEFAULT || STASTR < 10)
+		damage = STASTR
+	else
+		damage = UNARMED_DAMAGE_DEFAULT
 
 	var/used_str = STASTR
 

--- a/modular_azurepeak/code/modules/spells/warscholar.dm
+++ b/modular_azurepeak/code/modules/spells/warscholar.dm
@@ -21,14 +21,14 @@
 	icon = 'icons/mob/actions/roguespells.dmi'
 	icon_state = "katar_bound"
 	charges = 20
-	force = 18
+	force = 24
 	possible_item_intents = list(/datum/intent/katar/cut, /datum/intent/katar/thrust)
 	gripsprite = FALSE
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_HUGE
 	parrysound = list('sound/combat/parry/bladed/bladedsmall (1).ogg','sound/combat/parry/bladed/bladedsmall (2).ogg','sound/combat/parry/bladed/bladedsmall (3).ogg')
 	max_blade_int = 999
-	max_integrity = 999
+	max_integrity = 50
 	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg','sound/combat/wooshes/bladed/wooshsmall (2).ogg','sound/combat/wooshes/bladed/wooshsmall (3).ogg')
 	associated_skill = /datum/skill/combat/unarmed
 	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'


### PR DESCRIPTION
## About The Pull Request
I had this branch lying around and decided to cap it off with other pending changes / problems.
- Katars no longer have a CHOP intent. With how our dismemberment works, it wasn't the best idea. CUT can still dismember, mind, it just requires the 80% limb damage threshold. CHOP ignores that.
- Knuckles have been pushed even harder into integrity damage territory. They will always deal more damage vs integrity, especially with their smash intent (1.8x) modifier.
- Weapon intents now tell you their integrity damage values, if applicable.
![dreamseeker_4fQjwnDH1A](https://github.com/user-attachments/assets/bf9a1ab9-7311-49df-b375-fe40be20f18f)
- Keep in mind, if both the weapon AND an intent on the weapon has an integrity damage modifier, only one (the highest  or lowest) will be used. They don't stack.

- STR now directly affects your punch damage, changing the starting value for the calculations to the user's STR, unless they have 10-12. Then 12 (old value) is used. This also means if your STR is under 10 your unarmed damage is affected rather severely (from 12 to 9 for base starting value.)
   - This puts fists directly on-par with weapons for high chad builds, (IE 45 damage at 15 STR), meaning they are far better at damaging unarmored parts.
   - However, punches now deal **half** as much damage to any armor. Making them really, really bad at punching plate, or really any armor. Even a shortsword with 10 STR would deal more damage than pure fists. This applies to parries, too.
![image](https://github.com/user-attachments/assets/8c16f67b-9745-4db1-83dd-38216a0797fd)
- Punches are now faster, slightly.

The idea is that fists deal more damage to unarmored bodyparts, while knuckles will deal more damage to armored bodyparts.
Juggling these two is still a pain in the butt, however, and this might also end up being too weird or overtuned in one way or another.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
👊💢
It's me trying to distinguish knuckles from fists when both are HECKING blunt damage 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
