### PR TITLE
Bandits/wretches can no longer claim bounties

### DIFF
--- a/code/modules/roguetown/roguemachine/bounty.dm
+++ b/code/modules/roguetown/roguemachine/bounty.dm
@@ -319,6 +319,16 @@
 	var/mob/living/carbon/human/M = null
 	for(var/l in buckled_mobs)
 		M = l
+		if(HAS_TRAIT(A, TRAIT_OUTLAW))
+			var/def_zone = "[(A.active_hand_index == 2) ? "r" : "l" ]_arm"
+			playsound(A, 'sound/combat/hits/bladed/genstab (1).ogg', 100, FALSE, -1)
+			loc.visible_message(span_warning("The castifico snaps at [A]'s hand!"))
+			to_chat(A, span_danger("The machine wants YOU!"))
+			A.flash_fullscreen("redflash3")
+			A.Stun(10)
+			A.apply_damage(10, BRUTE, def_zone)
+			A.emote("whimper")
+			return
 	if(!ismob(M))
 		say("Cannot begin skull structure analysis without a subject buckled to the Castifico.")
 		playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)


### PR DESCRIPTION
## About The Pull Request

Quick exploit patch from Scarlet Reach ( https://github.com/Scarlet-Reach/Scarlet-Reach/pull/249 )

Prevents anyone with the outlaw trait from claiming bounties. This stops bandits/wretches from cheesing the system by claiming their own bounty and/or claiming eachother's bounties only to immediately go remove the mask.

## Testing Evidence

Spawned in and tested, seems to work fine.

<img width="280" height="104" alt="image" src="https://github.com/user-attachments/assets/ec8e9d52-93fc-42aa-81d2-cb9dd0bc8188" />

## Why It's Good For The Game

Patches an easy potential exploit.

Doesn't port any of the other stuff from the linked PR; though if nobody else gets around to it I'll probably give the Hoardmaster a look-over sooner or later. There's currently a few infinite-favor exploits that should probably be patched out.