### PR TITLE
Repulse Nerf-Buff

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/invoked/repulse
 	name = "Repulse"
-	desc = "Conjure forth a wave of energy, repelling anyone around you."
+	desc = "Conjure forth a wave of energy, repelling anyone around you. Leaves them immobilized and vulnerable to followup attacks for a brief moment."
 	cost = 3
 	releasedrain = 30
 	chargedrain = 1

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
@@ -2,11 +2,10 @@
 	name = "Repulse"
 	desc = "Conjure forth a wave of energy, repelling anyone around you."
 	cost = 3
-	xp_gain = TRUE
-	releasedrain = 50
+	releasedrain = 30
 	chargedrain = 1
-	chargetime = 5
-	recharge_time = 30 SECONDS
+	chargetime = 6
+	recharge_time = 20 SECONDS
 	ignore_los = TRUE
 	warnie = "spellwarning"
 	no_early_release = TRUE
@@ -51,14 +50,15 @@
 		if(distfromcaster == 0)
 			if(isliving(AM))
 				var/mob/living/M = AM
-				M.Paralyze(10)
 				M.adjustBruteLoss(20)
 				to_chat(M, "<span class='danger'>You're slammed into the floor by [user]!</span>")
 		else
 			new sparkle_path(get_turf(AM), get_dir(user, AM)) //created sparkles will disappear on their own
 			if(isliving(AM))
 				var/mob/living/M = AM
-				M.Paralyze(stun_amt)
+				M.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
+				M.apply_status_effect(/datum/status_effect/debuff/exposed, 6 SECONDS)
+				M.Immobilize(3 SECONDS)
 				to_chat(M, "<span class='danger'>You're thrown back by [user]!</span>")
 			AM.safe_throw_at(throwtarget, ((CLAMP((maxthrow - (CLAMP(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1,user, force = repulse_force)//So stuff gets tossed around at the same time.
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
With https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3294 in TM and Lightning Bolt nerfed it is time to tackle the **last** item that let mage easily hardstun someone.

- Repulse now have a base CD of 20 seconds, 30 releasedrain instead of 50. This is closer to where it used to be before a rebalance in March.
- Repulse, instead of knocking you down and paralyzing you making you drop your weapon, applies 6 seconds of clickCD and exposed and 3 seconds of immobilize.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Hardstuns are inherently problematic. If we are removing the one way to instantly shutdown a mage, it logically make sense that the way for them to instantly shutdown and win a fight point blank is gone. This is regardless of whether you're a Spellblade, Zeretic or a Mage Apprentice helping the keep frag squad. 

Immobilizing for 3 seconds should prevent people from immediately re-engaging. The exposed + clickCD neuters someone offensively. So being hit by a repulse is still gonna bloody hurts and get you 1 - 4 free hits in. 

You may ask - but what if antags need this to escape? Well, most antags die when they get surrounded anyway. This mostly imperils them if they are in a narrow corridor (like that 1 tile wide corridor to the west of church), as otherwise this is still an effective escape tool.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
