### PR TITLE
Glass dupe fix

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 	debris = list(/obj/item/natural/glass_shard = 1)
 	var/desc_uncorked = "An open bottle. Hopefully the cork is nearby."
 	var/fancy		// for bottles with custom descriptors that you don't want to change when bottle manipulated
-	var/glass_on_impact = TRUE // If TRUE, bottle will generate glass shard on impact. Otherwise it won't.
+	var/glass_on_impact = FALSE // If TRUE, bottle will generate glass shard on impact. Otherwise it won't.
 
 /obj/item/reagent_containers/glass/bottle/update_icon(dont_fill=FALSE)
 	if(!fill_icon_thresholds || dont_fill)


### PR DESCRIPTION
## About The Pull Request

One glass = three bottles. Bottle = shard. Shard = glass. One glass = three bottles... As a result, you can make three bottles from one bottle. 
I made sure that there were no shards left after throwing the bottle.

## Testing Evidence

<img width="220" height="47" alt="image" src="https://github.com/user-attachments/assets/c54ec728-b340-46bf-bb65-dfe89e9d1519" />
<img width="165" height="110" alt="image" src="https://github.com/user-attachments/assets/b78f3c5d-f58b-40f0-903a-6564bb197782" />


## Why It's Good For The Game

No dupe.
