### PR TITLE
Minimizes fountain and water-turf drinking spam (port)

### DIFF
--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -73,14 +73,20 @@
 			var/mob/living/carbon/C = user
 			if(C.is_mouth_covered())
 				return
-		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 		user.visible_message(span_info("[user] starts to drink from [src]."))
-		if(do_after(L, 25, target = src))
-			var/list/waterl = list(/datum/reagent/water = 5)
-			var/datum/reagents/reagents = new()
-			reagents.add_reagent_list(waterl)
-			reagents.trans_to(L, reagents.total_volume, transfered_by = user, method = INGEST)
-			playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
-			onbite(user) // Auto repeat drinking
+		drink_act(user, L)
 		return
 	..()
+
+/obj/structure/well/fountain/proc/drink_act(mob/user, mob/living/L)
+	playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
+	if(L.stat != CONSCIOUS)
+		return
+	if(do_after(L, 25, target = src))
+		var/list/waterl = list(/datum/reagent/water = 5)
+		var/datum/reagents/reagents = new()
+		reagents.add_reagent_list(waterl)
+		reagents.trans_to(L, reagents.total_volume, transfered_by = user, method = INGEST)
+		playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
+		drink_act(user, L)
+	return

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -232,18 +232,23 @@
 			var/mob/living/carbon/C = user
 			if(C.is_mouth_covered())
 				return
-		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 		user.visible_message(span_info("[user] starts to drink from [src]."))
-		if(do_after(L, 25, target = src))
-			var/list/waterl = list()
-			waterl[water_reagent] = 5
-			var/datum/reagents/reagents = new()
-			reagents.add_reagent_list(waterl)
-			reagents.trans_to(L, reagents.total_volume, transfered_by = user, method = INGEST)
-			playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
-			onbite(user) // Auto repeat drinking
+		drink_act(user, L)
 		return
 	..()
+
+/turf/open/water/proc/drink_act(mob/user, mob/living/L)
+	playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
+	if(L.stat != CONSCIOUS)
+		return
+	if(do_after(L, 25, target = src))
+		var/list/waterl = list(/datum/reagent/water = 5)
+		var/datum/reagents/reagents = new()
+		reagents.add_reagent_list(waterl)
+		reagents.trans_to(L, reagents.total_volume, transfered_by = user, method = INGEST)
+		playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
+		drink_act(user, L)
+	return
 
 /turf/open/water/Destroy()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Patch being contributed back upstream after I was requested to port PR #2905 to Scarlet (Scarlet-Reach/Scarlet-Reach#81). I made implementation changes because the game definitely shouldn't need to constantly recheck for mouth coverings or spam the chat when you drink.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I tested this in-game on Scarlet and it works just fine. This got a compile test because both the before code and the after code are the same.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Nice things are good. I like people.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
