### PR TITLE
[Fix] Set outdoor rtfield as warden area

### DIFF
--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -157,6 +157,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter/rtfield
 	deathsight_message = "somewhere in the wilds, next to towering walls"
+	warden_area = TRUE
 
 /area/rogue/indoors/shelter/rtfield
 	icon_state = "rtfield"


### PR DESCRIPTION
## About The Pull Request

Set the flag warden_area for /area/rogue/outdoors/rtfield to TRUE.

## Testing Evidence

Compiled, entered rtfield as warden, got woodsman buff.
<img width="1134" height="974" alt="obraz" src="https://github.com/user-attachments/assets/906c055f-91fa-4a47-925a-42a2c2625e7a" />

## Why It's Good For The Game

As discussed on discord, rtfield not being a warden_area was basically an oversight so this PR is just fixing it.

