### PR TITLE
Allows martyrcloak to be worn on backslots.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -581,7 +581,7 @@
 	body_parts_covered = CHEST|GROIN
 	boobed = FALSE
 	sellprice = 100
-	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
+	slot_flags = ITEM_SLOT_BACK_R|ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
 	flags_inv = HIDECROTCH|HIDEBOOB
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/holysee


### PR DESCRIPTION
## About The Pull Request

Allows martyrcloak to be worn on backslots.

## Testing Evidence

Hosted, spawned it, wore it. Works.

## Why It's Good For The Game

Allows for a bit more customization.
