### PR TITLE
Knight Errant adventurer class parity 'jak

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -100,12 +100,8 @@
 				/obj/item/recipe_book/survival = 1,
 				)
 			H.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
@@ -123,28 +119,28 @@
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
 				if("Longsword")
-					H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+					H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 					beltr = /obj/item/rogueweapon/sword/long
 					r_hand = /obj/item/rogueweapon/scabbard/sword
 				if("Mace + Shield")
-					H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+					H.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
 					H.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
 					beltr = /obj/item/rogueweapon/mace
 					backr = /obj/item/rogueweapon/shield/tower/metal
 				if("Flail + Shield")
-					H.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
+					H.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 					H.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
 					beltr = /obj/item/rogueweapon/flail
 					backr = /obj/item/rogueweapon/shield/tower/metal
 				if("Billhook")
-					H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+					H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 					r_hand = /obj/item/rogueweapon/spear/billhook
 					backr = /obj/item/gwstrap
 				if("Battle Axe")
-					H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+					H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 					r_hand = /obj/item/rogueweapon/stoneaxe/battle
 				if("Greataxe")
-					H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+					H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 					r_hand = /obj/item/rogueweapon/greataxe
 					backr = /obj/item/gwstrap
 			H.change_stat("strength", 2)


### PR DESCRIPTION
## About The Pull Request

This PR removes all of the knight errant's weapon skills except for shields, knives, wrestling, and unarmed. Your skill with one weapon type is raised to expert when you pick a weapon.

## Testing Evidence
<img width="391" height="130" alt="image" src="https://github.com/user-attachments/assets/1936514d-c30a-40b4-a72c-001068c10bc1" />


## Why It's Good For The Game
Works similarly to Battlemaster and Duelist, except that Battlemaster will have a niche in that they still retain those unused weapon skills while KE gets stuck with a one and done.





There are a lot of things to call this PR, and "urgent" is not one of them.