### PR TITLE
Adds SHITTY_SEEPRICES to matthiosans

### DIFF
--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -67,7 +67,7 @@
 	desc = "The Man who stole fire from the sun and used it in his pursuit of immortality; exchanging the knowledge of how to make fire with the lessers for safety in doing so. He guides those who live in the dark, away from the flame of civilization; and those who believe in his cause bring the wealth of the undeserving in the light to the deserving in the dark."
 	worshippers = "Highwaymen, Alchemists, Downtrodden Peasants, and Merchants"
 	crafting_recipes = list(/datum/crafting_recipe/roguetown/sewing/bandithood)
-	mob_traits = list(TRAIT_COMMIE, TRAIT_MATTHIOS_EYES)
+	mob_traits = list(TRAIT_COMMIE, TRAIT_MATTHIOS_EYES, TRAIT_SEEPRICES_SHITTY)
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison					= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/appraise						= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/targeted/touch/lesserknock/miracle	= CLERIC_T0,
@@ -192,7 +192,7 @@
 	to_chat(follower, span_danger("For Matthios to hear my prayers I must either be in the church of the abandoned, near an inverted psycross, flaunting wealth upon me of at least 100 mammon, or offer a coin of at least five mammon up to him!"))
 	return FALSE
 
-// Baotha 
+// Baotha
 /datum/patron/inhumen/baotha/can_pray(mob/living/follower)
 	. = ..()
 	// Allows prayer in the Zzzzzzzurch(!)


### PR DESCRIPTION
## About The Pull Request

adds the shitty seeprice to matthiosans. 

<img width="743" height="84" alt="image" src="https://github.com/user-attachments/assets/f477bcd6-15f4-4ee4-aa61-46033b10812a" />


## Testing Evidence
<img width="555" height="94" alt="image" src="https://github.com/user-attachments/assets/7f0906d7-6e38-4ce9-afba-fc22a3b37519" />


## Why It's Good For The Game

1. let us be honest, the matthios traits are kinda poopy and do nothing for anything but an **_extremely small subset_** of a specific character archetype
2. Giving Matthiosan clerics the ability to transact (a heal based off of the value of an item) without being able to see how much an item is worth (ESPECIALLY when they can tell the most valuable item on someone!!) is devious. It should honestly probably be the normal seeprice trait, but _that_ is probably too much.