### PR TITLE
Fixes ERP preference bug

### DIFF
--- a/code/datums/sexcon/sexcon_helpers.dm
+++ b/code/datums/sexcon/sexcon_helpers.dm
@@ -38,19 +38,19 @@
 	var/can_do_sex = TRUE
 	var/virginity = FALSE
 
-/mob/living/carbon/human/MiddleMouseDrop_T(mob/living/target, mob/living/user)
+/mob/living/carbon/human/MiddleMouseDrop_T(mob/living/initiator, mob/living/user)
 	if(user.mmb_intent)
 		return ..()
-	if(!istype(target))
+	if(!istype(initiator))
 		return
-	if(target != user)
+	if(initiator != user)
 		return
 	if(!user.can_do_sex())
 		to_chat(user, "<span class='warning'>I can't do this.</span>")
 		return
-	if(!target.client || !target.client.prefs || (target.client.prefs.sexable == FALSE)) // Don't bang someone that dosn't want it.
-		to_chat(user, "<span class='warning'>[target] dosn't wish to be touched. (Their ERP preference under options)</span>")
-		to_chat(target, "<span class='warning'>[user] failed to touch you. (Your ERP preference under options)</span>")
+	if(!client || !client.prefs || (client.prefs.sexable == FALSE)) // Don't bang someone that dosn't want it.
+		to_chat(initiator, "<span class='warning'>[src] dosn't wish to be touched. (Their ERP preference under options)</span>")
+		to_chat(src, "<span class='warning'>[initiator] failed to touch you. (Your ERP preference under options)</span>")
 		return
 	user.sexcon.start(src)
 


### PR DESCRIPTION
## About The Pull Request

Apparently, there was a mistake in MiddleMouseDrop_T() proc that checked prefs of the initiating side, but not of the receiver. This allowed to start ERP actions bypassing ERP pref check. Actions were still interrupted by pref check in their loop, yet seeing a message pop up in chat when your ERP prefs are off is kinda bleak, to say the least.

## Testing Evidence

How it was:

![image](https://github.com/user-attachments/assets/b936c74e-46dd-4503-8d1c-c99994abf0f4)

Fixed:

![image](https://github.com/user-attachments/assets/a6eeb09d-b118-4cde-8767-82ef263b38c4)

## Why It's Good For The Game

A minor oversight, but a nasty one. 