### PR TITLE
Port SR Fix for Baotha's Blessing crash - by removing the animation.

### DIFF
--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -75,23 +75,8 @@
 		if(isliving(mymob))
 			var/mob/living/L = mymob
 			if(L.has_status_effect(/datum/status_effect/buff/druqks))
-				add_filter("druqks_ripple", 2, ripple_filter(0, 50, 1, x = 80))
-				var/filter = get_filter("druqks_ripple")
 				add_filter("druqks_color", 2, color_matrix_filter(list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0)))
-				animate(filter, 1 SECONDS, -1, radius=480, size=50, flags=ANIMATION_PARALLEL)
-//			if(L.has_status_effect(/datum/status_effect/buff/weed))
-//				filters += filter(type="bloom",threshold=rgb(255, 128, 255),size=5,offset=5)
-/*
-/atom/movable/screen/plane_master/byondlight
-	name = "byond lighting master"
-//	screen_loc = "CENTER-2"
-	plane = BYOND_LIGHTING_PLANE
-	appearance_flags = PLANE_MASTER
 
-/atom/movable/screen/plane_master/byondlight/proc/shadowblack()
-	filters = list()
-	filters += filter(type = "drop_shadow", x = 2, y = 2, color = "#04080FAA", size = 5, offset = 5)
-*/
 
 /atom/movable/screen/plane_master/lighting
 	name = "lighting plane master"
@@ -155,10 +140,7 @@
 		if(isliving(mymob))
 			var/mob/living/L = mymob
 			if(L.has_status_effect(/datum/status_effect/buff/druqks))
-				add_filter("druqks_ripple", 2, ripple_filter(0, 50, 1, x = 80))
-				var/filter = get_filter("druqks_ripple")
 				add_filter("druqks_color", 2, color_matrix_filter(list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0)))
-				animate(filter, 1 SECONDS, -1, radius=480, size=50, flags=ANIMATION_PARALLEL)
 	filters += filter(type = "alpha", render_source = FIELD_OF_VISION_BLOCKER_RENDER_TARGET, flags = MASK_INVERSE)
 
 /atom/movable/screen/plane_master/game_world_above
@@ -177,11 +159,7 @@
 		if(isliving(mymob))
 			var/mob/living/L = mymob
 			if(L.has_status_effect(/datum/status_effect/buff/druqks))
-				add_filter("druqks_ripple", 1, ripple_filter(0, 50, 1, x = 80))
-				var/filter = get_filter("druqks_ripple")
 				add_filter("druqks_color", 2, color_matrix_filter(list(0,0,1,0, 0,1,0,0, 1,0,0,0, 0,0,0,1, 0,0,0,0)))
-				animate(filter, 1 SECONDS, -1, radius=480, size=50, flags=ANIMATION_PARALLEL)
-
 /atom/movable/screen/plane_master/field_of_vision_blocker
 	name = "field of vision blocker plane master"
 	plane = FIELD_OF_VISION_BLOCKER_PLANE


### PR DESCRIPTION
## About The Pull Request
Port https://github.com/Scarlet-Reach/Scarlet-Reach/pull/580
Although I just outright remove the filter this time instead of commenting it out.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="652" height="667" alt="dreamseeker_TyRii5r8OO" src="https://github.com/user-attachments/assets/af90cd03-ad6e-4ecf-b8c4-fffa541d5a73" />
I cannot replicate the absence of a crash. TM this like on SR.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No crash.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
