### PR TITLE
Mob with Critical Weakness + Noblood dies to Rib Fracture

### DIFF
--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -260,8 +260,10 @@
 /datum/wound/fracture/chest/on_mob_gain(mob/living/affected)
 	. = ..()
 	affected.Immobilize(15)		//Stuns you, major downside
-	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS))
-		affected.death()
+	if(istype(affected, /mob/living/carbon)) // Intended for PVE skeletons
+		var/mob/living/carbon/CA = affected
+		if(HAS_TRAIT(CA, TRAIT_CRITICAL_WEAKNESS) && (NOBLOOD in CA.dna.species.species_traits))
+			CA.death()
 
 /datum/wound/fracture/chest/on_life()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
- If you are critically weak and have no blood, you can die to a rib fracture.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1350" height="1002" alt="NVIDIA_Overlay_hUTIxp7fOs" src="https://github.com/user-attachments/assets/7fe0cfb6-09ae-4b32-9622-1f77ab4be3d2" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gives an option for blunt / chop user to kill skeleton even on low perception. Doesn't help with cut / stab intent but oh well! Switch to your fists. Can't think of how to make it good without breaking the balance of crit elsewhere. 

This is largely intended as an option for PVE because skeletons in PVE are either the easiest shit ever (high perception build / aim throat) or the roughest opponent if you don't know that only head have fatal fractures.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
