### PR TITLE
Add striped tunic to the loadout

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -247,6 +247,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Tunic"
 	path = /obj/item/clothing/suit/roguetown/shirt/tunic
 
+/datum/loadout_item/stripedtunic
+	name = "Striped Tunic"
+	path = /obj/item/clothing/suit/roguetown/armor/workervest
+
 /datum/loadout_item/dress
 	name = "Dress"
 	path = /obj/item/clothing/suit/roguetown/shirt/dress/gen


### PR DESCRIPTION
## About The Pull Request
What it says on the tin: the striped tunic is a simple garment (that is a child of /armor for some reason) that I think should be readily available to access.

To my knowledge it doesn't provide any meaningful protections, or at least not any more than normal clothes.

## Testing Evidence
~~I would test it myself but every single time I've tried to fork and clone AP it's never made it past the lobby and DD lobotomizes itself. This is before I even change anything with my copy. The change is simple enough anyways.~~
Running the DMB directly out of VSC worked. Sort of. It blew itself up trying to equip literally anything in the armor slot though. I'm cursed!
<img width="302" height="304" alt="image" src="https://github.com/user-attachments/assets/6170da2b-12d3-413f-98d1-3d146d28bd02" />

## Why It's Good For The Game
more options more agency etc