### PR TITLE
Makes seneshal subclass names display properly.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -16,6 +16,7 @@
 	min_pq = 3
 	max_pq = null
 	round_contrib_points = 3
+	advjob_examine = TRUE
 
 /datum/job/roguetown/butler/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds advjob_examine set to true to the seneshal role.

## Testing Evidence

Spawned as a head maid, was head maid instead of seneshal:

<img width="1100" height="522" alt="obraz" src="https://github.com/user-attachments/assets/a0bead10-f6fb-4314-a6f3-0454d5411e8b" />

## Why It's Good For The Game

Since the split between seneshal, head maid, and chief butler is already purely cosmetic it doesn't make sense for those roles to not use their advclass names.
