### PR TITLE
"Enduring" statpack

### DIFF
--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -32,5 +32,5 @@
 
 /datum/statpack/physical/enduring
 	name = "Enduring"
-	desc = "You've spent yils willingly submitting your body through a most perilous journey. Stalwart in your faith, you've sworn to never flee again.
+	desc = "You've spent yils willingly submitting your body through a most perilous journey. Stalwart in your faith, you've sworn to never flee again."
 	stat_array = list(STAT_CONSTITUTION = 3, STAT_ENDURANCE = 3, STAT_PERCEPTION = -1, STAT_SPEED = -4)

--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -33,4 +33,4 @@
 /datum/statpack/physical/enduring
 	name = "Enduring"
 	desc = "You've spent yils willingly submitting your body through a most perilous journey. Stalwart in your faith, you've sworn to never flee again.
-	stat_array = list(STAT_CONSTITUTION = 3, STAT_ENDURANCE = 3, STAT_SPEED = -4)
+	stat_array = list(STAT_CONSTITUTION = 3, STAT_ENDURANCE = 3, STAT_PERCEPTION = -1, STAT_SPEED = -4)

--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -2,7 +2,7 @@
 
 /datum/statpack/physical/trained
 	name = "Trained"
-	desc = "Years honing your physique has left you with a physical edge, but your faculties have been neglected somewhat."
+	desc = "Years honing your physique has left you with a physical edge, but your faculties have been somewhat neglected."
 	stat_array = list(STAT_STRENGTH = 1, STAT_CONSTITUTION = 1, STAT_ENDURANCE = 1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1)
 
 /datum/statpack/physical/muscular
@@ -22,10 +22,15 @@
 
 /datum/statpack/physical/toil
 	name = "Toil-hardened"
-	desc = "Your life, hard-lived, has imparted one solitary adage: carry on above all else. And so you endure."
+	desc = "Your lyfe, hard-lyved, has imparted one solitary adage: carry on above all else. And so you endure."
 	stat_array = list(STAT_ENDURANCE = 2, STAT_CONSTITUTION = 1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1)
 
 /datum/statpack/physical/struggler
 	name = "Struggler"
 	desc = "Lyfe's dealt you a poor hand, so you've opted to simply flip the table instead."
 	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 2, STAT_ENDURANCE = 2, STAT_INTELLIGENCE = -3, STAT_PERCEPTION = -3, STAT_FORTUNE = -2)
+
+/datum/statpack/physical/enduring
+	name = "Enduring"
+	desc = "You've spent yils willingly submitting your body through a most perilous journey. Stalwart in your faith, you've sworn to never flee again.
+	stat_array = list(STAT_CONSTITUTION = 3, STAT_ENDURANCE = 3, STAT_SPEED = -4)


### PR DESCRIPTION
## About The Pull Request

You've spent yils willingly submitting your body through a most perilous journey.
**+3 CON  +3 END** 
Stalwart in your faith, 
**-1 PER**
you've sworn to never flee again.
**-4 SPD**


## Testing Evidence
<img width="499" height="188" alt="image" src="https://github.com/user-attachments/assets/14b6b070-a70b-4dd7-bd99-db34a09e09aa" />
<img width="475" height="142" alt="image" src="https://github.com/user-attachments/assets/a6f4b10f-b6df-42d6-a46a-3d914c876f08" />


## Why It's Good For The Game
We can afford a statpack that creates a "rooted" playstyle for warrior classes that want to forego speed for resistance. This is, in practice, a worse version of Hardy without the strength malus.

I'm considering getting rid of the -1 PER malus since I think -4 SPD is already punishing enough. Discuss if needed.