### PR TITLE
Decrepity & Damnation - Overhauls the presentation of 'decrepit'- and 'ancient'-tier items, reduces unintended accessability.

### DIFF
--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -226,12 +226,12 @@
 	base_type = CTYPE_COPP
 	plural_name = "zennies"
 
-// Ancient - Valueless
+// ANCIENT
 /obj/item/roguecoin/aalloy
 	name = "psilen"
-	desc = "Withered empires can never endure."
+	desc = "A coin of polished gilbranze, beheld to a fallen kingdom that hadn't endured the passage of tyme."
 	icon_state = "a1"
-	sellprice = 0
+	sellprice = 3 //Dungeon-specific coinage - valued by historians, collectors, and smelters. 
 	base_type = CTYPE_ANCIENT
 	plural_name = "psila"
 

--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -204,7 +204,7 @@
 
 /obj/item/rogueweapon/stoneaxe/woodcut/aaxe
 	name = "decrepit axe"
-	desc = "A hatchet of frayed bronze, weighted for chopping and tossing alike."
+	desc = "A hatchet of frayed bronze. It reigns from a tyme before the Comet Syon's impact; when Man wrought metal not to spill blood, but to better shape the world in His image."
 	icon_state = "ahandaxe"
 	force = 17
 	force_wielded = 20
@@ -306,7 +306,7 @@
 
 /obj/item/rogueweapon/stoneaxe/woodcut/steel/paaxe
 	name = "ancient alloy axe"
-	desc = "A hatchet of polished gilbranze. The palisades and walls of defenders-galore must be torn down, if Her will is to be imposed upon the unenlightened."
+	desc = "A hatchet of polished gilbranze. Vheslyn molested the hearts of Man with sin - of greed towards the better offerings, and of lust for His divinity. With a single blow, blood gouted from bone and seeped into the soil; the first murder."
 	icon_state = "ahandaxe"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -204,13 +204,15 @@
 
 /obj/item/rogueweapon/stoneaxe/woodcut/aaxe
 	name = "decrepit axe"
-	desc = "An axe which has fallen to Aeon's grasp. Withered and worn."
+	desc = "A hatchet of frayed bronze, weighted for chopping and tossing alike."
 	icon_state = "ahandaxe"
-	smeltresult = /obj/item/ingot/aalloy
 	force = 17
 	force_wielded = 20
 	max_integrity = 180
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/stoneaxe/hurlbat
 	name = "hurlbat"
@@ -304,7 +306,7 @@
 
 /obj/item/rogueweapon/stoneaxe/woodcut/steel/paaxe
 	name = "ancient alloy axe"
-	desc = "An ancient axe, Aeon's grasp has been lifted from it."
+	desc = "A hatchet of polished gilbranze. The palisades and walls of defenders-galore must be torn down, if Her will is to be imposed upon the unenlightened."
 	icon_state = "ahandaxe"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -85,13 +85,15 @@
 
 /obj/item/rogueweapon/mace/alloy
 	name = "decrepit mace"
-	desc = "A decrepit old mace. Aeon's grasp is upon it."
+	desc = "A weathered bludgeon, wrought from frayed bronze. If it was once considered 'ornate', it sure-as-hell isn't now."
 	icon_state = "amace"
-	smeltresult = /obj/item/ingot/aalloy
 	force = 17
 	force_wielded = 21
 	max_integrity = 180
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 
 /obj/item/rogueweapon/mace/church
@@ -117,7 +119,7 @@
 
 /obj/item/rogueweapon/mace/steel/palloy
 	name = "ancient alloy mace"
-	desc = "A ancient mace. Aeon's grasp has been lifted from it."
+	desc = "A bludgeon of polished gilbranze. A symbol of power, destined to be paraded through the kingdoms toppled by Her undying legionnaires."
 	icon_state = "amace"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -341,12 +343,14 @@
 
 /obj/item/rogueweapon/mace/goden/aalloy
 	name = "decrepit grand mace"
-	desc = "A decrepit old grand mace. Aeon's grasp is upon it."
+	desc = "Good nite, sire."
 	force = 12
 	force_wielded = 22
 	icon_state = "ancient_supermace"
-	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/mace/goden/steel
 	name = "grand mace"
@@ -360,7 +364,7 @@
 
 /obj/item/rogueweapon/mace/goden/steel/paalloy
 	name = "ancient grand mace"
-	desc = "A grand mace formed out of ancient alloys. Aeon's grasp lifted from its form."
+	desc = "Good evening, sire."
 	icon_state = "ancient_supermace"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -420,12 +424,14 @@
 
 /obj/item/rogueweapon/mace/warhammer/alloy
 	name = "decrepit warhammer"
-	desc = "A decrepit old warhammer. Aeon's grasp is upon it."
+	desc = "A warhammer, wrought of frayed bronze. If such a weapon was originally designed to be wielded on saigaback, then why do these undying fools have no noble steeds to ride?"
 	icon_state = "awarhammer"
-	smeltresult = /obj/item/ingot/aalloy
 	force = 17
 	max_integrity = 180
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/mace/warhammer/steel
 	force = 25
@@ -450,7 +456,7 @@
 
 /obj/item/rogueweapon/mace/warhammer/steel/paalloy
 	name = "ancient alloy warhammer"
-	desc = "A warhammer crafted of ancient alloys. Aeon's grasp has been lifted from it."
+	desc = "A warhammer, forged from polished gilbranze. An elegant weapon, reserved for far-more-inelegant foes."
 	icon_state = "awarhammer"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -364,7 +364,7 @@
 
 /obj/item/rogueweapon/mace/goden/steel/paalloy
 	name = "ancient grand mace"
-	desc = "A twisting polehammer, forged in polished gilbranze. hat did you think this was all about? This destruction, this war, this sacrifice; it was all to prepare Man for its true ascension."
+	desc = "A twisting polehammer, forged in polished gilbranze. What did you think this was all about? This destruction, this war, this sacrifice; it was all to prepare Man for its true ascension."
 	icon_state = "ancient_supermace"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -85,7 +85,7 @@
 
 /obj/item/rogueweapon/mace/alloy
 	name = "decrepit mace"
-	desc = "A weathered bludgeon, wrought from frayed bronze. If it was once considered 'ornate', it sure-as-hell isn't now."
+	desc = "Frayed bronze, perched atop a rotwooden shaft. His sacrifice had drowned Old Syon, and - in its wake - left Man bereft of all it had accomplished. With all other prayers falling upon deaf ears, Man had crafted this idol in tribute to its new God; violence."
 	icon_state = "amace"
 	force = 17
 	force_wielded = 21
@@ -119,7 +119,7 @@
 
 /obj/item/rogueweapon/mace/steel/palloy
 	name = "ancient alloy mace"
-	desc = "A bludgeon of polished gilbranze. A symbol of power, destined to be paraded through the kingdoms toppled by Her undying legionnaires."
+	desc = "Polished gilbranze, perched atop a reinforced shaft. Break the unenlightened into naught-but-giblets; like a potter's vessels, dashed against the rocks."
 	icon_state = "amace"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -364,7 +364,7 @@
 
 /obj/item/rogueweapon/mace/goden/steel/paalloy
 	name = "ancient grand mace"
-	desc = "Good evening, sire."
+	desc = "A twisting polehammer, forged in polished gilbranze. hat did you think this was all about? This destruction, this war, this sacrifice; it was all to prepare Man for its true ascension."
 	icon_state = "ancient_supermace"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -424,7 +424,7 @@
 
 /obj/item/rogueweapon/mace/warhammer/alloy
 	name = "decrepit warhammer"
-	desc = "A warhammer, wrought of frayed bronze. If such a weapon was originally designed to be wielded on saigaback, then why do these undying fools have no noble steeds to ride?"
+	desc = "A macehead of frayed bronze, spiked and perched atop a thin shaft. To see such a knightly implement abandoned to decay and neglect; that wounds the heart greater than any well-poised strike."
 	icon_state = "awarhammer"
 	force = 17
 	max_integrity = 180
@@ -456,7 +456,7 @@
 
 /obj/item/rogueweapon/mace/warhammer/steel/paalloy
 	name = "ancient alloy warhammer"
-	desc = "A warhammer, forged from polished gilbranze. An elegant weapon, reserved for far-more-inelegant foes."
+	desc = "A macehead of polished gilbranze, spiked and perched atop a reinforced shaft. An elegant weapon from a more civilizeed age; when Man lived in harmony with one-another, and when 'the undying' was nothing more than a nitemare's thought."
 	icon_state = "awarhammer"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -456,7 +456,7 @@
 
 /obj/item/rogueweapon/mace/warhammer/steel/paalloy
 	name = "ancient alloy warhammer"
-	desc = "A macehead of polished gilbranze, spiked and perched atop a reinforced shaft. An elegant weapon from a more civilizeed age; when Man lived in harmony with one-another, and when 'the undying' was nothing more than a nitemare's thought."
+	desc = "A macehead of polished gilbranze, spiked and perched atop a reinforced shaft. An elegant weapon from a more civilized age; when Man lived in harmony with one-another, and when 'the undying' was nothing more than a nitemare's thought."
 	icon_state = "awarhammer"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -102,7 +102,7 @@
 
 /obj/item/rogueweapon/flail/aflail
 	name = "decrepit flail"
-	desc = "A spiked ball of wrought bronze, chained to a rotwooden handle. Swing it a bit too hard, and there's a chance that the flailhead might completely fly off."
+	desc = "A spiked ball of wrought bronze, chained to a rotwooden handle. The chains groan with every twirl, strained by forces it hadn't felt in millenia; you feel as if each cycle will be this weapon's last."
 	icon_state = "aflail"
 	force = 22
 	max_integrity = 175
@@ -113,7 +113,7 @@
 
 /obj/item/rogueweapon/flail/sflail/paflail
 	name = "ancient flail"
-	desc = "A spiked ball of polished gilbranze, chained to a reinforced handle. Pray to Her with every twirl; both to crumple maille, and to avoid giving yourself an explosive trepanation."
+	desc = "A spiked ball of polished gilbranze, chained to a reinforced handle. They say that His children worshipped the flail above all else, for its twirls replicated the Comet Syon's blazing flights."
 	icon_state = "aflail"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -102,7 +102,7 @@
 
 /obj/item/rogueweapon/flail/aflail
 	name = "decrepit flail"
-	desc = "A spiked ball of wrought bronze, chained to a rotwooden handle. The chains groan with every twirl, strained by forces it hadn't felt in millenia; you feel as if each cycle will be this weapon's last."
+	desc = "A spiked ball of wrought bronze, chained to a rotwooden handle. The chains groan with every twirl, strained by forces it hadn't felt in millenia; swing it a bit too hard, and there's a chance that the flailhead might completely fly off."
 	icon_state = "aflail"
 	force = 22
 	max_integrity = 175

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -102,16 +102,18 @@
 
 /obj/item/rogueweapon/flail/aflail
 	name = "decrepit flail"
-	desc = "This is a swift, ancient flail. Strikes hard and far. Aeon's grasp is upon its form."
+	desc = "A spiked ball of wrought bronze, chained to a rotwooden handle. Swing it a bit too hard, and there's a chance that the flailhead might completely fly off."
 	icon_state = "aflail"
 	force = 22
 	max_integrity = 175
-	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/flail/sflail/paflail
 	name = "ancient flail"
-	desc = "This is a swift, ancient flail. Strikes hard and far. Aeon's grasp has been molded away from its form."
+	desc = "A spiked ball of polished gilbranze, chained to a reinforced handle. Pray to Her with every twirl; both to crumple maille, and to avoid giving yourself an explosive trepanation."
 	icon_state = "aflail"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -280,7 +280,7 @@
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
 	name = "ancient dagger"
-	desc = "A short blade, forged from polished gilbranze. It is violence that shepherds progress, and it is progress that will free this world from mortality's chains. Zizo, Zizo, Zizo; hear me!"
+	desc = "A short blade, forged from polished gilbranze. It is violence that shepherds progress, and it is progress that will free this world from mortality's chains. Zizo, Zizo, Zizo - I call upon thee; bring forth the undying, so that your works may yet be done!"
 	icon_state = "adagger"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -609,7 +609,7 @@
 
 /obj/item/rogueweapon/huntingknife/throwingknife/steel/palloy
 	name = "ancient alloy tossblade"
-	desc = "A sliver of polished gilbranze, delicately carved into a throwing dagger. A favorite amongst Zizo's undying cabal, and especially amongst Her assassins; what better-a-tool to slip through some unexpecting fool's spine?"
+	desc = "A sliver of polished gilbranze, delicately carved into a throwing dagger. A favorite amongst Zizo's undying cabal, and especially amongst Her assassins; what better-a-tool to slip through another's neck?"
 	icon_state = "throw_knifea"
 
 /obj/item/rogueweapon/huntingknife/throwingknife/psydon

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -268,17 +268,19 @@
 
 /obj/item/rogueweapon/huntingknife/idagger/adagger
 	name = "decrepit dagger"
-	desc = "an incredibly withered daggered. Aeon's grasp is upon its form."
+	desc = "A short blade, wrought from frayed bronze and tanged within a rotwooden grip. Pieces of a former legionnaire's scabbard cling to the glimmerless alloy."
 	force = 12
 	max_integrity = 75
 	icon_state = "adagger"
 	sheathe_icon = "adagger"
-	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
 	name = "ancient dagger"
-	desc = "A dagger made of ancient alloys. Aeon's grasp has been lifted from its form."
+	desc = "A short blade, forged from polished gilbranze. It is violence that shepherds progress, and it is progress that will break this world out from mortality's chains. Zizo, Zizo, Zizo; hear me!"
 	icon_state = "adagger"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -588,8 +590,9 @@
 
 /obj/item/rogueweapon/huntingknife/throwingknife/aalloy
 	name = "decrepit tossblade"
-	desc = "A decrepit old tossblade. You ought to throw cutlery instead."
+	desc = "Chunks of frayed bronze, crudely sharpened into throwing daggers. You might be better off chucking the silverware at them, at this rate."
 	icon_state = "throw_knifea"
+	color = "#bb9696"
 	force = 7
 	throwforce = 16
 
@@ -606,7 +609,7 @@
 
 /obj/item/rogueweapon/huntingknife/throwingknife/steel/palloy
 	name = "ancient alloy tossblade"
-	desc = "A tossblade crafted of ancient alloy. Aeon's grasp has been lifted from its form."
+	desc = "A sliver of polished gilbranze, delicately carved into a throwing dagger. A favorite amongst Zizo's undying cabal, and especially amongst Her assassins; what better-a-tool to slip through some unexpecting fool's spine?"
 	icon_state = "throw_knifea"
 
 /obj/item/rogueweapon/huntingknife/throwingknife/psydon

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -280,7 +280,7 @@
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
 	name = "ancient dagger"
-	desc = "A short blade, forged from polished gilbranze. It is violence that shepherds progress, and it is progress that will break this world out from mortality's chains. Zizo, Zizo, Zizo; hear me!"
+	desc = "A short blade, forged from polished gilbranze. It is violence that shepherds progress, and it is progress that will free this world from mortality's chains. Zizo, Zizo, Zizo; hear me!"
 	icon_state = "adagger"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -283,17 +283,19 @@
 
 /obj/item/rogueweapon/spear/aalloy
 	name = "decrepit spear"
-	desc = "A decrepit old spear. Aeon's grasp is upon it."
+	desc = "A rotting staff, tipped with frayed bronze. After the stone, but before the sword; an interlude for the violence yet to come."
 	icon_state = "ancient_spear"
-	smeltresult = /obj/item/ingot/aalloy
 	force = 13
 	force_wielded = 22
 	max_integrity = 180
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/spear/paalloy
 	name = "ancient spear"
-	desc = "A spear made of ancient alloys. Aeon's grasp has been lifted from it."
+	desc = "A gnarled staff, tipped with polished gilbranze. Millenia may pass, but one facet will always remain unchanged - it hurts to be stabbed with sharpened metal."
 	smeltresult = /obj/item/ingot/aaslag
 	icon_state = "ancient_spear"
 
@@ -619,17 +621,19 @@
 
 /obj/item/rogueweapon/halberd/bardiche/aalloy
 	name = "decrepit bardiche"
-	desc = "A decrepit bardiche. Aeon's grasp upon it."
+	desc = "An imposing poleaxe, wrought from frayed bronze. The metal may be chipped and worn, but the edge remains concerningly sharp."
 	max_integrity = 180
 	force = 12
 	force_wielded = 22
 	icon_state = "ancient_bardiche"
-	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/halberd/bardiche/paalloy
 	name = "ancient bardiche"
-	desc = "A bardiche made of ancient alloys. Aeon's grasp lifted from its form."
+	desc = "A terrifying poleaxe, forged from polished gilbranze. It sunders the chaff that the unenlightened fight-so-feverishly to protect."
 	icon_state = "ancient_bardiche"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -794,18 +798,20 @@
 
 /obj/item/rogueweapon/greatsword/aalloy
 	name = "decrepit greatsword"
-	desc = "A decrepit old greatsword. You'd be lucky if it chopped anything in half. Aeon's grasp is upon its form."
+	desc = "A massive blade, wrought in frayed bronze. It was too big to be called a sword; massive, thick, heavy, and far too rough. Indeed, it was more like a heap of raw metal."
 	force = 10
 	force_wielded = 25
 	max_integrity = 180
 	icon_state = "ancient_gsw"
-	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 
 /obj/item/rogueweapon/greatsword/paalloy
 	name = "ancient greatsword"
-	desc = "An ancient greatsword. Aeon's grasp lifted from its form."
+	desc = "A massive blade, forged from polished gilbronze. It's said that one of Her champions had slain a hundred knights in the span of just one dae, while wielding nothing more than this very weapon. A tall tale, or a terrible truth?"
 	icon_state = "ancient_gsw"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -283,7 +283,7 @@
 
 /obj/item/rogueweapon/spear/aalloy
 	name = "decrepit spear"
-	desc = "A rotting staff, tipped with frayed bronze. After the stone, but before the sword; an interlude for the violence yet to come."
+	desc = "A rotting staff, tipped with frayed bronze. After the stone, but before the sword; an interlude for the violence that would soon engulf His world."
 	icon_state = "ancient_spear"
 	force = 13
 	force_wielded = 22
@@ -295,7 +295,7 @@
 
 /obj/item/rogueweapon/spear/paalloy
 	name = "ancient spear"
-	desc = "A gnarled staff, tipped with polished gilbranze. Millenia may pass, but one facet will always remain unchanged - it hurts to be stabbed with sharpened metal."
+	desc = "A gnarled staff, tipped with polished gilbranze. Your breathing hilts, and your knuckles tighten around the staff; you see what is yet to come, yet your mind refuses to retain it. To know what fate this dying world has - it would drive any man inzane."
 	smeltresult = /obj/item/ingot/aaslag
 	icon_state = "ancient_spear"
 
@@ -621,7 +621,7 @@
 
 /obj/item/rogueweapon/halberd/bardiche/aalloy
 	name = "decrepit bardiche"
-	desc = "An imposing poleaxe, wrought from frayed bronze. The metal may be chipped and worn, but the edge remains concerningly sharp."
+	desc = "An imposing poleaxe, wrought from frayed bronze. Whatever noble purpose this weapon held has long since decayed; for it now persists to sunder the chaff that clings to this dying world."
 	max_integrity = 180
 	force = 12
 	force_wielded = 22
@@ -633,7 +633,7 @@
 
 /obj/item/rogueweapon/halberd/bardiche/paalloy
 	name = "ancient bardiche"
-	desc = "A terrifying poleaxe, forged from polished gilbranze. It sunders the chaff that the unenlightened fight-so-feverishly to protect."
+	desc = "A terrifying poleaxe, forged from polished gilbranze. When Her ascension came, these weapons - bereft of their wielders - sunk deep into the earth. Shadowed hands cradled the blades over the centuries, and would eventually create its steel-tipped successor; the glaive."
 	icon_state = "ancient_bardiche"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -798,7 +798,7 @@
 
 /obj/item/rogueweapon/greatsword/aalloy
 	name = "decrepit greatsword"
-	desc = "A massive blade, wrought in frayed bronze. It was too big to be called a sword; massive, thick, heavy, and far too rough. Indeed, it was more like a heap of raw metal."
+	desc = "A massive blade, wrought in frayed bronze. It is too big to be called a sword; massive, thick, heavy, and far too rough. Indeed, this blade was more like a heap of raw metal."
 	force = 10
 	force_wielded = 25
 	max_integrity = 180
@@ -811,7 +811,7 @@
 
 /obj/item/rogueweapon/greatsword/paalloy
 	name = "ancient greatsword"
-	desc = "A massive blade, forged from polished gilbronze. It's said that one of Her champions had slain a hundred knights in the span of just one dae, while wielding nothing more than this very weapon. A tall tale, or a terrible truth?"
+	desc = "A massive blade, forged from polished gilbronze. Your kind will discover your true nature, in wrath and ruin. You will take to the stars and burn them out, one by one. Only when the last star turns to dust, will you finally realize that She was trying to save you from Man's greatest foe; oblivion."
 	icon_state = "ancient_gsw"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -232,7 +232,7 @@
 
 /obj/item/rogueweapon/sword/short/pashortsword
 	name = "ancient shortsword"
-	desc = "A sword made of ancient alloys. Aeon's grasp has been lifted from its form."
+	desc = "A polished sidearm-sword, forged from gilbranze. The design, though weathered by the centuries, still bares the unmistakable motif of Grenzelhoftian balancing."
 	icon_state = "ashortsword"
 	sheathe_icon = "ashortsword"
 	smeltresult = /obj/item/ingot/aaslag
@@ -635,13 +635,15 @@
 
 /obj/item/rogueweapon/sword/iron/short/ashort
 	name = "decrepit short sword"
-	desc = "A decrepit old short sword. Aeon's grasp has withered its form."
+	desc = "A chipped sidearm-sword, wrought from frayed bronze. Or.. is this all that remains of a larger sword?"
 	icon_state = "ashortsword"
 	sheathe_icon = "ashortsword"
 	max_integrity = 75
 	force = 18
-	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/sword/iron/short/gladius
 	name = "gladius"
@@ -654,16 +656,18 @@
 
 /obj/item/rogueweapon/sword/iron/short/gladius/agladius
 	name = "decrepit gladius"
-	desc = "A decrepit old gladius. Aeon's grasp is upon its form."
+	desc = "A hefty shortsword, wrought from frayed bronze. Once, the sidearm of a proud legionnaire; now, a consequence of progress and sacrifice."
 	force = 18
 	max_integrity = 150
 	icon_state = "agladius"
-	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/sword/iron/short/gladius/pagladius
 	name = "ancient gladius"
-	desc = "A gladius made of ancient alloys. Aeon's grasp lifted from its form."
+	desc = "A polished shortsword, forged from gilbranze. Favored by the majority of Zizo's undying legionnaires, this antiquated tool serves a simple purpose; to spill the innards of unenlightened fools."
 	icon_state = "agladius"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -774,16 +778,18 @@
 
 /obj/item/rogueweapon/sword/sabre/alloy
 	name = "decrepit khopesh"
-	desc = "A decrepit old khopesh. Aeon's grasp is upon its form."
-	smeltresult = /obj/item/ingot/aalloy
+	desc = "A hooked sword, wrought from frayed bronze. The design is not only baffling, but seems to predate history itself."
 	force = 18
 	max_integrity = 115
 	icon_state = "akhopesh"
 	blade_dulling = DULLING_SHAFT_CONJURED
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/rogueweapon/sword/sabre/palloy
 	name = "ancient khopesh"
-	desc = "A ancient alloy khopesh. Aeon's grasp has been lifted from its form."
+	desc = "A polished hook-sword, forged from gilbronze. The Comet Syon's glare once graced this blade; now, it's wielded by those who can't even remember what came before His sacrifice."
 	smeltresult = /obj/item/ingot/aaslag
 	icon_state = "akhopesh"
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -232,7 +232,7 @@
 
 /obj/item/rogueweapon/sword/short/pashortsword
 	name = "ancient shortsword"
-	desc = "A polished sidearm-sword, forged from gilbranze. The design, though weathered by the centuries, still bares the unmistakable motif of Grenzelhoftian balancing."
+	desc = "A polished sidearm-sword, forged from gilbranze. From after His sacrifice, but before Her ascension; the tithe of a war without reason, waged between squabbling children who hadn't known that the world was about to end."
 	icon_state = "ashortsword"
 	sheathe_icon = "ashortsword"
 	smeltresult = /obj/item/ingot/aaslag
@@ -635,7 +635,7 @@
 
 /obj/item/rogueweapon/sword/iron/short/ashort
 	name = "decrepit short sword"
-	desc = "A chipped sidearm-sword, wrought from frayed bronze. Or.. is this all that remains of a larger sword?"
+	desc = "A chipped sidearm-sword, wrought from frayed bronze. It's hard to gauge whether it was naturally forged to be so short, or if it's all that remained of a longer blade."
 	icon_state = "ashortsword"
 	sheathe_icon = "ashortsword"
 	max_integrity = 75
@@ -667,7 +667,7 @@
 
 /obj/item/rogueweapon/sword/iron/short/gladius/pagladius
 	name = "ancient gladius"
-	desc = "A polished shortsword, forged from gilbranze. Favored by the majority of Zizo's undying legionnaires, this antiquated tool serves a simple purpose; to spill the innards of unenlightened fools."
+	desc = "A polished shortsword, forged from gilbranze. Favored by Zizo's undying legionnaires, this antiquated tool serves a simple purpose; to spill the innards of unenlightened fools."
 	icon_state = "agladius"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -32,7 +32,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/bolt/paalloy
 	name = "ancient bolt"
-	desc = "An ancient bolt, tipped with polished gilbranze. Thrice-sharpened, it's certain to punch through most hauberks."
+	desc = "An ancient bolt, tipped with polished gilbranze. The razor-thin tip resembles a sabot more than an arrowhead; something that most alloys cannot reliably withstand."
 	icon_state = "ancientbolt"
 	projectile_type = /obj/projectile/bullet/reusable/bolt/paalloy
 
@@ -111,7 +111,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/arrow/iron/aalloy 
 	name = "decrepit broadhead arrow"
-	desc = "An arrow; one end, tipped with flattened and frayed bronze - the other, inlaid with decayed feathers. It sunders flesh, not armor."
+	desc = "An arrow; one end, tipped with flattened and frayed bronze - the other, inlaid with decayed feathers. The alloy's decrepity forces it to burst into shrapnel upon impact, shredding flesh."
 	icon_state = "ancientarrow"
 	projectile_type = /obj/projectile/bullet/reusable/arrow/iron/aalloy
 	color = "#bb9696"
@@ -125,7 +125,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/arrow/steel/paalloy
 	name = "ancient bodkin arrow"
-	desc = "An arrow; one end, tipped with a sharpened rod of polished gilbranze - the other, inlaid with feathers. It sunders armor, not flesh."
+	desc = "An arrow; one end, tipped with a sharpened rod of polished gilbranze - the other, inlaid with feathers. The razor-thin tip resembles a sabot; an alloyed sliver that can punch straight through steel."
 	icon_state = "ancientarrow"
 	projectile_type = /obj/projectile/bullet/reusable/arrow/steel/paalloy
 
@@ -547,7 +547,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/javelin/aalloy
 	name = "decrepit javelin"
-	desc = "A spear of frayed bronze, weighted to be thrown - not thrusted."
+	desc = "A missile of frayed bronze. Before you is your weapon; that which rose Man out of the mud, and brought the Beasts of Old Syon to heel. When were you last aware of any other part of you? Do you recall seeing the world in any other way?"
 	icon_state = "ajavelin"
 	throwforce = 20
 	force = 9
@@ -569,7 +569,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/javelin/steel/paalloy
 	name = "ancient javelin"
-	desc = "A spear of polished gilbranze, weighted to be thrown - not thrusted. A favored predecessor to bolts and arrows, championed by Zizo's undying legionnaires."
+	desc = "A missile of polished gilbranze. Old Syon had drowned beneath His tears, and Her ascension had brought forth this world's end - so that You, with the killing blow, could become God."
 	icon_state = "ajavelin"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -647,7 +647,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/sling_bullet/aalloy
 	name = "decrepit sling bullet"
-	desc = "A pellet of frayed bronze."
+	desc = "A pellet of frayed bronze. The alloy flakes apart in your grasp, staining the palm with flecks of brown-and-red."
 	projectile_type = /obj/projectile/bullet/reusable/sling_bullet/aalloy
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "ancient_sling_bullet"
@@ -655,7 +655,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/sling_bullet/paalloy
 	name = "ancient sling bullet"
-	desc = "A pellet of polished gilbranze, reawakened from its millenia of disuse."
+	desc = "A pellet of polished gilbranze. The bigger they are, the harder they'll fall; be it Man or God."
 	projectile_type = /obj/projectile/bullet/reusable/sling_bullet/paalloy
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "ancient_sling_bullet"

--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -25,13 +25,14 @@
 
 /obj/item/ammo_casing/caseless/rogue/bolt/aalloy
 	name = "decrepit bolt"
-	desc = "a decrepit old bolt, the head is nearly in shambles. Aeon's grasp is upon it."
+	desc = "An ancient bolt, tipped with frayed bronze. It lacks the luster that it once held, many centuries ago."
 	icon_state = "ancientbolt"
 	projectile_type = /obj/projectile/bullet/reusable/bolt/aalloy
+	color = "#bb9696"
 
 /obj/item/ammo_casing/caseless/rogue/bolt/paalloy
 	name = "ancient bolt"
-	desc = "A ancient bolt. Aeon's grasp has been lifted from its form."
+	desc = "An ancient bolt, tipped with polished gilbranze. Thrice-sharpened, it's certain to punch through most hauberks."
 	icon_state = "ancientbolt"
 	projectile_type = /obj/projectile/bullet/reusable/bolt/paalloy
 
@@ -110,9 +111,10 @@
 
 /obj/item/ammo_casing/caseless/rogue/arrow/iron/aalloy 
 	name = "decrepit broadhead arrow"
-	desc = "A decrepit old arrow. Seems unlikely to penetrate anything."
+	desc = "An arrow; one end, tipped with flattened and frayed bronze - the other, inlaid with decayed feathers. It sunders flesh, not armor."
 	icon_state = "ancientarrow"
 	projectile_type = /obj/projectile/bullet/reusable/arrow/iron/aalloy
+	color = "#bb9696"
 
 /obj/item/ammo_casing/caseless/rogue/arrow/steel
 	name = "steel bodkin arrow"
@@ -123,7 +125,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/arrow/steel/paalloy
 	name = "ancient bodkin arrow"
-	desc = "a bodkin formed of ancient metals. Aeon's grasp lifted from its form."
+	desc = "An arrow; one end, tipped with a sharpened rod of polished gilbranze - the other, inlaid with feathers. It sunders armor, not flesh."
 	icon_state = "ancientarrow"
 	projectile_type = /obj/projectile/bullet/reusable/arrow/steel/paalloy
 
@@ -545,11 +547,13 @@
 
 /obj/item/ammo_casing/caseless/rogue/javelin/aalloy
 	name = "decrepit javelin"
-	desc = "A decrepit old javelin, surely used centuries ago. Aeon's grasp is upon its form."
+	desc = "A spear of frayed bronze, weighted to be thrown - not thrusted."
 	icon_state = "ajavelin"
-	smeltresult = /obj/item/ingot/aalloy
 	throwforce = 20
 	force = 9
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/ammo_casing/caseless/rogue/javelin/steel
 	force = 16
@@ -565,7 +569,7 @@
 
 /obj/item/ammo_casing/caseless/rogue/javelin/steel/paalloy
 	name = "ancient javelin"
-	desc = "A javelin made of ancient alloys. Aeon's grasp lifted from its form."
+	desc = "A spear of polished gilbranze, weighted to be thrown - not thrusted. A favored predecessor to bolts and arrows, championed by Zizo's undying legionnaires."
 	icon_state = "ajavelin"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -643,14 +647,15 @@
 
 /obj/item/ammo_casing/caseless/rogue/sling_bullet/aalloy
 	name = "decrepit sling bullet"
-	desc = "A decrepit ball of withered metal."
+	desc = "A pellet of frayed bronze."
 	projectile_type = /obj/projectile/bullet/reusable/sling_bullet/aalloy
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "ancient_sling_bullet"
+	color = "#bb9696"
 
 /obj/item/ammo_casing/caseless/rogue/sling_bullet/paalloy
 	name = "ancient sling bullet"
-	desc = "A ancient ball of re-awakened metal."
+	desc = "A pellet of polished gilbranze, reawakened from its millenia of disuse."
 	projectile_type = /obj/projectile/bullet/reusable/sling_bullet/paalloy
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "ancient_sling_bullet"

--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -30,9 +30,9 @@
 	name = "decrepit haubergeon"
 	desc = "Frayed bronze rings and rotting leather, woven together to form a short maille-atekon. There's a breach along the rings, where the leather is wet with blackness: the aftermath of a mortal wound, delivered centuries ago."
 	icon_state = "ancientchain"
+	max_integrity = ARMOR_INT_CHEST_MEDIUM_DECREPIT
 	color = "#bb9696"
 	smeltresult = /obj/item/ingot/aaslag
-	max_integrity = ARMOR_INT_CHEST_MEDIUM_DECREPIT
 	anvilrepair = null
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/paalloy
@@ -65,14 +65,14 @@
 	name = "decrepit hauberk"
 	desc = "Frayed bronze rings and rotting leather, woven together to form a sleeved maille-atekon. Once, the armored vestments of a paladin: now, the withered veil of Zizo's undying legionnaires."
 	icon_state = "ancienthauberk"
-	color = "#bb9696"
 	max_integrity = ARMOR_INT_CHEST_MEDIUM_DECREPIT
-	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
 	anvilrepair = null
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy
 	name = "ancient hauberk"
-	desc = "Gilded bronze rings and silk, woven together to form a sleeved maille-atekon. To bring the lyfeless back from decrepity, to elevate them to heights once thought unsurmountable; that is the will of Zizo, made manifest."
+	desc = "Polished gilbranze rings and silk, woven together to form a sleeved maille-atekon. To bring the lyfeless back from decrepity, to elevate them to heights once thought unsurmountable; that is the will of Zizo, made manifest."
 	icon_state = "ancienthauberk"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -28,14 +28,16 @@
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/aalloy
 	name = "decrepit haubergeon"
-	desc = "Decrepit old haubergeon. Aeon's grasp is upon it."
+	desc = "Frayed bronze rings and rotting leather, woven together to form a short maille-atekon. There's a breach along the rings, where the leather is wet with blackness: the aftermath of a mortal wound, delivered centuries ago."
 	icon_state = "ancientchain"
-	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
 	max_integrity = ARMOR_INT_CHEST_MEDIUM_DECREPIT
+	anvilrepair = null
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/paalloy
 	name = "ancient haubergeon"
-	desc = "Chainmail vest formed of ancient alloys. Aeon's grasp has been lifted from it."
+	desc = "Polished gilbranze rings and silk, woven together to form a short maille-atekon. The death of a million brought forth the ascension of Zizo; and if a million more must perish to complete Her works, then let it be done."
 	icon_state = "ancientchain"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -61,14 +63,16 @@
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy
 	name = "decrepit hauberk"
-	desc = "A hauberk worn out by time. Aeon's grasp is upon it."
+	desc = "Frayed bronze rings and rotting leather, woven together to form a sleeved maille-atekon. Once, the armored vestments of a paladin: now, the withered veil of Zizo's undying legionnaires."
 	icon_state = "ancienthauberk"
+	color = "#bb9696"
 	max_integrity = ARMOR_INT_CHEST_MEDIUM_DECREPIT
 	smeltresult = /obj/item/ingot/aalloy
+	anvilrepair = null
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy
 	name = "ancient hauberk"
-	desc = "A hauberk formed out of ancient alloys. Aeon's grasp is upon it."
+	desc = "Gilded bronze rings and silk, woven together to form a sleeved maille-atekon. To bring the lyfeless back from decrepity, to elevate them to heights once thought unsurmountable; that is the will of Zizo, made manifest."
 	icon_state = "ancienthauberk"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -33,15 +33,17 @@
 
 /obj/item/clothing/suit/roguetown/armor/plate/aalloy
 	name = "decrepit half-plate"
-	desc = "Worn out and decrepit halfplate. Aeon's grasp is upon it."
+	desc = "Frayed bronze layers, bolted into plate armor. Once, the hauberk of a rising champion; now, nothing more than a fool's tomb."
 	icon_state = "ancientplate"
 	item_state = "ancientplate"
 	max_integrity = ARMOR_INT_CHEST_PLATE_DECREPIT
-	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/suit/roguetown/armor/plate/paalloy
 	name = "ancient half-plate"
-	desc = "Plate formed out of ancient alloys. Aeon's grasp has been lifted from it."
+	desc = "Polished gilbronze layers, magewelded into plate armor. Let none impede the march of progress, and let Her champions bring the unenlightened masses to kneel."
 	icon_state = "ancientplate"
 	item_state = "ancientplate"
 	smeltresult = /obj/item/ingot/aaslag
@@ -315,14 +317,16 @@
 
 /obj/item/clothing/suit/roguetown/armor/plate/half/aalloy
 	name = "decrepit cuirass"
-	desc = "A withered cuirass. Aeon's grasp is upon its form."
+	desc = "Frayed bronze, pounded into a breastplate. It feels more like a corset than a cuirass; there's barely enough width to let those aching lungs breathe."
 	icon_state = "ancientcuirass"
-	smeltresult = /obj/item/ingot/aalloy
 	max_integrity = ARMOR_INT_CHEST_MEDIUM_DECREPIT
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/suit/roguetown/armor/plate/half/paalloy
 	name = "ancient cuirass"
-	desc = "A cuirass of ancient alloys. Aeon's grasp lifted from its form."
+	desc = "Polished gilbranze, curved into a breastplate. It is not for the heart that beats no more, but for the spirit that flows through luxless marrow; one of Her many gifts."
 	icon_state = "ancientcuirass"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -50,9 +50,10 @@
 
 /obj/item/clothing/shoes/roguetown/boots/aalloy
 	name = "decrepit boots"
-	desc = "decrepit old leather boots."
+	desc = "Frayed bronze greaves, shingled atop boots of rotted leather. The toebones of its former legionnaire rattle about with every step taken."
 	max_integrity = 40
 	icon_state = "ancientboots"
+	color = "#bb9696"
 
 /obj/item/clothing/shoes/roguetown/boots/psydonboots
 	name = "psydonian boots"
@@ -151,8 +152,9 @@
 
 /obj/item/clothing/shoes/roguetown/sandals/aalloy
 	name = "decrepit sandals"
-	desc = "Surely Psydon himself could've worn these sandals."
+	desc = "Sandals of frayed bronze, bereft of its wooden coverings. The beaches it once walked upon are no more; where there was once pearled sand, only glassy trinitite from SYON's impact remains."
 	icon_state = "ancientsandals"
+	color = "#bb9696"
 
 /obj/item/clothing/shoes/roguetown/shalal
 	name = "babouche"

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -50,7 +50,7 @@
 
 /obj/item/clothing/shoes/roguetown/boots/aalloy
 	name = "decrepit boots"
-	desc = "Frayed bronze greaves, shingled atop boots of rotted leather. The toebones of its former legionnaire rattle about with every step taken."
+	desc = "Frayed bronze greaves, shingled atop boots of rotted leather. The toebones of its former legionnaire remain within, rattling about with every step taken."
 	max_integrity = 40
 	icon_state = "ancientboots"
 	color = "#bb9696"
@@ -152,7 +152,7 @@
 
 /obj/item/clothing/shoes/roguetown/sandals/aalloy
 	name = "decrepit sandals"
-	desc = "Sandals of frayed bronze, bereft of its wooden coverings. The beaches it once walked upon are no more; where there was once pearled sand, only glassy trinitite from SYON's impact remains."
+	desc = "Frayed bronze platforms, curled about to cradle the feet. The beaches that these sandals once treaded are no more; pearly sands, long since turnt to glass from the Comet Syon's impact."
 	icon_state = "ancientsandals"
 	color = "#bb9696"
 

--- a/code/modules/clothing/rogueclothes/gloves/chain.dm
+++ b/code/modules/clothing/rogueclothes/gloves/chain.dm
@@ -16,14 +16,16 @@
 
 /obj/item/clothing/gloves/roguetown/chain/aalloy
 	name = "decrepit chain gauntlets"
-	desc = "Decrepit old chain gauntlets. Aeon's grasp is upon them."
+	desc = "Frayed bronze rings, interlinked together to form sagging mittens. Fingers, talons, claws; they're all the same, when smothered beneath maille and left to rot away."
 	icon_state = "acgloves"
 	max_integrity = ARMOR_INT_SIDE_DECREPIT
-	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/gloves/roguetown/chain/paalloy
 	name = "ancient chain gauntlets"
-	desc = "Chain gauntlets formed out of ancient alloys. Aeon's grasp is lifted from them."
+	desc = "Polished gilbranze rings, delicately daisy-chained together into mittens. The filament is ruptured, and it will never heal; Zizo's ascension made sure of that. By the hands of Her disciples, the final obstacle preventing this world's salvation shall be dismantled - lyfe."
 	icon_state = "acgloves"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/gloves/plate.dm
+++ b/code/modules/clothing/rogueclothes/gloves/plate.dm
@@ -26,14 +26,16 @@
 
 /obj/item/clothing/gloves/roguetown/plate/aalloy
 	name = "decrepit plate gauntlets"
-	desc = "Decrepit old plate gauntlets. Aeon's grasp is upon them."
+	desc = "Frayed bronze mechanisms, connected to form the shells of hands. Too clumsy to properly knock a bow, too rigid to comfortably grip a sword; clench those fists any tighter, and the segments'll cut into flesh."
 	icon_state = "agauntlets"
-	smeltresult = /obj/item/ingot/aalloy
 	max_integrity = ARMOR_INT_SIDE_DECREPIT
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/gloves/roguetown/plate/paalloy
 	name = "ancient plate gauntlets"
-	desc = "Ancient plate gauntlets. Aeon's grasp lifed from them."
+	desc = "Polished gilbranze mechanisms, meticulously interconnected to shroud splayed hands. 'Mercy' and 'innocence' are concepts paraded by the unenlightened; spill their blood without guilt, so that the world may yet be remade in Her image." 
 	icon_state = "agauntlets"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -14,11 +14,13 @@
 
 /obj/item/clothing/head/roguetown/helmet/heavy/aalloy
 	name = "decrepit barbute"
-	desc = "A withered old barbute. Aeon's grasp is upon it."
+	desc = "Frayed bronze plates, pounded into a visored helmet. Scrapes and dents line the curved plating, weathered from centuries of neglect. The remains of a plume's stub hang atop its rim."
 	max_integrity = ARMOR_INT_HELMET_HEAVY_DECREPIT
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
-	smeltresult = /obj/item/ingot/aalloy
 	icon_state = "ancientbarbute"
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/head/roguetown/helmet/heavy/aalloy/attackby(obj/item/W, mob/living/user, params)
 	..()
@@ -44,7 +46,7 @@
 
 /obj/item/clothing/head/roguetown/helmet/heavy/paalloy
 	name = "ancient barbute"
-	desc = "A barbute crafted of ancient alloys. Aeon's grasp has been lifted from its form."
+	desc = "Polished gilbranze plates, pounded to form a visored helmet. Zizo commands progress, and progress commands sacrifice; let these sundered legionnaires rise again, to spill the blood of unenlightened fools. A coiled pocket is perched atop the rim, awaiting to be plumed." 
 	icon_state = "ancientbarbute"
 	smeltresult = /obj/item/ingot/aaslag
 
@@ -74,15 +76,17 @@
 
 /obj/item/clothing/head/roguetown/helmet/heavy/guard/aalloy
 	name = "decrepit savoyard"
-	desc = "A decrepit old savoyard. Aeon's grasp is upon its form."
+	desc = "Frayed bronze plates, molded into a ventilated casket. It reeks of fetid shit, and each breath - labored and strained - is laced with flaked metal."
 	max_integrity = ARMOR_INT_HELMET_HEAVY_DECREPIT
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
-	smeltresult = /obj/item/ingot/aalloy
 	icon_state = "ancientsavoyard"
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/head/roguetown/helmet/heavy/guard/paalloy
 	name = "ancient savoyard"
-	desc = "A savoyard crafted of ancient materials. Aeon's grasp has been lifted from its form."
+	desc = "Polished gilbranze plates, molded into a bulwark's greathelm. The Comet Syon's glare has been forever burnt into the alloy; a decayed glimpse into the world that was, before Psydon's slumber and Zizo's awakening."
 	icon_state = "ancientsavoyard"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -126,10 +126,12 @@
 
 /obj/item/clothing/mask/rogue/facemask/aalloy
 	name = "decrepit mask"
-	desc = "A decrepit creepy old mask. Aeon's grasp is upon it."
+	desc = "Frayed bronze, molded into an unblinking visage. Only the statues, buried within the innards of Mount Decapitation, share its wrinkled lip and sneer of cold command."
 	icon_state = "ancientmask"
 	max_integrity = 75
-	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/mask/rogue/facemask/copper
 	name = "copper mask"
@@ -228,9 +230,9 @@
 
 /obj/item/clothing/mask/rogue/facemask/steel/paalloy
 	name = "ancient mask"
-	desc = "A mask forged of ancient alloys. Aeon's grasp has been lifted from its form."
+	desc = "Polished gilbranze, molded into an intimidating visage. Touch the cheek; it is warm, like flesh. But it is not flesh. Not yet."
 	icon_state = "ancientmask"
-
+	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/clothing/mask/rogue/facemask/steel/hound
 	name = "steel hound mask"

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -143,16 +143,18 @@
 
 /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	name = "ancient coif"
-	desc = "a coif made of ancient alloys. Aeon's grasp lifted from its form."
+	desc = "Polished gilbranze rings, linked together to form a billowing hood. Let it not be a crown of thorns that saves this dying world, but a crown of progress; of fettered metal and stained bone, rejuvenated by Zizo's will to herald Her greatest works yet."
 	icon_state = "achaincoif"
 	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/clothing/neck/roguetown/chaincoif/iron/aalloy
 	name = "decrepit coif"
-	desc = "a decrepit old coif. Aeon's grasp is upon it."
+	desc = "Frayed bronze rings, linked together to form a billowing hood. Shrapnel peppers the linkage; arrowheads and speartips, brought along from a battlefield who's history - and legionnaires - have been lost to tyme."
 	icon_state = "achaincoif"
-	smeltresult = /obj/item/ingot/aalloy
 	max_integrity = ARMOR_INT_SIDE_DECREPIT
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
 	name = "chain mantle"
@@ -255,10 +257,12 @@
 
 /obj/item/clothing/neck/roguetown/gorget/aalloy
 	name = "decrepit gorget"
-	desc = "a decrepit, worn out gorget. Aeon's grasp is upon it."
+	desc = "Frayed bronze plates, shingled together to shroud the neck. Primitive scrapes line the flanks, yet the center seems to've been cored out by a spear's thrust."
 	icon_state = "ancientgorget"
 	max_integrity = ARMOR_INT_SIDE_DECREPIT
-	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/neck/roguetown/gorget/copper
 	name = "neck protector"
@@ -322,7 +326,7 @@
 
 /obj/item/clothing/neck/roguetown/gorget/paalloy
 	name = "ancient gorget"
-	desc = "A gorget made of ancient alloys. Aeon's grasp lifted from its form."
+	desc = "Polished gilbranze plates, layered atop one-another to guard the neck. The spine; a sacred leyline between spirit and sinew. It must remain unsevered, lest the blessings of Zizo be lost."
 	icon_state = "ancientgorget"
 	max_integrity = ARMOR_INT_SIDE_STEEL
 	smeltresult = /obj/item/ingot/aaslag
@@ -385,13 +389,15 @@
 
 /obj/item/clothing/neck/roguetown/psicross/aalloy
 	name = "decrepit psicross"
-	desc = "Surely this one endures?"
+	desc = "'A comet capable of rending all the enemies of humanity apart; oh, how graceful His power was! And His sacrifice, ever so noble! Yet now He slumbers, unaware of the fruits His efforts came to give. And He sighs. And He weeps.'"
 	icon_state = "psycross_a"
+	color = "#bb9696"
 
 /obj/item/clothing/neck/roguetown/zcross/aalloy
 	name = "decrepit zcross"
-	desc = "A symbol of progress from an era that had reason to believe in it."
+	desc = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man. She called us forth from the edge of reality - and with Her dying breath, rasped out the final truth; the fire is gone, and the world will soon follow.'"
 	icon_state = "zcross_a"
+	color = "#bb9696"
 
 /obj/item/clothing/neck/roguetown/psicross/astrata
 	name = "amulet of Astrata"

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -326,7 +326,7 @@
 
 /obj/item/clothing/neck/roguetown/gorget/paalloy
 	name = "ancient gorget"
-	desc = "Polished gilbranze plates, layered atop one-another to guard the neck. The spine; a sacred leyline between spirit and sinew. It must remain unsevered, lest the blessings of Zizo be lost."
+	desc = "Polished gilbranze plates, layered atop one-another to guard the neck. The spine; a sacred leyline between spirit and sinew. It must remain unsevered, lest Her blessings be lost."
 	icon_state = "ancientgorget"
 	max_integrity = ARMOR_INT_SIDE_STEEL
 	smeltresult = /obj/item/ingot/aaslag

--- a/code/modules/clothing/rogueclothes/pants/chain.dm
+++ b/code/modules/clothing/rogueclothes/pants/chain.dm
@@ -111,15 +111,17 @@
 
 /obj/item/clothing/under/roguetown/chainlegs/kilt/aalloy
 	name = "decrepit chain kilt"
-	desc = "A decrepit old kilt. Aeon's grasp is upon it."
+	desc = "Frayed bronze rings, linked together with bindings of rotting leather to form a waist's drape. The maille jingles with every step, singing the hymn to a cadence once savored by marching legionnaires."
 	icon_state = "achainkilt"
 	sleevetype = "achainkilt"
-	smeltresult = /obj/item/ingot/aalloy
 	max_integrity = ARMOR_INT_LEG_DECREPIT_CHAIN
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/under/roguetown/chainlegs/kilt/paalloy
 	name = "ancient chain kilt"
-	desc = "A kilt formed out of ancient alloys. Aeon's grasp lifted from it."
+	desc = "Polished gilbranze rings, linked together with bindings of silk to form a waist's vestment. These undying legionnaires once marched for Vheslyn, and again for Zizo; but now, they are utterly beholden to the whims of their resurrector."
 	icon_state = "achainkilt"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/pants/plate.dm
+++ b/code/modules/clothing/rogueclothes/pants/plate.dm
@@ -42,7 +42,7 @@
 
 /obj/item/clothing/under/roguetown/platelegs/paalloy
 	name = "ancient plate chausses"
-	desc = "Polished gilbranze plates, layered atop silken chausses. Only the few who had embraced undeath were spared from Zizo's ascension; now, they lord over thralls who've been embraced to sunder the unenlightened in Her name."
+	desc = "Polished gilbranze plates, layered atop silken chausses. Only the few who had embraced undeath were spared from Zizo's ascension; now, they command the undying legionnaires who march forth to sunder creation in Her name."
 	icon_state = "ancientplate_legs"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/pants/plate.dm
+++ b/code/modules/clothing/rogueclothes/pants/plate.dm
@@ -33,14 +33,16 @@
 
 /obj/item/clothing/under/roguetown/platelegs/aalloy
 	name = "decrepit plate chausses"
-	desc = "Decrepit, old plate chausses. Aeon's grasp is upon them."
+	desc = "Frayed bronze plates, shingled over chausses of rotting leather-and-maille. Voided bowels are all that remains of its former legionnaire."
 	icon_state = "ancientplate_legs"
-	smeltresult = /obj/item/ingot/aalloy
 	max_integrity = ARMOR_INT_LEG_DECREPIT_PLATE
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/under/roguetown/platelegs/paalloy
 	name = "ancient plate chausses"
-	desc = "Plate chausses formed out of ancient alloys. Aeon's grasp lifted from them."
+	desc = "Polished gilbranze plates, layered atop silken chausses. Only the few who had embraced undeath were spared from Zizo's ascension; now, they lord over the thralls who've been embraced to sunder creation in Her name."
 	icon_state = "ancientplate_legs"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/pants/plate.dm
+++ b/code/modules/clothing/rogueclothes/pants/plate.dm
@@ -42,7 +42,7 @@
 
 /obj/item/clothing/under/roguetown/platelegs/paalloy
 	name = "ancient plate chausses"
-	desc = "Polished gilbranze plates, layered atop silken chausses. Only the few who had embraced undeath were spared from Zizo's ascension; now, they lord over the thralls who've been embraced to sunder creation in Her name."
+	desc = "Polished gilbranze plates, layered atop silken chausses. Only the few who had embraced undeath were spared from Zizo's ascension; now, they lord over thralls who've been embraced to sunder the unenlightened in Her name."
 	icon_state = "ancientplate_legs"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -22,9 +22,9 @@
 
 /obj/item/clothing/ring/aalloy
 	name = "decrepit ring"
-	desc = "A decrepit old ring"
+	desc = "A coil of frayed bronze."
 	icon_state = "ring_a"
-	sellprice = 5
+	sellprice = 11
 
 
 /obj/item/clothing/ring/gold

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -42,14 +42,16 @@
 
 /obj/item/clothing/wrists/roguetown/bracers/aalloy
 	name = "decrepit bracers"
-	desc = "Decrepit old bracers. Aeon's grasp is upon them."
+	desc = "Frayed bronze cuffings, bound across the wrists. Don't bother counting the tallies left behind by their former legionnaires; none of them ever returned from the battlefields."
 	max_integrity = ARMOR_INT_SIDE_DECREPIT
 	icon_state = "ancientbracers"
-	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	smeltresult = /obj/item/ingot/aaslag
+	anvilrepair = null
 
 /obj/item/clothing/wrists/roguetown/bracers/paalloy
 	name = "ancient bracers"
-	desc = "Bracers formed of ancient alloys. Aeon's grasp is lifted from their form."
+	desc = "Polished gilbranze cuffings, clasped around the wrists. Through ascension, the chains of mortality are broken; and only through death will the spirit be ready to embrace divinity."
 	icon_state = "ancientbracers"
 	smeltresult = /obj/item/ingot/aaslag
 

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -57,11 +57,13 @@
 
 /obj/item/rogueweapon/thresher/aalloy
 	name = "decrepit thresher"
-	desc = "A withered old thresher. Aeon's grasp is upon it."
+	desc = "A thresher of wrought bronze; from when the wheat was plentiful, and when Man wasn't burdened with the weight of sin."
 	force = 5
 	force_wielded = 7
 	icon_state = "athresh"
 	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	sellprice = 15
 
 
 /obj/item/rogueweapon/sickle
@@ -95,6 +97,8 @@
 /obj/item/rogueweapon/sickle/aalloy
 	name = "decrepit sickle"
 	icon_state = "asickle"
+	color = "#bb9696"
+	sellprice = 15
 
 /obj/item/rogueweapon/sickle/copper
 	name = "copper sickle"
@@ -126,6 +130,8 @@
 	name = "decrepit hoe"
 	icon_state = "ahoe"
 	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	sellprice = 15
 
 /obj/item/rogueweapon/hoe/copper
 	name = "copper hoe"
@@ -311,6 +317,8 @@
 	name = "decrepit pitchfork"
 	icon_state = "apitchfork"
 	smeltresult = /obj/item/ingot/aalloy
+	color = "#bb9696"
+	sellprice = 15
 
 /obj/item/rogueweapon/pitchfork/copper
 	name = "copper pitchfork"

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -96,6 +96,7 @@
 
 /obj/item/rogueweapon/sickle/aalloy
 	name = "decrepit sickle"
+	desc = "Her thought was simple; to seperate the wheat from the chaff. By removing the limitations set upon one's spirit by lyfe, only then could divinity be obtained. She was correct - yet Her ascension had gone terribly awry, all-the-same."
 	icon_state = "asickle"
 	color = "#bb9696"
 	sellprice = 15
@@ -128,6 +129,7 @@
 
 /obj/item/rogueweapon/hoe/aalloy
 	name = "decrepit hoe"
+	desc = "Food is what cultivates lyfe; and without lyfe, there would be nothing left. At least, that is what His children would want you to believe."
 	icon_state = "ahoe"
 	smeltresult = /obj/item/ingot/aalloy
 	color = "#bb9696"
@@ -315,6 +317,7 @@
 
 /obj/item/rogueweapon/pitchfork/aalloy
 	name = "decrepit pitchfork"
+	desc = "Do not fault the layman for fearing Her disciples, nor for driving them out of the villages with pitchforks-and-torches. They, too, will come to see the blessings of Zizo, all in due tyme." 
 	icon_state = "apitchfork"
 	smeltresult = /obj/item/ingot/aalloy
 	color = "#bb9696"

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -55,10 +55,11 @@
 
 /obj/item/roguestatue/aalloy
 	name = "decrepit statue"
-	desc = "A statue of withering metal"
+	desc = "A statue of wrought bronze, forged to venerate an ancient champion."
 	icon_state = "astatue1"
 	smeltresult = /obj/item/ingot/aalloy
-	sellprice = 5
+	sellprice = 77
+	color = "#bb9696"
 
 /obj/item/roguestatue/aalloy/Initialize()
 	. = ..()

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -191,11 +191,14 @@
 
 /obj/item/rogueweapon/hammer/aalloy
 	name = "decrepit hammer"
-	desc = "A decrepit old hammer."
+	desc = "A hammer of wrought bronze. It has pounded out the beginning of a thousand legacies; of humble adventurers, of noble legionnaires, and of foolish heroes."
 	icon_state = "ahammer"
 	force = 12
 	max_integrity = 10
-	smeltresult = /obj/item/ingot/aalloy
+	smeltresult = /obj/item/ingot/aaslag
+	color = "#bb9696"
+	sellprice = 15
+
 
 
 /obj/item/rogueweapon/hammer/copper
@@ -377,10 +380,13 @@
 
 /obj/item/rogueweapon/tongs/aalloy
 	name = "decrepit tongs"
+	desc = "Wrought bronze pincers the molten alloy, putting it before the anvil and hammer. Soon, it will fashion a new legacy; one unmarred by this dogmatic millenia."
 	icon_state = "atongs"
 	force = 5
 	smeltresult = null
 	max_integrity = 10
+	color = "#bb9696"
+	sellprice = 5
 
 /obj/item/rogueweapon/tongs/aalloy/update_icon()
 	. = ..()

--- a/code/modules/roguetown/roguejobs/fisher/rod.dm
+++ b/code/modules/roguetown/roguejobs/fisher/rod.dm
@@ -161,3 +161,5 @@
 /obj/item/fishingrod/aalloy
 	name = "decrepit fishing rod"
 	icon_state = "arod"
+	color = "#bb9696"
+	sellprice = 15

--- a/code/modules/roguetown/roguejobs/fisher/rod.dm
+++ b/code/modules/roguetown/roguejobs/fisher/rod.dm
@@ -160,6 +160,7 @@
 
 /obj/item/fishingrod/aalloy
 	name = "decrepit fishing rod"
+	desc = "The Comet Syon's impact drowned the world, long ago. The waves've long since receded, but His greatest works remain shrouded far beneath the sea."
 	icon_state = "arod"
 	color = "#bb9696"
 	sellprice = 15

--- a/code/modules/roguetown/roguejobs/gravedigger/tools.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/tools.dm
@@ -174,9 +174,11 @@
 /obj/item/rogueweapon/shovel/aalloy
 	force = 8
 	name = "decrepit shovel"
-	desc = "A decrepit old shovel. Aeon's grasp is upon it."
+	desc = "A tool of wrought bronze, for burying the lyfeless. His worshippers would say that death is necessary; that the bod will nourish this world, so that more lyfe may sprout. But to those who know the truth - Her truth, it is nothing more than a mockery."
 	icon_state = "ashovel"
-	smeltresult = /obj/item/ingot/aalloy
+	smeltresult = /obj/item/ingot/aaslag
+	color = "#bb9696"
+	sellprice = 15
 
 /obj/item/burial_shroud
 	name = "winding sheet"

--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -273,4 +273,4 @@
 	desc = "A mass of wrought bronze, rendered lame from the forge's heat. Sometimes, dead is better."
 	icon_state = "ancientslag"
 	smeltresult = /obj/item/ingot/aaslag
-	sellprice = 11
+	sellprice = 1

--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -252,24 +252,25 @@
 	sellprice = 100
 
 /obj/item/ingot/aalloy
-	name = "ancient alloy"
-	desc = "An old, decrepit slab of metal. Aeon has withered it's strength."
+	name = "decrepit ingot"
+	desc = "A decrepit slab of wrought bronze, uncomfortably cold to the touch. The gales shift into whispers, when held for long enough; 'progress commands sacrifice'."
 	icon_state = "ingotancient"
-	smeltresult = /obj/item/ingot/aalloy
-	sellprice = 5
+	smeltresult = /obj/item/ingot/aaslag
+	color = "#bb9696"
+	sellprice = 33
 
 
 /obj/item/ingot/purifiedaalloy
-	name = "purified ancient alloy"
-	desc = "An old slab of metal, sparked to life by Malum's craft."
+	name = "ancient alloy"
+	desc = "An ingot of polished gilbranze, teeming with forbidden knowledge. The reflection on its surface isn't yours; it smiles back at you with eternal malice."
 	icon_state = "ingotancient"
-	smeltresult = /obj/item/ingot/aaslag
-	sellprice = 100
+	smeltresult = /obj/item/ingot/purifiedaalloy
+	sellprice = 111
 
 
 /obj/item/ingot/aaslag
-	name = "ancient slag"
-	desc = "What was once great, cannot be maintained forever."
+	name = "glimmering slag"
+	desc = "A mass of wrought bronze, rendered lame from the forge's heat. Sometimes, dead is better."
 	icon_state = "ancientslag"
 	smeltresult = /obj/item/ingot/aaslag
-	sellprice = 0
+	sellprice = 11

--- a/code/modules/roguetown/roguejobs/miner/tools.dm
+++ b/code/modules/roguetown/roguejobs/miner/tools.dm
@@ -71,14 +71,16 @@
 
 /obj/item/rogueweapon/pick/aalloy
 	name = "decrepit pick"
-	desc = "A decrepit old pick. Aeon's grasp is upon it."
+	desc = "A chisel of wrought bronze, which once labored to gather the ores necessary for an ancient alloy; such was lost in the aftermath of Her ascension."
 	force = 12
 	force_wielded = 17
 	icon_state = "apick"
 	possible_item_intents = list(/datum/intent/pick)
 	gripped_intents = list(/datum/intent/pick)
 	max_integrity = 150
-	smeltresult = /obj/item/ingot/aalloy
+	smeltresult = /obj/item/ingot/aaslag
+	color = "#bb9696"
+	sellprice = 15
 
 /obj/item/rogueweapon/pick/copper
 	name = "copper pick"

--- a/modular/Neu_Food/code/cookware/bowl.dm
+++ b/modular/Neu_Food/code/cookware/bowl.dm
@@ -21,6 +21,7 @@
 /obj/item/reagent_containers/glass/bowl/aalloy
 	name = "decrepit bowl"
 	icon_state = "abowl"
+	sellprice = 15
 
 /obj/item/reagent_containers/glass/bowl/iron
 	name = "iron bowl"

--- a/modular/Neu_Food/code/cookware/cup.dm
+++ b/modular/Neu_Food/code/cookware/cup.dm
@@ -50,14 +50,17 @@
 
 /obj/item/reagent_containers/glass/cup/aalloymug
 	name = "decrepit mug"
-	desc = "A decrepit mug. Aeon's grasp is upon its form."
+	desc = "Frayed bronze, coiled into a cup. Here, adventurers of centuries-past would laugh and legendize; but now, nothing but empty chairs and empty tables remain."
+	color = "#bb9696"
 	icon_state = "amug"
+	sellprice = 10
 
 /obj/item/reagent_containers/glass/cup/aalloygob
 	name = "decrepit goblet"
-	desc = "A decrepit goblet. Aeon's grasp is upon its form."
+	desc = "Frayed bronze, coiled into a hooked vessel. To think that this was once a nobleman's goblet; yet, it has endured far longer than their now-withered bloodline."
+	color = "#bb9696"
 	icon_state = "agoblet"
-	sellprice = 0
+	sellprice = 20
 
 /obj/item/reagent_containers/glass/cup/silver
 	name = "silver goblet"

--- a/modular/Neu_Food/code/cookware/fork.dm
+++ b/modular/Neu_Food/code/cookware/fork.dm
@@ -10,6 +10,8 @@
 /obj/item/kitchen/fork/aalloy
 	name = "decrepit fork"
 	icon_state = "afork"
+	color = "#bb9696"
+	sellprice = 5
 
 /obj/item/kitchen/fork/iron
 	name = "iron fork"

--- a/modular/Neu_Food/code/cookware/pan.dm
+++ b/modular/Neu_Food/code/cookware/pan.dm
@@ -31,5 +31,7 @@
 
 /obj/item/cooking/pan/aalloy
 	name = "decrepit pan"
-	desc = "A decrepit old pan. Aeon's grasp is upon it."
+	desc = "Frayed bronze, wrought into a handheld griddle. Just a little oil's more than enough to slicken the surprisingly-unmarred surface."
 	icon_state = "apan"
+	color = "#bb9696"
+	sellprice = 25

--- a/modular/Neu_Food/code/cookware/platter.dm
+++ b/modular/Neu_Food/code/cookware/platter.dm
@@ -98,8 +98,10 @@ What it does:
 
 /obj/item/cooking/platter/aalloy
 	name = "decrepit platter"
-	desc = "A decrepit old platter. Aeon's grasp is upon its form."
+	desc = "Wrought bronze, flattened to serve. The edge remains wet with red; spilled merlot, meaty juices, or blood?"
 	icon_state = "aplatter"
+	color = "#bb9696"
+	sellprice = 15
 
 /obj/item/cooking/platter/copper
 	name = "copper platter"

--- a/modular/Neu_Food/code/cookware/pot.dm
+++ b/modular/Neu_Food/code/cookware/pot.dm
@@ -43,9 +43,11 @@
 
 /obj/item/reagent_containers/glass/bucket/pot/aalloy
 	name = "decrepit pot"
-	desc = "A decrepit old pot. Aeon's grasp is upon it."
+	desc = "A kettle of wrought bronze. One could only imagine what the stews of millenia prior must've tasted like; do you suppose they knew of seasonings-and-spices, too?"
 	icon_state = "apote"
 	volume = 99
+	color = "#bb9696"
+	sellprice = 25
 
 /obj/item/reagent_containers/glass/bucket/pot/stone
 	name = "stone pot"

--- a/modular/Neu_Food/code/cookware/spoon.dm
+++ b/modular/Neu_Food/code/cookware/spoon.dm
@@ -9,6 +9,8 @@
 /obj/item/kitchen/spoon/aalloy
 	name = "decrepit spoon"
 	icon_state = "aspoon"
+	color = "#bb9696"
+	sellprice = 5
 
 /obj/item/kitchen/spoon/iron
 	name = "iron spoon"


### PR DESCRIPTION
## About The Pull Request
* All *decrepit* items can no longer be smelted into ingots, are now flagged as _'unrepairable'_, and come with a premade dyejob _(to better differentiate them from their ancient counterparts)_.
* Most *decrepit* and *ancient* items now have completely overhauled descriptions, sprinkled with _lore_. This _should_ hopefully bring them up-to-parity with *'blessed silver'*-tier items.
_(Addendum: revalued most decrepit items, in order to account for their rarity. The only way to obtain decrepit ingots would either be by smelting the much-more-valuable statues, or by finding them in dungeons. Ancient alloys have been appropriately revalued, too, to account for the fact that they're made with decrepit-and-gold.)_

## Testing Evidence
Similar to my [other pull request](https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3305), this largely doesn't touch anything sensitive: it's mostly a bunch of one-line additions and rewritten variables. I _did_ log onto Azure to quickly see what hexcode'd look the nicest, however.

## Why It's Good For The Game
* Fixes the unintended consequence of *decrepit* items not actually being _decrepit_, and makes them more visually distinct than their *ancient* counterparts. Frugal adventurers can no longer rely on centuries-old bronze to get themselves through the week.
* Dripfeeding lore into the playerbase through mechanical exposure is always quite delightful.
_(Addendum: decrepit items having value - while being almost impossible to replicate - fills the original niche of being Dungeon-exclusive loot. This doesn't apply to weapons or armor; only tools and valuables. This should hopefully allow Dungeon-centric mappers to add more tiered loot to their works.)_