### PR TITLE
Pitchfork Feedback

### DIFF
--- a/code/modules/farming/composter.dm
+++ b/code/modules/farming/composter.dm
@@ -59,6 +59,7 @@
 	if(attacking_item)
 		if(istype(attacking_item, /obj/item/rogueweapon/pitchfork) || istype(attacking_item, /obj/item/rogueweapon/shovel))
 			using_tool = TRUE
+			to_chat(user, span_notice("I dig my pitchfork into the compost..."))
 	var/do_time = using_tool ? 4 SECONDS : 7 SECONDS
 	var/fatigue = using_tool ? 10 : 20
 	if(do_after(user, get_farming_do_time(user, do_time), target = src))


### PR DESCRIPTION
## About The Pull Request

Gives a line of text to tell peeps that they're using a pitchfork to flip compost.

## Testing Evidence

It works!

## Why It's Good For The Game

Incase a new player doesn't realize that using a pitchfork makes flipping compost faster. 4 seconds compared to 7 doesn't visually seem massive; and you can easily not notice it.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
