### PR TITLE
Changes Miner's weapon skill from axes to maces

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -33,7 +33,7 @@
 		armor = /obj/item/clothing/suit/roguetown/armor/workervest
 		pants = /obj/item/clothing/under/roguetown/trou
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
-	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE) // Tough. Well fed. The strongest of the strong.
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)


### PR DESCRIPTION
## About The Pull Request

Switches Miner's weapon skill from axes to maces, does not increase or decrease their skill level.

## Testing Evidence

This seems small enough to not need a manual test.

## Why It's Good For The Game

It makes more sense in a physical confrontation for Miners to be skilled at smashing their enemies to pieces with big blunt objects like hammers and maces than chopping them apart with axes, Woodcutters are already the go-to Villager class for axe-wielding conscripts. It would even make sense for them carry a large hammer or club for breaking ore boulders after they've been excavated from rock walls, this is something my Miner personally does to keep his pickaxe from breaking too quickly by sharing the work between multiple tools. I'm sure it's also easier to imagine them taking up a goedendag or war PICK in times of conscription than a battle axe, and the war pick uses mace skill instead of mining skill unlike other picks in the game.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
