### PR TITLE
FIX Witches. More balanced Zad-form of witch

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -30,7 +30,7 @@
 						/obj/item/chalk = 1
 						)
 	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/crow)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/witchcrow)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/arcynebolt)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -30,7 +30,7 @@
 						/obj/item/chalk = 1
 						)
 	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/witchcrow)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/crow)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/arcynebolt)

--- a/code/modules/spells/roguetown/vampire.dm
+++ b/code/modules/spells/roguetown/vampire.dm
@@ -28,3 +28,16 @@
 	die_with_shapeshifted_form =  FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow
 	sound = 'sound/vo/mobs/bird/birdfly.ogg'
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/witchcrow
+	name = "Zad Form"
+	overlay_state = "zad"
+	desc = "For witches"
+	invocation = ""
+	gesture_required = TRUE
+	chargetime = 5 SECONDS
+	recharge_time = 50
+	cooldown_min = 50
+	die_with_shapeshifted_form =  FALSE
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow
+	sound = 'sound/vo/mobs/bird/birdfly.ogg'

--- a/code/modules/spells/roguetown/vampire.dm
+++ b/code/modules/spells/roguetown/vampire.dm
@@ -22,18 +22,6 @@
 	overlay_state = "zad"
 	desc = ""
 	invocation = ""
-	chargetime = 5 SECONDS
-	recharge_time = 50
-	cooldown_min = 50
-	die_with_shapeshifted_form =  FALSE
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow
-	sound = 'sound/vo/mobs/bird/birdfly.ogg'
-
-/obj/effect/proc_holder/spell/targeted/shapeshift/witchcrow
-	name = "Zad Form"
-	overlay_state = "zad"
-	desc = "For witches"
-	invocation = ""
 	gesture_required = TRUE
 	chargetime = 5 SECONDS
 	recharge_time = 50

--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
@@ -12,6 +12,7 @@
 	chargedrain = 1
 	chargetime = 0
 	recharge_time = 4 SECONDS
+	human_req = TRUE
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Witch anymore cant cast "Zad form" when she in chains/roped. It will be possible to tie her up properly and not kill her/hope for a rag. More balance. Let her just not get caught. She is now CATCHABLE for further RP and talks. Also change arcyne bolt to able use only when u a witch, NOT a crow.

## Testing Evidence


https://github.com/user-attachments/assets/762eaa21-abda-4271-896f-5515c15eb423



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

More RP moment, NO Drone-crow with arcyne bolt and leave from RP with turning into a crow in chains

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
