### PR TITLE
EQUALIZE rework

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -97,12 +97,13 @@
 
 /obj/effect/proc_holder/spell/invoked/equalize
 	name = "Equalize"
-	desc = "Create equality between you and your target. Siphons the targets stats and adds onto yours if their total is higher."
+	desc = "Create equality, with a thumb on the scales, with your target. Siphon strength, speed, and constitution from them."
 	overlay_state = "equalize"
 	clothes_req = FALSE
 	overlay_state = "equalize"
 	associated_skill = /datum/skill/magic/holy
 	chargedloop = /datum/looping_sound/invokeascendant
+	sound = 'sound/magic/swap.ogg'
 	chargedrain = 0
 	chargetime = 50
 	releasedrain = 60
@@ -111,70 +112,63 @@
 	movement_interrupt = FALSE
 	recharge_time = 2 MINUTES
 	range = 4
-	var/totalstatshift = 0
-	var/totalstatchange = 0
-	var/outline_colour = "#FFD700"
+
+
 /obj/effect/proc_holder/spell/invoked/equalize/cast(list/targets, mob/living/user)
 	if(ishuman(targets[1]))
-		var/mob/living/carbon/human/target = targets[1]
-		totalstatchange += (target.STASPD-user.STASPD)
-		totalstatchange += ((target.STASTR-user.STASTR)*2) // We're gonna weigh strength as double, being the strongest stat.
-		totalstatchange += (target.STAEND-user.STAEND)
-		totalstatchange += (target.STALUC-user.STALUC)
-		totalstatchange += (target.STAINT-user.STAINT)
-		totalstatchange += (target.STACON-user.STACON)
-		totalstatchange += (target.STAPER-user.STAPER)
-		totalstatchange -=3 // We need Atleast a 4 point disadvantage before we start siphoning
-		totalstatshift = CLAMP((totalstatchange), 0, 2) // We DO NOT WANT Matthian Clerics stealing 30 stats from Ascendants, Cap the statshift by 2
-		if(totalstatshift <1)
-			to_chat(user, "<font color='yellow'>[target] fire burns dimly, there is nothing worth equalizing.</font>")
-			return
-		else
-			// there is SURELY a better way to do this
-			playsound(user, 'sound/magic/swap.ogg', 100, TRUE)
-			user.add_filter(EQUALIZED_GLOW, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
-			target.add_filter(EQUALIZED_GLOW, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
-			to_chat(target, span_danger("I feel my flame being siphoned!"))
-			to_chat(user, "<font color='yellow'>The Equalizing link is made, I am siphoning flame!</font>")
-			target.STASPD -= totalstatshift // LALA LA NOTHING TO SEE DOWN HERE OFFICER
-			user.STASPD += totalstatshift
-			target.STASTR -= totalstatshift
-			user.STASTR += totalstatshift
-			target.STAEND -=totalstatshift
-			user.STAEND += totalstatshift
-			target.STALUC -= totalstatshift
-			user.STALUC += totalstatshift
-			target.STAINT -= totalstatshift
-			user.STAINT += totalstatshift
-			target.STACON -= totalstatshift
-			user.STACON += totalstatshift
-			target.STAPER -= totalstatshift
-			user.STAPER += totalstatshift
-			addtimer(CALLBACK(src, PROC_REF(returnstatstarget), target), 1 MINUTES) // 2 timers incase only one guy gets deleted or smthing
-			addtimer(CALLBACK(src, PROC_REF(returnstatsuser), user), 1 MINUTES)
-			return
-			
-/obj/effect/proc_holder/spell/invoked/equalize/proc/returnstatstarget(mob/living/target)
-	target.remove_filter(EQUALIZED_GLOW)
-	target.STASPD += totalstatshift
-	target.STASTR += totalstatshift
-	target.STAEND += totalstatshift
-	target.STALUC += totalstatshift
-	target.STAINT += totalstatshift
-	target.STACON += totalstatshift
-	target.STAPER += totalstatshift
-	to_chat(target, span_danger("I feel my strength returned to me!"))
+		var/mob/living/target = targets[1]
+		target.apply_status_effect(/datum/status_effect/debuff/equalizedebuff)
+		user.apply_status_effect(/datum/status_effect/buff/equalizebuff)
+		return TRUE
+	revert_cast()
+	return FALSE
 
-/obj/effect/proc_holder/spell/invoked/equalize/proc/returnstatsuser(mob/living/user)
-	user.remove_filter(EQUALIZED_GLOW)
-	user.STASTR -= totalstatshift
-	user.STASPD -= totalstatshift
-	user.STAEND -= totalstatshift
-	user.STALUC -= totalstatshift
-	user.STAINT -= totalstatshift
-	user.STACON -= totalstatshift
-	user.STAPER -= totalstatshift
-	to_chat(user, "<font color='yellow'>My link wears off, their stolen fire returns to them</font>")
+
+ // buff
+/datum/status_effect/buff/equalizebuff
+	id = "equalize"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/equalized
+	effectedstats = list("strength" = 2, "constitution" = 2, "speed" = 2)
+	duration = 30 SECONDS
+	var/outline_colour = "#FFD700"
+
+
+/atom/movable/screen/alert/status_effect/buff/equalized
+	name = "Equalized"
+	desc = "Equalized, with a gentle thumb on the scale, tactfully."
+
+/datum/status_effect/buff/equalizebuff/on_apply()
+	. = ..()
+	owner.add_filter(EQUALIZED_GLOW, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+
+/datum/status_effect/buff/equalizebuff/on_remove()
+	. = ..()
+	owner.remove_filter(EQUALIZED_GLOW)
+	to_chat(owner, "<font color='yellow'>My link wears off, their stolen fire returns to them</font>")
+
+
+ // debuff
+/datum/status_effect/debuff/equalizedebuff
+	id = "equalize"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/equalized
+	effectedstats = list("strength" = -2, "constitution" = -2, "speed" = -2)
+	duration = 30 SECONDS
+	var/outline_colour = "#FFD700"
+
+/atom/movable/screen/alert/status_effect/debuff/equalized
+	name = "Equalized"
+	desc = "My fire is stolen from me!"
+
+/datum/status_effect/debuff/equalizedebuff/on_apply()
+	. = ..()
+	owner.add_filter(EQUALIZED_GLOW, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+
+/datum/status_effect/debuff/equalizedebuff/on_remove()
+	. = ..()
+	owner.remove_filter(EQUALIZED_GLOW)
+	to_chat(owner, "<font color='yellow'>My fire returns to me!</font>")
+
+
 
 //T3 COUNT WEALTH, HURT TARGET/APPLY EFFECTS BASED ON AMOUNT OF WEALTH. AT 500+, OLD STYLE CHURNS THE TARGET.
 

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -129,7 +129,7 @@
 	id = "equalize"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/equalized
 	effectedstats = list("strength" = 2, "constitution" = 2, "speed" = 2)
-	duration = 30 SECONDS
+	duration = 1 MINUTES
 	var/outline_colour = "#FFD700"
 
 
@@ -152,7 +152,7 @@
 	id = "equalize"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/equalized
 	effectedstats = list("strength" = -2, "constitution" = -2, "speed" = -2)
-	duration = 30 SECONDS
+	duration = 1 MINUTES
 	var/outline_colour = "#FFD700"
 
 /atom/movable/screen/alert/status_effect/debuff/equalized


### PR DESCRIPTION
## About The Pull Request

- Equalize no longer insane on the backend to do jumbo math.
- Now its just a stat steal, -2/+2 CON/STR/SPD from a target for a minute. Basically the same effect as last time but not so niche it was barely applicable unless you built wretched around the miracle.
-  Commission by Mashi

## Testing Evidence


https://github.com/user-attachments/assets/2f61c80c-14a7-4853-8b4e-bddeebb37e64



## Why It's Good For The Game

- Equalize has been mostly unusable for the longest time, I was far too careful with it at first. 
