### PR TITLE
Splitting the Silverface + Death of MPP

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -6076,6 +6076,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"bUo" = (
+/obj/structure/roguemachine/goldface/public/smith,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/outdoors/town)
 "bUr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -22639,6 +22643,10 @@
 /obj/structure/wild_plant/nospread/manabloom,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/magician)
+"hld" = (
+/obj/structure/roguemachine/goldface/public/tailor,
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town)
 "hlg" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -266949,7 +266957,7 @@ xfp
 xfp
 exD
 wRJ
-cDX
+hld
 uBc
 bKS
 hDX
@@ -270097,8 +270105,8 @@ eMe
 smL
 smL
 vgn
-qKs
-eBq
+bUo
+sns
 sns
 sns
 cDX

--- a/code/modules/cargo/packsrogue/_pack.dm
+++ b/code/modules/cargo/packsrogue/_pack.dm
@@ -12,8 +12,6 @@
 	var/crate_type = /obj/structure/closet/crate
 	var/no_name_quantity = FALSE // If TRUE, do not display the name as "[Name] x [Amount]".
 	var/not_in_public = FALSE // If true, this pack will not be listed in the public goldface.
-	var/mandated_public_profit = 0 // If set, this pack will always additional cost this much percentage on top of the base cost when in the public vendor. All of the forced profit
-	// Goes to the merchant in stored profit. It cannot be changed nor set by the merchant in anyway to avoid players seeing the merchant as the enemy.
 	var/dangerous = FALSE // Should we message admins?
 	var/special = FALSE //Event/Station Goals/Admin enabled packs
 	var/special_enabled = FALSE

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
@@ -48,8 +48,7 @@
 
 /datum/supply_pack/rogue/armor_iron/fullplate
 	name = "Full Plate"
-	cost = 115 // Uhhh I don't think I should be selling them for 80
-	mandated_public_profit = 1 // Just slap a 100% profit margin on top
+	cost = 220 // Uhhh I don't think I should be selling them for 80
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/full/iron)
 
 /datum/supply_pack/rogue/armor_iron/rearbraces

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
@@ -8,7 +8,6 @@
 /datum/supply_pack/rogue/armor_steel
 	group = "Armor (Steel)"
 	crate_name = "merchant guild's crate"
-	mandated_public_profit = 1 // 100% Mandatory Profit Margin on top
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
 // Steel Armor Section. Massive selection here so I am not going to include everything
@@ -34,12 +33,12 @@
 
 /datum/supply_pack/rogue/armor_steel/fullplate
 	name = "Full Plate"
-	cost = 180 // 4 Steel, 1 Cured Leather 
+	cost = 350 // 4 Steel, 1 Cured Leather - x2 cuz it is the best armor
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/full)
 
 /datum/supply_pack/rogue/armor_steel/fullplate_fluted
 	name = "Full Plate, Fluted"
-	cost = 210 // 4 Steel, 1 Iron, 1 Cured Leather
+	cost = 380 // 4 Steel, 1 Iron, 1 Cured Leather - x2 cuz it is the best armor
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/full/fluted)
 
 /datum/supply_pack/rogue/armor_steel/coatplates

--- a/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_gems.dm
@@ -2,7 +2,6 @@
 /datum/supply_pack/rogue/gems
 	group = "Gems"
 	crate_name = "merchant guild's crate"
-	mandated_public_profit = 1 // 100% Mandatory Profit Margin on top
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
 /datum/supply_pack/rogue/gems/amethyst

--- a/code/modules/cargo/packsrogue/merchant/merchant_potions.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_potions.dm
@@ -5,7 +5,6 @@
 /datum/supply_pack/rogue/potions
 	group = "Potions"
 	crate_name = "merchant guild's crate"
-	mandated_public_profit = 0.5 // 50% Mandatory Profit Margin on top. Let's not make it too expensive for lowpop.
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
 //Only two since that's 4 uses total; two sips each. You only need one sip for cure.

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
@@ -2,7 +2,6 @@
 /datum/supply_pack/rogue/merc_weapons
 	group = "Weapons (Foreign)"
 	crate_name = "merchant guild's crate"
-	mandated_public_profit = 1 // 100% Mandatory Profit Margin on top
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
 /datum/supply_pack/rogue/merc_weapons/saildagger

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
@@ -3,7 +3,6 @@
 /datum/supply_pack/rogue/steel_weapons
 	group = "Weapons (Steel)"
 	crate_name = "merchant guild's crate"
-	mandated_public_profit = 1 // 100% Mandatory Profit Margin on top
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
 /datum/supply_pack/rogue/steel_weapons/dagger

--- a/code/modules/roguetown/roguemachine/merchant/goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/goldface.dm
@@ -62,11 +62,57 @@
 	extra_fee = 0.5
 	is_public = TRUE
 	locked = FALSE
+	categories = list(
+		"Adventuring Supplies",
+		"Alcohols",
+		"Consumable",
+		"Gems",
+		"Instruments",
+		"Luxury",
+		"Livestock",
+		"Perfumes",
+		"Raw Materials",
+		"Seeds",
+		"Tools",
+		"Weapons (Foreign)",
+	)
+	categories_gamer = list()
 
 /obj/structure/roguemachine/goldface/public/examine()
 	. = ..()
 	. += "<span class='info'>A public version of the GOLDFACE. The guild charges a hefty fee for its usage. When locked, can be used to browse the inventory a merchant has.</span>"
-	. += "<span class='info'>An agreement between the Azurean Guild of Crafts and the Merchant's Guild mandates 100% extra profits on certain protected categories such as gems and steel gears when automated. And 50% on potions.</span>"
+	. += "<span class='info'>An agreement between the Guild of Craft and the Merchant's Guild mandates that certain protected goods are sold in a separate vendor that can be locked by the guildmembers.</span>"
+	. += "<span class='info'>The vendor can be locked by a key. The merchant make no profit whatsoever from the public vendor as the guild charges an exorbitant markup for automated handling.</span>"
+
+/obj/structure/roguemachine/goldface/public/smith
+	name = "Smithy's SILVERFACE"
+	lockid = "crafterguild"
+	categories = list(
+		"Armor (Iron)",
+		"Armor (Steel)",
+		"Weapons (Ranged)",
+		"Weapons (Iron and Shields)",
+		"Weapons (Steel)",
+	)
+	categories_gamer = list()
+
+/obj/structure/roguemachine/goldface/public/smith/examine()
+	. = ..()
+	. += span_info("This can be locked by a Guild's key")
+
+/obj/structure/roguemachine/goldface/public/tailor
+	name = "Tailor's SILVERFACE"
+	lockid = "tailor"
+	categories = list(
+		"Apparel",
+		"Wardrobe",
+		"Armor (Light)",
+	)
+	categories_gamer = list()
+
+/obj/structure/roguemachine/goldface/public/smith/examine()
+	. = ..()
+	. += span_info("This can be locked by a Tailor's key")
 
 /obj/structure/roguemachine/goldface/Initialize()
 	. = ..()

--- a/code/modules/roguetown/roguemachine/merchant/goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/goldface.dm
@@ -55,7 +55,6 @@
 	)
 	var/is_public = FALSE // Whether it is a public access vendor.
 	var/extra_fee = 0 // Extra Guild Fees on purchases. Meant to make publicface very unprofitable.
-	var/stored_profit = 0 // Stored profit from the public vendor.
 
 /obj/structure/roguemachine/goldface/public
 	name = "SILVERFACE"
@@ -110,7 +109,7 @@
 	)
 	categories_gamer = list()
 
-/obj/structure/roguemachine/goldface/public/smith/examine()
+/obj/structure/roguemachine/goldface/public/tailor/examine()
 	. = ..()
 	. += span_info("This can be locked by a Tailor's key")
 
@@ -169,17 +168,12 @@
 			return
 		var/datum/supply_pack/PA = SSmerchant.supply_packs[path]
 		var/cost = PA.cost + PA.cost * extra_fee
-		var/mandated_public_profit = is_public ? PA.cost * PA.mandated_public_profit : 0
 		var/tax_amt = round(SStreasury.tax_value * PA.cost)
-		if(is_public)
-			cost = cost + mandated_public_profit
 		if(!(upgrade_flags & UPGRADE_NOTAX))
 			cost = cost + tax_amt
 		cost = round(cost)
 		if(budget >= cost)
 			budget -= cost
-			if(mandated_public_profit)
-				stored_profit += mandated_public_profit
 			if(!(upgrade_flags & UPGRADE_NOTAX))
 				SStreasury.give_money_treasury(tax_amt, "goldface import tax")
 				record_featured_stat(FEATURED_STATS_TAX_PAYERS, human_mob, tax_amt)
@@ -205,9 +199,6 @@
 			var/mob/living/carbon/human/H = usr
 			if(!(H.job in list("Merchant","Shophand")))
 				return // Only merchants and shophands can withdraw profit. I see you href hacker
-			if(stored_profit > 0)
-				budget2change(stored_profit, usr)
-				stored_profit = 0
 	if(href_list["secrets"])
 		var/list/options = list()
 		if(upgrade_flags & UPGRADE_NOTAX)
@@ -254,9 +245,6 @@
 				contents += "<a href='?src=[REF(src)];secrets=1'>Secrets</a>"
 			else
 				contents += "<a href='?src=[REF(src)];secrets=1'>[stars("Secrets")]</a>"
-		else
-			contents += "<a href='?src=[REF(src)];withdrawgain=1'>Stored Profits:</a> [stored_profit]<BR>"
-
 	contents += "</center><BR>"
 
 	if(current_cat == "1")
@@ -284,8 +272,6 @@
 				pax += PA
 		for(var/datum/supply_pack/PA in sortNames(pax))
 			var/costy = PA.cost + PA.cost * extra_fee
-			if(is_public)
-				costy = costy + PA.cost * PA.mandated_public_profit
 			if(!(upgrade_flags & UPGRADE_NOTAX))
 				costy = costy + round(SStreasury.tax_value * PA.cost)
 			costy = round(costy)


### PR DESCRIPTION
## About The Pull Request

### Splitting up the Silverface:
-  Splitting up Tailor's Silverface (Apparel, Wardrobe and Light Armor). Now they can lock it to protect their own job if they wish.
- Splitting up most Metallic gears (excluding foreign weapons) away from the Merchant's Silverface to Smithy's Silverface. Lockable by Crafter's Guild key.

### Death of Mandated Public Profit
- Mandated Public Profit was a mechanic implemented to deal with some **very** strong wording certain very vocal players had for me as a compromise to avoid removing steel gears entirely from the Silverface. It was concurrent w/ a massive raise in the base price I used for steel armor ingot to 40 + 1.25x which made them pretty damn hard to afford for anyone but Roguetown Georg who speedrun a dungeon
- I removed the MPP variable and any effects it had. Steel Armor and Gears still remain quite expensive due to the formula I used but not extremely ridiculously so.
- To avoid Gamer Issues, Iron Full Plate and Steel Full Plate specifically have their base price 2x as I realized allowing merchant to cheaply armor everyone in the best chest armor wasn't a good idea nor was it worth snowflaking something for. If you want your no / less interaction full plate you still need a lot of money. Everything else is fine

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="728" height="496" alt="StrongDMM_7HNFCoUGZo" src="https://github.com/user-attachments/assets/b7e309e5-0f16-4d02-b311-2be65edb81b8" />
<img width="327" height="316" alt="StrongDMM_hXeTdMDzdO" src="https://github.com/user-attachments/assets/3fe8e276-4e14-4a20-ad55-1e97c0112f1c" />
<img width="251" height="401" alt="wg7W7eC4e7" src="https://github.com/user-attachments/assets/d906055b-1ebf-43a6-b158-47ee0fb7991a" />
<img width="251" height="401" alt="5cPRs2eKjy" src="https://github.com/user-attachments/assets/f3c5be5b-b41f-44a6-91b7-4ee16ecce9e7" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Allow Silverface to remain a money sink in the economy and a replacement for when roles isn't here, while allowing roles that join in to remove a no interaction alternative to them.
- Smith now can use it as a menu so people know better what they can order.
- Remove the MPP variable and just specifically hammer the price of Full Plate because literally 90% of the people advocating the hardest moved to another server so that steel gears are no longer ridiculously unaffordable (who am I kidding it is still unaffordable)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
