### PR TITLE
Balance: removes duke's blacksteel lootdrop for regents. Blacksteel armor set now spawns only on duke's spawn.

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -21335,15 +21335,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "gOQ" = (
-/obj/structure/closet/crate/roguecloset/lord,
-/obj/item/rogueweapon/sword/long/judgement,
-/obj/item/clothing/wrists/roguetown/bracers,
-/obj/item/storage/belt/rogue/leather/steel/tasset,
-/obj/item/clothing/gloves/roguetown/blacksteel/modern/plategloves,
-/obj/item/clothing/head/roguetown/helmet/blacksteel/modern/armet,
-/obj/item/clothing/shoes/roguetown/boots/blacksteel/modern/plateboots,
-/obj/item/clothing/suit/roguetown/armor/plate/modern/blacksteel_full_plate,
-/obj/item/clothing/under/roguetown/platelegs/blacksteel/modern,
+/obj/structure/closet/crate/roguecloset/lord/duke_preset,
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "gOR" = (

--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -1,0 +1,3 @@
+
+/// Called when SSticker's var/rulermob is set.
+#define COMSIG_TICKER_RULERMOB_SET "ticker_rulermob_set"

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -747,3 +747,12 @@ SUBSYSTEM_DEF(ticker)
 	update_everything_flag_in_db()
 
 	text2file(login_music, "data/last_round_lobby_music.txt")
+
+/// Wrapper for setting rulermob and rulertype
+/datum/controller/subsystem/ticker/proc/set_ruler_mob(mob/newruler)
+	rulermob = newruler
+	if(should_wear_femme_clothes(rulermob))
+		SSticker.rulertype = "Grand Duchess"
+	else
+		SSticker.rulertype = "Grand Duke"
+	SEND_GLOBAL_SIGNAL(COMSIG_TICKER_RULERMOB_SET, rulermob)

--- a/code/game/objects/structures/crates_lockers/roguetown.dm
+++ b/code/game/objects/structures/crates_lockers/roguetown.dm
@@ -180,3 +180,35 @@
 	else
 		base_icon_state = "drawer1"
 		pixel_y = 8
+/**
+ * Closet preset for the duke ().
+ * When opened for the first time by the ruler mob - spawns the blacksteel armor set.
+ * Done to prevent nobles taking regency just to loot blacksteel
+*/
+/obj/structure/closet/crate/roguecloset/lord/duke_preset
+	desc = "Covered in strange runic symbols that seem to pulse with some sort of energy in the dark."
+	/// Set to TRUE after it has spawned the gear.
+	var/has_spawned_gear = FALSE
+
+/obj/structure/closet/crate/roguecloset/lord/duke_preset/Initialize()
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_TICKER_RULERMOB_SET, PROC_REF(spawn_blacksteel))
+
+/obj/structure/closet/crate/roguecloset/lord/duke_preset/Destroy()
+	UnregisterSignal(SSdcs, COMSIG_TICKER_RULERMOB_SET)
+	return ..()
+
+/obj/structure/closet/crate/roguecloset/lord/duke_preset/proc/spawn_blacksteel(mob/living/user)
+	if(has_spawned_gear)
+		return
+
+	new /obj/item/rogueweapon/sword/long/judgement(get_turf(src))
+	new /obj/item/clothing/wrists/roguetown/bracers(get_turf(src))
+	new /obj/item/storage/belt/rogue/leather/steel/tasset(get_turf(src))
+	new /obj/item/clothing/gloves/roguetown/blacksteel/modern/plategloves(get_turf(src))
+	new /obj/item/clothing/head/roguetown/helmet/blacksteel/modern/armet(get_turf(src))
+	new /obj/item/clothing/shoes/roguetown/boots/blacksteel/modern/plateboots(get_turf(src))
+	new /obj/item/clothing/suit/roguetown/armor/plate/modern/blacksteel_full_plate(get_turf(src))
+	new /obj/item/clothing/under/roguetown/platelegs/blacksteel/modern(get_turf(src))
+	has_spawned_gear = TRUE
+	close()

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -146,11 +146,7 @@
 		//Coronate new King (or Queen)
 		HU.mind.assigned_role = "Grand Duke"
 		HU.job = "Grand Duke"
-		if(should_wear_femme_clothes(HU))
-			SSticker.rulertype = "Grand Duchess"
-		else
-			SSticker.rulertype = "Grand Duke"
-		SSticker.rulermob = HU
+		SSticker.set_ruler_mob(HU)
 		SSticker.regentmob = null
 		var/dispjob = mind.assigned_role
 		removeomen(OMEN_NOLORD)

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -51,11 +51,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 			GLOB.lordsurname = jointext(chopped_name, " ")
 		else
 			GLOB.lordsurname = "of [L.real_name]"
-		SSticker.rulermob = L
-		if(should_wear_femme_clothes(L))
-			SSticker.rulertype = "Grand Duchess"
-		else
-			SSticker.rulertype = "Grand Duke"
+		SSticker.set_ruler_mob(L)
 		to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is [SSticker.rulertype] of Azure Peak.</span></span></b>")
 		if(istype(SSticker.regentmob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/regentbuddy = SSticker.regentmob

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -142,6 +142,7 @@
 #include "code\__DEFINES\customization\sprite_accessory.dm"
 #include "code\__DEFINES\dcs\flags.dm"
 #include "code\__DEFINES\dcs\helpers.dm"
+#include "code\__DEFINES\dcs\signals\signals_global.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob.dm"
 #include "code\__DEFINES\dcs\signals\signals_movable.dm"
 #include "code\__DEFINES\dcs\signals\signals_objectives.dm"


### PR DESCRIPTION
## About The Pull Request

I couldn't help but notice *obnoxious* behavior when nobles assume regency and bunnyhop to loot blacksteel drip.
While Duke's blacksteel armor is *awesome* and lets them lead their soldiers in appropriate drip... This whole "guaranteed lootdrop for regents" situation is kinda bleak. Either you roll duke and drip, or you do not get duke's drip.

A solution: subtype of closet that subscribes to ``COMSIG_TICKER_RULERMOB_SET`` and spawns blacksteel on demand. This demand being Duke's spawn - be it roundstart or latejoin.

Also, I added a wrapper to set ``rulermob`` and ``rulertype`` directly in ticker. Both those variables were directly assigned from duke job code and priest coronation. Less duplicate code is better. 

## Testing Evidence

Works, here are breakpoints so you will believe me.

<img width="411" height="145" alt="image" src="https://github.com/user-attachments/assets/d405b0d8-0561-443d-aab8-e390d9e51dc9" />


<img width="2287" height="953" alt="image" src="https://github.com/user-attachments/assets/4651f715-30d6-4e42-9394-46a41c74106c" />

## Why It's Good For The Game

Players are already discouraged from raiding places whose owner is not here. Therefore, no thieves will be harmed by this PR.
This will completely remove situations when a court role assumes duties of the regent only to loot blacksteel armor.

