### PR TITLE
Don't allow beartraps to be armed over/next to travel tiles

### DIFF
--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -141,7 +141,7 @@
 			else
 				user.visible_message(span_warning("You couldn't get the shoddy [src.name] [armed ? "shut close!" : "to open up!"]"))
 
-/obj/item/restraints/legcuffs/beartrap/proc/close_trap()
+/obj/item/restraints/legcuffs/beartrap/proc/close_trap(play_sound = TRUE)
 	armed = FALSE
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 64
@@ -149,7 +149,8 @@
 	anchored = FALSE // Take it off the ground
 	alpha = 255
 	update_icon()
-	playsound(src.loc, 'sound/items/beartrap.ogg', 300, TRUE, -1)
+	if(play_sound)
+		playsound(src.loc, 'sound/items/beartrap.ogg', 300, TRUE, -1)
 
 /obj/item/restraints/legcuffs/beartrap/Crossed(AM as mob|obj)
 	if(armed && isturf(loc))
@@ -193,6 +194,24 @@
 					L.Stun(80)
 				L.consider_ambush(always = TRUE)
 	..()
+
+/obj/item/restraints/legcuffs/beartrap/dropped(mob/living/carbon/human/user)
+	..()
+	if(!armed)
+		return
+	for(var/obj/structure/fluff/traveltile/TT in range(1, src)) // don't allow armed traps to be placed near travel tiles
+		close_trap(FALSE)
+		log_combat(user, src, "armed and dropped [src] near travel tiles")
+		break
+
+/obj/item/restraints/legcuffs/beartrap/after_throw(datum/callback/callback)
+	..()
+	if(!armed)
+		return
+	for(var/obj/structure/fluff/traveltile/TT in range(1, src)) // don't allow armed traps to be placed near travel tiles
+		close_trap()
+		log_combat(src, null, "[src] was kicked towards travel tiles")
+		break
 
 // When craftable beartraps get added, make these the ones crafted.
 /obj/item/restraints/legcuffs/beartrap/crafted


### PR DESCRIPTION
## About The Pull Request

This PR prevents armed beartraps from being placed over or next to travel tiles. It also automatically disarms a beartrap if it was kicked/thrown next to/over on a travel tile.

## Testing Evidence

I've tested this and confirm it works.

<img width="674" height="311" alt="484004463-e83f108d-ec50-4883-a74e-834d376bfc44" src="https://github.com/user-attachments/assets/8d860ae4-2976-4665-9cd0-1e8e3e55537d" />

## Why It's Good For The Game

Anti-abusive mechanic to stop players from attempting to spawn camp travelers.