### PR TITLE
Sorted and ordered skills with highlight

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -116,4 +116,6 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 
 /proc/cmp_filter_priority_desc(list/A, list/B) // Compares two lists by their 'priority' key. Used for filters.
     return (A["priority"] || 0) - (B["priority"] || 0)
-	
+
+/proc/cmp_skills_for_display(datum/skill/A, datum/skill/B)
+	return sorttext("[B.abstract_type]", "[A.abstract_type]") || sorttext(B.name, A.name)

--- a/code/datums/skill_holder.dm
+++ b/code/datums/skill_holder.dm
@@ -198,12 +198,13 @@
 		return
 	var/msg = ""
 	msg += span_info("*---------*\n")
-	for(var/datum/skill/i in shown_skills)
+	var/list/sorted_skills = sortList(shown_skills, GLOBAL_PROC_REF(cmp_skills_for_display))
+	for(var/datum/skill/i in sorted_skills)
 		var/can_advance_post = current?.mind?.sleep_adv.enough_sleep_xp_to_advance(i.type, 1)
 		var/capped_post = current?.mind?.sleep_adv.enough_sleep_xp_to_advance(i.type, 2)
-		var/rankup_postfix = capped_post ? span_nicegreen(" <b>(!!)</b>") : can_advance_post ? span_nicegreen(" <b>(!)</b>") : ""
-		msg += "[i] - [SSskills.level_names[known_skills[i]]][rankup_postfix]"
-		msg += span_info(" <a href='?src=[REF(i)];skill_detail=1'>{?}</a>\n")
+		var/rankup_postfix = capped_post ? span_nicegreen(" ★ ") : can_advance_post ? span_nicegreen(" ☆ ") : ""
+		var/skill_name = "<span style='color: [i.color]'>[i]</span>"
+		msg += "[skill_name] - [SSskills.level_names[known_skills[i]]][rankup_postfix] <a href='?src=[REF(i)];skill_detail=1' style='font-size: 0.5em;'>{?}</a>\n"
 	msg += "</span>"
 
 	to_chat(user, msg)

--- a/code/datums/skills/_skill.dm
+++ b/code/datums/skills/_skill.dm
@@ -10,6 +10,7 @@
 	var/list/dreams
 	var/randomable_dream_xp = TRUE
 	var/expert_name
+	var/color = null
 
 /datum/skill/proc/get_skill_speed_modifier(level)
 	return

--- a/code/datums/skills/combat.dm
+++ b/code/datums/skills/combat.dm
@@ -4,6 +4,7 @@
 	desc = ""
 	dream_cost_base = 2
 	dream_cost_per_level = 1
+	color = "#ec994b"
 
 /datum/skill/combat/knives
 	name = "Knife-fighting"

--- a/code/datums/skills/craft.dm
+++ b/code/datums/skills/craft.dm
@@ -2,6 +2,7 @@
 	abstract_type = /datum/skill/craft
 	name = "Craft"
 	desc = ""
+	color = "#4e7bb1"
 
 /datum/skill/craft/crafting
 	name = "Crafting"

--- a/code/datums/skills/labor.dm
+++ b/code/datums/skills/labor.dm
@@ -2,6 +2,7 @@
 	abstract_type = /datum/skill/labor
 	name = "Labor"
 	desc = ""
+	color = "#78c472"
 
 /datum/skill/labor/farming
 	name = "Farming"

--- a/code/datums/skills/magic.dm
+++ b/code/datums/skills/magic.dm
@@ -3,6 +3,7 @@
 	name = "Magic"
 	desc = ""
 	randomable_dream_xp = FALSE
+	color = "#9f74d6"
 
 /datum/skill/magic/holy
 	name = "Miracles"


### PR DESCRIPTION
## About The Pull Request
Port from Twilight
Changes: 
- The character's skills are sorted by category and arranged alphabetically. Abilities (Labor, Craft, Magic etc) are highlighted in colors depending on the color.
- Level up ! and !! has been updated into ☆ - one level; ★ - two levels.

## Testing Evidence

<img width="472" height="615" alt="image" src="https://github.com/user-attachments/assets/eb7f09c6-ab90-43a7-9dc0-d495de44301b" />

<img width="458" height="600" alt="image" src="https://github.com/user-attachments/assets/7818da78-7ffd-4288-8dfe-119625a1c643" />

## Why It's Good For The Game

Better shown character's skills