### PR TITLE
fixes fire hand warming string to respect pronouns

### DIFF
--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -40,7 +40,7 @@
 		var/mob/living/carbon/human/H = user
 
 		if(istype(H))
-			H.visible_message("<span class='info'>[H] warms \his hand over the fire.</span>")
+			H.visible_message("<span class='info'>[H] warms [user.p_their()] hand over the fire.</span>")
 
 			if(do_after(H, 15, target = src))
 				var/obj/item/bodypart/affecting = H.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
@@ -577,7 +577,7 @@
 		if(on)
 			var/mob/living/carbon/human/H = user
 			if(istype(H))
-				H.visible_message(span_info("[H] warms \his hand over the embers."))
+				H.visible_message(span_info("[H] warms [user.p_their()] hand over the embers."))
 				if(do_after(H, 50, target = src))
 					var/obj/item/bodypart/affecting = H.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
 					to_chat(H, span_warning("HOT!"))
@@ -762,7 +762,7 @@
 		var/mob/living/carbon/human/H = user
 
 		if(istype(H))
-			H.visible_message("<span class='info'>[H] warms \his hand near the fire.</span>")
+			H.visible_message("<span class='info'>[H] warms [user.p_their()] hand near the fire.</span>")
 
 			if(do_after(H, 100, target = src))
 				H.apply_status_effect(/datum/status_effect/buff/healing, 1)


### PR DESCRIPTION
## About The Pull Request
<img width="497" height="64" alt="image" src="https://github.com/user-attachments/assets/ac68fba7-ba6c-44ab-a586-2df6f437e59c" />

Tiny in-line pronoun string fix.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="1120" height="719" alt="image" src="https://github.com/user-attachments/assets/baf93fdb-e52b-4c9b-801a-1dfbe7f8e911" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Fun fact, aside from the base macro, these were the last three versions of byond's \his in the repo.

<img width="230" height="175" alt="image" src="https://github.com/user-attachments/assets/4691211e-a268-4672-a0d5-c7134e7645a8" />

