### PR TITLE
Make searching bush search time 12 deciseconds.

### DIFF
--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -1,4 +1,4 @@
-
+#define SEARCHTIME 12 // Standard search cooldown = 1.2 seconds
 //newtree
 
 /obj/structure/flora/roguetree
@@ -359,7 +359,7 @@
 		var/mob/living/L = user
 		user.changeNext_move(CLICK_CD_INTENTCAP)
 		playsound(src.loc, "plantcross", 50, FALSE, -1)
-		if(do_after(L, rand(1,5), target = src))
+		if(do_after(L, SEARCHTIME, target = src))
 			if(!looty.len && (world.time > res_replenish))
 				loot_replenish()
 			if(prob(50) && looty.len)
@@ -638,7 +638,7 @@
 		var/mob/living/L = user
 		user.changeNext_move(CLICK_CD_INTENTCAP)
 		playsound(src.loc, "plantcross", 80, FALSE, -1)
-		if(do_after(L, rand(1,5), target = src))
+		if(do_after(L, SEARCHTIME, target = src))
 			if(!looty.len && (world.time > res_replenish))
 				loot_replenish2()
 			if(prob(50) && looty.len)
@@ -687,7 +687,7 @@
 		var/mob/living/L = user
 		user.changeNext_move(CLICK_CD_INTENTCAP)
 		playsound(src.loc, "plantcross", 80, FALSE, -1)
-		if(do_after(L, rand(1,5), target = src))
+		if(do_after(L, SEARCHTIME, target = src))
 			if(!looty.len && (world.time > res_replenish))
 				loot_replenish3()
 			if(prob(50) && looty.len)


### PR DESCRIPTION
## About The Pull Request
The autosearch bush PR kinda made searching bush take an excessively trivial amount of time by exposing that it was on a rand(1,5) cd averaging 0.3 decisecond lol. 

This make it so that it is standardized to 12 deciseconds - exactly the normal clickCD

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
We shouldn't make the game TOO easy.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
