### PR TITLE
Fracture & Wounds Bleeding Changes

### DIFF
--- a/code/datums/wounds/types/arteries.dm
+++ b/code/datums/wounds/types/arteries.dm
@@ -10,7 +10,7 @@
 	sewn_bleed_rate = 0.2
 	clotting_threshold = null
 	sewn_clotting_threshold = null
-	woundpain = 50
+	woundpain = 30		//Should hurt but believe it or not it doesn't hurt as much as people think. (Still urgently fatal.)
 	sewn_woundpain = 20
 	mob_overlay = "s1"
 	sewn_overlay = "cut"
@@ -79,7 +79,6 @@
 	var/static/list/heartaches = list(
 		"OOHHHH MY HEART!",
 		"MY HEART! IT HURTS!",
-		"I AM DYING!",
 		"MY HEART IS TORN!",
 		"MY HEART IS BLEEDING!",
 	)

--- a/code/datums/wounds/types/bites.dm
+++ b/code/datums/wounds/types/bites.dm
@@ -15,6 +15,7 @@
 /datum/wound/bite/small
 	name = "nip"
 	whp = 15
+	woundpain = 5
 
 /datum/wound/bite/large
 	name = "gnarly bite"

--- a/code/datums/wounds/types/bruises.dm
+++ b/code/datums/wounds/types/bruises.dm
@@ -22,7 +22,7 @@
 /datum/wound/bruise/large
 	name = "massive hematoma"
 	whp = 40
-	bleed_rate = 0.9
+	bleed_rate = 0.8
 	clotting_rate = 0.02
 	clotting_threshold = 0.3
 	woundpain = 25

--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -149,18 +149,20 @@
 		"The ear canal is pierced!",
 	)
 	embed_chance = 100
-	paralysis = TRUE
+	paralysis = FALSE
 	knockout = 25
 	clotting_threshold = 0.3	//Ears gonna bleed worse than just a fracture
 
 /datum/wound/fracture/head/ears/on_mob_gain(mob/living/affected)
 	. = ..()
 	to_chat(affected, span_warning("My ears ring before suddenly cutting out all sound!"))
+	affected.confused += 15	//Drunk-walk effect, basically.
 	ADD_TRAIT(affected, TRAIT_DEAF, "[type]")
 
 /datum/wound/fracture/head/ears/on_mob_loss(mob/living/affected)
 	. = ..()
 	to_chat(affected, span_notice("Slowly my hearing comes back to me.."))
+	affected.confused -= 15
 	REMOVE_TRAIT(affected, TRAIT_DEAF, "[type]")
 
 /datum/wound/fracture/head/nose
@@ -171,26 +173,21 @@
 	)
 	embed_chance = 100
 	mortal = FALSE
+	paralysis = FALSE	//Fucks your nose, but won't paralyze you anymore.
+	knockout = 20		//Longer knockout than a normal head-fracture
+	clotting_threshold = 0.3	//Nose bleeds as bad as ears gonna bleed worse than just a fracture
 
 /datum/wound/fracture/head/nose/on_mob_gain(mob/living/affected)
 	. = ..()
+	affected.confused += 10	//Mild-drunk-walk effect, basically.
+	affected.dizziness += 10
 	ADD_TRAIT(affected, TRAIT_MISSING_NOSE, "[type]")
-	ADD_TRAIT(affected, TRAIT_DISFIGURED, "[type]")
 
 /datum/wound/fracture/head/nose/on_mob_loss(mob/living/affected)
 	. = ..()
+	affected.confused -= 10
+	affected.dizziness -= 10
 	REMOVE_TRAIT(affected, TRAIT_MISSING_NOSE, "[type]")
-	ADD_TRAIT(affected, TRAIT_DISFIGURED, "[type]")
-
-/datum/wound/fracture/head/nose/on_mob_gain(mob/living/affected)
-	. = ..()
-	ADD_TRAIT(affected, TRAIT_MISSING_NOSE, "[type]")
-	ADD_TRAIT(affected, TRAIT_DISFIGURED, "[type]")
-
-/datum/wound/fracture/head/nose/on_mob_loss(mob/living/affected)
-	. = ..()
-	REMOVE_TRAIT(affected, TRAIT_MISSING_NOSE, "[type]")
-	ADD_TRAIT(affected, TRAIT_DISFIGURED, "[type]")
 
 /datum/wound/fracture/mouth
 	name = "mandibular fracture"

--- a/code/datums/wounds/types/punctures.dm
+++ b/code/datums/wounds/types/punctures.dm
@@ -9,6 +9,7 @@
 	clotting_threshold = 0.2
 	sewn_clotting_threshold = 0.1
 	sew_threshold = 75
+	woundpain = 6
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = TRUE
@@ -24,6 +25,7 @@
 	clotting_threshold = 0.1
 	sewn_clotting_threshold = 0.1
 	sew_threshold = 35
+	woundpain = 3
 
 /datum/wound/puncture/large
 	name = "gaping puncture"
@@ -36,6 +38,7 @@
 	clotting_threshold = 0.5
 	sewn_clotting_threshold = 0.25
 	sew_threshold = 100
+	woundpain = 10
 
 /datum/wound/puncture/drilling
 	name = "drilling"

--- a/code/datums/wounds/types/slashes.dm
+++ b/code/datums/wounds/types/slashes.dm
@@ -2,13 +2,14 @@
 	name = "slash"
 	whp = 30
 	sewn_whp = 10
-	bleed_rate = 0.4
+	bleed_rate = 0.8
 	sewn_bleed_rate = 0.02
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02
 	clotting_threshold = 0.2
 	sewn_clotting_threshold = 0.1
 	sew_threshold = 50
+	woundpain = 6
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = TRUE
@@ -17,25 +18,27 @@
 	name = "small slash"
 	whp = 15
 	sewn_whp = 5
-	bleed_rate = 0.2
+	bleed_rate = 0.4
 	sewn_bleed_rate = 0.01
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02
 	clotting_threshold = 0.1
 	sewn_clotting_threshold = 0.05
 	sew_threshold = 25
+	woundpain = 3
 
 /datum/wound/slash/large
 	name = "gruesome slash"
 	whp = 40
 	sewn_whp = 12
-	bleed_rate = 1
+	bleed_rate = 1.6
 	sewn_bleed_rate = 0.05
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02
 	clotting_threshold = 0.4
 	sewn_clotting_threshold = 0.1
 	sew_threshold = 75
+	woundpain = 10
 
 /datum/wound/slash/disembowel
 	name = "disembowelment"
@@ -48,13 +51,14 @@
 	sound_effect = 'sound/combat/crit2.ogg'
 	whp = 100
 	sewn_whp = 35
-	bleed_rate = 20
+	bleed_rate = 25
 	sewn_bleed_rate = 0.8
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02
 	clotting_threshold = 10
 	sewn_clotting_threshold = 0.5
 	sew_threshold = 150 //absolutely awful to sew up
+	woundpain = 50
 	critical = TRUE
 	/// Organs we can disembowel associated with chance to disembowel
 	var/static/list/affected_organs = list(

--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -143,7 +143,7 @@
 		"The tongue is severed!",
 		"The tongue flies off in an arc!"
 	)
-	woundpain = 20
+	woundpain = 25
 	can_sew = FALSE
 	can_cauterize = FALSE
 	critical = TRUE
@@ -168,7 +168,7 @@
 	severity = 0
 	crit_message = "The face is mangled beyond recognition!"
 	whp = null
-	woundpain = 20
+	woundpain = 25
 	mob_overlay = "cut"
 	can_sew = FALSE
 	can_cauterize = FALSE
@@ -286,7 +286,7 @@
 	)
 	sound_effect = 'sound/combat/crit.ogg'
 	whp = 80
-	woundpain = 30
+	woundpain = 40
 	can_sew = FALSE
 	can_cauterize = FALSE
 	disabling = TRUE


### PR DESCRIPTION
## About The Pull Request

Kind of a various wound tweak PR. I'll make a Tl;dr section below, and then a proper breakdown of stuff and why.

**Tl;dr - What It Do?**
Effectively increases bleed rates by nearly double on small and medium wounds; slight increase on max severity gruesome ones as well. Also adds pain to wound types. Fractures received a few bug-fixes and made them less paralyzation focused and instead blindness/deafness/drunk walk.

**Full Breakdown of Changes**
- Slash wounds now nearly doubled in bleeding. Slash wounds bleed more than stab wounds. Slash wounds now do pain.
- Stab wounds got very slight increase in bleed on some. Stab wounds bleed less than slash but are harder to patch-up. Stab wounds now do pain.
- Regular artery wounds got reduction in wound pain as other wounds already give more pain now across the board.
- Hemotoma got very slight bleed reduction to be equal to a moderate slash instead of higher than a slash.
- Nose fractures won't paralyze you anymore but _guarantee_ a knock-out and give you dizziness and confusion; fucking with your movement. (Also fixed error on them.) **See section of alternatives for alternative change if this is too much.**
- Increases to maim-tier wounds passive pain. I.e tongue cut out, scarring, disfiguring, etc. 

**ALTERNATIVES TO NOSE FRACTURE CHANGE:**
So, I made it so nose fractures no longer paralyze - but I'm on the fence about it. If it's too harsh I could add back its paralyzation but perhaps lock it behind pick/pierce weapons and blunt rather than stab being able to, as _most_ pick intents have a slower swing than stab (plus less damage on average than stab weapons so - less chance to max-severity crit) and blunt weapons have no AP.

**To-do:**
- Consider making pierce/pick weapons have unique wound types instead of using stab wounds.
- Test this before undrafting; need to figure out if bleed rates are too much for normal 10-con people.
- Maybe add more wound types for some blade classes; such as chop wounds having their own unique wounds that could maybe cripple limbs like a mace while also dealing slash damage. Etc.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Overall, I'd say this is a change for the better that makes getting cut/stabbed deadlier than current - but not by a huge amount. Fights are really prolonged due to the fact many people with high enough con - or pain immunities - can ignore stabs until it hits artery or until you have so many you finally fall over.

Paralysis also isn't too fun to deal with as a single crit can end a fight due to it. However, I tried keeping nose and ears VERY good damage-dealing areas without paralyzing your target for life on a crit. Instead you get drunk-walk, confusion, heavier knock-outs, etc allowing you to really hurt the target and make them easier to take down without breaking their skull open.