### PR TITLE
Crafting natural bundles dissapearance bugfix

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -392,8 +392,12 @@
 								B.update_bundle()
 								switch(B.amount)
 									if(1)
-										new B.stacktype(B.loc)
+										var/mob/living/carbon/old_loc = B.loc
 										qdel(B)
+										var/new_item = new B.stacktype(old_loc)
+										// Put in the person's hands if there were holding it.
+										if(ishuman(old_loc))
+											old_loc.put_in_hands(new_item)
 									if(0)
 										qdel(B)
 								amt = 0


### PR DESCRIPTION
## About The Pull Request

This PR fixes crafting causing natural bundles to disappear if they reduce to 1 item in-hand 

"Have a bundle of natural materials (fiber, cloth, stone block, leather, etc).
Hold the bundle in your hand.
Craft something that costs 1 more than the stack contains (eg. craft a cloth with 3 fiber in hand):
The single natural item that remains disappears into the mob's contents, never accessible again, instead of being placed into their hand or dropped.
I imagine you can gib the player to get the contents back but that's certainly not intended behavior.

This PR simply places the single remaining item back into the person's hand or drops it via mob.put_in_hands()." - Tastyfish

Ported from https://github.com/Rotwood-Vale/Ratwood-Keep/pull/2654

## Testing Evidence

Check where it was ported ^

<img width="508" height="103" alt="image" src="https://github.com/user-attachments/assets/741fbee2-635a-455c-aaa5-2befe540012e" />

## Why It's Good For The Game

Bugfixes are always good, aren't they?
