### PR TITLE
Fix homesteader not being able to level up a skill twice in one night.

### DIFF
--- a/code/datums/sleep_adv/sleep_adv.dm
+++ b/code/datums/sleep_adv/sleep_adv.dm
@@ -29,7 +29,7 @@
 
 /datum/sleep_adv/proc/adjust_sleep_xp(skill, adjust)
 	var/current_xp = get_sleep_xp(skill)
-	var/target_xp = current_xp + (HAS_TRAIT(mind?.current, TRAIT_JACKOFALLTRADES) ? (adjust * 1.5) : adjust)
+	var/target_xp = current_xp + ((adjust > 0 && HAS_TRAIT(mind?.current, TRAIT_JACKOFALLTRADES)) ? (adjust * 1.5) : adjust)
 	var/cap_exp = get_requried_sleep_xp_for_skill(skill, 2)
 	target_xp = clamp(target_xp, 0, cap_exp)
 	sleep_exp[skill] = target_xp


### PR DESCRIPTION
## About The Pull Request

`/datum/sleep_adv/proc/adjust_sleep_xp` where homesteader xp multiplier is applied is also called with a negative `adjust` value in `/datum/sleep_adv/proc/buy_skill` causing incorrect xp calculation after buying first skill level making it impossible for homesteader to level up a skill twice in one night.

This PR adds simple value check to `adjust_sleep_xp` proc to ensure that the homesteader multiplier is only applied when the `adjust` value is positive.

## Testing Evidence

Compiled, was able to level up a skill twice in one night as a homesteader.

## Why It's Good For The Game

Bugfix cause I heard somewhere that bugs are bad.
