### PR TITLE
Axes auxiliary ingredients for Mage summoning.

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/rituals/summons.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/summons.dm
@@ -28,7 +28,7 @@
 	desc = "summons an infernal imp"
 	blacklisted = FALSE
 	tier = 1
-	required_atoms = list(/obj/item/ash = 2, /obj/item/magic/obsidian = 1)
+	required_atoms = list(/obj/item/magic/obsidian = 1)
 	mob_to_summon = /mob/living/simple_animal/hostile/retaliate/rogue/infernal/imp
 
 /datum/runeritual/summoning/hellhound
@@ -36,7 +36,7 @@
 	desc = "summons a hellhound"
 	blacklisted = FALSE
 	tier = 2
-	required_atoms = list(/obj/item/magic/infernalash = 3, /obj/item/magic/obsidian = 2, /obj/item/magic/melded/t1 = 1)
+	required_atoms = list(/obj/item/magic/infernalash = 2, /obj/item/magic/obsidian = 2, /obj/item/magic/melded/t1 = 1)
 	mob_to_summon = /mob/living/simple_animal/hostile/retaliate/rogue/infernal/hellhound
 
 /datum/runeritual/summoning/watcher
@@ -52,7 +52,7 @@
 	desc = "summons an fiend"
 	blacklisted = FALSE
 	tier = 4
-	required_atoms = list(/obj/item/magic/infernalcore = 1, /obj/item/magic/obsidian = 3, /obj/item/magic/melded/t3 =1)
+	required_atoms = list(/obj/item/magic/infernalcore = 1, /obj/item/magic/obsidian = 2, /obj/item/magic/melded/t3 =1)
 	mob_to_summon = /mob/living/simple_animal/hostile/retaliate/rogue/infernal/fiend
 
 /datum/runeritual/summoning/sprite
@@ -60,7 +60,7 @@
 	desc = "summons an fae sprite"
 	blacklisted = FALSE
 	tier = 1
-	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 1, /obj/item/reagent_containers/food/snacks/grown/berries/rogue = 1)
+	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 1)
 	mob_to_summon = /mob/living/simple_animal/hostile/retaliate/rogue/fae/sprite
 
 /datum/runeritual/summoning/glimmer
@@ -68,7 +68,7 @@
 	desc = "summons an fae spirit"
 	blacklisted = FALSE
 	tier = 2
-	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 2, /obj/item/magic/fairydust = 3, /obj/item/magic/melded/t1 = 1)
+	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 2, /obj/item/magic/fairydust = 2, /obj/item/magic/melded/t1 = 1)
 	mob_to_summon = /mob/living/simple_animal/hostile/retaliate/rogue/fae/glimmerwing
 
 /datum/runeritual/summoning/dryad
@@ -92,7 +92,7 @@
 	desc = "summons a minor elemental"
 	blacklisted = FALSE
 	tier = 1
-	required_atoms = list(/obj/item/natural/stone = 2, /obj/item/magic/manacrystal = 1)
+	required_atoms = list(/obj/item/magic/manacrystal = 1)
 	mob_to_summon = /mob/living/simple_animal/hostile/retaliate/rogue/elemental/crawler
 
 /datum/runeritual/summoning/warden
@@ -100,7 +100,7 @@
 	desc = "summons an elemental"
 	blacklisted = FALSE
 	tier = 2
-	required_atoms = list(/obj/item/magic/elementalmote = 3, /obj/item/magic/manacrystal = 2, /obj/item/magic/melded/t1 = 1)
+	required_atoms = list(/obj/item/magic/elementalmote = 2, /obj/item/magic/manacrystal = 2, /obj/item/magic/melded/t1 = 1)
 	mob_to_summon = /mob/living/simple_animal/hostile/retaliate/rogue/elemental/warden
 
 /datum/runeritual/summoning/behemoth


### PR DESCRIPTION
## About The Pull Request

Removes berries/ash/stone from the requirements list; this was brought up to alleviate space issues due to the lack of plots after planting are calendula/paris/benedictus/etc. plants on top of a side display of manablooms.

This also leaves a singular remainder under tier two summons for the materials they yield, allowing said remainder to let Mages do their thing without being hounded by fifty billion extra summons

## Testing Evidence

I'll test it in the morning and respond to this post with images.

## Why It's Good For The Game

Tedious work is tedious work and not fun to engage with, also just because it is.