### PR TITLE
[Abyssor nerf] - Makes heretic crystals slightly weaker. It takes a while before they can be made.

### DIFF
--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -275,6 +275,11 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 	if(user.has_status_effect(/datum/status_effect/debuff/ritesexpended))
 		to_chat(user,span_smallred("I have performed enough rituals for the day... I must rest before communing more."))
 		return
+	var/time_elapsed = STATION_TIME_PASSED() / (1 MINUTES)
+	if(time_elapsed < 30)
+		var/time_left = 30 - time_elapsed
+		to_chat(user, span_smallred("The veil is too thin for this rite. Wait another [round(time_left, 0.1)] minutes."))
+		return
 	var/riteselection = input(user, "Rite of the Tidal Spire", src) as null|anything in stirringrites
 	switch(riteselection)
 		if("Rite of the Crystal Spire")
@@ -461,7 +466,7 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 	initial_fiend = /mob/living/simple_animal/hostile/rogue/dreamfiend/ancient/unbound
 	max_integrity = 1000
 	max_radius = 5
-	max_fiends = 10
+	max_fiends = 7
 
 /obj/structure/crystal_spire/tidal
 	name = "tidal spire"


### PR DESCRIPTION
## About The Pull Request
- Shrimply. The max amount of demons one spire for a heretic can have now is 7, down from 10.
- Abyssorite crystal spire markers can't be made before 30 minutes into the round.

## Testing Evidence
<img width="547" height="531" alt="image" src="https://github.com/user-attachments/assets/9ed0758f-afa6-4479-bed2-4b031bc1db42" />

## Why It's Good For The Game
There's been a lot of jassing about how there's a lot of these and it's kinda harsh on town and sometimes it murders everyone on lowpop. Which is fair. This small nerf should make the impact of an abyssorite saving up crystals for most of the round less... silly.
2:30 mark : 6 crystals => 5 crystals.

If more nerfs are needed I'll work on it. One step at a time.