### PR TITLE
Chain Gauntlets recipe to 2x. Chain Gauntlets cannot be smelted.

### DIFF
--- a/code/modules/clothing/rogueclothes/gloves/chain.dm
+++ b/code/modules/clothing/rogueclothes/gloves/chain.dm
@@ -11,21 +11,19 @@
 	break_sound = 'sound/foley/breaksound.ogg'
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	anvilrepair = /datum/skill/craft/armorsmithing
-	smeltresult = /obj/item/ingot/steel
+	smeltresult = null
 	unarmed_bonus = 1.15
 
 /obj/item/clothing/gloves/roguetown/chain/aalloy
 	name = "decrepit chain gauntlets"
 	desc = "Decrepit old chain gauntlets. Aeon's grasp is upon them."
 	icon_state = "acgloves"
-	smeltresult = /obj/item/ingot/aalloy
 	max_integrity = ARMOR_INT_SIDE_DECREPIT
 
 /obj/item/clothing/gloves/roguetown/chain/paalloy
 	name = "ancient chain gauntlets"
 	desc = "Chain gauntlets formed out of ancient alloys. Aeon's grasp is lifted from them."
 	icon_state = "acgloves"
-	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/clothing/gloves/roguetown/chain/psydon
 	name = "psydonian gloves"
@@ -37,5 +35,4 @@
 	icon_state = "icgloves"
 	desc = "Gauntlets made of interlinked iron rings. They offer decent protection against common weaponries, except for arrows."
 	anvilrepair = /datum/skill/craft/armorsmithing
-	smeltresult = /obj/item/ingot/iron
 	max_integrity = ARMOR_INT_SIDE_IRON

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -175,15 +175,17 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/chaingaunts
-	name = "Decrepit Alloy Chain Gauntlets"
+	name = "Decrepit Alloy Chain Gauntlets, 2x"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/gloves/roguetown/chain/aalloy
+	createditem_num = 2
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/chaingaunts
-	name = "Purified Alloy Chain Gauntlets"
+	name = "Purified Alloy Chain Gauntlets, 2x"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/gloves/roguetown/chain/paalloy
+	createditem_num = 2
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/plategaunts


### PR DESCRIPTION
## About The Pull Request
Unify all chain gauntlets recipe to 2x efficiency. Make them unsmeltable

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="276" height="241" alt="dreamseeker_2jcFa1C5hu" src="https://github.com/user-attachments/assets/76dfb28e-6970-4025-aafd-52f9345a7857" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Material exploit bad. Inconsistency bad.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
