### PR TITLE
Minor Steward Imports (for Garrison)

### DIFF
--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -279,14 +279,26 @@
 	new /obj/item/natural/glass(src)
 	new /obj/item/natural/glass(src)
 
+/datum/roguestock/import/extrakeyrings
+	name = "Extra Keyrings (2x)"
+	desc = "Keys for new Manor Guardsmen."
+	item_type = /obj/structure/closet/crate/chest/steward/extrakeyrings
+	export_price = 75
+	importexport_amt = 1
 
+/obj/structure/closet/crate/chest/steward/extrakeyrings/Initialize()
+	. = ..()
+	new /obj/item/storage/keyring/guardcastle(src)
+	new /obj/item/storage/keyring/guardcastle(src)
 
+/datum/roguestock/import/extrahoundstones
+	name = "Extra Houndstones (2x)"
+	desc = "Imported Houndstones from Grenzelhoft."
+	item_type = /obj/structure/closet/crate/chest/steward/extrahoundstones
+	export_price = 400 // expensive; discourages garrison from losing their shit
+	importexport_amt = 1
 
-
-
-
-
-
-
-
-
+/obj/structure/closet/crate/chest/steward/extrahoundstones/Initialize()
+	. = ..()
+	new /obj/item/scomstone/bad/garrison(src)
+	new /obj/item/scomstone/bad/garrison(src)

--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -290,15 +290,3 @@
 	. = ..()
 	new /obj/item/storage/keyring/guardcastle(src)
 	new /obj/item/storage/keyring/guardcastle(src)
-
-/datum/roguestock/import/extrahoundstones
-	name = "Extra Houndstones (2x)"
-	desc = "Imported Houndstones from Grenzelhoft."
-	item_type = /obj/structure/closet/crate/chest/steward/extrahoundstones
-	export_price = 400 // expensive; discourages garrison from losing their shit
-	importexport_amt = 1
-
-/obj/structure/closet/crate/chest/steward/extrahoundstones/Initialize()
-	. = ..()
-	new /obj/item/scomstone/bad/garrison(src)
-	new /obj/item/scomstone/bad/garrison(src)


### PR DESCRIPTION
## About The Pull Request

Gives **ONE new import: a cheap keyring set of two (MAA access). **Doesn't give houndstones anymore because group consensus is a no.**

## Testing Evidence

<img width="263" height="81" alt="3fd359add289d3b6792de5b97c32f0aa" src="https://github.com/user-attachments/assets/9f62bf87-ce96-4930-8cb1-7e915fd0bca1" />


## Why It's Good For The Game

Just makes it so you can import rings. Might make it do more if this PR is left open, but I'm not sure what else. I do kinda like the keyrings cus it's annoying to buy a whole MAA crate for new guards.
