### PR TITLE
Grabbing / Grabbed guarantee accuracy in melee.

### DIFF
--- a/code/modules/mob/living/combat/accuracy_checks.dm
+++ b/code/modules/mob/living/combat/accuracy_checks.dm
@@ -15,9 +15,8 @@
 		return zone
 	if(HAS_TRAIT(user, TRAIT_CIVILIZEDBARBARIAN) && (zone == BODY_ZONE_L_LEG || zone == BODY_ZONE_R_LEG))
 		return zone
-	if(target.grabbedby == user)
-		if(user.grab_state >= GRAB_AGGRESSIVE)
-			return zone
+	if(target.pulledby || target.pulling)
+		return zone
 	if(!(target.mobility_flags & MOBILITY_STAND))
 		return zone
 	// If you're floored, you will aim feet and legs easily. There's a check for whether the victim is laying down already.

--- a/code/modules/mob/living/combat/checkdefense.dm
+++ b/code/modules/mob/living/combat/checkdefense.dm
@@ -6,8 +6,6 @@
 		return FALSE
 	if(!canparry && !candodge) //mob can do neither of these
 		return FALSE
-	if(!cmode)
-		return FALSE
 	if(user == src)
 		return FALSE
 	if(!(mobility_flags & MOBILITY_MOVE))


### PR DESCRIPTION
## About The Pull Request
Spent 40 minutes investigating a non-existent bug about grabber being parryable. Found another issue instead.
- Grabbing anyone, or being grabbed by anyone guarantee accuracy on hitting a bodypart (in melee)
- Also removed a redundant cmode check in checkdefense

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
In the proc accuracy check, there was two lines of code that checked if used's grabbedby is equal to user and if so, return the zone (Aka guaranteeing a hit). 

Except it don't work because grabbedby is the item it creates in your hand for grabbing, which never exists.

Now, if you get grabbed or grab someone you're opening yourself to 100% accuracy shanking. MAD.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
