### PR TITLE
[Port] Fixes HUD eye displaying incorrectly

### DIFF
--- a/code/__HELPERS/customization.dm
+++ b/code/__HELPERS/customization.dm
@@ -13,7 +13,7 @@
 /mob/living/carbon/human/proc/get_eye_color()
 	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
 	if(!eyes)
-		return "FFFFFF"
+		return "#FFFFFF"
 	return eyes.eye_color
 
 /mob/living/carbon/human/proc/get_chest_color()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -803,7 +803,7 @@
 			iris.icon_state = "oeye_fixed"
 		else
 			iris.icon_state = "oeye"
-	iris.color = "#" + human.eye_color
+	iris.color = human.get_eye_color()
 	. += iris
 
 /atom/movable/screen/eye_intent/proc/toggle(mob/user)


### PR DESCRIPTION
## About The Pull Request

"Makes the eye on the hud display the characters eye colour

Credit to useroth for basically carrying this entire bugfix" - wow50000

Ported from https://github.com/Rotwood-Vale/Ratwood-Keep/pull/3076

## Testing Evidence

Ignore missing HUD (it's local build issue)

<img width="971" height="410" alt="image" src="https://github.com/user-attachments/assets/2ae6d70d-e5ce-4777-9084-3a804257efa8" />

<img width="925" height="531" alt="image" src="https://github.com/user-attachments/assets/ee88e94d-5a95-42a8-a33c-8282f9a2f76f" />


## Why It's Good For The Game

Bugfixes are always good, aren't they?