### PR TITLE
Shield / Parry fixes

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -68,7 +68,7 @@
 			return FALSE
 		if((owner.client?.chargedprog == 100 && owner.used_intent?.tranged) || prob(coverage))
 			owner.visible_message(span_danger("[owner] expertly blocks [hitby] with [src]!"))
-			src.take_damage(floor(damage / 2)) // Halved damage so they don't feel too fragile
+			src.take_damage(INTEG_PARRY_DECAY_NOSHARP) // Halved damage so they don't feel too fragile
 			return TRUE
 	return FALSE
 

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -68,7 +68,7 @@
 			return FALSE
 		if((owner.client?.chargedprog == 100 && owner.used_intent?.tranged) || prob(coverage))
 			owner.visible_message(span_danger("[owner] expertly blocks [hitby] with [src]!"))
-			src.take_damage(INTEG_PARRY_DECAY_NOSHARP) // Halved damage so they don't feel too fragile
+			src.take_damage(INTEG_PARRY_DECAY_NOSHARP)
 			return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -294,10 +294,12 @@
 				src.visible_message(span_boldwarning("<b>[src]</b> ripostes [user] with [W]!"))
 			else
 				src.visible_message(span_boldwarning("<b>[src]</b> parries [user] with [W]!"))
-			if(W.max_blade_int)
-				W.remove_bintegrity(SHARPNESS_ONHIT_DECAY, user)
-			else
-				W.take_damage(INTEG_PARRY_DECAY_NOSHARP, BRUTE, "slash")
+			if(!iscarbon(user))	//Non-carbon mobs never make it to the proper parry proc where the other calculations are done.
+				if(W.max_blade_int)
+					W.remove_bintegrity(SHARPNESS_ONHIT_DECAY, user)
+					W.take_damage(INTEG_PARRY_DECAY, BRUTE, "slash")
+				else
+					W.take_damage(INTEG_PARRY_DECAY_NOSHARP, BRUTE, "slash")
 			return TRUE
 		else
 			to_chat(src, span_warning("I'm too tired to parry!"))


### PR DESCRIPTION
## About The Pull Request
- Shield / off-hand blocks now appropriately take 5 integrity damage rather than 10.
- Shield blocking projectiles also take 5 integrity damage now.
- Parrying simple mobs applies all the expected parry downsides now.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
didn't take pics but trust
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
all should work as intended
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
