### PR TITLE
Buff Some Templar Unique Weapons slightly.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -385,8 +385,8 @@
 	name = "duel settler"
 	desc = "The tenets of ravoxian duels are enscribed upon the head of this maul."
 	icon_state = "ravoxhammer"
-	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash)
-
+	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash, /datum/intent/effect/daze) // It loses the Goden stab so I give it daze
+	max_integrity = 350 // I am reluctant to give a steel goden more force as it breaks weapon so durability it is.
 
 /obj/item/rogueweapon/mace/goden/psymace
 	name = "psydonian mace"

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -128,6 +128,7 @@
 	name = "swift journey"
 	desc = "The striking head is full of teeth, rattling viciously with ever strike, with every rotation. Each set coming from one the wielder has laid to rest. Carried alongside them as a great show of respect."
 	icon_state = "necraflail"
+	force = 33 // 10% force increase, yippee
 
 /obj/item/rogueweapon/flail/sflail/psyflail
 	name = "psydonian flail"

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -315,6 +315,7 @@
 	name ="plaguebringer sickle"
 	desc = "A wicked edge brings feculent delights."
 	icon_state = "pestrasickle"
+	force = 22 // 10% - This is a 8 clickCD weapon
 	max_integrity = 200
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/pestrasickle/Initialize()

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -643,6 +643,8 @@
 	desc = "Summer's verdancy runs through the head of this scythe. All the more to sow."
 	icon_state = "dendorscythe"
 	gripped_intents = list(/datum/intent/spear/thrust/eaglebeak, /datum/intent/spear/cut/bardiche, /datum/intent/axe/chop/scythe, SPEAR_BASH)
+	force_wielded = 33 // +3
+	max_integrity = 300 // +50
 
 /obj/item/rogueweapon/halberd/psyhalberd
 	name = "Stigmata"

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -299,6 +299,8 @@
 	name = "forgefiend flamberge"
 	desc = "This sword's creation took a riddle in its own making. A great sacrifice was made for a blade of perfect quality."
 	icon_state = "malumflamberge"
+	force = 28 // +3 force as a unique sword. Longsword isn't THAT good anyway
+	force_wielded = 33 // Also +3
 	max_integrity = 200
 
 /obj/item/rogueweapon/sword/long/zizo
@@ -964,6 +966,8 @@
 	grid_height = 64
 	dropshrink = 0
 	bigboy = FALSE
+	force = 25 // Same statline as the cup hilted etruscan rapier
+	wdefense = 8
 
 /obj/item/rogueweapon/sword/cutlass
 	name = "cutlass"


### PR DESCRIPTION
## About The Pull Request
5 minutes PR to pretend I am being productive while I am crying and sobbing looking at hard deletes. This PR buffs the templar weapon that are equal to their normal counterpart or in one case worse (Ravox's Hammer):

- Ravox Hammer: 250 -> 350 Max_Integrity. Gain Daze Intent. No force increase (It is a Steel Goden do you want that). Before this it is literally just a steel goden without the ranged stab.
- Necra's Flail: 30 -> 33. Purely offensive weapon. Shouldn't be too bad
- Plaguebringer Sickle: 20 -> 22 Force. 
- Dendor's Scythe: 30 -> 33 Wielded Force. Durability 250 -> 300. (Picked a more balanced profile as it is a polearm)
- Malum Longsword: 25 -> 28 Force. 30 -> 33 Wielded Force.
- Eoran Rapier: 22 -> 25 Force. WDefense 7 -> 8. 1 to 1 to the Cup Hilted Rapier

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested, compiled.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Give those templars more bonus and incentives to use their unique weapons and keep it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
