### PR TITLE
Tweaks armor dismember catch from 1 hit to 2, or 80% to 30%

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -42,9 +42,10 @@
 		var/obj/item/clothing/checked_armor = H.checkcritarmorreference(src.body_zone, bclass)
 		if(checked_armor && checked_armor.max_integrity != 0)
 			var/int_percent = round(((checked_armor.obj_integrity / checked_armor.max_integrity) * 100), 1) //lifted from examine
-			if(int_percent > 80 && !HAS_TRAIT(H, TRAIT_CRITICAL_WEAKNESS) && !HAS_TRAIT(H, TRAIT_EASYDISMEMBER))
-				to_chat(H, span_warning("My [checked_armor.name] just saved me from losing my [src.name]!"))
+			if(int_percent > 30 && !HAS_TRAIT(H, TRAIT_CRITICAL_WEAKNESS) && !HAS_TRAIT(H, TRAIT_EASYDISMEMBER))
+				to_chat(H, span_green("My [checked_armor.name] just saved me from losing my [src.name]!"))
 				checked_armor.obj_integrity -= checked_armor.max_integrity / 2 //Armor sundered
+				checked_armor.obj_integrity = max(1, checked_armor.obj_integrity) //No negative integrity
 				return FALSE
 
 	var/obj/item/bodypart/affecting = C.get_bodypart(BODY_ZONE_CHEST)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Suggested tweak to the armor dismemberment catch to take it from 80% to 30% threshold of working.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
![image](https://github.com/user-attachments/assets/0ff86e03-029b-4d53-bc11-bddbd014115d)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

There may be some edge case where the werewolf is hitting enough damage to put someone's new armor under 80% in one hit, I don't know, I didn't see the dismember but it's possible. Anything is possible