### PR TITLE
Re-adds the Pulaski and Steel Zweihander.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -543,12 +543,12 @@
 	created_item = /obj/item/rogueweapon/greatsword
 	craftdiff = 4
 
-/*datum/anvil_recipe/weapons/steel/steelzweihander //leaving this here for now; discussion with devgeneral.
+/datum/anvil_recipe/weapons/steel/steelzweihander
 	name = "Zweihander, Steel (+2 Steel)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel)
 	created_item = /obj/item/rogueweapon/greatsword/grenz
-	craftdiff = 4*/
+	craftdiff = 4
 
 /datum/anvil_recipe/weapons/estoc
 	name = "Estoc, Steel (+1 Steel)"
@@ -564,11 +564,11 @@
 	created_item = /obj/item/rogueweapon/stoneaxe/woodcut/steel
 	craftdiff = 2
 
-/*/datum/anvil_recipe/weapons/steel/pulaski // We left the other holy steel recipes in, so I'll leave this for now.
+//datum/anvil_recipe/weapons/steel/pulaski // Not a holy steel weapon.
 	name = "Pulaski axe (+1 Stick)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/grown/log/tree/stick)
-	created_item = /obj/item/rogueweapon/stoneaxe/woodcut/pick */
+	created_item = /obj/item/rogueweapon/stoneaxe/woodcut/pick
 
 /datum/anvil_recipe/weapons/steel/greataxe
 	name = "Greataxe, Steel (+1 Steel, +1 Small Log)"


### PR DESCRIPTION
## About The Pull Request
(undoes weapon smithing removals in https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3067 )
**Says as the name does**.

## Why It's Good For The Game

Trained smiths should be able to make "Axe with a spike on it." and "Big sword but steel."

We'll cut to the chase. It's absolutely a **terrible idea to remove these weapons entirely from smithing because "It's merc specific."**
Easily compared to basically going "Rogues can only use daggers, daggers are rogue weapons." or "Sabres are desert riders only!"

It's dare I say, CRINGE. To remove these weapons from the smithing chart entirely. I personally LOVE using the Pulaski axe and Zweihander. Steel Zweihanders are just seen as an upgraded variant of the Zweihander, like they should be.
Trying to tokenize these weapons to make them more "unique" is a poor idea.

**Instead, I suggest you make specific variants, similar to the Etruscan rapier and sail-dagger, instead of just entirely removing these options from the public.**

It's about time we leave perfectly functional and fine mechanics alone and not randomly change things under the guise of balance, no?
