### PR TITLE
Church Vaultkey

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -47289,7 +47289,7 @@
 "oHp" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
-	lockid = "priest"
+	lockid = "churchvault"
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
@@ -57948,8 +57948,6 @@
 	lockid = "priest"
 	},
 /obj/item/roguecoin/gold/pile,
-/obj/item/roguecoin/silver/pile,
-/obj/item/roguecoin/silver/pile,
 /obj/item/roguecoin/copper/pile,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -11619,7 +11619,9 @@
 /area/rogue/outdoors/town)
 "dIR" = (
 /obj/machinery/light/rogue/wallfire/candle/r,
-/obj/structure/mineral_door/wood/deadbolt,
+/obj/structure/mineral_door/wood/deadbolt{
+	name = "Bathroom"
+	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
 "dIS" = (
@@ -12642,6 +12644,14 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave/east)
+"dYQ" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Dormitorium"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/church/chapel)
 "dYT" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/hoe,
@@ -17092,6 +17102,14 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"fnM" = (
+/obj/structure/mineral_door/wood/donjon/stone{
+	locked = 1;
+	lockid = "church";
+	name = "Church Closet"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/church/chapel)
 "fnN" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner,
 /area/rogue/indoors/town/physician)
@@ -36517,7 +36535,8 @@
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
 	locked = 1;
-	lockid = "priest"
+	lockid = "priest";
+	name = "Martyr's Apartment"
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
@@ -44427,7 +44446,8 @@
 "nLg" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
-	lockid = "church"
+	lockid = "church";
+	name = "Belfry"
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church/chapel)
@@ -47289,7 +47309,8 @@
 "oHp" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
-	lockid = "churchvault"
+	lockid = "churchvault";
+	name = "Tithe Vault"
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/chapel)
@@ -65115,7 +65136,9 @@
 /area/rogue/indoors/shelter/woods)
 "ugb" = (
 /obj/machinery/light/rogue/wallfire/candle/l,
-/obj/structure/mineral_door/wood/deadbolt,
+/obj/structure/mineral_door/wood/deadbolt{
+	name = "Bathroom"
+	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church/basement)
 "ugc" = (
@@ -371688,7 +371711,7 @@ oKc
 gTY
 gTY
 oKc
-lCF
+fnM
 oKc
 gTY
 gTY
@@ -378009,7 +378032,7 @@ oKc
 eMQ
 gen
 gen
-lCF
+dYQ
 fwK
 fwK
 oKc

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -4545,7 +4545,7 @@
 "bwy" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
-	lockid = "priest"
+	lockid = "churchvault"
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -257,7 +257,10 @@
 	keys = list(/obj/item/roguekey/tavern, /obj/item/roguekey/tavernkeep, /obj/item/roguekey/roomviii, /obj/item/roguekey/roomvii, /obj/item/roguekey/roomvi, /obj/item/roguekey/roomv, /obj/item/roguekey/roomiv, /obj/item/roguekey/roomiii, /obj/item/roguekey/roomii, /obj/item/roguekey/roomi, /obj/item/roguekey/fancyroomi, /obj/item/roguekey/fancyroomii, /obj/item/roguekey/fancyroomiii, /obj/item/roguekey/fancyroomiv, /obj/item/roguekey/fancyroomv)
 
 /obj/item/storage/keyring/priest
-	keys = list(/obj/item/roguekey/priest, /obj/item/roguekey/inquisition, /obj/item/roguekey/church, /obj/item/roguekey/graveyard)
+	keys = list(/obj/item/roguekey/priest, /obj/item/roguekey/church, /obj/item/roguekey/graveyard, /obj/item/roguekey/churchvault)
+
+/obj/item/storage/keyring/templar
+	keys = list(/obj/item/roguekey/church, /obj/item/roguekey/graveyard, /obj/item/roguekey/churchvault)
 
 /obj/item/storage/keyring/churchie
 	keys = list(/obj/item/roguekey/church, /obj/item/roguekey/graveyard)

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -413,6 +413,12 @@
 	icon_state = "brownkey"
 	lockid = "church"
 
+/obj/item/roguekey/churchvault
+	name = "church vault key"
+	desc = "This green key has a few extra notches than the bronze ones; it will open the tithe vault."
+	icon_state = "greenkey"
+	lockid = "churchvault"
+
 /obj/item/roguekey/priest
 	name = "Bishop's key"
 	desc = "This is the master key of the church."

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -91,7 +91,7 @@
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
-	beltr = /obj/item/storage/keyring/churchie
+	beltr = /obj/item/storage/keyring/templar
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	shoes = /obj/item/clothing/shoes/roguetown/sandals


### PR DESCRIPTION
## About The Pull Request

Changes some of the things around:

- 1. Adds templar access to the vault.
- 1a. Compensates by removing SOME of the cash already in there(?); I think removing 2 of the silver piles is fair, it'll average less than 400-500 now.

- 2. Renames some of the room doors in the church for sovl reasons.

## Testing Evidence

Worked on my localhost; would like it if someone could check if it worked fine on their localhost too.

## Why It's Good For The Game

The vault doesn't get much usage unless there is a martyr or priest. Both of these dudes are really hard to kill.

Let's look at the Steward; you can break in, mug the steward, a guard, or so on--and you would have deeper access into the Keep.

This allows bandit players/other antags to possibly steal the Church vault's contents without necessarily needing to kill/mug the Priest or Martyr (good luck making this discrete).

Anyways, this is not just to encourage templar mugging. I wanted to add this because Templars are **basically knights** in the Church, and would logically be trusted with more duties; such as securing the tithe vault. Malumites would have a secure place to stow things they would like to keep--and it would see more traction for usage. Otherwise, it's a pretty underwhelming piggy bank that most templars don't touch.

This would also reduce Templars rushing out of the Church (what I have to do) to ultra-farm for resources to sell to stockpiles.

TL;DR: gives (bandits/matthosians) antags a reward for successfully killing templars (the usual reward is everyone hunting them); encourages the Church to use the vault



**This is my first mapping PR, I mostly did this to experience how it worked. Please go easy on me :(**