### PR TITLE
aborts combat buckling

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -56,13 +56,6 @@
 		return FALSE
 
 	M.buckling = src
-	if((M.cmode) && (M != usr))
-		if(istype(M, /mob/living/carbon))
-			var/mob/living/carbon/guy = M
-			if(!guy.handcuffed)
-				to_chat(usr, span_warning("I am unable to [buckleverb] [M] on [src]."))
-				M.buckling = null
-				return FALSE
 	if(!M.can_buckle() && !force)
 		if(M == usr)
 			to_chat(M, span_warning("I am unable to [buckleverb] on [src]."))

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -56,6 +56,13 @@
 		return FALSE
 
 	M.buckling = src
+	if((M.cmode) && (M != usr))
+		if(istype(M, /mob/living/carbon))
+			var/mob/living/carbon/guy = M
+			if(!guy.handcuffed)
+				to_chat(usr, span_warning("I am unable to [buckleverb] [M] on [src]."))
+				M.buckling = null
+				return FALSE
 	if(!M.can_buckle() && !force)
 		if(M == usr)
 			to_chat(M, span_warning("I am unable to [buckleverb] on [src]."))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1304,3 +1304,8 @@
 	if(istype(loc, /turf/open/water) && !(mobility_flags & MOBILITY_STAND))
 		return FALSE
 
+
+/mob/living/carbon/can_buckle()
+	if((cmode) && (mind) && (!handcuffed) && (stat == CONSCIOUS))
+		return 0
+	. = ..()


### PR DESCRIPTION
## About The Pull Request

- You can no longer buckle someone in combat mode, unless they are restrained(chained or roped), or unconscious.
- No longer get owned by pews

## Testing Evidence

<img width="454" height="112" alt="image" src="https://github.com/user-attachments/assets/dc319f1e-858f-4f9d-ad44-6928d8942e52" />

## Why It's Good For The Game

- Actual salt pr coming through after I got combat buckled for the 3rd time. This shit has always sucked though.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
