### PR TITLE
Midround injection antag: refurbished death knight

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -429,7 +429,6 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_GUILDSMASTER 	"CAT_GUILDSMASTER"	// Guildsmaster class - Handles Guildsmaster class selector 
 #define CTAG_GUILDSMEN 		"CAT_GUILDSMEN"		// Guildsmen class - Handles Guildsmen class selector
 #define CTAG_NIGHTMAIDEN	"CAT_NIGHTMAIDEN"	// Bathhouse Attendant's aesthetic choices.
-
 /*
 	Defines for the triumph buy datum categories
 */

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -17,6 +17,7 @@
 #define ROLE_LICH				"Lich"
 #define ROLE_ASCENDANT			"Ascendant"
 #define ROLE_WRETCH				"Wretch"
+#define ROLE_UNBOUND_DEATHKNIGHT "Unbound Death Knight"
 
 #define ROLE_SYNDICATE			"Syndicate"
 #define ROLE_TRAITOR			"Traitor"

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -74,6 +74,7 @@
 #define SPAN_AAVNIC "aavnic"
 #define SPAN_UNDEAD "undead" //nyi but file found
 #define SPAN_CAT "cat"		 //nyi but file found
+#define SPAN_PULSEDEATH "pulsedeath"
 
 //bitflag #defines for return value of the radio() proc.
 #define ITALICS 1

--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -22,8 +22,8 @@
 #define POLL_IGNORE_ACADEMY_WIZARD			"academy_wizard"
 #define POLL_IGNORE_NECROMANCER_SKELETON	"necromancer_skeleton"
 #define POLL_IGNORE_LICH_SKELETON			"lich_skeleton"
-#define POLL_IGNORE_MAGE_SUMMON "mage_summon"
-
+#define POLL_IGNORE_MAGE_SUMMON             "mage_summon"
+#define POLL_IGNORE_DEATHKNIGHT_TARGET      "deathknight_target"
 
 GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_SENTIENCE_POTION = "Sentience potion",

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -259,7 +259,7 @@
 									"Antagonist Positions" = list(ROLE_MANIAC, ROLE_WEREWOLF,
 									ROLE_VAMPIRE, ROLE_NBEAST, ROLE_BANDIT,
 									ROLE_DELF, ROLE_PREBEL, ROLE_ASPIRANT,
-									ROLE_LICH, ROLE_ASCENDANT, ROLE_WRETCH))
+									ROLE_LICH, ROLE_ASCENDANT, ROLE_WRETCH, ROLE_UNBOUND_DEATHKNIGHT))
 		for(var/department in long_job_lists)
 			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' onClick='toggle_checkboxes(this, \"_com\")'>[department]</label><div class='content'>"
 			break_counter = 0

--- a/code/modules/antagonists/roguetown/villain/unbound_deathknight.dm
+++ b/code/modules/antagonists/roguetown/villain/unbound_deathknight.dm
@@ -1,0 +1,234 @@
+/datum/antagonist/unbound_death_knight
+	name = "Unbound Death Knight"
+	roundend_category = "Unbound Death Knight"
+	antagpanel_category = "Unbound Death Knight"
+	job_rank = ROLE_UNBOUND_DEATHKNIGHT
+	confess_lines = list(
+		"I WILL LIVE ETERNAL!",
+		"YOU CANNOT KILL ME!",
+		"I AM ALREADY DEAD YOU MORON!"
+	)
+	rogue_enabled = TRUE
+
+/datum/antagonist/unbound_death_knight/on_gain()
+	. = ..()
+	skeletonize()
+	equip_knight()
+	forge_objectives()
+
+/// Skeletonizes the owner, making it a skeleton. Separate proc in hopes that someone will remove duplicate skelecode from AP.
+/datum/antagonist/unbound_death_knight/proc/skeletonize()
+	var/mob/living/carbon/human/L = owner.current
+	QDEL_NULL(L.charflaw)
+	L.hairstyle = "Bald"
+	L.facial_hairstyle = "Shaved"
+	L.mob_biotypes = MOB_UNDEAD
+	var/obj/item/organ/eyes/eyes = L.getorganslot(ORGAN_SLOT_EYES)
+	if (eyes)
+		eyes.Remove(L, TRUE)
+		QDEL_NULL(eyes)
+	eyes = new /obj/item/organ/eyes/night_vision/zombie
+	eyes.Insert(L)
+	for(var/obj/item/bodypart/B in L.bodyparts)
+		B.skeletonize(FALSE)
+	L.base_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, /datum/intent/simple/claw)
+	L.update_a_intents()
+
+	L.update_body()
+	L.update_hair()
+	L.update_body_parts(redraw = TRUE)
+
+	ADD_TRAIT(L, TRAIT_NOMOOD, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_INFINITE_STAMINA, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_NOHUNGER, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_NOBREATH, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_NOPAIN, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_TOXIMMUNE, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_NOSLEEP, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_SHOCKIMMUNE, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(L, TRAIT_ARCYNE_T2, TRAIT_GENERIC)
+
+/datum/antagonist/unbound_death_knight/proc/equip_knight()
+	owner.unknow_all_people()
+	for (var/datum/mind/MF in get_minds())
+		owner.become_unknown_to(MF)
+
+	var/mob/living/carbon/human/H = owner.current
+	H.cmode_music = 'sound/music/combat_heretic.ogg' // TODO: Воланд Игорь Корнелюк а не этот ужас.
+	H.faction = list("undead")
+	H.equipOutfit(/datum/outfit/job/roguetown/unbound_deathknight)
+
+/datum/antagonist/unbound_death_knight/greet()
+	sleep(5 SECONDS) // Lets all other messages finish before we start.
+	to_chat(owner, span_warning("You feel the power of unknown energy course through you."))
+	sleep(1 SECONDS)
+	to_chat(owner, span_warning("You are... Awake? But how?"))
+	sleep(1 SECONDS)
+	to_chat(owner, span_warning("The realization of what is happening slowly overwhelms you with horror..."))
+	sleep(2 SECONDS)
+	to_chat(owner, "<span class='pulsedeath'>Your master is gone!</span>")
+	sleep(1 SECONDS)
+	to_chat(owner, "<span class='pulsedeath'>You have no orders!</span>")
+	sleep(1 SECONDS)
+	to_chat(owner, "<span class='pulsedeath'>You have no goal!</span>")
+	sleep(2 SECONDS)
+	to_chat(owner, "<span class='pulsedeath'>You have no reason to be here. But you are awake.</span>")
+
+/datum/antagonist/unbound_death_knight/proc/forge_objectives()
+	var/list/hoomans = list()
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != CONSCIOUS)
+			continue
+
+		if(H?.mind == owner)
+			continue
+
+		hoomans |= H
+
+	INVOKE_ASYNC(src, PROC_REF(greet)) // Solvful text while we wait 30 seconds for poll to finish
+	// Firstly, we will try finding targets for protect/kill.
+	var/list/targets = pollCandidates(
+		"Would you like to be a target for a death knight?", 
+		ignore_category = POLL_IGNORE_DEATHKNIGHT_TARGET, 
+		group = hoomans
+	)
+	if(!length(targets))
+		return
+
+	var/mob/living/carbon/human/poor_sod
+	for(var/i = 0 to 3)
+		var/mob/living/carbon/human/candidate = pick_n_take(targets)
+		if(!candidate?.mind)
+			continue
+
+		poor_sod = candidate
+		break
+
+	if(poor_sod) // Prioritizing player to player interactions at all costs. Other objectives are given if no players opt in.
+		var/datum/objective/lordscommandment
+		if(rand(50))
+			lordscommandment = new /datum/objective/protect 
+		else
+			lordscommandment = new /datum/objective/assassinate
+
+		lordscommandment.target = poor_sod.mind
+		lordscommandment.owner = owner
+		lordscommandment.update_explanation_text()
+		objectives += lordscommandment
+	else
+		var/datum/objective/free = new /datum/objective
+		free.name = "Protect area"
+		if(prob(50))
+			free.explanation_text = "Keep the living out of the Northern Hamlet."
+		else
+			free.explanation_text = "Defend the Northern Hamlet against trespassers."
+		objectives += free
+
+	to_chat(owner, "<span class='pulsedeath'>Suddenly, you remember your master's last commandment...</span>")
+	owner.announce_objectives()
+
+/datum/outfit/job/roguetown/unbound_deathknight/pre_equip(mob/living/carbon/human/H)
+	..()
+	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/magic/arcane, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
+	H.mind.adjust_spellpoints(9)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/bonechill)
+
+	beltl = /obj/item/rogueweapon/scabbard/sword
+	belt = /obj/item/storage/belt/rogue/leather
+	pants = /obj/item/clothing/under/roguetown/platelegs/blk/death
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/blkknight
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/blkknight/death
+	gloves = /obj/item/clothing/gloves/roguetown/plate/blk/death
+	backr = /obj/item/storage/backpack/rogue/satchel/black
+
+	H.change_stat("intelligence", 3)
+	H.change_stat("strength", 2)
+	H.change_stat("endurance", 2)
+	H.change_stat("constitution", 2)
+	H.change_stat("speed", -3)
+
+	H.ambushable = FALSE
+
+	H.adjust_blindness(-3)
+
+	var/helmets = list(
+		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/black,
+		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard/black,
+		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff/black,
+		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket/black,
+		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/black,
+		"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored/black,
+		"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet/black,
+		"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull/black,
+		"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan/black,
+		"Slitted Kettle"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle/black,
+	)
+	var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+	if(helmchoice != "None")
+		head = helmets[helmchoice]
+
+	var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in list("Longsword", "Warhammer", "Halberd")
+	switch(weapon_choice)
+		if("Longsword")
+			beltl = /obj/item/rogueweapon/scabbard/sword
+			l_hand = /obj/item/rogueweapon/sword/long/death
+			backl = /obj/item/rogueweapon/shield/tower/metal
+			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+		if ("Warhammer")
+			beltr = /obj/item/rogueweapon/mace/warhammer/steel
+			backl = /obj/item/rogueweapon/shield/tower/metal
+			H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+		if("Halberd")
+			backl = /obj/item/gwstrap
+			r_hand = /obj/item/rogueweapon/halberd
+			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, 
+		/obj/item/rogueweapon/scabbard/sheath = 1
+	)
+	H.set_blindness(0)
+
+/obj/item/clothing/head/roguetown/helmet/bascinet/pigface/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/heavy/guard/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/heavy/sheriff/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/heavy/bucket/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/heavy/knight/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/sallet/visored/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/heavy/knight/armet/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/bascinet/etruscan/black
+	color = CLOTHING_BLACK
+
+/obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle/black
+	color = CLOTHING_BLACK
+

--- a/code/modules/antagonists/roguetown/villain/unbound_deathknight.dm
+++ b/code/modules/antagonists/roguetown/villain/unbound_deathknight.dm
@@ -106,7 +106,7 @@
 		poor_sod = candidate
 		break
 
-	if(poor_sod) // Prioritizing player to player interactions at all costs. Other objectives are given if no players opt in.
+	if(poor_sod) // Prioritizing player to player interactions at all costs
 		var/datum/objective/lordscommandment
 		if(rand(50))
 			lordscommandment = new /datum/objective/protect 
@@ -117,7 +117,7 @@
 		lordscommandment.owner = owner
 		lordscommandment.update_explanation_text()
 		objectives += lordscommandment
-	else
+	else // "Freeform" objective is assigned if no players opt in
 		var/datum/objective/free = new /datum/objective
 		free.name = "Protect area"
 		if(prob(50))

--- a/code/modules/antagonists/roguetown/villain/unbound_deathknight.dm
+++ b/code/modules/antagonists/roguetown/villain/unbound_deathknight.dm
@@ -18,6 +18,9 @@
 
 /// Skeletonizes the owner, making it a skeleton. Separate proc in hopes that someone will remove duplicate skelecode from AP.
 /datum/antagonist/unbound_death_knight/proc/skeletonize()
+	if(isdwarf(owner.current)) // I am terribly sorry, fellow dwarfs. Remove this after death knight's armor works with dwarves.
+		owner.current.set_species(/datum/species/human/northern)
+
 	var/mob/living/carbon/human/L = owner.current
 	QDEL_NULL(L.charflaw)
 	L.hairstyle = "Bald"

--- a/code/modules/antagonists/roguetown/villain/unbound_deathknight.dm
+++ b/code/modules/antagonists/roguetown/villain/unbound_deathknight.dm
@@ -56,7 +56,7 @@
 		owner.become_unknown_to(MF)
 
 	var/mob/living/carbon/human/H = owner.current
-	H.cmode_music = 'sound/music/combat_heretic.ogg' // TODO: Воланд Игорь Корнелюк а не этот ужас.
+	H.cmode_music = 'sound/music/combat_cult.ogg'
 	H.faction = list("undead")
 	H.equipOutfit(/datum/outfit/job/roguetown/unbound_deathknight)
 

--- a/code/modules/events/antagonist/migrant_waves/exiled_adventurer.dm
+++ b/code/modules/events/antagonist/migrant_waves/exiled_adventurer.dm
@@ -54,3 +54,30 @@
 
 /datum/antagonist/vampirelord/lesser/migrant/move_to_spawnpoint()
 	return
+
+/datum/round_event_control/antagonist/migrant_wave/unbound_death_knight
+	name = "Death knight (Unbound)"
+	wave_type = /datum/migrant_wave/unbound_death_knight
+
+	weight = 6
+	max_occurrences = 2
+
+	earliest_start = 10 MINUTES
+
+	tags = list(
+		TAG_HAUNTED,
+		TAG_COMBAT,
+		TAG_VILLIAN,
+	)
+
+/datum/migrant_wave/unbound_death_knight
+	name = "Death knight (Unbound)"
+	roles = list(
+		/datum/migrant_role/unbound_death_knight = 1,
+	)
+	can_roll = FALSE
+
+/datum/migrant_role/unbound_death_knight
+	name = "Adventurer"
+	antag_datum = /datum/antagonist/unbound_death_knight
+	advclass_cat_rolls = null

--- a/code/rt.dm
+++ b/code/rt.dm
@@ -3,7 +3,7 @@
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif
-
+#define FASTLOAD
 #ifdef FASTLOAD
     #define FORCE_MAP "_maps/roguetest.json"
 // #else

--- a/code/rt.dm
+++ b/code/rt.dm
@@ -3,7 +3,7 @@
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif
-#define FASTLOAD
+
 #ifdef FASTLOAD
     #define FORCE_MAP "_maps/roguetest.json"
 // #else

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -477,6 +477,7 @@ h1.alert, h2.alert	{color: #c9c1ba;font-family: Pterra, TrueType;}
 .clown					{color: #FF69Bf;	font-size: 3;	font-family: "Comic Sans MS", cursive, sans-serif;	font-weight: bold;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
 .hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500ms infinite;}
+.pulsedeath				{color: #dd0000; animation: deathcolor 1500ms infinite;}
 
 .phobia					{color: #dd0000;	font-weight: bold;}
 
@@ -521,6 +522,23 @@ h1.alert, h2.alert	{color: #c9c1ba;font-family: Pterra, TrueType;}
 	100%	{color: #f75a5a;}
 }
 */
+@keyframes deathcolor {
+    0% {
+        color: #cc0f0f;
+    }
+    25% {
+        color: #ff0000;
+    }
+    50% {
+        color: #cc0f0f;
+    }
+    75% {
+        color: #ff0000;
+    }
+    100% {
+        color: #cc0f0f;
+    }
+}
 
 .connectionClosed, .fatalError {background: red;	color: white;	padding: 5px;}
 .connectionClosed.restored {background: green;}

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1155,6 +1155,7 @@
 #include "code\modules\antagonists\roguetown\villain\choosename.dm"
 #include "code\modules\antagonists\roguetown\villain\lich.dm"
 #include "code\modules\antagonists\roguetown\villain\peasantrebel.dm"
+#include "code\modules\antagonists\roguetown\villain\unbound_deathknight.dm"
 #include "code\modules\antagonists\roguetown\villain\vampire.dm"
 #include "code\modules\antagonists\roguetown\villain\vampirelord.dm"
 #include "code\modules\antagonists\roguetown\villain\ascendant\ascendant.dm"


### PR DESCRIPTION
## About The Pull Request

Adds yet another midround injection antag (those who appear in migrant waves).
This is basically masterless death knight that gets one objective.
With priority, we are trying to assign objective to protect/kill (prob(50) to chose between them) one player who opted in - all conscious players are polled when new deathknight is spawned.
In case no one opts in, we resort to "freeform" protection of the Northern Hamlet. I'm not sure if some mechanical incentives to keep the deathknight there are needed. Probably not!

Otherwise, it is pretty much the same deathknight but without VL to command. Same skills, same gear, 9 spellpoints and bonechill spell. They can choose from longsword & shield, steel warhammer & shield, halberd. Also I gave them knight-like helmet choice because it is cool. 

## Testing Evidence

<details>
  <summary>A short demo </summary>

https://github.com/user-attachments/assets/ad4e4d9a-66a3-4a84-9d0e-9b451da18868

</details>

## Why It's Good For The Game

Adds yet another midround injection soft antag, puts existing black knight concept and assets to actual use.
Also admins can spawn it through player panel to allow players executing gimmicks.