### PR TITLE
Bugfix - Makes Terminus Est require Weaponsmithing instead of Blacksmithing to craft

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
@@ -171,6 +171,7 @@
 	additional_items = list(/obj/item/ingot/gold, /obj/item/ingot/steel, /obj/item/roguegem/ruby)
 	created_item = /obj/item/rogueweapon/sword/long/exe/cloth
 	craftdiff = 3
+	appro_skill = /datum/skill/craft/weaponsmithing
 	i_type = "Weapons"
 
 /datum/anvil_recipe/valuables/dragon


### PR DESCRIPTION
## About The Pull Request
For some reason Terminus Est used Blacksmithing instead of Weaponsmithing
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
trust
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
bug fix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
