### PR TITLE
Silver/Goldface armor fixes & misc additions

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/adventure_supplies.dm
+++ b/code/modules/cargo/packsrogue/merchant/adventure_supplies.dm
@@ -21,6 +21,11 @@
 	cost = 13
 	contains = list(/obj/item/storage/backpack/rogue/satchel)
 
+/datum/supply_pack/rogue/adventure_supplies/satchel
+	name = "Satchel, Short"
+	cost = 13
+	contains = list(/obj/item/storage/backpack/rogue/satchel/short)
+
 /datum/supply_pack/rogue/adventure_supplies/backpack
 	name = "Backpack"
 	cost = 18

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
@@ -36,11 +36,6 @@
 	cost = 35
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/half/iron)
 
-/datum/supply_pack/rogue/armor_iron/brigandine_light
-	name = "Brigandine, Light"
-	cost = 35
-	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine/light)
-
 /datum/supply_pack/rogue/armor_iron/halfplate
 	name = "Half-Plate Armor"
 	cost = 75 // Uhhh I don't think I should be selling them for 65 LOL
@@ -52,9 +47,9 @@
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/full/iron)
 
 /datum/supply_pack/rogue/armor_iron/rearbraces
-	name = "Bracers, Brigandine"
-	cost = 25
-	contains = list(/obj/item/clothing/wrists/roguetown/splintarms)
+	name = "Bracers, Splinted"
+	cost = 30 //1 Iron 1 Leather
+	contains = list(/obj/item/clothing/wrists/roguetown/splintarms/iron)
 
 /datum/supply_pack/rogue/armor_iron/bracers
 	name = "Bracers, Plate"
@@ -77,14 +72,19 @@
 	contains = list(/obj/item/clothing/under/roguetown/chainlegs/iron)
 
 /datum/supply_pack/rogue/armor_iron/chausses_brigandine
-	name = "Chausses, Brigandine"
-	cost = 25
-	contains = list(/obj/item/clothing/under/roguetown/splintlegs)
+	name = "Chausses, Splinted"
+	cost = 35 // 1 Iron 2 Leather
+	contains = list(/obj/item/clothing/under/roguetown/splintlegs/iron)
 
 /datum/supply_pack/rogue/armor_iron/chausses_plate
 	name = "Chausses, Plate"
 	cost = 40
 	contains = list(/obj/item/clothing/under/roguetown/platelegs/iron)
+
+/datum/supply_pack/rogue/armor_iron/chainkilt
+	name = "Chain Kilt"
+	cost = 25
+	contains = list(/obj/item/clothing/under/roguetown/chainlegs/iron/kilt)
 
 /datum/supply_pack/rogue/armor_iron/mask_iron
 	name = "Mask"

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -55,3 +55,8 @@
 	name = "Heavy Leather Gloves"
 	cost = 20 // No one buying this lmao it costs 1 fur
 	contains = list(/obj/item/clothing/gloves/roguetown/angle)
+
+/datum/supply_pack/rogue/light_armor/heavy_padded_coif
+	name = "Heavy Padded Coif"
+	cost = 35 // Equivalent to a padded gambeson on the head, so pricier
+	contains = list(/obj/item/clothing/neck/roguetown/coif/heavypadding)

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
@@ -61,6 +61,11 @@
 	cost = 100 // 2 Steel, 2 Cloth
 	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine)
 
+/datum/supply_pack/rogue/armor_steel/brigandine_light
+	name = "Brigandine, Light"
+	cost = 55 //1 Steel, 1 Leather
+	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine/light)
+
 /datum/supply_pack/rogue/armor_steel/chaincoif_steel
 	name = "Chain Coif"
 	cost = 50 // 1 Steel
@@ -81,6 +86,11 @@
 	cost = 50 // 1 Steel
 	contains = list(/obj/item/clothing/gloves/roguetown/plate)
 
+/datum/supply_pack/rogue/armor_steel/chausses_brigandine
+	name = "Chausses, Brigandine"
+	cost = 60 //1 Steel, 2 Leather
+	contains = list(/obj/item/clothing/under/roguetown/splintlegs)
+
 /datum/supply_pack/rogue/armor_steel/chainleg_steel
 	name = "Chausses, Chain"
 	cost = 50 // 1 Steel
@@ -90,6 +100,16 @@
 	name = "Chausses, Plate"
 	cost = 90 // 2 Steel
 	contains = list(/obj/item/clothing/under/roguetown/platelegs)
+	
+/datum/supply_pack/rogue/armor_steel/chainkilt
+	name = "Chain Kilt"
+	cost = 50 // 1 Steel
+	contains = list(/obj/item/clothing/under/roguetown/chainlegs/kilt)
+
+/datum/supply_pack/rogue/armor_steel/rearbraces
+	name = "Bracers, Brigandine"
+	cost = 55 // 1 Steel, 1 Leather
+	contains = list(/obj/item/clothing/wrists/roguetown/splintarms)
 
 /datum/supply_pack/rogue/armor_steel/bracers_plate
 	name = "Bracers, Plate"

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
@@ -86,7 +86,7 @@
 				)
 
 /datum/supply_pack/rogue/steel_weapons/kriegmesser
-	name = "Kriegmesser"
+	name = "Kriegsmesser"
 	cost = 70 // 2 Steel Ingot
 	contains = list(
 					/obj/item/rogueweapon/sword/long/kriegmesser,


### PR DESCRIPTION
## About The Pull Request

Light brigandine was changed to steel in a PR last week and it hadn't been reflected on the SILVERFACE and GOLDFACE yet. This fixes that, adds the new splinted gear to iron armors, adds chain kilts, adds heavy padded coifs and short satchels to the 'faces, and fixes a tiny typo on the kriegsmesser.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Bought Everything. It Just Works.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Fixes steel being cheaply buyable. New armor types hadn't been added to the merchant yet.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
