### PR TITLE
makes knives spinnable

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -104,6 +104,9 @@
 	grid_height = 64
 	grid_width = 32
 
+	//flipping knives has a cooldown on to_chat to reduce chatspam
+	COOLDOWN_DECLARE(flip_cooldown)
+
 /obj/item/rogueweapon/huntingknife/Initialize()
 	. = ..()
 	var/static/list/slapcraft_recipe_list = list(
@@ -123,6 +126,38 @@
 				return list("shrink" = 0.4,"sx" = -10,"sy" = 0,"nx" = 11,"ny" = 0,"wx" = -4,"wy" = 0,"ex" = 2,"ey" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
 			if("onbelt")
 				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
+/obj/item/rogueweapon/huntingknife/rmb_self(mob/user)
+	. = ..()
+	if(.)
+		return
+
+	SpinAnimation(4, 2) // The spin happens regardless of the cooldown
+
+	if(!COOLDOWN_FINISHED(src, flip_cooldown))
+		return
+
+	COOLDOWN_START(src, flip_cooldown, 3 SECONDS)
+	if((user.get_skill_level(/datum/skill/combat/knives) < 3) && prob(40))
+		user.visible_message(
+			span_danger("While trying to flip [src] [user] drops it instead!"),
+			span_userdanger("While trying to flip [src] you drop it instead!"),
+		)
+		var/mob/living/carbon/human/unfortunate_idiot = user
+		var/dropped_knife_target = pick(
+			BODY_ZONE_PRECISE_L_FOOT,
+			BODY_ZONE_PRECISE_R_FOOT,
+			)
+		unfortunate_idiot.apply_damage(src.force, BRUTE, dropped_knife_target)
+		user.dropItemToGround(src, TRUE)
+	else
+		user.visible_message(
+			span_notice("[user] spins [src] around [user.p_their()] finger"),
+			span_notice("You spin [src] around your finger"),
+		)
+		playsound(src, 'sound/foley/equip/swordsmall1.ogg', 20, FALSE)
+
+	return
 
 /obj/item/rogueweapon/huntingknife/copper
 	name = "copper knife"


### PR DESCRIPTION
## About The Pull Request

![dreamseeker_HxcydrEUpY](https://github.com/user-attachments/assets/c7dad4de-16cc-422f-a9d3-95fec67b2473)

the hunting knife and all of its children can now be spun to show off by clicking on them with RMB. all this does is apply a brief animation to the obj sprite and push a message to chat. it does not override the mordhau proc, though there's not any knives that use that anyway afaik. there's a cooldown implemented for the chat messages to cut down on spam.

spinning a dagger while having less than JOURNEYMAN knives has a chance to drop it on your foot, so watch out!

## Testing Evidence

![image](https://github.com/user-attachments/assets/3d13206b-a2dd-484b-bbf6-1b79855b6456)

yep it works 👍 

## Why It's Good For The Game

aura farming and comedic potential is pretty high in this pr i think
