### PR TITLE
[TM FIRST] LL Lupian Lore

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -813,7 +813,7 @@
 			if(3)
 				to_chat(owner, span_cultsmall("A sailor's leg is caught in naval rope. Their last thoughts are of home."))
 			if(4)
-				to_chat(owner, span_cultsmall("She sobbed over the vulpkian's corpse. The Brigand's mace stemmed her tears."))
+				to_chat(owner, span_cultsmall("She sobbed over the Venardine's corpse. The Brigand's mace stemmed her tears."))
 			if(5)
 				to_chat(owner, span_cultsmall("A farm son chokes up his last. At his bedside, a sister and mother weep."))
 			if(6)

--- a/code/modules/mob/dead/new_player/sprite_accessory/hair.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessory/hair.dm
@@ -1555,31 +1555,31 @@
 	icon = 'icons/mob/sprite_accessory/hair/vulpkian_hair.dmi'
 
 /datum/sprite_accessory/hair/head/vulpkian/anita
-	name = "Vulpkian Anita"
+	name = "Venardine Anita"
 	icon_state = "anita"
 
 /datum/sprite_accessory/hair/head/vulpkian/jagged
-	name = "Vulpkian Jagged"
+	name = "Venardine Jagged"
 	icon_state = "jagged"
 
 /datum/sprite_accessory/hair/head/vulpkian/kajam1
-	name = "Vulpkian Kajam 1"
+	name = "Venardine Kajam 1"
 	icon_state = "kajam1"
 
 /datum/sprite_accessory/hair/head/vulpkian/kajam2
-	name = "Vulpkian Kajam 2"
+	name = "Venardine Kajam 2"
 	icon_state = "kajam2"
 
 /datum/sprite_accessory/hair/head/vulpkian/keid
-	name = "Vulpkian Keid"
+	name = "Venardine Keid"
 	icon_state = "keid"
 
 /datum/sprite_accessory/hair/head/vulpkian/mizar
-	name = "Vulpkian Mizar"
+	name = "Venardine Mizar"
 	icon_state = "mizar"
 
 /datum/sprite_accessory/hair/head/vulpkian/raine
-	name = "Vulpkian Raine"
+	name = "Venardine Raine"
 	icon_state = "raine"
 
 /datum/sprite_accessory/hair/facial

--- a/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lupian.dm
@@ -5,14 +5,13 @@
 	name = "Lupian"
 	id = "lupian"
 	desc = "<b>Lupian</b><br>\
-	Lupians are the sons and daughters of Noc. They are a volf-like people hailing from the Northern Regions of the world. \
-	They are resilient, cunning and fight ready creachures capable of surviving the north thanks to their rugged pelts, \
-	sharp teeth and deep-rooted spirit of community. They are very dutiful individuals and make fantastic and fearsome \
-	warriors to those who earn their loyalty. Thanks to their pack minded nature they are slow to trust the other races \
-	but form deep connections with those they do. In recent years they have been driven from the forests by unrest and pressed \
-	into cohabitation with races they'd deem lesser.<br>\
+	As written by an Archivist from times before yours: Lupians, known by many as Volfmen, are a very prominent type of Beastkin that is easily found all across Psydonia. \
+	They are oft tall and slim, carrying with them a coat of discoloured short or medium length fur. \
+	Their bodies are naturally resilient and their minds as sharp as a Humen's own. \
+	A Lupian will usually display loyalty to a fault, as they are quite factional beings. \
+	Tales of old claim that they came to be when Noc stole Dendor’s curse to create lyfe of his own in an attempt to replicate Psydon’s, instead giving birth to a flawed beast-people.<br>\
 	(+1 Constitution, +1 Intelligence)"
-	skin_tone_wording = "Pack"
+	skin_tone_wording = "Ascendance"
 	species_traits = list(
 		MUTCOLORS,
 		EYECOLOR,
@@ -140,20 +139,15 @@
 	. = ..()
 	UnregisterSignal(C, COMSIG_MOB_SAY)
 
-/datum/species/lupian/get_skin_list()
+/datum/species/lupian/get_skin_list()		//This is completely, utterly deprecated as far as I know.
 	return list(
-		"Vakran" = "271f1b",
-		"Lanarain" = "271f1c",
-		"Frostfell" = "271f1d",
-		"Varghelm" = "271f1e",
-		"Dawnbreak" = "271f1f",
-		"Bloodmoon" = "271f2a",
-		"Felsaad" = "271f2b",
-		"Hizmut" = "271f2c",
-		"Langqan" = "271f2d",
-		"a tangled lineage" = "271f2e",
-		"disputed" = "271f2f",
-		"bastardized" = "271f3a"
+		"Forester" = "271f1b",
+		"Arctic" = "271f1c",
+		"Desert-dweller" = "271f1d",
+		"City Cur" = "271f1e",
+		"Coaster" = "271f1f",
+		"Islander" = "271f2a",
+		"Bastard" = "271f2b"
 	) // This is a dirty hack that stops me using mob defines, the colors do not do anything, it just a var that relates to their pack name on examine
 
 /datum/species/lupian/get_random_features()

--- a/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/vulpkanin.dm
@@ -1,11 +1,16 @@
 /mob/living/carbon/human/species/vulpkanin
 	race = /datum/species/vulpkanin
 
-/datum/species/vulpkanin
-	name = "Vulpkian"
+/datum/species/vulpkanin		//These should technically not exist, but completely exploding people's savefiles is too high a price to pay for some minor race bloat.
+	name = "Venardine"
 	id = "vulpkanin"
-	desc = "Foxy creatures known for their cleverness and mischief. In ancient history they were Dendor's original champions, but as His madness grew the connect became frey and forgotten, leaving them to their own devices. Or, at least, that's what they say.<br>\
-	(+1 Intelligence, +1 Perception)"
+	desc = "<b>Venardine</b><br>\
+	Based on the writings of the living Fietje von Zenitstadt: A subspecies of the more common \"Lupian\", found almost exclusively in thick forests.\
+	They are usually shorter and meeker, but in turn more perceptive than their Volf-like brethren. \
+	Their name is quite obvious, coming from the Venards they closely resemble. \
+	Venardines are often much more solitary than Lupians, lacking the fervent pack mentality of their parent race. \
+	To this dae, their origin is heavily disputed by few archivists across Psydonia - though the rest, perhaps for sanity's sake, consider them to be just Lupians.<br>\
+	(+1 Perception, +1 Intelligence)"
 	default_color = "444"
 	species_traits = list(
 		MUTCOLORS,

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -153,7 +153,7 @@
 	name = "lupian ears"
 
 /obj/item/organ/ears/vulpkanin
-	name = "vulpkian ears"
+	name = "venardine ears"
 	accessory_type = /datum/sprite_accessory/ears/fox
 
 /obj/item/organ/ears/tajaran

--- a/code/modules/surgery/organs/feature_organs/snout.dm
+++ b/code/modules/surgery/organs/feature_organs/snout.dm
@@ -22,7 +22,7 @@
 	name = "zardman snout"
 
 /obj/item/organ/snout/vulpkanin
-	name = "vulpkian snout"
+	name = "venardine snout"
 
 /obj/item/organ/snout/tajaran
 	name = "tajaran snout"

--- a/code/modules/surgery/organs/feature_organs/tails.dm
+++ b/code/modules/surgery/organs/feature_organs/tails.dm
@@ -39,7 +39,7 @@
 	name = "avali tail"
 
 /obj/item/organ/tail/vulpkanin
-	name = "vulpkian tail"
+	name = "venardine tail"
 	accessory_type = /datum/sprite_accessory/tail/fox
 	accessory_colors = "#fc8803#fff8f0"
 

--- a/strings/rt/timechangetips.txt
+++ b/strings/rt/timechangetips.txt
@@ -80,11 +80,11 @@ The Sovereignty of Otava is a lush wet country home to the best stoneworkers on 
 A traditional Psydonic greeting or farewell is 'Purity afloat.' The psycross is often held over the chest during this ritual.
 Blacksteel is a pale imitation of the Zizo-blessed Darksteel, which is gifted to Her followers in Her benevolence.
 Blacksteel is a blessed alloy of pure silver and steel. Its recipe was stolen by Zizite heretics and perverted into Darksteel.
-The Gronn Highlands is a mountainous region known for its jagged peaks and terrible blizzards. It is home to a hardy, brutal people who struggle to survive against the land, building fortified stone villages that cling to cliffsides. 
+The Gronn Highlands are a mountainous region known for its jagged peaks and terrible blizzards. It is home to a hardy, brutal people who struggle to survive against the land, building fortified stone villages that cling to cliffsides. 
 Dwarves are renowned for their artifice and craftsmanship, having been least affected by the collapse of the Celestial Empire. They are only mostly dead.
 The Raneshan Empire is a vast dry region primarily made up of sprawling forests and arid lands. It is famous for its rich silks, splendorous gold, and expansive slave trade.
 Most Dwarves hail from Hammerhold, either from above or below. Confusing a surface-dwarf and an underground-dwarf is likely to get you kicked in the shin.
-The Isles of Etrusca is a sun-kissed archipelago nestled in sparkling blue waters. Known for their rich maritime culture, the Etruscans are masterful sailors and traders, navigating the seas with swift, ornate galleons adorned with colorful sails.
+The Isles of Etrusca are a sun-kissed archipelago nestled in sparkling blue waters. Known for their rich maritime culture, the Etruscans are masterful sailors and traders, navigating the seas with swift, ornate galleons adorned with colorful sails.
 ZIZO. ZIZO. ZIZO.
 To seek progress is to paint with your blood. The greater the work, the harsher the price.
 Scent of rot and shit; my feet find fetid ground. A corpse—I am living on a corpse. And then the world is normal again.
@@ -103,3 +103,8 @@ ASTRATA is a VILE TYRANT and must be CONSUMED AND SUBSUMED.
 ASTRATA is law made manifest and must be respected, lest society fall into chaos.
 No pursuit was too perilous, no sacrifice too great. Until, well...
 Under the Heavens and the Many Stars, there are darker things than men may dream of.
+Lupians make exceptional zealots. Ask the Otavan Inquisition.
+Stories tell that Noc stole Dendor's curse to create Humen of his own, and thus Lupians came to be. A poor imitation.
+Stories tell that Noc stole Dendor's blessing to create Humen of his own, and thus Lupians came to be. An honest attempt.
+Solitary Lupians who stand tall are often mistaken for werevolves and shot without question, so they travel in packs.
+Drakian... Fluvian... Lupian... They're all wildkin, why do we bother giving them names?


### PR DESCRIPTION
## About The Pull Request
Ls in chat

This PR updates the species descriptions of Lupians, adds a couple of tooltips, and renames "Vulpkians" to "Venardines".
Lupian lore isn't published on the wiki yet, but can be read [here](https://docs.google.com/document/d/19r4klPXSq-R9jUfxO62ILWWMQ6JsII68PgqlWzGNqXs/edit?usp=sharing).

The underlying code for Venardines was not substantially changed unlike the Zardman PR. Still, I need this TMed first in the event it starts fucking up save files. It should, in theory, not do any such thing!

## Testing Evidence
<img width="484" height="190" alt="image" src="https://github.com/user-attachments/assets/9aba8a47-1cdb-4cdd-a7be-999cad59c394" />
<img width="588" height="358" alt="image" src="https://github.com/user-attachments/assets/d5120b9b-e45f-4e25-a750-8015630ac07f" />
<img width="287" height="193" alt="image" src="https://github.com/user-attachments/assets/ed4defd8-a2a5-403d-87d4-74ba9708ed50" />
<img width="592" height="355" alt="image" src="https://github.com/user-attachments/assets/cf18da1a-f768-4e1d-888b-01789d5e0185" />
<img width="279" height="182" alt="image" src="https://github.com/user-attachments/assets/be2e5b03-91e8-473b-94ad-7ff06168f349" />



## Why It's Good For The Game
I don't like bumass holdover lore from +1 yr ago
