### PR TITLE
Nerfs dreamwalker poison DPS by 5x

### DIFF
--- a/code/modules/antagonists/roguetown/villain/dreamwalker.dm
+++ b/code/modules/antagonists/roguetown/villain/dreamwalker.dm
@@ -804,7 +804,7 @@
 			target.visible_message(span_warning("[source] freezes [target] with scalding ice!"))
 		if("poison")
 			if(H.reagents)
-				H.reagents.add_reagent(/datum/reagent/berrypoison, 5)
+				H.reagents.add_reagent(/datum/reagent/berrypoison, 2)
 				target.visible_message(span_warning("[source] injects [target] with vile ooze!"))
 
 	// Set cooldown
@@ -911,7 +911,7 @@
 
 /obj/item/rogueweapon/greatsword/bsword/dreamscape/active/Initialize()
 	. = ..()
-	AddComponent(/datum/component/dream_weapon, "poison", 10 SECONDS)
+	AddComponent(/datum/component/dream_weapon, "poison", 20 SECONDS)
 
 /obj/item/rogueweapon/spear/dreamscape_trident/active/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Injects 60% less poison, takes 20 seconds between injections.

## Testing Evidence
Number change

## Why It's Good For The Game
All of the effects are meant to be rather minor nuisances that help you win a fight just a little quicker. Well, apparently berry poison is a lot stronger than I gave it credit for.
This should stop fully armored dudes from toppling quite as fast because they missed a couple parries.
