### PR TITLE
Fix crash loop from Baotha spell and spice

### DIFF
--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -78,12 +78,18 @@
 		if(isliving(mymob))
 			var/mob/living/L = mymob
 			if(L.has_status_effect(/datum/status_effect/buff/druqks))
-				filters += filter(type="ripple",x=80,size=50,radius=0,falloff = 1)
-				var/F1 = filters[filters.len]
-//				animate(F1, size=50, radius=480, time=4, loop=-1, flags=ANIMATION_PARALLEL)
-				filters += filter(type="color", color = list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0))
-				F1 = filters[filters.len-1]
-				animate(F1, size=50, radius=480, time=10, loop=-1, flags=ANIMATION_PARALLEL)
+				// Only add ripple effect if it's not already present to prevent conflicts
+				var/has_ripple = FALSE
+				for(var/filter in filters)
+					if(filter && filter:type == "ripple")
+						has_ripple = TRUE
+						break
+				if(!has_ripple)
+					filters += filter(type="ripple",x=80,size=50,radius=0,falloff = 1)
+					var/F1 = filters[filters.len]
+					filters += filter(type="color", color = list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0))
+					F1 = filters[filters.len-1]
+					animate(F1, size=50, radius=480, time=10, loop=-1, flags=ANIMATION_PARALLEL)
 //			if(L.has_status_effect(/datum/status_effect/buff/weed))
 //				filters += filter(type="bloom",threshold=rgb(255, 128, 255),size=5,offset=5)
 /*
@@ -160,11 +166,18 @@
 		if(isliving(mymob))
 			var/mob/living/L = mymob
 			if(L.has_status_effect(/datum/status_effect/buff/druqks))
-				filters += filter(type="ripple",x=80,size=50,radius=0,falloff = 1)
-				var/F1 = filters[filters.len]
-				filters += filter(type="color", color = list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0))
-				F1 = filters[filters.len-1]
-				animate(F1, size=50, radius=480, time=10, loop=-1, flags=ANIMATION_PARALLEL)
+				// Only add ripple effect if it's not already present to prevent conflicts
+				var/has_ripple = FALSE
+				for(var/filter in filters)
+					if(filter && filter:type == "ripple")
+						has_ripple = TRUE
+						break
+				if(!has_ripple)
+					filters += filter(type="ripple",x=80,size=50,radius=0,falloff = 1)
+					var/F1 = filters[filters.len]
+					filters += filter(type="color", color = list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0))
+					F1 = filters[filters.len-1]
+					animate(F1, size=50, radius=480, time=10, loop=-1, flags=ANIMATION_PARALLEL)
 	filters += filter(type = "alpha", render_source = FIELD_OF_VISION_BLOCKER_RENDER_TARGET, flags = MASK_INVERSE)
 
 /atom/movable/screen/plane_master/game_world_above
@@ -183,11 +196,18 @@
 		if(isliving(mymob))
 			var/mob/living/L = mymob
 			if(L.has_status_effect(/datum/status_effect/buff/druqks))
-				filters += filter(type="ripple",x=80,size=50,radius=0,falloff = 1)
-				var/F1 = filters[filters.len]
-				filters += filter(type="color", color = list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0))
-				F1 = filters[filters.len-1]
-				animate(F1, size=50, radius=480, time=10, loop=-1, flags=ANIMATION_PARALLEL)
+				// Only add ripple effect if it's not already present to prevent conflicts
+				var/has_ripple = FALSE
+				for(var/filter in filters)
+					if(filter && filter:type == "ripple")
+						has_ripple = TRUE
+						break
+				if(!has_ripple)
+					filters += filter(type="ripple",x=80,size=50,radius=0,falloff = 1)
+					var/F1 = filters[filters.len]
+					filters += filter(type="color", color = list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0))
+					F1 = filters[filters.len-1]
+					animate(F1, size=50, radius=480, time=10, loop=-1, flags=ANIMATION_PARALLEL)
 
 /atom/movable/screen/plane_master/field_of_vision_blocker
 	name = "field of vision blocker plane master"

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -92,12 +92,16 @@
 		return
 	var/atom/movable/screen/plane_master/floor/OT = locate(/atom/movable/screen/plane_master/floor) in client.screen
 	var/atom/movable/screen/plane_master/game_world/GW = locate(/atom/movable/screen/plane_master/game_world) in client.screen
-	GW.backdrop(src)
-	OT.backdrop(src)
+	if(GW)
+		GW.backdrop(src)
+	if(OT)
+		OT.backdrop(src)
 	GW = locate(/atom/movable/screen/plane_master/game_world_fov_hidden) in client.screen
-	GW.backdrop(src)
+	if(GW)
+		GW.backdrop(src)
 	GW = locate(/atom/movable/screen/plane_master/game_world_above) in client.screen
-	GW.backdrop(src)
+	if(GW)
+		GW.backdrop(src)
 
 ///Adjust the drugginess of a mob
 /mob/proc/adjust_drugginess(amount)


### PR DESCRIPTION
## About The Pull Request

Ported from https://github.com/Scarlet-Reach/Scarlet-Reach/pull/539

This PR fixes crash occuring by spice and Baotha's spell

## Testing Evidence

Literally check the link above.

## Why It's Good For The Game

Bugfixes are always good, aren't they?

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
