### PR TITLE
Enables Vampire Lord and Vampire/Werewolves on storyteller

### DIFF
--- a/code/modules/events/antagonist/solo/vampires.dm
+++ b/code/modules/events/antagonist/solo/vampires.dm
@@ -9,8 +9,8 @@
 	antag_flag = ROLE_NBEAST
 	shared_occurence_type = SHARED_HIGH_THREAT
 
-	weight = 0		//Disabled cus vampires too strong
-	max_occurrences = 0
+	weight = 4
+	max_occurrences = 1
 
 	denominator = 80
 

--- a/code/modules/events/antagonist/solo/vampires_and_werewolves.dm
+++ b/code/modules/events/antagonist/solo/vampires_and_werewolves.dm
@@ -15,8 +15,8 @@
 
 	earliest_start = 0 SECONDS
 
-	weight = 0		//Disabled cus vampires too strong.
-	max_occurrences = 0
+	weight = 1		//Disabled cus vampires too strong.
+	max_occurrences = 1
 
 	typepath = /datum/round_event/antagonist/solo/vampires_and_werewolves
 


### PR DESCRIPTION
## About The Pull Request

- Enables these storyteller rolls with a weight of 4(vampire) and 1(WWs/Vampires)
- Thats it

## Testing Evidence

tis 4 lines

## Why It's Good For The Game

Vampire Lord has received reasonable shifting around to try this, at least. 
