### PR TITLE
NPC Improvements - Port Juking from Ratwood & Fix NPC Stamcrit

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -43,51 +43,50 @@
 		for(var/datum/antagonist/A in mind.antag_datums)
 			A.on_life(src)
 
-	if(mode == NPC_AI_OFF)
-		handle_vamp_dreams()
-		if(IsSleeping())
-			if(health > 0)
-				if(has_status_effect(/datum/status_effect/debuff/sleepytime))
-					remove_status_effect(/datum/status_effect/debuff/sleepytime)
-					remove_stress(/datum/stressevent/sleepytime)
-					if(mind)
-						mind.sleep_adv.advance_cycle()
-						allmig_reward++
-						adjust_triumphs(1)
-						to_chat(src, span_danger("Nights Survived: \Roman[allmig_reward]"))
-		if(leprosy == 1)
-			adjustToxLoss(2)
-		else if(leprosy == 2)
-			if(client)
-				if(check_blacklist(client.ckey))
-					ADD_TRAIT(src, TRAIT_NOPAIN, TRAIT_GENERIC)
-					leprosy = 1
-					var/obj/item/bodypart/B = get_bodypart(BODY_ZONE_HEAD)
-					if(B)
-						B.sellprice = rand(16, 33)
-				else
-					leprosy = 3
-		//heart attack stuff
-		handle_heart()
-		handle_liver()
-		update_stamina()
-		update_energy()
-		if(charflaw && !charflaw.ephemeral && mind)
-			charflaw.flaw_on_life(src)
-		if(health <= 0)
-			adjustOxyLoss(0.5)
-		if(mode == NPC_AI_OFF && !client && !HAS_TRAIT(src, TRAIT_NOSLEEP))
-			if(mob_timers["slo"])
-				if(world.time > mob_timers["slo"] + 90 SECONDS)
-					Sleeping(100)
+	handle_vamp_dreams()
+	if(IsSleeping())
+		if(health > 0)
+			if(has_status_effect(/datum/status_effect/debuff/sleepytime))
+				remove_status_effect(/datum/status_effect/debuff/sleepytime)
+				remove_stress(/datum/stressevent/sleepytime)
+				if(mind)
+					mind.sleep_adv.advance_cycle()
+					allmig_reward++
+					adjust_triumphs(1)
+					to_chat(src, span_danger("Nights Survived: \Roman[allmig_reward]"))
+	if(leprosy == 1)
+		adjustToxLoss(2)
+	else if(leprosy == 2)
+		if(client)
+			if(check_blacklist(client.ckey))
+				ADD_TRAIT(src, TRAIT_NOPAIN, TRAIT_GENERIC)
+				leprosy = 1
+				var/obj/item/bodypart/B = get_bodypart(BODY_ZONE_HEAD)
+				if(B)
+					B.sellprice = rand(16, 33)
 			else
-				mob_timers["slo"] = world.time
+				leprosy = 3
+	//heart attack stuff
+	handle_heart()
+	handle_liver()
+	update_stamina()
+	update_energy()
+	if(charflaw && !charflaw.ephemeral && mind)
+		charflaw.flaw_on_life(src)
+	if(health <= 0)
+		adjustOxyLoss(0.5)
+	if(mode == NPC_AI_OFF && !client && !HAS_TRAIT(src, TRAIT_NOSLEEP))
+		if(mob_timers["slo"])
+			if(world.time > mob_timers["slo"] + 90 SECONDS)
+				Sleeping(100)
 		else
-			if(mob_timers["slo"])
-				mob_timers["slo"] = null
+			mob_timers["slo"] = world.time
+	else
+		if(mob_timers["slo"])
+			mob_timers["slo"] = null
 
-		if(dna?.species)
-			dna.species.spec_life(src) // for mutantraces
+	if(dna?.species)
+		dna.species.spec_life(src) // for mutantraces
 
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -524,6 +524,53 @@
 
 	return FALSE
 
+/mob/living/carbon/human/deadite/npc_try_backstep()
+	return FALSE // deadites cannot juke
+
+/mob/living/carbon/human/proc/npc_try_backstep()
+	// JUKE: backstep after attacking if you're fast and have movement left
+	var/const/base_juke_chance = 5
+	// for every point of STASPD above 10 you get an extra 5% juke chance
+	var/const/min_spd_for_juke = 10
+	var/const/juke_per_overspd = 5
+	if(mind?.has_antag_datum(/datum/antagonist/zombie)) // deadites cannot juke
+		return FALSE
+	if(!target)
+		return FALSE
+	if(steps_moved_this_turn >= maxStepsTick) // no movement left over
+		return FALSE
+	var/juke_spd_bonus = STASPD > min_spd_for_juke ? (STASPD - min_spd_for_juke) * juke_per_overspd : 0
+	if(!prob(base_juke_chance + juke_spd_bonus))
+		NPC_THINK("Failed juke roll ([base_juke_chance + juke_spd_bonus]%)!")
+		return FALSE
+	NPC_THINK("Succeeded juke roll ([base_juke_chance + juke_spd_bonus]%)!")
+	tempfixeye = TRUE //Change icon to 'target' red eye
+	if(!fixedeye) //If fixedeye isn't already enabled, we need to set this var
+		nodirchange = TRUE
+	var/list/newPath = list()
+	var/turf/lastTurf
+	// Use up to half your remaining distance, with a minimum of one tile.
+	var/juke_distance = rand(1, ceil((maxStepsTick - steps_moved_this_turn)/2))
+	for(var/i in 1 to juke_distance)
+		// pick random turfs to juke to until we're out of movement
+		var/list/turf/juke_candidates = get_dodge_destinations(target, lastTurf)
+		if(!length(juke_candidates))
+			break
+		lastTurf = pick(juke_candidates)
+		newPath += lastTurf
+	if(!length(newPath))
+		return FALSE
+	// temporarily force us to use the juke path
+	myPath = newPath
+	var/old_pathfinding_target = pathfinding_target
+	pathfinding_target = myPath[1]
+	steps_moved_this_turn += move_along_path()
+	pathfinding_target = old_pathfinding_target
+	tempfixeye = FALSE
+	if(!fixedeye)
+		nodirchange = FALSE
+	return TRUE // juke succeeded
+
 /mob/living/carbon/human/proc/handle_combat()
 	switch(mode)
 		if(NPC_AI_IDLE)		// idle
@@ -599,30 +646,12 @@
 			if(Adjacent(target) && isturf(target.loc))	// if right next to perp
 				frustration = 0
 				face_atom(target)
-				monkey_attack(target)
+				. = monkey_attack(target)
 				steps_moved_this_turn++ // an attack costs, currently, 1 movement step
-				// JUKE: backstep after attacking if you're fast and have movement left
 				NPC_THINK("Used [steps_moved_this_turn] moves out of [maxStepsTick]!")
-				if(target && (steps_moved_this_turn < maxStepsTick))
-					var/const/base_juke_chance = 5
-					// for every point of STASPD above 10 you get an extra 5% juke chance
-					var/const/min_spd_for_juke = 10
-					var/const/juke_per_overspd = 5
-					var/juke_spd_bonus = STASPD > min_spd_for_juke ? (STASPD - min_spd_for_juke) * juke_per_overspd : 0
-					if(prob(base_juke_chance + juke_spd_bonus))
-						NPC_THINK("Succeeded juke roll ([base_juke_chance + juke_spd_bonus]%)!")
-						// pick a random turf to juke to
-						var/list/turf/juke_candidates = get_dodge_destinations(target)
-						if(length(juke_candidates))
-							// temporarily force us to path to this turf
-							myPath = list(pick(juke_candidates))
-							var/old_pathfinding_target = pathfinding_target
-							pathfinding_target = myPath[1]
-							steps_moved_this_turn += move_along_path()
-							pathfinding_target = old_pathfinding_target
-					else
-						NPC_THINK("Failed juke roll ([base_juke_chance + juke_spd_bonus]%)!")
-				return TRUE
+				if(.) // attack was successful, try to backstep. todo: generalise to post-attack behaviour?
+					npc_try_backstep()
+					return
 			else if(should_frustrate) // not next to perp, and we didn't fail due to reaction time
 				frustration++
 
@@ -824,11 +853,11 @@
 // attack using a held weapon otherwise bite the enemy, then if we are angry there is a chance we might calm down a little
 /mob/living/carbon/human/proc/monkey_attack(mob/living/L)
 	if(next_move > world.time)
-		return
+		return FALSE // no time to attack this turn!
 
 	npc_choose_attack_zone(L)
 	NPC_THINK("Aiming for \the [zone_selected]!")
-	do_best_melee_attack(L)
+	return do_best_melee_attack(L)
 
 // get angry at a mob
 /mob/living/carbon/human/proc/retaliate(mob/living/L)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -64,11 +64,6 @@
 			return TRUE
 	return FALSE
 
-/mob/living/carbon/human/species/npc/deadite/npc_should_resist(ignore_grab = TRUE)
-	if(!check_mouth_grabbed())
-		ignore_grab ||= TRUE
-	return ..(ignore_grab = ignore_grab)
-
 /mob/living/carbon/human/proc/npc_should_resist(ignore_grab = FALSE)
 	// zombie antags don't try to resist non-mouthgrabs
 	if(mind?.has_antag_datum(/datum/antagonist/zombie) && !check_mouth_grabbed())
@@ -523,9 +518,6 @@
 		return TRUE
 
 	return FALSE
-
-/mob/living/carbon/human/deadite/npc_try_backstep()
-	return FALSE // deadites cannot juke
 
 /mob/living/carbon/human/proc/npc_try_backstep()
 	// JUKE: backstep after attacking if you're fast and have movement left

--- a/code/modules/mob/living/carbon/human/npc/deadite.dm
+++ b/code/modules/mob/living/carbon/human/npc/deadite.dm
@@ -38,6 +38,14 @@
 	GLOB.antagonists -= zombie_antag
 	update_body()
 
+/mob/living/carbon/human/species/npc/deadite/npc_try_backstep()
+	return FALSE // deadites cannot juke
+
+/mob/living/carbon/human/species/npc/deadite/npc_should_resist(ignore_grab = TRUE)
+	if(!check_mouth_grabbed())
+		ignore_grab ||= TRUE
+	return ..(ignore_grab = ignore_grab)
+
 /datum/outfit/job/roguetown/deadite/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = null

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -80,9 +80,9 @@
 // origin is used for multi-step dodges like jukes
 /mob/living/proc/get_dodge_destinations(mob/living/attacker, atom/origin = src)
 	var/dodge_dir = get_dir(attacker, origin)
-	if(!dodge_dir)
+	if(!dodge_dir) // dir is 0, so we're on the same tile.
 		return null
-	var/list/dirry = list()
+	var/list/dirry = list(turn(dodge_dir, -90), dodge_dir, turn(dodge_dir, 90))
 	// pick a random dir
 	var/list/turf/dodge_candidates = list()
 	for(var/dir_to_check in dirry)


### PR DESCRIPTION
## About The Pull Request
- Fix NPC stamcritting themselves by making NPC actually call update stamina and update energy (Their stamina never regenerated)
- Fixes existing Juking and then port the new, improved multi-step juke from Ratwood by Sutures.

All credits to Sutures for the original code. Main PR is: https://github.com/Rotwood-Vale/Ratwood-Keep/pull/2972/files for Juking

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_nKV5drJR3A](https://github.com/user-attachments/assets/6796b9ba-008d-42a5-bc96-f596c0c338a8)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No more NPC stamcritting themselves easily and improved difficulty - but in a fair manner. 

Radiant Quest adjustment will be coming next :tm:

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
