### PR TITLE
Improve mail feedback

### DIFF
--- a/code/modules/roguetown/roguemachine/mail.dm
+++ b/code/modules/roguetown/roguemachine/mail.dm
@@ -56,6 +56,8 @@
 					say("You have additional mail available.")
 					break
 		if(!any_additional_mail(M, H.real_name))
+			if(!addl_mail && H.has_status_effect(/datum/status_effect/ugotmail)) // we apparently got mail, but never got mail (hint: it was stolen by someone with access to the master mailer)
+				to_chat(user, span_notice("I look inside the machine and find no letter, how strange."))
 			H.remove_status_effect(/datum/status_effect/ugotmail)
 	if(!ishuman(user))
 		return	
@@ -481,7 +483,7 @@
 			return	
 		if(alert(user, "Send Mail?",,"YES","NO") == "YES")
 			var/send2place = input(user, "Where to? (Person or #number)", "ROGUETOWN", null)
-			var/sentfrom = input(user, "Who is this from?", "ROGUETOWN", null)
+			var/sentfrom = input(user, "Who is this from? (Leave blank to send anonymously)", "ROGUETOWN", null)
 			if(!sentfrom)
 				sentfrom = "Anonymous"
 			if(findtext(send2place, "#"))
@@ -507,6 +509,13 @@
 			else
 				if(!send2place)
 					return
+				var/mob/living/carbon/human/mailrecipient = null
+				for(var/mob/living/carbon/human/H in GLOB.human_list)
+					if(H.real_name == send2place)
+						mailrecipient = H
+						break
+				if(!mailrecipient && (alert("Could not find recipient [send2place]. Still send the letter?", "", "YES", "NO") == "NO")) // ask player if they still want to send a letter to a non-found character
+					return
 				var/findmaster
 				if(SSroguemachine.hermailermaster)
 					var/obj/item/roguemachine/mastermail/X = SSroguemachine.hermailermaster
@@ -526,10 +535,9 @@
 					visible_message(span_warning("[user] sends something."))
 					playsound(loc, 'sound/misc/disposalflush.ogg', 100, FALSE, -1)
 					send_ooc_note("New letter from <b>[sentfrom].</b>", name = send2place)
-					for(var/mob/living/carbon/human/H in GLOB.human_list)
-						if(H.real_name == send2place)
-							H.apply_status_effect(/datum/status_effect/ugotmail)
-							H.playsound_local(H, 'sound/misc/mail.ogg', 100, FALSE, -1)
+					if(mailrecipient)
+						mailrecipient.apply_status_effect(/datum/status_effect/ugotmail)
+						mailrecipient.playsound_local(mailrecipient, 'sound/misc/mail.ogg', 100, FALSE, -1)
 					return
 
 	if(istype(P, /obj/item/roguecoin/aalloy))
@@ -658,6 +666,10 @@
 			PA.cached_mailedto = null
 			PA.update_icon()
 			to_chat(user, span_warning("I carefully re-seal the letter and place it back in the machine, no one will know."))
+		if(PA.mailer && PA.mailedto)
+			for(var/mob/living/carbon/human/H in GLOB.human_list)
+				if(H.real_name == PA.mailedto && !H.has_status_effect(/datum/status_effect/ugotmail)) // quietly readd the status if they tried to check their mail while the letter was being spied on
+					H.apply_status_effect(/datum/status_effect/ugotmail)
 		P.forceMove(loc)
 		var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 		STR.handle_item_insertion(P, prevent_warning=TRUE)


### PR DESCRIPTION
## About The Pull Request

This PR adds more additional feedback to the mailing logic.

* Ask the player if they still wish to send the letter if the recipient is not found
* Adds a mention of leaving the from name field blank to be able to send mail anonymously
* Adds a chat notice message hint if tried to collect their mail if their mail was stolen/burned/missing
* If the recipient tried to collect their mail and there was none to be found, silently readd the `ugotmail` status effect for the recipient if their mail is readded into the mastermail machine

## Testing Evidence

I have tested this logically and confirm it does exactly as above describes.
<img width="502" height="224" alt="tested" src="https://github.com/user-attachments/assets/98f8fa05-63df-42af-b520-aa70f16cbc89" />

## Why It's Good For The Game

More feedback helps players get less frustrated and cuts down on false bug reports.