### PR TITLE
kills the final instance of 'Priest'?

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -193,7 +193,7 @@ GLOBAL_LIST_EMPTY(heretical_players)
 		visible_message(span_warning("[src] takes a deep breath, preparing to make an announcement.."))
 		if(do_after(src, 15 SECONDS, target = src)) // Reduced to 15 seconds from 30 on the original Herald PR. 15 is well enough time for sm1 to shove you.
 			say(announcementinput)
-			priority_announce("[announcementinput]", "The Priest Speaks", 'sound/misc/bell.ogg', sender = src)
+			priority_announce("[announcementinput]", "The Bishop Speaks", 'sound/misc/bell.ogg', sender = src)
 			COOLDOWN_START(src, priest_announcement, PRIEST_ANNOUNCEMENT_COOLDOWN)
 		else
 			to_chat(src, span_warning("Your announcement was interrupted!"))


### PR DESCRIPTION
## About The Pull Request

- groan
- Replaces 'Priest' with 'Bishop' in the church announcement

## Testing Evidence

one line

## Why It's Good For The Game

One of seven billion instances of the word 'priest' on the codebase, miss one of the most public facing.
