### PR TITLE
Allow face to be attacked on Decrepit Barbute

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -15,6 +15,7 @@
 /obj/item/clothing/head/roguetown/helmet/heavy/aalloy
 	name = "decrepit barbute"
 	desc = "Frayed bronze plates, pounded into a visored helmet. Scrapes and dents line the curved plating, weathered from centuries of neglect. The remains of a plume's stub hang atop its rim."
+	body_parts_covered = COVERAGE_HEAD
 	max_integrity = ARMOR_INT_HELMET_HEAVY_DECREPIT
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	icon_state = "ancientbarbute"


### PR DESCRIPTION
## About The Pull Request

Allows the face of the Decrepit Barbute to be attacked
## Testing Evidence

Spawned in Decrepit Barbute, attacked all areas of head with knife; ears, top, and general head are protected.

## Why It's Good For The Game

The Decrepit barbute is an open faced helmet, this will also allow adventurers who don't use peel weapons (Dagger, unarmed, hammers, etc) a way to score (semi reliable, as skullcrush/skullpierce is still luck based) kills on armored skeletons. Did not touch the normal Barbute as that is used by players. 
