### PR TITLE
Chopchop - Speed up cooking steps by 3x + Slicing scales to cooking skills

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -527,7 +527,8 @@ All foods are distributed among various categories. Use common sense.
 	if(chopping_sound)
 		playsound(get_turf(user), 'modular/Neu_Food/sound/chopping_block.ogg', 60, TRUE, -1) // added some choppy sound
 	if(slice_batch)
-		if(!do_after(user, 30, target = src))
+		var/cd = get_cooktime_divisor(user.get_skill_level(/datum/skill/craft/cooking))
+		if(!do_after(user, 1 SECONDS / cd, target = src))
 			return FALSE
 		var/reagents_per_slice = reagents.total_volume/slices_num
 		for(var/i in 1 to slices_num)

--- a/code/modules/roguetown/roguejobs/cook/tools/grinding.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/grinding.dm
@@ -1,4 +1,4 @@
-#define BASE_GRIND_TIME 2 SECONDS
+#define BASE_GRIND_TIME 1 SECONDS
 /obj/item/millstone // Previous structure path means it cannot be crafted on tables
 	name = "millstone"
 	desc = "A millstone used to grind grain into flour."

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -8,8 +8,8 @@
 
 /*	........   Templates / Base items   ................ */
 /obj/item/reagent_containers // added vars used in neu cooking, might be used for other things too in the future. How it works is in each items attackby code.
-	var/short_cooktime = 6 SECONDS
-	var/long_cooktime = 10 SECONDS
+	var/short_cooktime = 2 SECONDS
+	var/long_cooktime = 3 SECONDS
 
 /obj/item/reagent_containers/proc/update_cooktime(mob/user)
 	if(user.mind)


### PR DESCRIPTION
## About The Pull Request
- Reduce base time for short cookstep to 2 seconds from 6 seconds
- Long cookstep 10 to 3 seconds
- Slicing base time 3 seconds to 1 second. Scale to cooking skill

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="289" height="381" alt="NVIDIA_Overlay_kbWZrVKhCz" src="https://github.com/user-attachments/assets/cb58a9f1-a7d1-4fa6-936f-c2235a92a706" />
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This will massively inflate the food economy.

Serious Answer:
Food are but a mechanical set piece to roleplays that it creates and in AP's environment whatever makes the Innkeep prepare food faster and spend more time rping is better. RT food creation time is **far** longer than base SS13 and that is not conductive to good roleplay imo. 

This is a substitute (?) or part of a complement to more further food rework sometimes down the line.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
