### PR TITLE
New Grenzel crossbow class, and halberdier's athletics!

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -99,29 +99,22 @@
 			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)		// Make your energy count, little silly individual
-			H.adjust_skillrank(/datum/skill/labor/butchering, 3, TRUE)		// meant to live off the land and set up camp.
+			H.adjust_skillrank(/datum/skill/labor/butchering, 2, TRUE)		// meant to live off the land and set up camp.
 			H.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)		// learn 2 maintain your uniform.
 			H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)		// Just so you don't suck at cooking
 			H.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/tracking, 3, TRUE)		// track ur prey
 			H.adjust_skillrank(/datum/skill/labor/lumberjacking, 2, TRUE)	
 			H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)	// crafting for pallisades, lumberjacking for not fucking up wood
 			beltr = /obj/item/quiver/bolts
 			beltl = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+			r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 			H.change_stat("strength", 1) // 1 STR for the axe and crossbow reload. END for chopping trees, a bit of SPD for running, PER for shooting. -1 CON bc you aint a frontliner
 			H.change_stat("endurance", 2)
 			H.change_stat("constitution", -1)
 			H.change_stat("perception", 2)
 			H.change_stat("speed", 2)
-			var/weapons = list("Crossbow", "Slurbow")
-			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS", "DELIVER BOLTS") as anything in weapons
 			var/armor_options = list("Light Brigandine", "Studded Leather Vest")
 			var/armor_choice = input("Choose your armor.", "DRESS UP") as anything in armor_options
-			switch(weapon_choice)
-				if("Crossbow")
-					r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-				if("Slurbow")
-					r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
 			switch(armor_choice)
 				if("Light Brigandine")
 					armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light	// find a smithy to fix it
@@ -141,7 +134,9 @@
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
-		/obj/item/flashlight/flare/torch = 1
+		/obj/item/flashlight/flare/torch = 1,
+		/obj/item/rogueweapon/huntingknife = 1,
+		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 
 	H.grant_language(/datum/language/grenzelhoftian)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -16,7 +16,7 @@
 
 	// CLASS ARCHETYPES
 	H.adjust_blindness(-3)
-	var/classes = list("Doppelsoldner","Halberdier")
+	var/classes = list("Doppelsoldner","Halberdier","Armbrustschutze")
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -8,7 +8,8 @@
 	traits_applied = list(TRAIT_OUTLANDER)
 	cmode_music = 'sound/music/combat_grenzelhoft.ogg'	
 	classes = list("Doppelsoldner" = "You are a Doppelsoldner - \"Double-pay Mercenary\" - an experienced frontliner trained by the master swordsmen of the Zenitstadt fencing guild.",
-					"Halberdier" = "You're an experienced soldier skilled in the use of polearms and axes. Your equals make up the bulk of the mercenary guild's forces.")
+					"Halberdier" = "You're an experienced soldier skilled in the use of polearms and axes. Your equals make up the bulk of the mercenary guild's forces.",)
+					"Armbrustschutze" = "You're a proved marksman with a crossbow, and learned how to set up camp and defenses in the wild. The guild needs you.")
 
 /datum/outfit/job/roguetown/mercenary/grenzelhoft/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -36,19 +37,22 @@
 			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)		//Trust me, they'll need it due to stamina drain on their base-sword.
+			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate
 			H.change_stat("strength", 2)	//Should give minimum required stats to use Zweihander
 			H.change_stat("endurance", 3)
 			H.change_stat("constitution", 3)
 			H.change_stat("perception", 1)
 			H.change_stat("speed", -1)		//They get heavy armor now + sword option; so lower speed.
+			ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 			var/weapons = list("Zweihander", "Kriegmesser & Buckler")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
 				if("Zweihander")
 					r_hand = /obj/item/rogueweapon/greatsword/grenz
 				if("Kriegmesser & Buckler") // Buckler cuz they have no shield skill.
-					r_hand = /obj/item/rogueweapon/scabbard/sword
-					beltr = /obj/item/rogueweapon/sword/long/kriegmesser
+					beltr = /obj/item/rogueweapon/scabbard/sword
+					r_hand = /obj/item/rogueweapon/sword/long/kriegmesser
 					l_hand = /obj/item/rogueweapon/shield/buckler
 		if("Halberdier")
 			H.set_blindness(0)
@@ -65,12 +69,15 @@
 			H.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)		// Foot soldier that carries the Big Fuckin Polearm around. Also polearm stam drain from the fact they gon' be catching swings all day.
+			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate
 			H.change_stat("strength", 2) //same str, worse end, more speed - actually a good tradeoff, now.
 			H.change_stat("endurance", 2)
 			H.change_stat("constitution", 2)
 			H.change_stat("perception", -1)
 			H.change_stat("speed", 1)
+			ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 			var/weapons = list("Halberd", "Partizan")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
@@ -78,27 +85,65 @@
 					r_hand = /obj/item/rogueweapon/halberd
 				if("Partizan")
 					r_hand = /obj/item/rogueweapon/spear/partizan
-
+		if("Armbrustschutze")			//crossbow and axe class. Rearguard. Utility skills, no medium armor, no dodge expert. This is NOT a go-face-first-into-war class.
+			H.set_blindness(0)
+			to_chat(H, span_warning("You're a proved marksman with a crossbow, and learned how to set up camp and defenses in the wild. The guild needs you."))
+			H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)		// gotta get to a vantage point
+			H.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)		// this is not only a tool!
+			H.adjust_skillrank(/datum/skill/combat/crossbows, 5, TRUE)		//every combat class with a ranged weapon gets this . eat my jorts. They have no dodge expert.
+			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)		// Make your energy count, little silly individual
+			H.adjust_skillrank(/datum/skill/labor/butchering, 3, TRUE)		// meant to live off the land and set up camp.
+			H.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)		// learn 2 maintain your uniform.
+			H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)		// Just so you don't suck at cooking
+			H.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/tracking, 3, TRUE)		// track ur prey
+			H.adjust_skillrank(/datum/skill/labor/lumberjacking, 2, TRUE)	
+			H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)	// crafting for pallisades, lumberjacking for not fucking up wood
+			beltr = /obj/item/quiver/bolts
+			beltl = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+			H.change_stat("strength", 1) // 1 STR for the axe and crossbow reload. END for chopping trees, a bit of SPD for running, PER for shooting. -1 CON bc you aint a frontliner
+			H.change_stat("endurance", 2)
+			H.change_stat("constitution", -1)
+			H.change_stat("perception", 2)
+			H.change_stat("speed", 2)
+			var/weapons = list("Crossbow", "Slurbow")
+			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS", "DELIVER BOLTS") as anything in weapons
+			var/armor_options = list("Light Brigandine", "Studded Leather Vest")
+			var/armor_choice = input("Choose your armor.", "DRESS UP") as anything in armor_options
+			switch(weapon_choice)
+				if("Crossbow")
+					r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				if("Slurbow")
+					r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
+			switch(armor_choice)
+				if("Light Brigandine")
+					armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light	// find a smithy to fix it
+				if("Studded Leather Vest")
+					armor = /obj/item/clothing/suit/roguetown/armor/leather/studded		// or maintain it yourself!
 
 	//General gear regardless of class.
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/flashlight/flare/torch
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
 	head = /obj/item/clothing/head/roguetown/grenzelhofthat
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
 	shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backl = /obj/item/rogueweapon/scabbard/gwstrap
-
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary = 1,
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/flashlight/flare/torch = 1
 		)
 
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	H.grant_language(/datum/language/grenzelhoftian)
 	H.merctype = 7
+	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)		// me when my business is combat and I get shocked when ppl lose limbs

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -8,7 +8,7 @@
 	traits_applied = list(TRAIT_OUTLANDER)
 	cmode_music = 'sound/music/combat_grenzelhoft.ogg'	
 	classes = list("Doppelsoldner" = "You are a Doppelsoldner - \"Double-pay Mercenary\" - an experienced frontliner trained by the master swordsmen of the Zenitstadt fencing guild.",
-					"Halberdier" = "You're an experienced soldier skilled in the use of polearms and axes. Your equals make up the bulk of the mercenary guild's forces.",)
+					"Halberdier" = "You're an experienced soldier skilled in the use of polearms and axes. Your equals make up the bulk of the mercenary guild's forces.",
 					"Armbrustschutze" = "You're a proved marksman with a crossbow, and learned how to set up camp and defenses in the wild. The guild needs you.")
 
 /datum/outfit/job/roguetown/mercenary/grenzelhoft/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
@@ -31,7 +31,7 @@
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)   // they're noble knights, CLEARLY they know how to ride something
 	H.change_stat("strength", 2)
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 4)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
@@ -31,7 +31,7 @@
 	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)   // they're noble knights, CLEARLY they know how to ride something
+	H.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)   
 	H.change_stat("strength", 2)
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 4)


### PR DESCRIPTION
## About The Pull Request
Remember when Mercenaries weren't bloated? Me neither.

- ~~Routiers get +1 Riding skill, up to *Journeyman*. If this somehow makes Routiers 10x stronger than they already are, lemme know.~~ Nevermind. I tried it a bit more. The difference is day and night and Routiers are already strong.
- Halberdiers of the Grenzel variety get +1 Athletics, up to **Expert** to be on par with Zwei users. If this makes it suck 50% less, great!
- **NEW GRENZEL CLASS!** *Armbrustschutze!* Stands for *crossbowman*, literally.
- CROSSBOW ~~OR SLURBOW~~ AS PRIMARY! JOURNEYMAN AXE SO THEY CAN DEFEND THEMSELVES WITH A STEEL AXE! UTILITY SKILLS BECAUSE THEY'RE MEANT TO BE A SUPPORT SORT OF MERC!
- BUILD A FORT FOR YOU AND YOUR MERC BUDDIES! GO HUNT FOR FOOD! STITCH HOLES IN CLOTHES!
- **NO MEDIUM ARMOR, NO DODGE EXPERT. YOU'RE NOT JOHN-MELEE**. Choose between a *light brigandine* or a *studded leather vest*.
- Also gives Grenzels Steelhearted. Like. Man, they fight 4 money. They are used to seeing blood n shit.
- Removed Trey Liam.
- *Give Grenzels a hunting knife at the start.* Woe.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="493" height="92" alt="image" src="https://github.com/user-attachments/assets/9d28d991-0f74-4275-930a-f43351070fd9" />
<img width="279" height="156" alt="image" src="https://github.com/user-attachments/assets/0c732b8d-a7f4-4db5-9dfb-f7d18e57efd4" />
<img width="244" height="441" alt="image" src="https://github.com/user-attachments/assets/a2c8c549-71d7-452a-a6a5-142a5857589a" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
~~More riding SHOULDN'T hurt anyone.~~ Journeyman riding Routier fucked my wife then ran away laughing in Otavais.
+1 to Athletics bring Halberdier on par with Zwei - which is still an all-around better class, admittedly.
**Armbrustschutze** offers an alternative: a ranged class with a focus on setting up defenses (maybe ambushes), and being able to provide provisions to an encampment. Tag along with more Grenzels as the Kaiser intended, you can't survive on your own all too well! Slurbows sold separately.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
