### PR TITLE
Don't allow unconcious mobs to wave/beckon/shoo/taunt

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -471,6 +471,8 @@
 	intent_intdamage_factor = 0.5
 
 /datum/intent/unarmed/punch/rmb_ranged(atom/target, mob/user)
+	if(user.stat >= UNCONSCIOUS)
+		return
 	if(ismob(target))
 		var/mob/M = target
 		var/list/targetl = list(target)
@@ -513,6 +515,8 @@
 	item_d_type = "blunt"
 
 /datum/intent/unarmed/shove/rmb_ranged(atom/target, mob/user)
+	if(user.stat >= UNCONSCIOUS)
+		return
 	if(ismob(target))
 		var/mob/M = target
 		var/list/targetl = list(target)
@@ -538,6 +542,8 @@
 	item_d_type = "blunt"
 
 /datum/intent/unarmed/grab/rmb_ranged(atom/target, mob/user)
+	if(user.stat >= UNCONSCIOUS)
+		return
 	if(ismob(target))
 		var/mob/M = target
 		var/list/targetl = list(target)
@@ -560,6 +566,8 @@
 	rmb_ranged = TRUE
 
 /datum/intent/unarmed/help/rmb_ranged(atom/target, mob/user)
+	if(user.stat >= UNCONSCIOUS)
+		return
 	if(ismob(target))
 		var/mob/M = target
 		var/list/targetl = list(target)


### PR DESCRIPTION
## About The Pull Request

This PR fixes the bug that allows dead mobs to wave/beckon/shoo/taunt.

## Testing Evidence

I've tested this locally and confirm that the code changes fixes the bug.

## Why It's Good For The Game

It fixes a bug.