### PR TITLE
[God fluff] Foolproofs fluff area.

### DIFF
--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -298,11 +298,24 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 
 /obj/item/abyssal_marker/volatile
 	name = "volatile abyssal marker"
-	effect_desc = " Whispers fill your head. The crystal yearns to be used, it shall bring forth a beautiful dream. The first use shall mark, the second shall unleash. Seems fragile, like it would break when thrown..."
+	effect_desc = " Whispers fill your head. The crystal yearns to be used, it shall bring forth a beautiful dream. The first use shall mark, the second shall unleash. Seems fragile, like it might explode violently with energies when thrown..."
 	faith_locked = FALSE
 	icon_state = "abyssal_marker_volatile"
+	var/cooldown = 0
+	var/creation_time
+
+/obj/item/abyssal_marker/volatile/Initialize()
+	. = ..()
+	creation_time = world.time
+	var/area/A = get_area(src)
+	if(istype(A, /area/rogue/underworld/dream))
+		cooldown = 3 MINUTES
 
 /obj/item/abyssal_marker/volatile/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	if(cooldown > 0 && world.time < creation_time + cooldown)
+		visible_message(span_warning("[src] bounces off the floor. It doesn't seem ready yet."))
+		return ..()
+
 	var/turf/T = get_turf(hit_atom)
 	if(T)
 		marked_location = T
@@ -341,6 +354,12 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 		playsound(src, 'sound/magic/lightning.ogg', 50, TRUE)
 		new rune_type(marked_location)
 		qdel(src)
+
+/obj/item/abyssal_marker/volatile/attack_self(mob/user)
+	if(cooldown > 0 && world.time < creation_time + cooldown)
+		to_chat(user, span_warning("The crystal is still unstable. It needs more time to attune to this realm. Try again later."))
+		return
+	return ..()
 
 /obj/structure/active_abyssor_rune
 	name = "awakened abyssal rune"


### PR DESCRIPTION
## About The Pull Request
Obvious spoiler warning if you want to learn about this sort of secret fluff stuff organically.

- When appearing in their intended manner, volatile crystals can't be broken for a bit. This is to stop people from killing themselves with them whilst in the secret area.
- All items in the dream are returned with the last player to leave the area. This is a precaution to stop unique items like the master rod to end up trapped there as it's not easy to end up there.

## Testing Evidence
Tested both, it would be silly of me not to test a fix...

## Why It's Good For The Game
As much as I'm a fan of consequences for throwing the evil crystals, you're not really intended to die there and it would make the secret area dangerous for anyone that visits later.