### PR TITLE
Ports Oiling Up from Vanderlin.

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -776,3 +776,76 @@
 							C.update_health_hud()
 					if("No")
 						to_chat(user, span_warning("I decide [C] is unworthy."))
+
+/datum/status_effect/buff/oiled
+	id = "oiled"
+	duration = 5 MINUTES
+	alert_type = /atom/movable/screen/alert/status_effect/oiled
+	var/slip_chance = 2 // chance to slip when moving
+
+/datum/status_effect/buff/oiled/on_apply()
+	. = ..()
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+
+/datum/status_effect/buff/oiled/on_remove()
+	. = ..()
+	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+
+/datum/status_effect/buff/oiled/proc/on_move(mob/living/mover, atom/oldloc, direction, forced)
+	if(forced)
+		return
+	var/slipping_prob = slip_chance
+	if(iscarbon(mover))
+		var/mob/living/carbon/carbon = mover
+		if(!carbon.shoes) // being barefoot makes you slip lesss
+			slipping_prob /= 2
+
+	if(!prob(slip_chance))
+		return
+
+	if(istype(mover))
+		if(istype(mover.mind?.assigned_role, /datum/job/roguetown/jester))
+			mover.liquid_slip(total_time = 1 SECONDS, stun_duration = 1 SECONDS, height = 30, flip_count = 10)
+		else
+			mover.liquid_slip(total_time = 1 SECONDS, stun_duration = 1 SECONDS, height = 12, flip_count = 0)
+
+/atom/movable/screen/alert/status_effect/oiled
+	name = "Oiled"
+	desc = "I'm covered in oil, making me slippery and harder to grab!"
+	icon_state = "oiled"
+
+/atom/proc/liquid_slip(dir=null, total_time = 0.5 SECONDS, height = 16, stun_duration = 1 SECONDS, flip_count = 1)
+	animate(src) // cleanse animations as funny as a ton of stacked flips would be it would be an eye sore
+	var/matrix/M = transform
+	var/turn = 90
+	if(isnull(dir))
+		if(dir == EAST)
+			turn = 90
+		else if(dir == WEST)
+			turn = -90
+		else
+			if(prob(50))
+				turn = -90
+
+	var/flip_anim_step_time = total_time / (1 + 4 * flip_count)
+	animate(src, transform = matrix(M, turn, MATRIX_ROTATE | MATRIX_MODIFY), time = flip_anim_step_time, flags = ANIMATION_PARALLEL)
+	for(var/i in 1 to flip_count)
+		animate(transform = matrix(M, turn, MATRIX_ROTATE | MATRIX_MODIFY), time = flip_anim_step_time)
+		animate(transform = matrix(M, turn, MATRIX_ROTATE | MATRIX_MODIFY), time = flip_anim_step_time)
+		animate(transform = matrix(M, turn, MATRIX_ROTATE | MATRIX_MODIFY), time = flip_anim_step_time)
+		animate(transform = matrix(M, turn, MATRIX_ROTATE | MATRIX_MODIFY), time = flip_anim_step_time)
+	var/matrix/M2 = transform
+	animate(transform = matrix(M, 1.2, 0.7, MATRIX_SCALE | MATRIX_MODIFY), time = total_time * 0.125)
+	animate(transform = M2, time = total_time * 0.125)
+
+	animate(src, pixel_y=height, time= total_time * 0.5, flags=ANIMATION_PARALLEL)
+	animate(pixel_y=-4, time= total_time * 0.5)
+
+	if(isliving(src))
+		var/mob/living/living = src
+		living.Knockdown(stun_duration)
+		living.set_resting(FALSE, silent = TRUE)
+		animate(src, pixel_x = 0, pixel_y = 0, transform = src.transform.Turn(-turn), time = 3, easing = LINEAR_EASING, flags=ANIMATION_PARALLEL)
+	else
+		spawn(stun_duration + total_time)
+			animate(src, pixel_x = 0, pixel_y = 0, transform = src.transform.Turn(-turn), time = 3, easing = LINEAR_EASING, flags=ANIMATION_PARALLEL)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -406,34 +406,56 @@
 	update_pull_hud_icon()
 
 	if(isliving(AM))
-		var/mob/living/M = AM
-		log_combat(src, M, "grabbed", addition="passive grab")
+		var/mob/living/target = AM
+		log_combat(src, target, "grabbed", addition="passive grab")
 		if(!iscarbon(src))
-			M.LAssailant = null
+			target.LAssailant = null
 		else
-			M.LAssailant = usr
+			target.LAssailant = usr
 
-		M.update_damage_hud()
+		target.update_damage_hud()
 
-		if(HAS_TRAIT(M, TRAIT_GRABIMMUNE) && M.stat == CONSCIOUS) // Grab immunity check
-			if(M.cmode)
-				M.visible_message(span_warning("[M] breaks from [src]'s grip effortlessly!"), \
-						span_warning("I breaks from [src]'s grab effortlesly!"))
-				log_combat(src, M, "tried grabbing", addition="passive grab")
+		if(target.has_status_effect(/datum/status_effect/buff/oiled))
+			// Determine which limb we're trying to grab
+			var/target_zone = zone_selected
+			if(!target_zone)
+				target_zone = "chest" // Default if no zone selected
+
+			// Check if the target limb is covered by clothing
+			var/is_covered = FALSE
+			if(iscarbon(target))
+				var/mob/living/carbon/carbon_target = target
+				var/obj/item/bodypart/target_limb = carbon_target.get_bodypart(check_zone(target_zone))
+				if(target_limb)
+					is_covered = carbon_target.is_limb_covered(target_limb)
+
+			// If limb is not covered and oiled, chance to slip away
+			if(!is_covered)
+				if(prob(50)) // 35% chance to slip away from grab attempt
+					visible_message(span_warning("[target] slips away from [src]'s oily grasp!"), \
+							span_warning("[target.name] slips away from my grip - they're too oily!"))
+					log_combat(src, target, "failed to grab due to oil", addition="oiled skin")
+					return FALSE // Grab attempt fails
+
+		if(HAS_TRAIT(target, TRAIT_GRABIMMUNE) && target.stat == CONSCIOUS) // Grab immunity check
+			if(target.cmode)
+				target.visible_message(span_warning("[target] breaks from [src]'s grip effortlessly!"), \
+						span_warning("I break from [src]'s grab effortlessly!"))
+				log_combat(src, target, "tried grabbing", addition="passive grab")
 				stop_pulling()
 				return
 
 		// Makes it so people who recently broke out of grabs cannot be grabbed again
-		if(TIMER_COOLDOWN_RUNNING(M, "broke_free") && M.stat == CONSCIOUS)
-			M.visible_message(span_warning("[M] slips from [src]'s grip."), \
+		if(TIMER_COOLDOWN_RUNNING(target, "broke_free") && target.stat == CONSCIOUS)
+			target.visible_message(span_warning("[target] slips from [src]'s grip."), \
 					span_warning("I slip from [src]'s grab."))
-			log_combat(src, M, "tried grabbing", addition="passive grab")
+			log_combat(src, target, "tried grabbing", addition="passive grab")
 			return
 
-		log_combat(src, M, "grabbed", addition="passive grab")
+		log_combat(src, target, "grabbed", addition="passive grab")
 		playsound(src.loc, 'sound/combat/shove.ogg', 50, TRUE, -1)
-		if(iscarbon(M))
-			var/mob/living/carbon/C = M
+		if(iscarbon(target))
+			var/mob/living/carbon/C = target
 			var/obj/item/grabbing/O = new()
 			var/used_limb = C.find_used_grab_limb(src)
 			O.name = "[C]'s [parse_zone(used_limb)]"
@@ -453,26 +475,26 @@
 				supress_message = TRUE
 				C.grippedby(src)
 			if(!supress_message)
-				send_pull_message(M)
+				send_pull_message(target)
 		else
 			var/obj/item/grabbing/O = new()
-			O.name = "[M.name]"
-			O.grabbed = M
+			O.name = "[target.name]"
+			O.grabbed = target
 			O.grabbee = src
 			if(item_override)
 				O.sublimb_grabbed = item_override
 			else
-				O.sublimb_grabbed = M.simple_limb_hit(zone_selected)
+				O.sublimb_grabbed = target.simple_limb_hit(zone_selected)
 			put_in_hands(O)
 			O.update_hands(src)
 			if(HAS_TRAIT(src, TRAIT_STRONG_GRABBER) || item_override)
 				supress_message = TRUE
-				M.grippedby(src)
+				target.grippedby(src)
 			if(!supress_message)
-				send_pull_message(M)
+				send_pull_message(target)
 
 		update_pull_movespeed()
-		set_pull_offsets(M, state)
+		set_pull_offsets(target, state)
 	else
 		if(!supress_message)
 			var/sound_to_play = 'sound/combat/shove.ogg'
@@ -484,6 +506,16 @@
 		src.put_in_hands(O)
 		O.update_hands(src)
 		update_grab_intents()
+
+/mob/living/proc/is_limb_covered(obj/item/bodypart/limb)
+	if(!limb)
+		return FALSE
+
+	// Check for clothing covering this limb
+	for(var/obj/item/clothing/C in src.get_equipped_items())
+		if(C.body_parts_covered & limb.body_part)
+			return TRUE
+	return FALSE
 
 /mob/living/proc/send_pull_message(mob/living/target)
 	target.visible_message(span_warning("[src] grabs [target]."), \

--- a/modular/Neu_Food/code/others/fat.dm
+++ b/modular/Neu_Food/code/others/fat.dm
@@ -6,6 +6,7 @@
 	icon_state = "fat"
 	list_reagents = list(/datum/reagent/consumable/nutriment = SNACK_DECENT)
 	eat_effect = /datum/status_effect/debuff/uncookedfood
+	possible_item_intents = list(/datum/intent/food, /datum/intent/splash)
 	fat_yield = 20
 
 /obj/item/reagent_containers/food/snacks/fat/attackby(obj/item/I, mob/living/user, params)
@@ -24,6 +25,22 @@
 			to_chat(user, span_warning("You need to put [src] on a table to work on it."))
 	else
 		return ..()
+
+/obj/item/reagent_containers/food/snacks/fat/attack(mob/living/M, mob/user, proximity)
+	if(user.used_intent.type == /datum/intent/food)
+		return ..()
+
+	if(!isliving(M) || (M != user))
+		return ..()
+
+	user.visible_message("[user] starts to oil up [M]", "You start to oil up [M]")
+	if(!do_after(user, 5 SECONDS, M))
+		return
+	M.apply_status_effect(/datum/status_effect/buff/oiled)
+
+/obj/item/reagent_containers/food/snacks/fat/examine()
+	. = ..()
+	. += span_info("Use on splash intent on yourself to oil yourself up, making yourself slippery and harder to grab when uncovered. Being barefoot reduces the chance of slipping.")
 
 // TALLOW is used as an intermediate crafting ingredient for other recipes.
 /obj/item/reagent_containers/food/snacks/tallow


### PR DESCRIPTION
## About The Pull Request
Ports Oiling Up from Vanderlin. Original code by Dwasint.

Not visible on character yet.
- Fat can be used on splash intent to apply the oiled up status effect 
- Oiled Up gives you a 50% chance (from 35% chance originally) to just slip away from any grab if your bodypart is uncovered 
- Also gives you a 2% (from 3% originally) chance to slip, per movement and flop onto the floor.
- This ain't becoming meta. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="541" height="118" alt="NVIDIA_Overlay_dlajhdDmBH" src="https://github.com/user-attachments/assets/cb5af9b2-e723-433f-8106-43c9244773eb" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yes.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
