### PR TITLE
Autorepair on fumble. Fumble no longer damage things.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -60,6 +60,8 @@
 			return
 		else
 			user.visible_message(span_warning("[user] fumbles trying to repair [attacked_prosthetic]!"))
+			if(do_after(user, CLICK_CD_MELEE, target = attacked_object))
+				attack_obj(attacked_object, user)
 			return
 
 	if(isitem(attacked_object) && !user.cmode)
@@ -105,7 +107,8 @@
 			return
 		else
 			user.visible_message(span_warning("[user] fumbles trying to repair [attacked_item]!"))
-			attacked_item.obj_integrity = max(0, attacked_item.obj_integrity - (10 - repair_percent))
+			if(do_after(user, CLICK_CD_MELEE, target = attacked_object))
+				attack_obj(attacked_object, user)
 			return
 
 	if(isstructure(attacked_object) && !user.cmode)
@@ -121,6 +124,8 @@
 		blacksmith.mind.add_sleep_experience(attacked_structure.hammer_repair, exp_gained) //We gain as much exp as we fix
 		playsound(src,'sound/items/bsmithfail.ogg', 100, FALSE)
 		user.visible_message(span_info("[user] repairs [attacked_structure]!"))
+		if(attacked_object.obj_integrity <= attacked_object.max_integrity && do_after(user, CLICK_CD_MELEE, target = attacked_object))
+			attack_obj(attacked_object, user)
 		return
 
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
I got a bug report that smithing no longer give you XP or take ages. I found out it still works. 

Anyway:
1. When you fumble a repair, it repair automatically after
2. When you fumble a repair, you no longer damage the items.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="470" height="1134" alt="dreamseeker_hConFOlG3o" src="https://github.com/user-attachments/assets/c8873fda-bb31-4491-b821-d4c81325ec3b" />
Tested - It took me 5 minutes approximately to repair a steel mace I smashed with another steel mace - 250 durability. Gain XP.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes repair trait perhaps - a bit less "necessary" and the grind better.

In the future, I'll be adding in a proc to gate XP gain to Novice.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
