### PR TITLE
Priest -> Bishop, a title befitting of the role

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -188,7 +188,7 @@ SUBSYSTEM_DEF(vote)
 					if(H.stat != DEAD)
 						vote_power += 3
 					if(H.job)
-						var/list/list_of_powerful = list("Grand Duke", "Priest")
+						var/list/list_of_powerful = list("Grand Duke", "Bishop")
 						if(H.job in list_of_powerful)
 							vote_power += 5
 						else

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -216,7 +216,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/priest
-	name = "Priest"
+	name = "Bishop"
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/cleric

--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -193,7 +193,7 @@
 			user.say(m)
 
 /obj/item/book/rogue/bibble/attack(mob/living/M, mob/user)
-	if(user.mind && user.mind.assigned_role == "Priest")
+	if(user.mind && user.mind.assigned_role == "Bishop")
 		if(!user.can_read(src))
 			to_chat(user, span_warning("I don't understand these scribbly black lines."))
 			return

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -414,7 +414,7 @@
 	lockid = "church"
 
 /obj/item/roguekey/priest
-	name = "priest's key"
+	name = "Bishop's key"
 	desc = "This is the master key of the church."
 	icon_state = "cheesekey"
 	lockid = "priest"

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1078,7 +1078,7 @@
 
 /obj/structure/fluff/psycross/attackby(obj/item/W, mob/user, params)
 	if(user.mind)
-		if(user.mind.assigned_role == "Priest")
+		if(user.mind.assigned_role == "Bishop")
 			if(istype(W, /obj/item/reagent_containers/food/snacks/grown/apple))
 				if(!istype(get_area(user), /area/rogue/indoors/town/church/chapel))
 					to_chat(user, span_warning("I need to do this in the chapel."))

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -895,7 +895,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	triumph_count = 5
 
 /datum/objective/vampirelord/infiltrate/one/check_completion()
-	var/list/churchjobs = list("Priest", "Priestess", "Cleric", "Acolyte", "Templar", "Churchling", "Crusader", "Inquisitor", "Martyr")
+	var/list/churchjobs = list("Bishop", "Cleric", "Acolyte", "Templar", "Churchling", "Crusader", "Inquisitor", "Martyr")
 	for(var/datum/mind/V in SSmapping.retainer.vampires)
 		if(V.current.job in churchjobs)
 			return TRUE

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -396,7 +396,7 @@ GLOBAL_LIST_INIT(badomens, list())
 		if(OMEN_ROUNDSTART)
 			used = "Zizo."
 		if(OMEN_NOPRIEST)
-			used = "The Priest has perished! The Ten are weakened..."
+			used = "The Bishop has perished! The Ten are weakened..."
 		if(OMEN_SKELETONSIEGE)
 			used = "Unwelcome visitors!"
 		if(OMEN_NOLORD)

--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -18,7 +18,7 @@
 		"Men-at-arms",
 		"Marshal",
 		"Merchant",
-		"Priest",
+		"Bishop",
 		"Acolyte",
 		"Martyr",
 		"Templar",

--- a/code/modules/events/antagonist/solo/lich.dm
+++ b/code/modules/events/antagonist/solo/lich.dm
@@ -31,7 +31,7 @@
 		"Men-at-arms",
 		"Marshal",
 		"Merchant",
-		"Priest",
+		"Bishop",
 		"Acolyte",
 		"Martyr",
 		"Templar",

--- a/code/modules/events/antagonist/solo/rebels.dm
+++ b/code/modules/events/antagonist/solo/rebels.dm
@@ -29,7 +29,7 @@
 		"Men-at-arms",
 		"Marshal",
 		"Merchant",
-		"Priest",
+		"Bishop",
 		"Acolyte",
 		"Martyr",
 		"Templar",

--- a/code/modules/events/antagonist/solo/vampires.dm
+++ b/code/modules/events/antagonist/solo/vampires.dm
@@ -31,7 +31,7 @@
 		"Men-at-arms",
 		"Marshal",
 		"Merchant",
-		"Priest",
+		"Bishop",
 		"Acolyte",
 		"Martyr",
 		"Templar",

--- a/code/modules/events/antagonist/solo/vampires_and_werewolves.dm
+++ b/code/modules/events/antagonist/solo/vampires_and_werewolves.dm
@@ -29,7 +29,7 @@
 		"Men-at-arms",
 		"Marshal",
 		"Merchant",
-		"Priest",
+		"Bishop",
 		"Acolyte",
 		"Martyr",
 		"Templar",

--- a/code/modules/events/antagonist/solo/werewolf.dm
+++ b/code/modules/events/antagonist/solo/werewolf.dm
@@ -30,7 +30,7 @@
 		"Men-at-arms",
 		"Marshal",
 		"Merchant",
-		"Priest",
+		"Bishop",
 		"Acolyte",
 		"Martyr",
 		"Templar",

--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -176,7 +176,7 @@
 				H.dropItemToGround(parent)
 				return
 			var/datum/job/J = SSjob.GetJob(H.mind?.assigned_role)
-			if(!J.title == "Martyr" && !J.title == "Priest")		//Can't be a Martyr if you're not a Martyr. Or a Priest.
+			if(!J.title == "Martyr" && !J.title == "Bishop")		//Can't be a Martyr if you're not a Martyr. Or a Bishop.
 				to_chat(H, span_warn("It slips from my grasp. I can't get a hold."))
 				H.dropItemToGround(parent)
 				return
@@ -185,7 +185,7 @@
 				current_holder = user
 			if(J.title == "Martyr")
 				to_chat(user, span_warning("The blade binds to you."))
-			if(J.title == "Priest")
+			if(J.title == "Bishop")
 				to_chat(user, span_warning("You feel the shocking sensation as the sword attempts to bind to you. You know it will kill you. You can still drop it, and leave it for the Oathed."))
 	else
 		RegisterSignal(user, COMSIG_CLICK_ALT, PROC_REF(altclick), override = TRUE)
@@ -531,7 +531,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/datum/job/J = SSjob.GetJob(H.mind?.assigned_role)
-		if(J.title == "Priest" || J.title == "Martyr")
+		if(J.title == "Bishop" || J.title == "Martyr")
 			return ..()
 		else if (H.job in GLOB.church_positions)
 			to_chat(user, span_warning("You feel a jolt of holy energies just for a split second, and then the sword slips from your grasp! You are not devout enough."))

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -1,12 +1,12 @@
 /datum/job/roguetown/priest
-	title = "Priest"
+	title = "Bishop"
 	flag = PRIEST
 	department_flag = CHURCHMEN
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	selection_color = JCOLOR_CHURCH
-	f_title = "Priestess"
+	f_title = "Bishop"
 	allowed_races = RACES_NO_CONSTRUCT		//Too recent arrivals to ascend to priesthood.
 	allowed_patrons = ALL_DIVINE_PATRONS
 	allowed_sexes = list(MALE, FEMALE)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -89,7 +89,7 @@ GLOBAL_LIST_INIT(garrison_positions, list(
 ))
 
 GLOBAL_LIST_INIT(church_positions, list(
-	"Priest",
+	"Bishop",
 	"Confessor",
 	"Acolyte",
 	"Mortician",

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -128,7 +128,7 @@
 				for(var/mob/living/carbon/human/HU in GLOB.player_list)
 					if(!HU.stat && is_in_roguetown(HU))
 						HU.playsound_local(get_turf(HU), 'sound/music/lorddeath.ogg', 80, FALSE, pressure_affected = FALSE)
-			if("Priest")
+			if("Bishop")
 				addomen(OMEN_NOPRIEST)
 //		if(yeae)
 //			if(mind)
@@ -157,7 +157,7 @@
 	switch(job)
 		if("Grand Duke")
 			removeomen(OMEN_NOLORD)
-		if("Priest")
+		if("Bishop")
 			removeomen(OMEN_NOPRIEST)
 
 /mob/living/carbon/human/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)


### PR DESCRIPTION
## About The Pull Request

- The most ultimate of powercreeps, powercreeping a title
- Priest - > Bishop(With every instance of priest replaced by Bishop in checks/such)
- Probably more befitting of a regional head of religion, as previously 'Priest' sort of implied someone less important.
- It's cool(Objectively, not subjectively, by the way.)

## Testing Evidence

![image](https://github.com/user-attachments/assets/b5dfa57e-8e4e-4619-9123-452a24da855b)

## Why It's Good For The Game

Maybe help imply the Priest's real authority with a title more befitting what it is? Goodbye southern baptist local Priest, hello Bishop of Azurea.
