### PR TITLE
Port in next day system from Vanderlin.

### DIFF
--- a/code/controllers/subsystem/particle_weather_outdoors.dm
+++ b/code/controllers/subsystem/particle_weather_outdoors.dm
@@ -59,8 +59,7 @@ SUBSYSTEM_DEF(outdoor_effects)
 	                                                   new /datum/time_of_day/sunset(),
 	                                                   new /datum/time_of_day/dusk(),
 	                                                   new /datum/time_of_day/midnight())
-
-
+	var/next_day = FALSE // Resets when station_time is less than the next start time.
 
 /datum/controller/subsystem/outdoor_effects/proc/fullPlonk()
 	for (var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
@@ -86,9 +85,18 @@ SUBSYSTEM_DEF(outdoor_effects)
 
 
 /datum/controller/subsystem/outdoor_effects/proc/check_cycle()
-	if(station_time() > next_step_datum.start)
+	if(!next_step_datum)
 		get_time_of_day()
 		return TRUE
+
+	if(station_time() > next_step_datum.start)
+		if(next_day)
+			return FALSE
+		get_time_of_day()
+		return TRUE
+	else if (next_day) // It is now the next morning, reset our next day
+		next_day = FALSE
+
 	return FALSE
 
 /datum/controller/subsystem/outdoor_effects/proc/get_time_of_day()
@@ -114,6 +122,10 @@ SUBSYSTEM_DEF(outdoor_effects)
 
 	current_step_datum = new_step
 	picked_color = pick(current_step_datum.color)
+
+	// If the next start time is less than the current start time (i.e 10 PM vs 5 AM) then set our NextDay value
+	if(next_step_datum.start <= current_step_datum.start)
+		next_day = TRUE
 
 	//If it is round-start, we wouldn't have had a current_step_datum, so set our last_color to the current one
 	if(!last_color)


### PR DESCRIPTION
## About The Pull Request
It seems to be missing from our original particle weather port, and is causing us to fire transition_sunlight_color way more than necessary. Credits to Dwasint for pointing this out.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I was on Rogue World for like, 15 minutes 

```/datum/controller/subsystem/outdoor_effects/proc/transition_sunlight_color          0.000        0.000        0.001        0.000            6
```

Honestly test this on live.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Alternative to https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3406 that should end our current performance issue.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
