### PR TITLE
Throwing Net fix port + nerfs

### DIFF
--- a/code/game/objects/items/rogueitems/ropechainbola.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola.dm
@@ -219,8 +219,9 @@
 	throwforce = 5
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "net"
-	breakouttime = 35//easy to apply, easy to break out of
+	slipouttime = 2 SECONDS //ideally you're using this to catch a dodger, not in the middle of combat
 	gender = NEUTER
+	throw_speed = 2
 	var/knockdown = 0
 
 /obj/item/net/Initialize()

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_ranged.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_ranged.dm
@@ -137,5 +137,4 @@
 	cost = 20
 	contains = list(
 					/obj/item/net,
-					/obj/item/net
 				)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -58,22 +58,14 @@
 	if(!skipcatch)	//ugly, but easy
 		if(can_catch_item())
 			if(istype(AM, /obj/item))
-				if(!istype(AM, /obj/item/net))
-					var/obj/item/I = AM
-					if(isturf(I.loc))
-						I.attack_hand(src)
-						if(get_active_held_item() == I) //if our attack_hand() picks up the item...
-							visible_message("<span class='warning'>[src] catches [I]!</span>", \
-											"<span class='danger'>I catch [I] in mid-air!</span>")
-							throw_mode_off()
-							return 1
-				else
-					var/obj/item/net/N
-					visible_message("<span class='warning'>[src] tries to catch \the [N] but gets snared by it!</span>", \
-									"<span class='danger'>Why did I even try to do this...?</span>") // Hahaha dumbass!!!
-					throw_mode_off()
-					N.ensnare(src)
-					return
+				var/obj/item/I = AM
+				if(isturf(I.loc))
+					I.attack_hand(src)
+					if(get_active_held_item() == I) //if our attack_hand() picks up the item...
+						visible_message("<span class='warning'>[src] catches [I]!</span>", \
+										"<span class='danger'>I catch [I] in mid-air!</span>")
+						throw_mode_off()
+						return 1
 	..()
 
 


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/Scarlet-Reach/Scarlet-Reach/pull/192 by roarbark!
Throwing nets now take two seconds to break out of, instead of instant (or the supposed 3.5 seconds they originally were supposed to have). Buying a net at the merchant's now only gives you one instead of two.
Removed the exemption nets had from catching to allow counterplay.

## Testing Evidence

<details><summary>Screenies</summary>
<img width="560" height="294" alt="screenie1" src="https://github.com/user-attachments/assets/a87f8b8a-a042-4556-a4c1-1e79ef19329d" />
<img width="559" height="221" alt="screenie2" src="https://github.com/user-attachments/assets/1da6e608-7285-4d71-aadd-134cfd7abdfa" />
<img width="175" height="42" alt="screenie3" src="https://github.com/user-attachments/assets/c6ea30bc-0b12-43ed-964b-01729754da82" />

</details>

## Why It's Good For The Game

More fun and cool toys for you! Makes a situational tool relevant and desirable again. Not too crushing unless actively sprinting away was the only option left, and now a little less easy to hoard unless you have at least some crafting skill to make your own.
You also originally could not catch nets because of a special, net-specific exemption. Now you can, so it's a little less safer to use as an opener in any fight. Doesn't seem to break anything, and the debuff does not apply unless you're ensnared.

In my experience on SR it was only really WWs that consistently get tripped by this, with how reliant they are on easy escapes. Discuss?