### PR TITLE
Dungeoneer's Apprentice Virtue gives Whip instead of Axe

### DIFF
--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -78,9 +78,9 @@
 
 /datum/virtue/combat/executioner
 	name = "Dungeoneer's Apprentice"
-	desc = "I was set to be a dungeoneer some time ago, and I was taught by one. I have an axe stashed away if the need arises."
+	desc = "I was set to be a dungeoneer some time ago, and I was taught by one. I have a whip stashed away if the need arises."
 	custom_text = "+1 to Axes and Whips/Flails, Up to Journeyman, Minimum Apprentice."
-	added_stashed_items = list("Iron Axe" = /obj/item/rogueweapon/stoneaxe/woodcut)
+	added_stashed_items = list("Leather Whip" = /obj/item/rogueweapon/whip)
 
 /datum/virtue/combat/executioner/apply_to_human(mob/living/carbon/human/recipient)
 	if(recipient.get_skill_level(/datum/skill/combat/whipsflails) < SKILL_LEVEL_APPRENTICE)


### PR DESCRIPTION
## About The Pull Request

Instead of an iron axe, dungeoneer apprentice users get a basic leather whip.

## Testing Evidence

<img width="433" height="285" alt="image" src="https://github.com/user-attachments/assets/ee38a506-61e3-45fd-9a92-5b2bcf55954b" />

## Why It's Good For The Game

Something, something, "makes more sense, dungeoneers of azuria are associated with their whip usage"-

whatever, you already know