### PR TITLE
Armory Fixes for New Keep/Gari Map

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -63720,6 +63720,9 @@
 /obj/item/clothing/cloak/stabard/surcoat/guard,
 /obj/item/clothing/cloak/stabard/guardhood,
 /obj/item/clothing/cloak/stabard/guardhood,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
+/obj/item/clothing/cloak/stabard/guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "tiB" = (

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -2919,6 +2919,10 @@
 /obj/effect/landmark/start/prisonerr,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"aVo" = (
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "aVq" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -4197,7 +4201,6 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "bpF" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
 /obj/structure/rack/rogue,
 /obj/item/clothing/wrists/roguetown/bracers/leather/heavy,
 /obj/item/clothing/wrists/roguetown/bracers/leather/heavy,
@@ -5863,8 +5866,10 @@
 /area/rogue/indoors/town)
 "bOb" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/mace,
-/obj/item/rogueweapon/mace,
+/obj/item/rogueweapon/halberd/bardiche,
+/obj/item/rogueweapon/halberd/bardiche,
+/obj/item/rogueweapon/spear,
+/obj/item/rogueweapon/spear,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "bOf" = (
@@ -6287,11 +6292,8 @@
 /area/rogue/indoors/shelter)
 "bUe" = (
 /obj/structure/rack/rogue,
-/obj/item/clothing/shoes/roguetown/boots,
-/obj/item/clothing/shoes/roguetown/boots,
-/obj/item/clothing/shoes/roguetown/boots,
-/obj/item/clothing/shoes/roguetown/boots,
-/obj/item/clothing/shoes/roguetown/boots,
+/obj/item/clothing/head/roguetown/helmet,
+/obj/item/clothing/head/roguetown/helmet,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "bUf" = (
@@ -11584,6 +11586,15 @@
 /obj/structure/table/wood/poor,
 /obj/item/armor_brush,
 /obj/item/polishing_cream,
+/obj/structure/rack/rogue/shelf,
+/obj/item/rogueweapon/huntingknife/idagger/steel/special{
+	pixel_x = -6;
+	pixel_y = 32
+	},
+/obj/item/rogueweapon/huntingknife/idagger/steel/special{
+	pixel_x = 6;
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "dBG" = (
@@ -12749,6 +12760,13 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
+"dVm" = (
+/obj/machinery/light/rogue/wallfire/candle{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "dVn" = (
 /obj/structure/stairs{
 	dir = 1
@@ -14970,6 +14988,7 @@
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
+/obj/machinery/light/rogue/wallfire/candle,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "eBi" = (
@@ -18879,8 +18898,27 @@
 /area/rogue/indoors/town/magician)
 "fJo" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/sword,
-/obj/item/rogueweapon/sword,
+/obj/item/rogueweapon/sword{
+	pixel_y = 3
+	},
+/obj/item/rogueweapon/sword{
+	pixel_y = 3
+	},
+/obj/item/rogueweapon/sword{
+	pixel_y = 3
+	},
+/obj/item/rogueweapon/sword/short{
+	pixel_y = -3;
+	pixel_x = 3
+	},
+/obj/item/rogueweapon/sword/short{
+	pixel_y = -3;
+	pixel_x = 3
+	},
+/obj/item/rogueweapon/sword/short{
+	pixel_y = -3;
+	pixel_x = 3
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "fJp" = (
@@ -23809,8 +23847,7 @@
 /area/rogue/under/underdark/north)
 "hjT" = (
 /obj/structure/rack/rogue,
-/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
-/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/chainmail/bikini,
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron,
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron,
 /turf/open/floor/rogue/blocks,
@@ -27403,8 +27440,12 @@
 /area/rogue/indoors/town)
 "inv" = (
 /obj/structure/rack/rogue,
-/obj/item/clothing/head/roguetown/helmet,
-/obj/item/clothing/head/roguetown/helmet,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
+/obj/item/rogueweapon/mace/cudgel,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "inD" = (
@@ -32029,6 +32070,13 @@
 /obj/machinery/light/rogue/wallfire/candle/off/r,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"jHq" = (
+/obj/structure/mannequin,
+/obj/item/clothing/suit/roguetown/armor/plate/half,
+/obj/item/clothing/head/roguetown/helmet/sallet,
+/obj/machinery/light/rogue/wallfire/candle/r,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/basement/keep)
 "jHt" = (
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/cobble,
@@ -32215,6 +32263,14 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"jKE" = (
+/obj/structure/rack/rogue,
+/obj/item/clothing/head/roguetown/helmet/kettle/iron,
+/obj/item/clothing/head/roguetown/helmet/kettle/iron,
+/obj/item/clothing/head/roguetown/helmet/kettle/iron,
+/obj/item/clothing/head/roguetown/helmet/kettle/iron,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement/keep)
 "jKH" = (
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/shop)
@@ -38702,14 +38758,11 @@
 /obj/effect/decal/cobbleedge{
 	dir = 4
 	},
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
-/obj/item/rogueweapon/mace/cudgel,
 /obj/effect/decal/cobbleedge{
 	dir = 6
 	},
+/obj/item/rogueweapon/mace/warhammer,
+/obj/item/rogueweapon/mace/warhammer,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "lFb" = (
@@ -50672,10 +50725,30 @@
 /area/rogue/indoors/inq/office)
 "pnr" = (
 /obj/structure/rack/rogue,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/gloves/roguetown/fingerless_leather{
+	pixel_y = -5;
+	pixel_x = 4
+	},
+/obj/item/clothing/gloves/roguetown/fingerless_leather{
+	pixel_y = -5;
+	pixel_x = 4
+	},
+/obj/item/clothing/gloves/roguetown/fingerless_leather{
+	pixel_y = -5;
+	pixel_x = 4
+	},
+/obj/item/clothing/wrists/roguetown/bracers/leather{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/clothing/wrists/roguetown/bracers/leather{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/clothing/wrists/roguetown/bracers/leather{
+	pixel_x = -6;
+	pixel_y = -4
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "pnA" = (
@@ -53927,10 +54000,11 @@
 /area/rogue/indoors/inq/basement)
 "qqT" = (
 /obj/structure/rack/rogue,
-/obj/item/clothing/gloves/roguetown/leather,
-/obj/item/clothing/gloves/roguetown/leather,
-/obj/item/clothing/gloves/roguetown/leather,
-/obj/item/clothing/gloves/roguetown/leather,
+/obj/item/clothing/suit/roguetown/armor/gambeson/light,
+/obj/item/clothing/suit/roguetown/armor/gambeson/light,
+/obj/item/clothing/suit/roguetown/armor/gambeson/light,
+/obj/item/clothing/suit/roguetown/armor/gambeson/light,
+/obj/item/clothing/suit/roguetown/armor/gambeson/light,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "qqX" = (
@@ -60035,7 +60109,7 @@
 /area/rogue/outdoors/mountains/decap/stepbelow)
 "siF" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/halberd/glaive,
+/obj/item/rogueweapon/spear/partizan,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "siM" = (
@@ -63219,12 +63293,17 @@
 /area/rogue/indoors/town/garrison)
 "tcf" = (
 /obj/structure/rack/rogue,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
-/obj/item/clothing/shoes/roguetown/boots/armor/iron,
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 32
 	},
+/obj/item/clothing/shoes/roguetown/boots,
+/obj/item/clothing/shoes/roguetown/boots,
+/obj/item/clothing/shoes/roguetown/boots,
+/obj/item/clothing/shoes/roguetown/boots,
+/obj/item/clothing/shoes/roguetown/boots,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
+/obj/item/clothing/shoes/roguetown/boots/armor/iron,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
 "tcE" = (
@@ -69971,8 +70050,9 @@
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
 "vaW" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
-/obj/item/rogueweapon/huntingknife/idagger/steel/special,
+/obj/item/rogueweapon/mace/goden,
+/obj/item/rogueweapon/mace,
+/obj/item/rogueweapon/mace,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "vbf" = (
@@ -76915,7 +76995,7 @@
 /area/rogue/outdoors/town/roofs/keep)
 "xfz" = (
 /obj/structure/rack/rogue,
-/obj/item/rogueweapon/eaglebeak/lucerne,
+/obj/item/rogueweapon/eaglebeak,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
 "xfA" = (
@@ -170813,10 +170893,10 @@ mID
 hof
 bHV
 bHV
+hof
 bHV
 bHV
-bHV
-bHV
+hof
 iad
 bYC
 vtx
@@ -172172,7 +172252,7 @@ ktO
 bHV
 qZN
 bpF
-bHV
+dVm
 iad
 bYC
 act
@@ -173977,10 +174057,10 @@ fAM
 ojQ
 hOT
 hOT
-dEP
+jHq
 dEP
 tqO
-bHV
+aVo
 bHV
 iad
 skC
@@ -175783,7 +175863,7 @@ lNs
 iad
 jZI
 eWv
-eWv
+jKE
 bTz
 hjT
 dxk


### PR DESCRIPTION
## About The Pull Request

I'll just list it here.
- Added light gambesons to squire armory; they had no gamby's prior and don't spawn with any.
- Added short swords, iron big mace, spears, and bardiches to squire armory
- Added 4 iron kettle helms to squire armory; they had no helms prior
- Added 4 fingerless gloves to squire armory; technically a buff, better than leather ones they spawn with
- Remove glaive from knight armory, placed partizaner in its place.
- Replaced Lucerne with Eaglebeak given it's just worse than the grand mace anyway so let them have it instead of the iron one.
- Added 2 iron warhammers to MAA armory since someone pointed out MAA can spawn with them but have no extras. It's not steel warhammers so - gave two. We get two backup knives anyway.

Also fixed the floating candle in knight armory and missing tabbards in MAA aux armory

## Testing Evidence

It's a map change. It works.

Also screenshot of armories besides MAA one.
<img width="945" height="628" alt="image" src="https://github.com/user-attachments/assets/161d0e69-d501-4294-a28b-5d39537f51cc" />

## Why It's Good For The Game

All of these were requested changes.

Squire armory lacked some gear.
Knight players said glaive was icky and asked for a partizaner or stuff in its place.
MAA asked for spare warhammers given we sapwn with them so it's a backup.