### PR TITLE
add inventory to hierophant sash

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -1704,6 +1704,18 @@
 	item_state = "naledisash"
 	desc = "A limp piece of fabric traditionally used to fasten bags that are too baggy, but in modern days has become more of a fashion statement than anything."
 
+/obj/item/clothing/cloak/hierophant/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete/roguetown/cloak)
+
+/obj/item/clothing/cloak/hierophant/dropped(mob/living/carbon/human/user)
+	..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	if(STR)
+		var/list/things = STR.contents()
+		for(var/obj/item/I in things)
+			STR.remove_from_storage(I, get_turf(src))
+
 /obj/item/clothing/cloak/wardencloak
 	name = "warden cloak"
 	desc = "A cloak worn by the Wardens of Azuria's Forests"


### PR DESCRIPTION
## About The Pull Request
Simply adds inventory space to the hierophant's sash the Naledi Warscholars spawn with, featuring a grid you'd expect to see from other cloaks like it.

## Testing Evidence
<img width="414" height="340" alt="image" src="https://github.com/user-attachments/assets/51243616-ba1f-4fa8-9d00-6374a349b884" />

## Why It's Good For The Game
If a Warscholar wants more inventory then they might ditch their sash to get a halfcloak or other cloak that already has inventory, which means they'd be sacrificing their aesthetic consistency for inventory. Woe!