### PR TITLE
Fixes potion loot spawners & a few other small dungeon pass oversights

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -7661,7 +7661,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/orcdungeon)
 "czw" = (
-/mob/living/carbon/human/species/skeleton/npc/hard,
+/obj/item/rogueweapon/sword/rapier,
+/obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
 "czy" = (

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -71899,6 +71899,10 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"xky" = (
+/obj/item/rogueweapon/sword/sabre,
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/cave)
 "xkB" = (
 /obj/item/bedsheet/rogue/double_pelt,
 /obj/structure/bed/rogue/inn/double,
@@ -269865,7 +269869,7 @@ gAt
 qPv
 qPv
 mlk
-mlk
+xky
 mlk
 qPv
 qPv

--- a/code/game/objects/effects/spawners/roguemapgen.dm
+++ b/code/game/objects/effects/spawners/roguemapgen.dm
@@ -73,41 +73,45 @@
 
 /obj/effect/spawner/lootdrop/potion_vitals
 	icon_state = "lootpotion"
-	spawned = list(
-		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 10,
-		/obj/item/reagent_containers/glass/bottle/rogue/healthpotnew = 5,
+	lootcount = 1
+	loot = list(
+		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 5,
+		/obj/item/reagent_containers/glass/bottle/rogue/healthpotnew = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/manapot = 10,
-		/obj/item/reagent_containers/glass/bottle/rogue/strongmanapot = 5,
+		/obj/item/reagent_containers/glass/bottle/rogue/strongmanapot = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/stampot = 10,
-		/obj/item/reagent_containers/glass/bottle/rogue/strongstampot = 5
+		/obj/item/reagent_containers/glass/bottle/rogue/strongstampot = 1
 	)
 
 /obj/effect/spawner/lootdrop/potion_poisons
 	icon_state = "lootpoison"
-	spawned = list(
-		/obj/item/reagent_containers/glass/bottle/rogue/poison = 10,
-		/obj/item/reagent_containers/glass/bottle/rogue/strongpoison = 5,
+	lootcount = 1
+	loot = list(
+		/obj/item/reagent_containers/glass/bottle/rogue/berrypoison = 10,
+		/obj/item/reagent_containers/glass/bottle/rogue/poison = 5,
+		/obj/item/reagent_containers/glass/bottle/rogue/strongpoison = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/stampoison = 10,
-		/obj/item/reagent_containers/glass/bottle/rogue/strongstampoison = 5,
+		/obj/item/reagent_containers/glass/bottle/rogue/strongstampoison = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/stampot = 10,
-		/obj/item/reagent_containers/glass/bottle/rogue/strongstampot = 5
+		/obj/item/reagent_containers/glass/bottle/rogue/strongstampot = 1
 	)
 
 /obj/effect/spawner/lootdrop/potion_ingredient
 	icon_state = "lootpotioning"
 	var/static/list/all_potion_ings = list()
-	spawned = list()
+	loot = list()
 
 /obj/effect/spawner/lootdrop/potion_ingredient/Initialize(mapload)
 	if(!all_potion_ings.len)
 		all_potion_ings = subtypesof(/obj/item/alch)
-	if(!spawned.len)
-		spawned = all_potion_ings.Copy()
+	if(!loot.len)
+		loot = all_potion_ings.Copy()
 	return ..()
 
 /obj/effect/spawner/lootdrop/potion_ingredient/herb
 	icon_state = "lootpotionherb"
-	spawned = list(
+	lootcount = 2
+	loot = list(
 		/obj/item/alch/atropa = 5,
 		/obj/item/alch/matricaria = 5,
 		/obj/item/alch/symphitum = 5,
@@ -126,7 +130,8 @@
 	)
 /obj/effect/spawner/lootdrop/potion_stats
 	icon_state = "lootstatpot"
-	spawned = list(
+	lootcount = 1
+	loot = list(
 		/obj/item/reagent_containers/glass/bottle/alchemical/strpot = 10,
 		/obj/item/reagent_containers/glass/bottle/alchemical/perpot = 10,
 		/obj/item/reagent_containers/glass/bottle/alchemical/endpot = 10,

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -949,7 +949,7 @@
 	to the siege that smashed the Mad Duke's keep to rubble, and burnt the Duke himself to cinders."
 	icon_state = "lordrap"
 	sheathe_icon = "lordrapier"
-	sellprice = 100
+	sellprice = 150
 	max_integrity = 300
 	max_blade_int = 300
 	wdefense = 7


### PR DESCRIPTION
## About The Pull Request

- Fixes potion loot spawners.
- Unique mad duke's rapier is now worth slightly more than regular decorated rapiers instead of slightly less.
- This one's not exactly a bug-fix but I added regular steel sabres/rapiers in a few spots where decorated sabres/rapiers were previously prior to the dungeon pass. *Hopefully* shouldn't conflict with anything - I only edited like two whole tiles here.

## Testing Evidence

Spawned in, tested potion spawners, seems to work fine.

## Why It's Good For The Game

Bug fixes good
