### PR TITLE
Gives Undivided Templar Thier bonus

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -278,6 +278,8 @@
 	H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)	//May tone down to 2; seems OK.
 	// -- Start of section for god specific bonuses --
+	if(H.patron?.type == /datum/patron/divine/undivided)
+		H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 	if(H.patron?.type == /datum/patron/divine/astrata)
 		H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 		H.cmode_music = 'sound/music/cmode/church/combat_astrata.ogg'


### PR DESCRIPTION
## About The Pull Request

For some reason Undivided Crusadors weren't give their +1 skill boost, only undivided monks. This PR fixes that.

## Testing Evidence

<img width="461" height="505" alt="code stuff" src="https://github.com/user-attachments/assets/d7bc5cc9-bb42-46d6-a8c3-5c54aa91d635" />

## Why It's Good For The Game

Keeps consistency between the different choices. Probably was just forgotten when coded.