### PR TITLE
Give Adv. Missionary Divine Blast + Dendor Nerf

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -340,6 +340,9 @@
 					head = /obj/item/clothing/head/roguetown/roguehood
 			var/datum/devotion/C = new /datum/devotion(H, H.patron)
 			C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)	//Minor regen, capped to T3.
+	if(istype(H.patron, /datum/patron/divine))
+		// For now, only Tennites get this. Heretics can have a special treat later
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
 			neck = /obj/item/clothing/neck/roguetown/psicross

--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -92,8 +92,7 @@
 					H.Dizzy(5)
 					H.emote("drown")
 				if(/datum/patron/divine/dendor)
-					H.Immobilize(10)
-					H.OffBalance(10)
+					H.Slowdown(2) // Shared with Ravox cuz immobilize + offbal is 2 strong
 					H.visible_message(span_warning("Roots coil around [H]'s legs!"), span_warning("Roots tangle around my legs!"))
 				if(/datum/patron/divine/necra)
 					if(H.mob_biotypes & MOB_UNDEAD)


### PR DESCRIPTION
## About The Pull Request
- Cleric with Divine patron now get access to Divine Blast (You won't have enough devotion to spam it, sry)
- Dendor Bolt now just applies Slowdown(2) instead of Immobilize + Offbalance for 1 second which is extremely strong if you know what you are doing.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="578" height="498" alt="NVIDIA_Overlay_3xGELAmAkX" src="https://github.com/user-attachments/assets/7e1c9e22-c4ef-4d97-a03e-393184d6d995" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gives cleric a lil bit of offensive bite. It won't compare to mage, but at least they got heal. 
Also Dendor nerf is a request cuz it is absurdly stronk.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
