### PR TITLE
Nitpick patch: Bodypart_attacked_by consistently returns a wound or null

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -120,8 +120,9 @@
 
 /// Called after a bodypart is attacked so that wounds and critical effects can be applied
 /obj/item/bodypart/proc/bodypart_attacked_by(bclass = BCLASS_BLUNT, dam, mob/living/user, zone_precise = src.body_zone, silent = FALSE, crit_message = FALSE, armor)
+	RETURN_TYPE(/datum/wound)
 	if(!bclass || !dam || !owner || (owner.status_flags & GODMODE))
-		return FALSE
+		return null
 	var/do_crit = TRUE
 	var/acheck_dflag
 	switch(bclass)


### PR DESCRIPTION
## About The Pull Request
Impetus was the Scarlet omniwounds PR, gave this another quick look when porting here and ended up implementing a simpler patch than what I originally did for Scarlet.

I went ahead and made `bodypart_attacked_by()` only return either the wound or `null`, because:
- The majority of cases where the proc is called aren't assigning the return value to anything
- The few cases that do assign the return value expect a ref with type `/datum/wound` 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles. Dreamchecker still loves me. Fucking *nothing* wants this code to specifically return 0.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Actually this is horrible for the game and I'm secretly sneaking 500 balancejaks in this PR
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
