### PR TITLE
ACTUAL fix for muffling you while gagged/mouthgrabbed while also allowing mutes to audibly emote.

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -158,7 +158,7 @@
 			var/modifier
 			if(H.age == AGE_OLD)
 				modifier = "old"
-			if((!ignore_silent && (H.silent)) || (!ignore_silent && H.mouth?.muteinmouth))
+			if((!ignore_silent && (H.silent)) || (!ignore_silent && !is_emote_muffled(H)))
 				modifier = "silenced"
 			if(user.gender == FEMALE && H.dna.species.soundpack_f)
 				possible_sounds = H.dna.species.soundpack_f.get_sound(key,modifier)
@@ -209,7 +209,7 @@
 		var/mob/living/carbon/C = user
 		if(C.silent)
 			. = message_muffled
-		if(!muzzle_ignore && C.mouth?.muteinmouth && emote_type == EMOTE_AUDIBLE)
+		if(!muzzle_ignore && !is_emote_muffled(C) && emote_type == EMOTE_AUDIBLE)
 			. = message_muffled
 	if(user.mind && user.mind.miming && message_mime)
 		. = message_mime
@@ -269,3 +269,13 @@
 			break
 	
 	return target
+
+/datum/emote/proc/is_emote_muffled(mob/living/carbon/H) //ONLY for audible emote use
+	if(H.mouth?.muteinmouth)
+		return FALSE
+	for(var/obj/item/grabbing/grab in H.grabbedby)
+		if(grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH)
+			return FALSE
+	if(istype(H.loc, /turf/open/water) && !(H.mobility_flags & MOBILITY_STAND))
+		return FALSE
+	return TRUE


### PR DESCRIPTION
## About The Pull Request
There's been some issues with being able to scream through mouthgrabs. This results from my previous attempts to fix gagging not properly muffling you because yada yada I made some stuff and probably didn't properly test it enough but. Mutes can now audibly emote UNLESS they meet the conditions to be muffled, which also affects non-mutes. To do this I made a proc similar to the carbon version of can_speak_vocal that doesn't call the parent proc of can_speak_vocal. By doing this we decouple speaking, which mutes still obv. cannot do, from emoting with noises.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I tested both with mute and without mute, and I was able to scream unless i had a hand or cloth covering my mouth.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Actually fixes my bugs.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
