### PR TITLE
Adds balloon alerts on parry / dodge to combat aware virtue

### DIFF
--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -260,6 +260,15 @@
 
 			user.visible_message(span_warning("<b>[user]</b> clips [src]'s weapon!"))
 			playsound(user, 'sound/misc/weapon_clip.ogg', 100)
+
+	if(mind && user.mind && HAS_TRAIT(src, TRAIT_COMBAT_AWARE))
+		var/text = "[bodyzone2readablezone(user.zone_selected)]..."
+		if(HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
+			if(prob(10))
+				text = "<i>Can't tell...</i>"
+				user.balloon_alert(src, text)
+		else
+			user.balloon_alert(src, text)
 	dodgecd = FALSE
 //		if(H)
 //			if(H.IsOffBalanced())

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -257,6 +257,15 @@
 					intdam = INTEG_PARRY_DECAY_NOSHARP
 				used_weapon.take_damage(intdam, BRUTE, used_weapon.d_type)
 				used_weapon.remove_bintegrity(SHARPNESS_ONHIT_DECAY, user)
+
+			if(mind && user.mind && HAS_TRAIT(src, TRAIT_COMBAT_AWARE))
+				var/text = "[bodyzone2readablezone(user.zone_selected)]..."
+				if(HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
+					if(prob(10))
+						text = "<i>Somewhere...</i>"
+						user.balloon_alert(src, text)
+				else
+					user.balloon_alert(src, text)
 			return TRUE
 		else
 			return FALSE


### PR DESCRIPTION
## About The Pull Request
My last PR was *meant* to have this, but I never noticed this wasn't the case cus I restricted it to clients only and couldn't parry myself with all the self-hitting.

This might have been a happy little accident that stopped the virtue from being problematic for baits. We'll see.

This specific balloon float appears ONLY for the Defender (with the virtue), not for everyone in the vicinity with the virtue. It's PvP only.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
trvst me (a TM will be needed)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Virtue does what it's meant to
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
