### PR TITLE
merchant qol: examine prices now works on bags!

### DIFF
--- a/code/game/objects/examine.dm
+++ b/code/game/objects/examine.dm
@@ -10,6 +10,9 @@
 	. += integrity_check()
 
 	var/real_value = get_real_price()
+	for(var/obj/item/I in src.contents) // runs a loop on anytihng that's got contents under our current inv system
+		if(I)
+			real_value += I.get_real_price() // adds the price to the total real_value. simple, but it works!
 	if(real_value > 0)
 		if(HAS_TRAIT(user, TRAIT_SEEPRICES) || simpleton_price)
 			. += span_info("Value: [real_value] mammon")


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
originally made as practice to understand for loops
- uses a for loop in the examine.dm
- checks through examined things, adding the price of each of them to the total price of the object
- this then prints out through the already in place see_prices
- even works on shitty_prices, with disturbed numbers, too!!
## Testing Evidence
maed a vid showing it worked with shitty/see and that nothing happened if u didnt have see_pries but uhgmmmmmmmmmmm i dont want 2 bother editing it down awnd handbraking it to make it small just trust me i tested it. shit might still explode im not good at for loops free plsloo kat it to make sure it doesnt infinite or somes hito. i even made sure that hte matthios examine thing wouldnt be fucked, looks like it isnt.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- merchant qol. sacks of heads can now be easily examined for their full value.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
