### PR TITLE
Nerfs devitalized debuff caused by matthiosite and graggarite rituals

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -236,7 +236,7 @@
 	id = "ritualdefiled"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/ritualdefiled
 	effectedstats = list("strength" = -1, "endurance" = -1, "constitution" = -1, "speed" = -1, "fortune" = -1)
-	duration = 1 HOUR // Punishing AS FUCK, but not as punishing as being dead.
+	duration = 1 HOURS // Punishing AS FUCK, but not as punishing as being dead.
 
 /atom/movable/screen/alert/status_effect/debuff/ritualdefiled
 	name = "Tainted Lux"

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -235,8 +235,8 @@
 /datum/status_effect/debuff/ritualdefiled
 	id = "ritualdefiled"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/ritualdefiled
-	effectedstats = list("strength" = -2, "perception" = -1, "intelligence" = -1, "endurance" = -2, "constitution" = -2, "speed" = -1, "fortune" = -1)
-	duration = 2 HOURS // Punishing AS FUCK, but not as punishing as being dead.
+	effectedstats = list("strength" = -1, "endurance" = -1, "constitution" = -1, "speed" = -1, "fortune" = -1)
+	duration = 1 HOUR // Punishing AS FUCK, but not as punishing as being dead.
 
 /atom/movable/screen/alert/status_effect/debuff/ritualdefiled
 	name = "Tainted Lux"


### PR DESCRIPTION
## About The Pull Request

<img width="1193" height="116" alt="image" src="https://github.com/user-attachments/assets/fdc6d38f-786d-45d4-95f6-477fdffa5a4c" />

## Testing Evidence

trust me pookie

## Why It's Good For The Game

Basically it was too punishing to the point that resisting until death and being revived/sent to lobby was more favorable than allowing your lux to be drained via evil ritual. Not the way it was intended.
Debuff is now statwise on par with revival debuff, duration is one hour. Because cope with it. (I feel like 15 minute revival debuff time needs to be increased but it is what it is)