### PR TITLE
Refactor Unholy Blast - It can arc, is a subtype of divine blast now.

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -403,6 +403,7 @@
 	desc = "'Progress. Ascension. Destiny. A mandate, commanded by God, to be fufilled by Man. She called us forth from the edge of reality - and with Her dying breath, rasped out the final truth; the fire is gone, and the world will soon follow.'"
 	icon_state = "zcross_a"
 	color = "#bb9696"
+	possible_item_intents = list(/datum/intent/use, /datum/intent/special/magicarc)
 
 /obj/item/clothing/neck/roguetown/psicross/undivided
 	name = "amulet of Ten"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -353,7 +353,7 @@
 				// For now, only Tennites get this. Heretics can have a special treat later
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)
 			if(istype(H.patron, /datum/patron/inhumen))
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/unholyblast)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast/unholyblast)
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
 			neck = /obj/item/clothing/neck/roguetown/psicross

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -1,30 +1,10 @@
-/obj/effect/proc_holder/spell/invoked/projectile/unholyblast
+/obj/effect/proc_holder/spell/invoked/projectile/divineblast/unholyblast
 	name = "Unholy Blast"
 	desc = "Channel unholy power and sunder the unbelievers. Deals additional damage to wretched conformists and Psydonites! \n\
-	Damage is increased by 100% versus INFERIOR BEINGS."
-	clothes_req = FALSE
-	range = 12
+	Damage is increased by 100% versus simple-minded creechurs.\n\
+	Can be fired in an arc over an ally's head with a mage's staff, spellbook or psicross on arc intent. It will deals 25% less damage that way."
 	projectile_type = /obj/projectile/energy/unholyblast
-	overlay_state = "divine_blast"
-	sound = list('sound/magic/vlightning.ogg')
-	active = FALSE
-	releasedrain = 20
-	chargedrain = 1
-	chargetime = 0
-	recharge_time = 5 SECONDS
-	warnie = "spellwarning"
-	no_early_release = TRUE
-	movement_interrupt = FALSE
 	invocations = list("Fortschritt macht!")
-	invocation_type = "shout"
-	glow_color = GLOW_COLOR_LIGHTNING
-	glow_intensity = GLOW_INTENSITY_LOW
-	charging_slowdown = 3
-	chargedloop = /datum/looping_sound/invokegen
-	associated_skill = /datum/skill/magic/holy
-	miracle = TRUE
-	devotion_cost = 25
-
 
 /obj/projectile/energy/unholyblast
 	name = "Unholy Blast"
@@ -35,6 +15,20 @@
 	npc_damage_mult = 2 // The Simple Skele Gibber
 	hitsound = 'sound/magic/churn.ogg'
 	speed = 1
+
+/obj/projectile/energy/unholyblast/arc
+	name = "Arced Unholy Blast"
+	damage = 15 // Slightly lower base damage
+	arcshot = TRUE
+
+/obj/effect/proc_holder/spell/invoked/projectile/divineblast/unholyblast/cast(list/targets, mob/user = user)
+	var/mob/living/carbon/human/H = user
+	var/datum/intent/a_intent = H.a_intent
+	if(istype(a_intent, /datum/intent/special/magicarc))
+		projectile_type = /obj/projectile/energy/unholyblast/arc
+	else
+		projectile_type = /obj/projectile/energy/unholyblast
+	. = ..()
 
 /obj/projectile/energy/unholyblast/on_hit(target)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
- Implemented the arcing code for Divine Blast for Unholy Blast
- Made unholyblast a subtype of holy blast, removing repeated code. 
- Zcross now also have a arc intent, if you wanna out yourself.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="332" height="536" alt="NVIDIA_Overlay_2n666jM2a2" src="https://github.com/user-attachments/assets/3ed736e6-99e8-4758-bccc-86050f1ebec0" />
<img width="961" height="675" alt="NVIDIA_Overlay_yc7hPBFvDc" src="https://github.com/user-attachments/assets/7c2398da-a9ee-4963-9387-1a9775234b91" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Cleaner code and avoid diverging balance between the two abilities.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
