### PR TITLE
Bait can be used in RTField (Azure Basin) again.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1625,7 +1625,8 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	/area/rogue/outdoors/beach/forest, \
 	/area/rogue/outdoors/woods, \
 	/area/rogue/outdoors/bog, \
-	/area/rogue/outdoors/mountains \
+	/area/rogue/outdoors/mountains, \
+	/area/rogue/outdoors/rtfield \
 )
 
 /proc/is_valid_hunting_area(area/A)


### PR DESCRIPTION
## About The Pull Request
- Azure Basin is a valid target for bait deployment again
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="1090" height="554" alt="dreamseeker_yqJKUIeuW9" src="https://github.com/user-attachments/assets/b2a5c52d-48cb-40a5-899e-ce181489cbe8" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The towner safe zone has been expanded considerably w/ the latest remap which brought an issue introduced before to the forefront - RTField don't count as a valid bait zone. It always should have.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
