### PR TITLE
Ports Tennite Templar Helms + SOVL patron bonuses Tennite Heretics

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -78,12 +78,76 @@
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'
+			head = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface
 		if(/datum/patron/inhumen/matthios)
 			H.cmode_music = 'sound/music/combat_matthios.ogg'
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket/gold
 		if(/datum/patron/inhumen/baotha)
 			H.cmode_music = 'sound/music/combat_baotha.ogg'
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle
 		if(/datum/patron/inhumen/graggar)
 			H.cmode_music = 'sound/music/combat_graggar.ogg'
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/guard
+		if(/datum/patron/divine/astrata)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/astrata
+			head = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan
+			H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
+		if(/datum/patron/divine/abyssor)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/abyssor
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/abyssorgreathelm
+			cloak = /obj/item/clothing/cloak/abyssortabard
+			H.adjust_skillrank(/datum/skill/labor/fishing, 2, TRUE)
+			ADD_TRAIT(H, TRAIT_WATERBREATHING, TRAIT_GENERIC)
+		if(/datum/patron/divine/xylix)
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle
+			H.cmode_music = 'sound/music/combat_jester.ogg'
+			H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/music, 1, TRUE)
+		if(/datum/patron/divine/dendor)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/dendor
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/volfplate
+			H.cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg'
+			H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+		if(/datum/patron/divine/necra)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/necra
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/guard
+			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
+		if(/datum/patron/divine/pestra)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/pestra
+			head = /obj/item/clothing/head/roguetown/helmet/sallet/visored
+			ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+			H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE)
+		if(/datum/patron/divine/eora)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/eora
+			head = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull
+			ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+		if(/datum/patron/divine/noc)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/noc
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight
+			H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE) // Really good at reading... does this really do anything? No. BUT it's soulful.
+			H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
+		if(/datum/patron/divine/ravox)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/ravox
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket
+			H.adjust_skillrank(/datum/skill/misc/athletics, 1, TRUE)
+		if(/datum/patron/divine/malum)
+			wrists = /obj/item/clothing/neck/roguetown/psicross/malum
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/sheriff
+			H.adjust_skillrank(/datum/skill/craft/blacksmithing, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/smelting, 1, TRUE)
+		if(/datum/patron/old_god)
+			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet
+			wrists = /obj/item/clothing/neck/roguetown/psicross
+			cloak = /obj/item/clothing/cloak/tabard/crusader/psydon
+			H.change_stat("endurance", 2) //ENDVRE
 
 /obj/effect/proc_holder/spell/invoked/convert_heretic
 	name = "Convert The Downtrodden"


### PR DESCRIPTION
## About The Pull Request

We enabled Tennites to play heretic wretch, but they had no means to actually display their extremist allegiance </3 

Also makes the absolute GUTTING of Heretic's loadout be not as egregious as it was before, due to the virtue of Tennite heretics being a thing, and being unable to summon a set of fullplate like the 3/4 ascendants (RIP BAOTHA). 

I did NOT give them fullplate or anything - just different helmets depending on your patron, and actual plate boots + chainmail. Nothing insane. 

I didnt touch their statblock or weapon skills or anything (except Psydonite cuz they dont get rituals, higher tier miracles, or benefit from other miracles. They get +2 end as a touch-up). 

Just minor touch-ups and sovl additions for Pantheon Heretics. 

## Testing Evidence

It compiles and I'm not doing allat for a balancejak

## Why It's Good For The Game

I think it's COOL and SOVLFUL for Tennite heretics to rep their Patron's allegiance.

I understand the friction this may cause between Churchies and Heretics, but I think that's a good thing. They aren't identical to Templars or anything - most notably because they have higher miracle tiers and dont spawn with their relic weapon. 

This shouldn't be disruptive in any way to the gameplay loop - it's just flavor and sovl for the most part. 