### PR TITLE
Remove preload ambience button.

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -265,11 +265,3 @@ GLOBAL_LIST_INIT(ambience_files, list(
 	'sound/music/area/towngen.ogg',
 	'sound/music/area/townstreets.ogg'
 	))
-
-/client/verb/preload_sounds()
-	set category = "Options"
-	set name = "Preload Ambience"
-
-	for(var/music in GLOB.ambience_files)
-		mob.playsound_local(mob, music, 0.1)
-		sleep(10)


### PR DESCRIPTION
## About The Pull Request
Remove the preload ambience button

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="622" height="254" alt="dreamseeker_9WIQDUHRWE" src="https://github.com/user-attachments/assets/66ec7a9c-f5f2-4e69-a3a9-108c273c9322" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
On demand lag button on server shouldn't exist. This has been tested in game and causes a measurable stutter serverwide for between 5 - 15 seconds.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
