### PR TITLE
bugfixes for some inventory dupes + hella list indentations

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -39,7 +39,12 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	mask = /obj/item/clothing/mask/rogue/facemask/psydonmask
 	head = /obj/item/clothing/head/roguetown/roguehood/psydon
-	backpack_contents = list(/obj/item/roguekey/inquisition = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger, /obj/item/grapplinghook = 1)
+	backpack_contents = list(
+		/obj/item/roguekey/inquisition = 1,
+		/obj/item/lockpickring/mundane = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/silver/psydagger,
+		/obj/item/grapplinghook = 1,
+		)
 	H.change_stat("strength", -1) // weasel
 	H.change_stat("endurance", 3)
 	H.change_stat("perception", 2)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -90,7 +90,13 @@
 	wrists = /obj/item/clothing/neck/roguetown/psicross/silver
 	beltl = /obj/item/rogueweapon/sword/rapier
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale/inqcoat
-	backpack_contents = list(/obj/item/storage/keyring/puritan = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger, /obj/item/grapplinghook = 1, /obj/item/storage/belt/rogue/pouch/coins/rich = 1)
+	backpack_contents = list(
+		/obj/item/storage/keyring/puritan = 1,
+		/obj/item/lockpickring/mundane = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/silver/psydagger,
+		/obj/item/grapplinghook = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
+		)
 
 
 ///The dirty, violent side of the Inquisition. Meant for confrontational, conflict-driven situations as opposed to simply sneaking around and asking questions. Templar with none of the miracles, but with all the muscles and more. 
@@ -148,7 +154,13 @@
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm
 	gloves = /obj/item/clothing/gloves/roguetown/otavan/inqgloves
 	beltl = /obj/item/rogueweapon/sword/long/psysword
-	backpack_contents = list(/obj/item/storage/keyring/puritan = 1, /obj/item/lockpickring/mundane = 1, /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger, /obj/item/grapplinghook = 1, /obj/item/storage/belt/rogue/pouch/coins/rich = 1)
+	backpack_contents = list(
+		/obj/item/storage/keyring/puritan = 1,
+		/obj/item/lockpickring/mundane = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/silver/psydagger,
+		/obj/item/grapplinghook = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
+		)
 
 /obj/item/clothing/gloves/roguetown/chain/blk
 		color = CLOTHING_GREY

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -107,7 +107,7 @@
 			backpack_contents = list(
 				/obj/item/flashlight/flare/torch = 1, 
 				/obj/item/recipe_book/survival = 1,
-			)
+				)
 			H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
@@ -198,7 +198,10 @@
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
 			C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
-			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.adjust_skillrank(/datum/skill/misc/music, 4, TRUE)
 			H.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
@@ -269,7 +272,11 @@
 			backr = /obj/item/rogueweapon/woodstaff
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/flashlight/flare/torch/lantern
-			backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/magic/holy, 4, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/wrestling, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -40,7 +40,10 @@
 			H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE) 			//this shouldn't be enough to allow them to craft shit, rather just repair their prone-to-break armor
-			backpack_contents = list(/obj/item/recipe_book/survival = 1, /obj/item/flashlight/flare/torch/lantern)
+			backpack_contents = list(
+				/obj/item/recipe_book/survival = 1,
+				/obj/item/flashlight/flare/torch/lantern,
+				)
 			H.change_stat("strength", 2)
 			H.change_stat("endurance", 1)
 			H.change_stat("constitution", 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -94,7 +94,10 @@
 			belt = /obj/item/storage/belt/rogue/leather/steel/tasset
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltl = /obj/item/flashlight/flare/torch/lantern
-			backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -32,7 +32,11 @@
 			cloak = /obj/item/clothing/cloak/raincloak/green
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltr = /obj/item/flashlight/flare/torch/lantern
-			backpack_contents = list(/obj/item/bait = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/bait = 1,
+				/obj/item/rogueweapon/huntingknife = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
@@ -82,7 +86,10 @@
 			beltl = /obj/item/rogueweapon/huntingknife/idagger/steel
 			beltr = /obj/item/quiver/bolts
 			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
@@ -116,7 +123,11 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltr = /obj/item/flashlight/flare/torch/lantern
 			beltl = /obj/item/rogueweapon/mace/cudgel
-			backpack_contents = list(/obj/item/bomb = 4, /obj/item/rogueweapon/huntingknife = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/bomb = 4,
+				/obj/item/rogueweapon/huntingknife = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
@@ -143,7 +154,10 @@
 			cloak = /obj/item/clothing/cloak/raincloak/green
 			backl = /obj/item/storage/backpack/rogue/satchel
 			beltr = /obj/item/rogueweapon/stoneaxe/woodcut // Technical main weapon?
-			backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1, /obj/item/flashlight/flare/torch/lantern = 1)
+			backpack_contents = list(
+				/obj/item/rogueweapon/huntingknife = 1,
+				/obj/item/flashlight/flare/torch/lantern = 1,
+				)
 			H.cmode_music = 'sound/music/combat_condottiero.ogg'
 			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE) // Base skill, if not wanted, pick another weapon.

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -82,7 +82,12 @@
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			beltl = /obj/item/quiver/Warrows
 			beltr = /obj/item/rogueweapon/mace/cudgel
-			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/lockpickring/mundane = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
+				/obj/item/lockpickring/mundane = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.cmode_music = 'sound/music/combat_rogue.ogg'
 			H.adjust_skillrank(/datum/skill/misc/tracking, 4, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
@@ -133,7 +138,10 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
 			backl = /obj/item/storage/backpack/rogue/satchel
 			cloak = /obj/item/clothing/cloak/half/red
-			backpack_contents = list(/obj/item/lockpick = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/lockpick = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			if(H.mind)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
@@ -176,7 +184,12 @@
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			beltl = /obj/item/flashlight/flare/torch/lantern
 			beltr = /obj/item/rogueweapon/sword/cutlass
-			backpack_contents = list(/obj/item/bomb = 1, /obj/item/lockpick = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/bomb = 1,
+				/obj/item/lockpick = 1,
+				/obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.cmode_music = 'sound/music/jukeboxes/oldschool/Sea_Shanty2.ogg'
 			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -45,7 +45,13 @@
 			backr = /obj/item/storage/backpack/rogue/satchel
 			beltr = /obj/item/storage/belt/rogue/surgery_bag/full
 			beltl = /obj/item/flashlight/flare/torch/lantern
-			backpack_contents = list(/obj/item/reagent_containers/powder/spice = 2, /obj/item/reagent_containers/powder/ozium = 1, /obj/item/reagent_containers/powder/moondust = 2, /obj/item/rogueweapon/huntingknife = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/reagent_containers/powder/spice = 2,
+				/obj/item/reagent_containers/powder/ozium = 1,
+				/obj/item/reagent_containers/powder/moondust = 2,
+				/obj/item/rogueweapon/huntingknife = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.change_stat("intelligence", 3)
 			H.change_stat("perception", 2)
 			H.change_stat("speed", 1)
@@ -73,7 +79,8 @@
 			backr = /obj/item/storage/backpack/rogue/satchel
 			beltr = /obj/item/rogueweapon/mace/cudgel
 			beltl = /obj/item/flashlight/flare/torch/lantern
-			backpack_contents = list(/obj/item/reagent_containers/glass/bottle/rogue/beer/gronnmead = 1, 
+			backpack_contents = list(
+				/obj/item/reagent_containers/glass/bottle/rogue/beer/gronnmead = 1, 
 				/obj/item/reagent_containers/glass/bottle/rogue/beer/voddena = 1,
 				/obj/item/reagent_containers/glass/bottle/rogue/beer/blackgoat = 1, 
 				/obj/item/reagent_containers/glass/bottle/rogue/elfred = 1, 
@@ -111,7 +118,15 @@
 			neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 			beltl = /obj/item/flashlight/flare/torch/lantern
 			beltr = /obj/item/rogueweapon/huntingknife
-			backpack_contents = list(/obj/item/clothing/ring/silver = 2, /obj/item/clothing/ring/gold = 1, /obj/item/rogueweapon/tongs = 1, /obj/item/rogueweapon/hammer/steel = 1, /obj/item/roguegem/yellow = 1, /obj/item/roguegem/green = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/clothing/ring/silver = 2,
+				/obj/item/clothing/ring/gold = 1,
+				/obj/item/rogueweapon/tongs = 1,
+				/obj/item/rogueweapon/hammer/steel = 1,
+				/obj/item/roguegem/yellow = 1,
+				/obj/item/roguegem/green = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.change_stat("intelligence", 3)
 			H.change_stat("perception", 1)
 			H.change_stat("strength", 1)
@@ -141,7 +156,13 @@
 			neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 			beltl = /obj/item/flashlight/flare/torch/lantern
 			beltr = /obj/item/rogueweapon/stoneaxe/woodcut
-			backpack_contents = list(/obj/item/clothing/neck/roguetown/psicross/silver = 3, /obj/item/clothing/neck/roguetown/psicross = 2, /obj/item/clothing/neck/roguetown/psicross/wood = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/clothing/neck/roguetown/psicross/silver = 3,
+				/obj/item/clothing/neck/roguetown/psicross = 2,
+				/obj/item/clothing/neck/roguetown/psicross/wood = 1,
+				/obj/item/rogueweapon/huntingknife = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.change_stat("intelligence", 3)
 			H.change_stat("perception", 1)
 			H.change_stat("strength", 1)
@@ -170,7 +191,15 @@
 			beltr = /obj/item/rogueweapon/huntingknife/idagger
 			if(H.mind)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-			backpack_contents = list(/obj/item/paper/scroll = 3, /obj/item/book/rogue/knowledge1 = 1, /obj/item/reagent_containers/glass/bottle/rogue/manapot = 1, /obj/item/reagent_containers/glass/bottle/rogue/strongmanapot = 1, /obj/item/natural/feather = 1, /obj/item/roguegem/amethyst = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/paper/scroll = 3,
+				/obj/item/book/rogue/knowledge1 = 1,
+				/obj/item/reagent_containers/glass/bottle/rogue/manapot = 1,
+				/obj/item/reagent_containers/glass/bottle/rogue/strongmanapot = 1,
+				/obj/item/natural/feather = 1,
+				/obj/item/roguegem/amethyst = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.change_stat("intelligence", 3)
 			H.change_stat("perception", 1)
 			H.change_stat("speed", 1)
@@ -188,7 +217,12 @@
 			head = /obj/item/clothing/head/roguetown/jester
 			neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 			H.cmode_music = 'sound/music/combat_jester.ogg'
-			backpack_contents = list(/obj/item/smokebomb = 3, /obj/item/storage/pill_bottle/dice = 1, /obj/item/toy/cards/deck = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/smokebomb = 3,
+				/obj/item/storage/pill_bottle/dice = 1,
+				/obj/item/toy/cards/deck = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -38,7 +38,7 @@
 			H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 			H.set_blindness(0)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-			var/weapons = list("Longsword","Mace","Billhook","Battle Axe","Short Sword & Heater Shield")
+			var/weapons = list("Longsword","Mace","Billhook","Battle Axe","Short Sword & Iron Shield"")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
 				if("Longsword")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -38,7 +38,7 @@
 			H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 			H.set_blindness(0)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-			var/weapons = list("Longsword","Mace","Billhook","Battle Axe","Short Sword & Iron Shield"")
+			var/weapons = list("Longsword","Mace","Billhook","Battle Axe","Short Sword & Iron Shield")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
 				if("Longsword")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -85,7 +85,11 @@
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			shoes = /obj/item/clothing/shoes/roguetown/boots
 			cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
-			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/rogueweapon/huntingknife = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 
 		if("Duelist")
 			to_chat(H, span_warning("You are an esteemed swordsman who foregoes armor in exchange for a more nimble fighting style."))
@@ -129,7 +133,11 @@
 			backl = /obj/item/storage/backpack/rogue/satchel
 			backr = /obj/item/rogueweapon/shield/buckler
 			belt = /obj/item/storage/belt/rogue/leather
-			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1, /obj/item/recipe_book/survival = 1)
+			backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
 
 		if("Barbarian")
 			to_chat(H, span_warning("You are a brutal warrior who foregoes armor in order to showcase your raw strength. You specialize in unarmed combat and wrestling."))
@@ -227,14 +235,20 @@
 			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 			head = /obj/item/clothing/head/roguetown/bucklehat
 			gloves = /obj/item/clothing/gloves/roguetown/angle
-			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/recipe_book/survival = 1)
-			beltl = pick(/obj/item/reagent_containers/glass/bottle/alchemical/strpot,
-						/obj/item/reagent_containers/glass/bottle/alchemical/conpot,
-						/obj/item/reagent_containers/glass/bottle/alchemical/endpot,
-						/obj/item/reagent_containers/glass/bottle/alchemical/spdpot,
-						/obj/item/reagent_containers/glass/bottle/alchemical/perpot,
-						/obj/item/reagent_containers/glass/bottle/alchemical/intpot,
-						/obj/item/reagent_containers/glass/bottle/alchemical/lucpot)
+			backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/rogueweapon/huntingknife = 1,
+				/obj/item/recipe_book/survival = 1,
+				)
+			beltl = pick(
+				/obj/item/reagent_containers/glass/bottle/alchemical/strpot,
+				/obj/item/reagent_containers/glass/bottle/alchemical/conpot,
+				/obj/item/reagent_containers/glass/bottle/alchemical/endpot,
+				/obj/item/reagent_containers/glass/bottle/alchemical/spdpot,
+				/obj/item/reagent_containers/glass/bottle/alchemical/perpot,
+				/obj/item/reagent_containers/glass/bottle/alchemical/intpot,
+				/obj/item/reagent_containers/glass/bottle/alchemical/lucpot,
+				)
 
 		if("Flagellant")
 			to_chat(H, span_warning("You are a pacifistic warrior who embraces suffering, believing pain is the path to enlightenment."))
@@ -264,4 +278,7 @@
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/rogueweapon/whip
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-			backpack_contents = list(/obj/item/recipe_book/survival = 1, /obj/item/flashlight/flare/torch = 1)
+			backpack_contents = list(
+				/obj/item/recipe_book/survival = 1,
+				/obj/item/flashlight/flare/torch = 1,
+				)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -20,7 +20,12 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	neck = /obj/item/clothing/neck/roguetown/leather
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife = 1,
+		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/rope/chain = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -116,7 +116,11 @@
 			belt = /obj/item/storage/belt/rogue/leather/steel
 			beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 			backl = /obj/item/storage/backpack/rogue/satchel //gwstraps landing on backr asyncs with backpack_contents
-			backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1)
+			backpack_contents = list(
+				/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+				/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+				/obj/item/rope/chain = 1,
+				)
 
 
 			wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
@@ -25,7 +25,13 @@
 	beltl = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff/ruby
-	backpack_contents = list(/obj/item/spellbook_unfinished/pre_arcyne = 1, /obj/item/roguegem/amethyst = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(
+		/obj/item/spellbook_unfinished/pre_arcyne = 1,
+		/obj/item/roguegem/amethyst = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+		/obj/item/rope/chain = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -64,7 +64,12 @@
 	backr = /obj/item/rogueweapon/shield/tower/metal
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/rogueweapon/huntingknife
-	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/ritechalk = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/ritechalk = 1,
+		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+		/obj/item/rope/chain = 1,
+		)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR)	//Minor regen, can level up to T4.
 	wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -23,7 +23,13 @@
 	beltl = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff/ruby
-	backpack_contents = list(/obj/item/spellbook_unfinished/pre_arcyne = 1, /obj/item/roguegem/amethyst = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/necro_relics/necro_crystal = 2)
+	backpack_contents = list(
+		/obj/item/spellbook_unfinished/pre_arcyne = 1,
+		/obj/item/roguegem/amethyst = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+		/obj/item/necro_relics/necro_crystal = 2,
+		)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/outlaw.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/outlaw.dm
@@ -35,7 +35,14 @@
 			mask = /obj/item/clothing/mask/rogue/ragmask/black
 			beltr = /obj/item/quiver/bolts
 			r_hand = /obj/item/rogueweapon/mace/cudgel //From thief PR
-			backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/lockpickring/mundane = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1, /obj/item/storage/roguebag = 1, /obj/item/ammo_casing/caseless/rogue/bolt/water = 3)
+			backpack_contents = list(
+				/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+				/obj/item/lockpickring/mundane = 1,
+				/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+				/obj/item/rope/chain = 1,
+				/obj/item/storage/roguebag = 1,
+				/obj/item/ammo_casing/caseless/rogue/bolt/water = 3,
+				)
 			H.adjust_skillrank(/datum/skill/misc/tracking, 5, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
@@ -85,7 +92,12 @@
 			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 			mask = /obj/item/clothing/mask/rogue/ragmask/black
 			r_hand = /obj/item/rogueweapon/mace/cudgel //From thief PR
-			backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1, /obj/item/storage/roguebag = 1)
+			backpack_contents = list(
+				/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+				/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+				/obj/item/rope/chain = 1,
+				/obj/item/storage/roguebag = 1,
+				)
 			H.adjust_skillrank(/datum/skill/misc/tracking, 4, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
@@ -23,7 +23,13 @@
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	beltl = /obj/item/quiver/arrows
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
-	backpack_contents = list(/obj/item/bait = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(
+		/obj/item/bait = 1,
+		/obj/item/rogueweapon/huntingknife = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+		/obj/item/rope/chain = 1,
+		)
 	H.adjust_skillrank(/datum/skill/misc/tracking, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -26,9 +26,6 @@
 	job_bitflag = BITFLAG_CHURCH
 	has_loadout = TRUE
 	allowed_patrons = ALL_DIVINE_PATRONS
-	id = /obj/item/clothing/ring/silver
-	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/ritechalk)
 
 /datum/job/roguetown/templar/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
@@ -49,6 +46,11 @@
 	..()
 	neck = /obj/item/clothing/neck/roguetown/psicross/astrata
 	cloak = /obj/item/clothing/cloak/tabard/crusader/tief
+	id = /obj/item/clothing/ring/silver
+	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+		/obj/item/ritechalk = 1,
+		)
 	switch(H.patron?.type)
 		if(/datum/patron/divine/astrata)
 			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
@@ -179,6 +181,11 @@
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
 	wrists = /obj/item/clothing/neck/roguetown/psicross/astrata
 	cloak = /obj/item/clothing/cloak/tabard/crusader/tief
+	id = /obj/item/clothing/ring/silver
+	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+		/obj/item/ritechalk = 1,
+		)
 	switch(H.patron?.type)
 		if(/datum/patron/divine/astrata)
 			wrists = /obj/item/clothing/neck/roguetown/psicross/astrata

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -43,10 +43,10 @@
 	r_hand = /obj/item/rogueweapon/woodstaff/riddle_of_steel/magos
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
-	/obj/item/reagent_containers/glass/bottle/rogue/poison, 
-	/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-	/obj/item/recipe_book/alchemy
-	)
+		/obj/item/reagent_containers/glass/bottle/rogue/poison, 
+		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
+		/obj/item/recipe_book/alchemy
+		)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, "[type]")
 	ADD_TRAIT(H, TRAIT_INTELLECTUAL, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_ARCYNE_T4, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -60,7 +60,10 @@
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	beltr = /obj/item/quiver/arrows
 	beltl = /obj/item/rogueweapon/huntingknife/idagger/steel
-	backpack_contents = list(/obj/item/storage/keyring/guard = 1, /obj/item/flashlight/flare/torch/lantern = 1)
+	backpack_contents = list(
+		/obj/item/storage/keyring/guard = 1,
+		/obj/item/flashlight/flare/torch/lantern = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE) 
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
@@ -105,7 +108,10 @@
 	beltr = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
 	beltl = /obj/item/rogueweapon/huntingknife
 	r_hand = /obj/item/rogueweapon/spear
-	backpack_contents = list(/obj/item/storage/keyring/guard = 1, /obj/item/flashlight/flare/torch/lantern = 1)
+	backpack_contents = list(
+		/obj/item/storage/keyring/guard = 1,
+		/obj/item/flashlight/flare/torch/lantern = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -50,7 +50,10 @@
 	beltl = /obj/item/storage/keyring/dungeoneer
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	id = /obj/item/scomstone/bad/garrison
-	backpack_contents = list(/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 2, /obj/item/flashlight/flare/torch/lantern = 1)//No armoury access
+	backpack_contents = list(
+		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 2,
+		/obj/item/flashlight/flare/torch/lantern = 1,
+		) //No armoury access
 	H.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE) //hilarious
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -111,7 +111,11 @@
 		if("Greataxe")
 			r_hand = /obj/item/rogueweapon/greataxe
 			backl = /obj/item/gwstrap
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/keyring/guardcastle)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/rope/chain = 1,
+		/obj/item/storage/keyring/guardcastle,
+		)
 	H.verbs |= /mob/proc/haltyell
 
 	var/helmets = list(
@@ -179,7 +183,11 @@
 			beltr = /obj/item/quiver/sling/iron
 			r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling // Both are belt slots and it's not worth setting where the cugel goes for everyone else, sad.
 
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/keyring/guardcastle)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/rope/chain = 1,
+		/obj/item/storage/keyring/guardcastle,
+		)
 	H.verbs |= /mob/proc/haltyell
 
 	var/helmets = list(
@@ -246,7 +254,11 @@
 			beltr = /obj/item/rogueweapon/sword/sabre
 			backl = /obj/item/rogueweapon/shield/wood
 	
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/keyring/guardcastle)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/rope/chain = 1,
+		/obj/item/storage/keyring/guardcastle,
+		)
 	H.verbs |= /mob/proc/haltyell
 
 	var/helmets = list(

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -101,7 +101,11 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/focustarget)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/guard) // We'll just use Watchmen as sorta conscripts yeag?
 	H.verbs |= list(/mob/living/carbon/human/proc/request_outlaw, /mob/proc/haltyell, /mob/living/carbon/human/mind/proc/setorders)
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/keyring/guardsergeant = 1)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/rope/chain = 1,
+		/obj/item/storage/keyring/guardsergeant = 1,
+		)
 	H.adjust_blindness(-3)
 	var/weapons = list("Rhomphaia","Flail & Shield","Halberd","Sabre & Crossbow")	//Bit more unique than footsman, you are a jack-of-all-trades + slightly more 'elite'.
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -97,7 +97,10 @@ Archer is basically a 'bounty-catcher' in function, less specialized at close-qu
 	beltl = /obj/item/storage/keyring/guardcastle
 	belt = /obj/item/storage/belt/rogue/leather/black
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
+		/obj/item/rope/chain = 1,
+		)
 	H.verbs |= /mob/proc/haltyell
 
 /datum/advclass/watchman/archer
@@ -142,7 +145,10 @@ Archer is basically a 'bounty-catcher' in function, less specialized at close-qu
 	beltl = /obj/item/storage/keyring/guardcastle
 	belt = /obj/item/storage/belt/rogue/leather/black
 	gloves = /obj/item/clothing/gloves/roguetown/leather
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
+		/obj/item/rope/chain = 1,
+		)
 	H.verbs |= /mob/proc/haltyell
 
 // Added to baliff under assumption townguard.dm will not be enabled.

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -58,7 +58,6 @@
 	beltl = /obj/item/rogueweapon/sword/sabre
 	beltr = /obj/item/storage/keyring/guardcastle
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backl = /obj/item/gwstrap
 	cloak = /obj/item/clothing/cloak/half/vet
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
@@ -302,6 +301,7 @@
 			r_hand = /obj/item/rogueweapon/greatsword/grenz
 			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+			backl = /obj/item/gwstrap
 		if("Halberd")
 			r_hand = /obj/item/rogueweapon/halberd
 			H.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE) // SO, fun fact. The description of the grenzel halbardier says they specialize in axes, but they get no axe skill. Maybe this guy is where that rumor came from.

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -120,7 +120,10 @@
 	r_hand = /obj/item/rogueweapon/spear/billhook
 	belt = /obj/item/storage/belt/rogue/leather/black
 	cloak = /obj/item/clothing/cloak/half/vet
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/rope/chain = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
@@ -327,7 +330,10 @@
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 	belt = /obj/item/storage/belt/rogue/leather/black
 	cloak = /obj/item/clothing/cloak/half/vet
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/storage/keyring/guardcastle = 1)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/storage/keyring/guardcastle = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
@@ -388,7 +394,12 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	belt = /obj/item/storage/belt/rogue/leather/knifebelt/iron
 	cloak = /obj/item/clothing/cloak/raincloak/mortus
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish = 1, /obj/item/storage/keyring/guardcastle = 1, /obj/item/reagent_containers/glass/bottle/rogue/poison = 1, /obj/item/lockpickring/mundane)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/silver/elvish = 1,
+		/obj/item/storage/keyring/guardcastle = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1,
+		/obj/item/lockpickring/mundane,
+		)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -58,6 +58,7 @@
 	beltl = /obj/item/rogueweapon/sword/sabre
 	beltr = /obj/item/storage/keyring/guardcastle
 	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backl = /obj/item/gwstrap
 	cloak = /obj/item/clothing/cloak/half/vet
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
@@ -109,7 +109,10 @@
 			H.cmode_music = 'sound/music/combat_shaman2.ogg'
 
 	H.grant_language(/datum/language/gronnic)
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife)
+	backpack_contents = list(
+		/obj/item/roguekey/mercenary,
+		/obj/item/rogueweapon/huntingknife,
+		)
 
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/atgervi

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/blackoak.dm
@@ -47,7 +47,10 @@
 			beltr = /obj/item/flashlight/flare/torch
 			r_hand = /obj/item/rogueweapon/halberd/glaive
 			backr = /obj/item/gwstrap
-			backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor)
+			backpack_contents = list(
+				/obj/item/roguekey/mercenary,
+				/obj/item/storage/belt/rogue/pouch/coins/poor,
+				)
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 		if("Ranged (Bows)")
 			H.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
@@ -71,7 +74,12 @@
 			beltr = /obj/item/rogueweapon/huntingknife/idagger/silver/elvish
 			beltl = /obj/item/quiver/arrows
 			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-			backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/flashlight/flare/torch)
+			backpack_contents = list(
+				/obj/item/roguekey/mercenary,
+				/obj/item/storage/belt/rogue/pouch/coins/poor,
+				/obj/item/rogueweapon/huntingknife/idagger/navaja,
+				/obj/item/flashlight/flare/torch,
+				)
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 
 	//Shared minor skillblock from Wardens

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/condottiero.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/condottiero.dm
@@ -23,7 +23,12 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/lockpick = 1)
+	backpack_contents = list(
+		/obj/item/roguekey/mercenary,
+		/obj/item/storage/belt/rogue/pouch/coins/poor,
+		/obj/item/rogueweapon/huntingknife/idagger/navaja,
+		/obj/item/lockpick = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 5, TRUE) //Possibly too high, no idea.
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -50,7 +50,12 @@
 			gloves = /obj/item/clothing/gloves/roguetown/chain
 			pants = /obj/item/clothing/under/roguetown/splintlegs
 			backr = /obj/item/storage/backpack/rogue/satchel/black
-			backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/clothing/neck/roguetown/shalal, /obj/item/flashlight/flare/torch)
+			backpack_contents = list(
+				/obj/item/roguekey/mercenary,
+				/obj/item/rogueweapon/huntingknife/idagger/navaja,
+				/obj/item/clothing/neck/roguetown/shalal,
+				/obj/item/flashlight/flare/torch,
+				)
 			H.grant_language(/datum/language/celestial)
 			var/weapons = list("Heavy Mace","Shamshir and Shield","Spear and Shield")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
@@ -99,7 +104,12 @@
 			gloves = /obj/item/clothing/gloves/roguetown/angle
 			pants = /obj/item/clothing/under/roguetown/trou/leather/pontifex/raneshen
 			backr = /obj/item/storage/backpack/rogue/satchel/black
-			backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/clothing/neck/roguetown/shalal, /obj/item/flashlight/flare/torch)
+			backpack_contents = list(
+				/obj/item/roguekey/mercenary,
+				/obj/item/rogueweapon/huntingknife/idagger/navaja,
+				/obj/item/clothing/neck/roguetown/shalal,
+				/obj/item/flashlight/flare/torch,
+				)
 			H.grant_language(/datum/language/celestial)
 			var/weapons = list("Shamshir and Javelin","Whips and Knives", "Recurve Bow")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
@@ -156,7 +166,13 @@
 			gloves = /obj/item/clothing/gloves/roguetown/angle
 			pants = /obj/item/clothing/under/roguetown/trou/leather/pontifex/raneshen
 			backr = /obj/item/storage/backpack/rogue/satchel/black
-			backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/clothing/neck/roguetown/shalal, /obj/item/spellbook_unfinished/pre_arcyne, /obj/item/flashlight/flare/torch)
+			backpack_contents = list(
+				/obj/item/roguekey/mercenary,
+				/obj/item/rogueweapon/huntingknife/idagger/navaja,
+				/obj/item/clothing/neck/roguetown/shalal,
+				/obj/item/spellbook_unfinished/pre_arcyne,
+				/obj/item/flashlight/flare/torch,
+				)
 			H.grant_language(/datum/language/celestial)
 
 	shoes = /obj/item/clothing/shoes/roguetown/shalal

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/forlorn.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/forlorn.dm
@@ -23,7 +23,10 @@
 	beltl = /obj/item/rogueweapon/mace/warhammer/steel
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/rogueweapon/shield/heater
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife, /obj/item/roguekey/mercenary)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife,
+		/obj/item/roguekey/mercenary,
+		)
 	
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgebearer.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgebearer.dm
@@ -43,7 +43,15 @@
 				gloves = /obj/item/clothing/gloves/roguetown/plate/dwarven
 				pants = /obj/item/clothing/under/roguetown/trou/leather
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/half
-				backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/hammer/iron, /obj/item/paper/scroll/grudge, /obj/item/natural/feather, /obj/item/rogueweapon/tongs = 1, /obj/item/clothing/head/roguetown/helmet/heavy/dwarven)
+				backpack_contents = list(
+					/obj/item/roguekey/mercenary,
+					/obj/item/storage/belt/rogue/pouch/coins/poor,
+					/obj/item/rogueweapon/hammer/iron,
+					/obj/item/paper/scroll/grudge,
+					/obj/item/natural/feather,
+					/obj/item/rogueweapon/tongs = 1,
+					/obj/item/clothing/head/roguetown/helmet/heavy/dwarven,
+					)
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_TRAINED_SMITH, TRAIT_GENERIC)
 			if("Soldier")
@@ -70,7 +78,13 @@
 				pants = /obj/item/clothing/under/roguetown/trou/leather
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/full/dwarven
 				head = /obj/item/clothing/head/roguetown/helmet/heavy/dwarven
-				backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/hammer/iron, /obj/item/paper/scroll/grudge, /obj/item/natural/feather)
+				backpack_contents = list(
+					/obj/item/roguekey/mercenary,
+					/obj/item/storage/belt/rogue/pouch/coins/poor,
+					/obj/item/rogueweapon/hammer/iron,
+					/obj/item/paper/scroll/grudge,
+					/obj/item/natural/feather,
+					)
 				var/weapons = list("Axe", "Mace")
 				var/wepchoice = input("Choose your weapon", "Available weapons") as anything in weapons
 				switch(wepchoice)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/kashira.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/kashira.dm
@@ -15,7 +15,11 @@
 	beltr = /obj/item/rogueweapon/sword/sabre/mulyeog/rumacaptain
 	beltl = /obj/item/scabbard/rumacaptain
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/flashlight/flare/torch, /obj/item/flashlight/flare/torch/lantern)
+	backpack_contents = list(
+		/obj/item/roguekey/mercenary,
+		/obj/item/flashlight/flare/torch,
+		/obj/item/flashlight/flare/torch/lantern,
+		)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
@@ -62,7 +62,10 @@
 	gloves = /obj/item/clothing/gloves/roguetown/otavan
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backl = /obj/item/rogueweapon/shield/tower/metal
-	backpack_contents = list(/obj/item/roguekey/mercenary = 1, /obj/item/flashlight/flare/torch = 1)
+	backpack_contents = list(
+		/obj/item/roguekey/mercenary = 1,
+		/obj/item/flashlight/flare/torch = 1,
+		)
 
 	H.grant_language(/datum/language/otavan)
 	

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
@@ -31,7 +31,10 @@
 			shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 			gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
 			backr = /obj/item/storage/backpack/rogue/satchel
-			backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/flashlight/flare/torch/lantern)
+			backpack_contents = list(
+				/obj/item/roguekey/mercenary,
+				/obj/item/flashlight/flare/torch/lantern,
+				)
 			H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
@@ -62,7 +65,11 @@
 			gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			backr = /obj/item/storage/backpack/rogue/satchel
-			backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/huntingknife/idagger)
+			backpack_contents = list(
+				/obj/item/roguekey/mercenary,
+				/obj/item/storage/belt/rogue/pouch/coins/poor,
+				/obj/item/rogueweapon/huntingknife/idagger,
+				)
 			H.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
@@ -17,7 +17,13 @@
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/chargah
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/flashlight/flare/torch, /obj/item/rogueweapon/huntingknife/idagger/steel, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/rogueweapon/whip/nagaika)
+	backpack_contents = list(
+		/obj/item/roguekey/mercenary,
+		/obj/item/flashlight/flare/torch,
+		/obj/item/rogueweapon/huntingknife/idagger/steel,
+		/obj/item/storage/belt/rogue/pouch/coins/poor,
+		/obj/item/rogueweapon/whip/nagaika,
+		)
 
 	//Universal skills
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/underdweller.dm
@@ -30,7 +30,11 @@
 	beltr = /obj/item/rogueweapon/huntingknife
 	backl = /obj/item/storage/backpack/rogue/backpack
 	backr = /obj/item/rogueweapon/shield/wood
-	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/storage/belt/rogue/pouch/coins/poor, /obj/item/bomb = 2)
+	backpack_contents = list(
+		/obj/item/roguekey/mercenary,
+		/obj/item/storage/belt/rogue/pouch/coins/poor,
+		/obj/item/bomb = 2,
+		)
 	H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/labor/mining, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -94,7 +94,11 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hierophant
 			shirt = /obj/item/clothing/suit/roguetown/shirt/robe/hierophant
 			pants = /obj/item/clothing/under/roguetown/trou/leather
-			backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife/idagger, /obj/item/spellbook_unfinished/pre_arcyne)
+			backpack_contents = list(
+				/obj/item/roguekey/mercenary,
+				/obj/item/rogueweapon/huntingknife/idagger,
+				/obj/item/spellbook_unfinished/pre_arcyne,
+				)
 
 		if("Pontifex")
 			H.set_blindness(0)

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -36,7 +36,10 @@
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	id = /obj/item/scomstone/garrison
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/signal_horn = 1)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/signal_horn = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -69,7 +69,10 @@
 /datum/outfit/job/roguetown/hand/handclassic/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/dtace = 1, /obj/item/storage/keyring/hand = 1)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/dtace = 1,
+		/obj/item/storage/keyring/hand = 1,
+		)
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/hand
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	id = /obj/item/scomstone/garrison
@@ -102,7 +105,11 @@
 //Spymaster start. More similar to the rogue adventurer - loses heavy armor and sword skills for more sneaky stuff. 
 /datum/outfit/job/roguetown/hand/spymaster/pre_equip(mob/living/carbon/human/H)
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/dtace = 1, /obj/item/storage/keyring/hand = 1, /obj/item/lockpickring/mundane)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/dtace = 1,
+		/obj/item/storage/keyring/hand = 1,
+		/obj/item/lockpickring/mundane = 1,
+		)
 	if(H.dna.species.type in NON_DWARVEN_RACE_TYPES)
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/shadowrobe
 		cloak = /obj/item/clothing/cloak/half/shadowcloak
@@ -154,7 +161,11 @@
 /datum/outfit/job/roguetown/hand/advisor/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/dtace = 1, /obj/item/storage/keyring/hand = 1, /obj/item/reagent_containers/glass/bottle/rogue/poison = 1) //starts with a vial of poison, like all wizened evil advisors do!
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/dtace = 1,
+		/obj/item/storage/keyring/hand = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1, //starts with a vial of poison, like all wizened evil advisors do!
+		)
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/hand
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	id = /obj/item/scomstone/garrison

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -66,15 +66,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		if(STATION_TIME_PASSED() <= 10 MINUTES) //Late to the party? Stuck with default colors, sorry!
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
 
-/datum/outfit/job/roguetown/lord
-	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	cloak = /obj/item/clothing/cloak/lordcloak
-	belt = /obj/item/storage/belt/rogue/leather/plaquegold
-	beltl = /obj/item/storage/keyring/lord
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
-	id = /obj/item/scomstone/garrison
-
-/datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H) //parent /datum/outfit/job/roguetown/lord isnt explicitly defined because it carried no vars of its own. this implicit definition is perfectly functional.
 	..()
 	if(SSroguemachine.crown == null || (QDELETED(SSroguemachine.crown)))
 		SSroguemachine.crown = null
@@ -114,8 +106,13 @@ GLOBAL_LIST_EMPTY(lord_titles)
 
 /datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
 	..()
-	l_hand = /obj/item/rogueweapon/lordscepter // If you put something in l hand with a mother outfit
-	// It will dupe
+	l_hand = /obj/item/rogueweapon/lordscepter
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	cloak = /obj/item/clothing/cloak/lordcloak
+	belt = /obj/item/storage/belt/rogue/leather/plaquegold
+	beltl = /obj/item/storage/keyring/lord
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+	id = /obj/item/scomstone/garrison
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
@@ -156,7 +153,12 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/merchant/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
-	
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	cloak = /obj/item/clothing/cloak/lordcloak
+	belt = /obj/item/storage/belt/rogue/leather/plaquegold
+	beltl = /obj/item/storage/keyring/lord
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+	id = /obj/item/scomstone/garrison
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE) // Weapons suitable for defending yourself as a merchant.
@@ -197,6 +199,12 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/inbred/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	cloak = /obj/item/clothing/cloak/lordcloak
+	belt = /obj/item/storage/belt/rogue/leather/plaquegold
+	beltl = /obj/item/storage/keyring/lord
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+	id = /obj/item/scomstone/garrison
 	ADD_TRAIT(H, TRAIT_CRITICAL_WEAKNESS, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NORUN, TRAIT_GENERIC)
 	H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -36,7 +36,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 
 /datum/outfit/job/roguetown/lord
 	job_bitflag = BITFLAG_ROYALTY
-	cloak = /obj/item/clothing/cloak/lordcloak
 
 /datum/job/roguetown/lord/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
@@ -66,6 +65,14 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_marriage_choice)), 50)
 		if(STATION_TIME_PASSED() <= 10 MINUTES) //Late to the party? Stuck with default colors, sorry!
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
+
+/datum/outfit/job/roguetown/lord
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	cloak = /obj/item/clothing/cloak/lordcloak
+	belt = /obj/item/storage/belt/rogue/leather/plaquegold
+	beltl = /obj/item/storage/keyring/lord
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+	id = /obj/item/scomstone/garrison
 
 /datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -108,11 +115,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
-	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	belt = /obj/item/storage/belt/rogue/leather/plaquegold
-	beltl = /obj/item/storage/keyring/lord
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
-	id = /obj/item/scomstone/garrison
+
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
@@ -153,11 +156,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/merchant/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
-	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	belt = /obj/item/storage/belt/rogue/leather/plaquegold
-	beltl = /obj/item/storage/keyring/lord
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
-	id = /obj/item/scomstone/garrison
+
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE) // Weapons suitable for defending yourself as a merchant.
@@ -198,11 +197,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/inbred/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
-	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	belt = /obj/item/storage/belt/rogue/leather/plaquegold
-	beltl = /obj/item/storage/keyring/lord
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
-	id = /obj/item/scomstone/garrison
+
 	ADD_TRAIT(H, TRAIT_CRITICAL_WEAKNESS, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NORUN, TRAIT_GENERIC)
 	H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		if(STATION_TIME_PASSED() <= 10 MINUTES) //Late to the party? Stuck with default colors, sorry!
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, lord_color_choice)), 50)
 
-/datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H) //parent /datum/outfit/job/roguetown/lord isnt explicitly defined because it carried no vars of its own. this implicit definition is perfectly functional.
+/datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(SSroguemachine.crown == null || (QDELETED(SSroguemachine.crown)))
 		SSroguemachine.crown = null

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 
 /datum/outfit/job/roguetown/lord
 	job_bitflag = BITFLAG_ROYALTY
+	cloak = /obj/item/clothing/cloak/lordcloak
 
 /datum/job/roguetown/lord/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
@@ -108,7 +109,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	cloak = /obj/item/clothing/cloak/lordcloak
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold
 	beltl = /obj/item/storage/keyring/lord
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
@@ -154,7 +154,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	cloak = /obj/item/clothing/cloak/lordcloak
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold
 	beltl = /obj/item/storage/keyring/lord
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
@@ -200,7 +199,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	cloak = /obj/item/clothing/cloak/lordcloak
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold
 	beltl = /obj/item/storage/keyring/lord
 	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)

--- a/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
@@ -131,7 +131,10 @@
 		armor = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress
 	if(should_wear_masc_clothes(H))
 		armor = /obj/item/clothing/suit/roguetown/armor/longcoat
-	backpack_contents = list(/obj/item/reagent_containers/glass/bottle/rogue/poison = 1, /obj/item/lockpick = 1)
+	backpack_contents = list(
+		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1,
+		/obj/item/lockpick = 1,
+		)
 	if(H.mind)
 		var/datum/antagonist/new_antag = new /datum/antagonist/suitor()
 		H.mind.add_antag_datum(new_antag)

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -32,7 +32,12 @@
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltr = /obj/item/storage/keyring/soilson
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/recipe_book/survival = 1, /obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/flint = 1)
+	backpack_contents = list(
+		/obj/item/recipe_book/survival = 1,
+		/obj/item/flashlight/flare/torch = 1,
+		/obj/item/rogueweapon/huntingknife = 1,
+		/obj/item/flint = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -62,7 +62,11 @@
 		shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/artificer
 		backl = /obj/item/storage/backpack/rogue/backpack
-		backpack_contents = list(/obj/item/rogueweapon/hammer/iron = 1, /obj/item/rogueweapon/tongs = 1, /obj/item/recipe_book/blacksmithing = 1)
+		backpack_contents = list(
+			/obj/item/rogueweapon/hammer/iron = 1,
+			/obj/item/rogueweapon/tongs = 1,
+			/obj/item/recipe_book/blacksmithing = 1,
+			)
 		belt = /obj/item/storage/belt/rogue/leather
 		beltl = /obj/item/storage/belt/rogue/pouch/coins/rich
 		beltr = /obj/item/storage/keyring/guildmaster

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
@@ -65,7 +65,11 @@
 		pants = /obj/item/clothing/under/roguetown/trou
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 		backr = /obj/item/storage/backpack/rogue/satchel
-		backpack_contents = list(/obj/item/rogueweapon/hammer/iron = 1, /obj/item/rogueweapon/tongs = 1, /obj/item/recipe_book/blacksmithing = 1)
+		backpack_contents = list(
+			/obj/item/rogueweapon/hammer/iron = 1,
+			/obj/item/rogueweapon/tongs = 1,
+			/obj/item/recipe_book/blacksmithing = 1,
+			)
 		shoes = /obj/item/clothing/shoes/roguetown/shortboots
 		belt = /obj/item/storage/belt/rogue/leather
 		cloak = /obj/item/clothing/cloak/apron/blacksmith
@@ -76,7 +80,11 @@
 		shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 		shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt
 		backr = /obj/item/storage/backpack/rogue/satchel
-		backpack_contents = list(/obj/item/rogueweapon/hammer/iron = 1, /obj/item/rogueweapon/tongs = 1, /obj/item/recipe_book/blacksmithing = 1)
+		backpack_contents = list(
+			/obj/item/rogueweapon/hammer/iron = 1,
+			/obj/item/rogueweapon/tongs = 1,
+			/obj/item/recipe_book/blacksmithing = 1,
+			)
 		belt = /obj/item/storage/belt/rogue/leather
 		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 		beltr = /obj/item/roguekey/crafterguild

--- a/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
@@ -36,7 +36,7 @@
 	H.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/lockpicking, 2, TRUE)
-	backpack_contents = /obj/item/rogueweapon/huntingknife/idagger/navaja
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/navaja)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, type)
 	ADD_TRAIT(H, TRAIT_CICERONE, TRAIT_GENERIC) //Makes up for loss of alchemy to see reagents.
 	neck = /obj/item/clothing/neck/roguetown/horus

--- a/code/modules/jobs/job_types/roguetown/yeomen/nightmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/nightmaster.dm
@@ -29,7 +29,11 @@
 	beltl = /obj/item/rogueweapon/whip
 
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry = 2, /obj/item/reagent_containers/powder/moondust = 2, /obj/item/reagent_containers/powder/spice = 1)
+	backpack_contents = list(
+		/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry = 2,
+		/obj/item/reagent_containers/powder/moondust = 2,
+		/obj/item/reagent_containers/powder/spice = 1,
+		)
 	H.grant_language(/datum/language/thievescant)
 	ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/yeomen/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/villagechief.dm
@@ -36,7 +36,11 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backl = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/scomstone/bad//He is meant to be helping people around - hard to do when he can't hear their calls
-	backpack_contents = list(/obj/item/storage/keyring/velder  = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/storage/belt/rogue/pouch/coins/rich = 1)
+	backpack_contents = list(
+		/obj/item/storage/keyring/velder  = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
+		)
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request

fixes a couple of instances where roundstart inventories were being duped due to duplicate outfit calls. also indents a bunch of backpack_contents properly since we have a freeze that lets me touch 50 .dms without creating 100 conflicts. this isnt even comprehensive, we got WAY too many classes to do before my brain leaked out of my ears. plus i probably missed shit.

technically the indenting isnt necessary but the more examples of good syntax we have the more likely future contributions will follow that example :3c

## Testing Evidence

remember! testing prs is an important part of the development process! anyway i spawned in as roles i knew had buggy inventories and they dont now yippee

## Why It's Good For The Game

fixes bugs 👍 
