### PR TITLE
[TM TESTING NEEDED] Message spell update

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/message.dm
+++ b/code/modules/spells/spell_types/wizard/utility/message.dm
@@ -1,7 +1,7 @@
 /obj/effect/proc_holder/spell/self/message
 	name = "Message"
 	desc = "Latch onto the mind of one who is familiar to you, whispering a message into their head."
-	cost = 2 // Message is quite powefrful so 1 cost is too low
+	cost = 1 // Cost 1 so mages can message people more after SCOM updates?
 	xp_gain = TRUE
 	releasedrain = 30
 	recharge_time = 60 SECONDS
@@ -9,7 +9,8 @@
 	spell_tier = 1
 	associated_skill = /datum/skill/magic/arcane
 	overlay_state = "message"
-	var/identify_difficulty = 15 //the stat threshold needed to pass the identify check
+	var/identify_difficulty = 2 //base difficulty. it will ultimately be 2+int of the sender
+	var/anon_bypass = 0 //if the message is not anonymous, we give the user a bonus +20 to succeed
 
 /obj/effect/proc_holder/spell/self/message/cast(list/targets, mob/user)
 	. = ..()
@@ -37,10 +38,11 @@
 				return
 			if(alert(user, "Send anonymously?", "", "Yes", "No") == "No") //yes or no popup, if you say No run this code
 				identify_difficulty = 0 //anyone can clear this
+				anon_bypass = 20 //if the message is not anonymous, we give the user a bonus +20 to succeed to ensure this
 
 			var/identified = FALSE
 			HL.playsound_local(HL, 'sound/magic/message.ogg', 100)
-			if(HL.STAPER >= identify_difficulty) //quick stat check
+			if(HL.STAPER >= identify_difficulty+((user.STAINT)+(anon_bypass)) //quick stat check
 				if(HL.mind)
 					if(HL.mind.do_i_know(name=user.real_name)) //do we know who this person is?
 						identified = TRUE // we do


### PR DESCRIPTION
## About The Pull Request

Reduces the cost of message to one, since SCOM changes. Also changes the DC of identifying the anonymous sender from a flat 14 PER to a dynamically scaling vs. target INT, which actually makes it easier vs anyone on a spellblade class who'd grab this.

## Testing Evidence

I literally can not test this on a private server and this needs to be testmerged. It compiles, bro.

## Why It's Good For The Game

Idk maybe it's not

Actual difficulty of check subject to change, idm
