### PR TITLE
Fix Ravox & Graggar Incantations. Give CTA an actual debuff.

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -293,6 +293,7 @@
 /datum/status_effect/debuff/call_to_arms
 	id = "call_to_arms"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/call_to_arms
+	effectedstats = list("endurance" = -2, "constitution" = -2)
 	duration = 2.5 MINUTES
 
 /atom/movable/screen/alert/status_effect/debuff/call_to_arms

--- a/code/modules/spells/roguetown/acolyte/ravox.dm
+++ b/code/modules/spells/roguetown/acolyte/ravox.dm
@@ -23,7 +23,7 @@
 	if(!isliving(user))
 		return FALSE
 	user.apply_status_effect(/datum/status_effect/divine_strike, user.get_active_held_item())
-	return ..()
+	return TRUE
 
 /datum/status_effect/divine_strike
 	id = "divine_strike"
@@ -102,7 +102,7 @@
 		if(target.mob_biotypes & MOB_UNDEAD)
 			continue
 		target.apply_status_effect(/datum/status_effect/buff/call_to_arms)
-	return ..()
+	return TRUE
 
 //Persistence - Harms the shit out of an undead mob/player while causing bleeding/pain wounds to clot at higher rate for living ones. Basically a 'shittier' yet still good greater heal effect.
 /obj/effect/proc_holder/spell/invoked/persistence
@@ -160,7 +160,7 @@
 				if(!isnull(bleeder.clotting_threshold) && bleeder.bleed_rate > bleeder.clotting_threshold)
 					var/difference = bleeder.bleed_rate - bleeder.clotting_threshold
 					bleeder.bleed_rate = max(bleeder.clotting_threshold, bleeder.bleed_rate - difference * situational_bonus)
-		return ..()
+		return TRUE
 	return FALSE
 
 /atom/movable/screen/alert/status_effect/buff/divine_strike

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -24,7 +24,7 @@
 		if(target.mob_biotypes & MOB_UNDEAD)
 			continue
 		target.apply_status_effect(/datum/status_effect/debuff/call_to_slaughter)	//Debuffs non-inhumens/psydonians
-	return ..()
+	return TRUE
 
 //Unholy Grasp - Throws disappearing net made of viscera at enemy. Creates blood on impact.
 /obj/effect/proc_holder/spell/invoked/projectile/blood_net
@@ -78,7 +78,6 @@
 	devotion_cost = 70
 
 /obj/effect/proc_holder/spell/invoked/revel_in_slaughter/cast(atom/A, list/targets, mob/living/user = usr)
-	. = ..()
 	var/success = 0
 	for(var/obj/effect/decal/cleanable/blood/B in view(3, user))
 		success++
@@ -97,7 +96,8 @@
 			addtimer(VARSET_CALLBACK(phy, pain_mod, phy.pain_mod /= 1.5), 15 SECONDS)
 			human_target.visible_message(span_danger("[target]'s wounds become inflammed as their vitality is sapped away!"))
 			to_chat(target, span_warning("My skins feels like pins and needles, as if something were ripping and tearing at me!"))
-			return ..()
+			return TRUE
+	return FALSE
 
 //Bloodrage T0 -- Uncapped STR buff.
 /obj/effect/proc_holder/spell/self/graggar_bloodrage


### PR DESCRIPTION
## About The Pull Request
Continuing my trend of buffing and reworking a role and then maining it 4 PRs and 1 month later.
- Ravox Spells **actually** have an incantation - they were returning parent which didn't return TRUE leading to them not using their incantation. That's why Ravoxian templars / monk are so damn silent.
- Call to Arms now actually debuff the inhumen instead of having no stat attached to the debuff. Mirror of Gagger
- Graggar's Call to Slaughter and Revel in Slaughter will now have functional incantation.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_2JBoUji0O6](https://github.com/user-attachments/assets/f78bbdb2-96a5-4128-ba23-ed90c4a3741e)
![dreamseeker_bpwxtJj3SF](https://github.com/user-attachments/assets/9088abe2-73d5-4612-bad4-130801313e96)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugfix for a templar I seldomly see played. (I see one monk)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
