### PR TITLE
Add Apothecary Silverface for Potions - reduce base price of non-buff…

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -33757,11 +33757,6 @@
 /obj/structure/fermentation_keg/random,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
-"kKf" = (
-/obj/structure/roguewindow,
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/physician)
 "kKh" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt/road,
@@ -69544,6 +69539,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/cave/orcdungeon)
+"vWy" = (
+/obj/structure/roguemachine/goldface/public/apothecary,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/physician)
 "vWB" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/tile/masonic{
@@ -73783,7 +73782,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle,
 /obj/effect/decal/mossy{
 	dir = 8
 	},
@@ -266485,7 +266483,7 @@ hbC
 nbL
 nbL
 vRV
-kKf
+dkS
 noZ
 rZi
 xUD
@@ -266936,8 +266934,8 @@ rXa
 sGj
 dkS
 tdZ
-qoV
-sGj
+dkS
+vWy
 xmw
 qNR
 qzj

--- a/code/modules/cargo/packsrogue/merchant/merchant_potions.dm
+++ b/code/modules/cargo/packsrogue/merchant/merchant_potions.dm
@@ -18,22 +18,22 @@
 
 /datum/supply_pack/rogue/potions/healthpot
 	name = "Healing Potion"
-	cost = 35
+	cost = 25
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/healthpot)
 
 /datum/supply_pack/rogue/potions/manapot
 	name = "Mana Potion"
-	cost = 35
+	cost = 25
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/manapot)
 
 /datum/supply_pack/rogue/potions/stamina
 	name = "Stamina Potion"
-	cost = 35
+	cost = 25
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/stampot)
 
 /datum/supply_pack/rogue/potions/antidote
 	name = "Poison Antidote"
-	cost = 35
+	cost = 25
 	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/antidote)
 
 /datum/supply_pack/rogue/potions/strpot

--- a/code/modules/roguetown/roguemachine/merchant/goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/goldface.dm
@@ -97,7 +97,7 @@
 
 /obj/structure/roguemachine/goldface/public/smith/examine()
 	. = ..()
-	. += span_info("This can be locked by a Guild's key")
+	. += span_info("This can be locked by a guild's key")
 
 /obj/structure/roguemachine/goldface/public/tailor
 	name = "Tailor's SILVERFACE"
@@ -111,7 +111,19 @@
 
 /obj/structure/roguemachine/goldface/public/tailor/examine()
 	. = ..()
-	. += span_info("This can be locked by a Tailor's key")
+	. += span_info("This can be locked by a tailor's key")
+
+/obj/structure/roguemachine/goldface/public/apothecary
+	name = "Apothecary's SILVERFACE"
+	lockid = "physician"
+	categories = list(
+		"Potions",
+	)
+	categories_gamer = list()
+
+/obj/structure/roguemachine/goldface/public/tailor/examine()
+	. = ..()
+	. += span_info("This can be locked by a physician's key")
 
 /obj/structure/roguemachine/goldface/Initialize()
 	. = ..()
@@ -137,14 +149,18 @@
 		else
 			to_chat(user, span_warning("Wrong key."))
 			return
-	if(istype(P, /obj/item/storage/keyring))
-		var/obj/item/storage/keyring/K = P
-		for(var/obj/item/roguekey/KE in K.keys)
+	else if(istype(P, /obj/item/storage/keyring))
+		var/right_key = FALSE
+		for(var/obj/item/roguekey/KE in P.contents)
 			if(KE.lockid == lockid)
+				right_key = TRUE
 				locked = !locked
 				playsound(loc, 'sound/misc/gold_misc.ogg', 100, FALSE, -1)
 				update_icon()
 				return attack_hand(user)
+		if(!right_key)
+			to_chat(user, span_warning("Wrong key."))
+			return
 	if(istype(P, /obj/item/roguecoin))
 		budget += P.get_real_price()
 		qdel(P)


### PR DESCRIPTION
## About The Pull Request
- Add a separate apothecary Silverface so that potions is sold again in it (Oops)
- Reduce the base price of health, poison, mana and stamina potion to 25 instead of 35. They got overadjusted and were too expensive imo
- Keyring can now be used to lock and unlock silverfaces / goldfaces properly

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="500" height="800" alt="jNp0FzVX4g" src="https://github.com/user-attachments/assets/a7e30fa2-d2f3-465a-be0d-f55e468e8cda" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Niche protection for Apothecary and a lowpop substitute yada. Also corrects overadjustment on the cheaper potions.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
