### PR TITLE
Mantrapcraftchange

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -211,8 +211,8 @@
 /datum/crafting_recipe/roguetown/survival/mantrap
 	name = "mantrap"
 	result = list(
-		/obj/item/restraints/legcuffs/beartrap,
-		/obj/item/restraints/legcuffs/beartrap,
+		/obj/item/restraints/legcuffs/beartrap/crafted,
+		/obj/item/restraints/legcuffs/beartrap/crafted,
 		)
 	reqs = list(
 		/obj/item/grown/log/tree/small = 1,


### PR DESCRIPTION
## About The Pull Request

In the beartrap item file, it specifically requests that if mantraps ever be made craftable, it instead uses this version: It has not. I have no clue when mantraps were actually MADE craftable- Can't find the PR, so due to not being able to confirm if this is purposeful I am correcting it.

## Testing Evidence

Loaded up, took some cool screenies, confirmed the description is the new one:
<img width="793" height="548" alt="testim1" src="https://github.com/user-attachments/assets/17fea2a7-3bf6-4f8f-baf0-fda5c3ca109c" />
<img width="342" height="118" alt="testim2" src="https://github.com/user-attachments/assets/1b776c32-5538-42c8-a3f8-b4eebab38e0a" />
I also tested to make sure the Rusty tag actually worked by stepping in a crafted mantrap 20 times, and it did not break, so it does appear that tag actually does something.


## Why It's Good For The Game

One it's marked down in the folder so I assume it was wanted at some point millennia ago. Two it'll make it so when you craft a mantrap it no longer has examine text explaining to you that you've just created an already incredibly rusted mantrap.
The third one is technically a MAJOR BALANCE CHANGE: The rusty tag is removed so I guess the crafted mantraps won't break after two uses anymore.
