### PR TITLE
[Bishop role] - Fix miracle change bugs & functionality rebalance.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -47,6 +47,8 @@
 #define TRAIT_SQUIRE_REPAIR "Squire Knowledge"
 #define TRAIT_TRAINED_SMITH "Trained Smith"
 #define TRAIT_CAUTIOUS_FISHER "Cautious Fisher"
+#define TRAIT_POLYTHEIST "Polytheist"
+#define TRAIT_MONOTHEIST "Monotheist"
 #define TRAIT_GUARDSMAN "Vigilant Guardsman"
 #define TRAIT_TAVERN_FIGHTER "Tavern Fighter"
 #define TRAIT_WOODSMAN "Talented Woodsman"

--- a/code/datums/gods/_curses.dm
+++ b/code/datums/gods/_curses.dm
@@ -6,6 +6,7 @@
 	COOLDOWN_DECLARE(priest_apostasy)
 	COOLDOWN_DECLARE(priest_excommunicate)
 	COOLDOWN_DECLARE(priest_curse)
+	COOLDOWN_DECLARE(priest_change_miracles)
 
 /mob/living/carbon/human/proc/handle_curses()
 	for(var/curse in curses)

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -7,6 +7,7 @@ GLOBAL_LIST_EMPTY(heretical_players)
 #define PRIEST_APOSTASY_COOLDOWN (10 MINUTES)
 #define PRIEST_EXCOMMUNICATION_COOLDOWN (10 MINUTES)
 #define PRIEST_CURSE_COOLDOWN (15 MINUTES)
+#define PRIEST_SWAP_COOLDOWN (20 MINUTES)
 
 /datum/job/roguetown/priest
 	title = "Bishop"
@@ -103,30 +104,137 @@ GLOBAL_LIST_EMPTY(heretical_players)
 /mob/living/carbon/human/proc/change_miracle_set(mob/living/user)
 	set name = "Change Miracle Set"
 	set category = "Priest"
+	var/mono_first_pick = FALSE
+
 	if(!mind)
 		return
+
+	if(!COOLDOWN_FINISHED(src, priest_change_miracles))
+		to_chat(src, "<font color='yellow'>I am not yet ready to call upon another god.</font>")
+		return
+
+	if(HAS_TRAIT(src, TRAIT_MONOTHEIST))
+		to_chat(src, "<font color='yellow'>I have dedicated myself to a single god.</font>")
+		return
+
+	if(!HAS_TRAIT(src, TRAIT_POLYTHEIST))
+		var/choice = alert(src, "Do you wish to dedicate yourself to a single god? This choice is permanent and will prevent changing miracles in the future.", "Divine Dedication", "Dedicate (Monotheist)", "Remain Flexible (Polytheist)", "Cancel")
+
+		switch(choice)
+			if("Dedicate (Monotheist)")
+				ADD_TRAIT(src, TRAIT_MONOTHEIST, "divine_dedication")
+				mono_first_pick = TRUE
+			if("Remain Flexible (Polytheist)")
+				ADD_TRAIT(src, TRAIT_POLYTHEIST, "divine_dedication")
+			else
+				return
+
+	// Create god selection menu
 	var/list/god_choice = list()
 	var/list/god_type = list()
-	for (var/path as anything in GLOB.patrons_by_faith[/datum/faith/divine])
+	for(var/path as anything in GLOB.patrons_by_faith[/datum/faith/divine])
 		var/datum/patron/patron = GLOB.patronlist[path]
-		god_choice += list("[patron.name]" = icon(icon = 'icons/mob/overhead_effects.dmi', icon_state = "sign_[patron.name]"))
+		god_choice[patron.name] = icon(icon = 'icons/mob/overhead_effects.dmi', icon_state = "sign_[patron.name]")
 		god_type[patron.name] = patron
+
+	// Show radial menu
 	var/string_choice = show_radial_menu(src, src, god_choice, require_near = FALSE)
 	if(!string_choice)
 		return
+
+	// Apply new miracle set
 	var/datum/patron/god = god_type[string_choice]
-	mind.RemoveAllSpells()
+
+	if(patron.type == god.type && !mono_first_pick)
+		to_chat(src, "<font color='yellow'>I'm already blessed by that [patron.name].</font>")
+		return
+
 	var/datum/devotion/patrondev = new /datum/devotion(src, god)
-	patrondev.grant_miracles(src, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_4)
-	if (string_choice == "Astrata")
+	if(mono_first_pick)
+		for(var/obj/effect/proc_holder/spell/S in devotion.granted_spells)
+			if(src?.mind)
+				src.mind.RemoveSpell(S)
+		devotion.granted_spells.Cut()
+		patron = god
+		patrondev.grant_miracles(src, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_4)
+	else
+		// Define whitelist of swapable spells (T0-T2 only)
+		var/list/whitelist = list(
+			// Astrata
+			/obj/effect/proc_holder/spell/targeted/touch/orison,
+			/obj/effect/proc_holder/spell/invoked/ignition,
+			/obj/effect/proc_holder/spell/self/astrata_gaze,
+			/obj/effect/proc_holder/spell/invoked/lesser_heal,
+			/obj/effect/proc_holder/spell/invoked/blood_heal,
+			/obj/effect/proc_holder/spell/invoked/projectile/lightningbolt/sacred_flame_rogue,
+			/obj/effect/proc_holder/spell/invoked/heal,
+			// Noc
+			/obj/effect/proc_holder/spell/invoked/noc_sight,
+			/obj/effect/proc_holder/spell/targeted/touch/darkvision/miracle,
+			/obj/effect/proc_holder/spell/invoked/invisibility/miracle,
+			// Dendor
+			/obj/effect/proc_holder/spell/invoked/spiderspeak,
+			/obj/effect/proc_holder/spell/targeted/wildshape,
+			// Abyssor
+			/obj/effect/proc_holder/spell/self/abyssor_wind,
+			/obj/effect/proc_holder/spell/invoked/abyssor_bends,
+			/obj/effect/proc_holder/spell/invoked/abyssor_undertow,
+			/obj/effect/proc_holder/spell/invoked/abyssheal,
+			// Ravox
+			/obj/effect/proc_holder/spell/invoked/tug_of_war,
+			/obj/effect/proc_holder/spell/self/divine_strike,
+			/obj/effect/proc_holder/spell/self/call_to_arms,
+			/obj/effect/proc_holder/spell/invoked/challenge,
+			// Necra
+			/obj/effect/proc_holder/spell/invoked/necras_sight,
+			/obj/effect/proc_holder/spell/invoked/avert,
+			/obj/effect/proc_holder/spell/invoked/deaths_door,
+			/obj/effect/proc_holder/spell/invoked/raise_spirits_vengeance,
+			// Xylix
+			/obj/effect/proc_holder/spell/self/xylixslip,
+			/obj/effect/proc_holder/spell/invoked/mockery,
+			/obj/effect/proc_holder/spell/invoked/mastersillusion,
+			// Pestra
+			/obj/effect/proc_holder/spell/invoked/diagnose,
+			/obj/effect/proc_holder/spell/invoked/pestra_leech,
+			/obj/effect/proc_holder/spell/invoked/heal,
+			/obj/effect/proc_holder/spell/invoked/infestation,
+			/obj/effect/proc_holder/spell/invoked/attach_bodypart,
+			// Malum
+			/obj/effect/proc_holder/spell/invoked/malum_flame_rogue,
+			/obj/effect/proc_holder/spell/invoked/conjure_tool,
+			/obj/effect/proc_holder/spell/invoked/vigorousexchange,
+			/obj/effect/proc_holder/spell/invoked/heatmetal,
+			// Eora
+			/obj/effect/proc_holder/spell/invoked/eora_blessing,
+			/obj/effect/proc_holder/spell/invoked/bud,
+			/obj/effect/proc_holder/spell/invoked/heartweave
+		)
+		for(var/obj/effect/proc_holder/spell/S in mind.spell_list)
+			if(S.type in whitelist)
+				mind.RemoveSpell(S)
+		
+		for(var/spell_type in god.miracles)
+			if(god.miracles[spell_type] <= CLERIC_T4 && (spell_type in whitelist))
+				var/obj/effect/proc_holder/spell/new_spell = new spell_type
+				mind.AddSpell(new_spell)
+
+	var/list/base_spells = list(
+		/obj/effect/proc_holder/spell/invoked/revive
+	)
+	for(var/type in base_spells)
+		if(!mind.has_spell(type))
+			mind.AddSpell(new type)
+
+	// Special messages
+	if(string_choice == "Astrata")
 		to_chat(src, "<font color='yellow'>HEAVEN SHALL THEE RECOMPENSE. THOU BEARS MYNE POWER ONCE MORE.</font>")
 	else
 		to_chat(src, "<font color='yellow'>Thou wieldeth now the power of [string_choice].</font>")
-	to_chat(src, "<font color='yellow'>TThe strain of changing your miracles has consumed all your devotion.</font>")
-	mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cure_rot) 
-	mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/monk) 
-	mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/templar)
-	mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)
+
+	to_chat(src, "<font color='yellow'>The strain of changing your miracles has consumed all your devotion.</font>")
+
+	COOLDOWN_START(src, priest_change_miracles, PRIEST_SWAP_COOLDOWN)
 
 /mob/living/carbon/human/proc/coronate_lord()
 	set name = "Coronate"

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -106,15 +106,15 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	set category = "Priest"
 	var/mono_first_pick = FALSE
 
-	if(!mind)
-		return
-
-	if(!COOLDOWN_FINISHED(src, priest_change_miracles))
-		to_chat(src, "<font color='yellow'>I am not yet ready to call upon another god.</font>")
+	if(!mind || user != src)
 		return
 
 	if(HAS_TRAIT(src, TRAIT_MONOTHEIST))
 		to_chat(src, "<font color='yellow'>I have dedicated myself to a single god.</font>")
+		return
+
+	if(!COOLDOWN_FINISHED(src, priest_change_miracles))
+		to_chat(src, "<font color='yellow'>I am not yet ready to call upon another god.</font>")
 		return
 
 	if(!HAS_TRAIT(src, TRAIT_POLYTHEIST))
@@ -134,6 +134,8 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	var/list/god_type = list()
 	for(var/path as anything in GLOB.patrons_by_faith[/datum/faith/divine])
 		var/datum/patron/patron = GLOB.patronlist[path]
+		if(!patron || !patron.name)
+			continue
 		god_choice[patron.name] = icon(icon = 'icons/mob/overhead_effects.dmi', icon_state = "sign_[patron.name]")
 		god_type[patron.name] = patron
 
@@ -149,12 +151,12 @@ GLOBAL_LIST_EMPTY(heretical_players)
 		to_chat(src, "<font color='yellow'>I'm already blessed by that [patron.name].</font>")
 		return
 
+	if(mono_first_pick)
+		for(var/obj/effect/proc_holder/spell/S in src.devotion.granted_spells)
+			src.mind.RemoveSpell(S)
 	var/datum/devotion/patrondev = new /datum/devotion(src, god)
 	if(mono_first_pick)
-		for(var/obj/effect/proc_holder/spell/S in devotion.granted_spells)
-			if(src?.mind)
-				src.mind.RemoveSpell(S)
-		devotion.granted_spells.Cut()
+		//devotion.granted_spells.Cut()
 		patron = god
 		patrondev.grant_miracles(src, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_4)
 	else


### PR DESCRIPTION
## About The Pull Request
- Fixes an issue where bishop swap would get rid of innate spells, admin provided spells. This also made it so that if we ever add more innate bishop spells, we don't have to be careful about swap purging them deus vult style.
- Limits the swap with a 20 minute cooldown. This is in part to make combat swapping multiple times impossible (like dropping 4 different debuffs on the same person). And to prevent resetting cooldowns of spells.
- Swapping now makes you keep your T3-4 spells, swapping out your T0-T2 spells for those of other patrons. This process uses a whitelist that excludes certain low tier spells that have broad usefulness outside of combat or medical use. This should work seamlessly with undivided as well.
- You can however, still DEDICATE yourself to a single patron. This will change your patron to that god, clean out all your old god spells (priest abilities are kept.) This will lock you out of changing your spells, but you do get the full list of spells from your new god.
- In any case, you get anastasis.
- Fixes an issue where you could change miracles of OTHER PEOPLE??? (if you could see them)

## Testing Evidence
Post swap, mixed astrata + eora kit with eora covering most of the T0-T2 spells. Note how innate priest abilities such as recruit templar are still present.
<img width="916" height="737" alt="image" src="https://github.com/user-attachments/assets/aefd6ff1-78ed-4e63-a942-5c2139792afb" />

## Why It's Good For The Game
Allows for flavorful swapping whilst disallowing the bishop of subsuming the tasks meant to be delegated to templar/acolytes because of the convenience of having the spells in his own kit. This is a multiplayer game and leader roles such as Duke, Inquisitor deliberately don't have all the abilities their subordinates do so they have to delegate to get certain benefits out of mechanical constraint. This follows that intent.

Stops silly situations where a well protected bishop could dump like 10 different debuffs on a single person.

Facilitates the ability for people that want to flavor their bishop to be a monotheistic follower favoring a certain god to do so. Applies all the flavor such as the right faith salute and other niche effects in the code like the eoran tree specifics, which were previously disabled as there was no patron change present. This -should- also stop people from asking the bishop to swap to spell X if they're obviously monotheistic.

LOTS OF BUGFIXES YAY!!!