### PR TITLE
Makes the dye brush recipe actually craft a dye brush

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -359,7 +359,7 @@
 
 /datum/crafting_recipe/roguetown/survival/dye_brush
 	name = "dye brush"
-	result = /obj/item/needle
+	result = /obj/item/dye_brush
 	reqs = list(
 		/obj/item/grown/log/tree/stick = 2,
 		/obj/item/natural/fur = 1


### PR DESCRIPTION
## About The Pull Request

Makes the dye brush crafting recipe actually craft a dye brush instead of... a singular needle

## Testing Evidence

<img width="1920" height="790" alt="image" src="https://github.com/user-attachments/assets/26ccc9cf-5698-45fb-a303-cfd8a868c44b" />

## Why It's Good For The Game

Crafting recipes should make what they say they're going to make