### PR TITLE
Fixes spatial harddel

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -559,6 +559,7 @@
 			oldloc.Exited(src, null)
 			if(old_area)
 				old_area.Exited(src, null)
+			Moved(oldloc, NONE, TRUE)
 		loc = null
 
 /atom/movable/proc/onTransitZ(old_z,new_z)

--- a/code/modules/mob/living/simple_animal/rogue/farm/goat.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/goat.dm
@@ -5,8 +5,8 @@
 		tamed()
 
 /mob/living/simple_animal/hostile/retaliate/rogue/goat/Destroy()
-	..()
 	GLOB.farm_animals = max(GLOB.farm_animals - 1, 0)
+	return ..()
 
 /mob/living/simple_animal/hostile/retaliate/rogue/goat/find_food()
 	..()


### PR DESCRIPTION
## About The Pull Request

Apparently, movement to nullspace was not calling Moved(), in turn causing a harddel since atom was not leaving its spatial cell properly

Ideally, we need to port this - https://github.com/tgstation/tgstation/pull/82085

Also removes lack of goat's QDEL_HINT because it irks me