### PR TITLE
Half-Revert of No Smelting Gaunlets PR; Fixes Duplication

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -106,7 +106,7 @@
 // Glove Armor
 #define ARMOR_GLOVES_LEATHER list("blunt" = 60, "slash" = 10, "stab" = 20, "piercing" = 0, "fire" = 0, "acid" = 0)
 #define ARMOR_GLOVES_LEATHER_GOOD list("blunt" = 60, "slash" = 25, "stab" = 40, "piercing" = 10, "fire" = 0, "acid" = 0)
-#define ARMOR_GLOVES_CHAIN list("blunt" = 20, "slash" = 100, "stab" = 80, "piercing" = 20, "fire" = 0, "acid" = 0)
+#define ARMOR_GLOVES_CHAIN list("blunt" = 20, "slash" = 100, "stab" = 70, "piercing" = 20, "fire" = 0, "acid" = 0)
 #define ARMOR_GLOVES_PLATE list("blunt" = 5, "slash" = 100, "stab" = 80, "piercing" = 40, "fire" = 0, "acid" = 0)
 #define ARMOR_GLOVES_PLATE_GOOD list("blunt" = 20, "slash" = 100, "stab" = 80, "piercing" = 50, "fire" = 0, "acid" = 0)
 

--- a/code/modules/clothing/rogueclothes/gloves/chain.dm
+++ b/code/modules/clothing/rogueclothes/gloves/chain.dm
@@ -11,7 +11,7 @@
 	break_sound = 'sound/foley/breaksound.ogg'
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	anvilrepair = /datum/skill/craft/armorsmithing
-	smeltresult = null
+	smeltresult = /obj/item/ingot/steel
 	unarmed_bonus = 1.15
 
 /obj/item/clothing/gloves/roguetown/chain/aalloy
@@ -19,20 +19,24 @@
 	desc = "Decrepit old chain gauntlets. Aeon's grasp is upon them."
 	icon_state = "acgloves"
 	max_integrity = ARMOR_INT_SIDE_DECREPIT
+	smeltresult = /obj/item/ingot/aalloy
 
 /obj/item/clothing/gloves/roguetown/chain/paalloy
 	name = "ancient chain gauntlets"
 	desc = "Chain gauntlets formed out of ancient alloys. Aeon's grasp is lifted from them."
 	icon_state = "acgloves"
+	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/clothing/gloves/roguetown/chain/psydon
 	name = "psydonian gloves"
 	desc = "Blacksteel-bound gauntlets. These ritualistic restraints, when left to dangle-and-sway, assist in the deflection of unpredictable blows."
 	icon_state = "psydongloveschain"
 	item_state = "psydongloveschains"
+	smeltresult = null	//So you can't melt down your start gear for blacksteel brigadines etc.
 
 /obj/item/clothing/gloves/roguetown/chain/iron
 	icon_state = "icgloves"
 	desc = "Gauntlets made of interlinked iron rings. They offer decent protection against common weaponries, except for arrows."
 	anvilrepair = /datum/skill/craft/armorsmithing
+	smeltresult = /obj/item/ingot/iron
 	max_integrity = ARMOR_INT_SIDE_IRON

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -175,17 +175,15 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/chaingaunts
-	name = "Decrepit Alloy Chain Gauntlets, 2x"
+	name = "Decrepit Alloy Chain Gauntlets"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/gloves/roguetown/chain/aalloy
-	createditem_num = 2
 	craftdiff = 1
 
 /datum/anvil_recipe/armor/paalloy/chaingaunts
-	name = "Purified Alloy Chain Gauntlets, 2x"
+	name = "Purified Alloy Chain Gauntlets"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/gloves/roguetown/chain/paalloy
-	createditem_num = 2
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/aalloy/plategaunts
@@ -278,10 +276,9 @@
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/iron/chainglove
-	name = "Chain Gauntlets, 2x"
+	name = "Chain Gauntlets"
 	req_bar = /obj/item/ingot/iron
 	created_item = /obj/item/clothing/gloves/roguetown/chain/iron
-	createditem_num = 2
 	craftdiff = 0
 
 /datum/anvil_recipe/armor/iron/plategauntlets
@@ -555,10 +552,9 @@
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/chainglove
-	name = "Chain Gauntlets, 2x"
+	name = "Chain Gauntlets"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/gloves/roguetown/chain
-	createditem_num = 2
 	craftdiff = 2
 
 /datum/anvil_recipe/armor/steel/plateglove


### PR DESCRIPTION
## About The Pull Request

Half-reverts prior PR that stopped you from smelting chain gauntlets to fix a duplication issue.

I reverted it so you can smelt them down and just removed the smith being able to make 2 of them with one bar.

Also, I reduced the protection on chain gaunlets by 10 to make plate ones have a slight niche for higher skill and all to make them.

## Why It's Good For The Game

Lets you smelt the chain gaunlets again. Makes plate ones have a difference than just piercing protection and 15 blunt.