### PR TITLE
[bishop] Gives them immolation when polytheist

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -159,6 +159,8 @@ GLOBAL_LIST_EMPTY(heretical_players)
 		//devotion.granted_spells.Cut()
 		patron = god
 		patrondev.grant_miracles(src, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_4)
+		if(!mind.has_spell(/obj/effect/proc_holder/spell/invoked/revive))
+			mind.AddSpell(/obj/effect/proc_holder/spell/invoked/revive)
 	else
 		// Define whitelist of swapable spells (T0-T2 only)
 		var/list/whitelist = list(

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -221,12 +221,13 @@ GLOBAL_LIST_EMPTY(heretical_players)
 				var/obj/effect/proc_holder/spell/new_spell = new spell_type
 				mind.AddSpell(new_spell)
 
-	var/list/base_spells = list(
-		/obj/effect/proc_holder/spell/invoked/revive
-	)
-	for(var/type in base_spells)
-		if(!mind.has_spell(type))
-			mind.AddSpell(new type)
+		var/list/base_spells = list(
+			/obj/effect/proc_holder/spell/invoked/revive,
+			/obj/effect/proc_holder/spell/invoked/immolation
+		)
+		for(var/type in base_spells)
+			if(!mind.has_spell(type))
+				mind.AddSpell(new type)
 
 	// Special messages
 	if(string_choice == "Astrata")


### PR DESCRIPTION
## About The Pull Request
Polytheist bishops now always get immolation & anastasis as t4s in addition to being able to swap between various t0-t2 spells from other patrons.

## Testing Evidence
It's a couple line change in working code that compiles, chief.

## Why It's Good For The Game
Stopgap measure until undivided can be given a unique T4 spell.
