### PR TITLE
Fix Iron Hauberk recipe to require 2 iron bars.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -234,6 +234,7 @@
 /datum/anvil_recipe/armor/iron/hauberk
 	name = "Hauberk (+1 Iron)"
 	req_bar = /obj/item/ingot/iron
+	additional_items = list(/obj/item/ingot/iron)
 	created_item = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 
 /datum/anvil_recipe/armor/iron/chaincoif


### PR DESCRIPTION
## About The Pull Request
Fix Iron Hauberk recipe to require 2 iron bars.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
copiled
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fix Iron Hauberk recipe to require 2 iron bars.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
