### PR TITLE
NPC Damage Multiplier only applies to simple animals.

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -50,7 +50,7 @@
 	woundclass = BCLASS_PIERCE
 	flag = "piercing"
 	speed = 0.5
-	npc_damage_mult = 2
+	simple_damage_mult = 2
 
 /obj/projectile/bullet/reusable/bolt/aalloy
 	damage = 40
@@ -133,7 +133,7 @@
 	name = "arrow"
 	damage = 20
 	damage_type = BRUTE
-	npc_damage_mult = 2
+	simple_damage_mult = 2
 	armor_penetration = 10
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"
@@ -174,7 +174,7 @@
 	damage = 40
 	armor_penetration = 20
 	embedchance = 30
-	npc_damage_mult = 2
+	simple_damage_mult = 2
 
 /obj/projectile/bullet/reusable/arrow/iron/aalloy
 	name = "decrepit broadhead arrow"
@@ -191,7 +191,7 @@
 	armor_penetration = 45
 	embedchance = 80
 	speed = 0.6
-	npc_damage_mult = 3
+	simple_damage_mult = 3
 
 /obj/projectile/bullet/reusable/arrow/steel/paalloy
 	name = "decrepit bodkin arrow"
@@ -673,7 +673,7 @@
 	damage = 25
 	damage_type = BRUTE
 	armor_penetration = 0
-	npc_damage_mult = 2
+	simple_damage_mult = 2
 	icon = 'icons/roguetown/items/natural.dmi'
 	icon_state = "stone1"
 	range = 15

--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -50,7 +50,7 @@
 	woundclass = BCLASS_PIERCE
 	flag = "piercing"
 	speed = 0.5
-	simple_damage_mult = 2
+	npc_simple_damage_mult = 2
 
 /obj/projectile/bullet/reusable/bolt/aalloy
 	damage = 40
@@ -133,7 +133,7 @@
 	name = "arrow"
 	damage = 20
 	damage_type = BRUTE
-	simple_damage_mult = 2
+	npc_simple_damage_mult = 2
 	armor_penetration = 10
 	icon = 'icons/roguetown/weapons/ammo.dmi'
 	icon_state = "arrow_proj"
@@ -174,7 +174,7 @@
 	damage = 40
 	armor_penetration = 20
 	embedchance = 30
-	simple_damage_mult = 2
+	npc_simple_damage_mult = 2
 
 /obj/projectile/bullet/reusable/arrow/iron/aalloy
 	name = "decrepit broadhead arrow"
@@ -191,7 +191,7 @@
 	armor_penetration = 45
 	embedchance = 80
 	speed = 0.6
-	simple_damage_mult = 3
+	npc_simple_damage_mult = 3
 
 /obj/projectile/bullet/reusable/arrow/steel/paalloy
 	name = "decrepit bodkin arrow"
@@ -673,7 +673,7 @@
 	damage = 25
 	damage_type = BRUTE
 	armor_penetration = 0
-	simple_damage_mult = 2
+	npc_simple_damage_mult = 2
 	icon = 'icons/roguetown/items/natural.dmi'
 	icon_state = "stone1"
 	range = 15

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -80,7 +80,7 @@
 	var/ignore_source_check = FALSE
 
 	var/damage = 10
-	var/npc_damage_mult = 1 // Multiplicative bonus damage.
+	var/simple_damage_mult = 1 // Multiplicative bonus damage vs simple animals.
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
 	var/nodamage = FALSE //Determines if the projectile will skip any damage inflictions
 	var/flag = "piercing" //Defines what armor to use when it hits things. Setting this to "blunt" might result in unexpected behavior (i.e. knockout on hit, figure out the root causes and excise it)
@@ -187,8 +187,8 @@
 
 	var/mob/living/L = target
 
-	if (!L.mind)
-		damage *= npc_damage_mult // bonus damage against NPCs.
+	if (!L.mind && istype(L, /mob/living/simple_animal))
+		damage *= simple_damage_mult // bonus damage against simple animals.
 	if(blocked != 100) // not completely blocked
 		if(damage && L.blood_volume && damage_type == BRUTE)
 			var/splatter_dir = dir

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -80,7 +80,7 @@
 	var/ignore_source_check = FALSE
 
 	var/damage = 10
-	var/simple_damage_mult = 1 // Multiplicative bonus damage vs simple animals.
+	var/npc_simple_damage_mult = 1 // Multiplicative bonus damage vs mindless simple animals.
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
 	var/nodamage = FALSE //Determines if the projectile will skip any damage inflictions
 	var/flag = "piercing" //Defines what armor to use when it hits things. Setting this to "blunt" might result in unexpected behavior (i.e. knockout on hit, figure out the root causes and excise it)
@@ -188,7 +188,7 @@
 	var/mob/living/L = target
 
 	if (!L.mind && istype(L, /mob/living/simple_animal))
-		damage *= simple_damage_mult // bonus damage against simple animals.
+		damage *= npc_simple_damage_mult // bonus damage against simple animals.
 	if(blocked != 100) // not completely blocked
 		if(damage && L.blood_volume && damage_type == BRUTE)
 			var/splatter_dir = dir

--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -42,7 +42,7 @@
 	damage = 20 // wont do much to a divine worshipper
 	woundclass = BCLASS_STAB // divine blade!
 	nodamage = FALSE
-	simple_damage_mult = 2 // The Simple Skele Gibber
+	npc_simple_damage_mult = 2 // The Simple Skele Gibber
 	hitsound = 'sound/magic/churn.ogg'
 	speed = 1
 

--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -42,7 +42,7 @@
 	damage = 20 // wont do much to a divine worshipper
 	woundclass = BCLASS_STAB // divine blade!
 	nodamage = FALSE
-	npc_damage_mult = 2 // The Simple Skele Gibber
+	simple_damage_mult = 2 // The Simple Skele Gibber
 	hitsound = 'sound/magic/churn.ogg'
 	speed = 1
 

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -12,7 +12,7 @@
 	damage = 20 // wont do much to a heretical worshipper
 	woundclass = BCLASS_CUT // I REALLY wanted to do cut
 	nodamage = FALSE
-	simple_damage_mult = 2 // The Simple Skele Gibber
+	npc_simple_damage_mult = 2 // The Simple Skele Gibber
 	hitsound = 'sound/magic/churn.ogg'
 	speed = 1
 

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -12,7 +12,7 @@
 	damage = 20 // wont do much to a heretical worshipper
 	woundclass = BCLASS_CUT // I REALLY wanted to do cut
 	nodamage = FALSE
-	npc_damage_mult = 2 // The Simple Skele Gibber
+	simple_damage_mult = 2 // The Simple Skele Gibber
 	hitsound = 'sound/magic/churn.ogg'
 	speed = 1
 

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -32,7 +32,7 @@
 	exp_fire = 1
 	damage = 60
 	damage_type = BURN
-	npc_damage_mult = 2 // HAHAHA
+	simple_damage_mult = 2 // HAHAHA
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE
 	flag = "magic"

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -32,7 +32,7 @@
 	exp_fire = 1
 	damage = 60
 	damage_type = BURN
-	simple_damage_mult = 2 // HAHAHA
+	npc_simple_damage_mult = 2 // HAHAHA
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE
 	flag = "magic"

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
@@ -30,5 +30,5 @@
 	exp_flash = 2
 	exp_fire = 2
 	damage = 90 // This is gonna fucking HURT
-	npc_damage_mult = 2 // HAHAHA
+	simple_damage_mult = 2 // HAHAHA
 	flag = "magic"

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
@@ -30,5 +30,5 @@
 	exp_flash = 2
 	exp_fire = 2
 	damage = 90 // This is gonna fucking HURT
-	simple_damage_mult = 2 // HAHAHA
+	npc_simple_damage_mult = 2 // HAHAHA
 	flag = "magic"

--- a/code/modules/spells/spell_types/wizard/projectiles_single/air_blade.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/air_blade.dm
@@ -63,7 +63,7 @@
 	damage = 40
 	woundclass = BCLASS_CUT
 	nodamage = FALSE
-	npc_damage_mult = 1.5 // Makes it more effective against NPCs.
+	simple_damage_mult = 1.5 // Makes it more effective against NPCs.
 	hitsound = 'sound/combat/hits/bladed/smallslash (1).ogg'
 	speed = 1
 

--- a/code/modules/spells/spell_types/wizard/projectiles_single/air_blade.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/air_blade.dm
@@ -63,7 +63,7 @@
 	damage = 40
 	woundclass = BCLASS_CUT
 	nodamage = FALSE
-	simple_damage_mult = 1.5 // Makes it more effective against NPCs.
+	npc_simple_damage_mult = 1.5 // Makes it more effective against NPCs.
 	hitsound = 'sound/combat/hits/bladed/smallslash (1).ogg'
 	speed = 1
 

--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
@@ -42,7 +42,7 @@
 	damage = 40
 	woundclass = BCLASS_BLUNT
 	nodamage = FALSE
-	npc_damage_mult = 1.5 // Makes it more effective against NPCs.
+	simple_damage_mult = 1.5 // Makes it more effective against NPCs.
 	hitsound = 'sound/combat/hits/blunt/shovel_hit2.ogg'
 	speed = 1
 

--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
@@ -42,7 +42,7 @@
 	damage = 40
 	woundclass = BCLASS_BLUNT
 	nodamage = FALSE
-	simple_damage_mult = 1.5 // Makes it more effective against NPCs.
+	npc_simple_damage_mult = 1.5 // Makes it more effective against NPCs.
 	hitsound = 'sound/combat/hits/blunt/shovel_hit2.ogg'
 	speed = 1
 

--- a/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
@@ -34,7 +34,7 @@
 	movement_type = UNSTOPPABLE
 	light_color = LIGHT_COLOR_WHITE
 	damage = 40
-	simple_damage_mult = 2 // Good news it is not a trap to shoot at NPC anymore
+	npc_simple_damage_mult = 2 // Good news it is not a trap to shoot at NPC anymore
 	damage_type = BURN
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE

--- a/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
@@ -34,7 +34,7 @@
 	movement_type = UNSTOPPABLE
 	light_color = LIGHT_COLOR_WHITE
 	damage = 40
-	npc_damage_mult = 2 // Good news it is not a trap to shoot at NPC anymore
+	simple_damage_mult = 2 // Good news it is not a trap to shoot at NPC anymore
 	damage_type = BURN
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	nodamage = FALSE

--- a/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
@@ -43,7 +43,7 @@
 	exp_flash = 0
 	exp_fire = 0
 	damage = 20
-	simple_damage_mult = 2 // Makes it more effective against NPCs.
+	npc_simple_damage_mult = 2 // Makes it more effective against NPCs.
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	damage_type = BURN
 	nodamage = FALSE

--- a/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
@@ -43,7 +43,7 @@
 	exp_flash = 0
 	exp_fire = 0
 	damage = 20
-	npc_damage_mult = 2 // Makes it more effective against NPCs.
+	simple_damage_mult = 2 // Makes it more effective against NPCs.
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	damage_type = BURN
 	nodamage = FALSE


### PR DESCRIPTION
## About The Pull Request
- NPC damage multiplier has been renamed simple damage multiplier
- It now only applies to **Mindless** Simple Animals.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="452" height="183" alt="dreamseeker_LO9zDui5kY" src="https://github.com/user-attachments/assets/7a3eb845-5bfe-4be2-a873-8cd652813cb5" />
<img width="450" height="190" alt="dreamseeker_SSzhEe5jQ0" src="https://github.com/user-attachments/assets/c1c0fead-9c71-475e-aee6-c8653661e1ca" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
NPC Damage Multiplier were added originally to ensure that after bow & crossbow rebalance PR hunter can still reasonably one shot animals and volves. 

But when applied to complex NPC it made archers and mages - especially archers way too OP (and arguably also fire mages), with them blasting through armor they have no business doing and .50 bmging two tapping heavy armor mob. 

This make it so that it retain its original purpose of keeping ranged build competitive against meatsack simples without fucking up PVE balance vs complex.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
