### PR TITLE
Headshot in Chat initial push

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -165,6 +165,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/update_mutant_colors = TRUE
 
 	var/headshot_link
+	var/chatheadshot
 	var/ooc_extra_link
 	var/ooc_extra
 	var/list/descriptor_entries = list()
@@ -466,6 +467,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			if(is_legacy)
 				dat += "<br><i><font size = 1>(Legacy)<a href='?_src_=prefs;preference=legacyhelp;task=input'>(?)</a></font></i>"
 
+			dat += "<br><b>Headshots in chat?:</b> <a href='?_src_=prefs;preference=headshotchat;task=input'>[chatheadshot == 2 ? "Yes" : "No"]</a><a href='?_src_=prefs;preference=chatheadshothelp;task=input'>(?)</a>"
 			dat += "<br><b>[(length(flavortext) < MINIMUM_FLAVOR_TEXT) ? "<font color = '#802929'>" : ""]Flavortext:[(length(flavortext) < MINIMUM_FLAVOR_TEXT) ? "</font>" : ""]</b><a href='?_src_=prefs;preference=formathelp;task=input'>(?)</a><a href='?_src_=prefs;preference=flavortext;task=input'>Change</a>"
 
 			dat += "<br><b>[(length(ooc_notes) < MINIMUM_OOC_NOTES) ? "<font color = '#802929'>" : ""]OOC Notes:[(length(ooc_notes) < MINIMUM_OOC_NOTES) ? "</font>" : ""]</b><a href='?_src_=prefs;preference=formathelp;task=input'>(?)</a><a href='?_src_=prefs;preference=ooc_notes;task=input'>Change</a>"
@@ -1664,6 +1666,11 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					headshot_link = new_headshot_link
 					to_chat(user, "<span class='notice'>Successfully updated headshot picture</span>")
 					log_game("[user] has set their Headshot image to '[headshot_link]'.")
+				if("headshotchat")
+					if(chatheadshot == 1)
+						chatheadshot = 2
+					else
+						chatheadshot = 1
 				if("legacyhelp")
 					var/list/dat = list()
 					dat += "This slot was around since before major Flavortext / OOC changes.<br>"
@@ -1690,6 +1697,12 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					dat += "-=FFFFFFtext=- : Adds a specific <font color = '#FFFFFF'>colour</font> to text.<br><br>"
 					dat += "Minimum Flavortext: <b>[MINIMUM_FLAVOR_TEXT]</b> characters.<br>"
 					dat += "Minimum OOC Notes: <b>[MINIMUM_OOC_NOTES]</b> characters."
+					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 350)
+					popup.set_content(dat.Join())
+					popup.open(FALSE)
+				if("chatheadshothelp")
+					var/list/dat = list()
+					dat +="Click this option to make other's headshots appear in chat<br>"
 					var/datum/browser/popup = new(user, "Formatting Help", nwidth = 400, nheight = 350)
 					popup.set_content(dat.Join())
 					popup.open(FALSE)
@@ -2473,6 +2486,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 	character.dna.real_name = character.real_name
 
 	character.headshot_link = headshot_link
+
+	character.chatheadshot = chatheadshot
 
 	character.statpack = statpack
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -543,6 +543,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(!valid_headshot_link(null, headshot_link, TRUE))
 		headshot_link = null
 
+	S["chatheadshot"]		>> chatheadshot
 	S["flavortext"]			>> flavortext
 	S["flavortext_display"]	>> flavortext_display
 	S["ooc_notes"]			>> ooc_notes
@@ -710,6 +711,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	WRITE_FILE(S["update_mutant_colors"] , update_mutant_colors)
 	WRITE_FILE(S["headshot_link"] , headshot_link)
+	WRITE_FILE(S["chatheadshot"] , chatheadshot)
 	WRITE_FILE(S["flavortext"] , html_decode(flavortext))
 	WRITE_FILE(S["flavortext_display"], flavortext_display)
 	WRITE_FILE(S["ooc_notes"] , html_decode(ooc_notes))

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -21,6 +21,7 @@
 		ooc_extra_link = null
 		ooc_extra = null
 		headshot_link = null
+		chatheadshot = 1
 	features = pref_species.get_random_features()
 	body_markings = pref_species.get_random_body_markings(features)
 	accessory = "Nothing"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -27,6 +27,7 @@
 	var/t_is = p_are()
 	var/obscure_name = FALSE
 	var/race_name = dna.species.name
+	var/mob/living/carbon/human/viewer = user
 	var/datum/antagonist/maniac/maniac = user.mind?.has_antag_datum(/datum/antagonist/maniac)
 	var/datum/antagonist/skeleton/skeleton = user.mind?.has_antag_datum(/datum/antagonist/skeleton)
 	if(maniac && (user != src))
@@ -781,6 +782,9 @@
 		if(heart?.inscryption && (heart.inscryption_key in maniac.key_nums))
 			. += span_danger("[t_He] know[p_s()] [heart.inscryption_key], I AM SURE OF IT!")
 
+	if((!obscure_name || client?.prefs.masked_examine) && (flavortext || headshot_link || ooc_notes) && (viewer?.chatheadshot == 2))
+		if(headshot_link)
+			. += "<span class='info'><img src=[headshot_link] width=100 height=100/></span>"
 	if(Adjacent(user))
 		if(observer_privilege)
 			var/static/list/check_zones = list(

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -110,6 +110,7 @@
 	var/datum/devotion/devotion = null // Used for cleric_holder for priests
 
 	var/headshot_link = null
+	var/chatheadshot = null
 	var/flavortext = null
 	var/flavortext_display = null
 	var/ooc_notes = null


### PR DESCRIPTION
## About The Pull Request

This will be a PR to allow headshots to be down in chat. its an option right below the headshot button and will show the headshot in 100x100.

Based on Helmsdeep/dreamkeep's idea, I decided to add this in as an option. it can be turned on or off before you join the game.

Based on my [prior work on Solaris](https://github.com/NovaSector/Solaris/pull/358), I'd like this upstream to help with future rebases. I left out the bloodsucker flip, since those don't exist here.

## Testing Evidence

Showing an examine if the option is turned off 
<img width="458" height="441" alt="image" src="https://github.com/user-attachments/assets/aaba4994-3087-48bb-8da3-875c1210af9e" />

if its turned on
<img width="466" height="543" alt="image" src="https://github.com/user-attachments/assets/4cb42efe-2b57-45f3-8cb1-425b36a1248e" />

what it looks like in preferences and the tool tip
<img width="551" height="226" alt="image" src="https://github.com/user-attachments/assets/75915508-af65-4369-a6f9-1a4ee9f0a24b" />

and showing it one last time if headshots are enabled, but there's none set (it looks just standard)
<img width="1121" height="458" alt="image" src="https://github.com/user-attachments/assets/9fca1433-7d8e-4612-9856-af943fbefeaf" />

## Why It's Good For The Game

Gives players an option to see someone's headshot and more easily identify people they know by their "face" rather than name. This can be turned off though if it's not to their taste.