### PR TITLE
Ports stunlock removal from SR

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1761,7 +1761,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 							H.emote("painscream")
 						else
 							H.emote("pain")
-				if(damage_amount > ((H.STACON*12.5) / 3) && !HAS_TRAIT(H, TRAIT_NOPAINSTUN)) //We want this effect only on heavy hits.
+				if(damage_amount > (H.STACON * 3.5) && !HAS_TRAIT(H, TRAIT_NOPAINSTUN)) //We want this effect only on heavy hits.
 					H.Immobilize(5) //The fastest you can swing a weapon is once each 0.6 seconds, anything higher than 0.5 Immob. opens the door for stunlocking (see: katar).
 					shake_camera(H, 2, 2)
 					H.stuttering += 5


### PR DESCRIPTION
## About The Pull Request

Title. Ports [this](https://github.com/Scarlet-Reach/Scarlet-Reach/pull/701/files).

## Testing Evidence

trust me free

## Why It's Good For The Game

I'll just copy and paste original explanation, it is excessive.

So a little bit of context and explanation to this:
When you are hit by an attack, if it exceeds a damage value of (10xCON)/3, you are immobilized for 0.8 seconds. You can't turn around, parry, dodge or move. This is in addition to the slowdown you receive on any attack that exceeds 10 damage.

This by itself is a bit unfun and makes fights feel quite one-sided (whenever your armor breaks, you are most likely being subjected to this with every attack). However an even bigger issue is that some weapons (cough cough katar) are capable of exceeding that damage threshold while also being capable of attacking faster than or exactly once every 0.8 seconds.

This resulted in a very recurrent scenario of katar users getting a hit in, then circling around to someone's back while continuing to hit, effectively "comboing" them by refreshing the Immobilize while their victim was completely helpless to it.

This PR reduces the Immobilize from that proc, from 0.8 seconds to 0.5 seconds, and slightly increases the impact Constitution has on preventing it.

