### PR TITLE
Makes fyritius grindable for nectar

### DIFF
--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -388,6 +388,7 @@
 	tastes = list("tastes like a burning coal and fire" = 1)
 	bitesize = 1
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/fyritiusnectar = 5)
+	grind_results = list(/datum/reagent/toxin/fyritiusnectar = 10)
 	dropshrink = 0.8
 	rotprocess = null
 	w_class = WEIGHT_CLASS_TINY


### PR DESCRIPTION
## About The Pull Request

You can middleclick a fyritius inside mortar to grind it into nectar now

## Testing Evidence

compiled, worked in local

## Why It's Good For The Game

There is a recipe for vitae decotion to cure the Lux taint rituals from heretics. But there is currently no way to actually get the nectar to create it
