### PR TITLE
Fixes maneater.dm limb eating with new dismember armor catch

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -76,17 +76,17 @@
 				spawn(50)
 					if(C && (C.buckled == src))
 						var/obj/item/bodypart/limb
-						var/list/limb_list = list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+						var/list/limb_list = shuffle(list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
 						for(var/zone in limb_list)
 							limb = C.get_bodypart(zone)
 							if(limb)
 								playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
-								limb.dismember()
-								qdel(limb)
-								seednutrition += 20
-								if(C.mind) // eat only one limb of things with minds
-									maneater_spit_out(C)
-									return
+								if(limb.dismember())
+									qdel(limb)
+									seednutrition += 20
+									if(C.mind) // eat only one limb of things with minds
+										maneater_spit_out(C)
+										return
 								return
 						if(C.mind) // nugget case, just spit them out
 							maneater_spit_out(C)
@@ -94,8 +94,8 @@
 						limb = C.get_bodypart(BODY_ZONE_HEAD)
 						if(limb)
 							playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
-							limb.dismember()
-							qdel(limb)
+							if(limb.dismember())
+								qdel(limb)
 							return
 						limb = C.get_bodypart(BODY_ZONE_CHEST)
 						if(limb)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<img width="931" height="426" alt="image" src="https://github.com/user-attachments/assets/dedd6e0a-42c4-446a-b4b3-3e3a8bd0c362" />

Dismember returns true/false, made that respect whether the limb gets qdel'd. Maneater list is now shuffled, maybe it will eat a leg first this time instead of your left arm, ooh. And it will keep chewing until it eats a limb or you escape. Armor will save you pretty good from these, especially with the random eating order. So maybe they could be spun up a little faster, who knows. Something to think about.


## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

https://github.com/user-attachments/assets/c1f1a321-d202-42f5-bb6e-4315756ddbc9


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Watch out boy, she'll chew you up