### PR TITLE
Reverts miracle swap + Some other bishop stuff.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	whitelist_req = FALSE
 	cmode_music = 'sound/music/cmode/church/combat_astrata.ogg'
 
-	spells = list(/obj/effect/proc_holder/spell/invoked/cure_rot, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk, /obj/effect/proc_holder/spell/invoked/projectile/divineblast)
+	spells = list(/obj/effect/proc_holder/spell/invoked/cure_rot, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/invoked/convert_heretic_priest, /obj/effect/proc_holder/spell/self/convertrole/monk, /obj/effect/proc_holder/spell/invoked/projectile/divineblast, /obj/effect/proc_holder/spell/invoked/revive)
 	outfit = /datum/outfit/job/roguetown/priest
 	display_order = JDO_PRIEST
 	give_bank_account = 115
@@ -92,155 +92,48 @@ GLOBAL_LIST_EMPTY(heretical_players)
 	H.verbs |= /mob/living/carbon/human/proc/churchpriestcurse //snowflake priests button. Will not sacrifice them
 	H.verbs |= /mob/living/carbon/human/proc/churcheapostasy //punish the lamb reward the wolf
 	H.verbs |= /mob/living/carbon/human/proc/completesermon
-	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic_priest)
 
 /datum/job/priest/vice //just used to change the priest title
-	title = "Vice Priest"
-	f_title = "Vice Priestess"
+	title = "Vice Bishop"
+	f_title = "Vice Bishop"
 	flag = PRIEST
 	department_flag = CHURCHMEN
 	total_positions = 0
 	spawn_positions = 0
 
-/mob/living/carbon/human/proc/change_miracle_set(mob/living/user)
+/mob/living/carbon/human/proc/change_miracle_set()
 	set name = "Change Miracle Set"
 	set category = "Priest"
-	var/mono_first_pick = FALSE
-
-	if(!mind || user != src)
+	if(!mind)
 		return
-
-	if(HAS_TRAIT(src, TRAIT_MONOTHEIST))
-		to_chat(src, "<font color='yellow'>I have dedicated myself to a single god.</font>")
-		return
-
 	if(!COOLDOWN_FINISHED(src, priest_change_miracles))
 		to_chat(src, "<font color='yellow'>I am not yet ready to call upon another god.</font>")
 		return
-
-	if(!HAS_TRAIT(src, TRAIT_POLYTHEIST))
-		var/choice = alert(src, "Do you wish to dedicate yourself to a single god? This choice is permanent and will prevent changing miracles in the future.", "Divine Dedication", "Dedicate (Monotheist)", "Remain Flexible (Polytheist)", "Cancel")
-
-		switch(choice)
-			if("Dedicate (Monotheist)")
-				ADD_TRAIT(src, TRAIT_MONOTHEIST, "divine_dedication")
-				mono_first_pick = TRUE
-			if("Remain Flexible (Polytheist)")
-				ADD_TRAIT(src, TRAIT_POLYTHEIST, "divine_dedication")
-			else
-				return
-
-	// Create god selection menu
 	var/list/god_choice = list()
 	var/list/god_type = list()
-	for(var/path as anything in GLOB.patrons_by_faith[/datum/faith/divine])
+	for (var/path as anything in GLOB.patrons_by_faith[/datum/faith/divine])
 		var/datum/patron/patron = GLOB.patronlist[path]
-		if(!patron || !patron.name)
-			continue
-		god_choice[patron.name] = icon(icon = 'icons/mob/overhead_effects.dmi', icon_state = "sign_[patron.name]")
+		god_choice += list("[patron.name]" = icon(icon = 'icons/mob/overhead_effects.dmi', icon_state = "sign_[patron.name]"))
 		god_type[patron.name] = patron
-
-	// Show radial menu
 	var/string_choice = show_radial_menu(src, src, god_choice, require_near = FALSE)
 	if(!string_choice)
 		return
-
-	// Apply new miracle set
 	var/datum/patron/god = god_type[string_choice]
-
-	if(patron.type == god.type && !mono_first_pick)
-		to_chat(src, "<font color='yellow'>I'm already blessed by that [patron.name].</font>")
-		return
-
-	if(mono_first_pick)
-		for(var/obj/effect/proc_holder/spell/S in src.devotion.granted_spells)
-			src.mind.RemoveSpell(S)
-	if(mono_first_pick)
-		//devotion.granted_spells.Cut()
-		var/datum/devotion/patrondev = new /datum/devotion(src, god)
-		patron = god
-		patrondev.grant_miracles(src, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_4)
-		if(!mind.has_spell(/obj/effect/proc_holder/spell/invoked/revive))
-			mind.AddSpell(/obj/effect/proc_holder/spell/invoked/revive)
-	else
-		// Define whitelist of swapable spells (T0-T2 only)
-		var/list/whitelist = list(
-			// Astrata
-			/obj/effect/proc_holder/spell/targeted/touch/orison,
-			/obj/effect/proc_holder/spell/invoked/ignition,
-			/obj/effect/proc_holder/spell/self/astrata_gaze,
-			/obj/effect/proc_holder/spell/invoked/lesser_heal,
-			/obj/effect/proc_holder/spell/invoked/blood_heal,
-			/obj/effect/proc_holder/spell/invoked/projectile/lightningbolt/sacred_flame_rogue,
-			/obj/effect/proc_holder/spell/invoked/heal,
-			// Noc
-			/obj/effect/proc_holder/spell/invoked/noc_sight,
-			/obj/effect/proc_holder/spell/targeted/touch/darkvision/miracle,
-			/obj/effect/proc_holder/spell/invoked/invisibility/miracle,
-			// Dendor
-			/obj/effect/proc_holder/spell/invoked/spiderspeak,
-			/obj/effect/proc_holder/spell/targeted/wildshape,
-			// Abyssor
-			/obj/effect/proc_holder/spell/self/abyssor_wind,
-			/obj/effect/proc_holder/spell/invoked/abyssor_bends,
-			/obj/effect/proc_holder/spell/invoked/abyssor_undertow,
-			/obj/effect/proc_holder/spell/invoked/abyssheal,
-			// Ravox
-			/obj/effect/proc_holder/spell/invoked/tug_of_war,
-			/obj/effect/proc_holder/spell/self/divine_strike,
-			/obj/effect/proc_holder/spell/self/call_to_arms,
-			/obj/effect/proc_holder/spell/invoked/challenge,
-			// Necra
-			/obj/effect/proc_holder/spell/invoked/necras_sight,
-			/obj/effect/proc_holder/spell/invoked/avert,
-			/obj/effect/proc_holder/spell/invoked/deaths_door,
-			/obj/effect/proc_holder/spell/invoked/raise_spirits_vengeance,
-			// Xylix
-			/obj/effect/proc_holder/spell/self/xylixslip,
-			/obj/effect/proc_holder/spell/invoked/mockery,
-			/obj/effect/proc_holder/spell/invoked/mastersillusion,
-			// Pestra
-			/obj/effect/proc_holder/spell/invoked/diagnose,
-			/obj/effect/proc_holder/spell/invoked/pestra_leech,
-			/obj/effect/proc_holder/spell/invoked/heal,
-			/obj/effect/proc_holder/spell/invoked/infestation,
-			/obj/effect/proc_holder/spell/invoked/attach_bodypart,
-			// Malum
-			/obj/effect/proc_holder/spell/invoked/malum_flame_rogue,
-			/obj/effect/proc_holder/spell/invoked/conjure_tool,
-			/obj/effect/proc_holder/spell/invoked/vigorousexchange,
-			/obj/effect/proc_holder/spell/invoked/heatmetal,
-			// Eora
-			/obj/effect/proc_holder/spell/invoked/eora_blessing,
-			/obj/effect/proc_holder/spell/invoked/bud,
-			/obj/effect/proc_holder/spell/invoked/heartweave
-		)
-		for(var/obj/effect/proc_holder/spell/S in mind.spell_list)
-			if(S.type in whitelist)
-				mind.RemoveSpell(S)
-		
-		for(var/spell_type in god.miracles)
-			if(god.miracles[spell_type] <= CLERIC_T4 && (spell_type in whitelist))
-				var/obj/effect/proc_holder/spell/new_spell = new spell_type
-				mind.AddSpell(new_spell)
-
-		var/list/base_spells = list(
-			/obj/effect/proc_holder/spell/invoked/revive,
-			/obj/effect/proc_holder/spell/invoked/immolation
-		)
-		for(var/type in base_spells)
-			if(!mind.has_spell(type))
-				mind.AddSpell(new type)
-
-	src.devotion.devotion *= 0.4
-
-	// Special messages
-	if(string_choice == "Astrata")
-		to_chat(src, "<font color='yellow'>HEAVEN SHALL THEE RECOMPENSE. THOU BEARS MYNE POWER ONCE MORE.</font>")
+	mind.RemoveAllSpells()
+	var/datum/devotion/patrondev = new /datum/devotion(src, god)
+	patrondev.grant_miracles(src, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_4)
+	if (string_choice == "Undivided")
+		to_chat(src, "<font color='yellow'>HEAVEN SHALL THEE RECOMPENSE. THE TEN SMILE UPON THEIR CHOSEN!</font>")
 	else
 		to_chat(src, "<font color='yellow'>Thou wieldeth now the power of [string_choice].</font>")
-
 	to_chat(src, "<font color='yellow'>The strain of changing your miracles has consumed all your devotion.</font>")
+	mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cure_rot) 
+	mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/monk) 
+	mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/templar)
+	mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic_priest)
+	mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)
+	if(!mind.has_spell(/obj/effect/proc_holder/spell/invoked/revive))
+		mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/revive)
 
 	COOLDOWN_START(src, priest_change_miracles, PRIEST_SWAP_COOLDOWN)
 


### PR DESCRIPTION
## About The Pull Request

- At the request of Architect/Witty:
- Reverts miracle swap to its old functionality in whole
- Maintains the bugfixes + Cooldown
- Bishop now always gets Anastasis(but not immolate)

## Testing Evidence


https://github.com/user-attachments/assets/ff840aa2-1d36-4bdb-9f3d-d90bac6f81f0

<img width="492" height="96" alt="image" src="https://github.com/user-attachments/assets/27ef311d-6de7-4555-b062-61f7b4120db0" />

## Why It's Good For The Game

- Main Miracle Guy now gets their former glory back
- Cooldown prevents abuse/cooldown exploits
- Anastasis always up(alongside cure rot) incase the Bishop is the only person doing revivals.
- Also fixes a handful of bugs relating to the new miracle swap, by nature of stripping it out

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
