### PR TITLE
Non-Ascendant Heretics

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -9,9 +9,6 @@
 
 
 /datum/outfit/job/roguetown/wretch/heretic/pre_equip(mob/living/carbon/human/H)
-	if (!(istype(H.patron, /datum/patron/inhumen/zizo) || istype(H.patron, /datum/patron/inhumen/matthios) || istype(H.patron, /datum/patron/inhumen/graggar) || istype(H.patron, /datum/patron/inhumen/baotha)))
-		to_chat(H, span_warning("My former deity frowned upon my practices. I have since turned to a new god."))
-		H.set_patron(pick(/datum/patron/inhumen/zizo, /datum/patron/inhumen/matthios, /datum/patron/inhumen/graggar, /datum/patron/inhumen/baotha))
 	H.mind.current.faction += "[H.name]_faction"
 	H.adjust_skillrank(/datum/skill/magic/holy, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)


### PR DESCRIPTION
## About The Pull Request

- You can now worship any God and be a heretic.
- User be warned, that basically any heretic who isnt an Ascendant Worshipper is probably weaker than the ascendant heretics(makes cents to me)

## Testing Evidence

- yes.
- Just stripped out the check and loaded

## Why It's Good For The Game

While probably weaker, the gimmick of people playing some Tennite heretic or Psydonian heretic(hardmode) has been wanted for awhile.