### PR TITLE
2x Javelins cannot be smelted anymore.

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -552,7 +552,7 @@
 	throwforce = 20
 	force = 9
 	color = "#bb9696"
-	smeltresult = /obj/item/ingot/aaslag
+	smeltresult = null // Override iron inherit
 	anvilrepair = null
 
 /obj/item/ammo_casing/caseless/rogue/javelin/steel
@@ -565,13 +565,13 @@
 	throwforce = 28							//Equal to steel knife BUT this has peircing damage type so..
 	thrown_bclass = BCLASS_PICK				//Bypasses crit protection better than stabbing. Makes it better against heavy-targets.
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 45, "embedded_fall_chance" = 10) //Better than steel throwing knife by 10%
-	smeltresult = /obj/item/ingot/steel
+	smeltresult = null // 1 Ingot = 2 Javelins
 
 /obj/item/ammo_casing/caseless/rogue/javelin/steel/paalloy
 	name = "ancient javelin"
 	desc = "A missile of polished gilbranze. Old Syon had drowned beneath His tears, and Her ascension had brought forth this world's end - so that You, with the killing blow, could become God."
 	icon_state = "ajavelin"
-	smeltresult = /obj/item/ingot/aaslag
+	smeltresult = null // 1 Ingots = 2 Javelin s
 
 /obj/item/ammo_casing/caseless/rogue/javelin/silver
 	name = "silver javelin"


### PR DESCRIPTION
## About The Pull Request
As per title. Iron Javelin, Steel Javelin and Decrepit Javelin are no longer smeltable

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="378" height="327" alt="NVIDIA_Overlay_WqQwLONFK1" src="https://github.com/user-attachments/assets/c8a815ff-a09e-4f17-acd6-09b8f3f7779d" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's an exploit

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
