### PR TITLE
[Cl*ss edit] boak wyrm jakking

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/blackoak.dm
@@ -49,18 +49,19 @@
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backl = /obj/item/storage/backpack/rogue/satchel
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/black
-	pants = /obj/item/clothing/under/roguetown/trou/leather
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	head = /obj/item/clothing/head/roguetown/helmet/sallet/elven
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/trophyfur
-	neck = /obj/item/clothing/neck/roguetown/chaincoif
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
+	neck = /obj/item/clothing/neck/roguetown/chaincoif/full
 	beltl = /obj/item/rogueweapon/huntingknife/idagger/steel/special
-	beltr = /obj/item/flashlight/flare/torch
 	r_hand = /obj/item/rogueweapon/halberd/glaive
 	backr = /obj/item/rogueweapon/scabbard/gwstrap
 	backpack_contents = list(
 				/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 				/obj/item/rogueweapon/scabbard/sheath = 1,
-				/obj/item/book/rogue/blackoak = 1
+				/obj/item/book/rogue/blackoak = 1,
+				/obj/item/flashlight/flare/torch/lantern/prelit = 1,
 				)
 
 	if(H.mind)


### PR DESCRIPTION
## About The Pull Request

Gives boak wyrm
- Full coif
- Hardened leather bracers
- Hardened leather pants
- Lamptern

## Testing Evidence

Trust me pookie

## Why It's Good For The Game

So, in a world where everyone and their mother are a PLATE CREECHUR with two layers of protection - having absolutely no limb protection sucks. Even with 90% dodge, this basically means that the first hit through 90% dodge will fuck you up *unless* you con-max.

Currently boak wyrms have no leg/arm coverage and tis sucks. Let them actually antagonize players instead of spending half an hour getting hardened leather pants.

Lamptern is a standard across wretches, do not see why they should not get it.

