### PR TITLE
Throat and Crownstone

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -342,6 +342,7 @@
 //wip
 /obj/item/scomstone/attack_right(mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_INTENTCAP)
+	visible_message(span_notice ("[user] presses their ring against their mouth."))
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(!input_text)
 		return
@@ -728,6 +729,7 @@
 
 /obj/item/scomstone/garrison/attack_right(mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_INTENTCAP)
+	visible_message(span_notice ("[user] presses their ring against their mouth."))
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(!input_text)
 		return

--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_EMPTY(outlawed_players)
 GLOBAL_LIST_EMPTY(lord_decrees)
 GLOBAL_LIST_EMPTY(court_agents)
 GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
+GLOBAL_VAR_INIT(last_crown_announcement_time, -1000)
 
 /proc/initialize_laws_of_the_land()
 	var/list/laws = strings("laws_of_the_land.json", "lawsets")
@@ -149,6 +150,9 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 				if(nocrown)
 					say("You need the crown.")
 					playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
+					return
+				if (world.time < GLOB.last_crown_announcement_time + 5 MINUTES)
+					say(("My throat is sore."))
 					return
 				if(!SScommunications.can_announce(H))
 					say("I must gather my strength!")
@@ -313,6 +317,7 @@ GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 	try_make_rebel_decree(user)
 
 	SScommunications.make_announcement(user, FALSE, raw_message)
+	GLOB.last_crown_announcement_time = world.time 
 
 /obj/structure/roguemachine/titan/proc/try_make_rebel_decree(mob/living/user)
 	if(!SScommunications.can_announce(user))

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
@@ -34,6 +34,7 @@
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/attack_right(mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_MELEE)
+	visible_message(span_notice ("[user] presses their hands against their crown."))
 	var/input_text = input(user, "Enter your ducal message:", "Crown SCOM")
 	if(input_text)
 		var/usedcolor = user.voice_color


### PR DESCRIPTION
## About The Pull Request

Gives Throat announcements 5 minute cooldown like the rest.
You get a message if someone starts speaking into their crownstone (not for matthiosans) and the actual crown

## Testing Evidence

<img width="456" height="420" alt="image" src="https://github.com/user-attachments/assets/538d20d5-eaf1-46d7-bbf8-c788630729c4" />
<img width="406" height="84" alt="image" src="https://github.com/user-attachments/assets/d59b9153-657c-44ba-938e-fe75eba7da48" />


## Why It's Good For The Game

Every other announcement now has 5 minute cooldown so it's not so annoyingly spammable.
It is mechanics to call for help this just makes it obvious.
