### PR TITLE
Stops gibbing from runtiming simplemobs.

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -947,7 +947,7 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 
 /mob/living/simple_animal/proc/update_grid()
 	var/turf/our_turf = get_turf(src)
-	if(isnull(our_turf))
+	if(isnull(our_turf) || isnull(our_cells))
 		return
 
 	var/list/cell_collections = our_cells.recalculate_cells(our_turf)


### PR DESCRIPTION
## About The Pull Request

I spotted this while trying to figure out harddels with simplemobs. This is relatively new code, added 3 days ago, and I noticed an error in it. When you gib a mob, it goes through the Destroy() functions, etc. It gets moved into nullspace which counts for proccing moved, which then calls a function and uses a value we arleady nulled. This makes sure it just returns if it's been nulled already.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
No runtime with it on.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
its' not
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
