### PR TITLE
Bite Through Helms - Graggar/Vampire Lord helmet

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -181,6 +181,7 @@
 #define TRAIT_ARCYNE_T2 "Arcyne Training (Apprentice)"
 #define TRAIT_ARCYNE_T3 "Arcyne Training (Expert)"
 #define TRAIT_ARCYNE_T4 "Arcyne Training (Master)"
+#define TRAIT_BITERHELM "Biter Helm" // just use this to get helmets which are bitey.
 #define TRAIT_STRENGTH_UNCAPPED "Strength Unbound"	//ignores the STR softcap.
 #define TRAIT_EORAN_CALM "Eoran Calm"
 #define TRAIT_EORAN_SERENE "Eoran Serenity"

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -402,7 +402,7 @@
 					return
 				if(src.incapacitated())
 					return
-				if(!get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH, grabs="other"))
+				if(!get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH, grabs="other") && (!HAS_TRAIT(src, TRAIT_BITERHELM)))
 					to_chat(src, span_warning("My mouth is blocked."))
 					return
 				if(HAS_TRAIT(src, TRAIT_NO_BITE))

--- a/code/modules/antagonists/roguetown/villain/vampirelord.dm
+++ b/code/modules/antagonists/roguetown/villain/vampirelord.dm
@@ -240,6 +240,23 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	max_integrity = 250
 	block2add = FOV_BEHIND
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	var/active_item = FALSE
+
+
+/obj/item/clothing/head/roguetown/helmet/heavy/vampire/equipped(mob/living/user, slot)
+	. = ..()
+	if(active_item)
+		return
+	if(slot == SLOT_HEAD)
+		active_item = TRUE
+		ADD_TRAIT(user, TRAIT_BITERHELM, TRAIT_GENERIC)
+
+/obj/item/clothing/head/roguetown/helmet/heavy/vampire/dropped(mob/living/user)
+	..()
+	if(!active_item)
+		return
+	active_item = FALSE
+	REMOVE_TRAIT(user, TRAIT_BITERHELM, TRAIT_GENERIC)
 
 /obj/item/clothing/gloves/roguetown/chain/vampire
 	name = "ancient ceremonial gloves"

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -540,6 +540,7 @@
 	icon_state = "graggarplatehelm"
 	max_integrity = ARMOR_INT_HELMET_ANTAG
 	flags_inv = HIDEEARS|HIDEFACE|HIDESNOUT|HIDEHAIR|HIDEFACIALHAIR
+	var/active_item = FALSE
 
 /obj/item/clothing/head/roguetown/helmet/heavy/graggar/pickup(mob/living/user)
 	if(!HAS_TRAIT(user, TRAIT_HORDE))
@@ -548,6 +549,21 @@
 		user.IgniteMob()
 		user.Stun(40)
 	..()
+
+/obj/item/clothing/head/roguetown/helmet/heavy/graggar/equipped(mob/living/user, slot)
+	. = ..()
+	if(active_item)
+		return
+	if(slot == SLOT_HEAD)
+		active_item = TRUE
+		ADD_TRAIT(user, TRAIT_BITERHELM, TRAIT_GENERIC)
+
+/obj/item/clothing/head/roguetown/helmet/heavy/graggar/dropped(mob/living/user)
+	..()
+	if(!active_item)
+		return
+	active_item = FALSE
+	REMOVE_TRAIT(user, TRAIT_BITERHELM, TRAIT_GENERIC)
 
 /obj/item/clothing/head/roguetown/helmet/heavy/matthios/pickup(mob/living/user)
 	if(!HAS_TRAIT(user, TRAIT_COMMIE))


### PR DESCRIPTION
## About The Pull Request

- Adds a TRAIT to two helmets, the Graggar heretic set + the Vampire lord's helmet. On equip, grants the user the ability to bite through their own bevor/helmet/anymouthcoverage.
- Commissioned by witty
## Testing Evidence


https://github.com/user-attachments/assets/f36eb4a2-71ce-48b5-94f0-efc6f5e56aff



https://github.com/user-attachments/assets/8ba6f96a-f993-4756-946e-349fb441ab0a


## Why It's Good For The Game

- Vampire lords can do their thing without being decapped
- Graggin on my Graggar