### PR TITLE
Fixes SLOT_SHIRT integrity_check()

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -238,7 +238,10 @@
 
 	if(wear_shirt && !(SLOT_SHIRT in obscured))
 		if(!wear_armor)
-			. += "[m3] [wear_shirt.get_examine_string(user)]."
+			var/str = "[m3] [wear_shirt.get_examine_string(user)]."
+			if(!is_stupid)
+				str += " [wear_shirt.integrity_check()]"
+			. += str
 		else
 			if(is_smart)
 				var/str = "[m3] [wear_shirt.get_examine_string(user)]. "


### PR DESCRIPTION
## About The Pull Request

Turns out that wear_shirt was not adding integrity_check() if not obscured by armor. Added ``integrity_check()`` for anyone but stupid mobs.
~~TBH, we need to unify SLOT_SHIRT and SLOT_ARMOR examine in one proc because they are essentialy doing the same and some armor can be worn in both slots~~

## Testing Evidence

![image](https://github.com/user-attachments/assets/530f88c2-0206-4bd4-bb4e-187cb6bef0fd)

## Why It's Good For The Game

Bugfix. Period.