### PR TITLE
Gives Hunter journeyman polearm skills for spear-hunting

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/hunter.dm
@@ -37,6 +37,7 @@
 
 	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request

Just adds level 3 polearm skills to Hunter so they can participate in spear-hunting if they choose.

## Testing Evidence

This feels like a small enough coding change that I didn't need to manually test it.

## Why It's Good For The Game

Spear-hunting is cool, it feels like something Hunters that follow Dendor would also learn how to do. We'd see some more diversity in what Hunters use for weapons with this change.
