### PR TITLE
Parry level ups and bucklers now only work with combat skills

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -296,7 +296,7 @@
 			weapon_parry = TRUE
 	if(istype(mainhand, /obj/item/rogueweapon/shield/buckler))
 		associated_skill = /datum/skill/combat/shields
-	if(weapon_parry && mainhand.associated_skill)
+	if(weapon_parry && mainhand.associated_skill && ispath(mainhand.associated_skill, /datum/skill/combat))
 		associated_skill = mainhand.associated_skill
 	else
 		associated_skill = /datum/skill/combat/shields

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -208,7 +208,7 @@
 				var/skill_target = attacker_skill
 				if(!HAS_TRAIT(U, TRAIT_GOODTRAINER))
 					skill_target -= SKILL_LEVEL_NOVICE
-				if (can_train_combat_skill(src, used_weapon.associated_skill, skill_target))
+				if (can_train_combat_skill(src, used_weapon.associated_skill, skill_target) && ispath(used_weapon.associated_skill, /datum/skill/combat))
 					mind.add_sleep_experience(used_weapon.associated_skill, max(round(STAINT*exp_multi), 0), FALSE)
 
 			var/obj/item/AB = intenty.masteritem
@@ -225,7 +225,7 @@
 					var/skill_target = defender_skill
 					if(!HAS_TRAIT(src, TRAIT_GOODTRAINER))
 						skill_target -= SKILL_LEVEL_NOVICE
-					if (can_train_combat_skill(U, attacker_skill_type, skill_target))
+					if (can_train_combat_skill(U, attacker_skill_type, skill_target) && ispath(attacker_skill_type, /datum/skill/combat))
 						U.mind.add_sleep_experience(attacker_skill_type, max(round(STAINT*exp_multi), 0), FALSE)
 
 			if(prob(66) && AB)


### PR DESCRIPTION
## About The Pull Request
you can no longer wield a pickaxe / frying pan with a buckler, the buckler won't inherit the gimmick skill
nor can you level up knights with your legendary pancake flipping skills

this does not change the offensive boons of those gimmick weapons, beware the chef clobbering you
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="579" height="490" alt="dreamseeker_mBAPVMw4ex" src="https://github.com/user-attachments/assets/708bcce1-c9d2-498d-ae5a-fdb8744daa84" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
you guys need to do less "stop and think" about all these edgecase mechanics and start topping some twinks I feel like a janitor over here
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
