### PR TITLE
Bugfix role restriction for Lich

### DIFF
--- a/code/modules/events/antagonist/solo/lich.dm
+++ b/code/modules/events/antagonist/solo/lich.dm
@@ -43,7 +43,7 @@
 		"Steward",
 		"Court Physician",
 		"Town Elder",
-		"Captain",
+		"Knight Captain",
 		"Archivist",
 		"Knight",
 		"Court Magician",


### PR DESCRIPTION
## About The Pull Request

Someone forgot to rename Knight Captain in Lich.dm role restriction therefore captain was able be Lich all the time

## Testing Evidence

It's literally just one word fix in one file...

## Why It's Good For The Game

Bugfixes are always good, aren't they?