### PR TITLE
allows game bags to hold animal heads

### DIFF
--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -128,7 +128,8 @@
 		/obj/item/natural/hide,
 		/obj/item/alch/sinew,
 		/obj/item/alch/viscera,
-		/obj/item/alch/bone
+		/obj/item/alch/bone,
+		/obj/item/natural/head // this only works for animal heads
 		))
 
 /datum/component/storage/concrete/grid/magebag


### PR DESCRIPTION
## About The Pull Request
- allows game bags, which hunters start with, to carry animal heads alongside their regular products
- does NOT allow them to hold carbon hads
tl;dr, as a hunter, you now have way too many fucking items. the game bag wouldve been okay if you didn't also have a sword, but right now, you have a satchel, sword, bow, quiver, and lamptern PLUS the game bag. that is _**six**_ different items that all compete for a slot. only one of these (the lamptern) can even be tucked into a cloak or bag.

this pr tries to fix some of this, so that hunters can fetch what they need to from the satchel, put it into their pouch, belt, etc, then swap it out for the game bag. or dont! toss the game-bag aside. who cares. use the satchel if you want more general-purpose storage.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1502" height="668" alt="image" src="https://github.com/user-attachments/assets/d0e743a5-9fa9-4650-a91d-797fd245c288" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- hunters can now reasonably discard their satchels and not have to juggle five hip/back slot items across four slots
- regular bags could already do this. lmao.
- still gives headhooks a niche since those are specialized for carbon heads
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
