### PR TITLE
Mob attacker use skills on parry. Again.

### DIFF
--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -81,26 +81,25 @@
 		prob2defend += highest_defense
 		weapon_parry = TRUE
 
-	if(U.mind)
-		if(intenty.masteritem)
-			attacker_skill = U.get_skill_level(intenty.masteritem.associated_skill)
-			prob2defend -= (attacker_skill * 20)
-			if((intenty.masteritem.wbalance == WBALANCE_SWIFT) && (user.STASPD > src.STASPD)) //enemy weapon is quick, so get a bonus based on spddiff
-				var/spdmod = ((user.STASPD - src.STASPD) * 10)
-				var/permod = ((src.STAPER - user.STAPER) * 10)
-				var/intmod = ((src.STAINT - user.STAINT) * 3)
-				if(mind)
-					if(permod > 0)
-						spdmod -= permod
-					if(intmod > 0)
-						spdmod -= intmod
-				var/finalmod = spdmod
-				if(mind)
-					finalmod = clamp(spdmod, 0, 30)
-				prob2defend -= finalmod
-		else
-			attacker_skill = U.get_skill_level(/datum/skill/combat/unarmed)
-			prob2defend -= (attacker_skill * 20)
+	if(intenty.masteritem)
+		attacker_skill = U.get_skill_level(intenty.masteritem.associated_skill)
+		prob2defend -= (attacker_skill * 20)
+		if((intenty.masteritem.wbalance == WBALANCE_SWIFT) && (user.STASPD > src.STASPD)) //enemy weapon is quick, so get a bonus based on spddiff
+			var/spdmod = ((user.STASPD - src.STASPD) * 10)
+			var/permod = ((src.STAPER - user.STAPER) * 10)
+			var/intmod = ((src.STAINT - user.STAINT) * 3)
+			if(mind)
+				if(permod > 0)
+					spdmod -= permod
+				if(intmod > 0)
+					spdmod -= intmod
+			var/finalmod = spdmod
+			if(mind)
+				finalmod = clamp(spdmod, 0, 30)
+			prob2defend -= finalmod
+	else
+		attacker_skill = U.get_skill_level(/datum/skill/combat/unarmed)
+		prob2defend -= (attacker_skill * 20)
 
 	if(HAS_TRAIT(src, TRAIT_GUIDANCE))
 		prob2defend += 20


### PR DESCRIPTION
## About The Pull Request
This was regressed as part of the roguetown procs split, leading to mob attacker not using skills on attack.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="612" height="206" alt="NVIDIA_Overlay_ozqjnXRzeD" src="https://github.com/user-attachments/assets/9c7dc7ee-69d9-4d81-ab6b-e529a674e54a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bug

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
