### PR TITLE
Hyperspecific Sword Balance Pass.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -778,7 +778,7 @@
 	minstr = 9
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/swords
-	max_blade_int = 200
+	max_blade_int = 300
 	wdefense = 5
 	smelt_bar_num = 3
 
@@ -833,6 +833,7 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 3
 	max_blade_int = 240
+	wdefense = 4
 	force = 14
 	force_wielded = 35
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -12,6 +12,9 @@
 	damfactor = 1.1
 	item_d_type = "slash"
 
+/datum/intent/sword/cut/arming
+	clickcd = 10 // Versatile, this create 26 EDPS instead of 20. But still easily beaten by the Sabre
+
 /datum/intent/sword/cut/militia
 	penfactor = 30
 	damfactor = 1.2
@@ -34,6 +37,14 @@
 	chargetime = 0
 	swingdelay = 0
 	item_d_type = "stab"
+
+/datum/intent/sword/thrust/arming
+	clickcd = 10 // Less than rapier
+	penfactor = 35 // 22 + 35 = 57. Beats light leather slightly more than rapier per strike, but less strike
+
+/datum/intent/sword/thrust/long
+	penfactor = 30 // 2h Longsword already have 30 damage. This let it pierce light armor easily
+	// Their cut is actually pretty decent when 2handed and should be inferior to zwei.
 
 /datum/intent/sword/thrust/krieg
 	damfactor = 0.9
@@ -88,6 +99,7 @@
 	penfactor = 40
 
 /datum/intent/sword/cut/krieg
+	damfactor = 1.2
 	clickcd = 10
 
 /datum/intent/sword/thrust/krieg
@@ -104,8 +116,8 @@
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
 	force = 22
 	force_wielded = 25
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/peel)
+	possible_item_intents = list(/datum/intent/sword/cut/arming, /datum/intent/sword/thrust/arming, /datum/intent/sword/peel)
+	gripped_intents = list(/datum/intent/sword/cut/arming, /datum/intent/sword/thrust/arming, /datum/intent/sword/strike, /datum/intent/sword/peel)
 	damage_deflection = 14
 	icon_state = "sword1"
 	sheathe_icon = "sword1"
@@ -216,8 +228,8 @@
 		 It has great cultural significance in the empires of Grenzelhoft and Etrusca, where legendary swordsmen have created and perfected many fighting techniques of todae."
 	force = 25
 	force_wielded = 30
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/peel)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/sword/chop)
+	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/sword/strike, /datum/intent/sword/peel)
+	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/sword/peel, /datum/intent/sword/chop)
 	alt_intents = list(/datum/intent/effect/daze, /datum/intent/sword/strike, /datum/intent/sword/bash)
 	icon_state = "longsword"
 	icon = 'icons/roguetown/weapons/64.dmi'
@@ -238,6 +250,7 @@
 	throwforce = 15
 	thrown_bclass = BCLASS_CUT
 	max_blade_int = 280
+	wdefense_wbonus = 4
 	dropshrink = 0.75
 	smeltresult = /obj/item/ingot/steel
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -13,6 +13,7 @@
 	item_d_type = "slash"
 
 /datum/intent/sword/cut/arming
+	damfactor = 1.2
 	clickcd = 10 // Versatile, this create 26 EDPS instead of 20. But still easily beaten by the Sabre
 
 /datum/intent/sword/cut/militia


### PR DESCRIPTION
## About The Pull Request
I pulled out a chart and reviewed some numbers hoping to make Arming Sword and Longsword slightly better compared to the more meta choice of rapier / sabre and here are my conclusions:
- Greatsword (Base) gain +100 Blade Integrity so that it lasts longer than the zwei, which are stronger offensively with more force
- Steel Zweihander loses 1 WDefense as god intended cuz it was meant to be an offensive sidegrade to Greatsword and not a str8 upgrade.
- Arming Sword's Cut Intent is now 1.2x and 10 clickCD instead of 1.1x and 10 clickCD. This means it has slightly higher EDPS at 26.4 instead of 20, but is still handily beaten by the sabre at pure cutting (with 22 damage, 1.25x, and 8 clickCD)
- Arming Sword's Stab Intent now have 35 Penfactor instead of 20. No damfactor changes. This allow it to beat hardened leather armor with some damage going through at 10 strength and more. 
- Longsword gets its stab intent upgrade to 30 penfactor from 20. This again, allows it to pierce light armor somewhat reliably in 2h mode and sometimes in 1h mode.
- Longsword Dynamic Defense is now +4 instead of +3, making it very good defensively. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="326" height="147" alt="NVIDIA_Overlay_tNNkLI8O3p" src="https://github.com/user-attachments/assets/014e9355-0160-4d8e-b900-0e590eb7b81d" />
<img width="417" height="929" alt="NVIDIA_Overlay_qfG0TBodlq" src="https://github.com/user-attachments/assets/93b20e59-34ac-421d-9481-a486feec2b3f" />
<img width="494" height="634" alt="NVIDIA_Overlay_vWAg8vdLpl" src="https://github.com/user-attachments/assets/43373ebe-ce6b-445b-b83b-fc15c9911323" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This tries to make the choices between swords a little bit more dynamic. 

Arming Sword is now positioned as a versatile 1 handed sword that will be beaten by rapier or sabre at their specific functionalities but do better than the more specialized blade. 

Longsword's stab and defense is slightly improved, meaning in two handed mode it can pierce light just as well as Zwei (If not slightly better) who has loads of damage and reach to carry itself. In one handed mode, it is beaten by the Arming Sword in either of its function, as it should.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
