### PR TITLE
Big peelium

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -67,7 +67,6 @@
 
 /datum/intent/sword/peel/big
 	name = "big sword armor peel"
-	peel_divisor = 6 //You have way easier time doing so
 	reach = 2
 
 /datum/intent/sword/chop

--- a/code/modules/mob/living/combat/accuracy_checks.dm
+++ b/code/modules/mob/living/combat/accuracy_checks.dm
@@ -39,7 +39,7 @@
 		if(I.wlength == WLENGTH_SHORT)
 			chance2hit += 10
 		if((I.wlength >= WLENGTH_LONG) && (used_intent.blade_class == BCLASS_PEEL))
-			chance2hit -= 10
+			chance2hit -= 20
 
 	if(user.STAPER > 10)
 		chance2hit += (min((user.STAPER-10)*8, 40))


### PR DESCRIPTION
## About The Pull Request

Reduces accuracy and doubles the required amount of hits for greatweapons to peel.

## Testing Evidence

Number change.

## Why It's Good For The Game

Greatweapons already do more damage, have higher range and on top of all that require less hits than something like an arming sword to peel off armour which they can instantly delimb.
