### PR TITLE
Split between coastal sea and deep sea fishing.

### DIFF
--- a/code/game/objects/items/rogueitems/fishing_cage.dm
+++ b/code/game/objects/items/rogueitems/fishing_cage.dm
@@ -48,6 +48,8 @@
 				STOP_PROCESSING(SSobj, src)
 				icon_state = "fishingcage_deployed"
 				add_sleep_experience(user, /datum/skill/labor/fishing, 20)
+				record_featured_stat(FEATURED_STATS_FISHERS, user)
+				GLOB.azure_round_stats[STATS_FISH_CAUGHT]++
 				new caught(user.loc)
 				caught = null
 				desc = initial(desc)

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -447,18 +447,29 @@
 		/obj/item/reagent_containers/food/snacks/fish/eel = 150,
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 20,
 	)
-	seafishloot = list(
+	coastalseafishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/cod = 200,
-		/obj/item/reagent_containers/food/snacks/fish/plaice = 200,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 220,
 		/obj/item/reagent_containers/food/snacks/fish/sole = 305,
-		/obj/item/reagent_containers/food/snacks/fish/angler = 150,
-		/obj/item/reagent_containers/food/snacks/fish/lobster = 300,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 45,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 120,
 		/obj/item/reagent_containers/food/snacks/fish/bass = 200,
-		/obj/item/reagent_containers/food/snacks/fish/clam = 100,
-		/obj/item/reagent_containers/food/snacks/fish/clownfish = 50,
-		/mob/living/carbon/human/species/goblin/npc/sea = 25,
-		/mob/living/simple_animal/hostile/rogue/deepone = 30,
-		/mob/living/simple_animal/hostile/rogue/deepone/spit = 30,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 30,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 15,
+		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,
+	)
+	deepseafishloot = list(
+		/obj/item/reagent_containers/food/snacks/fish/cod = 100,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 100,
+		/obj/item/reagent_containers/food/snacks/fish/sole = 91,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 210,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 390,
+		/obj/item/reagent_containers/food/snacks/fish/bass = 120,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 200,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 100,
+		/mob/living/carbon/human/species/goblin/npc/sea = 45,
+		/mob/living/simple_animal/hostile/rogue/deepone = 50,
+		/mob/living/simple_animal/hostile/rogue/deepone/spit = 50,
 	)
 	mudfishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/mudskipper = 200,
@@ -469,7 +480,8 @@
 	var/ft = 160 //Time to get a catch, in ticks
 	var/fpp =  130 - (40 + (sl * 15)) // Fishing power penalty based on fishing skill level
 	var/frwt = list(/turf/open/water/river, /turf/open/water/cleanshallow, /turf/open/water/pond)
-	var/salwt = list(/turf/open/water/ocean, /turf/open/water/ocean/deep)
+	var/salwt_coast = list(/turf/open/water/ocean)
+	var/salwt_deep = list(/turf/open/water/ocean/deep)
 	var/mud = list(/turf/open/water/swamp, /turf/open/water/swamp/deep)
 	if(istype(target, /turf/open/water))
 		if(user.used_intent.type == SPEAR_CAST && !user.doing)
@@ -491,8 +503,10 @@
 						var/A
 						if(target.type in frwt)
 							A = pickweight(freshfishloot)
-						else if(target.type in salwt)
-							A = pickweight(seafishloot)
+						else if(target.type in salwt_coast)
+							A = pickweight(coastalseafishloot)
+						else if(target.type in salwt_deep)
+							A = pickweight(deepseafishloot)
 						else if(target.type in mud)
 							A = pickweight(mudfishloot)
 						if(A)

--- a/code/modules/roguetown/roguejobs/fisher/leeches.dm
+++ b/code/modules/roguetown/roguejobs/fisher/leeches.dm
@@ -21,31 +21,49 @@
 		/obj/item/reagent_containers/glass/bottle/rogue = 1,		
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 20,		
 	)
-	seafishloot = list(
+	coastalseafishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/cod = 230,
-		/obj/item/reagent_containers/food/snacks/fish/plaice = 180,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 198,
 		/obj/item/reagent_containers/food/snacks/fish/sole = 250,
-		/obj/item/reagent_containers/food/snacks/fish/angler = 170,
-		/obj/item/reagent_containers/food/snacks/fish/lobster = 180,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 51,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 72,
 		/obj/item/reagent_containers/food/snacks/fish/bass = 230,
-		/obj/item/reagent_containers/food/snacks/fish/clam = 50,
-		/obj/item/reagent_containers/food/snacks/fish/clownfish = 40,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 15,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 12,
 		/obj/item/grown/log/tree/stick = 3,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/natural/cloth = 1,
 		/obj/item/ammo_casing/caseless/rogue/arrow = 1,
 		/obj/item/clothing/ring/gold = 1,
-		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a fish...?
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a coastal fish...?
 		/obj/item/reagent_containers/glass/bottle/rogue/wine = 1,
-		/obj/item/reagent_containers/glass/bottle/rogue = 1,	
-		/mob/living/carbon/human/species/goblin/npc/sea = 25,
-		/mob/living/simple_animal/hostile/rogue/deepone = 30,
-		/mob/living/simple_animal/hostile/rogue/deepone/spit = 30,			
+		/obj/item/reagent_containers/glass/bottle/rogue = 1,
+		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,
+	)
+	deepseafishloot = list(
+		/obj/item/reagent_containers/food/snacks/fish/cod = 115,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 90,
+		/obj/item/reagent_containers/food/snacks/fish/sole = 75,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 238,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 234,
+		/obj/item/reagent_containers/food/snacks/fish/bass = 138,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 100,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 80,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 10,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 5,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
+		/obj/item/clothing/ring/gold = 5,
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a deepfish...?
+		/obj/item/reagent_containers/glass/bottle/rogue/wine = 1,
+		/mob/living/carbon/human/species/goblin/npc/sea = 45,
+		/mob/living/simple_animal/hostile/rogue/deepone = 50,
+		/mob/living/simple_animal/hostile/rogue/deepone/spit = 50,
 	)
 	mudfishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/mudskipper = 200,
 		/obj/item/natural/worms/leech = 50,
 		/obj/item/clothing/ring/gold = 1,	
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //Thats one dirty... not a fish...?
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,			
 	)
 	// This is super trimmed down from the ratwood list to focus entirely on shellfishes

--- a/code/modules/roguetown/roguejobs/fisher/rod.dm
+++ b/code/modules/roguetown/roguejobs/fisher/rod.dm
@@ -66,7 +66,8 @@
 	var/ft = 120 //Time to get a catch, in ticks
 	var/fpp =  100 - (40 + (sl * 10)) // Fishing power penalty based on fishing skill level
 	var/frwt = list(/turf/open/water/river, /turf/open/water/cleanshallow, /turf/open/water/pond)
-	var/salwt = list(/turf/open/water/ocean, /turf/open/water/ocean/deep)
+	var/salwt_coast = list(/turf/open/water/ocean)
+	var/salwt_deep = list(/turf/open/water/ocean/deep)
 	var/mud = list(/turf/open/water/swamp, /turf/open/water/swamp/deep)
 	if(user.used_intent.type == SPEAR_BASH)
 		return ..()
@@ -101,8 +102,10 @@
 							var/A
 							if(target.type in frwt)
 								A = pickweight(baited.freshfishloot)
-							else if(target.type in salwt)
-								A = pickweight(baited.seafishloot)
+							else if(target.type in salwt_coast)
+								A = pickweight(baited.coastalseafishloot)
+							else if(target.type in salwt_deep)
+								A = pickweight(baited.deepseafishloot)
 							else if(target.type in mud)
 								A = pickweight(baited.mudfishloot)
 							if(A)

--- a/code/modules/roguetown/roguejobs/fisher/worms.dm
+++ b/code/modules/roguetown/roguejobs/fisher/worms.dm
@@ -2,7 +2,8 @@
 	var/baitpenalty = 100 // Using this as bait will incurr a penalty to fishing chance. 100 makes it useless as bait. Lower values are better, but Never make it past 10.
 	var/isbait = FALSE	// Is the item in question bait to be used?
 	var/list/freshfishloot = null
-	var/list/seafishloot = null
+	var/list/coastalseafishloot = null
+	var/list/deepseafishloot = null
 	var/list/mudfishloot = null
 	var/list/fishloot = null
 	var/list/cageloot = null	
@@ -31,31 +32,49 @@
 		/obj/item/reagent_containers/glass/bottle/rogue = 1,	
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 20,			
 	)
-	seafishloot = list(
+	coastalseafishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/cod = 190,
-		/obj/item/reagent_containers/food/snacks/fish/plaice = 210,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 231,
 		/obj/item/reagent_containers/food/snacks/fish/sole = 340,
-		/obj/item/reagent_containers/food/snacks/fish/angler = 140,
-		/obj/item/reagent_containers/food/snacks/fish/lobster = 150,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 42,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 60,
 		/obj/item/reagent_containers/food/snacks/fish/bass = 210,
-		/obj/item/reagent_containers/food/snacks/fish/clam = 40,
-		/obj/item/reagent_containers/food/snacks/fish/clownfish = 20,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 12,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 6,
 		/obj/item/grown/log/tree/stick = 3,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/natural/cloth = 1,
 		/obj/item/ammo_casing/caseless/rogue/arrow = 1,
 		/obj/item/clothing/ring/gold = 1,
-		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a fish...?
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a coastal fish...?
 		/obj/item/reagent_containers/glass/bottle/rogue/wine = 1,
-		/obj/item/reagent_containers/glass/bottle/rogue = 1,	
-		/mob/living/carbon/human/species/goblin/npc/sea = 25,
-		/mob/living/simple_animal/hostile/rogue/deepone = 30,
-		/mob/living/simple_animal/hostile/rogue/deepone/spit = 30,			
+		/obj/item/reagent_containers/glass/bottle/rogue = 1,
+		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,
+	)
+	deepseafishloot = list(
+		/obj/item/reagent_containers/food/snacks/fish/cod = 95,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 105,
+		/obj/item/reagent_containers/food/snacks/fish/sole = 102,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 196,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 195,
+		/obj/item/reagent_containers/food/snacks/fish/bass = 126,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 80,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 40,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 10,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 5,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
+		/obj/item/clothing/ring/gold = 5,
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a deepfish...?
+		/obj/item/reagent_containers/glass/bottle/rogue/wine = 1,
+		/mob/living/carbon/human/species/goblin/npc/sea = 45,
+		/mob/living/simple_animal/hostile/rogue/deepone = 50,
+		/mob/living/simple_animal/hostile/rogue/deepone/spit = 50,
 	)
 	mudfishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/mudskipper = 200,
 		/obj/item/natural/worms/leech = 50,
 		/obj/item/clothing/ring/gold = 1,
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //Thats one dirty... not a fish...?
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,				
 	)
 	// This is super trimmed down from the ratwood list to focus entirely on shellfishes
@@ -89,31 +108,49 @@
 		/obj/item/reagent_containers/glass/bottle/rogue = 1,
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 20,				
 	)
-	seafishloot = list(
+	coastalseafishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/cod = 230,
-		/obj/item/reagent_containers/food/snacks/fish/plaice = 180,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 198,
 		/obj/item/reagent_containers/food/snacks/fish/sole = 250,
-		/obj/item/reagent_containers/food/snacks/fish/angler = 170,
-		/obj/item/reagent_containers/food/snacks/fish/lobster = 180,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 51,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 72,
 		/obj/item/reagent_containers/food/snacks/fish/bass = 230,
-		/obj/item/reagent_containers/food/snacks/fish/clam = 50,
-		/obj/item/reagent_containers/food/snacks/fish/clownfish = 40,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 15,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 12,
 		/obj/item/grown/log/tree/stick = 3,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/natural/cloth = 1,
 		/obj/item/ammo_casing/caseless/rogue/arrow = 1,
 		/obj/item/clothing/ring/gold = 1,
-		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a fish...?
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a coastal fish...?
 		/obj/item/reagent_containers/glass/bottle/rogue/wine = 1,
-		/obj/item/reagent_containers/glass/bottle/rogue = 1,		
-		/mob/living/carbon/human/species/goblin/npc/sea = 25,
-		/mob/living/simple_animal/hostile/rogue/deepone = 30,
-		/mob/living/simple_animal/hostile/rogue/deepone/spit = 30,		
+		/obj/item/reagent_containers/glass/bottle/rogue = 1,
+		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,
+	)
+	deepseafishloot = list(
+		/obj/item/reagent_containers/food/snacks/fish/cod = 115,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 90,
+		/obj/item/reagent_containers/food/snacks/fish/sole = 75,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 238,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 234,
+		/obj/item/reagent_containers/food/snacks/fish/bass = 138,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 100,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 80,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 10,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 5,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
+		/obj/item/clothing/ring/gold = 5,
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //That's not a deepfish...?
+		/obj/item/reagent_containers/glass/bottle/rogue/wine = 1,
+		/mob/living/carbon/human/species/goblin/npc/sea = 45,
+		/mob/living/simple_animal/hostile/rogue/deepone = 50,
+		/mob/living/simple_animal/hostile/rogue/deepone/spit = 50,
 	)
 	mudfishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/mudskipper = 200,
 		/obj/item/natural/worms/leech = 50,
 		/obj/item/clothing/ring/gold = 1,
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //Thats one dirty... not a fish...?
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,				
 	)	
 /obj/item/natural/worms/grubs/attack_right(mob/user)

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -126,7 +126,8 @@
 	devotion_cost = 10
 	//Horrendous carry-over from fishing code
 	var/frwt = list(/turf/open/water/river, /turf/open/water/cleanshallow, /turf/open/water/pond)
-	var/salwt = list(/turf/open/water/ocean, /turf/open/water/ocean/deep)
+	var/salwt_coast = list(/turf/open/water/ocean)
+	var/salwt_deep = list(/turf/open/water/ocean/deep)
 	var/mud = list(/turf/open/water/swamp, /turf/open/water/swamp/deep)
 	var/list/freshfishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/carp = 225,
@@ -136,24 +137,36 @@
 		/obj/item/reagent_containers/food/snacks/smallrat = 1, //funny
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 20,			
 	)
-	var/list/seafishloot = list(
+	var/list/coastalseafishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/cod = 190,
-		/obj/item/reagent_containers/food/snacks/fish/plaice = 210,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 231,
 		/obj/item/reagent_containers/food/snacks/fish/sole = 340,
-		/obj/item/reagent_containers/food/snacks/fish/angler = 140,
-		/obj/item/reagent_containers/food/snacks/fish/lobster = 150,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 42,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 60,
 		/obj/item/reagent_containers/food/snacks/fish/bass = 210,
-		/obj/item/reagent_containers/food/snacks/fish/clam = 40,
-		/obj/item/reagent_containers/food/snacks/fish/clownfish = 20,
-		/obj/item/reagent_containers/food/snacks/smallrat = 1, //still funny
-		/mob/living/carbon/human/species/goblin/npc/sea = 10,
-		/mob/living/simple_animal/hostile/rogue/deepone = 3,
-		/mob/living/simple_animal/hostile/rogue/deepone/spit = 3,			
+		/obj/item/reagent_containers/food/snacks/fish/clam = 12,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 6,
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //still funny, but shallow
+		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,
+	)
+	var/list/deepseafishloot = list(
+		/obj/item/reagent_containers/food/snacks/fish/cod = 95,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 105,
+		/obj/item/reagent_containers/food/snacks/fish/sole = 102,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 196,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 195,
+		/obj/item/reagent_containers/food/snacks/fish/bass = 126,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 80,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 40,
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //still funny, and this one is deep
+		/mob/living/carbon/human/species/goblin/npc/sea = 18,
+		/mob/living/simple_animal/hostile/rogue/deepone = 5,
+		/mob/living/simple_animal/hostile/rogue/deepone/spit = 5,			
 	)
 	var/list/mudfishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/mudskipper = 200,
 		/obj/item/natural/worms/leech = 50,
-		/obj/item/reagent_containers/food/snacks/smallrat = 1, //even funnier the third time
+		/obj/item/reagent_containers/food/snacks/smallrat = 1, //even funnier the fourth time
 		/mob/living/simple_animal/hostile/retaliate/rogue/mudcrab = 25,				
 	)	
 
@@ -164,8 +177,10 @@
 		var/A
 		if(T.type in frwt)
 			A = pickweight(freshfishloot)
-		else if(T.type in salwt)
-			A = pickweight(seafishloot)
+		else if(T.type in salwt_coast)
+			A = pickweight(coastalseafishloot)
+		else if(T.type in salwt_deep)
+			A = pickweight(deepseafishloot)
 		else if(T.type in mud)
 			A = pickweight(mudfishloot)
 		if(A)

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -1028,7 +1028,23 @@
 		/obj/item/clothing/ring/gold = 15,
 		/obj/item/reagent_containers/glass/bottle/rogue/wine = 15,	
 	)
-	seafishloot = list(
+	// magic bait is magic so coastal and deep sea weights are the same, split made just for the compatibility reasons
+	coastalseafishloot = list(
+		/obj/item/reagent_containers/food/snacks/fish/cod = 50,
+		/obj/item/reagent_containers/food/snacks/fish/plaice = 75,
+		/obj/item/reagent_containers/food/snacks/fish/sole = 50,
+		/obj/item/reagent_containers/food/snacks/fish/angler = 100,
+		/obj/item/reagent_containers/food/snacks/fish/lobster = 50,
+		/obj/item/reagent_containers/food/snacks/fish/bass = 50,
+		/obj/item/reagent_containers/food/snacks/fish/clam = 50,
+		/obj/item/reagent_containers/food/snacks/fish/clownfish = 200,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 75,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 25,
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 10,
+		/obj/item/clothing/ring/gold = 25,
+		/obj/item/reagent_containers/glass/bottle/rogue/wine = 25,		
+	)
+	deepseafishloot = list(
 		/obj/item/reagent_containers/food/snacks/fish/cod = 50,
 		/obj/item/reagent_containers/food/snacks/fish/plaice = 75,
 		/obj/item/reagent_containers/food/snacks/fish/sole = 50,


### PR DESCRIPTION
## About The Pull Request

Splits sea fishing into two separate types: coastal fishing and deep sea fishing.

### Coastal fishing
- much safer than normal sea fishing (similar to fresh water fishing)
- higher chance for low value fish, much lower chance for high value fish (almost impossible to catch high value fish consistently)
- chance for trash, low chance for low value treasure

### Deep sea fishing
- more dangerous than normal sea fishing (much higher chance of pulling out a goblin or a deep one), meant to be done with some sort of protection
- lower chance for low value fish, higher chance for high value fish (high risk, high reward)
- almost no chance trash, slightly higher chance for more valuable treasures

### Misc
- eaora's "cerulean aril" weights were not changed - magic bait and such so it has its own rules, still differentiating between coastal and deep for the sake of consistency
- fixed minor bug in fishing cage code where fish caught with the cage did not count towards fish statistics
- fixed horrendous bug where some types of bait did not allow for fishing out a rat (I have no idea how something this big could have been in the game for so long)

## Testing Evidence

Caught some fish, kicked shit out of few deep ones and goblins (okay, they kicked my shit in and I had to summon mossback to kick theirs).
<img width="473" height="424" alt="obraz" src="https://github.com/user-attachments/assets/c613d6aa-1d0d-4e45-8dd5-4a8e92afe131" />

Kinda hard to test the probabilities. I tried to follow common sense when setting them and decided to keep them relatively parallel between various types of bait, i.e. when deciding new weights I used the same change ratio from original values for different baits. If anyone would like to discuss this further I have prepared an excel file with all probabilities. I am open to discussion regarding the probabilities and am willing to adjust them later if needed.

## Why It's Good For The Game
Some examples for a good start:
- Are you a servant/an inkeeper and want to expand your menu with some delicious sea fish? Go right ahead and fish em/send your tapster to fish em, you wont get the best but at least you will survive! 
- What is it? Your lord/wealthy patron wants some of those delicious deep sea fish? Well you better send some guards or hire some mercs with the fisher because they are not coming back alive otherwise.

---
More diversity in minor mechanics which is always good!

In my opinion change like this allows for a few new playstyles in a field that was underutilized to say the least.

Now people that want to RP a quaint, little fish stand, expand the inn/keep menu, or do other things that requires them to have access to more variety of fish can now do just that.

On the other hand the wardens/MAAs might now have more reason to patrol the beach as reckless fishermen can quickly flood it with monsters, mercenaries might get more contracts from people that want to catch rare fish in peace, and people that can both fish and take care of the dangers might be able to turn nice profit on the deep sea fishing.

All in all I hope that this change will revitalize, even if just a little, the idea of sea fishing and in turn give more traffic to the beach area.
