### PR TITLE
Right click now sell items on your turf instead of in front of stockp…

### DIFF
--- a/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
@@ -21,6 +21,10 @@
 	SSroguemachine.stock_machines -= src
 	return ..()
 
+/obj/structure/roguemachine/stockpile/examine(mob/user)
+	. = ..()
+	. += span_info("Right click to sell everything on your turf into the stockpile.")
+
 /obj/structure/roguemachine/stockpile/Topic(href, href_list)
 	. = ..()
 	if(!usr.canUseTopic(src, BE_CLOSE))
@@ -162,7 +166,7 @@
 
 /obj/structure/roguemachine/stockpile/attack_right(mob/user)
 	if(ishuman(user))
-		for(var/obj/I in get_turf(src))
+		for(var/obj/I in get_turf(user))
 			attemptsell(I, user, FALSE, FALSE)
 		say("Bulk selling in progress...")
 		playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)


### PR DESCRIPTION
## About The Pull Request
Change stockpile code such that it bulk sell items that is on **YOUR** turf when you bulk sell, instead of on its turf. This has various benefits:

- No need to do fuckery on map to make sure the offset is right or make sure the stockpile always face south for convenient use
- You can stand on top of your pile of crap to prevent someone from selling it on your behalf :)

Also add examine to describe this function

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="996" height="724" alt="dreamseeker_KEUqhNIeXD" src="https://github.com/user-attachments/assets/cf7f7c4e-757d-499f-88e2-4ed818bddf5c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Said above

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
