### PR TITLE
Minor Bugfix #I - Readds the missing 'Psydonic Devotion' trait by fixing an argument in the old_god.dm file.

### DIFF
--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -109,18 +109,26 @@
 	if(!holder || !holder.mind)
 		return
 
-	if(patron && length(patron.miracles))
-		for(var/spell_type in patron.miracles)
-			var/required_tier = patron.miracles[spell_type]			
-			if(required_tier <= level)
-				if(holder.mind.has_spell(spell_type))
-					continue
+	if(patron)
+		if(length(patron.miracles))
+			for(var/spell_type in patron.miracles)
+				var/required_tier = patron.miracles[spell_type]			
+				if(required_tier <= level)
+					if(holder.mind.has_spell(spell_type))
+						continue
 
-				var/obj/effect/proc_holder/spell/newspell = new spell_type
-				if(!silent)
-					to_chat(holder, span_boldnotice("I have unlocked a new spell: [newspell]"))
-				holder.mind.AddSpell(newspell)
-				LAZYADD(granted_spells, newspell)
+					var/obj/effect/proc_holder/spell/newspell = new spell_type
+					if(!silent)
+						to_chat(holder, span_boldnotice("I have unlocked a new spell: [newspell]"))
+					holder.mind.AddSpell(newspell)
+					LAZYADD(granted_spells, newspell)
+		if(length(patron.traits_tier))
+			for(var/trait in patron.traits_tier)
+				var/required_tier = patron.traits_tier[trait]
+				if(required_tier <= level)
+					if(!silent)
+						to_chat(holder, span_boldnotice("I have unlocked a new trait: [trait]"))
+					ADD_TRAIT(holder, trait, TRAIT_MIRACLE)
 
 
 //The main proc that distributes all the needed devotion tweaks to the given class.

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -10,7 +10,7 @@
 					/obj/effect/proc_holder/spell/invoked/psydonendure			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/self/psydonrespite			= CLERIC_T2,
 	)
-	traits_tier = list(TRAIT_PSYDONITE => CLERIC_T1)
+	traits_tier = list(TRAIT_PSYDONITE = > CLERIC_T1)
 	confess_lines = list(
 		"THERE IS ONLY ONE TRUE GOD!",
 		"PSYDON YET LYVES! PSYDON YET ENDURES!",

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -10,7 +10,7 @@
 					/obj/effect/proc_holder/spell/invoked/psydonendure			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/self/psydonrespite			= CLERIC_T2,
 	)
-	traits_tier = list(TRAIT_PSYDONITE = CLERIC_T1)
+	traits_tier = list(TRAIT_PSYDONITE => CLERIC_T1)
 	confess_lines = list(
 		"THERE IS ONLY ONE TRUE GOD!",
 		"PSYDON YET LYVES! PSYDON YET ENDURES!",

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -10,7 +10,7 @@
 					/obj/effect/proc_holder/spell/invoked/psydonendure			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/self/psydonrespite			= CLERIC_T2,
 	)
-	traits_tier = list(TRAIT_PSYDONITE >= CLERIC_T1)
+	traits_tier = list(TRAIT_PSYDONITE = CLERIC_T1)
 	confess_lines = list(
 		"THERE IS ONLY ONE TRUE GOD!",
 		"PSYDON YET LYVES! PSYDON YET ENDURES!",

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -10,7 +10,7 @@
 					/obj/effect/proc_holder/spell/invoked/psydonendure			= CLERIC_T1,
 					/obj/effect/proc_holder/spell/self/psydonrespite			= CLERIC_T2,
 	)
-	traits_tier = list(TRAIT_PSYDONITE = > CLERIC_T1)
+	traits_tier = list(TRAIT_PSYDONITE >= CLERIC_T1)
 	confess_lines = list(
 		"THERE IS ONLY ONE TRUE GOD!",
 		"PSYDON YET LYVES! PSYDON YET ENDURES!",


### PR DESCRIPTION
## About The Pull Request

Courtesy of Yische and Vex, who were polite enough to help me diagnose the issue at hand.
This _should_ fix the ongoing issue of Psydonites _(with at least Novice-tier Holy skills)_ not receiving the _"Psydonite Devotion"_ trait, which would prevent them from being healed by Pantheonic miracles.

## Testing Evidence

It's just a one letter change, so nothing _should_ go wrong.

## Why It's Good For The Game

Restores the intended balance of dedicated Psydonites _(like the Clerics, Adjudicator, Disciple, and Ordinator)_ being physically tougher, at the cost of losing access to the now-very-useful miracles that the worshippers of the Pantheon have.


