### PR TITLE
Touches hand loadouts to prevent double unique weapon spawn

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -24,9 +24,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	belt = /obj/item/storage/belt/rogue/leather/steel
 	beltr = /obj/item/rogueweapon/scabbard/sword
-	r_hand = /obj/item/rogueweapon/sword/rapier/dec
 	beltl = /obj/item/rogueweapon/scabbard/sheath
-	l_hand = /obj/item/rogueweapon/huntingknife/idagger/dtace
 	job_bitflag = BITFLAG_ROYALTY
 
 /datum/job/roguetown/hand/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
@@ -60,6 +58,8 @@
 /datum/outfit/job/roguetown/hand/handclassic/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 	backr = /obj/item/storage/backpack/rogue/satchel/black
+	l_hand = /obj/item/rogueweapon/huntingknife/idagger/dtace
+	r_hand = /obj/item/rogueweapon/sword/rapier/dec
 	backpack_contents = list(
 		/obj/item/storage/keyring/hand = 1
 		)
@@ -95,6 +95,8 @@
 //Spymaster start. More similar to the rogue adventurer - loses heavy armor and sword skills for more sneaky stuff. 
 /datum/outfit/job/roguetown/hand/spymaster/pre_equip(mob/living/carbon/human/H)
 	backr = /obj/item/storage/backpack/rogue/satchel/black
+	l_hand = /obj/item/rogueweapon/huntingknife/idagger/dtace
+	r_hand = /obj/item/rogueweapon/sword/rapier/dec
 	backpack_contents = list(
 		/obj/item/storage/keyring/hand = 1,
 		/obj/item/lockpickring/mundane = 1
@@ -150,6 +152,8 @@
 /datum/outfit/job/roguetown/hand/advisor/pre_equip(mob/living/carbon/human/H)
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 	backr = /obj/item/storage/backpack/rogue/satchel/black
+	l_hand = /obj/item/rogueweapon/huntingknife/idagger/dtace
+	r_hand = /obj/item/rogueweapon/sword/rapier/dec
 	backpack_contents = list(
 		/obj/item/storage/keyring/hand = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1 //starts with a vial of poison, like all wizened evil advisors do!


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Hand weapons in the parent loadout were double-applying on the subsequent child loadout execution, meaning copies of the weapons were dropped at feet. Puts the weapons in the advloadout child lines, only one spawn now.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->


https://github.com/user-attachments/assets/a9a71877-3953-4e5f-972f-c31b982a059e



## Why It's Good For The Game
Gee Hand why does your Duke let you have TWO de taces?
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
