### PR TITLE
Repulse now set resting instead of paralyze. CD 30 to 25.

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
@@ -6,7 +6,7 @@
 	releasedrain = 50
 	chargedrain = 1
 	chargetime = 5
-	recharge_time = 30 SECONDS
+	recharge_time = 25 SECONDS
 	ignore_los = TRUE
 	warnie = "spellwarning"
 	no_early_release = TRUE
@@ -51,14 +51,14 @@
 		if(distfromcaster == 0)
 			if(isliving(AM))
 				var/mob/living/M = AM
-				M.Paralyze(10)
+				M.set_resting(TRUE, TRUE)
 				M.adjustBruteLoss(20)
 				to_chat(M, "<span class='danger'>You're slammed into the floor by [user]!</span>")
 		else
 			new sparkle_path(get_turf(AM), get_dir(user, AM)) //created sparkles will disappear on their own
 			if(isliving(AM))
 				var/mob/living/M = AM
-				M.Paralyze(stun_amt)
+				M.set_resting(TRUE, TRUE)
 				to_chat(M, "<span class='danger'>You're thrown back by [user]!</span>")
 			AM.safe_throw_at(throwtarget, ((CLAMP((maxthrow - (CLAMP(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1,user, force = repulse_force)//So stuff gets tossed around at the same time.
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Second attempt to nerf it to remove the hardstun. Now it just force you to rest instead of making you drop your weapons. CD reduced by 5 seconds to compensate. This should retain all utility as an escape tool and CC tool while making it less of an autowin button.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_KmQNq1y4N8](https://github.com/user-attachments/assets/6a980c16-e8bd-4150-a0c0-10735438db33)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Death to hardstuns.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
