### PR TITLE
JULY 4th PR: Buff Fireball like it is Vanderlin.

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -8,8 +8,8 @@
 	sound = list('sound/magic/fireball.ogg')
 	releasedrain = 30
 	chargedrain = 1
-	chargetime = 25
-	recharge_time = 15 SECONDS
+	chargetime = 15
+	recharge_time = 10 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
@@ -27,17 +27,17 @@
 /obj/projectile/magic/aoe/fireball/rogue
 	name = "fireball"
 	exp_heavy = 0
-	exp_light = 0
+	exp_light = 3
 	exp_flash = 0
-	exp_fire = 1
-	damage = 60
+	exp_fire = 3
+	damage = 10
 	damage_type = BURN
-	npc_damage_mult = 2 // HAHAHA
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE
 	flag = "magic"
 	hitsound = 'sound/blank.ogg'
 	aoe_range = 0
+	speed = 3
 
 
 /obj/projectile/magic/aoe/fireball/rogue/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
@@ -9,8 +9,8 @@
 	active = FALSE
 	releasedrain = 50
 	chargedrain = 1
-	chargetime = 25
-	recharge_time = 15 SECONDS
+	chargetime = 15
+	recharge_time = 20 SECONDS
 	warnie = "spellwarning"
 	spell_tier = 4 // Highest tier AOE
 	invocation = "Maior Sphaera Ignis!"
@@ -25,10 +25,9 @@
 
 /obj/projectile/magic/aoe/fireball/rogue/great
 	name = "fireball"
-	exp_heavy = 0
-	exp_light = 1
-	exp_flash = 2
-	exp_fire = 2
-	damage = 90 // This is gonna fucking HURT
-	npc_damage_mult = 2 // HAHAHA
+	exp_heavy = 1
+	exp_light = 5
+	exp_flash = 0
+	exp_fire = 4
 	flag = "magic"
+	speed = 6


### PR DESCRIPTION
## About The Pull Request
People keep saying Mages are underpowered so I plug in Vanderlin's fireball stats without any consideration for how mage balance here works.
- Fireball now have a 3 range light and fire explosion and a speed of 3. 
- Greater Fireball now have a 1 range heavy explosion, 5 light explosion and 4 range fire explosion alongside a speed range of 6.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![TabTip_A327GZHKNa](https://github.com/user-attachments/assets/5c2ca595-bf4c-42b5-a349-9dc396546430)
![TabTip_82RImB3303](https://github.com/user-attachments/assets/b4b0ab5e-620e-4e36-af24-08756c84da63)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
i am correct on matter of balance

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
