### PR TITLE
Fixes mob harddel + parallax runtime from tgstation#63877 and tgstati…

### DIFF
--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -26,24 +26,31 @@ SUBSYSTEM_DEF(parallax)
 	var/list/currentrun = src.currentrun
 
 	while(length(currentrun))
-		var/client/C = currentrun[currentrun.len]
+		var/client/processing_client = currentrun[currentrun.len]
 		currentrun.len--
-		if (!C || !C.eye)
+		if (QDELETED(processing_client) || !processing_client.eye)
 			if (MC_TICK_CHECK)
 				return
 			continue
-		var/atom/movable/A = C.eye
-		if(!istype(A))
+		var/atom/movable/movable_eye = processing_client.eye
+		if(!istype(movable_eye))
 			continue
-		for (A; isloc(A.loc) && !isturf(A.loc); A = A.loc);
 
-		if(A != C.movingmob)
-			if(C.movingmob != null)
-				C.movingmob.client_mobs_in_contents -= C.mob
-				UNSETEMPTY(C.movingmob.client_mobs_in_contents)
-			LAZYINITLIST(A.client_mobs_in_contents)
-			A.client_mobs_in_contents += C.mob
-			C.movingmob = A
+		while(isloc(movable_eye.loc) && !isturf(movable_eye.loc))
+			movable_eye = movable_eye.loc
+		//get the last movable holding the mobs eye
+
+		if(movable_eye == processing_client.movingmob)
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		//eye and the last recorded eye are different, and the last recorded eye isnt just the clients mob
+		if(!isnull(processing_client.movingmob))
+			LAZYREMOVE(processing_client.movingmob.client_mobs_in_contents, processing_client.mob)
+		LAZYADD(movable_eye.client_mobs_in_contents, processing_client.mob)
+
+		processing_client.movingmob = movable_eye
 		if (MC_TICK_CHECK)
 			return
 	currentrun = null

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -462,6 +462,8 @@
 		orbiting.end_orbit(src)
 		orbiting = null
 
+	LAZYNULL(client_mobs_in_contents)
+
 // Make sure you know what you're doing if you call this, this is intended to only be called by byond directly.
 // You probably want CanPass()
 /atom/movable/Cross(atom/movable/AM)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1058,6 +1058,8 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	. = ..() //Even though we're going to be hard deleted there are still some things that want to know the destroy is happening
 	QDEL_NULL(droning_sound)
 	last_droning_sound = null
+	if(mob)
+		mob.become_uncliented()
 	return QDEL_HINT_HARDDEL_NOW
 
 /client/proc/set_client_age_from_db(connectiontopic)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -32,6 +32,8 @@
 	client.screen = list()				//remove hud items just in case
 	client.images = list()
 
+	canon_client = client
+
 	if(!hud_used)
 		create_mob_hud()
 	if(hud_used && client && client.prefs)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -44,7 +44,7 @@ GLOBAL_VAR_INIT(mobids, 1)
 	testing("EPICWIN!! [src] [type]")
 	ghostize(drawskip=TRUE)
 	..()
-	return QDEL_HINT_HARDDEL
+	return QDEL_HINT_QUEUE
 
 /**
  * Intialize a mob
@@ -1397,3 +1397,14 @@ GLOBAL_VAR_INIT(mobids, 1)
 	if(HAS_TRAIT(src, TRAIT_MISSING_NOSE))
 		return FALSE
 	return TRUE
+
+/mob/proc/become_uncliented()
+	if(!canon_client)
+		return
+
+	if(canon_client?.movingmob)
+		LAZYREMOVE(canon_client.movingmob.client_mobs_in_contents, src)
+		canon_client.movingmob = null
+
+	clear_important_client_contents()
+	canon_client = null

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -172,6 +172,12 @@
 	/// A list of factions that this mob is currently in, for hostile mob targetting, amongst other things
 	var/list/faction = list("neutral")
 
+	/// The current client inhabiting this mob. Managed by login/logout
+	/// This exists so we can do cleanup in logout for occasions where a client was transfere rather then destroyed
+	/// We need to do this because the mob on logout never actually has a reference to client
+	/// We also need to clear this var/do other cleanup in client/Destroy, since that happens before logout 
+	var/client/canon_client 
+
 	/// Can this mob enter shuttles
 	var/move_on_shuttle = 1
 


### PR DESCRIPTION
## About The Pull Request
Used Luto's ref tracking branch to track down the mob harddel which shows it has to do with client_mobs_in_content and something about spatial grid. 

Also turn off the forced harddel on mobs.

Implement fixes from: 
[tgstation#](https://github.com/tgstation/tgstation/pull/63877)
[tgstation](https://github.com/tgstation/tgstation/pull/52897/)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This might fix one of the biggest harddel source in the game and may or may not impact performance. Maybe turning off the forced harddel makes it lag more. Who knows.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
