### PR TITLE
NEW spell for Druid - last chanse

### DIFF
--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -94,6 +94,7 @@
 					/obj/effect/proc_holder/spell/targeted/wildshape			= CLERIC_T2,
 					/obj/effect/proc_holder/spell/targeted/conjure_glowshroom	= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/wound_heal			= CLERIC_T3,
+					/obj/effect/proc_holder/spell/self/call_of_dendor			= CLERIC_T3,
 					/obj/effect/proc_holder/spell/self/howl/call_of_the_moon	= CLERIC_T4,
 					/obj/effect/proc_holder/spell/invoked/resurrect/dendor		= CLERIC_T4,
 	)

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -525,3 +525,14 @@
 	desc = "I was on the sermon. My patron is not proud of me."
 	icon_state = "debuff"
 	color ="#af9f9f"
+
+/datum/status_effect/debuff/dyspnea
+	id = "dyspnea"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/dyspnea
+	effectedstats = list("strength" = -2, "perception" = -2, "endurance" = -2, "constitution" = -3, "speed" = -3)
+	duration = 1 MINUTES
+
+/atom/movable/screen/alert/status_effect/debuff/dyspnea
+	name = "Dyspnea"
+	desc = "The forces of Dendor have left you, taking their price."
+	icon_state = "revived"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -987,7 +987,7 @@
 /datum/status_effect/buff/call_of_dendor
 	id = "call_of_dendor"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/call_of_dendor
-	duration = 2.5 MINUTES
+	duration = 1.5 MINUTES
 	effectedstats = list("strength" = 2,"constitution" = 2 , "speed" = 4, "intelligence" = -6) //fast legs not afraid
 
 /atom/movable/screen/alert/status_effect/buff/call_of_dendor

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -988,7 +988,7 @@
 	id = "call_of_dendor"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/call_of_dendor
 	duration = 1.5 MINUTES
-	effectedstats = list("strength" = 2,"constitution" = 2 , "speed" = 4, "intelligence" = -6) //fast legs not afraid
+	effectedstats = list("strength" = 1,"constitution" = 2 , "speed" = 4, "intelligence" = -6) //fast legs not afraid
 
 /atom/movable/screen/alert/status_effect/buff/call_of_dendor
 	name = "Call of Dendor"
@@ -997,12 +997,12 @@
 
 /datum/status_effect/buff/call_of_dendor/on_apply()
 	. = ..()
-	ADD_TRAIT(owner, TRAIT_INFINITE_STAMINA, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_GRABIMMUNE, TRAIT_GENERIC)
 
 /datum/status_effect/buff/call_of_dendor/on_remove()
 	. = ..()
 	owner.apply_status_effect(/datum/status_effect/debuff/dyspnea)
-	REMOVE_TRAIT(owner, TRAIT_INFINITE_STAMINA, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_GRABIMMUNE, TRAIT_GENERIC)
 
 /atom/movable/screen/alert/status_effect/buff/xylix_joy
 	name = "Trickster's Joy"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -984,6 +984,26 @@
 	desc = span_bloody("LAMBS TO THE SLAUGHTER!")
 	icon_state = "call_to_slaughter"
 
+/datum/status_effect/buff/call_of_dendor
+	id = "call_of_dendor"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/call_of_dendor
+	duration = 2.5 MINUTES
+	effectedstats = list("strength" = 2,"constitution" = 2 , "speed" = 4, "intelligence" = -6) //fast legs not afraid
+
+/atom/movable/screen/alert/status_effect/buff/call_of_dendor
+	name = "Call of Dendor"
+	desc = span_bloody("I FEEL DENDOR'S MIGHT!")
+	icon_state = "tamebeast"
+
+/datum/status_effect/buff/call_of_dendor/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_INFINITE_STAMINA, TRAIT_GENERIC)
+
+/datum/status_effect/buff/call_of_dendor/on_remove()
+	. = ..()
+	owner.apply_status_effect(/datum/status_effect/debuff/dyspnea)
+	REMOVE_TRAIT(owner, TRAIT_INFINITE_STAMINA, TRAIT_GENERIC)
+
 /atom/movable/screen/alert/status_effect/buff/xylix_joy
 	name = "Trickster's Joy"
 	desc = "The sound of merriment fills me with fortune."

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -157,7 +157,7 @@
 	sound = 'sound/magic/timestop.ogg'
 	releasedrain = 30
 	miracle = TRUE
-	devotion_cost = 250
+	devotion_cost = 300
 	invocations = list("The Treefather! Give me power!")
 	invocation_type = "shout"
 	var/static/list/purged_effects = list(

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -147,3 +147,37 @@
 		return TRUE
 	revert_cast()
 	return FALSE
+
+/obj/effect/proc_holder/spell/self/call_of_dendor
+	name = "Call of Dendor"
+	desc = "The power of the Dendor overwhelms you! But, it have very big cost... Its your last chanse!"
+	overlay_state = "tamebeast"
+	recharge_time = 5 MINUTES
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross/dendor)
+	sound = 'sound/magic/timestop.ogg'
+	releasedrain = 30
+	miracle = TRUE
+	devotion_cost = 250
+	invocations = list("The Treefather! Give me power!")
+	invocation_type = "shout"
+	var/static/list/purged_effects = list(
+	/datum/status_effect/incapacitating/immobilized,
+	/datum/status_effect/incapacitating/paralyzed,
+	/datum/status_effect/incapacitating/stun,
+	/datum/status_effect/incapacitating/knockdown,)
+
+/obj/effect/proc_holder/spell/self/call_of_dendor/cast(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		revert_cast()
+		return FALSE
+	var/mob/living/carbon/human/H = user
+	if(H.resting)
+		H.set_resting(FALSE, FALSE)
+	H.emote("warcry")
+	for(var/effect in purged_effects)
+		H.remove_status_effect(effect)
+	H.apply_status_effect(/datum/status_effect/buff/call_of_dendor)
+	H.visible_message(span_danger("[H] is enveloped in green energy!"))
+	to_chat(H, span_userdanger("RUN OR KILL!!"))
+	return TRUE

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -155,11 +155,13 @@
 	recharge_time = 5 MINUTES
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross/dendor)
 	sound = 'sound/magic/timestop.ogg'
-	releasedrain = 30
+	associated_skill = /datum/skill/magic/holy
+	releasedrain = 0
 	miracle = TRUE
 	devotion_cost = 300
 	invocations = list("The Treefather! Give me power!")
 	invocation_type = "shout"
+	var/stamregenmod = 25
 	var/static/list/purged_effects = list(
 	/datum/status_effect/incapacitating/immobilized,
 	/datum/status_effect/incapacitating/paralyzed,
@@ -174,6 +176,9 @@
 	var/mob/living/carbon/human/H = user
 	if(H.resting)
 		H.set_resting(FALSE, FALSE)
+	var/regen = (stamregenmod / 150) * H.get_skill_level(associated_skill)
+	H.stamina_add(-(regen * H.max_stamina))
+	H.energy_add(regen * H.max_energy)
 	H.emote("warcry")
 	for(var/effect in purged_effects)
 		H.remove_status_effect(effect)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

-New druid's T3 spell "Call of dendor" - gain: 1 str, 4 spd, 2 con and lost 6 int. Gain trait ANTIGRAB. All it for 1.5 minutes. Also remove: stun, knockdown, paralyzed, immobilized, regen stamina and energy. Than gain debuff on one minute: -2 str, -3 const, -3 spd, -2 end, -2 perc. Cost: 300 devotion. Recharge - 5 minutes.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. --> trust the code. If need - i can make video

## Why It's Good For The Game

New skill for last chanse to survive - win in fight or exit the fight. It have good price to using it.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
