### PR TITLE
Removes glaive from anvil and drows

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
@@ -63,3 +63,8 @@
 	name = "Kazengun Hook Sword"
 	cost = 100
 	contains = list(/obj/item/rogueweapon/sword/sabre/hook)
+
+/datum/supply_pack/rogue/merc_weapons/glaive
+	name = "Glaive"
+	cost = 120
+	contains = list(/obj/item/rogueweapon/halberd/glaive)

--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -142,7 +142,7 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 		r_hand = /obj/item/rogueweapon/sword/falx
 		l_hand = /obj/item/rogueweapon/shield/tower
 	else
-		r_hand = /obj/item/rogueweapon/halberd/glaive
+		r_hand = /obj/item/rogueweapon/halberd/bardiche
 	H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -674,12 +674,6 @@
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/rogueweapon/sword/falx
 	craftdiff = 2
-
-/datum/anvil_recipe/weapons/steel/glaive
-	name = "Glaive, Steel (+2 Steel, +1 Small Log)"
-	req_bar = /obj/item/ingot/steel
-	additional_items = list(/obj/item/ingot/steel, /obj/item/ingot/steel, /obj/item/grown/log/tree/small)
-	created_item = /obj/item/rogueweapon/halberd/glaive
 /// UPGRADED WEAPONS
 
 //GOLD


### PR DESCRIPTION
## About The Pull Request

<img width="507" height="507" alt="image" src="https://github.com/user-attachments/assets/4c2a796d-20cb-4ed0-9550-37767ed5cd78" />

- Removes glaives from anvi recipes
- Removes glaives from drow NPCs, replacing it with bardiche (which is iron, btw!)

Why? Because glaives are, frankly, best polearms in the game. 
It is a problem if they are easily accessible (Knight's armory, for example, but thanks to Rebel for rectifying this) - by smithing or looting drow NPCs. Not a problem if they are limited in supply.

After this change glaives will be obtainable:
- By spawning as a melee boak
- Through high tier general loot spawners (borderline acceptable since those spawners are rare and have other unique weapons)
- Buying it as a sellsword bandit (seems acceptable since hedge knights can get grenzel zweis)
- Importing via merchant (on par with other unique weapons)

## Testing Evidence

Trust me brother!

## Why It's Good For The Game

Discussed above.