### PR TITLE
BUGFIX - Matthios flail repair

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -184,6 +184,7 @@
 	associated_skill = /datum/skill/combat/whipsflails
 	slot_flags = ITEM_SLOT_BACK
 	blade_dulling = DULLING_SHAFT_GRAND
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 
 /obj/item/rogueweapon/flail/peasantwarflail/matthios/pickup(mob/living/user)


### PR DESCRIPTION
## About The Pull Request
- Repairing the matthios flail now takes weaponsmithing.
- That's it

## Testing Evidence

- one line

## Why It's Good For The Game

aaahhghngfhnghfnghngfgnfgnfhd I LOVE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! TOYS!
