### PR TITLE
Adds stat ceiling functionality to jobs

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -1,3 +1,12 @@
+/*STAT DEFINES*/
+#define STAT_STRENGTH "strength"
+#define STAT_PERCEPTION "perception"
+#define STAT_INTELLIGENCE "intelligence"
+#define STAT_CONSTITUTION "constitution"
+#define STAT_ENDURANCE "endurance"
+#define STAT_SPEED "speed"
+#define STAT_FORTUNE "fortune"
+
 /*------------------------\
 | ARMOR INTEGRITY DEFINES | // Use these when possible on armor to keep value consistent.	
 \------------------------*/

--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -43,6 +43,9 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		character.mind.special_items[player.prefs.loadout2::name] += player.prefs.loadout2.path
 	if(player.prefs.loadout3)
 		character.mind.special_items[player.prefs.loadout3::name] += player.prefs.loadout3.path
+	var/datum/job/assigned_job = SSjob.GetJob(character.mind.assigned_role)
+	if(length(assigned_job.stat_ceilings))
+		assigned_job.clamp_stats(character)
 
 /proc/apply_prefs_virtue(mob/living/carbon/human/character, client/player)
 	if (!player)

--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -43,8 +43,8 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		character.mind.special_items[player.prefs.loadout2::name] += player.prefs.loadout2.path
 	if(player.prefs.loadout3)
 		character.mind.special_items[player.prefs.loadout3::name] += player.prefs.loadout3.path
-	var/datum/job/assigned_job = SSjob.GetJob(character.mind.assigned_role)
-	if(length(assigned_job.stat_ceilings))
+	var/datum/job/assigned_job = SSjob.GetJob(character.mind?.assigned_role)
+	if(assigned_job && length(assigned_job.stat_ceilings))
 		assigned_job.clamp_stats(character)
 
 /proc/apply_prefs_virtue(mob/living/carbon/human/character, client/player)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -322,7 +322,6 @@
 
 	if(!visualsOnly && announce)
 		announce(H)
-	//clamp_stats(H)
 
 /datum/job/proc/get_access()
 	if(!config)	//Needed for robots.

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -152,6 +152,9 @@
 	var/list/virtue_restrictions
 	var/list/vice_restrictions
 
+	//The job's stat UPPER ceilings, clamped after statpacks and job stats are applied.
+	var/list/stat_ceilings
+
 
 /datum/job/proc/special_job_check(mob/dead/new_player/player)
 	return TRUE
@@ -319,6 +322,7 @@
 
 	if(!visualsOnly && announce)
 		announce(H)
+	//clamp_stats(H)
 
 /datum/job/proc/get_access()
 	if(!config)	//Needed for robots.
@@ -405,6 +409,14 @@
 	if(CONFIG_GET(flag/security_has_maint_access))
 		return list(ACCESS_MAINT_TUNNELS)
 	return list()
+
+/datum/job/proc/clamp_stats(var/mob/living/carbon/human/H)
+	if(length(stat_ceilings))
+		for(var/stat in stat_ceilings)
+			if(stat_ceilings[stat] < H.get_stat(stat))
+				H.change_stat(stat, (stat_ceilings[stat] - H.get_stat(stat)))
+				to_chat(H, "Your [stat] was reduced to \Roman[stat_ceilings[stat]].")
+
 
 // LETHALSTONE EDIT: Helper functions for pronoun-based clothing selection
 /proc/should_wear_masc_clothes(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -24,6 +24,8 @@
 
 	cmode_music = 'sound/music/combat_dungeoneer.ogg'
 
+	stat_ceilings = list(STAT_STRENGTH = 16, STAT_CONSTITUTION = 16, STAT_ENDURANCE = 16)
+
 /datum/job/roguetown/dungeoneer/New()
 	. = ..()
 	peopleknowme = list()

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -24,7 +24,7 @@
 
 	cmode_music = 'sound/music/combat_dungeoneer.ogg'
 
-	stat_ceilings = list(STAT_STRENGTH = 16, STAT_CONSTITUTION = 16, STAT_ENDURANCE = 16)
+	stat_ceilings = list(STAT_STRENGTH = 16, STAT_CONSTITUTION = 15, STAT_ENDURANCE = 16)
 
 /datum/job/roguetown/dungeoneer/New()
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -24,7 +24,7 @@
 
 	cmode_music = 'sound/music/combat_dungeoneer.ogg'
 
-	stat_ceilings = list(STAT_STRENGTH = 16, STAT_CONSTITUTION = 15, STAT_ENDURANCE = 16)
+	stat_ceilings = list(STAT_STRENGTH = 16, STAT_CONSTITUTION = 16, STAT_ENDURANCE = 16)
 
 /datum/job/roguetown/dungeoneer/New()
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -99,6 +99,7 @@
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+	to_chat(world, "entering pre_equip")
 	H.change_stat("strength", 2)
 	H.change_stat("perception", 1)
 	H.change_stat("intelligence", 2)

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -99,7 +99,6 @@
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
-	to_chat(world, "entering pre_equip")
 	H.change_stat("strength", 2)
 	H.change_stat("perception", 1)
 	H.change_stat("intelligence", 2)

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -1,11 +1,4 @@
 	
-#define STAT_STRENGTH "strength"
-#define STAT_PERCEPTION "perception"
-#define STAT_INTELLIGENCE "intelligence"
-#define STAT_CONSTITUTION "constitution"
-#define STAT_ENDURANCE "endurance"
-#define STAT_SPEED "speed"
-#define STAT_FORTUNE "fortune"
 
 /mob/living
 	var/STASTR = 10
@@ -90,6 +83,27 @@
 				testing("foundpsych")
 				H.eye_color = "ff0000"
 				H.voice_color = "ff0000"
+
+/mob/living/proc/get_stat(stat)
+	if(!stat)
+		return
+	switch(stat)
+		if(STAT_STRENGTH)
+			return STASTR
+		if(STAT_PERCEPTION)
+			return STAPER
+		if(STAT_INTELLIGENCE)
+			return STAINT
+		if(STAT_CONSTITUTION)
+			return STACON
+		if(STAT_ENDURANCE)
+			return STAEND
+		if(STAT_SPEED)
+			return STASPD
+		if(STAT_FORTUNE)
+			return STALUC
+		else
+			return
 
 /mob/living/proc/change_stat(stat, amt, index)
 	if(!stat)


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Adds a `stat_ceilings` list variable which you can fill like so:
<img width="679" height="43" alt="image" src="https://github.com/user-attachments/assets/7b0c73fa-96dd-4042-a7bb-43898b74d260" />

Spawning in with stats above that (statpack + job stats + race stats) will reduce it to that limit.
(I reduced it to 15 for this example)
<img width="385" height="26" alt="image" src="https://github.com/user-attachments/assets/cdce9212-95be-47ee-b0ab-47e99887837c" />

Only dungeoneer was given a token one (STR, CON, END at 16 -- you can't actually get any higher atm), it's mostly just there for functionality.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Above!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
they timed me out so I figured why not jak myself off

Keep in mind the limits are not shown / displayed anywhere atm, which would be worth adding probably
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
