### PR TITLE
RCP Fix

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -571,11 +571,11 @@ SUBSYSTEM_DEF(gamemode)
 	if(ttime >= GLOB.round_timer)
 		if(roundvoteend)
 			if(ttime >= round_ends_at)
-				for(var/mob/living/carbon/human/H in GLOB.human_list)
-					if(H.stat != DEAD)
-						if(H.allmig_reward)
-							H.adjust_triumphs(H.allmig_reward)
-							H.allmig_reward = 0
+//				for(var/mob/living/carbon/human/H in GLOB.human_list)
+//					if(H.stat != DEAD)
+//						if(H.allmig_reward)
+//							H.adjust_triumphs(H.allmig_reward)
+//							H.allmig_reward = 0
 				return TRUE
 		else
 			if(!SSvote.mode)


### PR DESCRIPTION
## About The Pull Request
if the round ended via an End Round vote, the variable used to determine Nites Survived/Triumph Gain was being reset to 0. 

thus, no RCP (unless the round was ended manually via end round in an admin’s server tab)

this comments out the reset

vanderlin’s storyteller has the exact same lines commented out, so this shouldn’t break anything 


## Testing Evidence
<img width="360" height="158" alt="rcp_test" src="https://github.com/user-attachments/assets/9d20801c-94b0-4a62-90fe-3abb82967f21" />


## Why It's Good For The Game

I LOVE POINTS!!
