### PR TITLE
Fixes tracking bug in Radiant

### DIFF
--- a/code/modules/roguetown/roguemachine/questing/questing_landmarks.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_landmarks.dm
@@ -100,6 +100,7 @@
 		new_mob.faction |= "quest"
 		new_mob.AddComponent(/datum/component/quest_object, quest)
 		add_quest_faction_to_nearby_mobs(spawn_turf)
+		quest.add_tracked_atom(new_mob)
 		sleep(1)
 
 /obj/effect/landmark/quest_spawner/proc/add_quest_faction_to_nearby_mobs(turf/center)

--- a/code/modules/roguetown/roguemachine/questing/questing_landmarks.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_landmarks.dm
@@ -121,11 +121,13 @@
 	var/list/possible_turfs = list()
 
 	for(var/turf/open/T in view(7, selected_landmark))
-		if(!T.density)
-			for(var/mob/M in view(9, T))
-				if(!M.ckey)
-					possible_turfs += T
-					break
+		if(T.density || istransparentturf(T))
+			continue
+
+		for(var/mob/M in view(9, T))
+			if(!M.ckey)
+				possible_turfs += T
+				break
 
 	return length(possible_turfs) ? pick(possible_turfs) : get_turf(src)
 


### PR DESCRIPTION
## About The Pull Request

Forgot to add kill mobs in the tracked atoms list, therefore compass was tripping and not showing direction to anything.

Also removes levitating skeletons from Radiant.

## Testing Evidence

Tested, works, trust me. 

## Why It's Good For The Game

I think I need those bugs fixed.