### PR TITLE
Ambush fixes & stuffs

### DIFF
--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -488,6 +488,10 @@
 /obj/item/clothing/shoes/roguetown/boots/leather,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
+"qt" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "qA" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
@@ -1774,17 +1778,17 @@ Og
 WN
 WN
 WN
+qt
 WN
 WN
 WN
 WN
 WN
-WN
-WN
+qt
 WN
 LM
 WN
-WN
+qt
 WN
 Th
 Th
@@ -1826,7 +1830,7 @@ Og
 WN
 WN
 WN
-WN
+qt
 WN
 WN
 LM
@@ -1932,7 +1936,7 @@ WN
 WN
 WN
 WN
-WN
+qt
 WN
 WN
 WN
@@ -2087,7 +2091,7 @@ Fo
 Fo
 Fo
 WN
-WN
+qt
 WN
 WN
 WN
@@ -2096,7 +2100,7 @@ LM
 WN
 WN
 WN
-WN
+qt
 WN
 Th
 Th
@@ -2142,7 +2146,7 @@ WN
 WN
 WN
 WN
-WN
+qt
 WN
 WN
 WN
@@ -2397,12 +2401,12 @@ HA
 hp
 WN
 WN
-WN
+qt
 WN
 WN
 LM
 WN
-WN
+qt
 WN
 WN
 WN
@@ -2450,11 +2454,11 @@ HA
 WN
 WN
 WN
+qt
 WN
 WN
 WN
-WN
-WN
+qt
 WN
 LM
 WN
@@ -2564,7 +2568,7 @@ WN
 zD
 zD
 zD
-WN
+qt
 WN
 Th
 Th
@@ -2606,13 +2610,13 @@ HA
 WN
 WN
 WN
+qt
 WN
 WN
+qt
 WN
 WN
-WN
-WN
-WN
+qt
 zD
 gy
 zD
@@ -2712,7 +2716,7 @@ WN
 LM
 WN
 WN
-WN
+qt
 WN
 WN
 WN
@@ -2770,7 +2774,7 @@ LM
 WN
 WN
 WN
-WN
+qt
 WN
 LM
 WN
@@ -3130,8 +3134,8 @@ WN
 LM
 WN
 WN
-WN
-WN
+qt
+qt
 WN
 WN
 WN
@@ -3185,7 +3189,7 @@ WN
 WN
 WN
 WN
-WN
+qt
 WN
 WN
 LM
@@ -3231,7 +3235,7 @@ WN
 WN
 WN
 WN
-WN
+qt
 WN
 WN
 LM
@@ -3284,7 +3288,7 @@ WN
 WN
 WN
 WN
-WN
+qt
 WN
 WN
 WN
@@ -3333,7 +3337,7 @@ HA
 HA
 WN
 WN
-WN
+qt
 WN
 WN
 WN
@@ -3387,7 +3391,7 @@ WN
 WN
 WN
 LM
-WN
+qt
 WN
 WN
 WN
@@ -3443,7 +3447,7 @@ WN
 WN
 WN
 WN
-WN
+qt
 WN
 WN
 WN
@@ -3491,7 +3495,7 @@ WN
 LM
 WN
 WN
-WN
+qt
 WN
 WN
 WN
@@ -3500,7 +3504,7 @@ LM
 WN
 WN
 WN
-WN
+qt
 WN
 Th
 Th
@@ -3545,7 +3549,7 @@ WN
 WN
 WN
 WN
-WN
+qt
 WN
 WN
 WN

--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -743,6 +743,10 @@
 /obj/item/clothing/gloves/roguetown/plate,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
+"zW" = (
+/obj/structure/flora/roguegrass/bush,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors/rtfield)
 "zZ" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/grass,
@@ -1780,7 +1784,7 @@ WN
 WN
 qt
 WN
-WN
+zW
 WN
 WN
 WN
@@ -1835,7 +1839,7 @@ WN
 WN
 LM
 WN
-WN
+zW
 WN
 WN
 WN
@@ -1986,7 +1990,7 @@ HA
 WN
 WN
 WN
-WN
+zW
 WN
 WN
 WN
@@ -2045,7 +2049,7 @@ LM
 WN
 WN
 WN
-WN
+zW
 WN
 WN
 WN
@@ -2505,11 +2509,11 @@ HA
 hp
 WN
 WN
-WN
+zW
 WN
 LM
 WN
-WN
+zW
 WN
 WN
 WN
@@ -2715,13 +2719,13 @@ WN
 WN
 LM
 WN
-WN
+zW
 qt
 WN
 WN
 WN
 WN
-WN
+zW
 WN
 WN
 WN
@@ -3191,7 +3195,7 @@ WN
 WN
 qt
 WN
-WN
+zW
 LM
 WN
 Th
@@ -3233,7 +3237,7 @@ HA
 HA
 WN
 WN
-WN
+zW
 WN
 qt
 WN
@@ -3292,7 +3296,7 @@ qt
 WN
 WN
 WN
-WN
+zW
 zD
 zD
 zD
@@ -3445,13 +3449,13 @@ WN
 WN
 WN
 WN
-WN
+zW
 WN
 qt
 WN
 WN
 WN
-WN
+zW
 WN
 WN
 Th
@@ -3494,7 +3498,7 @@ hp
 WN
 LM
 WN
-WN
+zW
 qt
 WN
 WN

--- a/code/game/area/actualcoast.dm
+++ b/code/game/area/actualcoast.dm
@@ -13,10 +13,6 @@
 
 /area/rogue/outdoors/beach/north
 	name = "Northern Coast"
-	ambush_types = list(
-		/turf/open/floor/rogue/dirt,
-		/turf/open/floor/rogue/grass,
-		/turf/open/floor/rogue/AzureSand)
 	ambush_mobs = list(
 		/mob/living/carbon/human/species/human/northern/searaider/ambush = 10,
 		/mob/living/carbon/human/species/goblin/npc/ambush/sea = 20,
@@ -27,10 +23,6 @@
 
 /area/rogue/outdoors/beach/south
 	name = "Southern Coast"
-	ambush_types = list(
-			/turf/open/floor/rogue/dirt,
-			/turf/open/floor/rogue/grass,
-			/turf/open/floor/rogue/AzureSand)
 	ambush_mobs = list(
 		/mob/living/carbon/human/species/human/northern/searaider/ambush = 5,
 		/mob/living/carbon/human/species/goblin/npc/ambush/sea = 20,

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -104,7 +104,6 @@
 	/// typecache to limit the areas that atoms in this area can smooth with, used for shuttles IIRC
 	var/list/canSmoothWithAreas
 
-	var/list/ambush_types
 	var/list/ambush_mobs
 	var/list/ambush_times
 

--- a/code/game/area/mountdecap.dm
+++ b/code/game/area/mountdecap.dm
@@ -2,13 +2,6 @@
 /area/rogue/outdoors/mountains/decap
 	name = "mt decapitation"
 	icon_state = "decap"
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt,
-				/turf/open/floor/rogue/dirt/road,
-				/turf/open/floor/rogue/snow,
-				/turf/open/floor/rogue/grasscold,
-				/turf/open/floor/rogue/grass,
-				)
 	ambush_mobs = list(
 				new /datum/ambush_config/pair_of_direbear = 10,
 				new /datum/ambush_config/trio_of_highwaymen = 10,
@@ -37,13 +30,6 @@
 /area/rogue/outdoors/mountains/decap/stepbelow
 	name = "Tarichea - Valley of Loss"
 	icon_state = "decap"
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt,
-				/turf/open/floor/rogue/dirt/road,
-				/turf/open/floor/rogue/snow,
-				/turf/open/floor/rogue/grasscold,
-				/turf/open/floor/rogue/grass,
-				)
 	ambush_mobs = list(
 				new /datum/ambush_config/pair_of_direbear = 10,
 				new /datum/ambush_config/trio_of_highwaymen = 10,
@@ -64,10 +50,6 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak
 	name = "Gundu Zirak"
 	icon_state = "decap"
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt,
-				/turf/open/floor/rogue/cobble,
-				)
 	ambush_mobs = list(
 				new /datum/ambush_config/treasure_hunter_posse = 1,
 				/mob/living/carbon/human/species/dwarfskeleton/ambush = 30,

--- a/code/game/area/northcoast.dm
+++ b/code/game/area/northcoast.dm
@@ -12,9 +12,6 @@
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	soundenv = 15
 	ambush_times = list("night","dusk")
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt,
-				/turf/open/floor/rogue/grass)
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 30,
 				/mob/living/simple_animal/hostile/retaliate/rogue/mole = 10,
@@ -33,7 +30,6 @@
 /area/rogue/outdoors/beach/forest/hamlet
 	name = "The Azure Coast - Hamlet"
 	first_time_text = "THE HAMLET"
-	ambush_types = null
 	ambush_mobs = null // We don't want actual ambushes in Hamlet but we also don't want to misuse outdoors/beach lol
 
 /area/rogue/outdoors/beach/forest/north

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -143,9 +143,6 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	icon_state = "rtfield"
 	soundenv = 19
 	ambush_times = list("night")
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt,
-				/turf/open/floor/rogue/grass)
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf/bobcat = 20,
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 30,
@@ -188,10 +185,6 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound = 'sound/music/area/morosewaters.ogg'
 	droning_sound_dusk = 'sound/music/area/morosewaters.ogg'
 	droning_sound_night = 'sound/music/area/angrywaters.ogg'
-	ambush_types = list(
-		/turf/open/floor/rogue/grasscold,
-		/turf/open/floor/rogue/dirt
-	)
 	ambush_mobs = list(
 		/mob/living/simple_animal/hostile/rogue/deepone = 50,
 		/mob/living/simple_animal/hostile/rogue/deepone/spit = 30
@@ -241,8 +234,6 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = null
 	droning_sound_night = null
 	ambush_times = list("night","dawn","dusk","day")
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt)
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 30,
 				/mob/living/carbon/human/species/goblin/npc/ambush/cave = 20,
@@ -298,8 +289,6 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	spookysounds = SPOOKY_CAVE
 	spookynight = SPOOKY_CAVE
 	ambush_times = list("night","dawn","dusk","day")
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt)
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 10,
 				/mob/living/carbon/human/species/skeleton/npc/ambush = 20,

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -167,9 +167,6 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	icon_state = "eora"
 	soundenv = 19
 	ambush_times = list("night")
-	ambush_mobs = list(
-				/mob/living/simple_animal/hostile/retaliate/rogue/fae/glimmerwing = 20,
-				/mob/living/simple_animal/hostile/retaliate/rogue/fae/sprite = 30)
 	first_time_text = "EORAN SHRINE"
 	droning_sound = 'sound/newmusic/lovecraft2.ogg'
 	droning_sound_dusk = 'sound/newmusic/lovecraft2.ogg'

--- a/code/game/area/terrorbog.dm
+++ b/code/game/area/terrorbog.dm
@@ -10,10 +10,6 @@
 	droning_sound_dusk = null
 	droning_sound_night = null
 	ambush_times = list("night","dawn","dusk","day")
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt,
-				/turf/open/floor/rogue/grass,
-				/turf/open/water)
 	//Minotaurs too strong for the lazy amount of places this area covers
 	ambush_mobs = list(
 				/mob/living/carbon/human/species/skeleton/npc/ambush = 20,

--- a/code/game/area/underdark.dm
+++ b/code/game/area/underdark.dm
@@ -11,8 +11,6 @@
 	droning_sound_dusk = null
 	droning_sound_night = null
 	ambush_times = list("night","dawn","dusk","day")
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt)
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated = 20,
 				/mob/living/carbon/human/species/elf/dark/drowraider/ambush = 10,

--- a/code/game/area/undergrove.dm
+++ b/code/game/area/undergrove.dm
@@ -11,8 +11,6 @@
 	droning_sound_dusk = null
 	droning_sound_night = null
 	ambush_times = list("night","dawn","dusk","day")
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt)
 	ambush_mobs = list(
 				/mob/living/carbon/human/species/skeleton/npc/easy = 10,
 				/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 30,

--- a/code/game/area/woods.dm
+++ b/code/game/area/woods.dm
@@ -13,9 +13,6 @@
 	soundenv = 15
 	warden_area = TRUE
 	ambush_times = list("night","dawn","dusk","day")
-	ambush_types = list(
-				/turf/open/floor/rogue/dirt,
-				/turf/open/floor/rogue/grass)
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 40,
 				/mob/living/carbon/human/species/skeleton/npc/easy = 10,

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -55,26 +55,18 @@ GLOBAL_LIST_INIT(valid_ambush_turfs, list(
 		if(istype(RT,/obj/structure/flora/roguetree/stump))
 			continue
 		if(isturf(RT.loc))
-			var/turf/src_turf = get_turf(RT)
-			for(var/turf/AT in get_adjacent_turfs(RT))
-				if(src_turf.LinkBlockedWithAccess(AT, src))
-					continue	
-				possible_targets += AT
-//	for(var/obj/structure/flora/roguegrass/bush/RB in range(7, src))
-//		if(can_see(src, RB))
-//			possible_targets += RB
-	for(var/obj/structure/flora/rogueshroom/RX in view(5, src))
+			possible_targets += get_adjacent_ambush_turfs(RT.loc)
+	for(var/obj/structure/flora/roguegrass/bush/RB in view(5, src))
+		if(isturf(RB.loc))
+			possible_targets += get_adjacent_ambush_turfs(RB.loc)
+	for(var/obj/structure/flora/rogueshroom/RX in view(5, src))w
 		if(isturf(RX.loc))
-			possible_targets += RX.loc
+			possible_targets += get_adjacent_ambush_turfs(RX.loc)
 	for(var/obj/structure/flora/newtree/RS in view(5, src))
 		if(!RS.density)
 			continue
 		if(isturf(RS.loc))
-			var/turf/src_turf = get_turf(RS)
-			for(var/turf/AT in get_adjacent_turfs(RS))
-				if(src_turf.LinkBlockedWithAccess(AT, src))
-					continue
-				possible_targets += AT
+			possible_targets += get_adjacent_ambush_turfs(RS.loc)
 	if(possible_targets.len)
 		mob_timers["ambushlast"] = world.time
 		for(var/mob/living/V in victimsa)
@@ -128,3 +120,11 @@ GLOBAL_LIST_INIT(valid_ambush_turfs, list(
 			var/mob/living/carbon/C = src
 			if(C.get_stress_amount() >= 30 && (prob(0)))
 				C.heart_attack()
+
+/proc/get_adjacent_ambush_turfs(turf/T)
+	var/list/adjacent = list()
+	for(var/turf/AT in get_adjacent_turfs(T))
+		if(AT.density || T.LinkBlockedWithAccess(AT, null))
+			continue
+		adjacent += AT
+	return adjacent

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -1,5 +1,17 @@
 GLOBAL_VAR_INIT(ambush_chance_pct, 20) // Please don't raise this over 100 admins :')
 GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 5 MINUTES) // Cooldown for each individual mob being considered for an ambush
+// Instead of setting it on area and hoping no one forgets it on area we're just doing this
+GLOBAL_LIST_INIT(valid_ambush_turfs, list(
+	/turf/open/floor/rogue/dirt,
+	/turf/open/floor/rogue/dirt/road,
+	/turf/open/floor/rogue/grass,
+	/turf/open/floor/rogue/grasscold,
+	/turf/open/floor/rogue/cobble,
+	/turf/open/floor/rogue/sand,
+	/turf/open/floor/rogue/snow,
+	/turf/open/floor/rogue/AzureSand,
+	/turf/open/water
+))
 
 /mob/living/proc/ambushable()
 	if(stat)
@@ -21,7 +33,7 @@ GLOBAL_VAR_INIT(ambush_mobconsider_cooldown, 5 MINUTES) // Cooldown for each ind
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
-	if(!(T.type in AR.ambush_types))
+	if(!(T.type in GLOB.valid_ambush_turfs))
 		return
 	var/campfires = 0
 	for(var/obj/machinery/light/rogue/RF in view(5, src))

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(valid_ambush_turfs, list(
 	for(var/obj/structure/flora/roguegrass/bush/RB in view(5, src))
 		if(isturf(RB.loc))
 			possible_targets += get_adjacent_ambush_turfs(RB.loc)
-	for(var/obj/structure/flora/rogueshroom/RX in view(5, src))w
+	for(var/obj/structure/flora/rogueshroom/RX in view(5, src))
 		if(isturf(RX.loc))
 			possible_targets += get_adjacent_ambush_turfs(RX.loc)
 	for(var/obj/structure/flora/newtree/RS in view(5, src))

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -55,21 +55,26 @@ GLOBAL_LIST_INIT(valid_ambush_turfs, list(
 		if(istype(RT,/obj/structure/flora/roguetree/stump))
 			continue
 		if(isturf(RT.loc))
-			testing("foundtree")
-			possible_targets += RT.loc
+			var/turf/src_turf = get_turf(RT)
+			for(var/turf/AT in get_adjacent_turfs(RT))
+				if(src_turf.LinkBlockedWithAccess(AT, src))
+					continue	
+				possible_targets += AT
 //	for(var/obj/structure/flora/roguegrass/bush/RB in range(7, src))
 //		if(can_see(src, RB))
 //			possible_targets += RB
 	for(var/obj/structure/flora/rogueshroom/RX in view(5, src))
 		if(isturf(RX.loc))
-			testing("foundshroom")
 			possible_targets += RX.loc
 	for(var/obj/structure/flora/newtree/RS in view(5, src))
 		if(!RS.density)
 			continue
 		if(isturf(RS.loc))
-			testing("foundshroom")
-			possible_targets += RS.loc
+			var/turf/src_turf = get_turf(RS)
+			for(var/turf/AT in get_adjacent_turfs(RS))
+				if(src_turf.LinkBlockedWithAccess(AT, src))
+					continue
+				possible_targets += AT
 	if(possible_targets.len)
 		mob_timers["ambushlast"] = world.time
 		for(var/mob/living/V in victimsa)


### PR DESCRIPTION
## About The Pull Request
- Add some grass and bushes to Roguetest for testing purposes
- Ambush_type no longer exist in areas, instead pulling from a globally defined list of turfs that could trigger ambush if you walk on grass. **This means more reliable ambush triggering instead of ambush not triggering on dirt/road (???)**
- Ambush now spawn mobs adjacent to instead of on top of a potentially dense tile
- Eoran shrine ambush list of two fae types (not used) removed

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Should fix issues with mobs getting stuck due to pathfinding.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
