### PR TITLE
Fixes for Ruma Clan lenticular tattoos

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -73,6 +73,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/body_parts_covered = 0 //see setup.dm for appropriate bit flags
 	var/body_parts_covered_dynamic = 0
 	var/body_parts_inherent	= 0 //bodypart coverage areas you cannot peel off because it wouldn't make any sense (peeling chest off of torso armor, hands off of gloves, head off of helmets, etc)
+	var/surgery_cover = TRUE // binary, whether this item is considered covering its bodyparts in respect to surgery. Tattoos, etc. are false. 
 	var/gas_transfer_coefficient = 1 // for leaking gas from turf to mask and vice-versa (for masks right now, but at some point, i'd like to include space helmets)
 	var/permeability_coefficient = 1 // for chemicals/diseases
 	var/siemens_coefficient = 1 // for electrical admittance/conductance (electrocution checks and shit)

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -596,6 +596,8 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	allowed_race = NON_DWARVEN_RACE_TYPES
+	flags_inv = null //free the breast
+	surgery_cover = FALSE // cauterize and surgery through it.
 
 /obj/item/clothing/suit/roguetown/shirt/easttats/easttats/dropped(mob/living/carbon/human/user)
 	. = ..()

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -116,7 +116,7 @@
 				if(grab.sublimb_grabbed == location)
 					return TRUE
 		for(var/obj/item/equipped_item in carbon_victim.get_equipped_items(include_pockets = FALSE, include_beltslots = FALSE))
-			if(zone2covered(location, equipped_item.body_parts_covered))
+			if(equipped_item.surgery_cover && zone2covered(location, equipped_item.body_parts_covered))
 				return FALSE
 		if(ishuman(carbon_victim))
 			var/mob/living/carbon/human/human_victim = carbon_victim

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -116,7 +116,7 @@
 				if(grab.sublimb_grabbed == location)
 					return TRUE
 		for(var/obj/item/equipped_item in carbon_victim.get_equipped_items(include_pockets = FALSE, include_beltslots = FALSE))
-			if(equipped_item.surgery_cover && zone2covered(location, equipped_item.body_parts_covered))
+			if(zone2covered(location, equipped_item.body_parts_covered) && equipped_item.surgery_cover)
 				return FALSE
 		if(ishuman(carbon_victim))
 			var/mob/living/carbon/human/human_victim = carbon_victim


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Ruma clan lenticular tattoos have a couple collisions with not drawing breast layer and preventing surgery on arms. This PR handles both of those issues.

New surgery_cover var on obj/item, very expensive, very decadent. Puts check in /proc/get_location_accessible, which from my cursory inspection is only otherwise used for naughty verbs, so no surprises there.

## Testing Evidence

https://github.com/user-attachments/assets/9b0ad1b8-7283-4ea1-bf38-a955d731ee23


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

It makes sense?
