### PR TITLE
Showing steward some love or nerve master now shows jobs, not advjobs

### DIFF
--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -284,7 +284,7 @@
 				for(var/mob/living/carbon/human/A in SStreasury.bank_accounts)
 					if(ishuman(A))
 						var/mob/living/carbon/human/tmp = A
-						contents += "[tmp.real_name] ([job_filter(tmp.advjob, tmp.job)]) - [SStreasury.bank_accounts[A]]m"
+						contents += "[tmp.real_name] ([job_filter(tmp.advjob, tmp.job, compact)]) - [SStreasury.bank_accounts[A]]m"
 					else
 						contents += "[A.real_name] - [SStreasury.bank_accounts[A]]m"
 					contents += " / <a href='?src=\ref[src];givemoney=\ref[A]'>\[PAY\]</a> <a href='?src=\ref[src];fineaccount=\ref[A]'>\[FINE\]</a><BR><BR>"
@@ -292,7 +292,7 @@
 				for(var/mob/living/carbon/human/A in SStreasury.bank_accounts)
 					if(ishuman(A))
 						var/mob/living/carbon/human/tmp = A
-						contents += "[tmp.real_name] ([job_filter(tmp.advjob, tmp.job)]) - [SStreasury.bank_accounts[A]]m<BR>"
+						contents += "[tmp.real_name] ([job_filter(tmp.advjob, tmp.job, compact)]) - [SStreasury.bank_accounts[A]]m<BR>"
 					else
 						contents += "[A.real_name] - [SStreasury.bank_accounts[A]]m<BR>"
 					contents += "<a href='?src=\ref[src];givemoney=\ref[A]'>\[Give Money\]</a> <a href='?src=\ref[src];fineaccount=\ref[A]'>\[Fine Account\]</a><BR><BR>"
@@ -419,16 +419,19 @@
 	popup.set_content(contents)
 	popup.open()
 
-/obj/structure/roguemachine/steward/proc/job_filter(advj, j)
+/obj/structure/roguemachine/steward/proc/job_filter(advj, j, compact = FALSE)
 	if(advj in excluded_jobs)
 		return "Adventurer"
 	if(j in excluded_jobs)
 		return "Adventurer"
-	if(advj)
-		return advj
-	else
+	if(compact && j)
 		return j
-
+	else if(!compact && advj && j)
+		return "[j] ([advj])"
+	else if(j)
+		return j
+	else if(advj)
+		return advj
 
 #undef TAB_MAIN
 #undef TAB_BANK


### PR DESCRIPTION
## About The Pull Request

Have you ever been confused by Slampig the Squreplougher (footman) in the nerve master interface, trying to understand who that is - a knight, a man-at-arms or a random hobo?

No more! This makes nerve master output characters' jobs only in compact mode. Regular mode will display jobs like knight (royal champion), because I think that paying royal champions less than other knights is a good practice.

## Testing Evidence

It worked and was not borked!
Compact:
<img width="714" height="246" alt="image" src="https://github.com/user-attachments/assets/e4dc61d9-2176-4d00-bdf1-7f2652fb6800" />

Not-so-compact:
<img width="694" height="264" alt="image" src="https://github.com/user-attachments/assets/06276a7d-1c73-4d45-9a62-d52e29382d62" />

## Why It's Good For The Game

I have no idea why nerve master was outputting adjobs - that is likely a design oversight. Steward mains complained about it in the past. QoL is good and so on and so on.