### PR TITLE
Remove Coin Scattering - Coin of same type now automerges.

### DIFF
--- a/code/game/objects/items/rogueitems/coins.dm
+++ b/code/game/objects/items/rogueitems/coins.dm
@@ -41,24 +41,13 @@
 
 /obj/item/roguecoin/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	playsound(loc, 'sound/foley/coins1.ogg', 100, TRUE, -2)
-	scatter(get_turf(src))
 	..() 
 
-/obj/item/roguecoin/proc/scatter(turf/T)
-	if(istransparentturf(T))
-		scatter(GET_TURF_BELOW(T))
+/obj/item/roguecoin/Crossed(atom/movable/AM)
+	. = ..()
+	if(istype(AM, /obj/item/roguecoin) && isturf(loc)) // Only on floor
+		merge(AM, null)
 		return
-	pixel_x = rand(-8, 8)
-	pixel_y = rand(-5, 5)
-	if(isturf(T) && quantity > 1)
-		var/obj/structure/table/TA = locate() in T
-		if(!TA) //no table
-			for(var/i in 2 to quantity)
-				var/obj/item/roguecoin/new_coin = new type(T)
-				new_coin.set_quantity(1) // prevent exploits with coin piles
-				new_coin.pixel_x = rand(-8, 8)
-				new_coin.pixel_y = rand(-5, 5)
-				set_quantity(quantity - 1)
 
 /obj/item/roguecoin/get_real_price()
 	return sellprice * quantity
@@ -88,10 +77,11 @@
 	G.set_quantity(G.quantity - amt_to_merge)
 	rigged_outcome = 0
 	G.rigged_outcome = 0
-	if(G.quantity <= 0)
-		user.doUnEquip(G)
-		qdel(G)
-	user.update_inv_hands()
+	if(user)
+		if(G.quantity <= 0 && user)
+			user.doUnEquip(G)
+			qdel(G)
+		user.update_inv_hands()
 	playsound(loc, 'sound/foley/coins1.ogg', 100, TRUE, -2)
 
 /obj/item/roguecoin/attack_right(mob/user)


### PR DESCRIPTION
## About The Pull Request
- Coin cannot be scattered by being thrown anymore 
- Coin of the same type, when crossing a turf, now automerges with eachother

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Probably not a good idea to have a lag machine generatable by withdrawing a 1800 coinstacks, throwing it, and then alt clicking it right?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
