### PR TITLE
Minor Bugfix: Headhook Recipe

### DIFF
--- a/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
+++ b/code/modules/roguetown/roguejobs/engineer/anvil_recipes/mechanical.dm
@@ -128,7 +128,7 @@
 	name = "Headhook, Bronze (+2 Fibers)"
 	req_bar = /obj/item/ingot/bronze
 	created_item = /obj/item/storage/hip/headhook/bronze
-	additional_items = list(/obj/item/natural/fibers = 2)
+	additional_items = list(/obj/item/natural/fibers, /obj/item/natural/fibers)
 	craftdiff = 3
 
 // ------------ PROSTHETICS ----------------


### PR DESCRIPTION
## About The Pull Request

Makes headhooks actually need +2 fibers, currently doesn't work cuz of the recipe being = 2 (smithing doesn't give a shit about that)

## Testing Evidence

Compiles, works. Similar to other way multi-item recipe works now.

## Why It's Good For The Game

Bugfix. It's either this, or make it cost 1 fiber.
