### PR TITLE
Unsmithable Pulaski + minor smithing adjustments

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -13,13 +13,13 @@
 	abstract_type = /datum/anvil_recipe/armor/copper
 
 /datum/anvil_recipe/armor/copper/mask
-	name = "Copper Mask"
+	name = "Mask, Copper"
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/clothing/mask/rogue/facemask/copper
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/copper/bracers
-	name = "Copper Bracers"
+	name = "Bracers, Copper"
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/clothing/wrists/roguetown/bracers/copper
 	craftdiff = 0
@@ -31,13 +31,13 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/copper/gorget
-	name = "Copper Neck Protector"
+	name = "Neck Protector, Copper"
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/clothing/neck/roguetown/gorget/copper
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/copper/chest
-	name = "Copper Heart Protector"
+	name = "Heart Protector, Copper"
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half/copper
 	craftdiff = 0
@@ -46,13 +46,13 @@
 // --------- Decrepit Alloy RECIPES -----------
 
 /datum/anvil_recipe/armor/aalloy/barbute
-	name = "Decrepit Alloy Barbute(+1 Alloy)"
+	name = "Barbute, Decrepit (+1 Alloy)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/barbute
-	name = "Purified Alloy Barbute(+1 Alloy)"
+	name = "Barbute, Decrepit (+1 Alloy)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/paalloy
 	additional_items = /obj/item/ingot/aalloy
@@ -60,165 +60,165 @@
 
 
 /datum/anvil_recipe/armor/aalloy/savoyard
-	name = "Decrepit Alloy Savoyard(+1 Alloy)"
+	name = "Savoyard, Decrepit (+1 Alloy)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/guard/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/savoyard
-	name = "Purified Alloy Savoyard(+1 Purified Alloy)"
+	name = "Savoyard, Ancient (+1 Purified Alloy)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/guard/paalloy
 	additional_items = /obj/item/ingot/purifiedaalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/mask
-	name = "Decrepit Alloy Mask"
+	name = "Mask, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/mask/rogue/facemask/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/mask
-	name = "Purified Alloy Mask"
+	name = "Mask, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/mask/rogue/facemask/steel/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/coif
-	name = "Decrepit Alloy Coif"
+	name = "Coif, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/iron/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/coif
-	name = "Purified Alloy Coif"
+	name = "Coif, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/gorget
-	name = "Decrepit Alloy Gorget"
+	name = "Gorget, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/neck/roguetown/gorget/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/gorget
-	name = "Purified Alloy Gorget"
+	name = "Gorget, Purified"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/neck/roguetown/gorget/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/cuirass
-	name = "Decrepit Alloy Cuirass (+1 Alloy)"
+	name = "Cuirass, Decrepit (+1 Alloy)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/ingot/aalloy)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/cuirass
-	name = "Purified Alloy Cuirass (+1 Purified Alloy)"
+	name = "Cuirass, Ancient (+1 Purified Alloy)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/ingot/purifiedaalloy)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/halfplate
-	name = "Decrepit Alloy Half-Plate Armour (+2 Alloy, +1 Cured Leather)"
+	name = "Half-Plate, Decrepit (+2 Alloy, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/ingot/aalloy,/obj/item/ingot/aalloy,/obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/halfplate
-	name = "Purified Alloy Half-Plate Armour (+2 Purified Alloy, +1 Cured Leather)"
+	name = "Half-Plate, Ancient (+2 Purified Alloy, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/ingot/purifiedaalloy,/obj/item/ingot/purifiedaalloy,/obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/chainmail
-	name = "Decrepit Alloy Chainmail"
+	name = "Chainmail, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/chainmail
-	name = "Purified Alloy Chainmail"
+	name = "Chainmail, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/hauberk
-	name = "Decrepit Alloy Hauberk(+1 Alloy)"
+	name = "Hauberk, Decrepit (+1 Alloy)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy
 	additional_items = list(/obj/item/ingot/aalloy)
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/hauberk
-	name = "Purified Alloy Hauberk(+1 Purified Alloy)"
+	name = "Hauberk, Ancient (+1 Purified Alloy)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy
 	additional_items = list(/obj/item/ingot/purifiedaalloy)
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/bracers
-	name = "Decrepit Alloy Bracers"
+	name = "Bracers, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/bracers
-	name = "Purified Alloy Bracers"
+	name = "Bracers, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/wrists/roguetown/bracers/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/chaingaunts
-	name = "Decrepit Alloy Chain Gauntlets"
+	name = "Chain Gauntlets, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/gloves/roguetown/chain/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/chaingaunts
-	name = "Purified Alloy Chain Gauntlets"
+	name = "Chain Gauntlets, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/gloves/roguetown/chain/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/plategaunts
-	name = "Decrepit Alloy Plate Gauntlets"
+	name = "Plate Gauntlets, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/gloves/roguetown/plate/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/plategaunts
-	name = "Purified Alloy Plate Gauntlets"
+	name = "Plate Gauntlets, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/gloves/roguetown/plate/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/chainkilt
-	name = "Decrepit Alloy Chainkilt"
+	name = "Chainkilt, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/kilt/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/chainkilt
-	name = "Purified Alloy Chainkilt"
+	name = "Chainkilt, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/kilt/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/platelegs
-	name = "Decrepit Alloy Plated Chausses (+1 Steel)"
+	name = "Plated Chausses, Decrepit (+1 Alloy)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/ingot/aalloy)
 	created_item = /obj/item/clothing/under/roguetown/platelegs/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/platelegs
-	name = "Purified Alloy Plated Chausses (+1 Steel)"
+	name = "Plated Chausses, Ancient (+1 Purified Alloy)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/ingot/purifiedaalloy)
 	created_item = /obj/item/clothing/under/roguetown/platelegs/paalloy
@@ -227,169 +227,169 @@
 // --------- IRON RECIPES -----------
 
 /datum/anvil_recipe/armor/iron/haubergeon
-	name = "Haubergeon"
+	name = "Haubergeon, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
 
 /datum/anvil_recipe/armor/iron/hauberk
-	name = "Hauberk (+1 Iron)"
+	name = "Hauberk, Iron (+1 Iron)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 
 /datum/anvil_recipe/armor/iron/chaincoif
-	name = "Chain Coif"
+	name = "Chain Coif, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/iron
 	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/gorget
-	name = "Gorget"
+	name = "Gorget, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/neck/roguetown/gorget
 	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/bevor
-	name = "Bevor"
+	name = "Bevor, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/neck/roguetown/bevor/iron
 
 /datum/anvil_recipe/armor/iron/breastplate
-	name = "Breastplate (+1 Iron)"
+	name = "Breastplate, Iron (+1 Iron)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
 
 /datum/anvil_recipe/armor/iron/lbrigandine
-	name = "Light Brigandine (+1 Cloth)"
+	name = "Light Brigandine, Iron (+1 Cloth)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/natural/cloth)
 	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	i_type = "Armor"
 
 /datum/anvil_recipe/armor/iron/halfplate
-	name = "Half-Plate Armour (+2 Iron, +1 Cured Leather)"
+	name = "Half-Plate, Iron (+2 Iron, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron, /obj/item/ingot/iron, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/iron
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/iron/fullplate
-	name = "Full-Plate Armour (+3 Iron, +1 Cured Leather)"
+	name = "Full-Plate, Iron (+3 Iron, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron, /obj/item/ingot/iron, /obj/item/ingot/iron, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/iron
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/iron/chainglove
-	name = "Chain Gauntlets, 2x"
+	name = "Chain Gauntlets, Iron (x2)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/gloves/roguetown/chain/iron
 	createditem_num = 2
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/plategauntlets
-	name = "Plate Gauntlet"
+	name = "Plate Gauntlets, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/gloves/roguetown/plate/iron
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/chainleg
-	name = "Chain Chausses"
+	name = "Chain Chausses, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/iron
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/chainleg/kilt
-	name = "Chain Kilt"
+	name = "Chain Kilt, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/iron/kilt
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/splintlegs
-	name = "Brigandine Chausses (+1 Cloth)"
+	name = "Brigandine Chausses, Iron (+1 Cloth)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/natural/cloth)
 	created_item = /obj/item/clothing/under/roguetown/splintlegs
 
 /datum/anvil_recipe/armor/iron/platelegs
-	name = "Plate Chausses (+1 Bar)"
+	name = "Plate Chausses, Iron (+1 Bar)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron)
 	created_item = /obj/item/clothing/under/roguetown/platelegs/iron
 
 /datum/anvil_recipe/armor/iron/mask
-	name = "Iron Mask"
+	name = "Mask, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/mask/rogue/facemask
 	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/mask/hound
-	name = "Mask (Hound)"
+	name = "Hound Mask, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/mask/rogue/facemask/hound
 	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/wildguard
-	name = "Wild guard Mask"
+	name = "Wild Guard, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/mask/rogue/wildguard
 	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/splintarms
-	name = "Brigandine Rerebraces (+1 Cloth)"
+	name = "Brigandine Rerebraces, Iron (+1 Cloth)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/natural/cloth)
 	created_item = /obj/item/clothing/wrists/roguetown/splintarms
 	
 /datum/anvil_recipe/armor/iron/bracers
-	name = "Plate Bracers"
+	name = "Plate Bracers, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/wrists/roguetown/bracers/iron
 	createditem_num = 1
 	craftdiff = 0
 	
 /datum/anvil_recipe/armor/iron/jackchain
-	name = "Jack Chain, 2x"
+	name = "Jack Chain, Iron (x2)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/wrists/roguetown/bracers/jackchain
 	createditem_num = 2
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/boot
-	name = "Light Plated Boots"
+	name = "Light Plated Boots, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/shoes/roguetown/boots/armor/iron
 	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/skullcap
-	name = "Skullcap"
+	name = "Skullcap, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/head/roguetown/helmet/skullcap
 
 /datum/anvil_recipe/armor/iron/kettle
-	name = "Kettle Helmet"
+	name = "Kettle Helmet, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/head/roguetown/helmet/kettle/iron
 
 /datum/anvil_recipe/armor/iron/sallet
-	name = "Sallet Helmet"
+	name = "Sallet Helmet, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/head/roguetown/helmet/sallet/iron
 
 /datum/anvil_recipe/armor/iron/sallet/visor
-	name = "Visored Sallet (+1 Iron)"
+	name = "Visored Sallet, Iron (+1 Iron)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron)
 	created_item = /obj/item/clothing/head/roguetown/helmet/sallet/visored/iron
 
 /datum/anvil_recipe/armor/iron/knighthelmet
-	name = "Knight's Helmet (+1 Iron)"
+	name = "Knight's Helmet, Iron (+1 Iron)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/knight/iron
@@ -407,7 +407,7 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/leather/studded/bikini
 
 /datum/anvil_recipe/armor/iron/helmethorned
-	name = "Horned Helmet"
+	name = "Horned Helmet, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/head/roguetown/helmet/horned
 	craftdiff = 2
@@ -430,187 +430,187 @@
 // --------- STEEL RECIPES -----------
 
 /datum/anvil_recipe/armor/steel/haubergeon
-	name = "Haubergeon"
+	name = "Haubergeon, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/chainkini
-	name = "Chainmail Corslet (+1 Cloth)"
+	name = "Chainmail Corslet, Steel (+1 Cloth)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/natural/cloth)
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/bikini
 
 /datum/anvil_recipe/armor/steel/hauberk
-	name = "Hauberk (+1 Steel)"
+	name = "Hauberk, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/halfplate
-	name = "Half-Plate Armour (+2 Steel, +1 Cured Leather)"
+	name = "Half-Plate, Steel (+2 Steel, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel,/obj/item/ingot/steel,/obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/halfplate/fluted
-	name = "Fluted Half-Plate Armour (+2 Steel, +1 Iron, +1 Cured Leather)"
+	name = "Fluted Half-Plate, Steel (+2 Steel, +1 Iron, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/ingot/iron, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/fluted
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/halfplate/fluted/ornate
-	name = "Psydonian Half-Plate Armour (+ P.Cuirass, +1 Steel, +1 Blessed Silver, +1 Cured Leather)"
+	name = "Psydonian Half-Plate (+ P.Cuirass, +1 Steel, +1 Blessed Silver, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/half/fluted/ornate, /obj/item/ingot/steel, /obj/item/ingot/silverblessed, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/fullplate
-	name = "Full-Plate Armour (+3 Steel, +1 Cured Leather)"
+	name = "Full-Plate, Steel (+3 Steel, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full
 	craftdiff = 4
 
 /datum/anvil_recipe/armor/steel/fullplate/fluted
-	name = "Fluted Full-Plate Armour (+3 Steel, +1 Iron, +1 Cured Leather)"
+	name = "Fluted Full-Plate, Steel (+3 Steel, +1 Iron, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/ingot/iron, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/fluted
 	craftdiff = 4
 
 /datum/anvil_recipe/armor/steel/fullplate/fluted/ornate
-	name = "Psydonian Full-Plate Armour (+ P.Half-Plate, +1 Blessed Silver, +1 Cured Leather)"
+	name = "Psydonian Full-Plate (+ P.Half-Plate, +1 Blessed Silver, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate, /obj/item/ingot/silverblessed, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/fluted/ornate
 	craftdiff = 4
 
 /datum/anvil_recipe/armor/steel/fullplate/fluted/ornate/alt
-	name = "Psydonian Full-Plate Armour (+ P.Hauberk, +1 Steel, +2 Blessed Silver, +1 Cured Leather)"
+	name = "Psydonian Full-Plate, Alt (+ P.Hauberk, +1 Steel, +2 Blessed Silver, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/ornate, /obj/item/ingot/steel, /obj/item/ingot/silverblessed, /obj/item/ingot/silverblessed, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/fluted/ornate
 	craftdiff = 4
 
 /datum/anvil_recipe/armor/steel/platebikini
-	name = "Half-Plate Corslet (+1 Steel, +1 Cured Leather)"
+	name = "Half-Plate Corslet, Steel (+1 Steel, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/bikini
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/fullplatebikini
-	name = "Full-Plate Corslet (+2 Steel, +1 Cured Leather)"
+	name = "Full-Plate Corslet, Steel (+2 Steel, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/bikini
 	craftdiff = 4
 
 /datum/anvil_recipe/armor/steel/coatplates
-	name = "Coat Of Plates (+1 Steel, +1 Cured Leather)"
+	name = "Coat Of Plates, Steel (+1 Steel, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel,/obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/steel/brigandine
-	name = "Brigandine (+1 Steel, +2 Cloth)"
+	name = "Brigandine, Steel (+1 Steel, +2 Cloth)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/cloth, /obj/item/natural/cloth)
 	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/chaincoif
-	name = "Chain Coif"
+	name = "Chain Coif, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif
 	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/chainmantle
-	name = "Chain Mantle"
+	name = "Chain Mantle, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
 	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/fullchaincoif
-	name = "Full Chain Coif"
+	name = "Full Chain Coif, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/neck/roguetown/chaincoif/full
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/chainglove
-	name = "Chain Gauntlets, 2x"
+	name = "Chain Gauntlets, Steel (x2)"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/gloves/roguetown/chain
 	createditem_num = 2
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/plateglove
-	name = "Plate Gauntlets"
+	name = "Plate Gauntlets, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/gloves/roguetown/plate
 	createditem_num = 1
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/chainleg
-	name = "Chain Chausses"
+	name = "Chain Chausses, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/under/roguetown/chainlegs
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/chainlegs/kilt
-	name = "Chain Kilt"
+	name = "Chain Kilt, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/kilt
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/brayette
-	name = "Brayette"
+	name = "Brayette, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/under/roguetown/brayette
 
 /datum/anvil_recipe/armor/steel/chainskirt
-	name = "Chain Skirt"
+	name = "Chain Skirt, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/skirt
 
 /datum/anvil_recipe/armor/steel/plateskirt
-	name = "Plate Tassets (+1 Steel)"
+	name = "Plate Tassets, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/under/roguetown/platelegs/skirt
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/platelegs
-	name = "Plated Chausses (+1 Steel)"
+	name = "Plated Chausses, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/under/roguetown/platelegs
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/cuirass
-	name = "Cuirass (+1 Steel)"
+	name = "Cuirass, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/lightcuirass
-	name = "Fencing Cuirass (+1 Fur, +1 Tallow, +3 Cured Leather)"
+	name = "Fencing Cuirass, Steel (+1 Fur, +1 Tallow, +3 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/fur, /obj/item/reagent_containers/food/snacks/tallow, /obj/item/natural/hide/cured, /obj/item/natural/hide/cured, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half/fencer
 	craftdiff = 5
 
 /datum/anvil_recipe/armor/steel/cuirass/fluted
-	name = "Fluted Cuirass (+1 Steel, +1 Iron)"
+	name = "Fluted Cuirass, Steel (+1 Steel, +1 Iron)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/iron)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted
@@ -624,51 +624,51 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/scalemail
-	name = "Scalemail (+1 Steel)"
+	name = "Scalemail, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/scale
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/platebracer
-	name = "Plate Bracers"
+	name = "Plate Bracers, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/wrists/roguetown/bracers
 	createditem_num = 1
 
 /datum/anvil_recipe/armor/steel/helmetnasal
-	name = "Nasal Helmet"
+	name = "Nasal Helmet, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/head/roguetown/helmet
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/helmetwinged
-	name = "Winged Helmet"
+	name = "Winged Helmet, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/head/roguetown/helmet/winged
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/helmetkettle
-	name = "Kettle Helmet"
+	name = "Kettle Helmet, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/head/roguetown/helmet/kettle
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/widehelmetkettle
-	name = "Wide Kettle Helmet"
+	name = "Wide Kettle Helmet, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/head/roguetown/helmet/kettle/wide
 	craftdiff = 2
 
 
 /datum/anvil_recipe/armor/steel/bevor
-	name = "Bevor"
+	name = "Bevor, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/neck/roguetown/bevor
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/sgorget
-	name = "Steel gorget"
+	name = "Gorget, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/neck/roguetown/gorget/steel
 	craftdiff = 2
@@ -680,89 +680,89 @@
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/steel/helmetsall
-	name = "Sallet"
+	name = "Sallet, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/head/roguetown/helmet/sallet
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/helmetsallv
-	name = "Sallet Visored (+1 Steel)"
+	name = "Visored Sallet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/sallet/visored
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/helmetbuc
-	name = "Bucket Helmet (+1 Steel)"
+	name = "Bucket Helmet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/helmetpig
-	name = "Pigface Helmet (+1 Steel)"
+	name = "Pigface Helmet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/helmethounskull
-	name = "Hounskull Helmet (+1 Steel)"
+	name = "Hounskull Helmet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/bascinet
-	name = "Bascinet Helmet"
+	name = "Bascinet Helmet, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/head/roguetown/helmet/bascinet
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/etruscanbascinet
-	name = "Etruscan Bascinet (+1 Steel)"
+	name = "Etruscan Bascinet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/helmetknight
-	name = "Knight's Helmet (+1 Steel)"
+	name = "Knight's Helmet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/knight
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/helmetarmet
-	name = "Armet (+1 Steel)"
+	name = "Armet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/slittedkettle
-	name = "Slitted Kettle (+1 Steel)"
+	name = "Slitted Kettle, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/savoyard
-	name = "Savoyard Helmet (+1 Steel)"
+	name = "Savoyard Helmet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/guard
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/barredhelm
-	name = "Barred Helmet (+1 Steel)"
+	name = "Barred Helmet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/sheriff
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/helmetvolf
-	name = "Volf Face Helmet (+1 Steel)"
+	name = "Volf Face Helmet, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/volfplate
@@ -770,76 +770,76 @@
 	i_type = "Armor"
 
 /datum/anvil_recipe/armor/steel/plateboot
-	name = "Plated Boots"
+	name = "Plated Boots, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/shoes/roguetown/boots/armor
 	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/mask
-	name = "Steel Mask"
+	name = "Mask, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/mask/rogue/facemask/steel
 	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/mask/hound
-	name = "Mask (Hound)"
+	name = "Hound Mask, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/mask/rogue/facemask/steel/hound
 	createditem_num = 1
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/astratahelm
-	name = "Astrata Helmet (+1 Steel)"
+	name = "Astratan Helmet (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/astratahelm
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/abyssorhelm
-	name = "Abyssor Helmet (+1 Steel)"
+	name = "Abyssorite Helmet (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/abyssorgreathelm
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/necrahelm
-	name = "Necra Helmet (+1 Steel)"
+	name = "Necran Helmet (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/necrahelm
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/nochelm
-	name = "Noc Helmet (+1 Steel)"
+	name = "Noccian Helmet (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/nochelm
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/dendorhelm
-	name = "Dendor Helmet (+1 Steel)"
+	name = "Dendorite Helmet (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/dendorhelm
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/frogmouth
-	name = "Froggemund Helmet (+2 Steel)"
+	name = "Froggemund Helmet, Steel (+2 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/frogmouth
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/steel/belt
-	name = "Steel Plated Belt"
+	name = "Plated Belt, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/storage/belt/rogue/leather/steel
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/belt/tasset
-	name = "Tasseted Steel Plated Belt"
+	name = "Tasseted Plate Belt, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/storage/belt/rogue/leather/steel/tasset
 	craftdiff = 2
@@ -847,7 +847,7 @@
 // --------- SILVER RECIPES-----------
 
 /datum/anvil_recipe/armor/silver/belt
-	name = "Silver Plated Belt"
+	name = "Plated Belt, Silver"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/storage/belt/rogue/leather/plaquesilver
 	craftdiff = 3
@@ -855,13 +855,13 @@
 // --------- GOLD RECIPES-----------
 
 /datum/anvil_recipe/armor/gold/belt
-	name = "Gold Plated Belt"
+	name = "Plated Belt, Gold"
 	req_bar = /obj/item/ingot/gold
 	created_item = /obj/item/storage/belt/rogue/leather/plaquegold
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/gold/mask
-	name = "Gold Mask"
+	name = "Mask, Gold"
 	req_bar = /obj/item/ingot/gold
 	created_item = /obj/item/clothing/mask/rogue/facemask/goldmask
 	craftdiff = 3
@@ -869,14 +869,14 @@
 // --------- BLACKSTEEL RECIPES-----------
 
 /datum/anvil_recipe/armor/blacksteel/cuirass
-	name = "Blacksteel Cuirass (+1 B.Steel)"
+	name = "Cuirass, Blacksteel (+1 B.Steel)"
 	req_bar = /obj/item/ingot/blacksteel
 	additional_items = list(/obj/item/ingot/blacksteel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate
 	craftdiff = 5
 
 /datum/anvil_recipe/armor/blacksteel/modern/platechest
-	name = "Blacksteel Plate Armor (+3 B.Steel)"
+	name = "Full-Plate, Blacksteel (+3 B.Steel)"
 	req_bar = /obj/item/ingot/blacksteel
 	additional_items = list(/obj/item/ingot/blacksteel, /obj/item/ingot/blacksteel, /obj/item/ingot/blacksteel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/modern/blacksteel_full_plate
@@ -884,27 +884,27 @@
 
 
 /datum/anvil_recipe/armor/blacksteel/modern/plategloves
-	name = "Blacksteel Plate Gauntlets"
+	name = "Plate Gauntlets, Blacksteel"
 	req_bar = /obj/item/ingot/blacksteel
 	created_item = /obj/item/clothing/gloves/roguetown/blacksteel/modern/plategloves
 	craftdiff = 5
 
 /datum/anvil_recipe/armor/blacksteel/modern/platelegs
-	name = "Blacksteel Plate Chausses (+1 B.Steel)"
+	name = "Plate Chausses, Blacksteel (+1 B.Steel)"
 	req_bar = /obj/item/ingot/blacksteel
 	additional_items = list(/obj/item/ingot/blacksteel)
 	created_item = /obj/item/clothing/under/roguetown/platelegs/blacksteel/modern
 	craftdiff = 5
 
 /datum/anvil_recipe/armor/blacksteel/modern/armet
-	name = "Blacksteel Armet (+1 B.Steel)"
+	name = "Armet, Blacksteel (+1 B.Steel)"
 	req_bar = /obj/item/ingot/blacksteel
 	additional_items = list(/obj/item/ingot/blacksteel)
 	created_item = /obj/item/clothing/head/roguetown/helmet/blacksteel/modern/armet
 	craftdiff = 5
 
 /datum/anvil_recipe/armor/blacksteel/modern/plateboots
-	name = "Blacksteel Plate Boots"
+	name = "Plate Boots, Blacksteel"
 	req_bar = /obj/item/ingot/blacksteel
 	created_item = /obj/item/clothing/shoes/roguetown/boots/blacksteel/modern/plateboots
 	craftdiff = 5

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -103,7 +103,7 @@
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/gorget
-	name = "Gorget, Purified"
+	name = "Gorget, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/neck/roguetown/gorget/paalloy
 	craftdiff = 3

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
@@ -5,33 +5,33 @@
 
 // --------- Copper -----------
 /datum/anvil_recipe/tools/sickle/copper
-	name = "Copper Sickle (+Stick)"
+	name = "Sickle, Copper (+1 Stick)"
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/sickle/copper
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/pick/copper
-	name = "Copper Pick (+Stick)"
+	name = "Pick, Copper (+1 Stick)"
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/pick/copper
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/pitchfork/copper
-	name = "Copper Pitchfork (+Stick x2)"
+	name = "Pitchfork, Copper (+2 Sticks)"
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/grown/log/tree/stick, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/pitchfork/copper
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/lamptern/copper
-	name = "Copper Lamptern"
+	name = "Lamptern, Copper"
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/flashlight/flare/torch/lantern/copper
 
 /datum/anvil_recipe/tools/hammer/copper
-	name = "Copper Hammer (+Stick)"
+	name = "Hammer, Copper (+Stick)"
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/hammer/copper
@@ -41,35 +41,35 @@
 // --------- ANCIENT ALLOY -----------
 
 /datum/anvil_recipe/tools/aalloy/thresher
-	name = "Decrepit Thresher (+1 Stick)"
+	name = "Thresher, Decrepit (+1 Stick)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/thresher/aalloy
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/aalloy/hoe
-	name = "Decrepit Hoe (+2 Sticks)"
+	name = "Hoe, Decrepit (+2 Sticks)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick,/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/hoe/aalloy
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/aalloy/pitchfork
-	name = "Decrepit Pitchfork (+2 Sticks)"
+	name = "Pitchfork, Decrepit (+2 Sticks)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick,/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/pitchfork/aalloy
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/aalloy/hammer
-	name = "Decrepit Hammer (+1 Stick)"
+	name = "Hammer, Decrepit (+1 Stick)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/hammer/aalloy
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/aalloy/sickle
-	name = "Decrepit Sickle (+1 Stick)"
+	name = "Sickle, Decrepit (+1 Stick)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/sickle/aalloy
@@ -77,79 +77,79 @@
 
 
 /datum/anvil_recipe/tools/aalloy/tongs
-	name = "Decrepit Tongs"
+	name = "Tongs, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/tongs/aalloy
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/aalloy/pick
-	name = "Decrepit Pickaxe (+1 Stick)"
+	name = "Pickaxe, Decrepit (+1 Stick)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/pick/aalloy
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/aalloy/shovel
-	name = "Decrepit Shovel (+2 Sticks)"
+	name = "Shovel, Decrepit (+2 Sticks)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick,/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/shovel/aalloy
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/aalloy/sewingneedle
-	name = "Decrepit Needles x3"
+	name = "Needles, Decrepit (x3)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/needle/aalloy
 	createditem_num = 3
 	craftdiff = 0
 
 /datum/anvil_recipe/tools/aalloy/pan
-	name = "Decrepit Frypan"
+	name = "Frypan, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/cooking/pan/aalloy
 	craftdiff = 0
 
 /datum/anvil_recipe/tools/aalloy/agobs
-	name = "Decrepit Goblets x3"
+	name = "Goblet, Decrepit (x3)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/reagent_containers/glass/cup/aalloygob
 	createditem_num = 3
 
 /datum/anvil_recipe/tools/aalloy/amugs
-	name = "Decrepit Mugs x3"
+	name = "Mug, Decrepit (x3)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/reagent_containers/glass/cup/aalloymug
 	createditem_num = 3
 
 
 /datum/anvil_recipe/tools/aalloy/pot
-	name = "Decrepit Cooking Pot"
+	name = "Cooking Pot, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/reagent_containers/glass/bucket/pot/aalloy
 
 
 /datum/anvil_recipe/tools/platter
-	name = "Decrepit Platter x3"
+	name = "Platter, Decrepit (x3)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/cooking/platter/aalloy
 	craftdiff = 1
 	createditem_num = 3
 
 /datum/anvil_recipe/tools/aalloy/bowl
-	name = "Decrepit Bowl"
+	name = "Bowl, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/reagent_containers/glass/bowl/aalloy
 	craftdiff = 1
 
 /datum/anvil_recipe/tools/aalloy/fork
-	name = "Decrepit Fork x3"
+	name = "Fork, Decrepit (x3)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/kitchen/fork/aalloy
 	createditem_num = 3
 	craftdiff = 1
 
 /datum/anvil_recipe/tools/aalloy/spoon
-	name = "Decrepit Spoon x3"
+	name = "Spoon, Decrepit (x3)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/kitchen/spoon/aalloy
 	createditem_num = 3
@@ -171,7 +171,7 @@
 	created_item = /obj/item/storage/belt/rogue/surgery_bag/full
 
 /datum/anvil_recipe/tools/iron/torch
-	name = "Torches x5 (+1 Coal)"
+	name = "Torches, Iron (x5) (+1 Coal)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/rogueore/coal)
 	created_item = /obj/item/flashlight/flare/torch/metal
@@ -179,27 +179,27 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/tools/iron/shaft
-	name = "Metal Shaft x2"
+	name = "Metal Shaft (x2)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/shaft/metal
 	createditem_num = 2
 	craftdiff = 1
 
 /datum/anvil_recipe/tools/iron/pan
-	name = "Frypan"
+	name = "Frypan, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/cooking/pan
 	craftdiff = 0
 
 /datum/anvil_recipe/tools/iron/keyring
-	name = "Keyrings x3"
+	name = "Keyrings (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/storage/keyring
 	createditem_num = 3
 	craftdiff = 0
 
 /datum/anvil_recipe/tools/ironsewingneedle
-	name = "Sewing Needles x3"
+	name = "Needles, Iron (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/needle
 	createditem_num = 3 // They can be refilled with fiber now
@@ -222,92 +222,92 @@
 */
 
 /datum/anvil_recipe/tools/iron/shovel
-	name = "Shovel (+2 Sticks)"
+	name = "Shovel, Iron (+2 Sticks)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick,/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/shovel
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/iron/hammer
-	name = "Hammer (+1 Stick)"
+	name = "Hammer, Iron (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/hammer/iron
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/iron/handsaw
-	name = "Handsaw (+1 Stick)"
+	name = "Handsaw, Iron (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/handsaw
 
 /datum/anvil_recipe/tools/iron/chisel
-	name = "Chisel"
+	name = "Chisel, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/chisel
 
 /datum/anvil_recipe/tools/iron/tongs
-	name = "Tongs"
+	name = "Tongs, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/tongs
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/iron/sickle
-	name = "Iron Sickle (+1 Stick)"
+	name = "Sickle, Iron (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/sickle
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/iron/pick
-	name = "Iron Pickaxe (+1 Stick)"
+	name = "Pickaxe, Iron (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/pick
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/iron/hoe
-	name = "Iron Hoe (+2 Sticks)"
+	name = "Hoe, Iron (+2 Sticks)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick,/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/hoe
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/iron/pitchfork
-	name = "Iron Pitchfork (+2 Sticks)"
+	name = "Pitchfork, Iron (+2 Sticks)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick,/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/pitchfork
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/iron/lamptern
-	name = "Lamptern x3"
+	name = "Lampterns, Iron (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/flashlight/flare/torch/lantern
 	createditem_num = 3
 
 /datum/anvil_recipe/tools/iron/cups
-	name = "Cups x3"
+	name = "Cups, Iron (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/reagent_containers/glass/cup
 	createditem_num = 3
 	craftdiff = 0
 
 /datum/anvil_recipe/tools/iron/thresher
-	name = "Thresher (+1 Stick)"
+	name = "Thresher, Iron (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/thresher
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/scissors
-	name = "Scissors"
+	name = "Scissors, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/huntingknife/scissors
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/headhook
-	name = "Iron Headhook (+2 Fibers)"
+	name = "Headhook, Iron (+2 Fibers)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/natural/fibers = 2)
 	created_item = /obj/item/storage/hip/headhook
@@ -317,20 +317,20 @@
 // --------- Steel -----------
 
 /datum/anvil_recipe/tools/steel/hammer
-	name = "Claw hammer (+1 Stick)"
+	name = "Claw Hammer (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/hammer/steel
 
 /datum/anvil_recipe/tools/steel/pick
-	name = "Pickaxe (+1 Stick)"
+	name = "Pickaxe, Steel (+1 Stick)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/pick/steel
 	i_type = "Tools"
 
 /datum/anvil_recipe/tools/steel/cups
-	name = "Goblets x3"
+	name = "Goblet, Steel (x3)"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/reagent_containers/glass/cup/steel
 	createditem_num = 3
@@ -348,7 +348,7 @@
 	createditem_num = 1
 
 /datum/anvil_recipe/tools/steelscissors
-	name = "Scissors"
+	name = "Scissors, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/huntingknife/scissors/steel
 	i_type = "Tools"
@@ -357,7 +357,7 @@
 // --------- SILVER -----------
 
 /datum/anvil_recipe/tools/silver/cups
-	name = "Goblets x3"
+	name = "Goblet, Silver (x3)"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/reagent_containers/glass/cup/silver
 	createditem_num = 3
@@ -366,7 +366,7 @@
 // --------- GOLD RECIPES-----------
 
 /datum/anvil_recipe/tools/gold/cups
-	name = "Goblets x3"
+	name = "Goblet, Gold (x3)"
 	req_bar = /obj/item/ingot/gold
 	created_item = /obj/item/reagent_containers/glass/cup/golden
 	createditem_num = 3
@@ -375,68 +375,68 @@
 
 // --------- COOKING RECIPES -----------
 /datum/anvil_recipe/tools/iron/pot
-	name = "Cooking Pot (Iron)"
+	name = "Cooking Pot, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/reagent_containers/glass/bucket/pot
 
 /datum/anvil_recipe/tools/iron/kettle
-	name = "Cooking Kettle (Iron)"
+	name = "Cooking Kettle, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/reagent_containers/glass/bucket/pot/kettle
 
 /datum/anvil_recipe/tools/pote/copper
-	name = "Cooking Pot (Copper)"
+	name = "Cooking Pot, Copper"
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/reagent_containers/glass/bucket/pot/copper
 
 /datum/anvil_recipe/tools/platter
-	name = "2x Platters (Copper)"
+	name = "Platter, Copper (x2)"
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/cooking/platter/copper
 	craftdiff = 1
-	createditem_num = 1
+	createditem_num = 2
 
 /datum/anvil_recipe/tools/platter/tin
-	name = "2x Platters (Tin)"
+	name = "Platter, Tin (x2)"
 	req_bar = /obj/item/ingot/tin
 	created_item = /obj/item/cooking/platter/pewter
 
 /datum/anvil_recipe/tools/platter/gold
-	name = "2x Platters (Gold)"
+	name = "Platter, Gold (x2)"
 	req_bar = /obj/item/ingot/gold
 	created_item = /obj/item/cooking/platter/gold
 
 /datum/anvil_recipe/tools/platter/silver
-	name = "2x Platters (Silver)"
+	name = "Platter, Silver (x2)"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/cooking/platter/silver
 
 /datum/anvil_recipe/tools/spoon
-	name = "Iron Spoon x3"
+	name = "Spoon, Iron (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/kitchen/spoon/iron
 	createditem_num = 3
 	craftdiff = 1
 
 /datum/anvil_recipe/tools/spoon/tin
-	name = "Tin Spoon x3"
+	name = "Spoon, Tin (x3)"
 	req_bar = /obj/item/ingot/tin
 	created_item = /obj/item/kitchen/spoon/tin
 
 /datum/anvil_recipe/tools/fork
-	name = "Iron Fork x3"
+	name = "Fork, Iron (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/kitchen/fork/iron
 	createditem_num = 3
 	craftdiff = 1
 
 /datum/anvil_recipe/tools/fork/tin
-	name = "Tin Fork x3"
+	name = "Fork, Tin (x3)"
 	req_bar = /obj/item/ingot/tin
 	created_item = /obj/item/kitchen/fork/tin
 
 /datum/anvil_recipe/tools/iron/bowl
-	name = "Iron Bowl"
+	name = "Bowl, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/reagent_containers/glass/bowl/iron
 	craftdiff = 1

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
@@ -47,19 +47,19 @@
 //	i_type = "Valuables"
 
 /datum/anvil_recipe/valuables/ringg
-	name = "Rings 3x"
+	name = "Rings, Gold (x3)"
 	req_bar = /obj/item/ingot/gold
 	created_item = /obj/item/clothing/ring/gold
 	createditem_num = 3
 
 /datum/anvil_recipe/valuables/ringa
-	name = "Decrepit Rings 3x"
+	name = "Rings, Decrepit (x3)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/ring/aalloy
 	createditem_num = 3
 
 /datum/anvil_recipe/valuables/rings
-	name = "Rings 3x"
+	name = "Rings, Silver (x3)"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/clothing/ring/silver
 	createditem_num = 3
@@ -76,38 +76,38 @@
 
 //Gold Rings
 /datum/anvil_recipe/valuables/emeringg
-	name = "Gemerald Ring (+1 Gemerald)"
+	name = "Gemerald Ring, Gold (+1 Gemerald)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/roguegem/green)
 	created_item = /obj/item/clothing/ring/emerald
 
 /datum/anvil_recipe/valuables/rubyg
-	name = "Rontz Ring (+1 Rontz)"
+	name = "Rontz Ring, Gold (+1 Rontz)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/roguegem/ruby)
 	created_item = /obj/item/clothing/ring/ruby
 
 /datum/anvil_recipe/valuables/topazg
-	name = "Toper Ring (+1 Toper)"
+	name = "Toper Ring, Gold (+1 Toper)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/roguegem/yellow)
 	created_item = /obj/item/clothing/ring/topaz
 
 /datum/anvil_recipe/valuables/quartzg
-	name = "Blortz Ring (+1 Blortz)"
+	name = "Blortz Ring, Gold (+1 Blortz)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/roguegem/blue)
 	created_item = /obj/item/clothing/ring/quartz
 	i_type = "Valuables"
 
 /datum/anvil_recipe/valuables/sapphireg
-	name = "Saffira Ring (+1 Saffira)"
+	name = "Saffira Ring, Gold (+1 Saffira)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/roguegem/violet)
 	created_item = /obj/item/clothing/ring/sapphire
 
 /datum/anvil_recipe/valuables/diamondg
-	name = "Dorpel Ring (+1 Dorpel)"
+	name = "Dorpel Ring, Gold (+1 Dorpel)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/roguegem/diamond)
 	created_item = /obj/item/clothing/ring/diamond
@@ -120,37 +120,37 @@
 // Silver ingots are now in play, and as such, the steel rings have been converted to silver with their value adjusted accordingly. -Kyogon
 
 /datum/anvil_recipe/valuables/emerings
-	name = "Gemerald Ring (+1 Gemerald)"
+	name = "Gemerald Ring, Silver (+1 Gemerald)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/roguegem/green)
 	created_item = /obj/item/clothing/ring/emeralds
 
 /datum/anvil_recipe/valuables/rubys
-	name = "Rontz Ring (+1 Rontz)"
+	name = "Rontz Ring, Silver (+1 Rontz)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/roguegem/ruby)
 	created_item = /obj/item/clothing/ring/rubys
 
 /datum/anvil_recipe/valuables/topazs
-	name = "Toper Ring (+1 Toper)"
+	name = "Toper Ring, Silver (+1 Toper)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/roguegem/yellow)
 	created_item = /obj/item/clothing/ring/topazs
 
 /datum/anvil_recipe/valuables/quartzs
-	name = "Blortz Ring (+1 Blortz)"
+	name = "Blortz Ring, Silver (+1 Blortz)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/roguegem/blue)
 	created_item = /obj/item/clothing/ring/quartzs
 
 /datum/anvil_recipe/valuables/sapphires
-	name = "Saffira Ring (+1 Saffira)"
+	name = "Saffira Ring, Silver (+1 Saffira)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/roguegem/violet)
 	created_item = /obj/item/clothing/ring/sapphires
 
 /datum/anvil_recipe/valuables/diamonds
-	name = "Dorpel Ring (+1 Dorpel)"
+	name = "Dorpel Ring, Silver (+1 Dorpel)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/roguegem/diamond)
 	created_item = /obj/item/clothing/ring/diamonds

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
@@ -5,27 +5,27 @@
 	i_type = "Valuables"
 
 /datum/anvil_recipe/valuables/gold
-	name = "Statue"
+	name = "Statue, Gold"
 	req_bar = /obj/item/ingot/gold
 	created_item = /obj/item/roguestatue/gold
 
 /datum/anvil_recipe/valuables/silver
-	name = "Statue"
+	name = "Statue, Silver"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/roguestatue/silver
 
 /datum/anvil_recipe/valuables/iron
-	name = "Statue"
+	name = "Statue, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/roguestatue/iron
 
 /datum/anvil_recipe/valuables/aalloy
-	name = "Decrepit Statue"
+	name = "Statue, Decrepit" // decrepit
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/roguestatue/aalloy
 
 /datum/anvil_recipe/valuables/steel
-	name = "Statue"
+	name = "Statue, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/roguestatue/steel
 

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -666,28 +666,28 @@
 
 //GOLD
 /datum/anvil_recipe/weapons/decsword
-	name = "Decorated Sword (+1 Steel Sword)"
+	name = "Sword, Decorated (+1 Steel Sword)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/rogueweapon/sword)
 	created_item = /obj/item/rogueweapon/sword/decorated
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/decsaber
-	name = "Decorated Sabre (+1 Steel Sabre)"
+	name = "Sabre, Decorated (+1 Steel Sabre)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/rogueweapon/sword/sabre)
 	created_item = /obj/item/rogueweapon/sword/sabre/dec
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/decrapier
-	name = "Decorated Rapier (+1 Steel Rapier)"
+	name = "Rapier, Decorated (+1 Steel Rapier)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/rogueweapon/sword/rapier)
 	created_item = /obj/item/rogueweapon/sword/rapier/dec
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/declongsword
-	name = "Decorated Longsword (+1 Longsword)"
+	name = "Longsword, Decorated (+1 Steel Longsword)"
 	req_bar = /obj/item/ingot/gold
 	additional_items = list(/obj/item/rogueweapon/sword/long)
 	created_item = /obj/item/rogueweapon/sword/long/dec
@@ -695,14 +695,14 @@
 
 // SILVER
 /datum/anvil_recipe/weapons/silver/elfsaber
-	name = "Elvish Saber (+1 Silver)"
+	name = "Sabre, Elvish (+1 Silver)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/ingot/silver)
 	created_item = /obj/item/rogueweapon/sword/sabre/elf
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/silver/elfdagger
-	name = "Elvish Dagger"
+	name = "Dagger, Elvish"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/rogueweapon/huntingknife/idagger/silver/elvish
 	craftdiff = 3

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -7,7 +7,7 @@
 // Decrepit Alloy and Purified Decrepit Alloy
 
 /datum/anvil_recipe/weapons/aalloy/flail
-	name = "Decrepit Alloy Flail"
+	name = "Flail, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/flail/aflail
@@ -15,7 +15,7 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/flail/
-	name = "Purified Alloy Flail"
+	name = "Flail, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/flail/sflail/paflail
@@ -23,7 +23,7 @@
 
 
 /datum/anvil_recipe/weapons/aalloy/dagger
-	name = "Decrepit Alloy Dagger"
+	name = "Dagger, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/huntingknife/idagger/adagger
@@ -31,14 +31,14 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/dagger
-	name = "Purified Alloy Dagger"
+	name = "Dagger, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/knuckles
-	name = "Decrepit Alloy Knuckles"
+	name = "Knuckles, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/knuckles/aknuckles
@@ -46,14 +46,14 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/knuckles
-	name = "Purified Alloy Knuckles"
+	name = "Knuckles, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/knuckles/paknuckles
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/gladius
-	name = "Decrepit Alloy Gladius"
+	name = "Gladius, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/sword/iron/short/gladius/agladius
@@ -61,14 +61,14 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/gladius
-	name = "Purified Alloy Gladius"
+	name = "Gladius, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/sword/iron/short/gladius/pagladius
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/shortsword
-	name = "Decrepit Alloy Shortsword"
+	name = "Shortsword, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/sword/iron/short/ashort
@@ -76,14 +76,14 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/shortsword
-	name = "Purified Alloy Shortsword"
+	name = "Shortsword, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/sword/short/pashortsword
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/khopesh
-	name = "Decrepit Alloy Khopesh"
+	name = "Khopesh, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/sword/sabre/alloy
@@ -91,14 +91,14 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/khopesh
-	name = "Purified Alloy Khopesh"
+	name = "Khopesh, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/sword/sabre/palloy
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/handaxe
-	name = "Decrepit Alloy Axe"
+	name = "Axe, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/stoneaxe/woodcut/aaxe
@@ -106,14 +106,14 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/handaxe
-	name = "Purified Alloy Axe"
+	name = "Axe, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/stoneaxe/woodcut/steel/paaxe
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/mace
-	name = "Decrepit Alloy Mace"
+	name = "Mace, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/mace/alloy
@@ -121,14 +121,14 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/mace
-	name = "Purified Alloy Mace"
+	name = "Mace, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/mace/steel/palloy
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/warhammer
-	name = "Decrepit Alloy Warhammer"
+	name = "Warhammer, Decrepit"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/mace/warhammer/alloy
@@ -136,28 +136,28 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/warhammer
-	name = "Purified Alloy Warhammer"
+	name = "Warhammer, Ancient"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/mace/warhammer/steel/paalloy
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/tossblade
-	name = "Ancient Tossblades 4x"
+	name = "Tossblades, Decrepit (x4)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/aalloy
 	craftdiff = 0
 	createditem_num = 4
 
 /datum/anvil_recipe/weapons/paalloy/tossblade
-	name = "Purified Alloy Tossblades 4x"
+	name = "Tossblades, Ancient (x4)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/steel/palloy
 	craftdiff = 0
 	createditem_num = 4
 
 /datum/anvil_recipe/weapons/aalloy/gsw
-	name = "Decrepit Alloy Greatsword(+2 Alloy)"
+	name = "Greatsword, Decrepit (+2 Alloy)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/greatsword/aalloy
@@ -166,7 +166,7 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/gsw
-	name = "Purified Alloy Greatsword(+2 Purified Alloy)"
+	name = "Greatsword, Ancient (+2 Purified Alloy)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/greatsword/paalloy
@@ -175,7 +175,7 @@
 
 
 /datum/anvil_recipe/weapons/aalloy/bardiche
-	name = "Decrepit Alloy Bardiche(+1 log, +1 Alloy)"
+	name = "Bardiche, Decrepit (+1 log, +1 Alloy)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/halberd/bardiche/aalloy
@@ -184,7 +184,7 @@
 
 
 /datum/anvil_recipe/weapons/paalloy/bardiche
-	name = "Purified Alloy Bardiche(+1 log, +1 Purified Alloy)"
+	name = "Bardiche, Ancient (+1 log, +1 Purified Alloy)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/halberd/bardiche/paalloy
@@ -192,35 +192,35 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/grandmace
-	name = "Decrepit Grand Mace (+1 Alloy, +1 Small Log)"
+	name = "Grand Mace, Decrepit (+1 Alloy, +1 Small Log)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/ingot/aalloy, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/mace/goden/aalloy
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/paalloy/grandmace
-	name = "Decrepit Alloy Grand Mace (+1 Purified Alloy, +1 Small Log)"
+	name = "Grand Mace, Purified (+1 Purified Alloy, +1 Small Log)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/ingot/purifiedaalloy, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/mace/goden/steel/paalloy
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/aalloy/spear
-	name = "Decrepit Alloy Spear (+1 Small Log)"
+	name = "Spear, Decrepit(+1 Small Log)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/spear/aalloy
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/paalloy/spear
-	name = "Purified Alloy Spear (+1 Small Log)"
+	name = "Spear, Ancient (+1 Small Log)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/spear/paalloy
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/javelin
-	name = "2x Decrepit Alloy Javelin (+1 Small Log)"
+	name = "Javelin, Decrepit (+1 Small Log) (x2)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/ammo_casing/caseless/rogue/javelin/aalloy
@@ -228,7 +228,7 @@
 	craftdiff = 1
 
 /datum/anvil_recipe/weapons/paalloy/javelin
-	name = "2x Purified Alloy Javelin (+1 Small Log)"
+	name = "Javelin, Ancient (+1 Small Log) (x2)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/ammo_casing/caseless/rogue/javelin/steel/paalloy
@@ -238,7 +238,7 @@
 
 /// COPPER WEAPONS
 /datum/anvil_recipe/weapons/copper/caxe
-	name = "Copper Hatchet (+1 Copper)"
+	name = "Hatchet, Copper (+1 Copper)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/ingot/copper)
@@ -246,7 +246,7 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/copper/cbludgeon
-	name = "Copper Bludgeon (+1 Stick)"
+	name = "Budgeon, Copper (+1 Stick)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/grown/log/tree/stick)
@@ -254,7 +254,7 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/copper/cdagger
-	name = "x2 Copper Knives"
+	name = "Knife, Copper (x2)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/rogueweapon/huntingknife/copper
@@ -262,14 +262,14 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/copper/cmesser
-	name = "Copper Messer"
+	name = "Messer, Copper"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/copper
 	created_item = /obj/item/rogueweapon/sword/iron/messer/copper
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/copper/cspears
-	name = "2x Copper Spears (+ 1 Small Log)"
+	name = "Spear, Copper (+1 Small Log) (x2)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/grown/log/tree/small)
@@ -278,7 +278,7 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/copper/crhomphaia
-	name = "Copper Rhomphaia (+ 1 Bar)"
+	name = "Rhomphaia, Copper (+1 Copper)"
 	appro_skill = /datum/skill/craft/weaponsmithing
 	req_bar = /obj/item/ingot/copper
 	additional_items = list(/obj/item/ingot/copper)
@@ -288,111 +288,118 @@
 /// IRON WEAPONS
 
 /datum/anvil_recipe/weapons/iron/sword
-	name = "Sword"
+	name = "Sword, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/sword/iron
 
 /datum/anvil_recipe/weapons/iron/swordshort
-	name = "Short sword"
+	name = "Shortsword, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/sword/iron/short
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/iron/messer
-	name = "Hunting sword (Messer)"
+	name = "Messer, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/sword/iron/messer
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/iron/dagger
-	name = "Dagger"
+	name = "Dagger, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/huntingknife/idagger
 	createditem_num = 1
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/ironflail
-	name = "Flail"
+	name = "Flail, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/flail
 
 /datum/anvil_recipe/weapons/iron/huntknife
-	name = "Hunting knife"
+	name = "Hunting Knife, Iron"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/huntingknife
 	createditem_num = 1
 
 /datum/anvil_recipe/weapons/iron/zweihander
-	name = "Zweihander (+2 Iron)"
+	name = "Zweihander, Iron (+2 Iron)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron, /obj/item/ingot/iron)
 	created_item = /obj/item/rogueweapon/greatsword/zwei
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/iron/axe
-	name = "Axe (+1 Stick)"
+	name = "Axe, Iron (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/stoneaxe/woodcut
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/iron/greataxe
-	name = "Iron Greataxe (+1 Iron, +1 Small Log)"
+	name = "Greataxe, Iron (+1 Iron, +1 Small Log)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/greataxe
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/iron/cudgel
-	name = "Cudgel (+1 Stick)"
+	name = "Cudgel, Iron (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/mace/cudgel
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/iron/mace
-	name = "Mace (+1 Stick)"
+	name = "Mace, Iron (+1 Stick)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/mace
 	craftdiff = 0
 
+/datum/anvil_recipe/weapons/warhammer
+	name = "Warhammer, Iron (+1 Stick)"
+	req_bar = /obj/item/ingot/iron
+	additional_items = list(/obj/item/grown/log/tree/stick)
+	created_item = /obj/item/rogueweapon/mace/warhammer
+	i_type = "Weapons"
+
 /datum/anvil_recipe/weapons/iron/spear
-	name = "Spear (+1 Small Log)"
+	name = "Spear, Iron (+1 Small Log)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/spear
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/iron/bardiche
-	name = "Bardiche (+1 Iron, +1 Small Log)"
+	name = "Bardiche, Iron (+1 Iron, +1 Small Log)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/halberd/bardiche
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/iron/lucerne
-	name = "Lucerne (+1 Iron, +1 Small Log)"
+	name = "Lucerne, Iron (+1 Iron, +1 Small Log)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/eaglebeak/lucerne
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/iron/polemace
-	name = "Goedendag (+1 Small Log)"
+	name = "Goedendag, Iron (+1 Small Log)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/mace/goden
 
 /datum/anvil_recipe/weapons/iron/tossblade
-	name = "Iron Tossblades 4x"
+	name = "Tossblades, Iron (x4)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife
 	craftdiff = 0
 	createditem_num = 4
 
 /datum/anvil_recipe/weapons/iron/javelin
-	name = "2x Iron Javelin (+1 Small Log)"
+	name = "Javelin, Iron (+1 Small Log) (x2)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/ammo_casing/caseless/rogue/javelin
@@ -402,170 +409,172 @@
 /// STEEL WEAPONS
 
 /datum/anvil_recipe/weapons/steel/dagger
-	name = "Dagger"
+	name = "Dagger, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/huntingknife/idagger/steel
 	createditem_num = 1
 
 /datum/anvil_recipe/weapons/steel/daggerparrying
-	name = "Parrying Dagger (+1 Steel)"
+	name = "Parrying Dagger, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/katar
-	name = "Katar"
+	name = "Katar, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/katar
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/steelknuckle
-	name = "Steel Knuckle"
+	name = "Knuckles, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/knuckles
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/rapier
-	name = "Rapier"
+	name = "Rapier, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword/rapier
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/cutlass
-	name = "Cutlass"
+	name = "Cutlass, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword/cutlass
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/swordshort
-	name = "Steel Short Sword"
+	name = "Shortsword, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword/short
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/falchion
-	name = "Falchion"
+	name = "Falchion, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword/falchion
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/steel/messer
-	name = "Steel Messer"
+	name = "Messer, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword/short/messer
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/sword
-	name = "Sword"
+	name = "Sword, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/saber
-	name = "Sabre"
+	name = "Sabre, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword/sabre
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/flail
-	name = "Flail"
+	name = "Flail, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/flail/sflail
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/longsword
-	name = "Longsword (+1 Steel)"
+	name = "Longsword, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/sword/long
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/steel/kriegmesser
-	name = "Kriegmesser (+1 Steel)"
+	name = "Kriegmesser, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/sword/long/kriegmesser
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/steel/battleaxe
-	name = "Battle Axe (+1 Steel)"
+	name = "Battle Axe, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/stoneaxe/battle
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/steel/combatknife
-	name = "Combat Knife (+1 Steel)"
+	name = "Combat Knife, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/huntingknife/combat
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/mace
-	name = "Mace (+1 Steel)"
+	name = "Mace, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/mace/steel
 	craftdiff = 2
 
+/datum/anvil_recipe/weapons/swarhammer
+	name = "Warhammer, Steel (+1 Steel)"
+	req_bar = /obj/item/ingot/steel
+	additional_items = list(/obj/item/ingot/steel)
+	created_item = /obj/item/rogueweapon/mace/warhammer/steel
+	craftdiff = 2
+	i_type = "Weapons"
+
 /datum/anvil_recipe/weapons/steel/greatsword
-	name = "Greatsword (+2 Steel)"
+	name = "Greatsword, Steel (+2 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/greatsword
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/steel/steelzweihander
-	name = "Zweihander (+2 Steel)"
+	name = "Zweihander, Steel (+2 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/greatsword/grenz
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/estoc
-	name = "Estoc (+1 Steel)"
+	name = "Estoc, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/estoc
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/steel/axe
-	name = "Axe (+1 Stick)"
+	name = "Axe, Steel (+1 Stick)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/stoneaxe/woodcut/steel
 	craftdiff = 2
 
-/datum/anvil_recipe/weapons/steel/pulaski
-	name = "Pulaski axe (+1 Stick)"
-	req_bar = /obj/item/ingot/steel
-	additional_items = list(/obj/item/grown/log/tree/stick)
-	created_item = /obj/item/rogueweapon/stoneaxe/woodcut/pick
-
 /datum/anvil_recipe/weapons/steel/greataxe
-	name = "Steel Greataxe (+1 Steel, +1 Small Log)"
+	name = "Greataxe, Steel (+1 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/greataxe/steel
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/steel/greataxe/doublehead
-	name = "Steel Double-Headed Greataxe (+2 Steel, +1 Small Log)"
+	name = "Double-Headed Greataxe, Steel (+2 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/greataxe/steel/doublehead
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/steel/billhook
-	name = "Billhook (+1 Small Log)"
+	name = "Billhook, Steel (+1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/spear/billhook
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/halberd
-	name = "Halberd (+1 Steel, +1 Small Log)"
+	name = "Halberd, Steel (+1 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/halberd
@@ -579,49 +588,49 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/steel/grandmace
-	name = "Grand Mace (+1 Steel, +1 Small Log)"
+	name = "Grand Mace, Steel (+1 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/mace/goden/steel
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/steel/partizan
-	name = "Partizan (+1 Steel, +1 Small Log)"
+	name = "Partizan, Steel (+1 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/spear/partizan
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/steel/naginata
-	name = "Naginata (+1 Big Log)"
+	name = "Naginata, Steel (+1 Big Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/grown/log/tree/) //looong spear
 	created_item = /obj/item/rogueweapon/spear/naginata
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/steel/boarspear
-	name = "Boar Spear (+1 Steel, +1 Small Log)"
+	name = "Boar Spear, Steel (+1 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/spear/boar
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/steel/lance
-	name = "Lance (+1 Steel, +1 Small Log)"
+	name = "Lance, Steel (+1 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/spear/lance
 	craftdiff = 4
 
 /datum/anvil_recipe/weapons/steel/tossblade
-	name = "Steel Tossblades 4x"
+	name = "Tossblade, Steel (x4)"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/steel
 	craftdiff = 0
 	createditem_num = 4
 
 /datum/anvil_recipe/weapons/steel/javelin
-	name = "2x Steel Javelin (+1 Small Log)"
+	name = "Javelin, Steel (+1 Small Log) (x2)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/ammo_casing/caseless/rogue/javelin/steel
@@ -629,27 +638,27 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/fishspear
-	name = "Fishing Spear (+1 Steel, +1 Small Log)"
+	name = "Fishing Spear, Steel (+1 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/fishspear
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/rhomphaia
-	name = "Rhomphaia (+1 Steel)"
+	name = "Rhomphaia, Steel (+1 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/sword/long/rhomphaia
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/falx
-	name = "Falx"
+	name = "Falx, Steel"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword/falx
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/steel/glaive
-	name = "Glaive (+2 Steel, +1 Small Log)"
+	name = "Glaive, Steel (+2 Steel, +1 Small Log)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/halberd/glaive
@@ -699,41 +708,41 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/silver/dagger
-	name = "Silver Dagger"
+	name = "Dagger, Silver"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/rogueweapon/huntingknife/idagger/silver
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/silver/sword
-	name = "Silver Sword (+1 Silver)"
+	name = "Sword, Silver (+1 Silver)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/ingot/silver)
 	created_item = /obj/item/rogueweapon/sword/silver
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/silver/waraxe
-	name = "Silver War Axe (+1 Silver, +1 Stick)"
+	name = "War Axe, Silver (+1 Silver, +1 Stick)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/ingot/silver, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/stoneaxe/woodcut/silver
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/silver/warhammer
-	name = "Silver War Hammer (+1 Silver, +1 Stick)"
+	name = "Warhammer, Silver (+1 Silver, +1 Stick)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/ingot/silver, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/rogueweapon/mace/silver
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/silver/tossblade
-	name = "Silver Tossblades 4x"
+	name = "Tossblades, Silver (x4)"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/psydon
 	craftdiff = 3
 	createditem_num = 4
 
 /datum/anvil_recipe/weapons/silver/javelin
-	name = "Silver Javelin (+1 Small Log)"
+	name = "Javelin, Silver (+1 Small Log)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/ammo_casing/caseless/rogue/javelin/silver
@@ -743,20 +752,20 @@
 // ------ BRONZE ------
 
 /datum/anvil_recipe/weapons/gladius
-	name = "Gladius"
+	name = "Gladius, Bronze"
 	req_bar = /obj/item/ingot/bronze
 	created_item = /obj/item/rogueweapon/sword/iron/short/gladius
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/bronze/spear
-	name = "Bronze Spear (+1 Bronze, +1 Small Log)"
+	name = "Spear, Bronze (+1 Bronze, +1 Small Log)"
 	req_bar = /obj/item/ingot/bronze
 	additional_items = list(/obj/item/ingot/bronze, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/spear/bronze
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/bronze/bronzeknuckle
-	name = "Bronze Knuckle"
+	name = "Knuckles, Bronze"
 	req_bar = /obj/item/ingot/bronze
 	created_item = /obj/item/rogueweapon/knuckles/bronzeknuckles
 	craftdiff = 2
@@ -770,14 +779,14 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/weapons/alloy/shield
-	name = "Decrepit Alloy Shield (+1 Alloy, +1 Cured Leather)"
+	name = "Shield, Decrepit (+1 Alloy, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/ingot/aalloy, /obj/item/natural/hide/cured)
 	created_item = /obj/item/rogueweapon/shield/tower/metal/alloy
 	craftdiff = 1
 
 /datum/anvil_recipe/weapons/alloy/shield
-	name = "Purified Alloy Shield (+1 Purified Alloy, +1 Cured Leather)"
+	name = "Shield, Ancient (+1 Purified Alloy, +1 Cured Leather)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/ingot/purifiedaalloy, /obj/item/natural/hide/cured)
 	created_item = /obj/item/rogueweapon/shield/tower/metal/palloy
@@ -798,7 +807,7 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/iron/roundshield
-	name = "Iron Shield (+1 Iron)"
+	name = "Shield, Iron (+1 Iron)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/ingot/iron)
 	created_item = /obj/item/rogueweapon/shield/iron
@@ -812,7 +821,7 @@
 	created_item = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 
 /datum/anvil_recipe/weapons/iron/bolts
-	name = "Crossbow Bolts 10x (+2 Stick)"
+	name = "Crossbow Bolts (+2 Stick) (x10)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/ammo_casing/caseless/rogue/bolt
@@ -820,7 +829,7 @@
 	i_type = "Ammo"
 
 /datum/anvil_recipe/weapons/aalloy/bolts
-	name = "Decrepit Crossbow Bolts 10x (+2 Stick)"
+	name = "Bolts, Decrepit (+2 Stick) (x10)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/ammo_casing/caseless/rogue/bolt/aalloy
@@ -828,7 +837,7 @@
 	i_type = "Ammo"
 
 /datum/anvil_recipe/weapons/paalloy/bolts
-	name = "Ancient Crossbow Bolts 10x (+2 Stick)"
+	name = "Bolts, Ancient (+2 Stick) (x10)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/grown/log/tree/stick, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/ammo_casing/caseless/rogue/bolt/paalloy
@@ -837,7 +846,7 @@
 
 /// BOWS
 /datum/anvil_recipe/weapons/iron/arrows
-	name = "Iron Broadhead Arrows 10x (+2 Stick)"
+	name = "Broadhead Arrows, Iron (+2 Stick) (x10)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list(/obj/item/grown/log/tree/stick, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/ammo_casing/caseless/rogue/arrow/iron
@@ -846,7 +855,7 @@
 	craftdiff = 1
 
 /datum/anvil_recipe/weapons/aalloy/arrows
-	name = "Decrepit Broadhead Arrows 10x (+2 Stick)"
+	name = "Broadhead Arrows, Decrepit (+2 Stick) (x10)"
 	req_bar = /obj/item/ingot/aalloy
 	additional_items = list(/obj/item/grown/log/tree/stick, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/ammo_casing/caseless/rogue/arrow/iron/aalloy
@@ -854,10 +863,8 @@
 	i_type = "Ammo"
 	craftdiff = 1
 
-
-
 /datum/anvil_recipe/weapons/steel/arrows
-	name = "Steel Bodkin Arrows 10x (+2 Stick)"
+	name = "Bodkin Arrows, Steel (+2 Stick) (x10)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/grown/log/tree/stick, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/ammo_casing/caseless/rogue/arrow/steel
@@ -866,7 +873,7 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/weapons/paalloy/arrows
-	name = "Ancient Bodkin Arrows 10x (+2 Stick)"
+	name = "Bodkin Arrows, Ancient (+2 Stick) (x10)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	additional_items = list(/obj/item/grown/log/tree/stick, /obj/item/grown/log/tree/stick)
 	created_item = /obj/item/ammo_casing/caseless/rogue/arrow/steel/paalloy
@@ -876,7 +883,7 @@
 
 /// SLINGS
 /datum/anvil_recipe/weapons/iron/slingbullets
-	name = "Iron Sling Bullets 10x"
+	name = "Sling Bullets, Iron (x10)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/ammo_casing/caseless/rogue/sling_bullet/iron
 	createditem_num = 10
@@ -884,7 +891,7 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/aalloy/slingbullets
-	name = "Decrepit Sling Bullets 10x"
+	name = "Sling Bullets, Decrepit (x10)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/ammo_casing/caseless/rogue/sling_bullet/aalloy
 	createditem_num = 10
@@ -892,7 +899,7 @@
 	craftdiff = 0
 
 /datum/anvil_recipe/weapons/paalloy/slingbullets
-	name = "Ancient Sling Bullets 10x"
+	name = "Sling Bullets, Ancient (x10)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/ammo_casing/caseless/rogue/sling_bullet/paalloy
 	createditem_num = 10
@@ -901,7 +908,7 @@
 
 //Rarity
 /datum/anvil_recipe/valuables/steel/execution
-	name = "Execution Sword (+1 Steel, +1 Iron)"
+	name = "Execution Sword, Steel (+1 Steel, +1 Iron)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/iron, /obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/sword/long/exe
@@ -915,22 +922,6 @@
 	additional_items = list(/obj/item/ingot/blacksteel, /obj/item/roguegem/ruby)
 	created_item = /obj/item/rogueweapon/sword/long/blackflamb
 	craftdiff = 5
-
-
-/datum/anvil_recipe/weapons/swarhammer
-	name = "Warhammer (+1 Steel)"
-	req_bar = /obj/item/ingot/steel
-	additional_items = list(/obj/item/ingot/steel)
-	created_item = /obj/item/rogueweapon/mace/warhammer/steel
-	craftdiff = 2
-	i_type = "Weapons"
-
-/datum/anvil_recipe/weapons/warhammer
-	name = "Warhammer (+1 Stick)"
-	req_bar = /obj/item/ingot/iron
-	additional_items = list(/obj/item/grown/log/tree/stick)
-	created_item = /obj/item/rogueweapon/mace/warhammer
-	i_type = "Weapons"
 
 //Church Weapons forged from Holy Steel
 

--- a/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
+++ b/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
@@ -30,14 +30,14 @@
 
 //Lockpicks and rings moved from blacksmithing, to fit with locks being engineered
 /datum/anvil_recipe/engineering/lockpicks
-	name = "Lockpicks x3"
+	name = "Lockpick (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/lockpick
 	createditem_num = 3
 	craftdiff = 2
 
 /datum/anvil_recipe/engineering/lockpickring
-	name = "Lockpickrings x3"
+	name = "Lockpickring (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/lockpickring
 	createditem_num = 3
@@ -54,21 +54,21 @@
 // --------- BRONZE RECIPES -----------
 
 /datum/anvil_recipe/engineering/bronze/locks
-	name = "Lock 2x"
+	name = "Lock (x2)"
 	req_bar = /obj/item/ingot/bronze
 	created_item = /obj/item/customlock
 	createditem_num = 2
 	craftdiff = 1
 
 /datum/anvil_recipe/engineering/bronze/keys
-	name = "Keys 2x"
+	name = "Key (x2)"
 	req_bar = /obj/item/ingot/bronze
 	created_item = /obj/item/customblank
 	createditem_num = 2
 	craftdiff = 1
 
 /datum/anvil_recipe/engineering/bronze/cog
-	name = "Cog 2x"
+	name = "Cog (x2)"
 	req_bar = /obj/item/ingot/bronze
 	created_item = /obj/item/roguegear
 	createditem_num = 2
@@ -82,7 +82,7 @@
 	craftdiff = 1
 
 /datum/anvil_recipe/engineering/bronze/lamptern
-	name = "Bronze Lamptern 3x"
+	name = "Lamptern, Bronze (x3)"
 	req_bar = /obj/item/ingot/bronze
 	created_item = /obj/item/flashlight/flare/torch/lantern/bronzelamptern
 	createditem_num = 3
@@ -125,7 +125,7 @@
 	craftdiff = 5
 
 /datum/anvil_recipe/engineering/bronze/headhook
-	name = "Bronze Headhook (+2 Fibers)"
+	name = "Headhook, Bronze (+2 Fibers)"
 	req_bar = /obj/item/ingot/bronze
 	created_item = /obj/item/storage/hip/headhook/bronze
 	additional_items = list(/obj/item/natural/fibers = 2)

--- a/modular/code/modules/crafting/lewd/dildo_crafting.dm
+++ b/modular/code/modules/crafting/lewd/dildo_crafting.dm
@@ -4,28 +4,28 @@
 	reqs = list(/obj/item/grown/log/tree/small = 1)
 
 /datum/anvil_recipe/iron_dildo
-	name = "Iron dildo 3x"
+	name = "Dildo, Iron (x3)"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/dildo/iron
 	createditem_num = 3
 	i_type = "Utilities"
 
 /datum/anvil_recipe/steel_dildo
-	name = "Steel dildo 3x"
+	name = "Dildo, Steel (x3)"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/dildo/steel
 	createditem_num = 3
 	i_type = "Utilities"
 
 /datum/anvil_recipe/silver_dildo
-	name = "Silver dildo 3x"
+	name = "Dildo, Silver (x3)"
 	req_bar = /obj/item/ingot/silver
 	created_item = /obj/item/dildo/silver
 	createditem_num = 3
 	i_type = "Utilities"
 
 /datum/anvil_recipe/gold_dildo
-	name = "Golden dildo 3x"
+	name = "Dildo, Gold (x3)"
 	req_bar = /obj/item/ingot/gold
 	created_item = /obj/item/dildo/gold
 	createditem_num = 3


### PR DESCRIPTION
## About The Pull Request

Removes the Pulaski axe from the smithing menu; it's a merc weapon, which we've been pushing more and more to be unique to the class, as far as I can tell. I know it's still in the Merchant menu, but that's Ansari's domain and I'm just the balancejak.

This also redoes every single smithing recipe to use a unified naming scheme. Every item should obey the naming scheme of 'Item, material (bonus materials) (quantity), with sparing exceptions where I felt it wasn't necessary(i.e. we only have one kind of Grappler)

## Testing Evidence

Compiles, checked through every ingot recipe in the game, forgot to record it, closed the test window. MB.

## Why It's Good For The Game

Smithing is hard enough. Now you can use 'G' to find 'gorget', no matter what you're making it out of. Yes, even my hated enemy, the steel gorget.