### PR TITLE
Fixes lack of post equipment for migrants and guildmaster

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -265,7 +265,7 @@ SUBSYSTEM_DEF(migrants)
 		hugboxify_for_class_selection(character)
 	else
 		// Apply a special if we're not applying an adv class, otherwise let the adv class apply it afterwards
-		apply_prefs_special(character)
+		try_apply_character_post_equipment(character, character.client)
 
 /datum/controller/subsystem/migrants/proc/get_priority_players(list/players, role_type)
 	var/list/priority = list()

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -7,7 +7,6 @@
 	spawn_positions = 1
 	min_pq = 0
 	selection_color = JCOLOR_YEOMAN
-	advclass_cat_rolls = list(CTAG_GUILDMASTER = 20)
 
 	allowed_races = RACES_ALL_KINDS
 


### PR DESCRIPTION
## About The Pull Request

Fixes #2931 - for reasons unknown to me guildmaster had advclass cat rolls set up. Despite the fact that there are no advclasses for them.

Fixes lack of postequipment for heartfelt migrants. Actually, it fixes lack of postequipment for *any* migrants without advclasses.

## Testing Evidence

<details>
  <summary>Heartfelt migrants, as well as any advclass-less migrants, now get their post equipment </summary>

![image](https://github.com/user-attachments/assets/361141ec-64b9-4801-a4a0-6ec164a440ee)

</details>

<details>
  <summary>Guildmaster gets it too after removal of faux advclass rolls </summary>

![image](https://github.com/user-attachments/assets/f74f9866-b970-40d8-82ce-d20e23b03623)

</details>

## Why It's Good For The Game

Remove all bugs.