### PR TITLE
Health examine shows rotting and cure rot fix

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -72,6 +72,7 @@
 		if(is_zombie)
 			var/datum/antagonist/zombie/Z = C.mind.has_antag_datum(/datum/antagonist/zombie)
 			if(Z && !Z.has_turned && !Z.revived && C.stat == DEAD)
+				C.infected = TRUE
 				wake_zombie(C, infected_wake = TRUE, converted = FALSE)
 
 	var/findonerotten = FALSE

--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -19,6 +19,9 @@
 	// Remove rot component
 	remove_rot_component(target)
 
+	// Remove Infected var
+	target.infected = FALSE
+
 	// Clean body parts
 	clean_body_parts(target)
 

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -136,6 +136,7 @@
 
 	//Special because deadite status is latent as opposed to the others. 
 	if(admin_granted)
+		zombie.infected = TRUE
 		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(wake_zombie), zombie, FALSE, TRUE), 5 SECONDS, TIMER_STOPPABLE)
 	return ..()
 

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -376,6 +376,9 @@
 	Proc for our newly infected to wake up as a zombie
 */
 /proc/wake_zombie(mob/living/carbon/zombie, infected_wake = FALSE, converted = FALSE)
+	if(!zombie.infected) //Ensure they werent cured
+		return
+		
 	if (!zombie || QDELETED(zombie)) 
 		return
 

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -148,7 +148,7 @@
 	var/mob/living/carbon/human/zombie = owner?.current
 	if(zombie)
 
-		infected = FALSE // Makes sure admins removing deadification removes the infected var if they do it before they turn
+		zombie.infected = FALSE // Makes sure admins removing deadification removes the infected var if they do it before they turn
 		zombie.verbs -= /mob/living/carbon/human/proc/zombie_seek
 		zombie.mind?.special_role = special_role
 		zombie.ambushable = ambushable

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -351,6 +351,7 @@
 	var/datum/antagonist/zombie/zombie_antag = source.mind?.has_antag_datum(/datum/antagonist/zombie)
 	if (!zombie_antag || !zombie_antag.has_turned) //Check that the zombie who bit us is real
 		return FALSE
+	victim.infected = TRUE //They are being infected
 
 	//How did the victim get infected
 	switch (infection_type)
@@ -411,6 +412,7 @@
 	zombie.update_mobility()
 	zombie.update_sight()
 	zombie.reload_fullscreen()
+	zombie.infected = FALSE //The infection has finished and they are now a zombie
 
 	var/datum/antagonist/zombie/zombie_antag = zombie.mind?.has_antag_datum(/datum/antagonist/zombie)
 	if(zombie_antag)

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -148,6 +148,7 @@
 	var/mob/living/carbon/human/zombie = owner?.current
 	if(zombie)
 
+		infected = FALSE // Makes sure admins removing deadification removes the infected var if they do it before they turn
 		zombie.verbs -= /mob/living/carbon/human/proc/zombie_seek
 		zombie.mind?.special_role = special_role
 		zombie.ambushable = ambushable

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -707,6 +707,12 @@
 		examination += bodypart.check_for_injuries(user, deep_examination)
 
 	examination += "ø ------------ ø</span>"
+	if(infected)
+		if(user == src)
+			examination += span_boldwarning("I feel rot slowly seepinging into me...")
+		else
+			examination += span_boldwarning("Rot slowly seeps into their body")
+
 	if(!silent)
 		to_chat(user, examination.Join("\n"))
 	return examination

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -708,7 +708,7 @@
 
 	examination += "ø ------------ ø</span>"
 	if(infected)
-		examination += span_boldwarning("[m1] slowly rotting away")
+		examination += span_boldwarning("[m1] slowly rotting away.")
 
 	if(!silent)
 		to_chat(user, examination.Join("\n"))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -708,10 +708,7 @@
 
 	examination += "ø ------------ ø</span>"
 	if(infected)
-		if(user == src)
-			examination += span_boldwarning("I feel rot slowly seepinging into me...")
-		else
-			examination += span_boldwarning("Rot slowly seeps into their body")
+		examination += span_boldwarning("[m1] slowly rotting away")
 
 	if(!silent)
 		to_chat(user, examination.Join("\n"))

--- a/code/modules/mob/living/carbon/human/npc/deadite.dm
+++ b/code/modules/mob/living/carbon/human/npc/deadite.dm
@@ -8,6 +8,7 @@
 	flee_in_pain = FALSE
 	ambushable = FALSE
 	wander = TRUE
+	infected = TRUE
 
 /mob/living/carbon/human/species/npc/deadite/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/npc/deadite.dm
+++ b/code/modules/mob/living/carbon/human/npc/deadite.dm
@@ -159,6 +159,7 @@
 	to_chat(src, span_danger("I feel horrible... REALLY horrible..."))
 	mob_timers["puke"] = world.time
 	vomit(1, blood = TRUE, stun = FALSE)
+	src.infected = TRUE //Is this in use? Just in case it is
 	addtimer(CALLBACK(src, PROC_REF(wake_zombie)), 1 MINUTES)
 	return zombie_antag
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -42,6 +42,8 @@
 	var/last_special = 0 //Used by the resist verb, likely used to prevent players from bypassing next_move by logging in/out.
 	var/timeofdeath = 0
 
+	var/infected = FALSE //Used to tell if the mob is in progress of turning into deadite
+
 	//Allows mobs to move through dense areas without restriction. For instance, in space or out of holder objects.
 	var/incorporeal_move = FALSE //FALSE is off, INCORPOREAL_MOVE_BASIC is normal, INCORPOREAL_MOVE_SHADOW is for ninjas
 								 //and INCORPOREAL_MOVE_JAUNT is blocked by holy water/salt

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -37,11 +37,12 @@
 		burndam -= (user.get_skill_level(/datum/skill/misc/medicine) * 3)
 
 	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
-	if(target.stat == DEAD || was_zombie)											//Checks if the target is a dead rotted corpse.
-		target.death()	//Kills the target if they are a zombie as a fail-safe.
-		var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
-		if(rot && rot.amount && rot.amount >= 5 MINUTES)	//Fail-safe to make sure the dead person has at least rotted for ~5 min.
-			stinky = TRUE				
+	if(target.infected == FALSE)
+		if(target.stat == DEAD || was_zombie)											//Checks if the target is a dead rotted corpse.
+			target.death()	//Kills the target if they are a zombie as a fail-safe.
+			var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
+			if(rot && rot.amount && rot.amount >= 5 MINUTES)	//Fail-safe to make sure the dead person has at least rotted for ~5 min.
+				stinky = TRUE				
 
 	if(remove_rot(target = target, user = user, method = "surgery", damage = burndam,
 		success_message = "You burn away the rot inside of [target].",

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
@@ -30,6 +30,7 @@
 		return
 	to_chat(H, span_danger("A growing cold seeps into my body. I feel horrible... REALLY horrible..."))
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(wake_zombie), H, FALSE, TRUE), infection_timer, TIMER_STOPPABLE)
+	H.infected = TRUE
 
 GLOBAL_LIST_INIT(animal_to_undead, list(
 	/mob/living/simple_animal/hostile/retaliate/rogue/saiga = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/undead,


### PR DESCRIPTION
## About The Pull Request

Clicking on your heart or using diagnosis now shows if someone is slowly turning into a deadite.
Fixes cure rot surgery causing people who weren't yet deadites dying, and then reviving when the timer finished

I used "[m1] slowly rotting away" as the examine text, but if there's something more fitting I can change it
## Testing Evidence

The only way I found to test infection wasn't great, so it's possible I might have missed something.

Tested being infected gave the Infected var properly
checked that having infected var made examining self and using diagnose on self not give double message
used diagnose on another carbon with infected var to check the message showed up on diagnose and hammer showed the message

Spawned deadite NPC, possessed it, bit a carbon until they got an infection. Then cured the infection with surgery.
Did same but without curing it
Spawned a deadite volf and had it infect my character and checked it checked the var
Used the TP panel to make myself a deadite

## Why It's Good For The Game

No more missing one message during fighting a deadite and turning in the middle of a conversation. 