### PR TITLE
Comments out blur eyes in eora's curse, client culling bug

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -94,7 +94,7 @@
 		target.apply_status_effect(/datum/status_effect/buff/druqks)
 		target.apply_status_effect(/datum/status_effect/buff/drunk)
 		target.visible_message("<span class='info'>A purple haze shrouds [target]!</span>", "<span class='notice'>I feel much calmer.</span>")
-		target.blur_eyes(10)
+		//target.blur_eyes(10)
 		return TRUE
 	revert_cast()
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Report of Eora's curse causing BYOND client failure, reproduced on local on my machine. Seems to be an interaction between druqks/on_apply() and blur_eyes, will need some time to make them play nice again. But for now just removes the blur from the Eora spell so that it isn't a possible client nuke.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
