### PR TITLE
MAKING KAZENGUN SCABBARDS GREAT AGAIN (MAKING THEIR GIMMICK ACTUALLY FUNCTIONAL)

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
@@ -56,7 +56,7 @@
 
 /datum/supply_pack/rogue/merc_weapons/kazengunscabbard
 	name = "Kazengun Scabbard"
-	cost = 80
+	cost = 250
 	contains = list(/obj/item/rogueweapon/scabbard/sword/kazengun)
 
 /datum/supply_pack/rogue/merc_weapons/kazengunhookblade

--- a/modular_azurepeak/code/game/objects/items/scabbard.dm
+++ b/modular_azurepeak/code/game/objects/items/scabbard.dm
@@ -512,9 +512,9 @@
 	associated_skill = /datum/skill/combat/shields
 	possible_item_intents = list(SHIELD_BASH, SHIELD_BLOCK)
 	can_parry = TRUE
-	wdefense = 9
+	wdefense = 8
 
-	max_integrity = 100
+	max_integrity = 0
 
 
 /obj/item/rogueweapon/scabbard/sword/kazengun/steel


### PR DESCRIPTION
## About The Pull Request

Hi, so I was wondering where all the Ruma Clan mercenaries were, and now I see why. 

Their scabbards? Their main gimmick? Broken, absolutely-so, especially if you manage to break it in combat and repair it. Once it's repaired, you can't even slide a weapon into the scabbard nor parry with it after.

So this is a band-aid fix until someone can do this better than me, because honestly this is a shitty way to do it. 

Reduced the defense from 9 to 8, so it isn't as gross as before. I may lower it in the future.

Made the integrity to 0, so that it has FUNCTIONAL INFINITE DURABILITY as it did before. 

And I made the foreign goods for the normal scabbard a lot more expensive, though at this rate I may just remove it to encourage Kazengunites to not lose their unique scabbard. I haven't since I want people to actually buy it for their characters if they want, but if it's abused by players, it may just be removed in favor for it being exclusive to the classes that start with it.
 

## Testing Evidence

WORKS ON MY MACHINE. [PICTURES PENDING]

## Why It's Good For The Game

So the main gimmick doesn't seem to function. At all. And that's honestly pretty annoying given now you are forced in buying a new scabbard or getting an admin to fix it for you, given it's a buggy mess in of itself. This is a band-aid fix like I said until scabbards can functionally be repaired, and it brings back the gimmick of an unbreaking scabbard these classes used to have.
