### PR TITLE
Continuous butchery Port + Meathook Buff

### DIFF
--- a/code/game/objects/structures/roguetown/meathook.dm
+++ b/code/game/objects/structures/roguetown/meathook.dm
@@ -12,6 +12,10 @@
 	buckle_lying = 0
 	can_buckle = 1
 
+/obj/structure/meathook/examine()
+	. = ..()
+	. += span_notice("Improves the yield of butchering. Also increases speed by 25%.")
+
 /obj/structure/meathook/attack_paw(mob/user)
 	return attack_hand(user)
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -401,20 +401,18 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		var/obj/item/held_item = user.get_active_held_item()
 		if(held_item)
 			if((butcher_results || guaranteed_butcher_results) && held_item.get_sharpness() && held_item.wlength == WLENGTH_SHORT)
-				var/used_time = 210
+				var/used_time = 3 SECONDS
 				if(src.buckled && istype(src.buckled, /obj/structure/meathook))
-					used_time -= 30
+					used_time -= 3 SECONDS
 					visible_message("[user] begins to efficiently butcher [src]...")
 				else
 					visible_message("[user] begins to butcher [src]...")
 				if(user.mind)
 					used_time -= (user.get_skill_level(/datum/skill/labor/butchering) * 30)
 				playsound(src, 'sound/foley/gross.ogg', 100, FALSE)
-				if(do_after(user, used_time, target = src))
+				if(do_after(user, 3 SECONDS, target = src))
 					butcher(user)
-					if(user.mind)
-						user.mind.add_sleep_experience(/datum/skill/labor/butchering, user.STAINT * 4)
-		
+
 	else if (stat != DEAD && istype(ssaddle, /obj/item/natural/saddle))		//Fallback saftey for saddles
 		var/datum/component/storage/saddle_storage = ssaddle.GetComponent(/datum/component/storage)
 		var/access_time = (user in buckled_mobs) ? 10 : 30
@@ -422,15 +420,18 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 			saddle_storage.show_to(user)
 	..()
 
-/mob/living/simple_animal/proc/butcher(mob/user)
+/mob/living/simple_animal/proc/butcher(mob/living/user)
 	if(ssaddle)
 		ssaddle.forceMove(get_turf(src))
 		ssaddle = null
-	var/list/butcher = list()
+
 	var/butchery_skill_level = user.get_skill_level(/datum/skill/labor/butchering)
+	var/time_per_cut = max(5, 30 - butchery_skill_level * 5) // 3 seconds for no skill, 5 ticks for master
+	
 	var/botch_chance = 0
 	if(length(botched_butcher_results) && butchery_skill_level < SKILL_LEVEL_JOURNEYMAN)
 		botch_chance = 70 - (20 * butchery_skill_level) // 70% at unskilled, 20% lower for each level above it, 0% at journeyman or higher
+	
 	var/perfect_chance = 0
 	if(length(perfect_butcher_results))
 		switch(butchery_skill_level)
@@ -442,30 +443,76 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 				perfect_chance = 50
 			if(SKILL_LEVEL_MASTER to INFINITY)
 				perfect_chance = 100
-	butcher = butcher_results
-	if(prob(botch_chance))
-		butcher = botched_butcher_results
-		to_chat(user, "<span class='smallred'>I BOTCHED THE BUTCHERY! ([botch_chance]%!)</span>")
-	else if(prob(perfect_chance))
-		butcher = perfect_butcher_results
-		to_chat(user,"<span class='smallgreen'>My butchering was perfect! ([perfect_chance]%!)</span>")
-	if(guaranteed_butcher_results)
-		butcher += guaranteed_butcher_results
-	
+
 	var/rotstuff = FALSE
 	var/datum/component/rot/simple/CR = GetComponent(/datum/component/rot/simple)
-	if(CR)
-		if(CR.amount >= 10 MINUTES)
-			rotstuff = TRUE
+	if(CR && CR.amount >= 10 MINUTES)
+		rotstuff = TRUE
 	var/atom/Tsec = drop_location()
-	for(var/path in butcher)
-		for(var/i in 1 to butcher[path])
+
+	// Track results
+	var/botch_count = 0
+	var/perfect_count = 0
+	var/normal_count = 0
+
+	for(var/path in butcher_results)
+		var/amount = butcher_results[path]
+		if(!do_after(user, time_per_cut, target = src))
+			if(botch_count || normal_count || perfect_count)
+				to_chat(user, "<span class='notice'>I stop butchering: [butcher_summary(botch_count, normal_count, perfect_count, botch_chance, perfect_chance)].</span>")
+			else
+				to_chat(user, "<span class='notice'>I stop butchering for now.</span>")
+			break
+
+		// Check for botch first
+		if(prob(botch_chance))
+			botch_count++
+			if(length(botched_butcher_results) && (path in botched_butcher_results))
+				amount = botched_butcher_results[path]
+			else
+				amount = 0
+
+		// Otherwise check for perfect
+		else if(length(perfect_butcher_results) && (path in perfect_butcher_results) && prob(perfect_chance))
+			amount = perfect_butcher_results[path]
+			perfect_count++
+
+		else
+			normal_count++
+
+		butcher_results -= path
+
+		// Spawn the item(s)
+		for(var/j in 1 to amount)
 			var/obj/item/I = new path(Tsec)
 			I.add_mob_blood(src)
 			if(rotstuff && istype(I,/obj/item/reagent_containers/food/snacks))
 				var/obj/item/reagent_containers/food/snacks/F = I
 				F.become_rotten()
-	gib()
+		
+		if(user.mind)
+			user.mind.add_sleep_experience(/datum/skill/labor/butchering, user.STAINT * 0.5)
+		playsound(src, 'sound/foley/gross.ogg', 100, FALSE)
+	if(isemptylist(butcher_results))
+		to_chat(user, "<span class='notice'>I finish butchering: [butcher_summary(botch_count, normal_count, perfect_count, botch_chance, perfect_chance)].</span>")
+		gib()
+
+/mob/living/proc/butcher_summary(botch_count, normal_count, perfect_count, botch_chance, perfect_chance)
+    var/list/parts = list()
+    if(botch_count)
+        parts += "[botch_count] botched ([botch_chance]%)"
+    if(normal_count)
+        parts += "[normal_count] normal"
+    if(perfect_count)
+        parts += "[perfect_count] perfect ([perfect_chance]%)"
+
+    var/msg = ""
+    for(var/i = 1, i <= length(parts), i++)
+        msg += parts[i]
+        if(i < length(parts))
+            msg += ", "
+
+    return msg
 
 /mob/living/simple_animal/spawn_dust(just_ash = FALSE)
 	if(just_ash || !remains_type)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -402,7 +402,9 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		if(held_item)
 			if((butcher_results || guaranteed_butcher_results) && held_item.get_sharpness() && held_item.wlength == WLENGTH_SHORT)
 				var/used_time = 3 SECONDS
+				var/on_meathook = FALSE
 				if(src.buckled && istype(src.buckled, /obj/structure/meathook))
+					on_meathook = TRUE
 					used_time -= 3 SECONDS
 					visible_message("[user] begins to efficiently butcher [src]...")
 				else
@@ -411,7 +413,7 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 					used_time -= (user.get_skill_level(/datum/skill/labor/butchering) * 30)
 				playsound(src, 'sound/foley/gross.ogg', 100, FALSE)
 				if(do_after(user, 3 SECONDS, target = src))
-					butcher(user)
+					butcher(user, on_meathook)
 
 	else if (stat != DEAD && istype(ssaddle, /obj/item/natural/saddle))		//Fallback saftey for saddles
 		var/datum/component/storage/saddle_storage = ssaddle.GetComponent(/datum/component/storage)
@@ -420,14 +422,15 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 			saddle_storage.show_to(user)
 	..()
 
-/mob/living/simple_animal/proc/butcher(mob/living/user)
+/mob/living/simple_animal/proc/butcher(mob/living/user, on_meathook = FALSE)
 	if(ssaddle)
 		ssaddle.forceMove(get_turf(src))
 		ssaddle = null
 
 	var/butchery_skill_level = user.get_skill_level(/datum/skill/labor/butchering)
 	var/time_per_cut = max(5, 30 - butchery_skill_level * 5) // 3 seconds for no skill, 5 ticks for master
-	
+	if(on_meathook)
+		time_per_cut *= 0.75
 	var/botch_chance = 0
 	if(length(botched_butcher_results) && butchery_skill_level < SKILL_LEVEL_JOURNEYMAN)
 		botch_chance = 70 - (20 * butchery_skill_level) // 70% at unskilled, 20% lower for each level above it, 0% at journeyman or higher


### PR DESCRIPTION
## About The Pull Request
- Port Continuous Butchery by EIDIS from https://github.com/Scarlet-Reach/Scarlet-Reach/pull/576
- Meathook now improves butchering speed by 25%. It still improves yield as per before. This is now shown on an examine text.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![NVIDIA_Overlay_vcPeDueLYH](https://github.com/user-attachments/assets/f9db1d5b-d633-4382-ae17-02c4d621daab)
![NVIDIA_Overlay_zpCp6mhTME](https://github.com/user-attachments/assets/056856ff-ad7a-4267-ae35-0c199b052f00)
<img width="488" height="152" alt="NVIDIA_Overlay_ZtlU7KBQNc" src="https://github.com/user-attachments/assets/6f350d77-f6d7-4736-87a1-285edc873b72" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Spreading out the butcher results is less abrupt and more immersive.
- Gives another reason to make a dedicated meathook to save time.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
