### PR TITLE
Make Darkvision an AOE spell around yourself.

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -10,7 +10,7 @@
 	mob_traits = list(TRAIT_UNDIVIDED)
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI, // ONLY Lower miracles of other lists. A much more varied utility miracle list, and a much wider selection. Also, our generic miracles(Lesser heal + Divine blast for acolytes) are better. But no specialization makes a lower level list. We're going to exclude Abyssor.
 					/obj/effect/proc_holder/spell/self/astrata_gaze				= CLERIC_T0,
-					/obj/effect/proc_holder/spell/targeted/touch/darkvision/miracle	= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/darkvision/miracle	= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/blood_heal			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/bless_food            = CLERIC_T1,
@@ -63,7 +63,7 @@
 	mob_traits = list(TRAIT_NIGHT_OWL)
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/noc_sight				= CLERIC_T0,
-					/obj/effect/proc_holder/spell/targeted/touch/darkvision/miracle	= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/darkvision/miracle	= CLERIC_T0,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/blood_heal			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/invisibility/miracle	= CLERIC_T1,

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -175,7 +175,7 @@ GLOBAL_LIST_EMPTY(heretical_players)
 			/obj/effect/proc_holder/spell/invoked/heal,
 			// Noc
 			/obj/effect/proc_holder/spell/invoked/noc_sight,
-			/obj/effect/proc_holder/spell/targeted/touch/darkvision/miracle,
+			/obj/effect/proc_holder/spell/invoked/darkvision/miracle,
 			/obj/effect/proc_holder/spell/invoked/invisibility/miracle,
 			// Dendor
 			/obj/effect/proc_holder/spell/invoked/spiderspeak,

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/darkvision.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/darkvision.dm
@@ -1,50 +1,31 @@
-/obj/effect/proc_holder/spell/targeted/touch/darkvision
+/obj/effect/proc_holder/spell/invoked/darkvision
 	name = "Darkvision"
-	desc = "Enhance the night vision of a target you touch for 15 minutes."
+	desc = "Enhance the night vision of yourself and everyone around you for 5 minutes per level in the associated skill."
 	overlay_state = "darkvision"
 	clothes_req = FALSE
-	drawmessage = "I prepare to grant Darkvision."
-	dropmessage = "I release my arcyne focus."
 	school = "transmutation"
-	recharge_time = 1 MINUTES
+	releasedrain = 80
+	chargedrain = 0
+	chargetime = 1 SECONDS
+	no_early_release = TRUE
+	recharge_time = 1.5 MINUTES
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
-	hand_path = /obj/item/melee/touch_attack/darkvision
 	spell_tier = 1
 	invocations = list("Nox Oculus")
 	invocation_type = "whisper"
-	hide_charge_effect = TRUE
+	glow_color = GLOW_COLOR_BUFF
+	glow_intensity = GLOW_INTENSITY_LOW
+	charging_slowdown = 1
 	xp_gain = TRUE
 	cost = 2
 
-/obj/effect/proc_holder/spell/targeted/touch/darkvision/miracle
+/obj/effect/proc_holder/spell/invoked/darkvision/miracle
 	cost = 0
 	spell_tier = 0
 	associated_skill = /datum/skill/magic/holy
 
-/obj/item/melee/touch_attack/darkvision
-	name = "\improper arcyne focus"
-	desc = "Touch a creature to grant them Darkvision for 15 minutes."
-	catchphrase = null
-	possible_item_intents = list(INTENT_HELP)
-	icon = 'icons/mob/roguehudgrabs.dmi'
-	icon_state = "pulling"
-	icon_state = "grabbing_greyscale"
-	color = "#3FBAFD"
-
-/obj/item/melee/touch_attack/darkvision/attack_self()
-	attached_spell.remove_hand()
-
-/obj/item/melee/touch_attack/darkvision/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if(isliving(target))
-		var/mob/living/spelltarget = target
-		if(!do_after(user, 5 SECONDS, target = spelltarget))
-			return
-		spelltarget.apply_status_effect(/datum/status_effect/buff/darkvision, user.get_skill_level(associated_skill))
-		user.stamina_add(80)
-		if(spelltarget != user)
-			user.visible_message("[user] draws a glyph in the air and touches [spelltarget] with an arcyne focus.")
-		else
-			user.visible_message("[user] draws a glyph in the air and touches themselves with an arcyne focus.")
-		attached_spell.remove_hand()
-	return
+/obj/effect/proc_holder/spell/invoked/darkvision/cast(list/targets, mob/user = usr)
+	for(var/mob/living/L in range(1, usr))
+		L.apply_status_effect(/datum/status_effect/buff/darkvision, user.get_skill_level(associated_skill))
+	return TRUE

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/longstrider.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/longstrider.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/invoked/longstrider
 	name = "Longstrider"
-	desc = "Grant yourself and any creatures adjacent to you free movement through rough terrain."
+	desc = "Grant yourself and any creatures adjacent to you free movement through rough terrain for 15 minutes."
 	cost = 2
 	xp_gain = TRUE
 	school = "transmutation"

--- a/code/modules/spells/spell_types/wizard/spell_list.dm
+++ b/code/modules/spells/spell_types/wizard/spell_list.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(learnable_spells, (list(/obj/effect/proc_holder/spell/invoked/p
 //  	/obj/effect/proc_holder/spell/invoked/knock,
 		/obj/effect/proc_holder/spell/invoked/haste,
 		/obj/effect/proc_holder/spell/invoked/featherfall,
-		/obj/effect/proc_holder/spell/targeted/touch/darkvision,
+		/obj/effect/proc_holder/spell/invoked/darkvision,
 		/obj/effect/proc_holder/spell/invoked/longstrider,
 		/obj/effect/proc_holder/spell/invoked/invisibility,
 		/obj/effect/proc_holder/spell/invoked/projectile/acidsplash,


### PR DESCRIPTION
## About The Pull Request
- Makes Darkvision an AOE spell that apply the buff to yourself around yourself
- Release drain of 80 stamina. CD and charging slowdown based on longstrider
- Improved desc of Longstrider
- Improved description of darkvision to include that it scales with skills.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1148" height="556" alt="dreamseeker_FVZT2By167" src="https://github.com/user-attachments/assets/1758f217-746d-4fba-a2cc-78b7355d19d3" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Make Darkvision easier to use in an AOE / self-buff / other buff context. It was the only touch based buff left behind.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
