### PR TITLE
Gives Adv Monk and Templar Monk a Polearm class.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -50,12 +50,19 @@
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
 			C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = FALSE, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
 			H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
+			var/weapons = list("Quarterstaff","Unarmed")
+			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			switch(weapon_choice)
+				if ("Unarmed")
+					H.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+				if("Quarterstaff")
+					H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
+					r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 			H.cmode_music = 'sound/music/combat_holy.ogg'

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -96,7 +96,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
+	// if you are looking for unarmed, it was moved down to the weapon choices in an attempt to avoid the "take x apprentince virtue to get unintended legendary" thing
 	H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
@@ -153,24 +153,35 @@
 
 /datum/outfit/job/roguetown/templar/monk/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-	var/weapons = list("Katar","Knuckle Dusters")
+	var/weapons = list("Katar","Knuckle Dusters", "Polearm")
 	switch(H.patron?.type)
 		if(/datum/patron/divine/eora)
 			weapons += "Close Caress"
 		if(/datum/patron/divine/abyssor)
 			weapons += "Barotrauma"
+		if(/datum/patron/divine/dendor)
+			weapons += "Summer Scythe"
 
 	var/weapon_choice = input(H,"Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	switch(weapon_choice)
 		if("Katar")
 			H.put_in_hands(new /obj/item/rogueweapon/katar(H), TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)// 5 because that's what it was before I touched it
 		if("Knuckle Dusters")
 			H.put_in_hands(new /obj/item/rogueweapon/knuckles(H), TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)// ^
 		if("Close Caress")
 			H.put_in_hands(new /obj/item/rogueweapon/knuckles/eora(H), TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)// ^
 		if("Barotrauma")
 			H.put_in_hands(new /obj/item/rogueweapon/katar/abyssor(H), TRUE)
-
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)// ^
+		if("Summer Scythe")
+			H.put_in_hands(new /obj/item/rogueweapon/halberd/bardiche/scythe(H), TRUE)
+			H.adjust_skillrank(/datum/skill/combat/polearms, 5, TRUE)// I am hesitant to give them any unarmed 'cause legendary polearms'
+		if("Polearm")
+			H.put_in_hands(new /obj/item/rogueweapon/woodstaff/quarterstaff/steel, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/polearms, 5, TRUE)
 /datum/advclass/templar/crusader
 	name = "Templar"
 	tutorial = "You are a templar of the Church, trained in heavy weaponry and zealous warfare. You are the instrument of your God's wrath, clad in steel and faith."


### PR DESCRIPTION
Gives monks a choice between unarmed and polearms. Also adds the dendor (summer scythe) as an option for dendor-patron templar monks.

## About The Pull Request

<!-- Simple PR to add another option to Adv and Templar Monks. And to see if I can do something simple without anything exploding. 

<img width="1071" height="487" alt="adv monk quarterstaff" src="https://github.com/user-attachments/assets/575c2f2a-338c-43d6-94a0-75cedcc3cb8d" />
<img width="947" height="677" alt="templar monk menu + no default unarmed" src="https://github.com/user-attachments/assets/960f6114-ea00-4d1c-90c6-6426a0a1fd74" />
<img width="811" height="83" alt="scythe loads" src="https://github.com/user-attachments/assets/f54266f1-f515-4cb1-a94d-9120587bcbcf" />
Gives monks a choice between unarmed and polearms. Also adds the dendor (summer scythe) as an option for dendor-patron templar monks.-->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="1071" height="487" alt="adv monk quarterstaff" src="https://github.com/user-attachments/assets/575c2f2a-338c-43d6-94a0-75cedcc3cb8d" />
<img width="947" height="677" alt="templar monk menu + no default unarmed" src="https://github.com/user-attachments/assets/960f6114-ea00-4d1c-90c6-6426a0a1fd74" />
<img width="811" height="83" alt="scythe loads" src="https://github.com/user-attachments/assets/f54266f1-f515-4cb1-a94d-9120587bcbcf" />
## Why It's Good For The Game
Simple flavor just in case someone's character isn't exactly the type to pummel someone with their bare hands. I don't think this'll lead to monk suddenly becoming a meta-breaking class. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
