### PR TITLE
Minor Rebalancing #II - Changes 'Muscular' statpack's debuff from -I PER to -I INT, redoes the 'Struggler' statpack's description.

### DIFF
--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -8,7 +8,7 @@
 /datum/statpack/physical/muscular
 	name = "Muscular"
 	desc = "Hard labor has honed you into a mass of sinew - a valuable trait in a world where might makes right."
-	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 1, STAT_PERCEPTION = -1, STAT_SPEED = -2)
+	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 1, STAT_INTELLIGENCE = -1, STAT_SPEED = -2)
 
 /datum/statpack/physical/tactician
 	name = "Alert"
@@ -27,7 +27,7 @@
 
 /datum/statpack/physical/struggler
 	name = "Struggler"
-	desc = "Lyfe's dealt you a poor hand, so you've opted to simply flip the table instead."
+	desc = "Struggle, challenge, and rise to struggle again; for while fate itself seems to conspire against you, your unmatched physique ensures little is left to chance."
 	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 2, STAT_ENDURANCE = 2, STAT_INTELLIGENCE = -3, STAT_PERCEPTION = -3, STAT_FORTUNE = -2)
 
 /datum/statpack/physical/enduring


### PR DESCRIPTION
## About The Pull Request

This changes two things:
- In the 'Muscular' statpack, -I PER is changed to -I INT. This brings us full circle, and returns us back to how the statpack was originally balanced _(at the start of the server)_.
- In the 'Struggler' statpack, the description has been redone to bring it more in line with the verbosity of other strength-related statpacks. May-or-may not be a reference to a certain struggler in eastern media.

## Testing Evidence

Similar to the [other pull request](https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3710) that's currently up, this just involves a few line changes.

## Why It's Good For The Game

I feel like keeping it simple's the best way to go, especially with the heavier emphasis on fighting non-player-controlled mobs in armor _(who can't be readily killed with chestshots)_. The negative speed and intelligence malus should still balance this out pretty well, especially since - like before - it makes them prime for being feinted in a player-on-player conflict _(without the ability to easily worm away.)_

The redescription's part of a small effort I'll be undertaking, where I rewrite a lot of my previous descriptions _(to make them much more clear and less 'purple prosey' or confusing.)_ I think it's a nice touch.
