### PR TITLE
Force armed mantrap to be too big to fit anywhere.

### DIFF
--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -57,7 +57,9 @@
 				used_time -= max((C.get_skill_level(/datum/skill/craft/traps) * 2 SECONDS), 2 SECONDS)
 			if(do_after(user, used_time, target = src))
 				armed = FALSE
-				w_class = initial(w_class)
+				w_class = WEIGHT_CLASS_NORMAL
+				grid_width = 64
+				grid_height = 64
 				update_icon()
 				alpha = 255
 				C.visible_message(span_notice("[C] disarms \the [src]."), \
@@ -96,11 +98,15 @@
 	w_class = WEIGHT_CLASS_BULKY
 	armed = TRUE
 	anchored = TRUE // Pre mapped traps (bad mapping btw, don't) start anchored
+	grid_width = 256
+	grid_height = 256
 
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage
 	w_class = WEIGHT_CLASS_BULKY
 	armed = TRUE
 	alpha = 80
+	grid_width = 256
+	grid_height = 256
 
 /obj/item/restraints/legcuffs/beartrap/Initialize()
 	. = ..()
@@ -124,8 +130,12 @@
 				armed = !armed
 				if(armed)
 					w_class = WEIGHT_CLASS_BULKY
+					grid_width = 256
+					grid_height = 256
 				else
-					w_class = initial(w_class)
+					w_class = WEIGHT_CLASS_NORMAL
+					grid_width = 64
+					grid_height = 64
 				update_icon()
 				to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
 			else
@@ -133,7 +143,9 @@
 
 /obj/item/restraints/legcuffs/beartrap/proc/close_trap()
 	armed = FALSE
-	w_class = initial(w_class)
+	w_class = WEIGHT_CLASS_NORMAL
+	grid_width = 64
+	grid_height = 64
 	anchored = FALSE // Take it off the ground
 	alpha = 255
 	update_icon()


### PR DESCRIPTION
## About The Pull Request
I saw https://github.com/Scarlet-Reach/Scarlet-Reach/pull/603 but thought the code wasn't good so I did my own version.
- Armed Mantrap now have a height of 256 x 256 to make it impossible to fit inside sack or anywhere, hopefully pre-empting any armed mantrap cheese
- They resets back to w_class_normal and grid height / grid width (set manually instead of on compile, so that mapped trap is usable in theory?)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="172" height="188" alt="dreamseeker_IGhCOxCRCR" src="https://github.com/user-attachments/assets/02392142-89d1-4bc3-b36f-bd8b503014aa" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I load up my six shot revolver and mow down every powergamer who isn't me.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
