### PR TITLE
Dusters & Denim - Rearms the Adventure!Monks, reduces the stamina cost of punching, and undyes (+strengthens) the Monkvestments.

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -456,8 +456,8 @@
 	noaa = FALSE
 	animname = "bite"
 	hitsound = list('sound/combat/hits/punch/punch (1).ogg', 'sound/combat/hits/punch/punch (2).ogg', 'sound/combat/hits/punch/punch (3).ogg')
-	misscost = 5
-	releasedrain = 2	//Lowered for intent stam usage.
+	misscost = 4
+	releasedrain = 1
 	swingdelay = 0
 	clickcd = 10
 	rmb_ranged = TRUE

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -182,6 +182,7 @@
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT, BCLASS_TWIST)	//Same as gloves
 	max_integrity = 100			//Half that of iron boots
 	armor = ARMOR_BOOTS			//Better than regular leather.
+	color = null
 
 /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/short
 	name = "dress boots"

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -140,7 +140,8 @@
 	desc = "Nomadic vestments, worn by those who pursue faith above all else. The burlap is thickly-woven and padded, in order to ward off whatever threats may arise during one's pilgrimage: be it a biting chill or a volley of arrows."
 	icon_state = "monkvestments"
 	item_state = "monkvestments"
-	armor = ARMOR_PADDED	//Equal to gamby
+	armor = ARMOR_PADDED_GOOD	//Equal to a padded gambeson, like before.
+	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_CHOP)	 //Ensures that this inherits the padded gambeson's resistances, too.
 	color = null
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -128,16 +128,16 @@
 	if(!HAS_TRAIT(user, TRAIT_CHOSEN))	//Requires this cus it's a priest-only thing.
 		return
 	ADD_TRAIT(user, TRAIT_MONK_ROBE, TRAIT_GENERIC)
-	to_chat(user, span_notice("With my vows to poverty and my vestments, I feel vigerous - empowered by the gods!"))
+	to_chat(user, span_notice("With my vows to poverty and my vestments, I feel vigorous - empowered by my God!"))
 
 /obj/item/clothing/suit/roguetown/shirt/robe/priest/dropped(mob/living/user)
 	..()
 	REMOVE_TRAIT(user, TRAIT_MONK_ROBE, TRAIT_GENERIC)
-	to_chat(user, span_notice("I must lay down my robes and rest; even god's chosen must rest.."))
+	to_chat(user, span_notice("I must lay down my robes and rest; even God's chosen must rest.."))
 
 /obj/item/clothing/suit/roguetown/shirt/robe/monk
 	name = "monk vestments"
-	desc = "Holy vestments worn by the most faithful."
+	desc = "Nomadic vestments, worn by those who pursue faith above all else. The burlap is thickly-woven and padded, in order to ward off whatever threats may arise during one's pilgrimage: be it a biting chill or a volley of arrows."
 	icon_state = "monkvestments"
 	item_state = "monkvestments"
 	armor = ARMOR_PADDED	//Equal to gamby
@@ -149,12 +149,12 @@
 	if(!HAS_TRAIT(user, TRAIT_CIVILIZEDBARBARIAN))	//Requires this cus it's a monk-only thing.
 		return
 	ADD_TRAIT(user, TRAIT_MONK_ROBE, TRAIT_GENERIC)
-	to_chat(user, span_notice("With my vows to poverty and my vestments, I feel vigerous - empowered by the gods!"))
+	to_chat(user, span_notice("With my vows to poverty and my vestments, I feel vigorous - empowered by my God!"))
 
 /obj/item/clothing/suit/roguetown/shirt/robe/monk/dropped(mob/living/user)
 	..()
 	REMOVE_TRAIT(user, TRAIT_MONK_ROBE, TRAIT_GENERIC)
-	to_chat(user, span_notice("I must lay down my robes and rest; even god's chosen must rest.."))
+	to_chat(user, span_notice("I must lay down my robes and rest; even God's chosen must rest.."))
 
 /obj/item/clothing/suit/roguetown/shirt/robe/courtmage
 	color = "#6c6c6c"

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -141,6 +141,7 @@
 	icon_state = "monkvestments"
 	item_state = "monkvestments"
 	armor = ARMOR_PADDED	//Equal to gamby
+	color = null
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 
 /obj/item/clothing/suit/roguetown/shirt/robe/monk/equipped(mob/living/user, slot)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -58,6 +58,13 @@
 			H.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+			var/weapons = list("Katar","Knuckle Dusters")
+			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			switch(weapon_choice)
+				if("Katar")
+					backpack_contents += list(/obj/item/rogueweapon/katar = 1)
+				if("Knuckle Dusters")
+					backpack_contents += list(/obj/item/rogueweapon/knuckles/bronzeknuckles = 1)
 			H.cmode_music = 'sound/music/combat_holy.ogg' // left in bc i feel like monk players want their darktide
 			switch(H.patron?.type)
 				if(/datum/patron/old_god)


### PR DESCRIPTION
## About The Pull Request
In order..
* Restores the option for Adventure!Monks to pick either a _katar_ or some _knuckledusters_. Following the precedence set by Felinid, these will be _bronze_ instead of _steel_. I don't actually have a sprite for the _bronze katar_ yet, but we'll get that added within the week.
* Reduces the cost of punching to _one_ unit of stamina, compared to _two_. This doesn't affect _any_ other unarmed intent: the stamina costs for _grabbing_ and _wrestling_ remain the same. 
* Removes the dyes that're automatically applied to Monkvestments _(and, as I've just discovered, Heavy Leather Boots)_. Slightly tweaks the description of Monkvestments to better reflect the hidden armor values they have.
_(Addendum: upon looking at the code, I realized that monks actually had cruddier armor than before. This raises the Monkvestments' defensive values to be on par with a padded gambeson.)_

## Testing Evidence
Shouldn't cause any trouble.
Most of the changes in this pull request involve the tweaking of preexisting values, and the reintroduction of simple factors _(like the loadout system)_ for classes.

## Why It's Good For The Game
This should hopefully, _finally_, be the last major change for Monks.
* Adventure!Monks are now brought up to parity with the rest of the pugilist-centric classes, and should _now_ be more capable of defending themselves against the new _(and much-more armored)_ ambushes: highwaymen, legionnaires, etcetra.
* Punching should feel a bit less lethargic now, especially for characters who're solely dedicating themselves to pugilism _(over Unarmed-scaling weapons)_. Sacrifice your parrying percentage and integrity damage for a _full-scale_ beatdown.
* Monkvestments - like the Heavy Leather Boots - were never meant to be predyed. This restores their _intended_ coloration, and helps to better signify their _'armored'_ attribute.
_(Likewise, returning the monk's spawn-armor to 'padded gambeson'-tier levels should hopefully prevent newer players from being unwittingly instakilled. Did you know that you have to manually add critical resistances to non-armored clothes? I do, now!)_