### PR TITLE
Make purified alloy yield 3, make Blacksteel yield 1 from 4 input.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -224,11 +224,12 @@
 						maxore = 3
 						alloy = /obj/item/ingot/steel
 					else if(bronzealloy == 7)
-						testing("BRONZE ALLOYED")
 						alloy = /obj/item/ingot/bronze
 					else if(purifiedalloy == 10)
+						maxore = 3
 						alloy = /obj/item/ingot/purifiedaalloy // 2 aalloy, 2 gold, makes 3 purified alloy.
 					else if(blacksteelalloy == 7)
+						maxore = 1 // Blacksteel is supposed to be rare and inefficient. 3 steel and 1 silver into one. 
 						alloy = /obj/item/ingot/blacksteel
 					else
 						alloy = null


### PR DESCRIPTION
## About The Pull Request
I was informed that blacksmith were making one gazillion blacksteel and it turns out I accidentally made blacksteel formula 4 times as efficient as intended, making it yield 4 bars from 1 silver and 3 steel. Oops.
- Blacksteel now yield 1 bar instead of 4 bar from 3 steel and 1 silver
- Purified Alloy now yield 3 bars instead of 4 bars from 2 ancient and 2 gold. (This is as intended in the code but were changed to not be that way at some point)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="998" height="312" alt="TabTip_Uigg1wTcov" src="https://github.com/user-attachments/assets/383c4c3a-1db8-4d3e-84d6-cd1ba45bec5c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
10,000 blacksteel was never intended.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
