### PR TITLE
modified covetous crown desc, added candles to idol pool

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1004,6 +1004,8 @@
 		/obj/item/ingot/blacksteel,
 		/obj/item/clothing/neck/roguetown/psicross,
 		/obj/item/reagent_containers/glass/cup,
+		/obj/item/candle/gold,
+		/obj/item/candle/silver,
 		/obj/item/candle/candlestick/silver,
 		/obj/item/candle/candlestick/gold,
 		/obj/item/kitchen/fork/silver,

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -205,7 +205,7 @@
 
 /obj/item/coveter
 	name = "Covetous Crown"
-	desc = "A Crown which craves the brow of meisters and can drain the gold from a person's account if placed on their head."
+	desc = "A Crown which craves the brow of miesters and the vault's jawbank; it could be also be mounted upon a restrained person's head to drain their miester account in a pinch."
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "crown_object"
 	force = 10

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -205,7 +205,7 @@
 
 /obj/item/coveter
 	name = "Covetous Crown"
-	desc = "A Crown which craves the brow of meisters. The Covetous Crab"
+	desc = "A Crown which craves the brow of meisters and can drain the gold from a person's account if placed on their head."
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "crown_object"
 	force = 10


### PR DESCRIPTION
## About The Pull Request

Modified description of the covetous crown to mention that it can be used on people (I had no idea) since players get mechanical info from these descriptions. Added the silver and gold bowl candles to the idol's pool since it wasn't intended for these to not be offerable while the candlesticks are.

Description for the crown, courtesy of @radarseas 

## Testing Evidence

compiles just fine.

## Why It's Good For The Game

Player facing mechanics should be explained in a player facing way. Also things gotta be consistent!