### PR TITLE
Fixes a status effect exploit

### DIFF
--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -59,6 +59,12 @@
 
 /datum/status_effect/proc/on_apply() //Called whenever the buff is applied; returning FALSE will cause it to autoremove itself.
 	for(var/S in effectedstats)
+		if(effectedstats[S] < 0)	//We only care about negative bonuses here
+			if((owner.get_stat(S) + effectedstats[S]) < 1)	//The status effect would reduce our stats beyond the limit of !1! Not 0.
+				for(var/i in 1 to abs(effectedstats[S]))
+					if((owner.get_stat(S) + (effectedstats[S] + i)) == 1)	//We keep incrementing the status effect until it will reduce it to 1.
+						effectedstats[S] = (effectedstats[S] + i)
+						break
 		owner.change_stat(S, effectedstats[S])
 	return TRUE
 

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -65,6 +65,9 @@
 					if((owner.get_stat(S) + (effectedstats[S] + i)) == 1)	//We keep incrementing the status effect until it will reduce it to 1.
 						effectedstats[S] = (effectedstats[S] + i)
 						break
+		else
+			if((owner.get_stat(S) + effectedstats[S]) > 20)	//We check for overflow as well.
+				effectedstats[S] = max(((owner.get_stat(S) + effectedstats[S]) - 20), 0)
 		owner.change_stat(S, effectedstats[S])
 	return TRUE
 

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -103,6 +103,7 @@
 		if(STAT_FORTUNE)
 			return STALUC
 		else
+			CRASH("get_stat called on [src] with an erroneous stat flag: [stat]")
 			return
 
 /mob/living/proc/change_stat(stat, amt, index)

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -104,7 +104,6 @@
 			return STALUC
 		else
 			CRASH("get_stat called on [src] with an erroneous stat flag: [stat]")
-			return
 
 /mob/living/proc/change_stat(stat, amt, index)
 	if(!stat)


### PR DESCRIPTION
## About The Pull Request
If a status effect tries to add or remove stats that go under 1 or above 20, the amount it gives will be reduced until that threshold is met.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I have 3 SPD:
<img width="83" height="40" alt="dreamseeker_X8hgQI9qdV" src="https://github.com/user-attachments/assets/02a015c1-6804-4a50-82fc-c48f59b68bba" />

I sniff Ozium, which is meant to give -5:
<img width="533" height="51" alt="Code_7dqbQgzFk4" src="https://github.com/user-attachments/assets/e1207211-f064-41b8-883d-65488724d8bd" />

I end up with only -2 applied (and thus that's what I'll get back later, too):
<img width="160" height="89" alt="dreamseeker_Uzge9OJqr2" src="https://github.com/user-attachments/assets/6b234f47-d211-4f0d-8175-9b4a4ae65555" />

If I try to sniff Herozium after this (another -5 SPD debuff), it will simply not take away any speed at all:
<img width="250" height="146" alt="dreamseeker_pPmxJcg7On" src="https://github.com/user-attachments/assets/61b34004-b2b3-48ae-b01a-65218bdde49c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No more unintended status effect behaviour!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
