### PR TITLE
NPC AI leaping fixes and tweaks

### DIFF
--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -62,33 +62,33 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 	return b.f - a.f
 
 //wrapper that returns an empty list if A* failed to find a path
-/proc/get_path_to(caller, end, dist, maxnodes, maxnodedepth = 30, mintargetdist, adjacent = TYPE_PROC_REF(/turf, reachableTurftest), id=null, turf/exclude=null, allow_multiz = TRUE)
-	var/l = SSpathfinder.mobs.getfree(caller)
+/proc/get_path_to(traveler, end, dist, maxnodes, maxnodedepth = 30, mintargetdist, adjacent = TYPE_PROC_REF(/turf, reachableTurftest), id=null, turf/exclude=null, allow_multiz = TRUE)
+	var/l = SSpathfinder.mobs.getfree(traveler)
 	while(!l)
 		stoplag(3)
-		l = SSpathfinder.mobs.getfree(caller)
-	var/list/path = AStar(caller, end, dist, maxnodes, maxnodedepth, mintargetdist, adjacent,id, exclude)
+		l = SSpathfinder.mobs.getfree(traveler)
+	var/list/path = AStar(traveler, end, dist, maxnodes, maxnodedepth, mintargetdist, adjacent,id, exclude)
 
 	SSpathfinder.mobs.found(l)
 	if(!path)
 		path = list()
 	return path
 
-/proc/cir_get_path_to(caller, end, dist, maxnodes, maxnodedepth = 30, mintargetdist, adjacent = TYPE_PROC_REF(/turf, reachableTurftest), id=null, turf/exclude=null, allow_multiz = TRUE)
-	var/l = SSpathfinder.circuits.getfree(caller)
+/proc/cir_get_path_to(traveler, end, dist, maxnodes, maxnodedepth = 30, mintargetdist, adjacent = TYPE_PROC_REF(/turf, reachableTurftest), id=null, turf/exclude=null, allow_multiz = TRUE)
+	var/l = SSpathfinder.circuits.getfree(traveler)
 	while(!l)
 		stoplag(3)
-		l = SSpathfinder.circuits.getfree(caller)
-	var/list/path = AStar(caller, end, dist, maxnodes, maxnodedepth, mintargetdist, adjacent, id, exclude, allow_multiz)
+		l = SSpathfinder.circuits.getfree(traveler)
+	var/list/path = AStar(traveler, end, dist, maxnodes, maxnodedepth, mintargetdist, adjacent, id, exclude, allow_multiz)
 	SSpathfinder.circuits.found(l)
 	if(!path)
 		path = list()
 	return path
 
-/proc/AStar(caller, _end, dist, maxnodes, maxnodedepth = 30, mintargetdist, adjacent = TYPE_PROC_REF(/turf, reachableTurftest), id=null, turf/exclude=null, allow_multiz = TRUE)
+/proc/AStar(traveler, _end, dist, maxnodes, maxnodedepth = 30, mintargetdist, adjacent = TYPE_PROC_REF(/turf, reachableTurftest), id=null, turf/exclude=null, allow_multiz = TRUE)
 	//sanitation
 	var/turf/end = get_turf(_end)
-	var/turf/start = get_turf(caller)
+	var/turf/start = get_turf(traveler)
 	if(!start || !end)
 		stack_trace("Invalid A* start or destination")
 		return FALSE
@@ -98,7 +98,7 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 		return FALSE
 	if(maxnodes)
 		//if start turf is farther than maxnodes from end turf, no need to do anything
-		if(call(start, dist)(end, caller) > maxnodes)
+		if(call(start, dist)(end, traveler) > maxnodes)
 			return FALSE
 		maxnodedepth = maxnodes //no need to consider path longer than maxnodes
 	var/datum/Heap/open = new /datum/Heap(/proc/HeapPathWeightCompare) //the open list
@@ -106,11 +106,11 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 	var/list/path = null //the returned path, if any
 	//initialization
 	var/const/ALL_DIRS = NORTH|SOUTH|EAST|WEST
-	var/datum/PathNode/cur = new /datum/PathNode(start,null,0,call(start,dist)(end, caller),0,ALL_DIRS,1)//current processed turf
+	var/datum/PathNode/cur = new /datum/PathNode(start,null,0,call(start,dist)(end, traveler),0,ALL_DIRS,1)//current processed turf
 	open.Insert(cur)
 	openc[start] = cur
 	//then run the main loop
-	while(caller && !open.IsEmpty() && !path)
+	while(traveler && !open.IsEmpty() && !path)
 		cur = open.Pop() //get the lower f turf in the open list
 		//get the lower f node on the open list
 		//if we only want to get near the target, check if we're close enough
@@ -118,7 +118,7 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 		if(mintargetdist) // we let you stop early if you aren't on the same z-level because that enables fun shenanigans like taunting and climbing
 			// I lied, this one is also hardcoded; we don't want to use the heuristic for our termination condition,
 			// only the actual distance.
-			closeenough = cur.source.Distance_cardinal_3d(end, caller) <= mintargetdist
+			closeenough = cur.source.Distance_cardinal_3d(end, traveler) <= mintargetdist
 
 
 
@@ -137,6 +137,9 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 		for(var/dir_to_check in GLOB.cardinals)
 			if(!(cur.bf & dir_to_check)) // we can't proceed in this direction
 				continue
+			if(cur.source.LinkSelfBlocked(dir_to_check, traveler, id)) // check if this dir is blocked moving out of our current turf
+				cur.bf &= dir_to_check // don't check this dir again for this node
+				continue
 			// get the turf we end up at if we move in dir_to_check; this may have special handling for multiz moves
 			var/T = get_step(cur.source, dir_to_check)
 			// when leaving a turf with stairs on it, we can change Z, so take that into account
@@ -147,18 +150,18 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 			if(T != exclude)
 				var/datum/PathNode/CN = openc[T]  //current checking turf
 				var/reverse = GLOB.reverse_dir[dir_to_check]
-				var/newg = cur.g + call(cur.source,dist)(T, caller) // add the travel distance between these two tiles to the distance so far
+				var/newg = cur.g + call(cur.source,dist)(T, traveler) // add the travel distance between these two tiles to the distance so far
 				if(CN)
 				//is already in open list, check if it's a better way from the current turf
 					CN.bf &= ALL_DIRS^reverse //we have no closed, so just cut off exceed dir.00001111 ^ reverse_dir.We don't need to expand to checked turf.
 					if((newg < CN.g))
-						if(call(cur.source,adjacent)(caller, T, id))
+						if(call(cur.source,adjacent)(traveler, T, id))
 							CN.setp(cur,newg,CN.heuristic,cur.nodes_traversed+1)
 							open.ReSort(CN)//reorder the changed element in the list
 				else
 				//is not already in open list, so add it
-					if(call(cur.source,adjacent)(caller, T, id)) 
-						CN = new(T,cur,newg,call(T,dist)(end, caller),cur.nodes_traversed+1, ALL_DIRS^reverse)
+					if(call(cur.source,adjacent)(traveler, T, id)) 
+						CN = new(T,cur,newg,call(T,dist)(end, traveler),cur.nodes_traversed+1, ALL_DIRS^reverse)
 						open.Insert(CN)
 						openc[T] = CN
 		cur.bf = 0
@@ -171,35 +174,35 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 	//cleaning after us
 	return path
 
-/// returns TRUE if there exists a way for caller to (safely) move from src to T. non-z-aware
-/turf/proc/reachableTurftest(caller, turf/T, ID)
-	if(T && !T.density && T.can_traverse_safely(caller) && !LinkBlockedWithAccess(T,caller, ID))
+/// returns TRUE if there exists a way for traveler to (safely) move from src to T. non-z-aware
+/turf/proc/reachableTurftest(traveler, turf/T, ID)
+	if(T && !T.density && T.can_traverse_safely(traveler) && !LinkBlockedWithAccess(T,traveler, ID))
 		return TRUE
 
-/// returns TRUE if there exists a way for caller to (safely) move from src to T. z-aware
-/turf/proc/reachableTurftest3d(caller, turf/T, ID, recursive_call = 0)
+/// returns TRUE if there exists a way for traveler to (safely) move from src to T. z-aware
+/turf/proc/reachableTurftest3d(traveler, turf/T, ID, recursive_call = 0)
 	if(!T || T.density)
 		return FALSE
-	if(!T.can_traverse_safely(caller)) // dangerous turf! lava or openspace (or others in the future)
+	if(!T.can_traverse_safely(traveler)) // dangerous turf! lava or openspace (or others in the future)
 		// If we can jump, jump over it!
-		if(!ishuman(caller)) // sorry, only humanmobs can jump atm
+		if(!ishuman(traveler)) // sorry, only humanmobs can jump atm
 			return FALSE
-		var/mob/living/carbon/human/human_caller = caller
-		if(!human_caller.npc_jump_chance) // If we can't jump at all, don't bother.
+		var/mob/living/carbon/human/human_traveler = traveler
+		if(!human_traveler.npc_jump_chance) // If we can't jump at all, don't bother.
 			return FALSE
 		var/turf/landing_turf = get_step_away(T, src) // this is the turf we'd want to land on
 		// currently we'll only try to jump 2-tile gaps
-		if(recursive_call < 2 && T.reachableTurftest3d(caller, landing_turf, ID, recursive_call + 1))
+		if(recursive_call < 2 && T.reachableTurftest3d(traveler, landing_turf, ID, recursive_call + 1))
 			return TRUE // jumpable
 		return FALSE
 	var/z_distance = abs(T.z - z)
 	if(!z_distance) // standard check for same-z pathing
-		return !LinkBlockedWithAccess(T, caller, ID)
+		return !LinkBlockedWithAccess(T, traveler, ID)
 	if(z_distance != 1) // no single movement lets you move more than one z-level at a time (currently; update if this changes)
 		return FALSE
 	var/obj/structure/stairs/source_stairs = locate(/obj/structure/stairs) in src
-	var/mob/mob_caller = caller
-	if(ismob(caller) && HAS_TRAIT(mob_caller, TRAIT_ZJUMP)) // where we're going, we don't need stairs!
+	var/mob/mob_traveler = traveler
+	if(ismob(traveler) && HAS_TRAIT(mob_traveler, TRAIT_ZJUMP)) // where we're going, we don't need stairs!
 		return TRUE
 	if(T.z < z) // going down
 		if(source_stairs?.get_target_loc(GLOB.reverse_dir[source_stairs.dir]) == T)
@@ -209,13 +212,41 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 			return TRUE
 	return FALSE
 
-/turf/proc/LinkBlockedWithAccess(turf/T, caller, ID)
-	var/adir = get_dir(src, T)
-	var/rdir = GLOB.reverse_dir[adir]
-	for(var/obj/O in T)
-		if(!O.CanAStarPass(ID, rdir, caller))
+/turf/proc/LinkSelfBlocked(travel_dir, traveler, ID)
+	if(travel_dir & (travel_dir - 1)) // diagonal dir, split it into cardinals
+		var/in_dir = GLOB.reverse_dir[travel_dir] // for some reason TG chooses to go from target->src instead of src->target
+		var/first_step_dir = in_dir & (NORTH|SOUTH) // vertical component
+		var/second_step_dir = in_dir & (EAST|WEST) // horizontal component
+		// fail only if both are blocked. todo: is this desirable? maybe we want to block if only one fails
+		return LinkSelfBlocked(first_step_dir, traveler, ID) && LinkSelfBlocked(second_step_dir, traveler, ID)
+	var/turf/next_turf = get_step(src, travel_dir)
+	for(var/obj/O in src)
+		if(!O.CanAStarPass(ID, travel_dir, traveler) && O != traveler)
 			return TRUE
-	for(var/mob/living/M in T)
-		if(!M.CanPass(caller, src))
+	for(var/mob/living/M in src)
+		if(!M.CanPass(traveler, next_turf) && M != traveler)
+			return TRUE
+	return FALSE
+
+/turf/proc/LinkBlockedWithAccess(turf/target, traveler, ID)
+	if(target.x != x && target.y != y) // split diagonals into cardinals here
+		var/in_dir = get_dir(target, src) // for some reason TG chooses to go from target->src instead of src->target
+		var/first_step_dir = in_dir & (NORTH|SOUTH) // vertical component
+		var/second_step_dir = in_dir & (EAST|WEST) // horizontal component
+		// we only need to succeed on one for it to pass
+		var/turf/first_midstep_turf = get_step(target, first_step_dir)
+		var/turf/second_midstep_turf = get_step(target, second_step_dir)
+		#define WAY_IS_BLOCKED(TURF) (TURF.density || LinkBlockedWithAccess(TURF, traveler, ID) || TURF.LinkBlockedWithAccess(target, traveler, ID))
+		// only block if BOTH are blocked
+		return WAY_IS_BLOCKED(first_midstep_turf) && WAY_IS_BLOCKED(second_midstep_turf)
+		#undef WAY_IS_BLOCKED
+	var/travel_dir = get_dir(src, target)
+	var/reverse_dir = GLOB.reverse_dir[travel_dir] // dir from target to src, to check destination blockers.
+	// ^^ this assumes movement is always two-way and will break on cliffs/one-way blockers, afaik
+	for(var/obj/O in target)
+		if(!O.CanAStarPass(ID, reverse_dir, traveler))
+			return TRUE
+	for(var/mob/living/M in target)
+		if(!M.CanPass(traveler, target))
 			return TRUE
 	return FALSE

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -213,41 +213,43 @@
 /proc/inLineOfTravel(mob/traveler, atom/target)
 	var/turf/our_turf = get_turf(traveler)
 	var/turf/their_turf = get_turf(target)
-	var/X1 = our_turf.x
-	var/Y1 = our_turf.y
-	var/X2 = their_turf.x
-	var/Y2 = their_turf.y
-	var/Z = our_turf.z
 	var/turf/current_turf = our_turf
-	var/turf/last_turf
-	if(X1==X2)
-		if(Y1==Y2)
-			return TRUE //you're already on the tile
-		else
-			var/s = SIGN(Y2-Y1)
-			Y1+=s
-			while(Y1!=Y2)
-				last_turf = current_turf
-				current_turf = locate(X1,Y1,Z)
-				if(current_turf.density || last_turf.LinkBlockedWithAccess(current_turf, traveler))
-					return FALSE
-				Y1+=s
+	var/dist_x = their_turf.x-our_turf.x
+	var/dist_y = their_turf.y-our_turf.y
+	var/dir_x = dist_x > 0 ? EAST : WEST
+	var/dir_y = dist_y > 0 ? NORTH : SOUTH
+	dist_x = abs(dist_x)
+	dist_y = abs(dist_y)
+	var/pure_diagonal = dist_x == dist_y
+	var/short_leg
+	var/long_leg
+	var/long_dir
+	if(dist_x < dist_y)
+		short_leg = dist_x
+		long_leg = dist_y
+		long_dir = dir_y
 	else
-		var/m=(Y2-Y1)/(X2-X1) // slope
-		var/b=(Y1+0.5)-m*(X1+0.5) // y axis offset in tiles
-		var/signX = SIGN(X2-X1)
-		var/signY = SIGN(Y2-Y1)
-		if(X1<X2)
-			b+=m
-		while(X1!=X2 || Y1!=Y2)
-			if(round(m*X1+b-Y1))
-				Y1+=signY //Line exits tile vertically
-			else
-				X1+=signX //Line exits tile horizontally
-			last_turf = current_turf
-			current_turf = locate(X1,Y1,Z)
-			if(current_turf.density || last_turf.LinkBlockedWithAccess(current_turf, traveler))
-				return FALSE
+		long_leg = dist_x
+		long_dir = dir_x
+		short_leg = dist_y
+	var/diagonal_error = (long_leg/2) - short_leg
+	var/dist_travelled = 0
+	var/travel_dir = get_dir(our_turf, their_turf)
+	while(current_turf != their_turf && dist_travelled < 255) // no one should ever be leaping through 255 tiles.
+		if(dist_travelled >= long_leg) // we should've arrived by now, so recalculate our dir
+			travel_dir = get_dir(current_turf, their_turf)
+		var/current_dir = travel_dir
+		if(!pure_diagonal)
+			if(diagonal_error >= 0 && long_leg - dist_travelled != 1) // do a step forward unless we're right next to the target
+				current_dir = long_dir
+			diagonal_error += (diagonal_error < 0) ? long_leg/2 : -short_leg
+		var/turf/next_turf = get_step(current_turf, current_dir)
+		if(!next_turf) // went off the edge of the map
+			return FALSE
+		if(next_turf.density || current_turf.LinkSelfBlocked(current_dir, traveler) || current_turf.LinkBlockedWithAccess(next_turf, traveler))
+			return FALSE
+		dist_travelled++
+		current_turf = next_turf
 	return TRUE
 
 /proc/isInSight(atom/A, atom/B)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -46,6 +46,12 @@
 	/// When above this amount of stamina (Stamina is stamina damage), the NPC will not attempt to jump.
 	var/npc_max_jump_stamina = 50
 
+	// RETREATING
+	/// Above this percentage of stamloss, retreat to regain stamina.
+	var/stamina_retreat_threshold = 0.8
+	/// Do not finish retreating until below this percentage of stamina loss.
+	var/stamina_finish_retreat_threshold = 0.6
+
 /mob/living/carbon/human/proc/IsStandingStill()
 	return doing || resisting || pickpocketing
 
@@ -81,9 +87,14 @@
 		if(!ai_when_client)
 			walk_to(src,0)
 			return TRUE //remove us from processing
-	cmode = 1
+	cmode = TRUE
 	update_cone_show()
 	steps_moved_this_turn = 0
+	// Manage mob state here, like mode/movement intent/etc.
+	if(stamina >= (max_stamina * stamina_retreat_threshold))
+		m_intent = MOVE_INTENT_WALK
+		cmode = FALSE // try to regen stamina!
+		mode = NPC_AI_RETREAT
 	if(resisting) // already busy from a prior turn! stop!
 		walk_to(src, 0)
 		NPC_THINK("Still resisting, passing turn!")
@@ -647,7 +658,7 @@
 			else if(should_frustrate) // not next to perp, and we didn't fail due to reaction time
 				frustration++
 
-		if(NPC_AI_FLEE)
+		if(NPC_AI_FLEE, NPC_AI_RETREAT)
 			var/const/NPC_FLEE_DISTANCE = 8
 			if(!target || get_dist(src, target) >= NPC_FLEE_DISTANCE)
 				// try to flee from any enemies who aren't incapacitated
@@ -665,9 +676,14 @@
 					// we assume if we want to hurt them they want to hurt us back
 					if(should_target(bystander))
 						target = bystander // We're trying to run from this person now
-			if(!target || get_dist(src, target) >= NPC_FLEE_DISTANCE)
+			if(!target || (mode == NPC_AI_FLEE && get_dist(src, target) >= NPC_FLEE_DISTANCE))
 				NPC_THINK("Done fleeing!")
 				back_to_idle()
+				return TRUE
+			else if(mode == NPC_AI_RETREAT && (stamina < (max_stamina * stamina_finish_retreat_threshold)))
+				NPC_THINK("Done retreating!")
+				mode = NPC_AI_HUNT // back into the fray!
+				return TRUE
 			else if(!is_move_blocked_by_grab()) // try to run offscreen if we aren't being grabbed by someone else
 				NPC_THINK("Fleeing from [target]!")
 				// todo: use A* to find the shortest path to the farthest tile away from the flee target?

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -94,7 +94,10 @@
 	if(stamina >= (max_stamina * stamina_retreat_threshold))
 		m_intent = MOVE_INTENT_WALK
 		cmode = FALSE // try to regen stamina!
+		// todo: switch_mode() that clears path, resets m_intent, clears autowalk?
 		mode = NPC_AI_RETREAT
+		walk_to(src,0)
+		clear_path()
 	if(resisting) // already busy from a prior turn! stop!
 		walk_to(src, 0)
 		NPC_THINK("Still resisting, passing turn!")
@@ -200,6 +203,9 @@
 
 /// Attempts to jump towards our next pathfinding step if it's far enough, or our target if we don't have a path planned.
 /mob/living/carbon/human/proc/npc_try_jump(force = FALSE)
+	if(throwing)
+		// Don't jump while ALREADY jumping!
+		return FALSE
 	if(!prob(npc_jump_chance))
 		return FALSE
 	if(next_move > world.time) // Jumped too recently!
@@ -316,6 +322,7 @@
 /// progress along an existing path or cancel it
 /// returns # of steps taken
 /mob/living/carbon/human/proc/move_along_path()
+	walk(src, 0) // cancel any other automated movement we're doing
 	if(!length(myPath))
 		// no path, quit early
 		NPC_THINK("Tried to move along a nonexistent path?!")
@@ -683,6 +690,7 @@
 			else if(mode == NPC_AI_RETREAT && (stamina < (max_stamina * stamina_finish_retreat_threshold)))
 				NPC_THINK("Done retreating!")
 				mode = NPC_AI_HUNT // back into the fray!
+				walk_to(src, 0) // stop running off
 				return TRUE
 			else if(!throwing && !is_move_blocked_by_grab()) // try to run offscreen if we aren't being grabbed by someone else
 				NPC_THINK("Fleeing from [target]!")

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -351,7 +351,7 @@
 			clear_path()
 			return
 		var/movespeed = cached_multiplicative_slowdown // this is recalculated on Moved() so we don't need to do it ourselves
-		if(!(mobility_flags & MOBILITY_MOVE) || IsDeadOrIncap() || IsStandingStill() || is_move_blocked_by_grab())
+		if(!(mobility_flags & MOBILITY_MOVE) || IsDeadOrIncap() || IsStandingStill() || throwing || is_move_blocked_by_grab())
 			NPC_THINK("MOVEMENT TURN [movement_turn]: Waiting to move!")
 			sleep(1) // wait 1ds to see if we're finished/recovered
 			continue
@@ -684,7 +684,7 @@
 				NPC_THINK("Done retreating!")
 				mode = NPC_AI_HUNT // back into the fray!
 				return TRUE
-			else if(!is_move_blocked_by_grab()) // try to run offscreen if we aren't being grabbed by someone else
+			else if(!throwing && !is_move_blocked_by_grab()) // try to run offscreen if we aren't being grabbed by someone else
 				NPC_THINK("Fleeing from [target]!")
 				// todo: use A* to find the shortest path to the farthest tile away from the flee target?
 				walk_away(src, target, NPC_FLEE_DISTANCE, cached_multiplicative_slowdown)


### PR DESCRIPTION
i made these commits ages ago and never pushed/PR'd them until ansari reminded me. i also had a fix for the stam regen thing but ansari beat me to that too

- inLineOfTravel (proc used to check if leaping is blocked) now uses the exact same checks as throwing, so NPCs won't leap into walls or solid objects as much
- A* won't get stuck as much on objects in the mover's turf
- **EXPERIMENTAL:** carbon NPCs will retreat (similar to fleeing but they go back to combat at the end, plus they walk instead of sprinting
- attempts some fixes for npc leaps getting overwritten by the NPC walking, which teleported them back to the start of their leap. unfortunately it seems to still happen sometimes

i tested these like 20 days ago so i don't have any screenshots :)