### PR TITLE
Martyr true damage fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -298,6 +298,9 @@
 		REMOVE_TRAIT(parent, TRAIT_NODROP, TRAIT_GENERIC)	//The weapon can be moved by the Priest again (or used, I suppose)
 	is_active = FALSE
 	I.damtype = BRUTE
+	I.possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
+	I.gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
+	current_holder.update_a_intents()
 	I.force = initial(I.force)
 	I.force_wielded = initial(I.force_wielded)
 	I.max_integrity = initial(I.max_integrity)
@@ -360,6 +363,9 @@
 		flash_lightning(user)
 		var/obj/item/I = parent
 		I.damtype = BURN	//Changes weapon damage type to fire
+		I.possible_item_intents = list(/datum/intent/sword/cut/martyr, /datum/intent/sword/thrust/martyr, /datum/intent/sword/strike/martyr)
+		I.gripped_intents = list(/datum/intent/sword/cut/martyr, /datum/intent/sword/thrust/martyr, /datum/intent/sword/strike/martyr, /datum/intent/sword/chop/martyr)
+		user.update_a_intents()
 		I.slot_flags = null	//Can't sheathe a burning sword
 
 		ADD_TRAIT(parent, TRAIT_NODROP, TRAIT_GENERIC)	//You're committed, now.
@@ -526,6 +532,20 @@
 	is_silver = TRUE
 	toggle_state = null
 	is_important = TRUE
+
+/datum/intent/sword/cut/martyr
+		item_d_type = "fire"
+		blade_class = BCLASS_CUT
+/datum/intent/sword/thrust/martyr
+		item_d_type = "fire"
+		blade_class = BCLASS_PICK // so our armor-piercing attacks in ult mode can do crits(against most armors, not having crit)
+/datum/intent/sword/strike/martyr
+		item_d_type = "fire"
+		blade_class = BCLASS_SMASH
+/datum/intent/sword/chop/martyr
+		item_d_type = "fire"
+		blade_class = BCLASS_CHOP
+
 
 /obj/item/rogueweapon/sword/long/martyr/Initialize()
 	AddComponent(/datum/component/martyrweapon)


### PR DESCRIPTION
## About The Pull Request

- Makes Martyr's true damage(While powered up) work.
- Achieves this by basically making special intents that the martyr sword swaps to, which have better crits(so they can actually crit at all) + pierce any armor without fire resistance(which is most of them)
- (Stab becomes PICK crits, cut stays Cut, Chop is chop, strike becomes SMASH crits), meaning the Ult'd martyr will be able to do crits against whatever they're fighting.

## Testing Evidence

(normal sword)

https://github.com/user-attachments/assets/cd897323-6d28-4c13-8250-186ea0257654

(powered up)

https://github.com/user-attachments/assets/6c556dd3-848c-45c1-a077-3c3fe6a8a099



## Why It's Good For The Game

This was intended, and worked at some point in the past. Not sure when it broke.

<img width="595" height="385" alt="image" src="https://github.com/user-attachments/assets/be1184cc-4e71-4c89-aa3a-0e26f07744d4" />