### PR TITLE
Small missionary adjustments for Abyssor & Eora.

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -83,7 +83,7 @@
 					/obj/effect/proc_holder/spell/invoked/abyssor_undertow		= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/abyssheal				= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/call_mossback			= CLERIC_T3,
-					/obj/effect/proc_holder/spell/invoked/call_dreamfiend		= CLERIC_T4,
+					/obj/effect/proc_holder/spell/invoked/call_dreamfiend		= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/abyssal_infusion		= CLERIC_T4,
 					/obj/effect/proc_holder/spell/invoked/resurrect/abyssor		= CLERIC_T4,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -320,6 +320,7 @@
 				if (/datum/patron/divine/eora)
 					cloak = /obj/item/clothing/suit/roguetown/shirt/robe/eora
 					head = /obj/item/clothing/head/roguetown/eoramask
+					backpack_contents[/obj/item/reagent_containers/eoran_seed] = 1
 				if (/datum/patron/divine/xylix)
 					cloak = /obj/item/clothing/cloak/templar/xylix
 				if(/datum/patron/inhumen/zizo)

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -859,10 +859,11 @@
 				/obj/item/reagent_containers/food/snacks/eoran_aril/auric = 4,
 				/obj/item/reagent_containers/food/snacks/eoran_aril/ashen = 1,
 				/obj/item/reagent_containers/food/snacks/eoran_aril/ochre = 5,
-				/obj/item/reagent_containers/lux/eoran_aril = 1
+				/obj/item/reagent_containers/lux/eoran_aril = 1, //Lux equivalent
+				/obj/item/reagent_containers/eoran_seed = 1 // Seed for more trees
 			)
 
-    // Generate 4 arils +1 per tier.
+	// Generate 4 arils +1 per tier.
 	for(var/i in 1 to 4 + (floor(fruit_tier / 2)))
 		var/aril_type = pickweight(possible_arils)
 		aril_types += aril_type
@@ -994,7 +995,7 @@
 	desc = "An iridescent seed that shifts colors in the light."
 	icon_state = "opalescent"
 	effect_desc = "Transforms held gems into rubies."
-    
+	
 /obj/item/reagent_containers/food/snacks/eoran_aril/opalescent/apply_effects(mob/living/eater)
 	for(var/obj/item/roguegem/G in eater.held_items)
 		var/obj/item/roguegem/ruby/new_gem = new(eater.loc)
@@ -1132,6 +1133,41 @@
 	if(ishuman(eater))
 		var/mob/living/carbon/human/H = eater
 		H.apply_status_effect(/datum/status_effect/pearlescent_aril)
+
+/obj/item/reagent_containers/eoran_seed
+	name = "Satin aril"
+	desc = "A silky soft seed from Eora's sacred tree. It can be used to propagate her gift in fertile soil."
+	icon = 'modular_azurepeak/icons/obj/items/eora_pom.dmi'
+	icon_state = "roseate"
+
+/obj/item/reagent_containers/eoran_seed/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(!isturf(target) || !proximity_flag)
+		return ..()
+
+	var/turf/T = target
+
+	// Location checks
+	if(!isopenturf(T))
+		to_chat(user, span_warning("The seed needs open space to grow!"))
+		return
+	if(!(istype(T, /turf/open/floor/rogue/grass) || istype(T, /turf/open/floor/rogue/dirt)))
+		to_chat(user, span_warning("The seed must be planted on dirt or grass!"))
+		return
+
+	// Planting process
+	to_chat(user, span_notice("You begin to plant the seed in [T]. It pulses gently..."))
+	if(!do_after(user, 30 SECONDS, target))
+		to_chat(user, span_warning("Planting was interrupted!"))
+		return
+
+	// Re-check conditions after delay
+	if(!isopenturf(T) || !(istype(T, /turf/open/floor/rogue/grass) || istype(T, /turf/open/floor/rogue/dirt)))
+		to_chat(user, span_warning("The ground is no longer suitable!"))
+		return
+
+	// Create tree and consume seed
+	new /obj/structure/eoran_pomegranate_tree(T)
+	qdel(src)
 
 #undef SPROUT
 #undef GROWING


### PR DESCRIPTION
## About The Pull Request
Abyssorite missionaries can now use summon dreamfiend as a T3. Abyssal infusion remains T4 and acolyte/priest exlusive.
Eoran missionaries get ---ONE--- seed. They can plant an eoran tree with this. The main downside being that if anyone takes offense, that's it, your tree is gone.
Very rarely, eoran trees will spawn seeds when pommes are cut open. This is mostly to support the fact that the tree seeds exist as exotic rarities carried by the devout, they're extremely rare, so it's not a reliable way to plant multiple trees and maybe a once in a round thing.

## Testing Evidence
Simple code, tested it and it works.

## Why It's Good For The Game
Missionaries are kinda sad right now. A weak summon on a class with shoddy melee skills, no armor, and no dodge expert won't break any balance. Eoran trees are thematic for missionaries, going to an Eoran holy place or trying the ill advised act of spreading her love in the hamlet is peak rp flavor and conflict. 
