### PR TITLE
Fixes wood shaft recipe

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -390,7 +390,10 @@
 
 /datum/crafting_recipe/roguetown/survival/woodshaft
 	name = "wood shaft x2"
-	result = /obj/item/shaft/wood
+	result = list(
+		/obj/item/shaft/wood,
+		/obj/item/shaft/wood
+	)
 	tools = list(/obj/item/rogueweapon/huntingknife)
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 	skillcraft = /datum/skill/craft/carpentry


### PR DESCRIPTION


## About The Pull Request

`/datum/crafting_recipe/roguetown/survival/woodshaft` now makes 2 shafts as the recipe says it's supposed to.

## Testing Evidence

<img width="207" height="31" alt="image" src="https://github.com/user-attachments/assets/7fd9ceda-2340-4f21-b720-0be97db19ef7" />
<img width="240" height="175" alt="image" src="https://github.com/user-attachments/assets/9fb43ec2-faa9-4b88-a3b0-99a11f4c44ab" />


## Why It's Good For The Game

Bug is fixed?
