### PR TITLE
[Miraclejak] Bless food patron lock & skill increase.

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -303,8 +303,10 @@
 	var/quality
 	var/skill
 	var/bitesize_mod
+	// I hate this but let's be consistent.
+	var/datum/patron/patron
 
-/datum/component/blessed_food/Initialize(mob/living/_caster, var/holy_skill)
+/datum/component/blessed_food/Initialize(mob/living/_caster, var/holy_skill, var/patron_init)
 	if(!isitem(parent) || !istype(parent, /obj/item/reagent_containers/food/snacks))
 		return COMPONENT_INCOMPATIBLE
 
@@ -314,8 +316,9 @@
 	//Better food being blessed heals more
 	quality = F.faretype
 	bitesize_mod = 1 / F.bitesize
+	patron = patron_init
 	F.faretype = clamp(skill, 1, 5)
-	if(skill < 4)
+	if(skill < 5 || patron.type != /datum/patron/divine/eora)
 		F.add_filter(BLESSED_FOOD_FILTER, 1, list("type" = "outline", "color" = "#ff00ff", "size" = 1))
 	else
 		F.add_filter(BLESSED_FOOD_FILTER, 1, list("type" = "outline", "color" = "#f0b000", "size" = 1))
@@ -328,8 +331,8 @@
 		return
 
 	eater.apply_status_effect(/datum/status_effect/buff/healing, (quality + (skill / 5)) * bitesize_mod)
-	if(skill > 3)
-		eater.apply_status_effect(/datum/status_effect/buff/haste, 10 SECONDS)
+	if(skill > 4 && patron.type == /datum/patron/divine/eora)
+		eater.apply_status_effect(/datum/status_effect/buff/haste, 15 SECONDS)
 
 /obj/effect/proc_holder/spell/invoked/bless_food
 	name = "Bless Food"
@@ -351,7 +354,11 @@
 		return FALSE
 
 	var/holy_skill = user.get_skill_level(associated_skill)
-	target.AddComponent(/datum/component/blessed_food, user, holy_skill)
+	var/mob/living/carbon/human/H = user
+	var/patron = FALSE
+	if(ishuman(H))
+		patron = user.patron
+	target.AddComponent(/datum/component/blessed_food, user, holy_skill, patron)
 	to_chat(user, span_notice("You bless [target] with Eora's love!"))
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
- Expert => Master miracle skill for the haste benefit of bless food.
- Patron lock the haste benefit to Eoran casters.
- Increase haste duration from 10 to 15 seconds to make it less clunky to use in combat and chase (grab from belt pouch with hotkey + consume)

## Testing Evidence
Simple number change, I tested it, just didn't grab a screenie.

## Why It's Good For The Game
Bless food was made back when templars had apprentice miracle skill by default, and hence the haste buff was set to be expert+ skill level, as devotee (the virtue) could only be used to reach up to journeyman. Haste is 5 speed, it's a lot. It can invalidate dodge builds, so it's fair that the amount of round church has access to this kind of food stays limited. Templars were NEVER intended to be able to create haste food themselves.

This nerfs missionaries too since now they need devotee to get the haste effect, which is part of the reason I felt like making it more worthwhile for the to take devotee by upping the duration.

I was originally only going to increase the skill, but undivided templars can reach master miracle skill with devotee. Given they get bless food + bless crops anyways, it's probably fair they can't use both at maximum (or better efficiency, given bless food scales with holy skill for the healing effect too)
