### PR TITLE
Thralljak

### DIFF
--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -80,7 +80,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 			mypool = mansion
 		equip_spawn()
 		greet()
-		addtimer(CALLBACK(owner.current, TYPE_PROC_REF(/mob/living/carbon/human, spawn_pick_class), "VAMPIRE SPAWN"), 5 SECONDS)
+		addtimer(CALLBACK(owner.current, TYPE_PROC_REF(/mob/living/carbon/human, equipOutfit), /datum/outfit/job/roguetown/vampthrall), 5 SECONDS)
+
 	else
 		forge_vampirelord_objectives()
 		finalize_vampire()
@@ -131,21 +132,6 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	owner.current.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)
 	owner.current.ambushable = FALSE
 
-/mob/living/carbon/human/proc/spawn_pick_class()
-	var/list/classoptions = list("Ranger","Blacksmith","Carpenter","Seamstress","Rogue","Mage","Hunter","Trader")
-	var/list/visoptions = list()
-
-	for(var/T in 1 to 5)
-		if(length(classoptions))
-			visoptions += pick_n_take(classoptions)
-
-	var/selected = input(src, "Which class was I?", "VAMPIRE SPAWN") as anything in visoptions
-
-	for(var/datum/advclass/A in SSrole_class_handler.sorted_class_categories[CTAG_ALLCLASS])
-		if(A.name == selected)
-			equipOutfit(A.outfit)
-			return
-
 /datum/outfit/job/roguetown/vamplord/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_skillrank(/datum/skill/magic/blood, 2, TRUE)
@@ -165,6 +151,25 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	cloak = /obj/item/clothing/cloak/cape/puritan
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	backl = /obj/item/storage/backpack/rogue/satchel/black
+	H.ambushable = FALSE
+
+
+
+/datum/outfit/job/roguetown/vampthrall/pre_equip(mob/living/carbon/human/H)
+	H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/shields, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/misc/swimming, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/misc/climbing, 4, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 4, TRUE)
 	H.ambushable = FALSE
 
 ////////Outfits////////


### PR DESCRIPTION
## About The Pull Request

- Vampire thralls now get an array of skills up to expert, rather than getting outfits added on which often cranked them up to legendary. They still retain all the other traits/such they had, and just lose legendary weapon skills.
- Now you get basically every combat skill instead to expert, letting you use whatever you used in your prior life. You also can no longer gain magic or such as a heavy armor class.

## Testing Evidence

Before thralling(MAA FOOTMAN)

<img width="273" height="264" alt="image" src="https://github.com/user-attachments/assets/58a693e3-4df9-4d76-a85f-3f81c6170690" />

After Thralling

<img width="248" height="310" alt="image" src="https://github.com/user-attachments/assets/54e74b0c-6b64-4c77-90d8-022919cb1960" />


## Why It's Good For The Game

- I think vampire lords are perfectly fine on their own
- But
- When you get 5+ thralls running around, all mini vlords with legendary skills, it gets a bit silly.
