### PR TITLE
Bandits, wretches, vampires and other knaves should no longer be known to Azurians

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -203,9 +203,13 @@
 
 	for(var/X in peopleknowme)
 		for(var/datum/mind/MF in get_minds(X))
+			if(isnull(H.mind?.special_role) && (MF?.special_role in list(ROLE_VAMPIRE, ROLE_NBEAST, ROLE_BANDIT, ROLE_LICH, ROLE_WRETCH, ROLE_UNBOUND_DEATHKNIGHT)))
+				continue
 			H.mind.person_knows_me(MF)
 	for(var/X in peopleiknow)
 		for(var/datum/mind/MF in get_minds(X))
+			if(isnull(H.mind?.special_role) && (MF?.special_role in list(ROLE_VAMPIRE, ROLE_NBEAST, ROLE_BANDIT, ROLE_LICH, ROLE_WRETCH, ROLE_UNBOUND_DEATHKNIGHT)))
+				continue
 			H.mind.i_know_person(MF)
 
 	if(H.islatejoin && announce_latejoin)


### PR DESCRIPTION
## About The Pull Request

Topic name. Basically, wretches and bandits are in GLOB.peasant_positions - and any joining job with a bank account will know them. Similar - with vampire (and lich, I believe?), because those antag roles never change their original assigned role, they just change their special role var.

And thus - antags in list(ROLE_VAMPIRE, ROLE_NBEAST, ROLE_BANDIT, ROLE_LICH, ROLE_WRETCH, ROLE_UNBOUND_DEATHKNIGHT) will now be skipped. They will not know anyone, no one will know them. Antags (everyone with set special_role var) will still know each other, that's intentional. I think it is a win.

## Testing Evidence

Tested on local with two clients. Latejoining character was not learning about a pre-existing wretch, tis a success.

<img width="152" height="32" alt="image" src="https://github.com/user-attachments/assets/93631b25-3657-49c7-af7e-e67a1b2bb18c" />

## Why It's Good For The Game

You all know why.