### PR TITLE
The grimshartening (1 revive limit)

### DIFF
--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -86,10 +86,8 @@
 	var/list/guaranteed_butcher_results = null //these will always be yielded from butchering
 	var/butcher_difficulty = 0 //effectiveness prob. is modified negatively by this amount; positive numbers make it more difficult, negative ones make it easier
 
-	var/is_jumping = 0 //to differentiate between jumping and thrown mobs
-
-	var/hellbound = 0 //People who've signed infernal contracts are unrevivable.
-
+	var/is_jumping = 0	//To differentiate between jumping and thrown mobs
+	var/hellbound = 0	//People who've signed infernal contracts are unrevivable.
 	var/revived = 0		//People who have been revived already can no longer be revived.
 
 	var/list/weather_immunities = list()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -90,6 +90,8 @@
 
 	var/hellbound = 0 //People who've signed infernal contracts are unrevivable.
 
+	var/revived = 0		//People who have been revived already can no longer be revived.
+
 	var/list/weather_immunities = list()
 
 	var/stun_absorption = null //converted to a list of stun absorption sources this mob has when one is added

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -119,6 +119,10 @@
 		to_chat(user, span_warning("Nothing happens."))
 		revert_cast()
 		return FALSE
+	if(target.revived >= 1)
+		to_chat(user, span_warning("Due to prior revivals [target]'s soul appears too weak to continue on.."))
+		revert_cast()
+		return FALSE
 	if(GLOB.tod == "night")
 		to_chat(user, span_warning("Let there be light."))
 	for(var/obj/structure/fluff/psycross/S in oview(5, user))
@@ -154,6 +158,7 @@
 	target.mind.remove_antag_datum(/datum/antagonist/zombie)
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
 	target.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, revive_timer)), 2 MINUTES)
 	return TRUE
 
 /obj/effect/proc_holder/spell/invoked/revive/cast_check(skipcharge = 0,mob/user = usr)

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -120,7 +120,7 @@
 		revert_cast()
 		return FALSE
 	if(target.revived >= 1)
-		to_chat(user, span_warning("Due to prior revivals [target]'s soul appears too weak to continue on.."))
+		to_chat(user, span_warning("[target]'s soul has already been pried from Necra's grasp once. She shant permit such trespasses twice..."))
 		revert_cast()
 		return FALSE
 	if(GLOB.tod == "night")

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -63,7 +63,7 @@
 			revert_cast()
 			return FALSE
 		if(target.revived >= 1)
-			to_chat(user, span_warning("Due to prior revivals [target]'s soul appears too weak to continue on.."))
+			to_chat(user, span_warning("[target]'s soul has already been pried from Necra's grasp once. She shant permit such trespasses twice..."))
 			revert_cast()
 			return FALSE
 		if(HAS_TRAIT(target, TRAIT_NECRAS_VOW))

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -62,6 +62,10 @@
 			to_chat(user, "This one is inert.")
 			revert_cast()
 			return FALSE
+		if(target.revived >= 1)
+			to_chat(user, span_warning("Due to prior revivals [target]'s soul appears too weak to continue on.."))
+			revert_cast()
+			return FALSE
 		if(HAS_TRAIT(target, TRAIT_NECRAS_VOW))
 			to_chat(user, "This one has pledged themselves whole to Necra. They are Hers.")
 			revert_cast()
@@ -109,10 +113,15 @@
 		target.apply_status_effect(debuff_type)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
 		//Due to an increased cost and cooldown, these revival types heal quite a bit.
 		target.apply_status_effect(/datum/status_effect/buff/healing, 14)
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, revive_timer)), 2 MINUTES)
 		consume_items(target)
 		return TRUE
 	revert_cast()
 	return FALSE
+
+/mob/living/carbon/human/proc/revive_timer()
+	if(stat != DEAD)
+		revived += 1
 
 /obj/effect/proc_holder/spell/invoked/resurrect/cast_check(skipcharge = 0,mob/user = usr)
 	if(!..())

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -38,6 +38,9 @@
 	if(HAS_TRAIT(target, TRAIT_NECRAS_VOW))
 		to_chat(user, "[target] has pledged a vow to Necra. This will not work.")
 		return FALSE
+	if(target.revived >= 1)		//If the target has been revived before, and has not had their revived counter reduced at all, they will be unable to be revived.
+		to_chat(user, "[target] has been worked on before, their soul is too far gone to try again..")
+		return FALSE
 
 /datum/surgery_step/infuse_lux/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	display_results(user, target, span_notice("I begin to revive [target]... will their heart respond?"),
@@ -52,7 +55,7 @@
 			"[user] works the lux into [target]'s innards.",
 			"[user] works the lux into [target]'s innards.")
 		return FALSE
-	if (target.mind)
+	if(target.mind)
 		if(alert(target, "Are you ready to face the world, once more?", "Revival", "I must go on", "Let me rest") != "I must go on")
 			display_results(user, target, span_notice("[target]'s heart refuses the lux. They're only in sweet dreams, now."),
 				"[user] works the lux into [target]'s innards, but nothing happens.",
@@ -85,6 +88,7 @@
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
 	target.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, revive_timer)), 2 MINUTES)	//Adds revive counter to prevent future revives.
 	return TRUE
 
 /datum/surgery_step/infuse_lux/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -39,7 +39,7 @@
 		to_chat(user, "[target] has pledged a vow to Necra. This will not work.")
 		return FALSE
 	if(target.revived >= 1)		//If the target has been revived before, and has not had their revived counter reduced at all, they will be unable to be revived.
-		to_chat(user, "[target] has been worked on before, their soul is too far gone to try again..")
+		to_chat(user, "[target]'s heart bears the telltale signs of a previous infusion, their soul is too far gone to try again..")
 		return FALSE
 
 /datum/surgery_step/infuse_lux/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)


### PR DESCRIPTION
## About The Pull Request

All revives will now increase a counter until a person can no longer be revivable. A 2 minute grace period is given after a revival to see if the person actually survives before increasing the counter (to prevent unfortunate circumstance where someone is revived, immediately dies, and is then RR'd).

## Testing Evidence

Tested on a private host, surgery works great, miracles should be exactly the same as surgery, but could not be tested due to needing a second client
<img width="520" height="25" alt="image" src="https://github.com/user-attachments/assets/6437b82a-d9d1-4643-a07f-42a4d635a812" />

## Why It's Good For The Game

Making death actually have consequences beyond a respawn timer (in my belief) will allow higher stakes situations, and allows antagonists (who essentially dont get any revives) a chance to cause longer lasting damage without the knowledge that if they dont completely eradicate people or just win totally, the people they beat will just get revived. Likewise it will (hopefully) reduce the number of people who act invincible, because now they _**aren't**_
