### PR TITLE
Dev_Suggestions that are actually Suggestions

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/apparel.dm
+++ b/code/modules/cargo/packsrogue/merchant/apparel.dm
@@ -72,6 +72,12 @@
 	contains = list(
 					/obj/item/clothing/neck/roguetown/psicross/noc,)
 
+/datum/supply_pack/rogue/apparel/crosses/divinepantheonten
+	name = "Undivided Amulet"
+	cost = 10
+	contains = list(
+					/obj/item/clothing/neck/roguetown/psicross/undivided,)
+
 /datum/supply_pack/rogue/apparel/crosses/psicross
 	name = "Psicross"
 	cost = 20

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -599,7 +599,7 @@
 
 /obj/item/clothing/neck/roguetown/shalal
 	name = "desert rider medal"
-	desc = ""
+	desc = "Made out of the metal from the Ranesheni mercenaries' first slain enemy. A tradition is kept between these hired blades: to give this one away to someone is to symbolize a debt on their favor - to be redeemed by any other mercenary in times of need."
 	icon_state = "shalal"
 	//dropshrink = 0.75
 	resistance_flags = FIRE_PROOF

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -599,11 +599,12 @@
 
 /obj/item/clothing/neck/roguetown/shalal
 	name = "desert rider medal"
-	desc = "Made out of the metal from the Ranesheni mercenaries' first slain enemy. A tradition is kept between these hired blades: to give this one away to someone is to symbolize a debt on their favor - to be redeemed by any other mercenary in times of need."
+	desc = "Made out of the silver from the Ranesheni mercenaries' first pay. A tradition is kept between these hired blades: to give this one away to someone is to symbolize a debt on their favor - to be redeemed by any other mercenary in times of need."
 	icon_state = "shalal"
+	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HIP|ITEM_SLOT_WRISTS|ITEM_SLOT_RING		//Hey I guess you could pretend it is wrapped around your hand? Just keep it on, don't be a hoe.
 	//dropshrink = 0.75
 	resistance_flags = FIRE_PROOF
-	sellprice = 15
+	sellprice = 30		// what if the economy crashes...........
 	anvilrepair = /datum/skill/craft/armorsmithing
 
 /obj/item/clothing/neck/roguetown/ornateamulet

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -599,7 +599,7 @@
 
 /obj/item/clothing/neck/roguetown/shalal
 	name = "desert rider medal"
-	desc = "Made out of the silver from the Ranesheni mercenaries' first pay. A tradition is kept between these hired blades: to give this one away to someone is to symbolize a debt on their favor - to be redeemed by any other mercenary in times of need."
+	desc = "Made out of the silver from the Ranesheni mercenaries' first pay. A tradition is kept between these hired blades: to give this one away to someone is to symbolize a debt in their favor - to be redeemed by any other mercenary in times of need."
 	icon_state = "shalal"
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HIP|ITEM_SLOT_WRISTS|ITEM_SLOT_RING		//Hey I guess you could pretend it is wrapped around your hand? Just keep it on, don't be a hoe.
 	//dropshrink = 0.75

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -135,6 +135,7 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat
 	name = "fancy coat"
 	desc = "A fancy tunic and coat combo. How elegant."
+	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
 	icon_state = "noblecoat"
 	sleevetype = "noblecoat"
 	detail_tag = "_detail"

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -461,6 +461,14 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Amulet of Eora"
 	path = /obj/item/clothing/neck/roguetown/psicross/eora
 
+/datum/loadout_item/psicross/undivided
+	name = "Amulet of Ten"
+	path = /obj/item/clothing/neck/roguetown/psicross/undivided
+
+/datum/loadout_item/psicross/zizo
+	name = "Decrepit Zcross"
+	path = /obj/item/clothing/neck/roguetown/zcross/aalloy
+
 /datum/loadout_item/wedding_band
 	name = "silver wedding band"
 	path = /obj/item/clothing/ring/band


### PR DESCRIPTION
## About The Pull Request
I was bored and looked at dev_suggestions and saw a few that were easy to code, not harmful to the game, and I decided to be productive with anything that isn't pertaining to my real life stuff and therefore more important.

- **FANCY COAT** can now be worn in the Cloak Slot. Drip.
- **AMULET OF THE TEN** and **ZCROSS (Zizo's Cross)** are now available in the Loadout menu. Yay.
- **AMULET OF THE TEN** can be purchased from the Tailor's Silverface. Yay.
- Gave Desert Rider's medal some fluff because HOLY SHIIIIIT STOP DROPPING IT YOU COWARDS FUCK FUCK FUCK FUCK. ENJOY YOUR DRIP!!!
- Also you can wear your DRider's medal on your *wrists, ring or hip* as well as being a bit more valuable.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="280" height="193" alt="image" src="https://github.com/user-attachments/assets/508285b1-3b90-41df-a177-663b5644112f" />
<img width="241" height="424" alt="image" src="https://github.com/user-attachments/assets/cab0fa91-0d0a-4473-991c-b6b7f3cfc6fa" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Drip? QoL changes? 
Do you want me to go back to do adventurer/merc class changes? Huh? 
That's what I thought, Free. That's what I thought.

Love you Free. Keep it up.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
