### PR TITLE
Adds an objectively funny way (and the only way right now) to level up your riding skill

### DIFF
--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -82,11 +82,12 @@
 /obj/item/natural/saddle
 	name = "saddle"
 	icon_state = "saddle"
+	associated_skill = /datum/skill/misc/riding
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK_L
 	resistance_flags = FIRE_PROOF
-	gripped_intents = list(/datum/intent/use)
-	force = 0
+	gripped_intents = list(/datum/intent/use, /datum/intent/mace/strike)
+	force = 1
 	throwforce = 0
 	sellprice = 10
 	var/storage_type = /datum/component/storage/concrete/roguetown/saddle


### PR DESCRIPTION
## About The Pull Request
Saddles now deal 1 damage.
Saddles now rely on the riding skill.
Riding can be trained by hitting a training dummy with your saddle.

## Testing Evidence
<img width="389" height="607" alt="image" src="https://github.com/user-attachments/assets/ec46995b-79f4-4084-9c67-f6c7aeb06bc3" />


## Why It's Good For The Game
There is LITERALLY NO WAY to obtain any riding skill outside of random dream rolls. This is bad.
