### PR TITLE
Overwrites prosthetic limb dismember with bruises

### DIFF
--- a/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
+++ b/code/modules/roguetown/roguejobs/engineer/prostheticarm.dm
@@ -16,6 +16,7 @@
 	sellprice = 30
 	fingers = FALSE //can't swing weapons but can pick stuff up and punch
 	anvilrepair = /datum/skill/craft/carpentry
+	dismember_wound = /datum/wound/bruise/large
 
 /obj/item/bodypart/l_arm/prosthetic/bronzeleft
 	name = "bronze left arm"
@@ -34,6 +35,7 @@
 	fingers = TRUE // it acts like a normal arm
 	anvilrepair = /datum/skill/craft/engineering
 	smeltresult = /obj/item/ingot/bronze
+	dismember_wound = /datum/wound/bruise/large
 
 /obj/item/bodypart/l_arm/prosthetic/attack(mob/living/M, mob/user)
 	if(!ishuman(M))
@@ -66,6 +68,7 @@
 	sellprice = 30
 	fingers = FALSE //can't swing weapons but can pick stuff up and punch
 	anvilrepair = /datum/skill/craft/carpentry
+	dismember_wound = /datum/wound/bruise/large
 
 /obj/item/bodypart/r_arm/prosthetic/bronzeright
 	name = "bronze right arm"
@@ -84,6 +87,7 @@
 	fingers = TRUE // it acts like a normal arm
 	anvilrepair = /datum/skill/craft/engineering
 	smeltresult = /obj/item/ingot/bronze
+	dismember_wound = /datum/wound/bruise/large
 
 /obj/item/bodypart/r_arm/prosthetic/attack(mob/living/M, mob/user)
 	if(!ishuman(M))
@@ -117,6 +121,7 @@
 	max_integrity = 300
 	sellprice = 30
 	anvilrepair = /datum/skill/craft/carpentry
+	dismember_wound = /datum/wound/bruise/large
 
 /obj/item/bodypart/l_leg/prosthetic/bronzeleft
 	name = "bronze left leg"
@@ -167,6 +172,7 @@
 	max_integrity = 300
 	sellprice = 30
 	anvilrepair = /datum/skill/craft/carpentry
+	dismember_wound = /datum/wound/bruise/large
 
 /obj/item/bodypart/r_leg/prosthetic/bronzeright
 	name = "bronze right leg"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Got pointed out that prosthetic limb dismemberment is as severe as real limb dismemberment, which isn't ludo. This changes dismember_wound to give the chest a big bruise. Less lethal, but still significant in melee.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

https://github.com/user-attachments/assets/7e07ab11-62c1-4c2d-b3aa-ae8f62d2023c


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Buffs prosthetic limbs a little I guess. They're pretty fragile and the dismemberment wound is brutal to include with it, maybe.