### PR TITLE
Makes broken dwarven fortress door actually destructible and deletable.

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -822,16 +822,6 @@
 	repair_cost_second = /obj/item/natural/stone
 	repair_skill = /datum/skill/craft/masonry
 
-/obj/structure/mineral_door/wood/donjon/stone/broken // no repair
-	icon_state = "stonebr"
-	base_state = "stone"
-	density = 0
-	opacity = 0
-	obj_integrity = 0
-	gc_destroyed = 1
-	brokenstate = 1
-	obj_broken = 1
-
 /obj/structure/mineral_door/wood/donjon/stone/attack_right(mob/user)
 	if(user.get_active_held_item())
 		..()
@@ -870,6 +860,21 @@
 		to_chat(user, span_info("I slide the viewport closed."))
 		opacity = TRUE
 		playsound(src, 'sound/foley/doors/windowup.ogg', 100, FALSE)
+
+/obj/structure/mineral_door/wood/donjon/stone/broken
+	desc = "A broken stone door from an era bygone. A new one must be constructed in its place."
+	icon_state = "stonebr"
+	base_state = "stone"
+	density = 0
+	opacity = 0
+	obj_integrity = 150
+	brokenstate = 1
+	obj_broken = 1
+	repairable = FALSE
+
+/obj/structure/mineral_door/wood/donjon/stone/broken/Initialize()
+	..()
+	icon_state = "stonebr" // Weird override otherwise
 
 
 /obj/structure/mineral_door/bars


### PR DESCRIPTION
## About The Pull Request
- Remove the gc_destroyed variable literally making them undeletable
- Gave them 150 obj integrity so they are not destroyed in one left click
- Set repairable to false to achieve the same ffect of making them unrepariable.
- Gave them a new desc.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="476" height="72" alt="NVIDIA_Overlay_pDrJY4bB2L" src="https://github.com/user-attachments/assets/79289597-e6c8-4c39-b614-4a08220feb00" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Door that defeats admins are perhaps too strong for the balance of this server.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
