### PR TITLE
Printing storyteller description to world after vote end

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -705,11 +705,11 @@ SUBSYSTEM_DEF(gamemode)
 		return storyboy.desc
 
 
-/datum/controller/subsystem/gamemode/proc/storyteller_vote_result(winner_name)
+/datum/controller/subsystem/gamemode/proc/storyteller_vote_result(html_contaminated)
 	for(var/storyteller_type in storytellers)
 		var/datum/storyteller/storyboy = storytellers[storyteller_type]
-		if(storyboy.name == winner_name)
-			selected_storyteller = storyteller_type
+		if(findtext(html_contaminated, storyboy.name))
+			selected_storyteller = storyboy.type
 			break
 
 	var/datum/storyteller/storytypecasted = selected_storyteller


### PR DESCRIPTION
## About The Pull Request

Displays storyteller name and description after vote results are in
Fixes my retardation with arguably even more retardation. But it works.

## Testing Evidence

<img width="715" height="899" alt="image" src="https://github.com/user-attachments/assets/50f45122-af51-4b86-b159-e7ed9c44135a" />

## Why It's Good For The Game

uhhhhh I need that QOL here and bugs at bay