### PR TITLE
[******* Finally] Fixes deadite infection feedback

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -15,12 +15,15 @@
 		has_rot = TRUE
 	else if (istype(target, /mob/living/carbon))
 		has_rot = check_bodyparts_for_rot(target)
+	else if (target.has_status_effect(/datum/status_effect/zombie_infection))
+		has_rot = TRUE
 
 	// Remove rot component
 	remove_rot_component(target)
 
 	// Remove Infected var
 	target.infected = FALSE
+	target.remove_status_effect(/datum/status_effect/zombie_infection)
 
 	// Clean body parts
 	clean_body_parts(target)

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -337,44 +337,6 @@
 	return ..()
 
 /*
-	Check for zombie infection post bite
-		Bite chance is checked here
-		Wound chance is checked in zombie_wound_infection.dm
-*/
-/mob/living/carbon/human/proc/attempt_zombie_infection(mob/living/carbon/human/source, infection_type, wake_delay = 0)
-	var/mob/living/carbon/human/victim = src
-	if (QDELETED(src) || stat >= DEAD)
-		return FALSE
-
-	var/datum/antagonist/zombie/victim_zombie = victim.mind?.has_antag_datum(/datum/antagonist/zombie)
-	if (victim_zombie) //Check that the victim isn't already a zombie or on the way to becoming one
-		return FALSE
-
-	var/datum/antagonist/zombie/zombie_antag = source.mind?.has_antag_datum(/datum/antagonist/zombie)
-	if (!zombie_antag || !zombie_antag.has_turned) //Check that the zombie who bit us is real
-		return FALSE
-	victim.infected = TRUE //They are being infected
-
-	//How did the victim get infected
-	switch (infection_type)
-		if ("bite")
-			if (!prob(ZOMBIE_FIRST_BITE_CHANCE)) // Chance to infect via first bite (rare)
-				return FALSE
-			to_chat(victim, span_danger("A growing cold seeps into my body. I feel horrible... REALLY horrible..."))
-			mob_timers["puke"] = world.time
-			vomit(1, blood = TRUE, stun = FALSE)
-
-		if ("wound")	//Chance to infect via chewing to open wound
-			flash_fullscreen("redflash3")
-			to_chat(victim, span_danger("Ow! It hurts. I feel horrible... REALLY horrible..."))
-
-	victim.zombie_check_can_convert() //They are given zombie antag mind here unless they're already an antag.
-
-//Delay on waking up as a zombie. /proc/wake_zombie(mob/living/carbon/zombie, infected_wake = FALSE, converted = FALSE)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(wake_zombie), victim, FALSE, TRUE), wake_delay, TIMER_STOPPABLE)
-	return zombie_antag
-
-/*
 	Proc for our newly infected to wake up as a zombie
 */
 /proc/wake_zombie(mob/living/carbon/zombie, infected_wake = FALSE, converted = FALSE)

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie_disease.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie_disease.dm
@@ -1,0 +1,91 @@
+/datum/status_effect/zombie_infection
+	id = "zombie_infection"
+	alert_type = /atom/movable/screen/alert/status_effect/zombie_infection
+	/// Time until transformation completes
+	var/transformation_time
+	var/message_cooldown_time
+	var/message_cooldown_amount = 20 SECONDS
+	/// Whether this infection came from a living host (Aka, did we die and get infected that way?)
+	var/infected_wake = FALSE
+	// Doesn't hurt making this a static list.
+	var/static/list/infection_messages = list(
+		"I can feel rot creeping up in the back of my throat. An oily, coppery taste flooding my mouth.",
+		"My skin feels cold and clammy. I can feel my veins hardening up like cold steel.",
+		"A deep hunger gnaws at my stomach. Nothing sates it.",
+		"The color drains from the world as I view it, momentarily.",
+		"I keep hearing whispers. Is she calling for me?",
+		"My joints ache with a strange stiffness. It hurts to move.",
+		"My mind is fraying, who am I?",
+		"I can feel my pulse slowing. I've never felt this calm.",
+		"There's a strange numbness spreading through my limbs, I'm bleeding but I can't tell where.",
+		"I can smell my own flesh, it smells foul."
+	)
+
+/datum/status_effect/zombie_infection/on_creation(mob/living/new_owner, time_to_transform = 5 MINUTES, from_infected_wake = "wound")
+	. = ..()
+	transformation_time = world.time + time_to_transform
+	message_cooldown_time = world.time + message_cooldown_amount
+	infected_wake = from_infected_wake
+
+/datum/status_effect/zombie_infection/tick()
+	if(world.time > message_cooldown_time)
+		var/warning_message = pick(infection_messages)
+		if(prob(10))
+			to_chat(owner, span_userdanger("[warning_message]"))
+		else
+			to_chat(owner, span_danger("[warning_message]"))
+		message_cooldown_time = world.time + message_cooldown_amount
+	if(world.time > transformation_time)
+		var/mob/living/carbon/human/H = owner
+		if(!iscarbon(H))
+			owner.remove_status_effect(/datum/status_effect/zombie_infection)
+
+		if(H.stat == DEAD || infected_wake)
+			H.zombie_check_can_convert()
+			var/datum/antagonist/zombie/zombie_antag = H.mind?.has_antag_datum(/datum/antagonist/zombie)
+			if(zombie_antag && !zombie_antag.has_turned)
+				zombie_antag.wake_zombie(infected_wake)
+				owner.remove_status_effect(/datum/status_effect/zombie_infection)
+
+/datum/status_effect/zombie_infection/on_apply()
+	. = ..()
+	var/warning_message = pick(infection_messages)
+	if(prob(10))
+		to_chat(owner, span_userdanger("[warning_message]"))
+	else
+		to_chat(owner, span_danger("[warning_message]"))
+	var/mob/living/carbon/human/H = owner
+	if(!iscarbon(H))
+		owner.remove_status_effect(/datum/status_effect/zombie_infection)
+	H.vomit(1, blood = TRUE, stun = FALSE)
+	return TRUE
+
+/atom/movable/screen/alert/status_effect/zombie_infection
+	name = "Zombie Infection"
+	desc = "You feel a coldness spreading through your body. You're turning into one of -them-!"
+	icon_state = "zombie"
+
+// Updated proc to use status effect
+/mob/living/carbon/human/proc/attempt_zombie_infection(mob/living/carbon/human/source, infection_type, wake_delay = 0)
+	var/datum/antagonist/zombie/zombie_antag = source.mind?.has_antag_datum(/datum/antagonist/zombie)
+	if(!zombie_antag || !zombie_antag.has_turned)
+		return FALSE
+
+	if(mind?.has_antag_datum(/datum/antagonist/zombie))
+		return FALSE
+
+	// Apply status effect with timer
+	apply_status_effect(
+		/datum/status_effect/zombie_infection, 
+		wake_delay, 
+		infection_type == "wound"
+	)
+	
+	switch(infection_type)
+		if("bite")
+			to_chat(src, span_danger("A growing cold seeps into my body. I feel horrible... REALLY horrible..."))
+		if("wound")
+			flash_fullscreen("redflash3")
+			to_chat(src, span_danger("Ow! It hurts. I feel horrible... REALLY horrible..."))
+	
+	return TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -707,7 +707,7 @@
 		examination += bodypart.check_for_injuries(user, deep_examination)
 
 	examination += "ø ------------ ø</span>"
-	if(infected)
+	if(has_status_effect(/datum/status_effect/zombie_infection) || infected)
 		examination += span_boldwarning("[m1] slowly rotting away.")
 
 	if(!silent)

--- a/code/modules/mob/living/carbon/human/npc/deadite.dm
+++ b/code/modules/mob/living/carbon/human/npc/deadite.dm
@@ -164,11 +164,13 @@
 		return
 	if(stat >= DEAD) //do shit the natural way i guess
 		return
+	if(!prob(ZOMBIE_INFECTION_PROBABILITY))	//Failed the probability of infection
+		return
 	to_chat(src, span_danger("I feel horrible... REALLY horrible..."))
 	mob_timers["puke"] = world.time
 	vomit(1, blood = TRUE, stun = FALSE)
 	src.infected = TRUE //Is this in use? Just in case it is
-	addtimer(CALLBACK(src, PROC_REF(wake_zombie)), 1 MINUTES)
+	apply_status_effect(/datum/status_effect/zombie_infection, 5 MINUTES, "wound")
 	return zombie_antag
 
 /mob/living/carbon/human/proc/wake_zombie()

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
@@ -29,8 +29,8 @@
 	if(QDELETED(H) || !H.zombie_check_can_convert())
 		return
 	to_chat(H, span_danger("A growing cold seeps into my body. I feel horrible... REALLY horrible..."))
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(wake_zombie), H, FALSE, TRUE), infection_timer, TIMER_STOPPABLE)
 	H.infected = TRUE
+	H.apply_status_effect(/datum/status_effect/zombie_infection, infection_timer, "wound")
 
 GLOBAL_LIST_INIT(animal_to_undead, list(
 	/mob/living/simple_animal/hostile/retaliate/rogue/saiga = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/undead,

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1193,6 +1193,7 @@
 #include "code\modules\antagonists\roguetown\villain\werewolf\werewolf_wound_infection.dm"
 #include "code\modules\antagonists\roguetown\villain\zombie\remove_rot.dm"
 #include "code\modules\antagonists\roguetown\villain\zombie\zombie.dm"
+#include "code\modules\antagonists\roguetown\villain\zombie\zombie_disease.dm"
 #include "code\modules\antagonists\roguetown\villain\zombie\zombie_verbs.dm"
 #include "code\modules\antagonists\roguetown\villain\zombie\zombie_wound_infection.dm"
 #include "code\modules\antagonists\separatist\separatist.dm"


### PR DESCRIPTION
## About The Pull Request
- Reworks a small part of deadite code to provide PROPER USER FEEDBACK when infected.
- Fixes an issue where the timer on infection would get replaced by a new one, causing the old one to get cleaned up and immediately call deadite infection. (aka, instant infection)
- People will be periodically notified that they need to get cured via flavorful zombie messages.
- standard deadite infection time is now also 5 minutes instead of 1 minute. It was hard to tell you were infected at times, and this literally doesn't give you time to kill the deadite and get cured. With deadite NPCs being commonplace, this feels needed.

## Testing Evidence
<img width="1150" height="693" alt="image" src="https://github.com/user-attachments/assets/0ff451c5-03da-4fb2-b236-121597dfb332" />

## Why It's Good For The Game
Bugfixes, user feedback and QoL? OHMIGOD
