### PR TITLE
Gives Wardens Cooking/Butchery 1.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -77,7 +77,9 @@
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/tracking, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)	
+	H.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE) // This should let them fry meat on fires.
 	H.change_stat("perception", 2) //7 points weighted, same as MAA. They get temp buffs in the woods instead of in the city.
 	H.change_stat("endurance", 1)
 	H.change_stat("speed", 2)
@@ -123,6 +125,8 @@
 	H.adjust_skillrank(/datum/skill/misc/tracking, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE) // This should let them fry meat on fires.
 	H.change_stat("perception", 1) //7 points weighted, same as MAA. They get temp buffs in the woods instead of in the city.
 	H.change_stat("constitution", 1)
 	H.change_stat("endurance", 1)


### PR DESCRIPTION
## About The Pull Request

* Gives wardens Cooking 1 and Butchering 1.
## Testing Evidence
Just adds two skills to the subtypes. Works fine.

## Why It's Good For The Game

Gives the survivalists a slightly easier time when having to scrounge for an improvised meal. 

Remember when the Wardens used to be able to cook, farm, and make little camps for lost adventurers?
_(Probably not.)_

Wardens got nerfed a while back, which removes some of their little passive skills from being survivalists.
(I mean heck, they don't even get LUMBERJACKING.)

This just adds cooking and butchering 1 to both Warden archetypes (is that the right word?) so they can at very least, have a higher chance to skin animals better, and fry meat of cooking sources with less of a struggle.
