### PR TITLE
Allows Psydonite heirs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -21,7 +21,6 @@
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'
-	allowed_patrons = NON_PSYDON_PATRONS		//Same reason as lord. See Lord.
 
 
 /datum/job/roguetown/prince/after_spawn(mob/living/H, mob/M, latejoin)


### PR DESCRIPTION
## About The Pull Request

Simply nixes the Psydon lock that was added a hot minute ago for Lords and Princes, but only removed for Lords back in #2547.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

i actually did test it but i forgot to take the screenie uwaaaaaaaah
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

i actually fucking hate psydonites in the keep but it's an oversight

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
