### PR TITLE
Minor Cat-form and werewolf update

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -124,6 +124,7 @@
 
 	W.AddSpell(new /obj/effect/proc_holder/spell/self/howl)
 	W.AddSpell(new /obj/effect/proc_holder/spell/self/claws)
+	W.AddSpell(new /obj/effect/proc_holder/spell/targeted/woundlick)
 
 	ADD_TRAIT(src, TRAIT_NOSLEEP, TRAIT_GENERIC)
 
@@ -181,7 +182,7 @@
 
 	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/howl)
 	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/claws)
-
+	W.RemoveSpell(new /obj/effect/proc_holder/spell/targeted/woundlick)
 	W.regenerate_icons()
 
 	to_chat(W, span_userdanger("I return to my facade."))

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/cat.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/cat.dm
@@ -25,6 +25,7 @@
 		src.STALUC = 12 //Xylyx's critters
 
 		AddSpell(new /obj/effect/proc_holder/spell/self/catclaws)
+		AddSpell(new /obj/effect/proc_holder/spell/targeted/woundlick)
 		real_name = "cat" //Stealthy transform, lets give it a try
 
 // CAT SPECIES DATUM //
@@ -178,3 +179,42 @@
 		user.put_in_hands(r, TRUE, FALSE, TRUE)
 		//user.visible_message("Your claws extend.", "You feel your claws extending.", "You hear a sound of claws extending.")
 		extended = TRUE
+
+/obj/effect/proc_holder/spell/targeted/woundlick
+    action_icon = 'icons/mob/actions/roguespells.dmi'
+    name = "Lick the wounds"
+    desc = "Heal the wounds of somebody"
+    overlay_state = "diagnose"
+    range = 1
+    sound = 'sound/gore/flesh_eat_03.ogg'
+    associated_skill = /datum/skill/misc/climbing
+    recharge_time = 10 SECONDS
+    ignore_cockblock = TRUE
+
+/obj/effect/proc_holder/spell/targeted/woundlick/cast(list/targets, mob/user)
+    if(iscarbon(targets[1]))
+        var/mob/living/carbon/target = targets[1]
+        if(target.mind)
+            if(target.mind.has_antag_datum(/datum/antagonist/zombie))
+                to_chat(src, span_warning("I shall not lick it..."))
+                return
+            if(target.mind.has_antag_datum(/datum/antagonist/vampirelord))
+                to_chat(src, span_warning("... What? Its an elder vampire!"))
+                return
+        (!do_after(user, 7 SECONDS, target = target))
+        var/ramount = 20
+        var/rid = /datum/reagent/medicine/healthpot
+        target.reagents.add_reagent(rid, ramount)
+        ramount = 2
+        rid = /datum/reagent/medicine/healthpot
+        target.reagents.add_reagent(rid, ramount)
+        if(target.mind.has_antag_datum(/datum/antagonist/werewolf))
+            target.visible_message(span_green("[user] is licking [target]'s wounds with its tongue!"), span_notice("My kin has covered my wounds..."))
+            ramount = 20
+            rid = /datum/reagent/water
+            target.reagents.add_reagent(rid, ramount)
+        else
+            target.visible_message(span_green("[user] is licking [target]'s wounds with its tongue!"), span_notice("That thing... Did it lick my wounds?"))
+            ramount = 20
+            rid = /datum/reagent/water
+            target.reagents.add_reagent(rid, ramount)

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/cat.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/cat.dm
@@ -39,7 +39,8 @@
 		TRAIT_HARDDISMEMBER, //Decapping wildshapes causes them to bug out, badly, and need admin intervention to fix. Bandaid fix.
 		TRAIT_DODGEEXPERT,
 		TRAIT_BRITTLE,
-		TRAIT_LEAPER
+		TRAIT_LEAPER,
+		TRAIT_ZJUMP //its a CAT. Cats can jump so high!
 	)
 	inherent_biotypes = MOB_HUMANOID
 	no_equip = list(SLOT_SHIRT, SLOT_HEAD, SLOT_WEAR_MASK, SLOT_ARMOR, SLOT_GLOVES, SLOT_SHOES, SLOT_PANTS, SLOT_CLOAK, SLOT_BELT, SLOT_BACK_R, SLOT_BACK_L, SLOT_S_STORE)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

NEW spell for werewolf and cat-form:  licking the wounds. For cat - for fun. For werewolfes - to keep the victims alive longer
ALSO trait High-jumper for cat-form. BCS ITS A CAT!!

## Testing Evidence


https://github.com/user-attachments/assets/250fe3cb-5070-4bd1-b754-244d2786669f

<img width="1153" height="531" alt="ShareX_gNKgZ21aPD" src="https://github.com/user-attachments/assets/6a8fbaca-c8c9-4aae-9c61-3f08a2bd979e" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Cat-form more useful and funny
Werewolfes can heal their victims

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Fewer deaths when trying to convert someone in werewolf, more usefully thing for Dendorites!

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
