### PR TITLE
Fixes psydonian plate 

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1044,19 +1044,15 @@
 	id = "psydonic_endurance"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/psydonic_endurance
 	effectedstats = list("constitution" = 1,"endurance" = 1) 
-	/// Whether we added TRAIT_HEAVYARMOR to the user and need to remove or not.
-	var/added_trait = FALSE
 
 /datum/status_effect/buff/psydonic_endurance/on_apply()
 	. = ..()
 	if(HAS_TRAIT(owner, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(owner, TRAIT_HEAVYARMOR))
-		ADD_TRAIT(owner, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-		added_trait = TRUE
+		ADD_TRAIT(owner, TRAIT_HEAVYARMOR, src)
 
 /datum/status_effect/buff/psydonic_endurance/on_remove()
 	. = ..()
-	if(added_trait)
-		REMOVE_TRAIT(owner, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_HEAVYARMOR, src)
 
 /atom/movable/screen/alert/status_effect/buff/psydonic_endurance
 	name = "Psydonic Endurance"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1040,4 +1040,27 @@
 	owner.emote("breathgasp", forced = TRUE)
 	owner.Slowdown(3)
 
+/datum/status_effect/buff/psydonic_endurance
+	id = "psydonic_endurance"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/psydonic_endurance
+	effectedstats = list("constitution" = 1,"endurance" = 1) 
+	/// Whether we added TRAIT_HEAVYARMOR to the user and need to remove or not.
+	var/added_trait = FALSE
+
+/datum/status_effect/buff/psydonic_endurance/on_apply()
+	. = ..()
+	if(HAS_TRAIT(owner, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(owner, TRAIT_HEAVYARMOR))
+		ADD_TRAIT(owner, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+		added_trait = TRUE
+
+/datum/status_effect/buff/psydonic_endurance/on_remove()
+	. = ..()
+	if(added_trait)
+		REMOVE_TRAIT(owner, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+
+/atom/movable/screen/alert/status_effect/buff/psydonic_endurance
+	name = "Psydonic Endurance"
+	desc = "I am protected by blessed Psydonian plate armor."
+	icon_state = "buff"
+
 #undef BLOODRAGE_FILTER

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -961,30 +961,17 @@
 
 	max_integrity = 500
 
-	/// Whether the user has the Heavy Armour Trait prior to donning.
-	var/traited = FALSE
-
 /obj/item/clothing/suit/roguetown/armor/plate/full/fluted/ornate/equipped(mob/living/user, slot)
-	..()
+	. = ..()
 	if(slot != SLOT_ARMOR)
 		return
-	user.change_stat("endurance", 1)
-	user.change_stat("constitution", 1)
-	to_chat(user, span_notice("Endure til' inevitability."))
-	if (!HAS_TRAIT(user, TRAIT_MEDIUMARMOR))
-		return
-	if (HAS_TRAIT(user, TRAIT_HEAVYARMOR))
-		traited = TRUE
-		return
-	ADD_TRAIT(user, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 
-/obj/item/clothing/suit/roguetown/armor/plate/full/fluted/ornate/dropped(mob/living/user)
-	..()
-	user.change_stat("endurance", -1)
-	user.change_stat("constitution", -1)
-	to_chat(user, span_notice("Trust in thyself."))
-	if (!traited)
-		REMOVE_TRAIT(user, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	user.apply_status_effect(/datum/status_effect/buff/psydonic_endurance)
+
+/obj/item/clothing/suit/roguetown/armor/plate/full/fluted/ornate/dropped(mob/living/carbon/human/user)
+	. = ..()
+	if(istype(user) && user.wear_armor == src)
+		user.remove_status_effect(/datum/status_effect/buff/psydonic_endurance)
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/matthios
 	name = "gilded fullplate"


### PR DESCRIPTION
## About The Pull Request

Fixes #2930 

Psydonian plate will no longer remove heavy armor training.
On top of that, it will no longer blatantly deprive mobs of their stats. Apparently, ``dropped()`` is called any time mob drops an item. Consequently, psydonian plate was removing endurance and constitution even when dropped from hands.

I decided to transfer stat and trait addition/removal to buff. First of all, looks better code-wise. Secondly, it is more informative for user - players will now clearly see what buffs their stats.

Also it now removes trait from source, so it should not break in case we add other items/buffs that grant TRAIT_HEAVYARMOR.
~~I can't believe I wasted thirty minutes of my life staring at trait removal code~~

</details>

## Testing Evidence

Something like this.

![image](https://github.com/user-attachments/assets/5c69d23f-eb9f-4cac-95d4-15ef8bdaf0ce)

## Why It's Good For The Game

Psydon Endures, and so do I.