### PR TITLE
Peasant Nerf: No Experience Gain When Parrying With Non-Combat Skills

### DIFF
--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -205,35 +205,37 @@
 	if(istype(user.rmb_intent, /datum/rmb_intent/weak))
 		exp_multi = exp_multi/2
 
+	var/obj/item/AB = intenty.masteritem
+	var/attacker_skill_type
+
+	if(AB)
+		attacker_skill_type = AB.associated_skill
+	else
+		attacker_skill_type = /datum/skill/combat/unarmed
+
 	if(weapon_parry == TRUE)
 		if(do_parry(used_weapon, drained, user)) //show message
-			if ((mobility_flags & MOBILITY_STAND))
-				var/skill_target = attacker_skill
-				if(!HAS_TRAIT(U, TRAIT_GOODTRAINER))
-					skill_target -= SKILL_LEVEL_NOVICE
-				if(HAS_TRAIT(U, TRAIT_BADTRAINER))
-					skill_target -= SKILL_LEVEL_NOVICE
-				if (can_train_combat_skill(src, used_weapon.associated_skill, skill_target) && ispath(used_weapon.associated_skill, /datum/skill/combat))
-					mind.add_sleep_experience(used_weapon.associated_skill, max(round(STAINT*exp_multi), 0), FALSE)
-
-			var/obj/item/AB = intenty.masteritem
-
-			//attacker skill gain
-
-			if(U.mind)
-				var/attacker_skill_type
-				if(AB)
-					attacker_skill_type = AB.associated_skill
-				else
-					attacker_skill_type = /datum/skill/combat/unarmed
+			//only gain experience if attacker and defender aren't using non-combat skills for their weapons
+			if(ispath(attacker_skill_type, /datum/skill/combat) && ispath(used_weapon.associated_skill, /datum/skill/combat))
 				if ((mobility_flags & MOBILITY_STAND))
-					var/skill_target = defender_skill
-					if(!HAS_TRAIT(src, TRAIT_GOODTRAINER))
+					var/skill_target = attacker_skill
+					if(!HAS_TRAIT(U, TRAIT_GOODTRAINER))
 						skill_target -= SKILL_LEVEL_NOVICE
 					if(HAS_TRAIT(U, TRAIT_BADTRAINER))
 						skill_target -= SKILL_LEVEL_NOVICE
-					if (can_train_combat_skill(U, attacker_skill_type, skill_target) && ispath(attacker_skill_type, /datum/skill/combat))
-						U.mind.add_sleep_experience(attacker_skill_type, max(round(STAINT*exp_multi), 0), FALSE)
+					if (can_train_combat_skill(src, used_weapon.associated_skill, skill_target))
+						mind.add_sleep_experience(used_weapon.associated_skill, max(round(STAINT*exp_multi), 0), FALSE)
+
+				//attacker skill gain
+				if(U.mind)
+					if ((mobility_flags & MOBILITY_STAND))
+						var/skill_target = defender_skill
+						if(!HAS_TRAIT(src, TRAIT_GOODTRAINER))
+							skill_target -= SKILL_LEVEL_NOVICE
+						if(HAS_TRAIT(U, TRAIT_BADTRAINER))
+							skill_target -= SKILL_LEVEL_NOVICE
+						if (can_train_combat_skill(U, attacker_skill_type, skill_target))
+							U.mind.add_sleep_experience(attacker_skill_type, max(round(STAINT*exp_multi), 0), FALSE)
 
 			if(prob(66) && AB)
 				if((used_weapon.flags_1 & CONDUCT_1) && (AB.flags_1 & CONDUCT_1))
@@ -295,14 +297,17 @@
 
 	if(weapon_parry == FALSE)
 		if(do_unarmed_parry(drained, user))
-			if((mobility_flags & MOBILITY_STAND))
-				var/skill_target = attacker_skill
-				if(!HAS_TRAIT(U, TRAIT_GOODTRAINER))
-					skill_target -= SKILL_LEVEL_NOVICE
-				if(HAS_TRAIT(U, TRAIT_BADTRAINER))
-					skill_target -= SKILL_LEVEL_NOVICE
-				if(can_train_combat_skill(H, /datum/skill/combat/unarmed, skill_target))
-					H.mind?.add_sleep_experience(/datum/skill/combat/unarmed, max(round(STAINT*exp_multi), 0), FALSE)
+			//only gain experience if attacker isn't using a non-combat skill for their weapon
+			if(ispath(attacker_skill_type, /datum/skill/combat))
+				if((mobility_flags & MOBILITY_STAND))
+					var/skill_target = attacker_skill
+					if(!HAS_TRAIT(U, TRAIT_GOODTRAINER))
+						skill_target -= SKILL_LEVEL_NOVICE
+					if(HAS_TRAIT(U, TRAIT_BADTRAINER))
+						skill_target -= SKILL_LEVEL_NOVICE
+					if(can_train_combat_skill(H, /datum/skill/combat/unarmed, skill_target))
+						H.mind?.add_sleep_experience(/datum/skill/combat/unarmed, max(round(STAINT*exp_multi), 0), FALSE)
+
 			if(unarmed_bracers)
 				var/bracer_damage
 				var/d_flag = "blunt"


### PR DESCRIPTION
## About The Pull Request

We were only checking if the attacker or defender were using combat skills when parrying separately.
With this, if **_either_** the attacker or the defender are using a non-combat skill on their weapons, **_neither_** of them will gain experience from parrying.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Smacked a bunch of NPCs with my scythe and the to_chat(world) that I set up screamed at me whenever it was bad :]
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
While funny, people could level up their farming or mining to legendary and then train others to master with weapons that use those skills. Probably unintended.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
