### PR TITLE
[Bugfix] Fish summoned by aquatic compulsion are no longer instantly released when summoned from further water tiles

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -149,9 +149,10 @@
 			return
 	if(istype(AM, /obj/item/reagent_containers/food/snacks/fish))
 		var/obj/item/reagent_containers/food/snacks/fish/F = AM
-		SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_FISH_RELEASED, F.type, F.rarity_rank)
-		F.visible_message("<span class='warning'>[F] dives into \the [src] and disappears!</span>")
-		qdel(F)
+		if (F.sinkable)
+			SEND_GLOBAL_SIGNAL(COMSIG_GLOBAL_FISH_RELEASED, F.type, F.rarity_rank)
+			F.visible_message("<span class='warning'>[F] dives into \the [src] and disappears!</span>")
+			qdel(F)
 	if(isliving(AM) && !AM.throwing)
 		var/mob/living/L = AM
 		if(HAS_TRAIT(L, TRAIT_CURSE_ABYSSOR))

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -170,7 +170,12 @@
 			A = pickweight(mudfishloot)
 		if(A)
 			var/atom/movable/AF = new A(T)
-			AF.throw_at(get_turf(user), 5, 1, null)
+			if(istype(AF, /obj/item/reagent_containers/food/snacks/fish))
+				var/obj/item/reagent_containers/food/snacks/fish/F = AF
+				F.sinkable = FALSE
+				F.throw_at(get_turf(user), 5, 1, null)
+			else
+				AF.throw_at(get_turf(user), 5, 1, null)
 			record_featured_stat(FEATURED_STATS_FISHERS, user)
 			GLOB.azure_round_stats[STATS_FISH_CAUGHT]++
 			playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)

--- a/modular/Neu_Food/code/raw/raw_fish.dm
+++ b/modular/Neu_Food/code/raw/raw_fish.dm
@@ -8,6 +8,7 @@
 	obj_flags = CAN_BE_HIT
 	var/dead = TRUE
 	var/no_rarity_sprite = FALSE // Whether this fish has rarity based sprites. If not, don't change icon states
+	var/sinkable = TRUE
 	max_integrity = 50
 	sellprice = 10
 	dropshrink = 0.6
@@ -78,6 +79,9 @@
 		STOP_PROCESSING(SSobj, src)
 		return 1
 
+/obj/item/reagent_containers/food/snacks/fish/after_throw(datum/callback/callback)
+	. = ..()
+	sinkable = TRUE
 
 /obj/item/reagent_containers/food/snacks/fish/salmon
 	name = "salmon"


### PR DESCRIPTION
## About The Pull Request

What it says in the title.

- added var/sinkable to fish, set to TRUE by default
- flag sinkable is set to TRUE after the fish is finished being thrown
- /turf/open/water/Entered now checks if fish is sinkable
- aquatic compulsion sets sinkable flag to FALSE before throwing the fish

## Testing Evidence

Summoned some fish from further away, got hit by some, released some, had fun times all around.

<img width="1364" height="624" alt="obraz" src="https://github.com/user-attachments/assets/f311b0cb-6593-4cf9-918e-c1a849a4c204" />

Code compiles, releasing mechanic still works, and summoning fish with aquatic compulsion works from further water tiles.

## Why It's Good For The Game

Aquatic compulsion is now more intuitive to use as you no longer have to summon fish from the water tile bordering land. You can still release them afterwards as the sinkable will be changed to TRUE at the end of aquatic compulsion "throw".

Initially wanted to include this change in my other ongoing PR (separating coastal and deep sea fishing) but made it into a separate bugfix since I didn't want to push something only vaguely related in the original PR (also I heard somewhere that atomization of your PRs is good)
