### PR TITLE
[God fluff] Fixes god fluff probability math.

### DIFF
--- a/code/game/objects/effects/gods/unassuming_fluff.dm
+++ b/code/game/objects/effects/gods/unassuming_fluff.dm
@@ -24,14 +24,17 @@ GLOBAL_LIST_EMPTY(players_in_dream)
 	stressadd = 20
 	desc = span_userdanger("WHAT IS THAT THING?!")
 
-/proc/teleport_to_dream(mob/living/carbon/human/user, probability = 0.1)
+/proc/teleport_to_dream(mob/living/carbon/human/user, base_probability = 10000, probability = 10)
 	if(!ishuman(user))
 		return
 
+	var/effective_probability = probability
 	if(user.patron.type == /datum/patron/divine/abyssor)
-		probability *= 5
+		effective_probability *= 5
 
-	if(!prob(probability))
+	// Look kids, if you want accurate probability, don't use fractional numbers. Pickweight is safer and more accurate than prob() here.
+	var/list/options = list("teleport" = effective_probability, "no_teleport" = base_probability - effective_probability)
+	if(pickweight(options) == "no_teleport")
 		return
 
 	var/area/dream_area = GLOB.areas_by_type[/area/rogue/underworld/dream]
@@ -79,6 +82,7 @@ GLOBAL_LIST_EMPTY(players_in_dream)
 
 	// Schedule return
 	user.apply_status_effect(/datum/status_effect/dream_teleport, original_turf)
+	return TRUE
 
 /proc/return_from_dream(mob/living/carbon/human/user, turf/original_turf)
 	if(!user || QDELETED(user) || !original_turf)

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -488,7 +488,7 @@
 									user.mind.add_sleep_experience(/datum/skill/labor/fishing, fisherman.STAINT*2) // High risk high reward
 								else
 									new A(user.loc)
-									teleport_to_dream(user, 0.01)
+									teleport_to_dream(user, 10000, 1)
 									to_chat(user, "<span class='warning'>Pull 'em in!</span>")
 									user.mind.add_sleep_experience(/datum/skill/labor/fishing, round(fisherman.STAINT, 2), FALSE) // Level up!
 									record_featured_stat(FEATURED_STATS_FISHERS, fisherman)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -597,7 +597,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 					wound.heal_wound(wound.sleep_healing * sleepy_mod)
 			adjustToxLoss(-sleepy_mod)
 			if(eyesclosed && !HAS_TRAIT(src, TRAIT_NOSLEEP))
-				teleport_to_dream(src, 0.02)
+				teleport_to_dream(src, 10000, 2)
 				Sleeping(300)
 	else if(!IsSleeping() && !HAS_TRAIT(src, TRAIT_NOSLEEP))
 		// Resting on a bed or something
@@ -632,7 +632,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 					if(HAS_TRAIT(src, TRAIT_FASTSLEEP))
 						fallingas++
 					if(fallingas > 15)
-						teleport_to_dream(src, 0.02)
+						teleport_to_dream(src, 10000, 2)
 						Sleeping(300)
 			else
 				energy_add(sleepy_mod * 10)
@@ -656,7 +656,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 					if(HAS_TRAIT(src, TRAIT_FASTSLEEP))
 						fallingas++
 					if(fallingas > 25)
-						teleport_to_dream(src, 0.02)
+						teleport_to_dream(src, 10000, 2)
 						Sleeping(300)
 			else
 				energy_add(10)

--- a/code/modules/roguetown/roguejobs/fisher/rod.dm
+++ b/code/modules/roguetown/roguejobs/fisher/rod.dm
@@ -140,7 +140,7 @@
 									else
 										new A(user.loc)
 										to_chat(user, "<span class='warning'>Reel 'em in!</span>")
-										teleport_to_dream(user, 0.01)
+										teleport_to_dream(user, 10000, 1)
 										user.mind.add_sleep_experience(/datum/skill/labor/fishing, round(fisherman.STAINT, 2), FALSE) // Level up!
 										record_featured_stat(FEATURED_STATS_FISHERS, fisherman)
 										GLOB.azure_round_stats[STATS_FISH_CAUGHT]++

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -169,7 +169,7 @@
 			record_featured_stat(FEATURED_STATS_FISHERS, user)
 			GLOB.azure_round_stats[STATS_FISH_CAUGHT]++
 			playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)
-			teleport_to_dream(user, 0.01)
+			teleport_to_dream(user, 10000, 1)
 			user.visible_message("<font color='yellow'>[user] makes a beckoning gesture at [T]!</font>")
 			return TRUE
 		else

--- a/modular/Neu_Food/code/raw/raw_fish.dm
+++ b/modular/Neu_Food/code/raw/raw_fish.dm
@@ -198,7 +198,7 @@
 
 /obj/item/reagent_containers/food/snacks/fish/creepy_eel/pickup(mob/living/user)
 	if(!was_i_picked_up && ishuman(user))
-		teleport_to_dream(user, 100)
+		teleport_to_dream(user, 1, 1)
 		was_i_picked_up = TRUE
 		desc = "A slimy eel, you feel a strange mundanity looking at it... You're assured there's nothing weird about it whatsoever. It might as well be the most average thing in the realm."
 	..()

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -525,7 +525,7 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 
 	var/list/witnesses = view(7, src)
 	for(var/mob/living/carbon/human/H in witnesses)
-		teleport_to_dream(H, 0.1)
+		teleport_to_dream(H, 1000, 1)
 
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
I've no way to prove it, but I reckon something that's supposed to be a 1 to 5/10000 chance to occur, shouldn't be happening MULTIPLE times in the same round. Given byond fractions are known to be -messed up- due to being single point precision floats, I've made sure the math doesn't use these anymore.

## Testing Evidence
<img width="506" height="434" alt="image" src="https://github.com/user-attachments/assets/6313d801-327d-4266-a881-f2c062b5576f" />

## Why It's Good For The Game
As per the testing image I got 0.39% and 0.45% on an expected outcome of 0.5% (given this is an abyssorite the chance is 5x as high). This is within expected binomial distribution. (running 10000 test trails for a chance of 5/1000 or 0.5%, twice)
