### PR TITLE
Makes bandit injection open bandit slots instead of rolling antag wave

### DIFF
--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -20,3 +20,8 @@
 	if(bandit_job.total_positions < 6) // Not at max capacity, increasing goal.
 		SSmapping.retainer.bandit_goal += 3 * rand(200, 400)
 		SSrole_class_handler.bandits_in_round = TRUE
+		for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
+			if(!player.client)
+				continue
+
+			to_chat(player, span_danger("Matthios, is this true? Bandits flock to Azuria. Three bandit slots have been opened."))

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -1,6 +1,8 @@
 /datum/round_event_control/antagonist/migrant_wave/bandits
 	name = "Bandit Migration"
+	typepath = /datum/round_event/migrant_wave/bandits
 	wave_type = /datum/migrant_wave/bandit
+	max_occurrences = 2
 
 	weight = 12
 
@@ -10,3 +12,11 @@
 		TAG_COMBAT,
 		TAG_VILLIAN,
 	)
+
+/datum/round_event/migrant_wave/bandits/start()
+	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
+	bandit_job.total_positions = min(bandit_job.total_positions + 3, 6)
+	bandit_job.spawn_positions = min(bandit_job.spawn_positions + 3, 6)
+	if(bandit_job.total_positions < 6) // Not at max capacity, increasing goal.
+		SSmapping.retainer.bandit_goal += 3 * rand(200, 400)
+		SSrole_class_handler.bandits_in_round = TRUE

--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -46,7 +46,7 @@
 
 	earliest_start = 0 SECONDS
 
-	weight = 16
+	weight = 25
 
 	typepath = /datum/round_event/antagonist/solo/bandits
 	antag_datum = /datum/antagonist/bandit

--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -72,3 +72,14 @@
 		antag_mind.current.hud_used?.set_advclass()
 
 	SSrole_class_handler.bandits_in_round = TRUE
+
+/datum/round_event_control/antagonist/solo/bandits/canSpawnEvent(players_amt, gamemode, fake_check)
+	. = ..()
+	if(!.)
+		return
+	var/list/candidates = get_candidates()
+
+	if(length(candidates) < 1)
+		return FALSE
+
+	return TRUE

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -3,8 +3,8 @@
 	flag = BANDIT
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	antag_job = TRUE
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Long ago you did a crime worthy of your bounty being hung on the wall outside of the local inn. You now live with your fellow freemen in the bog, and generally get up to no good."

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -3,8 +3,8 @@
 	flag = BANDIT
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 0
-	spawn_positions = 0
+	total_positions = 4
+	spawn_positions = 4
 	antag_job = TRUE
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Long ago you did a crime worthy of your bounty being hung on the wall outside of the local inn. You now live with your fellow freemen in the bog, and generally get up to no good."

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
@@ -9,9 +9,6 @@
 
 /datum/outfit/job/roguetown/bandit/brigand/pre_equip(mob/living/carbon/human/H)
 	..()
-	if (!(istype(H.patron, /datum/patron/inhumen/zizo) || istype(H.patron, /datum/patron/inhumen/matthios) || istype(H.patron, /datum/patron/inhumen/graggar) || istype(H.patron, /datum/patron/inhumen/baotha)))
-		to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
-		H.set_patron(/datum/patron/inhumen/matthios)	//We allow other heretics into the cool-kids club, but if you are a tennite/psydonian it sets you to matthiosan.
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
@@ -63,3 +60,9 @@
 		if("Flail & Shield") //plate users beware, you're in for a scare!
 			backl= /obj/item/rogueweapon/shield/wood
 			beltr = /obj/item/rogueweapon/flail
+
+	if(!istype(H.patron, /datum/patron/inhumen/matthios))
+		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")
+		if(inputty == "Yes")
+			to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
+			H.set_patron(/datum/patron/inhumen/matthios)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
@@ -10,9 +10,6 @@
 
 /datum/outfit/job/roguetown/bandit/hedgeknight/pre_equip(mob/living/carbon/human/H)
 	..()
-	if (!(istype(H.patron, /datum/patron/inhumen/zizo) || istype(H.patron, /datum/patron/inhumen/matthios) || istype(H.patron, /datum/patron/inhumen/graggar) || istype(H.patron, /datum/patron/inhumen/baotha)))
-		to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
-		H.set_patron(/datum/patron/inhumen/matthios)	//We allow other heretics into the cool-kids club, but if you are a tennite/psydonian it sets you to matthiosan.
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/black
 	gloves = /obj/item/clothing/gloves/roguetown/chain/blk
 	pants = /obj/item/clothing/under/roguetown/chainlegs/blk
@@ -55,3 +52,9 @@
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC) //hey buddy you hear about roleplaying
+
+	if(!istype(H.patron, /datum/patron/inhumen/matthios))
+		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")
+		if(inputty == "Yes")
+			to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
+			H.set_patron(/datum/patron/inhumen/matthios)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
@@ -9,9 +9,6 @@
 
 /datum/outfit/job/roguetown/bandit/knave/pre_equip(mob/living/carbon/human/H)
 	..()
-	if (!(istype(H.patron, /datum/patron/inhumen/zizo) || istype(H.patron, /datum/patron/inhumen/matthios) || istype(H.patron, /datum/patron/inhumen/graggar) || istype(H.patron, /datum/patron/inhumen/baotha)))
-		to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
-		H.set_patron(/datum/patron/inhumen/matthios)	//We allow other heretics into the cool-kids club, but if you are a tennite/psydonian it sets you to matthiosan.
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
@@ -82,3 +79,9 @@
 						/obj/item/flashlight/flare/torch = 1,
 						) //poacher gets mantraps
 			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+
+	if(!istype(H.patron, /datum/patron/inhumen/matthios))
+		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")
+		if(inputty == "Yes")
+			to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
+			H.set_patron(/datum/patron/inhumen/matthios)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
@@ -9,9 +9,6 @@
 
 /datum/outfit/job/roguetown/bandit/roguemage/pre_equip(mob/living/carbon/human/H)
 	..()
-	if (!(istype(H.patron, /datum/patron/inhumen/zizo) || istype(H.patron, /datum/patron/inhumen/matthios) || istype(H.patron, /datum/patron/inhumen/graggar) || istype(H.patron, /datum/patron/inhumen/baotha)))
-		to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
-		H.set_patron(/datum/patron/inhumen/matthios)	//We allow other heretics into the cool-kids club, but if you are a tennite/psydonian it sets you to matthiosan.
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt
@@ -71,3 +68,9 @@
 	H.change_stat("speed", 1)
 	H?.mind.adjust_spellpoints(21) // On par with Mage Associate
 	H?.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+
+	if(!istype(H.patron, /datum/patron/inhumen/matthios))
+		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")
+		if(inputty == "Yes")
+			to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
+			H.set_patron(/datum/patron/inhumen/matthios)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -9,9 +9,6 @@
 
 /datum/outfit/job/roguetown/bandit/sawbones/pre_equip(mob/living/carbon/human/H)
 	..()
-	if (!(istype(H.patron, /datum/patron/inhumen/zizo) || istype(H.patron, /datum/patron/inhumen/matthios) || istype(H.patron, /datum/patron/inhumen/graggar) || istype(H.patron, /datum/patron/inhumen/baotha)))
-		to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
-		H.set_patron(/datum/patron/inhumen/matthios)	//We allow other heretics into the cool-kids club, but if you are a tennite/psydonian it sets you to matthiosan.
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
 	head = /obj/item/clothing/head/roguetown/nightman
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
@@ -56,3 +53,9 @@
 		H.change_stat("perception", 1)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
+
+	if(!istype(H.patron, /datum/patron/inhumen/matthios))
+		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")
+		if(inputty == "Yes")
+			to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
+			H.set_patron(/datum/patron/inhumen/matthios)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -31,7 +31,7 @@
 					/obj/item/bedroll = 1,
 					)
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
@@ -9,9 +9,6 @@
 
 /datum/outfit/job/roguetown/bandit/sellsword/pre_equip(mob/living/carbon/human/H)
 	..()
-	if (!(istype(H.patron, /datum/patron/inhumen/zizo) || istype(H.patron, /datum/patron/inhumen/matthios) || istype(H.patron, /datum/patron/inhumen/graggar) || istype(H.patron, /datum/patron/inhumen/baotha)))
-		to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
-		H.set_patron(/datum/patron/inhumen/matthios)	//We allow other heretics into the cool-kids club, but if you are a tennite/psydonian it sets you to matthiosan.
 	H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
@@ -65,3 +62,9 @@
 			beltr = /obj/item/rogueweapon/sword //steel sword like literally every adventurer gets
 			beltl = /obj/item/rogueweapon/scabbard/sword
 			head = /obj/item/clothing/head/roguetown/helmet/sallet
+
+	if(!istype(H.patron, /datum/patron/inhumen/matthios))
+		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")
+		if(inputty == "Yes")
+			to_chat(H, span_warning("My former deity has abandoned me.. Matthios is my new master."))
+			H.set_patron(/datum/patron/inhumen/matthios)


### PR DESCRIPTION
## About The Pull Request

~~Yes, this opens bandit roundstart.
4 guaranteed bandit slots.~~

Instead of using inconvenient migrant wave system - ST now simply opens 3 slots per bandit injection (up to 6 bandits in total). Previously, if no one signed up for migration - slots were lost. Now they wil be opened with to_chat() output to lobby players.

Also increases bandit roll weight. I have no fucking idea how that works and what that means, presumably - this should roll bandits more often.

ALSO removes swords 5 from sawbones. Swords 4. Sorry, my fellow physicians, you will no longer wield swords like knight captain!

ALSO ports [this](https://github.com/Scarlet-Reach/Scarlet-Reach/pull/191)

ALSO removes forced patron change from all bandit subtypes except for iconoclast. Now players will get a choice whether they want to change their patron to Matthios - but they will be able to reject it.

## Testing Evidence

<details>
  <summary>matthios, is this true?</summary>

https://github.com/user-attachments/assets/0f3163df-ec13-40ea-8237-778234f99ce7

</details>

## Why It's Good For The Game

To begin with, I'd like to state the obvious. Bandit != wretch. Wretch by design seems to be a solo antag who will antagonize adventurers, pester the garrison lightly and that's all. They are not expected to link up and organize joint gaggarite-zizite-baothan HQ to establish a FOB in the Northern Hamlet.

Bandits should fill that niche - the role that was designed around a bunch of antags that are expected to cooperate. 
Currently, bandits roll more often than not - and that is the problem. Bandits can serve as a good conflict driver and a trigger for unexpected interactions in game, yet they do not roll.

4 bandits seem to be a manageable threat (probablyyy?). Yes, we will encounter problems like 4 bandits + 4 wretches + lich. Well, we have adventurer murderballs to deal with them.

TL;DR - let's just see how it plays out.