### PR TITLE
"Refactors" rmb_intent attack chain, allowing guard to be used during click cd

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -101,6 +101,10 @@
 	if(SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, params) & COMSIG_MOB_CANCEL_CLICKON)
 		return
 
+	if(modifiers["right"] && !modifiers["shift"] && !modifiers["alt"] && !modifiers["ctrl"])
+		if(try_special_attack(A, modifiers))
+			return
+
 	if(next_move > world.time)
 		return
 
@@ -891,3 +895,52 @@
 	tempfixeye = TRUE
 	for(var/atom/movable/screen/eye_intent/eyet in hud_used.static_inventory)
 		eyet.update_icon(src) //Update eye icon
+
+/// A special proc to fire rmb_intents *before* checking click cooldown, since some intents (guard) should be used regardless of CD.
+/mob/proc/try_special_attack(atom/A, list/modifiers)
+	return FALSE
+
+/mob/living/try_special_attack(atom/A, list/modifiers)
+	if(!rmb_intent || !cmode || istype(A, /obj/item/clothing) || istype(A, /obj/item/quiver) || istype(A, /obj/item/storage))
+		return FALSE
+
+	if(next_move > world.time && !rmb_intent?.bypasses_click_cd)
+		return FALSE
+
+	if(rmb_intent?.adjacency && !Adjacent(A))
+		return FALSE
+
+	var/held = get_active_held_item()
+	if(held && istype(held, /obj/item))
+		var/obj/item/I = held
+		if(!I.associated_skill)
+			return FALSE
+
+		rmb_intent.special_attack(src, ismob(A) ? A : get_foe_from_turf(get_turf(A)))
+		return TRUE
+
+/mob/living/carbon/human/species/skeleton/try_special_attack(atom/A, list/modifiers)
+	return FALSE
+
+/// Used for "directional" style rmb attacks on a turf, prioritizing standing targets
+/mob/living/proc/get_foe_from_turf(turf/T)
+	if(!istype(T))
+		return
+
+	var/list/mob/living/foes = list()
+	for(var/mob/living/foe_in_turf in T)
+		var/foe_prio = rand(4, 8)
+		if(foe_in_turf.mobility_flags & MOBILITY_STAND)
+			foe_prio += 10
+		else if(foe_in_turf == src)
+			foe_prio = -10
+		else if(foe_in_turf.stat != CONSCIOUS)
+			foe_prio = 2
+		else if(foe_in_turf.surrendering)
+			foe_prio = -5
+
+		foes[foe_in_turf] = foe_prio
+
+	if(foes.len > 1)
+		sortTim(foes, cmp = /proc/cmp_numeric_dsc, associative = TRUE)
+	return foes[1]

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -112,20 +112,14 @@
 //	if(!user.Adjacent(src)) //alreadyu checked in rmb_on
 //		return
 	user.face_atom(src)
-	if(user.cmode)
-		if(user.rmb_intent && istype(user.rmb_intent))
-			user.rmb_intent.special_attack(user, src)
-	else
+	if(!user.cmode)
 		user.changeNext_move(CLICK_CD_RAPID)
 		ongive(user, params)
 
 /turf/attack_right(mob/user, params)
 	. = ..()
 	user.face_atom(src)
-	if(user.cmode)
-		if(user.rmb_intent && istype(user.rmb_intent))
-			user.rmb_intent.special_attack(user, src)
-	else
+	if(!user.cmode)
 		user.changeNext_move(CLICK_CD_RAPID)
 
 /atom/proc/ongive(mob/user, params)

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -2,7 +2,10 @@
 	var/name = "intent"
 	var/desc = ""
 	var/icon_state = ""
+	/// Whether this intent requires user to be adjacent to their target or not
 	var/adjacency = TRUE
+	/// Determines whether this intent can be used during click cd
+	var/bypasses_click_cd = FALSE
 
 /mob/living/carbon/human
 	var/bait_stacks
@@ -10,16 +13,6 @@
 /mob/living/carbon/human/on_cmode()
 	if(!cmode)	//We just toggled it off.
 		addtimer(CALLBACK(src, PROC_REF(purge_bait)), 30 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
-
-/mob/living/carbon/human/RightClickOn(atom/A, params)
-	if(rmb_intent && !rmb_intent.adjacency && !istype(A, /obj/item/clothing) && cmode && !istype(src, /mob/living/carbon/human/species/skeleton) && !istype(A, /obj/item/quiver) && !istype(A, /obj/item/storage))
-		var/held = get_active_held_item()
-		if(held && istype(held, /obj/item))
-			var/obj/item/I = held
-			if(I.associated_skill)
-				rmb_intent.special_attack(src, A)
-	else
-		. = ..()
 
 /datum/rmb_intent/proc/special_attack(mob/living/user, atom/target)
 	return
@@ -187,6 +180,7 @@
 	desc = "No delay between dodge and parry rolls.\n(RMB WHILE NOT GRABBING ANYTHING AND HOLDING A WEAPON)\nEnter a defensive stance, guaranteeing the next hit is defended against.\nTwo people who hit each other with the Guard up will have their weapons Clash, potentially disarming them.\nLetting it expire or hitting someone with it who has no Guard up is tiresome."
 	icon_state = "rmbdef"
 	adjacency = FALSE
+	bypasses_click_cd = TRUE
 
 /datum/rmb_intent/riposte/special_attack(mob/living/user, atom/target)	//Wish we could breakline these somehow.
 	if(!user.has_status_effect(/datum/status_effect/buff/clash) && !user.has_status_effect(/datum/status_effect/debuff/clashcd))


### PR DESCRIPTION
## About The Pull Request

Guard rmb intent was intended to bypass click cd. Unfortunately, this was not the case.

Solution: snowflake try_special_attack() chain that fires before next_move check happens (Opposed to a mob listening to their own signals).

- Special attacks can be fired in a 'non-targeted' fashion, by just clicking a turf. Special intent will hit a random mob on it, prioritizing standing mobs and giving lower priority to unconscious, resting and surrendering mobs.
- Guard can be raised bypassing click cd

## Testing Evidence

Non-targeted feint, targeted aimed and guard through click cd. WORKS!

https://github.com/user-attachments/assets/f645c4bc-7d4d-41f1-bc6a-e5b2e2b0ee7f

## Why It's Good For The Game

Guard special attack was intended to bypass click cd, so this is, basically, a bufgix.