### PR TITLE
Fixes muffles not muffling.

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -158,7 +158,7 @@
 			var/modifier
 			if(H.age == AGE_OLD)
 				modifier = "old"
-			if(!ignore_silent && (H.silent))
+			if((!ignore_silent && (H.silent)) || (!ignore_silent && H.mouth?.muteinmouth))
 				modifier = "silenced"
 			if(user.gender == FEMALE && H.dna.species.soundpack_f)
 				possible_sounds = H.dna.species.soundpack_f.get_sound(key,modifier)


### PR DESCRIPTION
## About The Pull Request
OOps! I kinda broke the mfing muffling for audio emotes. So. This makes muffling actually muffle. By using the same check I implemented for properly muzzling people using cloth. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I did self surgery and then stepped on mantraps while muzzled. I didn't make noise. I wasn't mute either.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Scremaing through cloth is kinda bad during surgery. It'ss supposed 2 muffle you.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
