### PR TITLE
Shields take quartered damage from projectile now.

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -68,7 +68,7 @@
 			return FALSE
 		if((owner.client?.chargedprog == 100 && owner.used_intent?.tranged) || prob(coverage))
 			owner.visible_message(span_danger("[owner] expertly blocks [hitby] with [src]!"))
-			src.take_damage(INTEG_PARRY_DECAY_NOSHARP)
+			src.take_damage(floor(damage / 4))
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request
Changes from https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3643
- As per title

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I have faith in the God-Emperor and my code. Do you?

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- I added this intentionally to make it possible to attrition a shield down. Using quartered damage encourage people to use broadhead (pending rebalance :tm:) instead of spamming bodkin. With the best case scenario of a 300 durability shield vs broadhead fired by a 15 perception (60 damage -> 15 damage) - that's lasting through 20 arrows. 18 Perception - that's 16 arrows. Arcyne Bolts - 30.
- We should retain attritioning a shield down (at cost of most of your quiver) as an option 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
