### PR TITLE
Removes the free aheal in un-shifting

### DIFF
--- a/code/game/objects/shapeshift_holder.dm
+++ b/code/game/objects/shapeshift_holder.dm
@@ -72,12 +72,12 @@
 	if(death)
 		stored.death()
 	else if(source.convert_damage)
-		stored.revive(full_heal = TRUE, admin_revive = FALSE)
-
 		var/damage_percent = (shape.maxHealth - shape.health)/shape.maxHealth;
 		var/damapply = stored.maxHealth * damage_percent
-
 		stored.apply_damage(damapply, source.convert_damage_type, forced = TRUE)
+	else
+		stored.revive(full_heal = TRUE, admin_revive = FALSE) // Convert damage FALSE shifts keep the aheal, regenerative shifting?
+
 	qdel(shape)
 	qdel(src)
 


### PR DESCRIPTION
## About The Pull Request
Back when shift code was refactored, or scrunched, the aheal found its way back in. Removing it, now shape shifting isn't a free omni heal. Unless we set one to be so! Which could be interesting.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

https://github.com/user-attachments/assets/59edd7be-21e0-4f40-8e61-d7fdfd1179a5


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
This was removed before the refactor, but got put back in during the scrunching, so good to remove it now that we found it again.