### PR TITLE
Revert stockpile selling changes.

### DIFF
--- a/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
@@ -23,7 +23,7 @@
 
 /obj/structure/roguemachine/stockpile/examine(mob/user)
 	. = ..()
-	. += span_info("Right click to sell everything on your turf into the stockpile.")
+	. += span_info("Right click to sell everything in front of the stockpile.")
 
 /obj/structure/roguemachine/stockpile/Topic(href, href_list)
 	. = ..()
@@ -172,7 +172,7 @@
 
 /obj/structure/roguemachine/stockpile/attack_right(mob/user)
 	if(ishuman(user))
-		for(var/obj/I in get_turf(user))
+		for(var/obj/I in get_turf(src))
 			attemptsell(I, user, FALSE, FALSE)
 		say("Bulk selling in progress...")
 		playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)


### PR DESCRIPTION
## About The Pull Request
Stockpile now sells on the tile in front of them again.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="219" height="206" alt="NVIDIA_Overlay_8evQDdBy5p" src="https://github.com/user-attachments/assets/83da0d47-4000-497d-9dd2-c07bb4860b7f" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes egg and barrel selling possible again

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
