### PR TITLE
Maneater incorrect limbs delete fix

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -82,11 +82,15 @@
 							if(limb)
 								playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
 								if(limb.dismember())
+									limb.drop_limb()
 									qdel(limb)
 									seednutrition += 20
 									if(C.mind) // eat only one limb of things with minds
 										maneater_spit_out(C)
 										return
+								if(!limb.dismemberable) //gib goblins right away as they cant be dismembered, meaning they will be stuck in infinit loop of being snatched and not dismembered
+									C.gib()
+									seednutrition += 50
 								return
 						if(C.mind) // nugget case, just spit them out
 							maneater_spit_out(C)
@@ -95,6 +99,7 @@
 						if(limb)
 							playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
 							if(limb.dismember())
+								limb.drop_limb()
 								qdel(limb)
 							return
 						limb = C.get_bodypart(BODY_ZONE_CHEST)


### PR DESCRIPTION
## About The Pull Request

Port from https://github.com/Scarlet-Reach/Scarlet-Reach/pull/446

"Currently maneater will ALWAYS delete your limb even if it was protected or you cant be dismembered
This pr makes a proper check for dismember(), also taking in account that goblin npc cant be dismembered (we gib them right away)" - Heheniy

This PR fixes issue about goblin endless loop eating by maneater and makes limbs not deletable instantly from the world.

## Testing Evidence

<img width="312" height="185" alt="image" src="https://github.com/user-attachments/assets/43af3ec8-1a67-402c-893b-fcd61cf268e4" />

<img width="350" height="273" alt="image" src="https://github.com/user-attachments/assets/e178b794-4d00-43f2-8ee0-bdce34ebf526" />


## Why It's Good For The Game

"You will no longer loose your limb to maneater even if your armor protected you or you have TRAIT_NODISMEMBER" - Heheniy