### PR TITLE
Matthios, is this true?

### DIFF
--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -4,7 +4,7 @@
 	wave_type = /datum/migrant_wave/bandit
 	max_occurrences = 2
 
-	weight = 12
+	weight = 18
 
 	earliest_start = 0 SECONDS
 
@@ -15,8 +15,8 @@
 
 /datum/round_event/migrant_wave/bandits/start()
 	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
-	bandit_job.total_positions = min(bandit_job.total_positions + 3, 6)
-	bandit_job.spawn_positions = min(bandit_job.spawn_positions + 3, 6)
+	bandit_job.total_positions = min(bandit_job.total_positions + 5, 10)
+	bandit_job.spawn_positions = min(bandit_job.spawn_positions + 5, 10)
 	if(bandit_job.total_positions < 6) // Not at max capacity, increasing goal.
 		SSmapping.retainer.bandit_goal += 3 * rand(200, 400)
 		SSrole_class_handler.bandits_in_round = TRUE

--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -41,12 +41,12 @@
 		"Apothecary"
 	)
 
-	base_antags = 4
-	maximum_antags = 6
+	base_antags = 5
+	maximum_antags = 10
 
 	earliest_start = 0 SECONDS
 
-	weight = 25
+	weight = 35
 
 	typepath = /datum/round_event/antagonist/solo/bandits
 	antag_datum = /datum/antagonist/bandit


### PR DESCRIPTION
## About The Pull Request

Roundstart bandit:
Increases bandit cap from 6 to 10.
Base antag from 4 to 5
Weight from 25 to 35

Midround injection:
Opens 5 slots instead of 3, up to 10
Weight from 12 to 18

## Testing Evidence

Trust me bro

## Why It's Good For The Game

Bandits get utterly mogged by murderballs of doom. There is no way three bandits will be able to actually antagonize anyone, because they always have to fight against overwhelming odds. 3 bandits vs 15 keepites/templars/psydonians/adventurers removes any opportunity to actually antagonize the town.