### PR TITLE
Replaces instanced turf icon_states to pre-existing subtypes

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -6,9 +6,7 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/under/town/sewer)
 "aal" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "aar" = (
 /obj/effect/decal/cobbleedge{
@@ -34,9 +32,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "aaC" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir4,
 /area/rogue/indoors/town/magician)
 "aaE" = (
 /obj/structure/fluff/statue/knightalt,
@@ -56,9 +52,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/manor)
 "aaK" = (
 /obj/structure/table/wood,
@@ -111,9 +105,7 @@
 /area/rogue/under/underdark/north)
 "abR" = (
 /obj/effect/decal/cleanable/debris/woody,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "ace" = (
 /obj/structure/table/wood{
@@ -311,9 +303,7 @@
 /area/rogue/indoors/town/garrison)
 "afq" = (
 /obj/item/fishingrod,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/north)
 "afs" = (
 /obj/structure/stairs,
@@ -321,9 +311,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "aft" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors/town/garrison)
 "afv" = (
 /obj/structure/chair/wood/rogue/fancy,
@@ -375,9 +363,7 @@
 /area/rogue/indoors/town)
 "agm" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "agp" = (
 /obj/effect/decal/cobbleedge{
@@ -595,9 +581,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "ajc" = (
 /obj/structure/fluff/statue/knight/r,
@@ -751,9 +735,7 @@
 "amu" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
 /obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "amv" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -824,11 +806,6 @@
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/tavern)
-"anY" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 8
-	},
-/area/rogue/indoors/town)
 "aoc" = (
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/dirt,
@@ -838,9 +815,7 @@
 /area/rogue/outdoors/rtfield)
 "aoq" = (
 /obj/structure/mineral_door/wood/deadbolt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "aoD" = (
 /obj/structure/fluff/railing/border{
@@ -988,9 +963,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "aoM" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir8,
 /area/rogue/indoors/town/garrison)
 "aoO" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -1521,9 +1494,7 @@
 /area/rogue/outdoors/town)
 "axG" = (
 /obj/effect/landmark/start/wretchlate,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "axM" = (
 /obj/structure/flora/roguegrass,
@@ -1552,11 +1523,6 @@
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/scarymaze)
-"aye" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 1
-	},
-/area/rogue/indoors/town)
 "ayl" = (
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/structure/closet/crate/roguecloset/inn,
@@ -1670,16 +1636,12 @@
 /area/rogue/outdoors/bog/south)
 "azP" = (
 /obj/structure/stairs,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "azT" = (
 /obj/structure/fluff/alch,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "azU" = (
 /turf/open/floor/rogue/wood/nosmooth,
@@ -1848,9 +1810,7 @@
 	pixel_x = -10;
 	pixel_y = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "aDh" = (
 /obj/structure/stairs,
@@ -2217,10 +2177,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "aJc" = (
 /obj/machinery/light/rogue/wallfire/candle{
@@ -2416,9 +2373,7 @@
 	lockid = "royal";
 	name = "Lord's Apartment"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "aMg" = (
 /obj/structure/mineral_door/wood/deadbolt,
@@ -2658,9 +2613,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/mountains)
 "aPB" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir8,
 /area/rogue/indoors/town/dwarfin)
 "aPH" = (
 /obj/structure/table/wood{
@@ -2739,10 +2692,7 @@
 	dir = 6
 	},
 /obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "aQQ" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -2775,9 +2725,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "aRS" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -3007,9 +2955,7 @@
 "aWX" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "aWY" = (
 /obj/structure/fluff/walldeco/church/line,
@@ -3090,9 +3036,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/forest/hamlet)
 "aYo" = (
 /obj/structure/mineral_door/wood/violet,
@@ -3142,9 +3086,7 @@
 	pixel_x = 8;
 	pixel_y = -3
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "aZb" = (
 /obj/effect/wisp,
@@ -3355,9 +3297,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave/underhamlet)
 "bbF" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/indoors/town/shop)
 "bbG" = (
 /obj/structure/mineral_door/wood{
@@ -3369,9 +3309,7 @@
 /area/rogue/indoors/town)
 "bbH" = (
 /obj/structure/fermentation_keg/random/beer,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "bbI" = (
 /turf/open/floor/rogue/tile,
@@ -3411,9 +3349,7 @@
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "bcu" = (
 /obj/structure/fermentation_keg,
@@ -3509,9 +3445,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "bdB" = (
 /obj/item/reagent_containers/glass/bowl/gold,
@@ -3817,14 +3751,6 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
-"bjx" = (
-/obj/structure/chair/wood/rogue/chair3{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "bjA" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -3961,9 +3887,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
 "bls" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/outdoors/beach/forest/hamlet)
 "blt" = (
 /obj/item/roguebin/water/gross,
@@ -4179,9 +4103,7 @@
 	icon_state = "largetable"
 	},
 /obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "boV" = (
 /obj/effect/landmark/events/haunts,
@@ -4202,9 +4124,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "bps" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -4224,9 +4144,7 @@
 /area/rogue/under/town/basement/keep)
 "bpK" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "bpP" = (
 /obj/effect/decal/cobbleedge{
@@ -4426,9 +4344,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "bsL" = (
 /turf/open/floor/rogue/dirt,
@@ -4533,9 +4449,7 @@
 /area/rogue/indoors/town)
 "btR" = (
 /obj/structure/chair/wood/rogue/fancy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "btZ" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -4643,9 +4557,7 @@
 /obj/item/storage/roguebag,
 /obj/item/storage/roguebag,
 /obj/effect/landmark/start/servant,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "bvC" = (
 /obj/structure/ladder,
@@ -4761,9 +4673,7 @@
 	pixel_x = -5;
 	pixel_y = 39
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "bxm" = (
 /obj/structure/fluff/psycross/copper,
@@ -4791,10 +4701,7 @@
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 4
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 8;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/west,
 /area/rogue/outdoors/town/roofs/keep)
 "bxE" = (
 /turf/open/floor/rogue/wood,
@@ -4834,9 +4741,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "byf" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -5200,9 +5105,7 @@
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "bEp" = (
 /obj/structure/noose/gallows{
@@ -5647,12 +5550,6 @@
 	},
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town)
-"bKU" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 1;
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/beach/forest/hamlet)
 "bLg" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -5660,12 +5557,6 @@
 /obj/effect/spawner/lootdrop/valuable_jewelry_spawner,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/goblinfort)
-"bLj" = (
-/obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "bLq" = (
 /obj/structure/mineral_door/bars,
 /turf/open/floor/rogue/dirt,
@@ -5678,23 +5569,12 @@
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "bLE" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/basement)
-"bLK" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "bLQ" = (
 /obj/machinery/light/rogue/wallfire{
 	pixel_x = 16;
@@ -5896,9 +5776,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet/bogcaves/north)
 "bPl" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir1,
 /area/rogue/indoors/shelter/woods)
 "bPo" = (
 /obj/structure/bed/rogue/inn/double{
@@ -5935,9 +5813,7 @@
 /area/rogue/indoors/town/church/chapel)
 "bPN" = (
 /obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "bPY" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -6000,9 +5876,7 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "bQX" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "bQY" = (
 /obj/structure/mineral_door/wood{
@@ -6314,14 +6188,6 @@
 /obj/structure/roguemachine/goldface/public/smith,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/town)
-"bUr" = (
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "bUt" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
@@ -6710,11 +6576,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap)
-"cbl" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
-/area/rogue/indoors/town)
 "cbn" = (
 /obj/structure/stairs{
 	dir = 8
@@ -6732,9 +6593,7 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "cbr" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/indoors/town/dwarfin)
 "cbw" = (
 /obj/structure/spider/stickyweb,
@@ -6959,9 +6818,7 @@
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/magician)
 "cfz" = (
 /obj/structure/bars/pipe{
@@ -6986,9 +6843,7 @@
 	dir = 8
 	},
 /obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "cfZ" = (
 /turf/open/floor/rogue/naturalstone,
@@ -7269,9 +7124,7 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
 /obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "cjR" = (
 /obj/structure/rack/rogue,
@@ -7342,11 +7195,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach/forest/north)
-"clf" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/cave)
 "cli" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grass,
@@ -7727,9 +7575,7 @@
 "crR" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/nitebeast,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "crS" = (
 /obj/effect/decal/cobbleedge{
@@ -7847,9 +7693,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "ctD" = (
 /obj/structure/fluff/railing/border{
@@ -7935,9 +7779,7 @@
 "cuE" = (
 /obj/structure/roguemachine/scomm/r,
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "cuF" = (
 /obj/structure/flora/roguegrass/water/reeds,
@@ -8115,9 +7957,7 @@
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 4
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/mountains)
 "cxv" = (
 /turf/open/floor/rogue/naturalstone,
@@ -8286,9 +8126,7 @@
 "czF" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "czG" = (
 /obj/structure/fluff/psycross/zizocross,
@@ -8344,9 +8182,7 @@
 /obj/item/scrying{
 	pixel_y = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "cBf" = (
 /obj/effect/decal/cobbleedge{
@@ -8588,9 +8424,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "cEY" = (
 /obj/effect/decal/wood/herringbone2{
@@ -8841,9 +8675,7 @@
 /area/rogue/indoors/town/dwarfin)
 "cJk" = (
 /obj/structure/closet/crate/chest,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "cJt" = (
 /obj/structure/rack/rogue,
@@ -9015,9 +8847,7 @@
 /area/rogue/under/cavewet/bogcaves/camp)
 "cLQ" = (
 /obj/structure/fluff/walldeco/bigpainting,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "cLR" = (
 /obj/structure/bed/rogue/inn/wool,
@@ -9041,14 +8871,6 @@
 /obj/item/natural/stone,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/underdark/north)
-"cMc" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "cMd" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 4;
@@ -9070,9 +8892,7 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/recipe_book/blacksmithing,
 /obj/item/recipe_book/engineering,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "cMu" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -9145,9 +8965,7 @@
 	icon_state = "longtable_mid"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "cNn" = (
 /obj/structure/fluff/railing/border,
@@ -9219,10 +9037,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "cOy" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/indoors/town)
 "cOC" = (
 /obj/structure/flora/roguetree/pine,
@@ -9542,9 +9357,7 @@
 /area/rogue/under/cave/orcdungeon)
 "cUF" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "cUH" = (
 /obj/structure/bars,
@@ -9906,9 +9719,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "cZI" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors/town/dwarfin)
 "cZN" = (
 /obj/structure/fluff/wallclock,
@@ -9977,11 +9788,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/skeletoncrypt)
-"daF" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/outdoors/rtfield)
 "daP" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
@@ -10113,9 +9919,7 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor)
 "ddn" = (
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/beach/forest/hamlet)
 "ddt" = (
 /obj/effect/decal/cobbleedge{
@@ -10159,9 +9963,7 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "deg" = (
 /turf/open/floor/rogue/metal{
@@ -10607,9 +10409,7 @@
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "dlQ" = (
 /obj/structure/table/wood{
@@ -10782,9 +10582,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "doE" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors)
 "doG" = (
 /obj/structure/roguewindow,
@@ -10827,11 +10625,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"dps" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 4
-	},
-/area/rogue/under/underdark)
 "dpt" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/indoors/cave/west)
@@ -10886,9 +10679,7 @@
 	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "dpQ" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -10989,9 +10780,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "drA" = (
 /obj/item/grown/log/tree/small,
@@ -11084,9 +10873,7 @@
 	lockid = "manor";
 	name = "Guest Room I"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "dsw" = (
 /obj/structure/plasticflaps,
@@ -11379,9 +11166,7 @@
 /obj/item/book/rogue/blackmountain,
 /obj/item/book/rogue/sword,
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "dyR" = (
 /obj/structure/table/church{
@@ -11489,9 +11274,7 @@
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "dAm" = (
 /obj/structure/stairs{
@@ -11648,9 +11431,7 @@
 /obj/item/book/rogue/law,
 /obj/item/book/rogue/necra,
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "dDD" = (
 /obj/structure/fluff/railing/border{
@@ -11801,14 +11582,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave/southern)
 "dGc" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/outdoors/beach/forest/hamlet)
 "dGg" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors/town/shop)
 "dGi" = (
 /obj/machinery/light/rogue/oven/south,
@@ -11898,9 +11675,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "dHx" = (
 /obj/structure/table/vtable,
@@ -11992,9 +11767,7 @@
 	dir = 1
 	},
 /obj/structure/fluff/wallclock/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "dJh" = (
 /obj/structure/flora/roguetree/pine/dead,
@@ -12331,11 +12104,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
-"dOo" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town)
 "dOE" = (
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
@@ -12389,9 +12157,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter)
 "dPo" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors/town/dwarfin)
 "dPq" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
@@ -12578,9 +12344,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "dSL" = (
 /obj/structure/flora/roguegrass/water,
@@ -12851,9 +12615,7 @@
 /area/rogue/indoors/town/bath)
 "dWW" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/vault)
 "dXi" = (
 /obj/structure/fluff/railing/border{
@@ -13120,9 +12882,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
 "ebM" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors)
 "ebP" = (
 /turf/open/floor/rogue/tile/masonic/inverted,
@@ -13241,9 +13001,7 @@
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/rogue/meat/coppiette,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "ecM" = (
 /obj/structure/stairs{
@@ -13519,14 +13277,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
-"ehn" = (
-/obj/structure/roguewindow/openclose{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "eho" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -13849,9 +13599,7 @@
 	pixel_x = 10;
 	pixel_y = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "elZ" = (
 /obj/machinery/light/rogue/wallfire{
@@ -13941,9 +13689,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-e"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "enr" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -14046,9 +13792,7 @@
 /area/rogue/outdoors/town/roofs)
 "eon" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "eoo" = (
 /obj/structure/well/poisoned,
@@ -14491,12 +14235,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
-"evD" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "evO" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town)
@@ -14756,9 +14494,7 @@
 /obj/item/reagent_containers/food/snacks/butter,
 /obj/item/reagent_containers/food/snacks/butter,
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "eyK" = (
 /turf/open/floor/rogue/cobble,
@@ -14816,9 +14552,7 @@
 	pixel_y = -32
 	},
 /obj/structure/globe,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "ezK" = (
 /obj/item/natural/stone,
@@ -14907,9 +14641,7 @@
 "eBi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/statue/femalestatue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "eBq" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -14923,9 +14655,7 @@
 /area/rogue/under/cave/mazedungeon)
 "eBz" = (
 /obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/south)
 "eBE" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
@@ -14962,9 +14692,7 @@
 /obj/structure/fluff/grindwheel,
 /obj/item/natural/wood/plank,
 /obj/effect/decal/cleanable/debris/woody,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "eCL" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -15183,9 +14911,7 @@
 "eFi" = (
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/manorguardsman,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "eFj" = (
 /obj/effect/decal/wood/herringbone{
@@ -15234,9 +14960,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap)
 "eGj" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town)
 "eGk" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
@@ -15440,9 +15164,7 @@
 /area/rogue/indoors/town)
 "eJA" = (
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "eJB" = (
 /obj/structure/stairs,
@@ -15484,9 +15206,7 @@
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "manor"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "eKx" = (
 /obj/structure/closet/crate/drawer,
@@ -15709,9 +15429,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
 "eOd" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/indoors/shelter/woods)
 "eOe" = (
 /obj/structure/fluff/railing/border{
@@ -15748,9 +15466,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
 "ePg" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/outdoors/beach/forest/hamlet)
 "ePj" = (
 /obj/structure/fluff/walldeco/chains,
@@ -16140,9 +15856,7 @@
 /obj/item/clothing/suit/roguetown/shirt/vampire,
 /obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/steward,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "eVi" = (
 /obj/item/natural/stone,
@@ -16539,9 +16253,7 @@
 /area/rogue/under/cave/orcdungeon)
 "fbg" = (
 /obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/tavern)
 "fbp" = (
 /obj/structure/roguewindow/openclose{
@@ -16627,9 +16339,7 @@
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/underdark/north)
 "fcB" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/outdoors/beach/forest/hamlet)
 "fcC" = (
 /obj/structure/bookcase,
@@ -16671,21 +16381,13 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
-"fcS" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 1;
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/mountains)
 "fdb" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flashlight/flare/torch/metal,
 /obj/item/flashlight/flare/torch/metal,
 /obj/item/flashlight/flare/torch/metal,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "fdd" = (
 /obj/structure/flora/rogueshroom,
@@ -16797,9 +16499,7 @@
 /obj/structure/mineral_door/wood/fancywood{
 	lockid = "manor"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "fep" = (
 /obj/structure/table/wood{
@@ -17263,10 +16963,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/rtfield)
 "flt" = (
 /obj/effect/decal/cobbleedge{
@@ -17285,9 +16982,7 @@
 /area/rogue/indoors/town/church/chapel)
 "flT" = (
 /obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "flU" = (
 /obj/structure/lever/wall{
@@ -17444,9 +17139,7 @@
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/indoors/cave)
 "foF" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir1,
 /area/rogue/indoors)
 "foK" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -17479,11 +17172,6 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
-"fph" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/cave)
 "fpk" = (
 /obj/item/cooking/platter/silver{
 	pixel_x = 6;
@@ -17594,9 +17282,7 @@
 	icon_state = "longtable"
 	},
 /obj/item/storage/bag/tray,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "fqG" = (
 /mob/living/simple_animal/hostile/rogue/deepone/arm,
@@ -17787,11 +17473,6 @@
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/mountains/decap)
-"ftD" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/dwarfin)
 "ftG" = (
 /obj/structure/chair/bench/church/r{
 	dir = 1
@@ -17826,9 +17507,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "fue" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors/town/church/chapel)
 "fum" = (
 /obj/structure/well/fountain{
@@ -17874,9 +17553,7 @@
 /obj/item/book/rogue/cardgame,
 /obj/item/book/rogue/tales1,
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "fvl" = (
 /obj/structure/flora/roguetree/burnt,
@@ -17887,10 +17564,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/rtfield)
 "fvt" = (
 /obj/structure/chair/wood/rogue/fancy,
@@ -18002,9 +17676,7 @@
 "fxp" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "fxr" = (
 /obj/machinery/light/rogue/torchholder/r{
@@ -18048,14 +17720,6 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/shelter/mountains/decap)
-"fyc" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/dwarfin)
 "fyh" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -18075,9 +17739,7 @@
 	dir = 10
 	},
 /obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fyq" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -18162,9 +17824,7 @@
 /obj/item/millstone{
 	pixel_y = 12
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fzO" = (
 /obj/effect/spawner/roguemap/stump,
@@ -18235,9 +17895,7 @@
 /area/rogue/indoors/town/tavern)
 "fAT" = (
 /obj/structure/roguemachine/withdraw,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fAU" = (
 /obj/structure/closet/crate/roguecloset,
@@ -18316,9 +17974,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/town/basement)
 "fCh" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/indoors/town/magician)
 "fCj" = (
 /obj/item/natural/stone{
@@ -18364,9 +18020,7 @@
 /obj/item/rogueweapon/mace/woodclub,
 /obj/item/rogueweapon/mace/woodclub,
 /obj/item/rogueweapon/mace/woodclub,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "fCU" = (
 /obj/structure/mineral_door/wood/donjon/stone/broken,
@@ -18396,9 +18050,7 @@
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "fDl" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 8
-	},
+/turf/open/floor/rogue/rooftop/west,
 /area/rogue/under/underdark)
 "fDz" = (
 /obj/structure/fermentation_keg,
@@ -18732,9 +18384,7 @@
 	icon_state = "longtable"
 	},
 /obj/item/candle/yellow/lit,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "fJF" = (
 /obj/structure/roguemachine/headeater{
@@ -18940,10 +18590,7 @@
 /area/rogue/outdoors/beach/forest/north)
 "fMK" = (
 /obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/woods)
 "fML" = (
 /turf/open/floor/rogue/dirt,
@@ -19131,9 +18778,7 @@
 /area/rogue/indoors/town/dwarfin)
 "fQw" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "fQA" = (
 /obj/structure/flora/rogueshroom,
@@ -19514,18 +19159,6 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
-"fWd" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
-"fWe" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs)
 "fWf" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/cave/underhamlet)
@@ -19761,9 +19394,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "fZm" = (
 /obj/structure/fermentation_keg/random/water,
@@ -19938,12 +19569,6 @@
 "gcw" = (
 /turf/closed/mineral/rogue/iron,
 /area/rogue/under/underdark/north)
-"gcy" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/shelter/woods)
 "gcQ" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/rogue/dirt/road,
@@ -19990,9 +19615,7 @@
 /area/rogue/outdoors/rtfield)
 "gdG" = (
 /obj/machinery/light/rogue/oven/east,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "gdL" = (
 /obj/structure/fluff/littlebanners/bluewhite{
@@ -20281,9 +19904,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/outdoors/mountains)
 "giw" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "giJ" = (
 /obj/structure/stairs/stone{
@@ -20310,9 +19931,7 @@
 /area/rogue/outdoors/rtfield/eora)
 "gjo" = (
 /obj/structure/fluff/statue/knight,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "gjv" = (
 /obj/machinery/light/rogue/wallfire/candle{
@@ -20382,10 +20001,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "gkp" = (
 /obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "gkq" = (
 /obj/structure/closet/crate/drawer,
@@ -20552,9 +20168,7 @@
 "gno" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "gnv" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -20629,12 +20243,6 @@
 "gpf" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/underdark/north)
-"gpg" = (
-/obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "gph" = (
 /obj/item/clothing/suit/roguetown/shirt/robe/astrata,
 /turf/open/floor/rogue/hexstone,
@@ -20767,9 +20375,7 @@
 /area/rogue/indoors/town)
 "gqn" = (
 /obj/item/natural/fibers,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "gqr" = (
 /obj/structure/roguewindow,
@@ -20786,9 +20392,7 @@
 "gqB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "gqJ" = (
 /obj/structure/bars,
@@ -20806,9 +20410,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "gqQ" = (
 /obj/item/grown/log/tree/stick,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "gqT" = (
 /obj/structure/fluff/railing/border{
@@ -20854,9 +20456,7 @@
 /area/rogue/indoors/town/manor)
 "grs" = (
 /obj/machinery/light/rogue/wallfire/candle/off,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "gru" = (
 /obj/structure/table/wood{
@@ -20884,9 +20484,7 @@
 /obj/structure/roguemachine/mail/r{
 	mailtag = "Veteran"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "grK" = (
 /obj/structure/fluff/railing/border{
@@ -21060,10 +20658,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "guB" = (
 /obj/structure/chair/wood/rogue{
@@ -21159,9 +20754,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/south)
 "gwr" = (
 /obj/structure/fluff/railing/border{
@@ -21356,15 +20949,11 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/yellow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "gyY" = (
 /obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "gzh" = (
 /obj/structure/table/wood,
@@ -21382,9 +20971,7 @@
 /obj/item/candle/candlestick/silver/lit{
 	pixel_y = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "gzs" = (
 /obj/structure/bars/cemetery,
@@ -21489,9 +21076,7 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/book/rogue/blackmountain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "gAt" = (
 /turf/open/water/swamp,
@@ -21580,9 +21165,7 @@
 /area/rogue/outdoors/beach/forest/north)
 "gCd" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "gCA" = (
 /obj/effect/decal/cobbleedge{
@@ -21790,9 +21373,7 @@
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "gGi" = (
 /obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "gGn" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -21846,9 +21427,7 @@
 	dir = 1;
 	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "gGW" = (
 /obj/structure/fluff/railing/border{
@@ -21907,9 +21486,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/orcdungeon)
 "gHH" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/indoors)
 "gHJ" = (
 /obj/structure/flora/roguegrass/herb/hypericum,
@@ -21934,10 +21511,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "gIl" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -21947,9 +21521,7 @@
 /obj/structure/roguemachine/atm{
 	location_tag = "Keep Sideroom"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "gIy" = (
 /obj/structure/closet/crate/chest/wicker{
@@ -22024,16 +21596,12 @@
 "gJJ" = (
 /obj/item/book/rogue/cooking,
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "gJM" = (
 /obj/structure/rack/rogue,
 /obj/item/natural/wood/plank,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "gJO" = (
 /obj/effect/decal/cobbleedge{
@@ -22169,9 +21737,7 @@
 	dir = 9
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "gLX" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -22187,9 +21753,7 @@
 "gMg" = (
 /obj/effect/decal/cobbleedge,
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "gMr" = (
 /obj/structure/fluff/railing/wood{
@@ -22208,10 +21772,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
 "gMC" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 1;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town)
 "gMJ" = (
 /obj/effect/decal/cobbleedge{
@@ -22380,9 +21941,7 @@
 /obj/item/rope/chain,
 /obj/item/rope/chain,
 /obj/item/clothing/cloak/stabard/guardhood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "gQh" = (
 /obj/structure/vine,
@@ -22579,9 +22138,7 @@
 "gTt" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "gTF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -22617,9 +22174,7 @@
 "gTN" = (
 /obj/machinery/light/rogue/torchholder/r,
 /obj/structure/bed/rogue/shit,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "gTV" = (
 /turf/closed/mineral/random/rogue/high,
@@ -22867,9 +22422,7 @@
 /obj/item/clothing/cloak/templar/necran,
 /obj/item/clothing/cloak/templar/necran,
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "gWL" = (
 /obj/structure/chair/stool/rogue,
@@ -23086,9 +22639,7 @@
 /area/rogue/under/cave/orcdungeon)
 "hao" = (
 /obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "haq" = (
 /obj/structure/table/wood{
@@ -23174,9 +22725,7 @@
 /area/rogue/indoors/shelter)
 "hbk" = (
 /obj/item/chair/stool/bar/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "hbp" = (
 /obj/structure/table/wood{
@@ -23206,9 +22755,7 @@
 /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
 /obj/item/reagent_containers/food/snacks/grown/cabbage/rogue,
 /obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "hbC" = (
 /obj/structure/table/wood{
@@ -23242,9 +22789,7 @@
 /area/rogue/outdoors/woods/northwest)
 "hce" = (
 /obj/structure/mineral_door/wood/towner/blacksmith,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "hcf" = (
 /turf/closed/wall/mineral/rogue/stone/red_moss,
@@ -23290,9 +22835,7 @@
 /area/rogue/under/underdark/south)
 "hcO" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "hcP" = (
 /obj/structure/fluff/railing/border{
@@ -23479,9 +23022,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/manor)
 "hfu" = (
 /obj/structure/flora/newleaf,
@@ -23552,9 +23093,7 @@
 /area/rogue/indoors/shelter)
 "hgM" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town)
 "hgP" = (
 /obj/item/roguebin/water/gross,
@@ -23664,9 +23203,7 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /obj/item/reagent_containers/food/snacks/butter,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "hib" = (
 /obj/structure/bars/pipe{
@@ -23853,10 +23390,7 @@
 /area/rogue/under/cave/dukecourt)
 "hkB" = (
 /obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
 "hkC" = (
 /obj/structure/fluff/railing/border{
@@ -24044,9 +23578,7 @@
 /area/rogue/outdoors/beach/forest/north)
 "hmW" = (
 /obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "hmZ" = (
 /obj/structure/flora/roguegrass/bush,
@@ -24220,9 +23752,7 @@
 /area/rogue/under/underdark/south)
 "hqn" = (
 /obj/structure/fermentation_keg/crafted,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "hqo" = (
 /obj/item/natural/stone{
@@ -24233,9 +23763,7 @@
 /area/rogue/under/cave/skeletoncrypt)
 "hqt" = (
 /obj/structure/bookcase/random/archive,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "hqx" = (
 /obj/structure/fluff/railing/border{
@@ -24314,9 +23842,7 @@
 /area/rogue/indoors/town)
 "hrg" = (
 /obj/structure/ladder,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town)
 "hri" = (
 /obj/structure/bars,
@@ -24422,9 +23948,7 @@
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "hsq" = (
 /obj/structure/roguemachine/boardbarrier,
@@ -24574,14 +24098,6 @@
 /obj/item/chair/stool/bar/rogue/crafted,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"hut" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "huu" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -24620,18 +24136,13 @@
 /area/rogue/indoors/town/physician)
 "huV" = (
 /obj/structure/fluff/statue/knight/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "huX" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/town/roofs)
 "hvg" = (
 /obj/effect/decal/cobbleedge{
@@ -24875,9 +24386,7 @@
 /obj/item/book/rogue/tales1,
 /obj/item/book/rogue/law,
 /obj/item/book/rogue/nitebeast,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "hyh" = (
 /obj/structure/stairs{
@@ -24948,9 +24457,7 @@
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/shelter/woods)
 "hyE" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir1,
 /area/rogue/indoors/town/physician)
 "hyG" = (
 /obj/structure/fluff/psycross{
@@ -24988,10 +24495,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/town/roofs)
 "hzG" = (
 /turf/open/floor/rogue/dirt/road,
@@ -25012,10 +24516,7 @@
 /area/rogue/outdoors/beach/forest/hamlet)
 "hAb" = (
 /obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/rooftop{
-	dir = 8;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/west,
 /area/rogue/outdoors/town/roofs)
 "hAd" = (
 /obj/structure/mineral_door/bars{
@@ -25109,9 +24610,7 @@
 /area/rogue/outdoors/mountains/decap)
 "hAT" = (
 /obj/machinery/gear_painter,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "hAV" = (
 /turf/open/floor/rogue/twig,
@@ -25150,9 +24649,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "hBY" = (
 /obj/structure/bars/pipe{
@@ -25212,9 +24709,7 @@
 /area/rogue/indoors/town/church/chapel)
 "hCF" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "hCN" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc_marauder/ravager,
@@ -25401,9 +24896,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-e"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "hFP" = (
 /obj/structure/table/wood,
@@ -25512,9 +25005,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
 "hHP" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/indoors/town/church/chapel)
 "hHU" = (
 /obj/structure/rack/rogue,
@@ -25531,9 +25022,7 @@
 	icon_state = "cobbleedge-w"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "hIw" = (
 /obj/structure/rack/rogue,
@@ -25651,9 +25140,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
 "hKI" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors/town/shop)
 "hKK" = (
 /obj/item/natural/rock,
@@ -25795,9 +25282,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
 "hML" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "hMR" = (
 /obj/structure/fluff/railing/border{
@@ -25985,9 +25470,7 @@
 /obj/structure/table/wood,
 /obj/machinery/light/rogue/wallfire/candle,
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "hQq" = (
 /obj/structure/closet/crate/roguecloset,
@@ -26138,9 +25621,7 @@
 /area/rogue/outdoors/town)
 "hRQ" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "hRU" = (
 /obj/structure/table/wood{
@@ -26148,9 +25629,7 @@
 	icon_state = "largetable"
 	},
 /obj/item/candle/silver/lit,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "hRZ" = (
 /turf/open/transparent/openspace,
@@ -26261,18 +25740,13 @@
 	dir = 10;
 	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "hVq" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "hVs" = (
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
@@ -26291,9 +25765,7 @@
 	pixel_y = 10
 	},
 /obj/item/rogueweapon/pitchfork,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "hVJ" = (
 /obj/structure/flora/rock,
@@ -26395,9 +25867,7 @@
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/manorguardsman,
 /obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "hWx" = (
 /turf/closed/wall/mineral/rogue/pipe{
@@ -26424,9 +25894,7 @@
 	pixel_x = -8;
 	pixel_y = -2
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "hWN" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -26637,18 +26105,13 @@
 "iag" = (
 /obj/structure/table/wood,
 /obj/structure/mineral_door/wood/deadbolt/shutter,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "iaw" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = 32
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 1;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town)
 "iay" = (
 /obj/item/rogueore/silver,
@@ -26771,18 +26234,13 @@
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "icF" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "icG" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -26808,9 +26266,7 @@
 /obj/structure/fluff/walldeco/bigpainting/lake,
 /obj/item/candle/skull/lit,
 /obj/structure/table/wood,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "icW" = (
 /turf/closed/wall/mineral/rogue/pipe{
@@ -26820,9 +26276,7 @@
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "ida" = (
 /obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "idc" = (
 /obj/structure/bars/pipe{
@@ -26933,9 +26387,7 @@
 /obj/effect/decal/mossy{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/magician)
 "ief" = (
 /obj/structure/closet/crate/drawer,
@@ -27093,9 +26545,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
 "ifV" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/outdoors/beach/forest/hamlet)
 "igw" = (
 /obj/structure/bed/rogue/inn,
@@ -27162,9 +26612,7 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "ihI" = (
 /obj/structure/roguemachine/scomm/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "ihP" = (
 /obj/structure/fluff/wallclock,
@@ -27317,9 +26765,7 @@
 	pixel_x = -6;
 	pixel_y = 16
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "ijG" = (
 /obj/structure/stairs{
@@ -27330,9 +26776,7 @@
 /area/rogue/under/town/basement)
 "ijI" = (
 /obj/structure/fermentation_keg/random/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "ijU" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
@@ -27443,9 +26887,7 @@
 /area/rogue/indoors/town)
 "ilA" = (
 /obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "ilE" = (
 /obj/effect/decal/remains/human,
@@ -27676,9 +27118,7 @@
 "ipy" = (
 /obj/structure/table/vtable/v2,
 /obj/item/clothing/neck/roguetown/psicross/pestra,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "ipE" = (
 /turf/open/floor/rogue/twig,
@@ -27761,9 +27201,7 @@
 	icon_state = "longtable_mid"
 	},
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "iqk" = (
 /obj/effect/landmark/quest_spawner/medium,
@@ -27782,9 +27220,7 @@
 	pixel_x = -4;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "iqF" = (
 /obj/structure/bars/passage{
@@ -27819,9 +27255,7 @@
 /area/rogue/outdoors/beach/forest/south)
 "iqS" = (
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/north)
 "iqT" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -27893,9 +27327,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "irz" = (
 /obj/structure/table/wood,
@@ -28317,9 +27749,7 @@
 	},
 /obj/effect/landmark/start/manorguardsman,
 /obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "iyu" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -28445,9 +27875,7 @@
 	dir = 6
 	},
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "iAR" = (
 /obj/structure/chair/bench/church/smallbench,
@@ -28490,9 +27918,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "iBF" = (
 /obj/structure/flora/roguegrass/herb/random,
@@ -28544,9 +27970,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "iCo" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "iCp" = (
 /turf/open/water/river{
@@ -28679,11 +28103,6 @@
 "iDZ" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
 /area/rogue/indoors/town/tavern)
-"iEf" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
-/area/rogue/indoors/town)
 "iEh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/cave)
@@ -28814,9 +28233,7 @@
 	dir = 6
 	},
 /obj/structure/closet/crate/chest/lootbox,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "iGI" = (
 /turf/open/floor/rogue/dirt,
@@ -28923,10 +28340,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "iIg" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 8;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/west,
 /area/rogue/outdoors/town/roofs/keep)
 "iIp" = (
 /obj/structure/bed/rogue,
@@ -29114,9 +28528,7 @@
 	locked = 1;
 	lockid = "farm"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "iKO" = (
 /obj/structure/roguemachine/scomm/l,
@@ -29127,9 +28539,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "iKX" = (
 /mob/living/carbon/human/species/elf/dark/drowraider,
@@ -29141,9 +28551,7 @@
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "iLb" = (
 /obj/structure/fluff/railing/border{
@@ -29215,9 +28623,7 @@
 	},
 /obj/item/natural/feather,
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "iLY" = (
 /obj/effect/landmark/events/deadite_animal_migration_point{
@@ -29359,9 +28765,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "iOf" = (
 /obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
 "iOo" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -29460,9 +28864,7 @@
 "iPD" = (
 /obj/structure/table/wood,
 /obj/item/book/rogue/festus,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "iPO" = (
 /turf/open/floor/rogue/church,
@@ -29513,9 +28915,7 @@
 "iQp" = (
 /obj/structure/fluff/statue/femalestatue,
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "iQA" = (
 /obj/structure/fluff/railing/border{
@@ -29546,12 +28946,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church/basement)
-"iRg" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "iRh" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp/deep,
@@ -30024,9 +29418,7 @@
 /area/rogue/under/cave/skeletoncrypt)
 "iYj" = (
 /obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "iYv" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -30044,9 +29436,7 @@
 /area/rogue/indoors/town/magician)
 "iYw" = (
 /obj/effect/decal/remains/human,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "iYx" = (
 /obj/structure/fluff/walldeco/rpainting/forest{
@@ -30233,9 +29623,7 @@
 /area/rogue/outdoors/mountains/decap)
 "jbt" = (
 /obj/item/clothing/head/roguetown/circlet,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "jbv" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
@@ -30288,10 +29676,7 @@
 	locked = 1;
 	lockid = "warden"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/woods)
 "jct" = (
 /obj/structure/stairs,
@@ -30338,15 +29723,11 @@
 	pixel_x = 5;
 	pixel_y = 39
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "jcT" = (
 /obj/structure/roguemachine/mail/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "jcV" = (
 /obj/effect/decal/cleanable/blood{
@@ -30451,9 +29832,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "jed" = (
 /obj/structure/fluff/statue/knight/interior,
@@ -30563,9 +29942,7 @@
 /obj/item/millstone{
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "jgm" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -31156,10 +30533,7 @@
 	dir = 1
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/town/roofs)
 "jrd" = (
 /obj/structure/mineral_door/swing_door,
@@ -31290,9 +30664,7 @@
 	lockid = "manor";
 	name = "Guest Room II"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "jsT" = (
 /obj/structure/closet/dirthole/closed/loot,
@@ -31495,9 +30867,7 @@
 /obj/item/book/rogue/law{
 	pixel_x = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "jvA" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -31509,9 +30879,7 @@
 	icon_state = "redcouch2"
 	},
 /obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "jvP" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -31536,9 +30904,7 @@
 /obj/structure/roguemachine/atm{
 	location_tag = "Keep Front Gate"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "jwl" = (
 /obj/effect/decal/cobbleedge,
@@ -31555,9 +30921,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "jwz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -31623,9 +30987,7 @@
 /obj/item/roguekey/manor,
 /obj/item/roguekey/manor,
 /obj/item/clothing/ring/silver,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "jxC" = (
 /obj/structure/rack/rogue,
@@ -31648,9 +31010,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "jyd" = (
 /obj/item/natural/stone,
@@ -31679,9 +31039,7 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "jyJ" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "jyK" = (
 /obj/structure/bed/rogue/inn/double{
@@ -31843,9 +31201,7 @@
 	dir = 1
 	},
 /obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "jAv" = (
 /obj/effect/decal/mossy{
@@ -31915,9 +31271,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "jBy" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/indoors/shelter/woods)
 "jBA" = (
 /obj/structure/ladder,
@@ -32258,14 +31612,6 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
-"jHB" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "jHC" = (
 /obj/structure/roguemachine/vendor{
 	keycontrol = "stall2"
@@ -32305,9 +31651,7 @@
 /obj/item/book/rogue/law,
 /obj/item/clothing/mask/cigarette/pipe,
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "jIG" = (
 /obj/structure/flora/roguegrass,
@@ -32333,9 +31677,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/tavern)
 "jIZ" = (
 /obj/structure/fluff/railing/border{
@@ -32345,9 +31687,7 @@
 /area/rogue/indoors/town)
 "jJm" = (
 /obj/structure/chair/wood/rogue/fancy,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "jJn" = (
 /obj/structure/fluff/railing/fence,
@@ -32413,12 +31753,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
-"jKv" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "jKw" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -32456,9 +31790,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "jLg" = (
 /obj/machinery/light/rogue/lanternpost{
@@ -32654,18 +31986,11 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/cave/northern)
-"jPc" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 4
-	},
-/area/rogue/indoors/town)
 "jPe" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "jPk" = (
 /obj/structure/fluff/railing/border{
@@ -32837,9 +32162,7 @@
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/shovel,
 /obj/item/rogueweapon/stoneaxe/woodcut,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "jSf" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -32967,10 +32290,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/town/roofs)
 "jUC" = (
 /obj/structure/fluff/railing/border{
@@ -33148,9 +32468,7 @@
 /obj/item/reagent_containers/food/snacks/rogue/bread,
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "jWX" = (
 /obj/item/roguebin/water/gross,
@@ -33472,9 +32790,7 @@
 	lockid = "royal";
 	name = "Lord's Dining Room"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "kbA" = (
 /obj/structure/handcart,
@@ -33569,9 +32885,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "kdj" = (
 /obj/structure/stairs,
@@ -33588,9 +32902,7 @@
 /obj/machinery/light/rogue/wallfire{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "kdE" = (
 /obj/structure/fluff/walldeco/customflag{
@@ -33628,14 +32940,6 @@
 /obj/structure/table/church,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/cave)
-"keu" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "key" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -33857,9 +33161,7 @@
 /obj/item/reagent_containers/food/snacks/grown/potato/rogue,
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "khk" = (
 /turf/closed/wall/mineral/rogue/stone/red_moss,
@@ -33899,9 +33201,7 @@
 /area/rogue/indoors)
 "khY" = (
 /obj/effect/landmark/start/wretchlate,
-/turf/open/floor/rogue/rooftop{
-	dir = 1
-	},
+/turf/open/floor/rogue/rooftop/north,
 /area/rogue/outdoors/beach/forest/south)
 "kid" = (
 /obj/item/rogueore/silver,
@@ -33927,9 +33227,7 @@
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "kis" = (
 /obj/structure/closet/crate/coffin,
@@ -33941,9 +33239,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/underdark/north)
 "kiz" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/vault)
 "kiD" = (
 /obj/structure/mineral_door/bars,
@@ -34257,9 +33553,7 @@
 	pixel_x = -10;
 	pixel_y = 12
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "koi" = (
 /obj/structure/meathook,
@@ -34705,9 +33999,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors)
 "kwK" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir8,
 /area/rogue/indoors/town/magician)
 "kwN" = (
 /mob/living/carbon/human/species/skeleton/npc/ambush,
@@ -34855,9 +34147,7 @@
 "kyG" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
 /obj/structure/closet/crate/chest/wicker,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "kyN" = (
 /obj/effect/decal/cobbleedge{
@@ -34946,9 +34236,7 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "kzK" = (
 /obj/structure/closet/crate/chest/old_crate,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "kzR" = (
 /obj/effect/decal/cobbleedge{
@@ -35079,9 +34367,7 @@
 /area/rogue/outdoors/town/roofs/keep)
 "kBo" = (
 /obj/structure/bed/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "kBq" = (
 /obj/structure/fluff/railing/border{
@@ -35124,9 +34410,7 @@
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "kBY" = (
 /obj/effect/decal/cobbleedge{
@@ -35148,9 +34432,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
 "kCd" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave/goblindungeon)
 "kCg" = (
 /obj/structure/fluff/railing/fence{
@@ -35250,9 +34532,7 @@
 /area/rogue/under/cave)
 "kDy" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "kDC" = (
 /obj/structure/stairs{
@@ -35439,9 +34719,7 @@
 /area/rogue/under/cave/dukecourt)
 "kFL" = (
 /obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "kFU" = (
 /obj/structure/table/wood,
@@ -35451,9 +34729,7 @@
 /obj/item/reagent_containers/powder/ozium,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "kFV" = (
 /turf/open/floor/rogue/cobble,
@@ -35624,9 +34900,7 @@
 "kIV" = (
 /obj/structure/table/wood/fancy/black,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "kJa" = (
 /obj/structure/flora/roguegrass,
@@ -35806,9 +35080,7 @@
 /area/rogue/under/cave/orcdungeon)
 "kMS" = (
 /obj/structure/mineral_door/wood/towner/generic,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "kMT" = (
 /obj/structure/chair/bench/couchamagenta,
@@ -35902,9 +35174,7 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/dwarfin)
 "kOq" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/indoors/town/shop)
 "kOv" = (
 /obj/structure/table/wood{
@@ -35993,9 +35263,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-w"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "kPX" = (
 /turf/open/floor/rogue/dirt/road,
@@ -36071,9 +35339,7 @@
 /area/rogue/outdoors/town)
 "kRb" = (
 /obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "kRg" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -36109,9 +35375,7 @@
 /area/rogue/outdoors/beach/forest/south)
 "kRK" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "kRO" = (
 /obj/structure/roguemachine/scomm,
@@ -36147,9 +35411,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
 "kSK" = (
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "kSN" = (
 /turf/open/floor/rogue/tile,
@@ -36290,9 +35552,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "kUH" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/indoors/town/garrison)
 "kUI" = (
 /obj/effect/decal/cobbleedge{
@@ -36964,9 +36224,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "lfG" = (
 /turf/closed/wall/mineral/rogue/pipe{
@@ -36988,9 +36246,7 @@
 	pixel_y = 5;
 	sellprice = 30
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "lfO" = (
 /turf/open/floor/rogue/naturalstone,
@@ -37145,9 +36401,7 @@
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "lhW" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir4,
 /area/rogue/indoors/town/dwarfin)
 "lhY" = (
 /obj/structure/bars,
@@ -37190,9 +36444,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "liV" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/indoors/town/magician)
 "liW" = (
 /obj/structure/bookcase,
@@ -37204,9 +36456,7 @@
 /obj/machinery/light/rogue/torchholder{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "ljk" = (
 /obj/item/reagent_containers/food/snacks/rogue/meat/steak,
@@ -37742,9 +36992,7 @@
 	icon_state = "largetable"
 	},
 /obj/item/candle/candlestick/silver/lit,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "lqL" = (
 /obj/structure/flora/roguegrass/herb/random,
@@ -38046,9 +37294,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "lve" = (
 /turf/open/floor/rogue/churchrough,
@@ -38313,9 +37559,7 @@
 /area/rogue/indoors)
 "lyG" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "lyI" = (
 /obj/item/roguebin/water/gross,
@@ -38355,9 +37599,7 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/structure/bookcase/random/archive,
 /obj/effect/decal/cleanable/dirt/cobweb,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "lzf" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
@@ -38889,9 +38131,7 @@
 /area/rogue/indoors/shelter)
 "lGu" = (
 /obj/structure/mineral_door/wood/towner/cheesemaker,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "lGv" = (
 /obj/effect/spawner/roguemap/stump,
@@ -38973,9 +38213,7 @@
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "lIw" = (
 /obj/effect/decal/wood/herringbone2,
@@ -39166,17 +38404,13 @@
 /obj/structure/bookcase/random/archive{
 	opacity = 0
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "lLL" = (
 /obj/item/book/rogue/nitebeast,
 /obj/item/book/rogue/noc,
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "lLM" = (
 /obj/machinery/light/rogue/wallfire/candle,
@@ -39203,14 +38437,10 @@
 "lLY" = (
 /obj/structure/table/vtable/v2,
 /obj/item/candle/skull,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "lMc" = (
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "lMe" = (
 /obj/effect/decal/cobbleedge{
@@ -39378,9 +38608,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "lPm" = (
 /obj/structure/stairs{
@@ -39581,9 +38809,7 @@
 	lockid = "manor";
 	name = "Kitchen"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "lSt" = (
 /obj/structure/stairs/stone{
@@ -39691,9 +38917,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "lVw" = (
 /obj/machinery/light/rogue/wallfire{
@@ -39727,9 +38951,7 @@
 /area/rogue/indoors/shelter/woods)
 "lWk" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "lWm" = (
 /obj/effect/decal/remains/mole,
@@ -39800,14 +39022,6 @@
 "lXu" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/cave/underhamlet)
-"lXw" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/shelter/woods)
 "lXx" = (
 /obj/structure/chair/wood/rogue{
 	dir = 4
@@ -39831,9 +39045,7 @@
 /area/rogue/under/underdark/north)
 "lXR" = (
 /obj/structure/chair/bench/coucha/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "lXS" = (
 /obj/structure/bars/pipe,
@@ -39865,14 +39077,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/shelter/woods)
-"lYA" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town/tavern)
 "lYB" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/cup/golden,
@@ -40484,9 +39688,7 @@
 	pixel_x = -8;
 	pixel_y = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "mhi" = (
 /obj/structure/vine,
@@ -40501,9 +39703,7 @@
 "mhs" = (
 /obj/structure/fermentation_keg/crafted,
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "mhv" = (
 /obj/structure/fermentation_keg/beer,
@@ -40765,9 +39965,7 @@
 /area/rogue/under/cave/goblinfort)
 "mmb" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/vault)
 "mme" = (
 /obj/structure/bars/tough,
@@ -40878,9 +40076,7 @@
 	locked = 1;
 	lockid = "manor"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "mnw" = (
 /obj/effect/decal/mossy{
@@ -41066,9 +40262,7 @@
 /obj/structure/bed/rogue,
 /obj/effect/landmark/start/manorguardsman,
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "mqX" = (
 /obj/structure/vine,
@@ -41173,9 +40367,7 @@
 	pixel_y = -2
 	},
 /obj/effect/decal/cleanable/debris/woody,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "msp" = (
 /obj/item/grown/log/tree/small,
@@ -41357,9 +40549,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
 "mvU" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir1,
 /area/rogue/indoors/town/dwarfin)
 "mvV" = (
 /mob/living/simple_animal/hostile/rogue/dragger,
@@ -41404,9 +40594,7 @@
 /obj/structure/fluff/walldeco/painting{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "mwS" = (
 /obj/structure/fluff/railing/wood{
@@ -41478,10 +40666,7 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "myr" = (
 /obj/structure/spider/stickyweb,
@@ -41603,12 +40788,6 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/underdark/south)
-"mAh" = (
-/obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "mAj" = (
 /obj/structure/table/vtable/v2,
 /obj/item/clothing/neck/roguetown/psicross/eora,
@@ -41700,9 +40879,7 @@
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "mBR" = (
 /obj/structure/flora/newleaf/corner{
@@ -41722,9 +40899,7 @@
 /area/rogue/indoors/town)
 "mCk" = (
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "mCp" = (
 /obj/structure/flora/roguegrass/herb/random,
@@ -42052,9 +41227,7 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "mHn" = (
 /obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "mHq" = (
 /obj/structure/fluff/statue/gargoyle,
@@ -42108,10 +41281,7 @@
 /turf/open/water/sewer,
 /area/rogue/indoors/cave)
 "mIp" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 8;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/west,
 /area/rogue/outdoors/beach/forest/hamlet)
 "mIt" = (
 /obj/machinery/light/rogue/cauldron,
@@ -42147,9 +41317,7 @@
 "mIU" = (
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/vault)
 "mJc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
@@ -42220,12 +41388,6 @@
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
-"mKM" = (
-/obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
-/area/rogue/indoors/town)
 "mKN" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/transparent/openspace,
@@ -42499,9 +41661,7 @@
 	},
 /obj/item/roguecoin/gold,
 /obj/item/roguecoin/gold,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "mOO" = (
 /obj/structure/closet/dirthole/closed/loot,
@@ -42519,14 +41679,10 @@
 /area/rogue/indoors/town)
 "mOZ" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "mPc" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors)
 "mPe" = (
 /obj/item/grown/log/tree/stick,
@@ -42565,9 +41721,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "mPH" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -42769,10 +41923,7 @@
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 4
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/town/roofs/keep)
 "mSG" = (
 /obj/structure/table/wood{
@@ -42782,9 +41933,7 @@
 	pixel_x = -8;
 	pixel_y = 16
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "mSN" = (
 /obj/structure/closet/crate/chest/old_crate,
@@ -42897,9 +42046,7 @@
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 1
-	},
+/turf/open/floor/rogue/rooftop/north,
 /area/rogue/outdoors/beach/forest/south)
 "mVc" = (
 /obj/structure/chair/bench/church/smallbench,
@@ -43040,9 +42187,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "mXi" = (
 /obj/structure/fluff/railing/border{
@@ -43100,9 +42245,7 @@
 	lockid = "manor";
 	name = "Throne Room"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "mXX" = (
 /obj/structure/fluff/railing/wood,
@@ -43135,9 +42278,7 @@
 	lockid = "royal";
 	name = "Lord's Apartment"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "mYw" = (
 /obj/structure/stairs{
@@ -43151,9 +42292,7 @@
 /obj/item/candle/candlestick/gold/lit{
 	pixel_y = 12
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "mYF" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -43295,9 +42434,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "naR" = (
 /turf/open/floor/carpet/purple,
@@ -43411,14 +42548,6 @@
 /obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/shop)
-"ncY" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "ndb" = (
 /obj/structure/bars/passage/shutter{
 	max_integrity = 15000;
@@ -43496,9 +42625,7 @@
 /area/rogue/indoors)
 "ndY" = (
 /obj/machinery/tanningrack,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nea" = (
 /obj/structure/flora/roguegrass/bush,
@@ -43860,9 +42987,7 @@
 /area/rogue/indoors/town/garrison)
 "njj" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "njw" = (
 /obj/structure/roguewindow,
@@ -43916,9 +43041,7 @@
 "nkf" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/blackmountain,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "nkg" = (
 /obj/item/rogueore/iron,
@@ -44022,9 +43145,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "nlt" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors/town/magician)
 "nlD" = (
 /turf/closed/wall/mineral/rogue/pipe{
@@ -44651,9 +43772,7 @@
 /area/rogue/outdoors/mountains/decap)
 "nwp" = (
 /obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nwt" = (
 /obj/structure/mineral_door/wood{
@@ -44795,9 +43914,7 @@
 	icon_state = "longtable"
 	},
 /obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "nzd" = (
 /obj/item/roguestatue/gold/loot,
@@ -44848,9 +43965,7 @@
 	lockid = "warden";
 	name = "warden's watchtower"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nAH" = (
 /obj/structure/rack/rogue{
@@ -45019,9 +44134,7 @@
 	dir = 5
 	},
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nCM" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -45077,9 +44190,7 @@
 	dir = 8;
 	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "nDL" = (
 /obj/structure/closet/crate/chest{
@@ -45175,9 +44286,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "nEP" = (
 /turf/open/floor/rogue/hay,
@@ -45226,9 +44335,7 @@
 /obj/item/candle/candlestick/gold/lit{
 	pixel_y = 12
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "nFh" = (
 /turf/open/floor/rogue/grass,
@@ -45505,10 +44612,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "nJF" = (
 /obj/item/chair/stool/bar/rogue/crafted{
@@ -45711,9 +44815,7 @@
 /area/rogue/indoors/town/dwarfin)
 "nMh" = (
 /obj/structure/mineral_door/wood/towner/miner,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nMi" = (
 /turf/open/water/ocean,
@@ -45873,9 +44975,7 @@
 /area/rogue/outdoors/town)
 "nOW" = (
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "nOY" = (
 /obj/item/natural/rock/salt,
@@ -45894,9 +44994,7 @@
 	dir = 10
 	},
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nPl" = (
 /obj/structure/flora/newtree,
@@ -46004,19 +45102,12 @@
 /obj/structure/roguemachine/scomm/l,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
-"nQL" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
-/area/rogue/indoors/town)
 "nQR" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
 	icon_state = "borderfall"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "nRd" = (
 /obj/structure/flora/roguegrass/water,
@@ -46064,9 +45155,7 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/skeletoncrypt)
 "nRO" = (
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/mountains)
 "nRQ" = (
 /obj/structure/fluff/railing/border{
@@ -46128,17 +45217,6 @@
 /obj/structure/chair/bench/church/r,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/underdark/south)
-"nSF" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "nSG" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/church/basement)
@@ -46258,9 +45336,7 @@
 /obj/item/clothing/neck/roguetown/psicross/malum,
 /obj/item/clothing/neck/roguetown/psicross/abyssor,
 /obj/item/clothing/neck/roguetown/psicross/abyssor,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "nUa" = (
 /mob/living/carbon/human/species/goblin/npc/sea{
@@ -46307,9 +45383,7 @@
 	dir = 1;
 	locked = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "nUS" = (
 /turf/open/floor/rogue/twig,
@@ -46398,9 +45472,7 @@
 /obj/item/rogueweapon/stoneaxe,
 /obj/structure/rack/rogue,
 /obj/effect/decal/cleanable/debris/woody,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "nWU" = (
 /obj/structure/flora/roguegrass,
@@ -46574,9 +45646,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "nZT" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
@@ -46684,9 +45754,7 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/cell)
 "obq" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors/shelter/woods)
 "obG" = (
 /obj/effect/decal/cobbleedge{
@@ -46797,9 +45865,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "odG" = (
 /obj/structure/fluff/walldeco/chains,
@@ -47112,9 +46178,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "oif" = (
 /obj/effect/decal/cobbleedge,
@@ -47137,15 +46201,8 @@
 	pixel_x = -6;
 	pixel_y = -16
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
-"oii" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
-/area/rogue/outdoors/beach/south)
 "oin" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/AzureSand,
@@ -47371,9 +46428,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "omX" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir1,
 /area/rogue/indoors/town/church/chapel)
 "ona" = (
 /obj/effect/decal/cleanable/blood,
@@ -47439,9 +46494,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblindungeon)
 "opr" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors/town/physician)
 "opt" = (
 /turf/closed/mineral/random/rogue,
@@ -47468,11 +46521,6 @@
 	icon_state = "iron_line"
 	},
 /area/rogue/under/cave)
-"oqf" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/under/underdark/north)
 "oqj" = (
 /obj/structure/bars/pipe,
 /turf/closed/wall/mineral/rogue/stone,
@@ -47570,9 +46618,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "orT" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir8,
 /area/rogue/indoors/town/church/chapel)
 "orV" = (
 /obj/structure/rack/rogue/shelf,
@@ -47682,11 +46728,6 @@
 "otQ" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/cave/northern)
-"otR" = (
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
-/area/rogue/indoors/town)
 "ouk" = (
 /obj/machinery/light/rogue/wallfire/candle/blue{
 	pixel_y = -32
@@ -47776,11 +46817,6 @@
 "owd" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/outdoors/woods/northeast)
-"owg" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
-/area/rogue/indoors/town)
 "owj" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -47936,9 +46972,7 @@
 /area/rogue/outdoors/beach/forest/south)
 "oyx" = (
 /obj/structure/chair/bench/couch,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "oyB" = (
 /obj/structure/hotspring/border/eleven,
@@ -48104,9 +47138,7 @@
 /obj/item/fishingrod,
 /obj/item/fishingrod,
 /obj/item/rogueweapon/huntingknife,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "oAQ" = (
 /obj/structure/chair/stool/rogue,
@@ -48300,9 +47332,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "oEU" = (
 /obj/structure/table/vtable,
@@ -48327,9 +47357,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "oFU" = (
 /obj/effect/decal/carpet/square{
@@ -48451,9 +47479,7 @@
 	lockid = "heir";
 	name = "Heir's Apartment"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "oHw" = (
 /obj/structure/fluff/walldeco/wantedposter,
@@ -48468,9 +47494,7 @@
 /area/rogue/indoors/town)
 "oHF" = (
 /obj/structure/stairs,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/manor)
 "oHH" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -48494,9 +47518,7 @@
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "oIt" = (
 /obj/structure/bars,
@@ -48543,9 +47565,7 @@
 /obj/structure/stairs{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "oIF" = (
 /obj/structure/table/wood{
@@ -48804,9 +47824,7 @@
 /area/rogue/indoors)
 "oMS" = (
 /obj/structure/chair/bench/coucha/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "oMT" = (
 /obj/effect/decal/cleanable/blood{
@@ -48895,12 +47913,6 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"oOM" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 1;
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs)
 "oON" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -48994,9 +48006,7 @@
 "oPR" = (
 /obj/structure/ladder,
 /obj/machinery/light/rogue/wallfire/candle/off,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "oPV" = (
 /obj/structure/stairs/stone{
@@ -49087,9 +48097,7 @@
 	pixel_x = 4;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "oRu" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -49159,9 +48167,7 @@
 /area/rogue/outdoors/town)
 "oSF" = (
 /obj/structure/fluff/alch,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "oSM" = (
 /obj/structure/flora/roguetree,
@@ -49751,9 +48757,7 @@
 	dir = 8;
 	pixel_y = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "paw" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -49934,9 +48938,7 @@
 /obj/item/rope,
 /obj/item/rope,
 /obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "pdC" = (
 /obj/item/roguegear,
@@ -49959,9 +48961,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "pdT" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -50049,9 +49049,7 @@
 /area/rogue/under/town/basement)
 "pfi" = (
 /obj/structure/roguemachine/mail/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "pfk" = (
 /obj/structure/rack/rogue/shelf/big{
@@ -50285,9 +49283,7 @@
 "pic" = (
 /obj/item/book/rogue/arcyne,
 /obj/structure/bookcase/random/archive,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "piw" = (
 /obj/structure/stairs,
@@ -50451,18 +49447,14 @@
 	dir = 4;
 	pixel_x = -10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "plt" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
 	locked = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "plx" = (
 /obj/structure/chair/stool/rogue,
@@ -50648,14 +49640,6 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains)
-"poW" = (
-/obj/machinery/light/rogue/wallfire/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "ppl" = (
 /obj/structure/table/wood{
 	dir = 4;
@@ -50726,9 +49710,7 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/north)
 "pqi" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -50757,9 +49739,7 @@
 /area/rogue/indoors/town/cell)
 "pqA" = (
 /obj/structure/mineral_door/wood/deadbolt,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "pqC" = (
 /obj/structure/flora/roguegrass/bush,
@@ -50844,9 +49824,7 @@
 /area/rogue/outdoors/beach/north)
 "psb" = (
 /obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "pso" = (
 /obj/structure/bed/rogue/inn/pileofshit,
@@ -50856,9 +49834,7 @@
 "psq" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "psu" = (
 /obj/item/roguebin/water,
@@ -50883,9 +49859,7 @@
 	},
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "psT" = (
 /obj/structure/fermentation_keg/distiller,
@@ -50898,9 +49872,7 @@
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/table/wood/fancy/black,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/spells,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "ptq" = (
 /obj/structure/fluff/statue/scare,
@@ -50920,19 +49892,6 @@
 /obj/item/kitchen/spoon,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town)
-"ptv" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-n"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
-/area/rogue/indoors/town/garrison)
 "ptF" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -50957,9 +49916,7 @@
 /area/rogue/outdoors/town)
 "puH" = (
 /obj/effect/landmark/start/veteran,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "puO" = (
 /turf/open/floor/rogue/hexstone,
@@ -51015,9 +49972,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/woods)
 "pvR" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir1,
 /area/rogue/indoors/town/magician)
 "pvX" = (
 /obj/structure/table/wood,
@@ -51191,9 +50146,7 @@
 /obj/item/book/rogue/tales3,
 /obj/item/book/rogue/yeoldecookingmanual,
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "pyR" = (
 /obj/effect/decal/mossy{
@@ -51224,11 +50177,6 @@
 /obj/item/rogueweapon/thresher,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"pze" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town/church/chapel)
 "pzh" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -51267,9 +50215,7 @@
 /area/rogue/indoors/town/physician)
 "pzw" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "pzA" = (
 /obj/structure/fluff/walldeco/painting/seraphina,
@@ -51554,9 +50500,7 @@
 "pDi" = (
 /obj/structure/fluff/statue/femalestatue,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "pDr" = (
 /obj/item/rogue/instrument/drum,
@@ -51570,9 +50514,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "pDT" = (
 /obj/structure/fluff/railing/border{
@@ -51626,9 +50568,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
 "pEB" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors/town/garrison)
 "pEO" = (
 /turf/closed/wall/mineral/rogue/decowood/vert,
@@ -51794,9 +50734,7 @@
 /area/rogue/outdoors/woods/north)
 "pHj" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "pHk" = (
 /obj/structure/bookcase/random/archive,
@@ -52010,14 +50948,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
-"pKE" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/shelter/woods)
 "pKH" = (
 /obj/structure/fluff/walldeco/bigpainting{
 	pixel_x = 0;
@@ -52108,10 +51038,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
 "pLZ" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roof"
-	},
+/turf/open/floor/rogue/rooftop/east,
 /area/rogue/under/underdark)
 "pMc" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -52132,9 +51059,7 @@
 "pMo" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "pMu" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -52283,9 +51208,7 @@
 /obj/structure/winch{
 	name = "Crane winch"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
 "pOL" = (
 /obj/structure/stairs,
@@ -52355,9 +51278,7 @@
 "pQm" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /obj/structure/closet/crate/chest/wicker,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "pQn" = (
 /obj/structure/closet/crate/chest,
@@ -52480,23 +51401,17 @@
 /obj/item/candle/gold/lit{
 	pixel_y = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "pSa" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/magician)
 "pSc" = (
 /obj/structure/table/vtable,
 /obj/item/storage/belt/rogue/surgery_bag/full{
 	pixel_y = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "pSf" = (
 /turf/open/lava/acid,
@@ -52968,9 +51883,7 @@
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "pZX" = (
 /obj/structure/fluff/railing/border,
@@ -53007,9 +51920,7 @@
 /obj/item/reagent_containers/food/snacks/grown/berries/rogue,
 /obj/item/reagent_containers/food/snacks/grown/berries/rogue,
 /obj/effect/decal/cobbleedge,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "qax" = (
 /obj/machinery/light/rogue/torchholder/l,
@@ -53284,10 +52195,7 @@
 /obj/structure/fluff/walldeco/customflag{
 	pixel_x = -32
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/indoors/town)
 "qeV" = (
 /obj/machinery/light/small/broken{
@@ -53329,9 +52237,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
 "qfC" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/indoors/town/dwarfin)
 "qfE" = (
 /obj/structure/fluff/walldeco/wantedposter,
@@ -53476,10 +52382,7 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/shop)
 "qic" = (
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach)
 "qim" = (
 /obj/effect/decal/cleanable/blood{
@@ -53499,10 +52402,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/rtfield)
 "qjb" = (
 /obj/effect/decal/cobbleedge{
@@ -53516,9 +52416,7 @@
 	dir = 4;
 	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "qjc" = (
 /obj/structure/table/wood{
@@ -53532,9 +52430,7 @@
 	pixel_y = 8
 	},
 /obj/effect/spawner/lootdrop/potion_ingredient/herb,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "qje" = (
 /obj/effect/decal/cobbleedge{
@@ -53560,9 +52456,7 @@
 /obj/structure/mineral_door/wood{
 	locked = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "qjq" = (
 /obj/structure/table/wood{
@@ -53611,15 +52505,6 @@
 "qjY" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/woods)
-"qke" = (
-/obj/effect/decal/cobbleedge{
-	dir = 10;
-	icon_state = "cobbleedge-w"
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "qkg" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -53630,9 +52515,7 @@
 /turf/open/floor/rogue/blocks/newstone,
 /area/rogue/under/underdark/north)
 "qkh" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 1
-	},
+/turf/open/floor/rogue/rooftop/north,
 /area/rogue/outdoors/beach/forest/south)
 "qki" = (
 /obj/structure/table/wood{
@@ -53675,9 +52558,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach)
 "qkN" = (
 /obj/effect/decal/cobbleedge{
@@ -53977,14 +52858,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"qps" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "qpx" = (
 /obj/effect/landmark/start/merchant,
 /turf/open/floor/carpet/stellar,
@@ -54072,9 +52945,7 @@
 /obj/item/fishingrod,
 /obj/item/fishingrod,
 /obj/item/rogueweapon/huntingknife,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "qqK" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -54105,9 +52976,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
 "qrn" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors/town/church/chapel)
 "qrp" = (
 /obj/structure/table/wood{
@@ -54367,9 +53236,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "qvp" = (
 /obj/structure/fluff/walldeco/customflag{
@@ -54540,10 +53407,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/rtfield)
 "qxL" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -54605,9 +53469,7 @@
 	aportalgoesto = "vikingshipin";
 	aportalid = "vikingshipout"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "qyR" = (
 /turf/open/floor/rogue/grassyel,
@@ -55028,9 +53890,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
 "qEZ" = (
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/woods/northeast)
 "qFa" = (
 /obj/structure/bed/rogue/inn/double,
@@ -55046,9 +53906,7 @@
 /area/rogue/under/underdark/north)
 "qFk" = (
 /obj/structure/rogue/trophy/deer,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "qFm" = (
 /obj/structure/table/wood{
@@ -55091,9 +53949,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "qFJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -55277,9 +54133,7 @@
 	},
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "qIg" = (
 /obj/effect/decal/cobbleedge{
@@ -55304,9 +54158,7 @@
 /obj/structure/chair/bench/couch{
 	icon_state = "redcouch2"
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "qIx" = (
 /obj/structure/stairs/stone{
@@ -55466,9 +54318,7 @@
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "qKY" = (
 /obj/structure/flora/roguegrass/water,
@@ -55545,9 +54395,7 @@
 /area/rogue/indoors)
 "qML" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "qMO" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
@@ -55567,9 +54415,7 @@
 	dir = 10
 	},
 /obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "qNk" = (
 /obj/structure/stairs{
@@ -55614,9 +54460,7 @@
 /obj/item/candle/candlestick/silver/single/lit{
 	pixel_y = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "qND" = (
 /obj/structure/roguemachine/mail,
@@ -55883,9 +54727,7 @@
 	},
 /obj/item/reagent_containers/glass/cup,
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "qRx" = (
 /obj/structure/fluff/railing/border{
@@ -56078,14 +54920,10 @@
 /obj/item/candle/silver/lit{
 	pixel_y = 6
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "qUS" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors/town/church/chapel)
 "qUU" = (
 /obj/structure/table/wood,
@@ -56282,9 +55120,7 @@
 	dir = 1
 	},
 /obj/structure/toilet,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "qYt" = (
 /obj/effect/decal/cleanable/blood,
@@ -56395,9 +55231,7 @@
 /area/rogue/outdoors/town)
 "qZl" = (
 /obj/structure/chair/bench/coucha,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "qZo" = (
 /turf/open/water/river{
@@ -56482,9 +55316,7 @@
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "raX" = (
 /obj/item/storage/keyring,
@@ -56512,9 +55344,7 @@
 /obj/item/scomstone/bad/garrison,
 /obj/item/scomstone/bad/garrison,
 /obj/item/scomstone/bad/garrison,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "rbf" = (
 /obj/structure/roguemachine/mail{
@@ -56783,9 +55613,7 @@
 /obj/item/candle/candlestick/gold/single/lit{
 	pixel_y = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "rfc" = (
 /obj/item/natural/stone,
@@ -56863,9 +55691,7 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
 "rgj" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors/town/physician)
 "rgo" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -57043,9 +55869,7 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
 /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess,
 /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "rjK" = (
 /obj/structure/chair/wood/rogue/fancy{
@@ -57066,9 +55890,7 @@
 "rjR" = (
 /obj/structure/rack/rogue,
 /obj/item/quiver,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "rkn" = (
 /obj/structure/glowshroom{
@@ -57311,9 +56133,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "rnU" = (
 /turf/open/floor/rogue/naturalstone,
@@ -57342,9 +56162,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "ros" = (
 /obj/machinery/light/rogue/wallfire/candle{
@@ -57354,9 +56172,7 @@
 /area/rogue/indoors/town/tavern)
 "rov" = (
 /obj/structure/fluff/clock,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "roT" = (
 /obj/structure/fluff/railing/border{
@@ -57532,9 +56348,7 @@
 	lockid = "hand";
 	name = "Hand's Chambers"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "rrZ" = (
 /obj/item/cooking/platter/silver{
@@ -57950,9 +56764,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 8
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/tavern)
 "ryX" = (
 /obj/structure/fluff/railing/border{
@@ -58414,9 +57226,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "rGg" = (
 /obj/structure/fluff/statue/gargoyle/moss{
@@ -58457,9 +57267,7 @@
 /obj/structure/fluff/wallclock{
 	dir = 3
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "rGK" = (
 /obj/structure/closet/crate/chest/old_crate,
@@ -58469,9 +57277,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "rGP" = (
 /obj/structure/fluff/railing/border{
@@ -58650,9 +57456,7 @@
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 4
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/tavern)
 "rKa" = (
 /obj/structure/table/wood{
@@ -58661,9 +57465,7 @@
 /obj/machinery/light/rogue/wallfire/candle/l,
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "rKi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -58979,9 +57781,7 @@
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
 /obj/item/rogueore/coal,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "rOz" = (
 /obj/effect/decal/cobbleedge{
@@ -59062,9 +57862,7 @@
 "rQo" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/sword,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "rQr" = (
 /obj/structure/bed/rogue/shit{
@@ -59081,9 +57879,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "rQw" = (
 /obj/item/grown/log/tree/stick,
@@ -59119,9 +57915,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/tavern)
 "rRl" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors/town/shop)
 "rRz" = (
 /obj/structure/fluff/railing/border{
@@ -59148,12 +57942,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/north)
-"rRQ" = (
-/obj/structure/stairs,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "rSa" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/dirt,
@@ -59197,9 +57985,7 @@
 /obj/effect/landmark/start/squire{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "rSN" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/spear,
@@ -59340,9 +58126,7 @@
 /area/rogue/indoors/town)
 "rUf" = (
 /obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "rUj" = (
 /obj/structure/fluff/railing/border{
@@ -59436,10 +58220,7 @@
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "rVf" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/beach/forest/hamlet)
 "rVx" = (
 /obj/structure/mineral_door/wood{
@@ -59544,9 +58325,7 @@
 	dir = 8
 	},
 /obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "rXI" = (
 /obj/structure/stairs/stone,
@@ -59842,15 +58621,11 @@
 /obj/structure/mineral_door/wood/deadbolt/shutter{
 	dir = 2
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "scw" = (
 /obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/vault)
 "scI" = (
 /obj/structure/table/wood{
@@ -59891,9 +58666,7 @@
 	pixel_y = 3
 	},
 /obj/item/book/rogue/tales3,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "sdh" = (
 /obj/structure/fluff/railing/border{
@@ -60103,9 +58876,7 @@
 /area/rogue/indoors/shelter/woods)
 "sgY" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "sgZ" = (
 /obj/structure/table/wood{
@@ -60233,14 +59004,6 @@
 /obj/item/rogueweapon/halberd/glaive,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
-"siI" = (
-/obj/machinery/light/rogue/wallfire{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "siN" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/garrison)
@@ -60321,10 +59084,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "sjQ" = (
 /obj/structure/chair/stool/rogue,
@@ -60350,9 +59110,7 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "skc" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "ske" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -60385,9 +59143,7 @@
 /area/rogue/outdoors/mountains/decap)
 "skw" = (
 /obj/item/roguestatue/gold/loot,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/vault)
 "skz" = (
 /obj/structure/table/wood{
@@ -60536,9 +59292,7 @@
 /area/rogue/indoors/town/tavern)
 "slQ" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "slS" = (
 /obj/structure/bookcase/random/archive,
@@ -60579,9 +59333,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "smL" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -60632,9 +59384,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "snb" = (
 /obj/structure/fluff/railing/border{
@@ -60718,9 +59468,7 @@
 /area/rogue/under/cave/orcdungeon)
 "snS" = (
 /obj/machinery/light/rogue/wallfire/candle,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "snZ" = (
 /obj/structure/chair/bench{
@@ -60849,9 +59597,7 @@
 	dir = 6
 	},
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "spS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
@@ -60914,10 +59660,7 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane)
 "sqG" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/mountains)
 "sqI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -61079,9 +59822,7 @@
 /area/rogue/indoors/town/cell)
 "sst" = (
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "ssz" = (
 /obj/machinery/light/rogue/cauldron,
@@ -61098,10 +59839,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/indoors/town)
 "ssK" = (
 /obj/structure/fluff/railing/fence{
@@ -61138,9 +59876,7 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "sto" = (
 /turf/open/floor/rogue/grass,
@@ -61413,14 +60149,6 @@
 "sxx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/cave)
-"sxy" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "sxD" = (
 /mob/living/carbon/human/species/elf/dark/drowraider,
 /turf/open/floor/rogue/cobblerock,
@@ -61483,10 +60211,7 @@
 /area/rogue/indoors/town/dwarfin)
 "syr" = (
 /obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/mountains)
 "syz" = (
 /obj/structure/closet/crate/drawer,
@@ -61527,9 +60252,7 @@
 	icon_state = "woodchestalt"
 	},
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "syT" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -61757,9 +60480,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "sDz" = (
 /obj/structure/fluff/railing/border{
@@ -62328,9 +61049,7 @@
 /area/rogue/under/town/basement/keep)
 "sNy" = (
 /obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/mountains)
 "sNz" = (
 /obj/structure/chair/wood/rogue{
@@ -62414,14 +61133,6 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
-"sOC" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "sON" = (
 /obj/structure/stairs{
 	dir = 8
@@ -62631,14 +61342,6 @@
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
-"sRx" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "sRA" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -62811,9 +61514,7 @@
 	icon_state = "longtable"
 	},
 /obj/item/rogueweapon/huntingknife,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "sUC" = (
 /obj/machinery/light/rogue/firebowl/standing,
@@ -62888,9 +61589,7 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "sVN" = (
 /obj/structure/bookcase/random/archive,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "sVR" = (
 /obj/machinery/light/rogue/hearth,
@@ -62926,9 +61625,7 @@
 /area/rogue/under/cave/dukecourt)
 "sWF" = (
 /obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "sWL" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/guard/shield,
@@ -63074,11 +61771,6 @@
 /obj/machinery/light/rogue/oven/south,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town)
-"sYZ" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "sZa" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
@@ -63125,9 +61817,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "sZq" = (
 /obj/structure/lever/wall{
@@ -63143,9 +61833,7 @@
 /area/rogue/outdoors/town)
 "sZH" = (
 /obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "sZK" = (
 /obj/item/kitchen/spoon,
@@ -63258,9 +61946,7 @@
 	aportalgoesto = "vikingshipout";
 	aportalid = "vikingshipin"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "taS" = (
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -63679,9 +62365,7 @@
 	pixel_x = 6;
 	pixel_y = -5
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "tgi" = (
 /obj/structure/stairs{
@@ -63854,9 +62538,7 @@
 /area/rogue/under/town/sewer)
 "tjI" = (
 /obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "tjK" = (
 /obj/structure/fluff/railing/fence{
@@ -63873,9 +62555,7 @@
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/outdoors/exposed/bath/vault)
 "tjY" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "tkf" = (
 /obj/structure/table/wood{
@@ -63922,9 +62602,7 @@
 	lockid = "manor";
 	name = "Seneschal's Quarters"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "tle" = (
 /obj/structure/vine{
@@ -64191,25 +62869,19 @@
 /obj/structure/rack/rogue/shelf{
 	pixel_y = -6
 	},
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir8,
 /area/rogue/indoors/town/church/chapel)
 "toE" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/beach/forest/south)
 "toG" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors/town/garrison)
 "toI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "toJ" = (
 /turf/open/floor/rogue/naturalstone,
@@ -64293,10 +62965,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/forest/north)
 "tqt" = (
 /obj/structure/fluff/walldeco/psybanner/red,
@@ -64356,9 +63025,7 @@
 /area/rogue/indoors/town/garrison)
 "trl" = (
 /obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "trm" = (
 /obj/structure/chair/stool/rogue,
@@ -64473,9 +63140,7 @@
 /obj/item/roguecoin/gold/pile,
 /obj/structure/closet/crate/chest/neu_fancy,
 /obj/item/roguegem/random,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "tsU" = (
 /obj/structure/stairs{
@@ -64697,18 +63362,8 @@
 /obj/item/rogueweapon/huntingknife{
 	pixel_y = 2
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"twH" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/shelter/woods)
 "twI" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/axe,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -64817,9 +63472,7 @@
 	icon_state = "tablewood1"
 	},
 /obj/item/candle/yellow/lit,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "tyl" = (
 /obj/structure/closet/crate/roguecloset,
@@ -64934,12 +63587,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
-"tzV" = (
-/obj/structure/bed/rogue/inn/hay,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
-/area/rogue/outdoors/beach/south)
 "tzW" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt/road,
@@ -65057,9 +63704,7 @@
 /area/rogue/under/underdark/north)
 "tCk" = (
 /obj/structure/fluff/walldeco/bigpainting/lake,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "tCn" = (
 /obj/effect/decal/cobble/mossy,
@@ -65197,9 +63842,7 @@
 	pixel_x = -8;
 	pixel_y = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "tDA" = (
 /obj/effect/decal/cobbleedge,
@@ -65239,15 +63882,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
-"tEk" = (
-/obj/effect/decal/cobbleedge{
-	dir = 5;
-	pixel_x = -6
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "tEt" = (
 /obj/structure/closet/crate/chest/crate,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -65382,9 +64016,7 @@
 	pixel_y = 32
 	},
 /obj/structure/chair/bench/couchablack,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "tGX" = (
 /turf/open/floor/rogue/carpet,
@@ -65658,9 +64290,7 @@
 /obj/item/rogueweapon/woodstaff,
 /obj/item/rogueweapon/woodstaff,
 /obj/item/rogueweapon/woodstaff,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "tMm" = (
 /obj/structure/bars/passage{
@@ -65674,9 +64304,7 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "tMv" = (
 /turf/open/floor/rogue/wood/herringbone,
@@ -65898,9 +64526,7 @@
 	},
 /obj/structure/rack/rogue,
 /obj/item/grown/log/tree/stick,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "tQj" = (
 /obj/structure/flora/roguegrass,
@@ -65993,9 +64619,7 @@
 /area/rogue/indoors/town)
 "tRD" = (
 /obj/structure/table/vtable,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "tRE" = (
 /obj/structure/fluff/railing/border,
@@ -66138,9 +64762,7 @@
 /area/rogue/under/cave/licharena)
 "tTW" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/cave)
 "tUg" = (
 /obj/structure/stairs{
@@ -66206,9 +64828,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "tVN" = (
 /obj/structure/closet/dirthole/closed/loot,
@@ -66359,9 +64979,7 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "tXs" = (
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "tXv" = (
 /obj/machinery/light/rogue/wallfire/candle/blue/l,
@@ -66734,14 +65352,6 @@
 	},
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"ucT" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "ucX" = (
 /obj/structure/flora/roguetree/stump/log,
 /turf/open/water/cleanshallow,
@@ -66807,9 +65417,7 @@
 	dir = 4
 	},
 /obj/machinery/light/rogue/wallfire/candle/blue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/magician)
 "ueA" = (
 /obj/structure/stairs{
@@ -67023,9 +65631,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "uhI" = (
 /turf/open/floor/rogue/grassred,
@@ -67203,9 +65809,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "ukB" = (
 /obj/structure/fluff/walldeco/customflag{
@@ -67663,9 +66267,7 @@
 	pixel_x = -8
 	},
 /obj/item/rogueweapon/huntingknife/chefknife,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "urY" = (
 /obj/structure/fluff/railing/border{
@@ -67709,9 +66311,7 @@
 	icon_state = "largetable"
 	},
 /obj/item/candle/silver/lit,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "usK" = (
 /obj/machinery/light/rogue/torchholder/c,
@@ -67761,9 +66361,7 @@
 /area/rogue/under/cave/mazedungeon)
 "utf" = (
 /obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "utr" = (
 /obj/structure/table/optable,
@@ -67816,9 +66414,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "uuc" = (
 /obj/item/roguegem/blue,
@@ -67840,9 +66436,7 @@
 /area/rogue/indoors/town)
 "uup" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "uuq" = (
 /obj/structure/chair/stool/rogue,
@@ -67905,9 +66499,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "uvi" = (
 /obj/structure/stairs{
@@ -67994,9 +66586,7 @@
 /area/rogue/indoors/town)
 "uwJ" = (
 /obj/structure/fluff/statue/gargoyle,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "uwU" = (
 /obj/effect/decal/cobbleedge{
@@ -68038,9 +66628,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
 "uxk" = (
 /obj/structure/closet/crate/chest/crate,
@@ -68056,12 +66644,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
-"uxy" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "uxz" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/concrete,
@@ -68416,9 +66998,7 @@
 /obj/item/candle/skull/lit{
 	pixel_y = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/mazedungeon)
 "uCm" = (
 /obj/item/clothing/neck/roguetown/psicross/naledi,
@@ -68479,9 +67059,7 @@
 /area/rogue/indoors/town)
 "uDa" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "uDg" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -68524,9 +67102,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "uDV" = (
 /obj/structure/fluff/railing/fence{
@@ -68593,9 +67169,7 @@
 /area/rogue/under/cave/orcdungeon)
 "uEt" = (
 /obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "uEw" = (
 /obj/structure/roguemachine/scomm,
@@ -68611,9 +67185,7 @@
 /area/rogue/under/cave)
 "uEK" = (
 /obj/machinery/light/rogue/wallfire/candle/off/r,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "uEQ" = (
 /obj/structure/fluff/walldeco/customflag{
@@ -68655,9 +67227,7 @@
 	pixel_x = -10;
 	pixel_y = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "uFd" = (
 /obj/structure/bars/cemetery,
@@ -68665,14 +67235,10 @@
 /area/rogue/indoors)
 "uFi" = (
 /mob/living/simple_animal/hostile/rogue/dragger,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/cave)
 "uFk" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/indoors)
 "uFl" = (
 /obj/structure/flora/roguetree/stump/log,
@@ -68728,12 +67294,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach/forest/south)
-"uGt" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "uGv" = (
 /obj/effect/decal/carpet/kover_purple{
 	pixel_x = 16;
@@ -68750,9 +67310,7 @@
 	lockid = "archive";
 	name = "Library"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "uGE" = (
 /obj/structure/flora/roguetree/burnt,
@@ -68935,12 +67493,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"uJz" = (
-/obj/structure/roguewindow/openclose/reinforced,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "uJE" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 8
@@ -68971,9 +67523,7 @@
 /obj/item/cooking/platter{
 	pixel_y = 12
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "uJM" = (
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
@@ -68996,9 +67546,7 @@
 /area/rogue/outdoors/town)
 "uJU" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "uJY" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -69024,9 +67572,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "uKD" = (
 /obj/structure/roguetent,
@@ -69268,10 +67814,7 @@
 	dir = 1
 	},
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/garrison)
 "uPk" = (
 /turf/open/floor/rogue/hexstone,
@@ -69330,9 +67873,7 @@
 /area/rogue/indoors/town/bath)
 "uQb" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "uQe" = (
 /obj/structure/stairs{
@@ -69382,9 +67923,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "uQP" = (
 /obj/structure/bed/rogue/inn/wooldouble,
@@ -69398,9 +67937,7 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet/bogcaves/north)
 "uQS" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "uQW" = (
 /obj/structure/closet/crate/coffin,
@@ -69535,9 +68072,7 @@
 /area/rogue/under/town/sewer)
 "uSY" = (
 /obj/structure/ladder,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
 "uSZ" = (
 /obj/structure/table/wood{
@@ -69889,10 +68424,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
 "uYO" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 8;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/west,
 /area/rogue/outdoors/mountains)
 "uYQ" = (
 /obj/structure/chair/wood/rogue/chair3,
@@ -69912,9 +68444,7 @@
 /turf/open/water/ocean/deep,
 /area/rogue/under/cavewet/bogcaves/south)
 "uZh" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors/town/magician)
 "uZi" = (
 /obj/structure/flora/hotspring_rocks,
@@ -70124,9 +68654,7 @@
 	pixel_x = 1;
 	pixel_y = 3
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "vbV" = (
 /obj/structure/table/wood{
@@ -70171,10 +68699,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/forest/north)
 "vcM" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -70336,9 +68861,7 @@
 	dir = 2
 	},
 /obj/structure/fluff/canopy/green,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "vfD" = (
 /obj/structure/chair/stool/rogue,
@@ -70368,9 +68891,7 @@
 	dir = 10;
 	pixel_y = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "vfU" = (
 /obj/structure/bed/rogue/shit{
@@ -70461,10 +68982,7 @@
 /obj/item/rope/chain,
 /obj/item/clothing/head/roguetown/helmet/kettle,
 /obj/item/clothing/head/roguetown/helmet/kettle,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
 "vhq" = (
 /obj/structure/flora/roguegrass/herb/random,
@@ -70605,9 +69123,7 @@
 /area/rogue/under/underdark/north)
 "vjk" = (
 /obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "vjB" = (
 /obj/structure/table/wood{
@@ -70713,9 +69229,7 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/beach/forest/south)
 "vkS" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/indoors/town/church/chapel)
 "vkV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -70833,9 +69347,7 @@
 /area/rogue/outdoors/beach/forest/north)
 "vmp" = (
 /mob/living/carbon/human/species/human/northern/searaider/ambush,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "vmr" = (
 /obj/structure/flora/roguegrass,
@@ -70854,9 +69366,7 @@
 /area/rogue/outdoors/mountains/decap)
 "vmB" = (
 /obj/structure/mineral_door/wood/towner/hunter,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "vmI" = (
 /obj/effect/decal/cobbleedge{
@@ -70877,14 +69387,6 @@
 "vmX" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"vnl" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "vno" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -71049,9 +69551,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church/chapel)
 "vpY" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors/town/dwarfin)
 "vqb" = (
 /obj/structure/table/wood,
@@ -71150,9 +69650,7 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak)
 "vri" = (
 /obj/item/reagent_containers/food/snacks/crow,
-/turf/open/floor/rogue/rooftop{
-	dir = 1
-	},
+/turf/open/floor/rogue/rooftop/north,
 /area/rogue/outdoors/beach/forest/south)
 "vro" = (
 /obj/structure/fluff/railing/border{
@@ -71213,14 +69711,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "vrN" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors/town/physician)
 "vrU" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors/town/magician)
 "vrW" = (
 /turf/open/floor/carpet/red,
@@ -71322,9 +69816,7 @@
 /area/rogue/outdoors/town)
 "vtQ" = (
 /obj/structure/roguewindow,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "vtR" = (
 /turf/open/floor/rogue/tile,
@@ -71345,9 +69837,7 @@
 /area/rogue/indoors/town/church/chapel)
 "vui" = (
 /obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "vul" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/direbear,
@@ -71391,9 +69881,7 @@
 "vuL" = (
 /obj/item/ash,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "vuU" = (
 /obj/structure/closet/crate/chest/crate,
@@ -71418,14 +69906,6 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mirespider/angry,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
-"vvb" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "vvf" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/cavewet/bogcaves/west)
@@ -71506,9 +69986,7 @@
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
 "vwp" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir4,
 /area/rogue/indoors/town/physician)
 "vwx" = (
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -71519,9 +69997,7 @@
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/outdoors/mountains/decap)
 "vwD" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir4,
 /area/rogue/indoors/town/church/chapel)
 "vwI" = (
 /obj/effect/decal/cobbleedge{
@@ -71701,9 +70177,7 @@
 "vAg" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /obj/item/roguecoin/gold/pile,
-/turf/open/floor/rogue/tile{
-	icon_state = "linoleum"
-	},
+/turf/open/floor/rogue/tile/checker,
 /area/rogue/indoors/town/vault)
 "vAm" = (
 /obj/effect/spawner/roguemap/stump,
@@ -71811,9 +70285,7 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/underdark/north)
 "vBd" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors/shelter/woods)
 "vBn" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
@@ -71957,14 +70429,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
-"vDG" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "vDJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/basement)
@@ -72089,9 +70553,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/beach/forest/hamlet)
 "vFt" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/indoors/town/garrison)
 "vFx" = (
 /obj/structure/roguemachine/scomm/r,
@@ -72116,9 +70578,7 @@
 	},
 /area/rogue/indoors/shelter)
 "vFY" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir1,
 /area/rogue/indoors/town/garrison)
 "vGa" = (
 /turf/open/floor/rogue/hexstone,
@@ -72211,9 +70671,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
 "vHy" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir1,
 /area/rogue/indoors/town/garrison)
 "vHA" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -72233,9 +70691,7 @@
 /obj/item/seeds/rice,
 /obj/item/seeds/rice,
 /obj/item/seeds/rice,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "vHI" = (
 /mob/living/simple_animal/hostile/rogue/deepone,
@@ -72296,9 +70752,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
 "vIB" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/mountains)
 "vIC" = (
 /obj/structure/closet/crate/chest/wicker,
@@ -72495,10 +70949,7 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/cave/licharena)
 "vLA" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/outdoors/town/roofs/keep)
 "vLB" = (
 /obj/structure/bars,
@@ -72562,9 +71013,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "vMe" = (
 /obj/structure/fluff/railing/border{
@@ -72576,9 +71025,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "vMm" = (
 /mob/living/carbon/human/species/skeleton/npc/ambush,
@@ -72714,9 +71161,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-n"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "vOg" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -72852,9 +71297,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/orcdungeon)
 "vPO" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir1,
 /area/rogue/indoors/town/physician)
 "vPQ" = (
 /turf/open/floor/rogue/dirt/road,
@@ -72872,12 +71315,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave/dungeon1/gethsmane)
-"vPZ" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 1;
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs/keep)
 "vQc" = (
 /obj/machinery/light/rogue/wallfire/candle/off/l,
 /turf/open/transparent/openspace,
@@ -72956,9 +71393,7 @@
 /area/rogue/under/cave/dukecourt)
 "vRR" = (
 /obj/structure/roguewindow,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/indoors/town/manor)
 "vRU" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/spear2,
@@ -73051,9 +71486,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "vTt" = (
 /turf/closed/wall/mineral/rogue/wooddark,
@@ -73130,9 +71563,7 @@
 /obj/item/seeds/tea,
 /obj/item/seeds/tea,
 /obj/item/seeds/tea,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "vUp" = (
 /obj/structure/closet/crate/chest,
@@ -73151,9 +71582,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "vUw" = (
 /obj/structure/spider/stickyweb,
@@ -73559,9 +71988,7 @@
 /area/rogue/outdoors/bog/south)
 "waq" = (
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "war" = (
 /obj/structure/flora/roguegrass/bush,
@@ -73572,10 +71999,7 @@
 	dir = 5;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/rooftop{
-	dir = 4;
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/east,
 /area/rogue/indoors/town)
 "waE" = (
 /obj/effect/decal/wood/herringbone{
@@ -73646,9 +72070,7 @@
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "wcm" = (
 /obj/effect/landmark/quest_spawner/hard,
@@ -73816,9 +72238,7 @@
 /area/rogue/outdoors/woods/southwest)
 "web" = (
 /obj/structure/fluff/wallclock/vampire,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "wed" = (
 /obj/structure/chair/bench{
@@ -73906,9 +72326,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "wfE" = (
 /obj/structure/chair/wood/rogue{
@@ -73924,9 +72342,7 @@
 /area/rogue/indoors/shelter)
 "wfI" = (
 /obj/structure/fermentation_keg/beer,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "wfL" = (
 /obj/structure/bars,
@@ -74027,9 +72443,7 @@
 "wha" = (
 /obj/item/book/rogue/abyssor,
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "whi" = (
 /obj/structure/fluff/wallclock,
@@ -74076,9 +72490,7 @@
 /area/rogue/indoors/cave/west)
 "whK" = (
 /obj/structure/telescope,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "whM" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -74269,9 +72681,7 @@
 /area/rogue/outdoors/town)
 "wkd" = (
 /obj/structure/bookcase/random_recipes,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "wkf" = (
 /obj/effect/decal/cobbleedge{
@@ -74284,9 +72694,7 @@
 /obj/item/candle/candlestick/silver/single/lit{
 	pixel_y = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "wkg" = (
 /obj/structure/stairs,
@@ -74551,9 +72959,7 @@
 "wnE" = (
 /obj/structure/fluff/grindwheel,
 /obj/effect/decal/cleanable/debris/woody,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "wnM" = (
 /obj/item/rogueweapon/shovel,
@@ -74687,9 +73093,7 @@
 	dir = 5
 	},
 /obj/machinery/light/rogue/wallfire/candle/l,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "wqR" = (
 /obj/structure/closet/crate/chest,
@@ -75062,9 +73466,7 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "wxn" = (
 /obj/effect/decal/cleanable/blood,
@@ -75089,9 +73491,7 @@
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "wxF" = (
 /obj/effect/particle_effect/smoke{
@@ -75166,9 +73566,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "wyE" = (
 /obj/structure/flora/roguegrass,
@@ -75221,9 +73619,7 @@
 /area/rogue/under/town/sewer)
 "wzy" = (
 /obj/structure/chair/bench/couch,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "wzD" = (
 /obj/structure/roguewindow,
@@ -75514,9 +73910,7 @@
 /obj/structure/rack/rogue,
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/stoneaxe,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "wED" = (
 /obj/machinery/light/rogue/lanternpost{
@@ -75528,9 +73922,7 @@
 /area/rogue/outdoors/rtfield)
 "wEE" = (
 /obj/item/grown/log/tree/stick,
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
 "wEI" = (
 /obj/structure/fluff/statue/knight/r,
@@ -75574,9 +73966,7 @@
 	icon_state = "barsbent";
 	layer = 2.81
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "wFf" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
@@ -75593,9 +73983,7 @@
 	},
 /area/rogue/under/cave/mazedungeon)
 "wFq" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir1,
 /area/rogue/indoors/town/magician)
 "wFx" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/orc2,
@@ -75626,9 +74014,7 @@
 	dir = 10;
 	pixel_y = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "wFJ" = (
 /obj/structure/table/wood{
@@ -75692,9 +74078,7 @@
 /area/rogue/outdoors/beach/forest/north)
 "wGB" = (
 /obj/machinery/light/rogue/oven/east,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "wGH" = (
 /obj/structure/mirror{
@@ -75850,9 +74234,7 @@
 "wKa" = (
 /obj/structure/chair/wood/rogue/fancy,
 /obj/effect/landmark/start/guildsman,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "wKh" = (
 /obj/structure/table/wood{
@@ -76148,9 +74530,7 @@
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "wNN" = (
 /obj/effect/decal/mossy{
@@ -76237,9 +74617,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "wPo" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir8,
 /area/rogue/indoors/town/physician)
 "wPp" = (
 /obj/machinery/light/rogue/wallfire{
@@ -76248,9 +74626,7 @@
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "wPD" = (
 /obj/structure/closet/crate/chest/neu_fancy,
@@ -76350,12 +74726,6 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
-"wRC" = (
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
-/area/rogue/indoors/shelter/woods)
 "wRJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -76522,9 +74892,7 @@
 /area/rogue/indoors/town/church/chapel)
 "wTY" = (
 /obj/structure/roguemachine/scomm,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "wUc" = (
 /obj/structure/roguemachine/scomm/l,
@@ -76542,9 +74910,7 @@
 /obj/machinery/light/rogue/torchholder/r{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
 "wUj" = (
 /obj/structure/mineral_door/wood/deadbolt{
@@ -76783,9 +75149,7 @@
 /obj/structure/mineral_door/wood{
 	lockid = "mansionvampire"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
 "wYl" = (
 /obj/structure/flora/roguegrass/maneater,
@@ -76896,9 +75260,7 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
 "wZS" = (
 /obj/machinery/light/rogue/torchholder/r,
@@ -77212,12 +75574,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/basement)
-"xfm" = (
-/turf/open/floor/rogue/rooftop{
-	dir = 8;
-	icon_state = "roofg"
-	},
-/area/rogue/outdoors/town/roofs)
 "xfn" = (
 /obj/machinery/light/rogue/wallfire/candle/blue,
 /obj/structure/bookcase,
@@ -77242,9 +75598,7 @@
 	dir = 6
 	},
 /obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xfz" = (
 /obj/structure/rack/rogue,
@@ -77267,9 +75621,7 @@
 /obj/structure/stairs{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement)
 "xga" = (
 /obj/structure/table/wood{
@@ -77310,9 +75662,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xgX" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -77475,11 +75825,6 @@
 /obj/structure/fluff/statue/astrata/gold,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/basement)
-"xkh" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
-/area/rogue/indoors/town)
 "xki" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -77494,11 +75839,6 @@
 "xkl" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woods/south)
-"xkp" = (
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/shelter/woods)
 "xkq" = (
 /obj/structure/chair/wood/rogue/fancy,
 /obj/structure/fluff/walldeco/customflag{
@@ -77513,17 +75853,13 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "xkH" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods)
 "xkI" = (
-/turf/closed/wall/mineral/rogue/roofwall/innercorner{
-	dir = 4
-	},
+/turf/closed/wall/mineral/rogue/roofwall/innercorner/dir4,
 /area/rogue/indoors/town/physician)
 "xkL" = (
 /obj/structure/fluff/signage{
@@ -77617,9 +75953,7 @@
 /obj/effect/landmark/start/servant{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "xmc" = (
 /turf/open/water/river{
@@ -77629,9 +75963,7 @@
 /area/rogue/outdoors/woods/southeast)
 "xml" = (
 /obj/structure/roguewindow/openclose,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xmm" = (
 /obj/structure/closet/crate/chest/neu,
@@ -77722,9 +76054,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "xmX" = (
 /obj/structure/mineral_door/wood/fancywood{
@@ -77747,9 +76077,7 @@
 /area/rogue/under/cave/mazedungeon)
 "xnc" = (
 /obj/structure/fermentation_keg/water,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "xnd" = (
 /mob/living/carbon/human/species/human/northern/highwayman,
@@ -77901,9 +76229,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xpU" = (
 /obj/effect/landmark/start/shophand,
@@ -77954,9 +76280,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/underdark/north)
 "xqW" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors/shelter/woods)
 "xqY" = (
 /obj/structure/bars/pipe{
@@ -78018,9 +76342,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/turf/open/floor/rogue/rooftop{
-	icon_state = "roofg"
-	},
+/turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs/keep)
 "xsp" = (
 /obj/structure/composter/halffull,
@@ -78054,17 +76376,13 @@
 "xsZ" = (
 /obj/machinery/tanningrack,
 /obj/item/needle/thorn,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xti" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "xtm" = (
 /obj/structure/chair/wood/rogue{
@@ -78167,9 +76485,7 @@
 "xvy" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
 "xvH" = (
 /obj/structure/fluff/railing/border{
@@ -78184,9 +76500,7 @@
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
 "xvX" = (
 /obj/structure/chair/wood/rogue{
@@ -78255,9 +76569,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xxj" = (
 /obj/structure/mirror,
@@ -78265,10 +76577,7 @@
 /area/rogue/indoors/town/dwarfin)
 "xxr" = (
 /obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
 "xxF" = (
 /obj/structure/closet/crate/coffin,
@@ -78443,9 +76752,7 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "xAk" = (
 /obj/structure/stairs,
@@ -78555,9 +76862,7 @@
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xCa" = (
 /obj/structure/table/wood{
@@ -78628,9 +76933,7 @@
 /area/rogue/indoors/town/dwarfin)
 "xDb" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xDd" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -78697,9 +77000,7 @@
 	dir = 4;
 	locked = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xEa" = (
 /obj/structure/bars/cemetery,
@@ -78716,9 +77017,7 @@
 "xEs" = (
 /obj/item/book/rogue/knowledge1,
 /obj/structure/bookcase,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "xEz" = (
 /turf/closed/mineral/rogue/bedrock,
@@ -79044,9 +77343,7 @@
 	dir = 5
 	},
 /obj/structure/closet/crate/chest/wicker,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "wooden_floort"
-	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
 "xJM" = (
 /obj/structure/closet/crate/roguecloset,
@@ -79138,9 +77435,7 @@
 	dir = 8
 	},
 /obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin)
 "xLa" = (
 /obj/structure/flora/newtree,
@@ -79360,9 +77655,7 @@
 /obj/structure/bookcase/random/archive{
 	opacity = 0
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xOu" = (
 /obj/effect/decal/mossy{
@@ -79484,9 +77777,7 @@
 /obj/machinery/light/rogue/wallfire/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "xOU" = (
 /obj/structure/bars/cemetery,
@@ -79601,14 +77892,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/south)
-"xQw" = (
-/obj/structure/roguewindow/openclose/reinforced{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/rogue/indoors/town)
 "xQI" = (
 /turf/open/water/bloody,
 /area/rogue/under/cave/orcdungeon)
@@ -79921,11 +78204,6 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/white,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
-"xVT" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
-/area/rogue/indoors/town)
 "xWd" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 8
@@ -79953,9 +78231,7 @@
 	lockid = "heir";
 	name = "Heir's Apartment"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "xWO" = (
 /obj/structure/bed/rogue/inn/hay,
@@ -80148,9 +78424,7 @@
 	},
 /obj/item/natural/cloth,
 /obj/item/kitchen/spoon,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "yaf" = (
 /obj/structure/mineral_door/wood/towner/fisher{
@@ -80354,9 +78628,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "ycO" = (
-/turf/closed/wall/mineral/rogue/roofwall/middle{
-	dir = 1
-	},
+/turf/closed/wall/mineral/rogue/roofwall/middle/dir1,
 /area/rogue/indoors/town/shop)
 "ycR" = (
 /obj/effect/decal/cobbleedge{
@@ -80387,9 +78659,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/sergeant,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "ydb" = (
 /obj/structure/table/wood{
@@ -80421,15 +78691,11 @@
 /area/rogue/indoors/town/tavern)
 "ydx" = (
 /obj/structure/closet/crate/chest/wicker,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "ydS" = (
 /obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "horzw"
-	},
+/turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/north)
 "yea" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -80540,9 +78806,7 @@
 /turf/open/floor/rogue/sand,
 /area/rogue/outdoors/beach/north)
 "yfn" = (
-/turf/closed/wall/mineral/rogue/roofwall/outercorner{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/roofwall/outercorner/dir8,
 /area/rogue/indoors/town/physician)
 "yfw" = (
 /obj/structure/fluff/railing/border{
@@ -80632,9 +78896,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "ygG" = (
 /obj/structure/table/wood{
@@ -80717,9 +78979,7 @@
 	dir = 10;
 	icon_state = "cobbleedge-e"
 	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor)
 "yib" = (
 /obj/structure/closet/crate/roguecloset/inn,
@@ -111216,9 +109476,9 @@ oKd
 oKd
 xYB
 xYB
-oqf
-oqf
-oqf
+jzb
+jzb
+jzb
 pmg
 vGo
 vGo
@@ -111668,7 +109928,7 @@ oKd
 oKd
 xYB
 xYB
-oqf
+jzb
 jLd
 eUX
 pmg
@@ -112118,7 +110378,7 @@ oKd
 oKd
 oKd
 xYB
-oqf
+jzb
 xYB
 xYB
 xKv
@@ -112570,7 +110830,7 @@ oKd
 oKd
 oKd
 xYB
-oqf
+jzb
 xYB
 pwS
 pmg
@@ -113023,7 +111283,7 @@ oKd
 oKd
 xYB
 xYB
-oqf
+jzb
 qjk
 vGo
 vGo
@@ -113507,7 +111767,7 @@ xfu
 pwS
 gqn
 mSG
-oqf
+jzb
 xYB
 pwS
 oKd
@@ -113927,7 +112187,7 @@ oKd
 oKd
 xYB
 xYB
-oqf
+jzb
 qjk
 vGo
 vGo
@@ -114379,7 +112639,7 @@ oKd
 oKd
 xYB
 xYB
-oqf
+jzb
 pwS
 vGo
 vGo
@@ -114411,7 +112671,7 @@ wBg
 pwS
 gqn
 hNq
-oqf
+jzb
 oKd
 oKd
 oKd
@@ -166218,8 +164478,8 @@ sXY
 nEW
 nub
 pMo
-oii
-tzV
+jXh
+lSu
 qzE
 nEW
 nEW
@@ -166669,9 +164929,9 @@ sXY
 sXY
 nEW
 nub
-tzV
-oii
-oii
+lSu
+jXh
+jXh
 qzE
 nEW
 sXY
@@ -168926,9 +167186,9 @@ lIE
 lIE
 nEW
 hxR
-oii
-oii
-oii
+jXh
+jXh
+jXh
 ecK
 qzE
 ePO
@@ -169381,7 +167641,7 @@ nub
 bbH
 pQm
 waq
-oii
+jXh
 qzE
 nEW
 nEW
@@ -170285,7 +168545,7 @@ nEW
 pQV
 nub
 kyG
-oii
+jXh
 qzE
 nEW
 sXY
@@ -211661,17 +209921,17 @@ uDO
 uDO
 uDO
 uDO
-dps
-dps
+pLZ
+pLZ
 pLZ
 gHj
 xqn
 gHj
 xqn
 gHj
-dps
-dps
-dps
+pLZ
+pLZ
+pLZ
 uDO
 uDO
 uDO
@@ -212114,16 +210374,16 @@ uDO
 uDO
 uDO
 uDO
-dps
-dps
-dps
-dps
+pLZ
+pLZ
+pLZ
+pLZ
 uDO
 uDO
-dps
-dps
-dps
-dps
+pLZ
+pLZ
+pLZ
+pLZ
 uDO
 uDO
 uDO
@@ -217999,13 +216259,13 @@ uDO
 uDO
 uDO
 uDO
-dps
-dps
-dps
-dps
-dps
-dps
-dps
+pLZ
+pLZ
+pLZ
+pLZ
+pLZ
+pLZ
+pLZ
 uDO
 uDO
 uDO
@@ -219335,11 +217595,11 @@ uDO
 uDO
 uDO
 uDO
-dps
-dps
-dps
-dps
-dps
+pLZ
+pLZ
+pLZ
+pLZ
+pLZ
 nsa
 uDO
 uDO
@@ -222507,7 +220767,7 @@ uDO
 uDO
 uDO
 uDO
-dps
+pLZ
 gHj
 gHj
 xqn
@@ -222515,7 +220775,7 @@ gHj
 xqn
 gHj
 gHj
-dps
+pLZ
 uDO
 uDO
 uDO
@@ -223767,7 +222027,7 @@ qZV
 bTH
 mOH
 wxj
-oqf
+jzb
 xQX
 xQX
 sso
@@ -224218,8 +222478,8 @@ yjO
 qZV
 bRk
 mOZ
-oqf
-oqf
+jzb
+jzb
 bBX
 xQX
 qZV
@@ -224669,9 +222929,9 @@ yjO
 yjO
 qZV
 wZL
-oqf
-oqf
-oqf
+jzb
+jzb
+jzb
 xQX
 xQX
 qZV
@@ -225121,8 +223381,8 @@ yjO
 yjO
 qZV
 fqC
-oqf
-oqf
+jzb
+jzb
 jyJ
 xQX
 xQX
@@ -225575,7 +223835,7 @@ qZV
 gGi
 eKd
 wQi
-oqf
+jzb
 xQX
 xQX
 qZV
@@ -234242,9 +232502,9 @@ rBo
 mhT
 mhT
 mhT
-clf
+nyz
 tTW
-clf
+nyz
 mhT
 szI
 szI
@@ -234696,7 +232956,7 @@ cjN
 jyO
 tIH
 tIH
-clf
+nyz
 mhT
 szI
 szI
@@ -235147,7 +233407,7 @@ tIH
 afx
 mhT
 tIH
-clf
+nyz
 mcA
 mhT
 szI
@@ -235598,8 +233858,8 @@ tIH
 tIH
 mhT
 mhT
-clf
-clf
+nyz
+nyz
 xRa
 mhT
 ujm
@@ -246597,11 +244857,11 @@ rZO
 sNZ
 eKH
 eKH
-ncY
+lbY
 xWk
 xWk
 ozA
-qps
+itv
 uBc
 ibp
 sNZ
@@ -247053,7 +245313,7 @@ kil
 xWk
 xWk
 xWk
-sYZ
+dra
 uBc
 sNZ
 sNZ
@@ -247505,7 +245765,7 @@ uJJ
 xWk
 xWk
 xWk
-sYZ
+dra
 uBc
 seL
 sNZ
@@ -247954,8 +246214,8 @@ pxF
 pxF
 uBc
 rUf
-sYZ
-jKv
+dra
+kIL
 icF
 naO
 uBc
@@ -255592,10 +253852,10 @@ lKO
 phl
 phl
 oAK
-sYZ
-sYZ
-sYZ
-sYZ
+dra
+dra
+dra
+dra
 mLN
 dra
 dra
@@ -256013,8 +254273,8 @@ exD
 exD
 uBc
 hIf
-qke
-qke
+kuD
+kuD
 xwR
 uBc
 hTO
@@ -256044,10 +254304,10 @@ gyu
 phl
 phl
 dlN
-sYZ
-sYZ
-sYZ
-bjx
+dra
+dra
+dra
+kCN
 phl
 oRu
 dra
@@ -256464,10 +254724,10 @@ exD
 exD
 exD
 lGu
-sYZ
-sYZ
-sYZ
-sYZ
+dra
+dra
+dra
+dra
 aoq
 sVK
 upM
@@ -256917,8 +255177,8 @@ exD
 exD
 uBc
 fAT
-sYZ
-sYZ
+dra
+dra
 xZQ
 uBc
 sVK
@@ -257368,9 +255628,9 @@ exD
 exD
 exD
 wFc
-sxy
-jHB
-keu
+qfJ
+agh
+eng
 urT
 flT
 sVK
@@ -257440,7 +255700,7 @@ uBc
 tmC
 nfC
 vKw
-mKM
+wZm
 fpx
 pWT
 lKO
@@ -257821,7 +256081,7 @@ exD
 exD
 uBc
 cuE
-rRQ
+bah
 cDX
 ngb
 uBc
@@ -260081,7 +258341,7 @@ exD
 exD
 exD
 vfz
-uxy
+saX
 rob
 jdu
 tRt
@@ -260533,9 +258793,9 @@ exD
 exD
 exD
 vfz
-uGt
-sYZ
-sRx
+ogj
+dra
+eiX
 jdu
 jdu
 uBc
@@ -260678,7 +258938,7 @@ srA
 pbF
 pyz
 apU
-xkp
+qOD
 abR
 apU
 ayY
@@ -260986,9 +259246,9 @@ exD
 exD
 scv
 rOu
-sYZ
-sYZ
-sRx
+dra
+dra
+eiX
 jqL
 uBc
 njB
@@ -261128,12 +259388,12 @@ bhJ
 srA
 srA
 apU
-xkp
-xkp
-xkp
-xkp
-xkp
-xkp
+qOD
+qOD
+qOD
+qOD
+qOD
+qOD
 apU
 pbF
 pbF
@@ -261439,8 +259699,8 @@ xPx
 cDX
 cDX
 wTY
-sxy
-sYZ
+qfJ
+dra
 cDX
 cDX
 owU
@@ -261580,12 +259840,12 @@ bhJ
 srA
 pbF
 gJM
-xkp
+qOD
 wnE
-xkp
-xkp
+qOD
+qOD
 eCr
-gcy
+szH
 tQf
 srA
 pbF
@@ -261890,8 +260150,8 @@ exD
 fpx
 vaw
 uBc
-sYZ
-iRg
+dra
+qFQ
 oID
 uBc
 jhP
@@ -262033,11 +260293,11 @@ srA
 pbF
 nWC
 hbk
-xkp
+qOD
 abR
-xkp
+qOD
 msf
-xkp
+qOD
 wEA
 srA
 pbF
@@ -262342,7 +260602,7 @@ exD
 exD
 exD
 hce
-sYZ
+dra
 xpS
 cDX
 uBc
@@ -262485,11 +260745,11 @@ srA
 pbF
 apU
 abR
-xkp
+qOD
 gqQ
-xkp
-xkp
-xkp
+qOD
+qOD
+qOD
 apU
 pbF
 vxZ
@@ -262938,8 +261198,8 @@ pbF
 vxZ
 iWz
 apU
-xkp
-xkp
+qOD
+qOD
 apU
 plD
 pbF
@@ -265054,9 +263314,9 @@ exD
 exD
 uBc
 vui
-sYZ
-sYZ
-sYZ
+dra
+dra
+dra
 uBc
 aFv
 aFv
@@ -265505,10 +263765,10 @@ exD
 exD
 exD
 kMS
-sYZ
-sYZ
-sxy
-sYZ
+dra
+dra
+qfJ
+dra
 uBc
 ftO
 njB
@@ -267765,9 +266025,9 @@ exD
 exD
 hVW
 uBc
-jKv
+kIL
 wGB
-sYZ
+dra
 cDX
 uBc
 qyR
@@ -268671,16 +266931,16 @@ hVW
 uBc
 ijE
 xWU
-iRg
-qps
+qFQ
+itv
 cDX
 cDX
 pWT
 jrV
 sns
 uBc
-sYZ
-rRQ
+dra
+bah
 cDX
 eWU
 ggq
@@ -269121,20 +267381,20 @@ exD
 exD
 exD
 kMS
-sYZ
-sYZ
-sOC
-sYZ
+dra
+dra
+qcH
+dra
 uBc
 pWT
 njB
 jrV
 sns
 uBc
-sOC
-vnl
+qcH
+dBl
 tVM
-sRx
+eiX
 dYv
 uBc
 sns
@@ -269575,18 +267835,18 @@ iYc
 uBc
 ndY
 ydx
-sYZ
-sYZ
+dra
+dra
 uBc
 njB
 pWT
 fpx
 ges
 uBc
-mAh
-sYZ
-sYZ
-sYZ
+bsC
+dra
+dra
+dra
 vGe
 uBc
 sns
@@ -270037,8 +268297,8 @@ njB
 uBc
 lzp
 xWk
-sYZ
-bLK
+dra
+haZ
 iIc
 phl
 sns
@@ -270489,7 +268749,7 @@ pWT
 uBc
 skz
 xWk
-sYZ
+dra
 cDX
 flT
 cDX
@@ -270941,7 +269201,7 @@ fpx
 uBc
 faB
 xWk
-fWd
+qVA
 fXC
 eGj
 veW
@@ -274096,9 +272356,9 @@ jiQ
 uBc
 nCL
 xBZ
-bUr
-sxy
-uxy
+mjw
+qfJ
+saX
 uBc
 sns
 mfi
@@ -274548,8 +272808,8 @@ pWT
 wZm
 lzp
 xWk
-sYZ
-iRg
+dra
+qFQ
 qci
 uBc
 btK
@@ -275000,8 +273260,8 @@ pWT
 wZm
 xUM
 xWk
-sYZ
-sOC
+dra
+qcH
 cDX
 uBc
 pWT
@@ -275452,7 +273712,7 @@ pWT
 wZm
 faB
 xWk
-sYZ
+dra
 gLW
 pqG
 uBc
@@ -275902,9 +274162,9 @@ pWT
 pWT
 njB
 uBc
-ncY
-sYZ
-sYZ
+lbY
+dra
+dra
 cDX
 uBc
 cDX
@@ -276340,9 +274600,9 @@ exD
 exD
 exD
 uBc
-qps
-ucT
-sRx
+itv
+mTw
+eiX
 xBZ
 uBc
 aFv
@@ -276356,7 +274616,7 @@ pWT
 uBc
 kOf
 aiZ
-ncY
+lbY
 uBc
 aHU
 pWT
@@ -276792,10 +275052,10 @@ exD
 exD
 exD
 cDX
-sYZ
-hut
-sYZ
-sYZ
+dra
+dbj
+dra
+dra
 uBc
 aFv
 pWT
@@ -277245,7 +275505,7 @@ exD
 exD
 cDX
 cDX
-ncY
+lbY
 cMj
 nHx
 flT
@@ -277697,7 +275957,7 @@ exD
 exD
 ehB
 fXC
-gpg
+eEU
 cMj
 phn
 flT
@@ -278149,7 +276409,7 @@ exD
 exD
 crS
 flT
-bUr
+mjw
 bIp
 paZ
 flT
@@ -278674,11 +276934,11 @@ aZG
 iXr
 exD
 uGz
-sYZ
+dra
 cMj
 cMj
 cMj
-sYZ
+dra
 eKH
 lwp
 puO
@@ -279127,9 +277387,9 @@ exD
 exD
 eKH
 wkd
-sYZ
-sYZ
-sYZ
+dra
+dra
+dra
 xOt
 eKH
 gzD
@@ -279579,9 +277839,9 @@ exD
 exD
 eKH
 wkd
-iRg
-qps
-ucT
+qFQ
+itv
+mTw
 xOt
 eKH
 csW
@@ -280031,9 +278291,9 @@ exD
 exD
 eKH
 xOt
-iRg
+qFQ
 bzY
-ucT
+mTw
 xOt
 eKH
 ocH
@@ -280482,11 +278742,11 @@ iXl
 exD
 exD
 flT
-sYZ
-sOC
-vnl
-hut
-sYZ
+dra
+qcH
+dBl
+dbj
+dra
 udK
 ocX
 puO
@@ -281299,8 +279559,8 @@ gyu
 cDX
 qfA
 uBc
-evD
-sYZ
+awp
+dra
 kIa
 uBc
 pQi
@@ -281752,7 +280012,7 @@ lKo
 qfA
 uBc
 cDX
-keu
+eng
 mqt
 vUD
 pQi
@@ -282203,8 +280463,8 @@ lKO
 lKo
 qfA
 uBc
-qps
-ucT
+itv
+mTw
 dra
 uBc
 pQi
@@ -282656,7 +280916,7 @@ cDX
 mIz
 cDX
 cZN
-hut
+dbj
 dra
 cDX
 uBc
@@ -283123,7 +281383,7 @@ xNl
 uBc
 uBc
 dJg
-sYZ
+dra
 uBc
 uBc
 aFv
@@ -283575,7 +281835,7 @@ xNl
 vUD
 rnT
 odA
-nSF
+iwO
 xOT
 uBc
 aFv
@@ -284477,7 +282737,7 @@ exD
 exD
 dQU
 bbG
-sYZ
+dra
 puH
 uvf
 bff
@@ -284929,8 +283189,8 @@ exD
 jlM
 eCc
 uBc
-mAh
-sYZ
+bsC
+dra
 uvf
 guo
 guo
@@ -285382,8 +283642,8 @@ ahN
 xNl
 vUD
 grD
-sYZ
-tEk
+dra
+aru
 smD
 uBc
 aFv
@@ -289117,15 +287377,15 @@ ebU
 ebU
 ebU
 rxe
-daF
-daF
+eXh
+eXh
 uSY
-daF
-daF
-daF
-daF
-daF
-daF
+eXh
+eXh
+eXh
+eXh
+eXh
+eXh
 mYZ
 ebU
 ebU
@@ -368708,8 +366968,8 @@ qFM
 gdT
 mgI
 oPR
-xkp
-xkp
+qOD
+qOD
 wGO
 mgI
 rvz
@@ -369161,7 +367421,7 @@ gdT
 hyD
 hyD
 qNd
-xkp
+qOD
 cKT
 oDn
 gdT
@@ -369497,8 +367757,8 @@ aBB
 aBB
 phl
 pLh
-xQw
-xQw
+ykK
+ykK
 phl
 pLh
 pLh
@@ -369613,8 +367873,8 @@ gdT
 hyD
 rqX
 psb
-xkp
-xkp
+qOD
+qOD
 uaK
 gdT
 hiH
@@ -369950,7 +368210,7 @@ phl
 phl
 phl
 cNa
-sYZ
+dra
 eyz
 phl
 uuD
@@ -370065,8 +368325,8 @@ gdT
 hyD
 hyD
 bxl
-xkp
-xkp
+qOD
+qOD
 mgI
 gdT
 hiH
@@ -370403,7 +368663,7 @@ phl
 eKH
 eKH
 fzK
-sYZ
+dra
 phl
 isf
 isf
@@ -370440,8 +368700,8 @@ kdE
 nRO
 nRO
 sqG
-fcS
-fcS
+nRO
+nRO
 oJW
 oJW
 cDX
@@ -370516,8 +368776,8 @@ qFM
 gdT
 rlV
 rGH
-xkp
-xkp
+qOD
+qOD
 xvO
 rlV
 gdT
@@ -370854,8 +369114,8 @@ tSF
 phl
 eKH
 rvW
-gpg
-sYZ
+eEU
+dra
 phl
 nfD
 mat
@@ -370892,8 +369152,8 @@ aBB
 nRO
 nRO
 sqG
-fcS
-fcS
+nRO
+nRO
 oJW
 oJW
 uAr
@@ -370967,9 +369227,9 @@ aBB
 qFM
 gdT
 rlV
-twH
-pKE
-pKE
+hOX
+uii
+uii
 fZi
 rlV
 gdT
@@ -371307,7 +369567,7 @@ phl
 eKH
 eKH
 tDz
-sYZ
+dra
 phl
 cDU
 kkB
@@ -371344,8 +369604,8 @@ kdE
 nRO
 sNy
 sqG
-fcS
-fcS
+nRO
+nRO
 oJW
 oJW
 gyu
@@ -371422,7 +369682,7 @@ oDn
 grs
 dKK
 tNg
-lXw
+dTG
 oDn
 rvz
 hiH
@@ -371758,7 +370018,7 @@ phl
 phl
 phl
 iqh
-sYZ
+dra
 tjI
 nAp
 fJs
@@ -371796,8 +370056,8 @@ aBB
 nRO
 nRO
 sqG
-fcS
-fcS
+nRO
+nRO
 aBB
 aBB
 gyu
@@ -372248,8 +370508,8 @@ aBB
 nRO
 nRO
 sqG
-fcS
-fcS
+nRO
+nRO
 aBB
 aBB
 gyu
@@ -372479,7 +370739,7 @@ amx
 amx
 amx
 kDy
-fph
+oXN
 iYj
 amx
 amx
@@ -372649,7 +370909,7 @@ bGf
 bGf
 qAY
 gWK
-pze
+hfa
 kFU
 wqP
 hLh
@@ -372700,8 +370960,8 @@ aBB
 nRO
 nRO
 sqG
-fcS
-fcS
+nRO
+nRO
 aBB
 aBB
 lKO
@@ -372930,8 +371190,8 @@ jFu
 nKe
 acF
 cUF
-fph
-fph
+oXN
+oXN
 iYj
 etM
 vNN
@@ -373068,7 +371328,7 @@ waE
 kHu
 dMG
 gyA
-cMc
+fhb
 cMj
 cMj
 cDX
@@ -373101,9 +371361,9 @@ gTY
 gTY
 qAY
 pdy
-pze
-pze
-pze
+hfa
+hfa
+hfa
 kPN
 gQx
 eEY
@@ -373152,8 +371412,8 @@ aBB
 nRO
 nRO
 sqG
-fcS
-fcS
+nRO
+nRO
 aBB
 aBB
 cDX
@@ -373163,7 +371423,7 @@ cDX
 syR
 qIf
 cDX
-dOo
+apZ
 vHB
 cDX
 aBB
@@ -373380,12 +371640,12 @@ qwL
 jUD
 vNN
 acF
-fph
-fph
+oXN
+oXN
 tIH
 tlO
 iIt
-fph
+oXN
 iIt
 tIH
 vNN
@@ -373553,9 +371813,9 @@ nrU
 gDZ
 qAY
 nTY
-pze
+hfa
 hAT
-pze
+hfa
 uDP
 gQx
 wXE
@@ -373604,18 +371864,18 @@ aBB
 nRO
 nRO
 sqG
-fcS
-fcS
+nRO
+nRO
 aBB
 aBB
 uAr
 wCl
-dOo
+apZ
 wUi
-dOo
-dOo
+apZ
+apZ
 wUi
-dOo
+apZ
 vUo
 uAr
 aBB
@@ -374056,20 +372316,20 @@ aBB
 nRO
 nRO
 sqG
-fcS
-fcS
+nRO
+nRO
 aBB
 aBB
-mKM
+wZm
 wCl
-dOo
-dOo
-dOo
+apZ
+apZ
+apZ
 wyB
 nZS
 nZS
-dOo
-mKM
+apZ
+wZm
 aBB
 aBB
 aBB
@@ -374512,16 +372772,16 @@ uBc
 cDX
 aBB
 aBB
-mKM
+wZm
 byn
-dOo
-dOo
-dOo
+apZ
+apZ
+apZ
 nOW
 bzY
 azP
-dOo
-mKM
+apZ
+wZm
 aBB
 aBB
 aBB
@@ -374744,7 +373004,7 @@ ikt
 sbR
 prh
 nHR
-fph
+oXN
 tIH
 acF
 amx
@@ -374966,13 +373226,13 @@ aBB
 aBB
 lKO
 cOn
-dOo
+apZ
 gTN
 utf
 nOW
 bTK
 azP
-dOo
+apZ
 lKO
 aBB
 aBB
@@ -375420,8 +373680,8 @@ cDX
 mjH
 pqo
 cDX
-mKM
-mKM
+wZm
+wZm
 cDX
 mjH
 pqo
@@ -375650,7 +373910,7 @@ qaF
 iIz
 mIf
 uEq
-fph
+oXN
 cNI
 ujm
 qPv
@@ -376102,7 +374362,7 @@ iIz
 uUc
 uEd
 uEq
-fph
+oXN
 amx
 ujm
 qPv
@@ -376554,7 +374814,7 @@ iIz
 qaF
 iIz
 uEq
-fph
+oXN
 cNI
 ujm
 qPv
@@ -377005,7 +375265,7 @@ uCF
 seN
 oSA
 jiU
-fph
+oXN
 tIH
 amx
 ujm
@@ -377219,8 +375479,8 @@ cDX
 uBc
 uBc
 gTt
-sYZ
-sYZ
+dra
+dra
 uBc
 pHr
 rep
@@ -377669,10 +375929,10 @@ wxQ
 aBB
 uBc
 spM
-jHB
-jHB
-keu
-sYZ
+agh
+agh
+eng
+dra
 uBc
 pHr
 wIV
@@ -378120,11 +376380,11 @@ aDs
 eQY
 aBB
 pWs
-sYZ
-cMc
+dra
+fhb
 bzY
-ucT
-sYZ
+mTw
+dra
 iKK
 pHr
 pHr
@@ -378573,9 +376833,9 @@ wxQ
 aBB
 uBc
 nPk
-vnl
-vnl
-hut
+dBl
+dBl
+dbj
 iKZ
 uBc
 pHr
@@ -378809,7 +377069,7 @@ vNN
 vNN
 kkC
 iIt
-fph
+oXN
 yee
 acF
 tKo
@@ -379017,7 +377277,7 @@ uyR
 nDZ
 kUG
 kUG
-lYA
+rRi
 kSK
 aDs
 aDs
@@ -379026,8 +377286,8 @@ aBB
 cDX
 uBc
 uBc
-sYZ
-sYZ
+dra
+dra
 fJD
 uBc
 iAW
@@ -379258,9 +377518,9 @@ nfV
 tKo
 tIH
 cUF
-fph
-fph
-fph
+oXN
+oXN
+oXN
 vNN
 iIt
 vNN
@@ -379840,9 +378100,9 @@ bGf
 bGf
 bGf
 bGf
-xfm
-xfm
-xfm
+bFl
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -380163,7 +378423,7 @@ qPv
 qPv
 amx
 lzc
-fph
+oXN
 vNN
 gDu
 amx
@@ -380614,7 +378874,7 @@ iEh
 gRl
 eWD
 pqA
-fph
+oXN
 jbt
 uFi
 vNN
@@ -381067,7 +379327,7 @@ xhB
 eWD
 cNI
 bco
-fph
+oXN
 jJm
 pRY
 amx
@@ -381196,9 +379456,9 @@ vvB
 vvB
 vvB
 bGf
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -381519,7 +379779,7 @@ hHa
 eDW
 cNI
 mwQ
-fph
+oXN
 vNN
 iIt
 cNI
@@ -383916,10 +382176,10 @@ bGf
 bGf
 bGf
 cDX
-mAh
-keu
-siI
-sYZ
+bsC
+eng
+jim
+dra
 xgT
 cDX
 bGf
@@ -383943,8 +382203,8 @@ uBc
 cDX
 bzY
 cwY
-uxy
-sYZ
+saX
+dra
 uBc
 bGf
 sGj
@@ -384368,10 +382628,10 @@ bGf
 bGf
 bGf
 uBc
-qps
-ucT
-sYZ
-jKv
+itv
+mTw
+dra
+kIL
 iPD
 uBc
 bGf
@@ -384393,10 +382653,10 @@ bGf
 bGf
 uBc
 fyl
-vnl
-vnl
-hut
-sYZ
+dBl
+dBl
+dbj
+dra
 uBc
 bGf
 sGj
@@ -384821,11 +383081,11 @@ bGf
 bGf
 xml
 bzY
-ucT
-sYZ
-sYZ
-sYZ
-ehn
+mTw
+dra
+dra
+dra
+fQm
 bGf
 bGf
 bGf
@@ -384844,9 +383104,9 @@ bGf
 bGf
 bGf
 uBc
-mAh
-sYZ
-sYZ
+bsC
+dra
+dra
 xWk
 ejh
 uBc
@@ -385272,11 +383532,11 @@ bGf
 bGf
 bGf
 uBc
-vnl
+dBl
 fQb
 cMj
 cMj
-sYZ
+dra
 uBc
 bGf
 bGf
@@ -385298,7 +383558,7 @@ bGf
 uBc
 xWk
 xWk
-sYZ
+dra
 jBj
 skz
 uBc
@@ -385728,7 +383988,7 @@ psq
 cMj
 uwH
 xcp
-poW
+gsp
 cDX
 bGf
 bGf
@@ -385750,7 +384010,7 @@ bGf
 uBc
 xWk
 xWk
-sYZ
+dra
 cDX
 uBc
 cDX
@@ -386202,7 +384462,7 @@ bGf
 uBc
 nJT
 bYL
-fWd
+qVA
 nUP
 fXz
 mYW
@@ -388173,9 +386433,9 @@ aBB
 aBB
 aBB
 aBB
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
 aBB
 aBB
 aBB
@@ -389077,8 +387337,8 @@ aBB
 aBB
 aBB
 aBB
-xfm
-xfm
+bFl
+bFl
 hAb
 aBB
 aBB
@@ -389355,10 +387615,10 @@ bGf
 bGf
 bGf
 uBc
-uxy
-sYZ
-sYZ
-sxy
+saX
+dra
+dra
+qfJ
 cDX
 uBc
 bGf
@@ -389809,8 +388069,8 @@ bGf
 flT
 tCv
 guB
-sYZ
-iRg
+dra
+qFQ
 bzY
 uBc
 bGf
@@ -389836,7 +388096,7 @@ eon
 kWN
 wna
 tPX
-fyc
+kEU
 vaz
 oCF
 kSK
@@ -390261,8 +388521,8 @@ bGf
 flT
 tHX
 xWk
-sYZ
-iRg
+dra
+qFQ
 spk
 uBc
 bGf
@@ -390284,11 +388544,11 @@ ebS
 ryO
 ryO
 ebS
-ftD
-ftD
-ftD
-ftD
-ftD
+dtV
+dtV
+dtV
+dtV
+dtV
 kRK
 iNw
 kSK
@@ -390697,8 +388957,8 @@ bGf
 bGf
 bGf
 uBc
-sYZ
-keu
+dra
+eng
 ptr
 xUM
 uBc
@@ -390712,10 +388972,10 @@ bGf
 bGf
 uBc
 kzK
-sYZ
-sYZ
+dra
+dra
 uhG
-sYZ
+dra
 uBc
 bGf
 bGf
@@ -390737,7 +388997,7 @@ ryO
 ryO
 lvw
 xKY
-ftD
+dtV
 wKa
 avk
 mbc
@@ -391150,7 +389410,7 @@ bGf
 bGf
 uBc
 ibB
-ucT
+mTw
 xWk
 hSY
 uBc
@@ -391602,7 +389862,7 @@ bGf
 bGf
 uBc
 bzY
-ucT
+mTw
 xWk
 aPK
 uBc
@@ -391616,7 +389876,7 @@ bGf
 bGf
 uBc
 bYL
-sYZ
+dra
 gGV
 uBc
 bGf
@@ -391642,10 +389902,10 @@ ryO
 kXy
 kXy
 eyK
-ftD
+dtV
 lRL
 ifU
-ftD
+dtV
 iNw
 kSK
 bGf
@@ -392054,7 +390314,7 @@ bGf
 bGf
 cDX
 cfQ
-hut
+dbj
 xWk
 jBj
 uBc
@@ -392068,8 +390328,8 @@ bGf
 bGf
 uBc
 aih
-fWd
-vDG
+qVA
+uQu
 uBc
 bGf
 bGf
@@ -392094,10 +390354,10 @@ lVw
 kXy
 nLX
 eyK
-ftD
-ftD
-ftD
-ftD
+dtV
+dtV
+dtV
+dtV
 oCF
 kSK
 bGf
@@ -392546,7 +390806,7 @@ ryO
 kXy
 kXy
 eyK
-ftD
+dtV
 nyk
 urJ
 dAi
@@ -393001,7 +391261,7 @@ plc
 wKa
 xCV
 fbP
-ftD
+dtV
 iNw
 kSK
 bGf
@@ -393449,8 +391709,8 @@ ryO
 ryO
 lvw
 vjB
-ftD
-ftD
+dtV
+dtV
 fvW
 krW
 dAi
@@ -393900,11 +392160,11 @@ ebS
 ryO
 ryO
 ebS
-ftD
-ftD
-ftD
-ftD
-ftD
+dtV
+dtV
+dtV
+dtV
+dtV
 sgY
 iNw
 kSK
@@ -394356,7 +392616,7 @@ vjk
 kWN
 vYb
 tPX
-fyc
+kEU
 vaz
 oCF
 kSK
@@ -396466,10 +394726,10 @@ iSP
 xcE
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 tDV
@@ -396918,10 +395178,10 @@ tbM
 xcE
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 tDV
@@ -397370,10 +395630,10 @@ iSP
 xcE
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -397822,10 +396082,10 @@ iSP
 xcE
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -398274,10 +396534,10 @@ iSP
 xcE
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -398726,10 +396986,10 @@ xcE
 xcE
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -399178,10 +397438,10 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -399365,8 +397625,8 @@ bGf
 bGf
 kSK
 kSK
-oOM
-oOM
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -399630,10 +397890,10 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -399817,8 +398077,8 @@ bGf
 bGf
 kSK
 kSK
-oOM
-oOM
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -400082,10 +398342,10 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
+ddn
+ddn
 wBI
-bKU
+ddn
 ddn
 ddn
 ddn
@@ -400269,8 +398529,8 @@ bGf
 bGf
 kSK
 kSK
-oOM
-oOM
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -400534,10 +398794,10 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
+ddn
+ddn
 wBI
-bKU
+ddn
 ddn
 ddn
 ddn
@@ -400693,7 +398953,7 @@ bSB
 ocq
 ewl
 yjG
-ptv
+bSB
 aIJ
 yjG
 jWw
@@ -400721,8 +398981,8 @@ bGf
 bGf
 kSK
 kSK
-oOM
-oOM
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -400986,10 +399246,10 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -401173,8 +399433,8 @@ bGf
 bGf
 kSK
 kSK
-oOM
-oOM
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -401591,7 +399851,7 @@ kSK
 hrE
 qNm
 iWa
-ptv
+bSB
 uOV
 rCV
 rCV
@@ -405509,9 +403769,9 @@ rJz
 uGX
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -405961,9 +404221,9 @@ qSd
 rJz
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -406413,9 +404673,9 @@ vDV
 cxb
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -406865,9 +405125,9 @@ rJz
 uGX
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -407317,9 +405577,9 @@ vDV
 cxb
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -407769,9 +406029,9 @@ vcM
 rJz
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -408222,8 +406482,8 @@ uGX
 tDV
 tDV
 wBI
-bKU
-bKU
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -408673,9 +406933,9 @@ vDV
 cxb
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -408887,8 +407147,8 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -409125,9 +407385,9 @@ qSd
 rJz
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -409339,8 +407599,8 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -409791,10 +408051,10 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -410243,10 +408503,10 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -410695,10 +408955,10 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -411147,10 +409407,10 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -411599,10 +409859,10 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -412051,10 +410311,10 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -412503,10 +410763,10 @@ nRO
 nRO
 nRO
 nRO
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -412833,10 +411093,10 @@ aDs
 bGf
 bGf
 oci
-iEf
-iEf
-iEf
-owg
+cPr
+cPr
+cPr
+omb
 bGf
 bGf
 bGf
@@ -413284,12 +411544,12 @@ aDs
 aDs
 bGf
 oci
-anY
+uwF
 bzY
 bzY
 fDc
-aye
-owg
+mvt
+omb
 bGf
 bGf
 bGf
@@ -413735,7 +411995,7 @@ eQY
 aDs
 aDs
 bGf
-xVT
+ajy
 rVU
 bzY
 bzY
@@ -414187,7 +412447,7 @@ wxQ
 aDs
 aDs
 bGf
-xVT
+ajy
 bzY
 bzY
 bzY
@@ -414639,7 +412899,7 @@ eQY
 aDs
 aDs
 bGf
-xVT
+ajy
 cdD
 kRg
 bzY
@@ -415091,7 +413351,7 @@ wxQ
 uzx
 aDs
 bGf
-xVT
+ajy
 rVU
 qkk
 kRg
@@ -415150,16 +413410,16 @@ vxe
 vmi
 vmi
 vmi
-vPZ
-vPZ
-vPZ
-vPZ
-vPZ
-vPZ
-vPZ
-vPZ
-vPZ
-vPZ
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
+lMc
 vmi
 vmi
 vmi
@@ -415543,13 +413803,13 @@ eQY
 aDs
 aDs
 bGf
-cbl
-jPc
+mwo
+xpR
 feX
 qkk
 cdD
 uZV
-xkh
+wzT
 bGf
 bGf
 bGf
@@ -415996,11 +414256,11 @@ aDs
 aDs
 bGf
 bGf
-cbl
-nQL
-nQL
-nQL
-xkh
+mwo
+srt
+srt
+srt
+wzT
 bGf
 bGf
 bGf
@@ -418370,8 +416630,8 @@ aBB
 aBB
 aBB
 aBB
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -418822,8 +417082,8 @@ aBB
 aBB
 aBB
 aBB
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -419274,8 +417534,8 @@ aBB
 aBB
 aBB
 aBB
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -419726,8 +417986,8 @@ aBB
 aBB
 aBB
 aBB
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -420178,8 +418438,8 @@ aBB
 aBB
 aBB
 aBB
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -420630,8 +418890,8 @@ aBB
 aBB
 aBB
 aBB
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -481662,7 +479922,7 @@ aBB
 aBB
 cwL
 fZN
-uJz
+jne
 prC
 puO
 puO
@@ -482566,7 +480826,7 @@ fZN
 fZN
 fZN
 fZN
-uJz
+jne
 puO
 iBM
 iBM
@@ -483063,11 +481323,11 @@ aBB
 aBB
 aBB
 bPl
-xkp
+qOD
 qKX
 gyT
-xkp
-xkp
+qOD
+qOD
 qqH
 jgM
 aBB
@@ -483516,10 +481776,10 @@ aBB
 aBB
 bPl
 hVq
-xkp
-xkp
-xkp
-xkp
+qOD
+qOD
+qOD
+qOD
 raV
 jgM
 aBB
@@ -483967,11 +482227,11 @@ aBB
 aBB
 aBB
 bPl
-xkp
+qOD
 ilA
 uEK
-xkp
-xkp
+qOD
+qOD
 xnc
 jgM
 aBB
@@ -485259,10 +483519,10 @@ nRO
 nRO
 sqG
 sqG
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -485659,7 +483919,7 @@ bGf
 bGf
 bGf
 kSK
-otR
+gMC
 txq
 hkB
 apZ
@@ -485711,10 +483971,10 @@ nRO
 nRO
 sqG
 sqG
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -486083,7 +484343,7 @@ bGf
 bGf
 kSK
 kSK
-fWe
+sqx
 rgo
 kSK
 kSK
@@ -486128,7 +484388,7 @@ bzY
 bzY
 bzY
 eVz
-otR
+gMC
 kSK
 bGf
 bGf
@@ -486163,10 +484423,10 @@ nRO
 nRO
 sqG
 sqG
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -486535,8 +484795,8 @@ bGf
 bGf
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -486563,7 +484823,7 @@ bGf
 bGf
 bGf
 kSK
-otR
+gMC
 txq
 hkB
 apZ
@@ -486615,10 +484875,10 @@ nRO
 nRO
 sqG
 sqG
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -486987,8 +485247,8 @@ bGf
 bGf
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -487067,10 +485327,10 @@ nRO
 nRO
 sqG
 sqG
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -487131,7 +485391,7 @@ aBB
 aBB
 aBB
 lKH
-wRC
+qjY
 kbo
 hhH
 tlX
@@ -487439,8 +485699,8 @@ bGf
 bGf
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -487456,15 +485716,15 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 kSK
 kSK
@@ -487519,10 +485779,10 @@ nRO
 nRO
 sqG
 sqG
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -487891,8 +486151,8 @@ bGf
 bGf
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -487908,15 +486168,15 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 kSK
@@ -487969,12 +486229,12 @@ nRO
 nRO
 nRO
 oci
-iEf
-iEf
-owg
-fcS
-fcS
-fcS
+cPr
+cPr
+omb
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -488343,8 +486603,8 @@ bGf
 bGf
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -488353,22 +486613,22 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -488420,13 +486680,13 @@ aBB
 nRO
 nRO
 nRO
-uJz
+jne
 mhs
-sYZ
-vvb
-fcS
-fcS
-fcS
+dra
+taV
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -488795,8 +487055,8 @@ bGf
 bGf
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -488805,29 +487065,29 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -488872,13 +487132,13 @@ aBB
 nRO
 nRO
 nRO
-xVT
+ajy
 hqn
-sYZ
+dra
 sMN
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -489257,29 +487517,29 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -489312,9 +487572,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -489324,13 +487584,13 @@ aBB
 nRO
 nRO
 nRO
-xVT
-sYZ
-sYZ
+ajy
+dra
+dra
 sMN
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -489709,29 +487969,29 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -489764,9 +488024,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -489776,13 +488036,13 @@ aBB
 nRO
 nRO
 nRO
-xVT
-sYZ
+ajy
+dra
 hcO
 sMN
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -490173,17 +488433,17 @@ qUS
 qUS
 qUS
 vkS
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -490216,9 +488476,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -490228,13 +488488,13 @@ aBB
 nRO
 nRO
 nRO
-uJz
-bLj
-sYZ
-vvb
-fcS
-fcS
-fcS
+jne
+wjj
+dra
+taV
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -490605,7 +488865,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -490625,17 +488885,17 @@ xPN
 jbB
 xPN
 vkY
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -490668,9 +488928,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -490680,13 +488940,13 @@ aBB
 nRO
 nRO
 nRO
-cbl
-nQL
-nQL
-xkh
-fcS
-fcS
-fcS
+mwo
+srt
+srt
+wzT
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -491057,7 +489317,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -491077,8 +489337,8 @@ jbB
 kTb
 fwK
 vkY
-fWe
-fWe
+sqx
+sqx
 nBH
 xoY
 xoY
@@ -491086,8 +489346,8 @@ jBn
 xoY
 xoY
 vkS
-fWe
-fWe
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -491120,9 +489380,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -491135,10 +489395,10 @@ nRO
 nRO
 sqG
 sqG
-fcS
-fcS
-fcS
-fcS
+nRO
+nRO
+nRO
+nRO
 aBB
 aBB
 aBB
@@ -491509,7 +489769,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -491538,8 +489798,8 @@ amw
 oIR
 nMB
 xoY
-fWe
-fWe
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -491572,9 +489832,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -491961,7 +490221,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -492024,9 +490284,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -492413,7 +490673,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 bGf
@@ -492476,9 +490736,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -492865,7 +491125,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 bGf
@@ -492928,9 +491188,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -493317,7 +491577,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 bGf
@@ -493346,8 +491606,8 @@ pbi
 xFv
 xkU
 xoY
-xfm
-xfm
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -493380,9 +491640,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -493769,7 +492029,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 bGf
@@ -493789,8 +492049,8 @@ qtm
 fwK
 fwK
 vkY
-xfm
-xfm
+bFl
+bFl
 qrn
 xoY
 xoY
@@ -493798,8 +492058,8 @@ jBn
 xoY
 xoY
 hHP
-xfm
-xfm
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -493832,9 +492092,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -494241,17 +492501,17 @@ jbB
 jbB
 xPN
 vkY
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -494284,9 +492544,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -494693,17 +492953,17 @@ fue
 fue
 fue
 hHP
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -494736,9 +492996,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -495124,8 +493384,8 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -495133,29 +493393,29 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
+sqx
+sqx
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -495188,9 +493448,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -495576,8 +493836,8 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -495585,29 +493845,29 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
+sqx
+sqx
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -495640,9 +493900,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -496028,8 +494288,8 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -496037,29 +494297,29 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
+sqx
+sqx
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -496092,9 +494352,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -496480,8 +494740,8 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -496489,22 +494749,22 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
+sqx
+sqx
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -496544,9 +494804,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -496932,8 +495192,8 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -496941,22 +495201,22 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
-xfm
+sqx
+sqx
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
+bFl
 bGf
 bGf
 bGf
@@ -496996,9 +495256,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 feA
 nRO
@@ -497384,8 +495644,8 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -497448,9 +495708,9 @@ bGf
 bGf
 nUS
 bGf
-oOM
-fcS
-fcS
+kSK
+nRO
+nRO
 sqG
 nRO
 nRO
@@ -497837,7 +496097,7 @@ kSK
 kSK
 kSK
 rgo
-fWe
+sqx
 kSK
 kSK
 bGf
@@ -498288,8 +496548,8 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
@@ -498740,21 +497000,21 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 hyE
 sPu
@@ -499179,7 +497439,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -499192,21 +497452,21 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 hyE
 rpt
@@ -499631,7 +497891,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -499644,21 +497904,21 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 hyE
 eLe
@@ -500083,7 +498343,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -500096,21 +498356,21 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 hyE
 pwV
@@ -500535,7 +498795,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -500548,21 +498808,21 @@ bGf
 kSK
 kSK
 kSK
-fWe
-fWe
+sqx
+sqx
 kSK
 kSK
 bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 hyE
 tYa
@@ -500987,7 +499247,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -501008,13 +499268,13 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 hyE
 gxX
@@ -501439,7 +499699,7 @@ bGf
 kSK
 kSK
 kSK
-fWe
+sqx
 kSK
 kSK
 kSK
@@ -501460,11 +499720,11 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -501912,11 +500172,11 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -504163,13 +502423,13 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -504615,13 +502875,13 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -505067,21 +503327,21 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -505506,11 +503766,11 @@ bGf
 bGf
 bGf
 oci
-iEf
-iEf
-iEf
-iEf
-owg
+cPr
+cPr
+cPr
+cPr
+omb
 bGf
 bGf
 bGf
@@ -505519,21 +503779,21 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -505957,11 +504217,11 @@ bGf
 bGf
 bGf
 bGf
-xVT
-evD
+ajy
+awp
 fOq
 fUU
-sYZ
+dra
 sMN
 bGf
 bGf
@@ -505971,21 +504231,21 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -506409,11 +504669,11 @@ bGf
 bGf
 bGf
 bGf
-xVT
-sYZ
+ajy
+dra
 xWk
 faB
-sYZ
+dra
 flT
 bGf
 bGf
@@ -506423,21 +504683,21 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -506861,11 +505121,11 @@ bGf
 bGf
 bGf
 bGf
-xVT
-sYZ
-sYZ
-sYZ
-sYZ
+ajy
+dra
+dra
+dra
+dra
 flT
 bGf
 bGf
@@ -506875,21 +505135,21 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -507313,9 +505573,9 @@ bGf
 bGf
 bGf
 bGf
-xVT
-bLj
-sYZ
+ajy
+wjj
+dra
 nwp
 hsp
 sMN
@@ -507327,21 +505587,21 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -507765,12 +506025,12 @@ bGf
 bGf
 bGf
 bGf
-cbl
+mwo
 flT
 plt
 flT
-nQL
-xkh
+srt
+wzT
 bGf
 bGf
 bGf
@@ -507779,21 +506039,21 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
 bGf
 gQM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -508222,7 +506482,7 @@ oxu
 oxu
 oxu
 jqX
-fWe
+sqx
 bGf
 bGf
 bGf
@@ -508240,12 +506500,12 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -508674,7 +506934,7 @@ fyk
 sEU
 gVv
 hzB
-fWe
+sqx
 bGf
 bGf
 bGf
@@ -508692,12 +506952,12 @@ bGf
 bGf
 bGf
 bGf
-oOM
-oOM
-oOM
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -509126,7 +507386,7 @@ huX
 huX
 huX
 jUz
-fWe
+sqx
 bGf
 bGf
 bGf
@@ -510363,9 +508623,9 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -510815,9 +509075,9 @@ tDV
 tDV
 tDV
 wBI
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -511268,8 +509528,8 @@ tDV
 tDV
 wBI
 wBI
-bKU
-bKU
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -511719,9 +509979,9 @@ tDV
 tDV
 tDV
 wBI
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -512171,9 +510431,9 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -512623,9 +510883,9 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -512835,8 +511095,8 @@ bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -513075,9 +511335,9 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -513287,8 +511547,8 @@ bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -513527,9 +511787,9 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -513739,8 +511999,8 @@ bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -513979,9 +512239,9 @@ tDV
 tDV
 tDV
 tDV
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
 ddn
 ddn
 ddn
@@ -514183,16 +512443,16 @@ kSK
 kSK
 kSK
 kSK
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -514635,16 +512895,16 @@ kSK
 kSK
 kSK
 kSK
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -515087,16 +513347,16 @@ kSK
 kSK
 kSK
 kSK
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -515539,16 +513799,16 @@ kSK
 kSK
 kSK
 kSK
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 cxr
 nRO
@@ -515991,16 +514251,16 @@ kSK
 kSK
 kSK
 kSK
-oOM
-oOM
-oOM
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 cxr
@@ -516441,18 +514701,18 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
 bGf
 bGf
-fcS
-fcS
+nRO
+nRO
 uYO
 nRO
 nRO
@@ -516892,12 +515152,12 @@ bGf
 bGf
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -517339,17 +515599,17 @@ jWw
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -517791,17 +516051,17 @@ iVE
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -518243,17 +516503,17 @@ vgL
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -518695,17 +516955,17 @@ iVE
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
-fWe
-fWe
-fWe
-fWe
-fWe
+sqx
+sqx
+sqx
+sqx
+sqx
 bGf
 bGf
 bGf
@@ -519147,16 +517407,16 @@ jWw
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
-fWe
+sqx
 ggH
-fWe
+sqx
 bGf
 bGf
 bGf
@@ -519599,11 +517859,11 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -520051,11 +518311,11 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -520503,11 +518763,11 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -520764,10 +519024,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -520955,10 +519215,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -521216,10 +519476,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -521407,10 +519667,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -521668,10 +519928,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -521859,10 +520119,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -522120,10 +520380,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -522311,10 +520571,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -522572,10 +520832,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -522763,10 +521023,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -523024,10 +521284,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -523476,10 +521736,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -523667,10 +521927,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -523928,10 +522188,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -524119,10 +522379,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -524380,10 +522640,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -524571,10 +522831,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -524832,10 +523092,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
-bKU
-bKU
-bKU
+ddn
+ddn
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -525023,10 +523283,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -525284,10 +523544,10 @@ ddn
 ddn
 ddn
 ddn
-bKU
+ddn
 wBI
-bKU
-bKU
+ddn
+ddn
 tDV
 tDV
 tDV
@@ -525475,10 +523735,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -525927,10 +524187,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -526379,10 +524639,10 @@ vmi
 dos
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -526831,10 +525091,10 @@ vmi
 ggH
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -527283,10 +525543,10 @@ vmi
 dos
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -527735,10 +525995,10 @@ vmi
 bGf
 kSK
 kSK
-fWe
-fWe
-oOM
-oOM
+sqx
+sqx
+kSK
+kSK
 bGf
 bGf
 bGf
@@ -534930,13 +533190,13 @@ vmi
 vmi
 vmi
 vmi
-vPZ
+lMc
 xpH
-vPZ
-vPZ
-vPZ
-vPZ
-vPZ
+lMc
+lMc
+lMc
+lMc
+lMc
 pvR
 iSm
 bov


### PR DESCRIPTION
## About The Pull Request

This PR makes large changes to dun_world.dmm by replacing tiles which have instanced iconstates with preexisting subtypes of that particular iconstate, for example, 995 instances of wooden tiles with the spiral iconstate being replaced with ruinedwood/spiral 

It should be noted I only replaced instances with already existing coded subtypes; this PR doesn't fix every instance (there are a lot). I'd be more than happy to trim out as many as possible if this PR is something that's wanted.

## Testing Evidence

https://i.imgur.com/fUBy4qY.png
https://i.imgur.com/0cNDr4f.png
https://i.imgur.com/GI9R0N0.png

Compiled, 
Flew around, didn't notice anything weird

## Why It's Good For The Game

This should assist with load times (slightly) and potential merge conflicts by reducing the number of[ lines in the DMM file.](https://i.imgur.com/giUEcrj.png) ((It will give literally everyone else merge conflicts tho))
