### PR TITLE
Snuff Light Incantation + CD

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -225,15 +225,17 @@
 	chargedrain = 0
 	chargetime = 0
 	chargedloop = /datum/looping_sound/invokeholy
+	invocation = "Embrace the darkness!"
+	invocation_type = "shout"
 	sound = 'sound/magic/zizo_snuff.ogg'
 	overlay_state = "rune2"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = FALSE
-	recharge_time = 12 SECONDS
+	recharge_time = 20 SECONDS
 	miracle = TRUE
 	devotion_cost = 30
 	range = 2
-	
+
 /obj/effect/proc_holder/spell/self/zizo_snuff/cast(list/targets, mob/user = usr)
 	. = ..()
 	if(!ishuman(user))


### PR DESCRIPTION
## About The Pull Request

Increases Zizo T0 Snuff Light cooldown by 8 seconds and gives it a shout incantation. 

## Testing Evidence

<img width="243" height="406" alt="Snímek obrazovky 2025-08-17 090536" src="https://github.com/user-attachments/assets/e0723dda-9510-49a9-a8e3-411b5d1c235d" />

## Why It's Good For The Game

For the radius it can have while used by Heretic or Missionary the cooldown is too low and the incantation should make it less of a get out of jail for free card (Were it not T0 I'd say it can stay that way but it's not)