### PR TITLE
Fix | Dobo robe upgrade

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/unique.dm
+++ b/code/modules/clothing/rogueclothes/armor/unique.dm
@@ -16,7 +16,7 @@
 
 /obj/item/clothing/suit/roguetown/armor/basiceast
 	name = "simple dobo robe"
-	desc = "A dirty dobo robe with white lapels. Can be upgraded through the use of a tailor."
+	desc = "A dirty dobo robe with white lapels. Can be upgraded through the use of a tailor to increase its integrity."
 	icon_state = "eastsuit3"
 	item_state = "eastsuit3"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_armor.dmi'
@@ -42,6 +42,7 @@
 	desc = "A dobo robe with a red tassel. Leather inlays are sewn in."
 	icon_state = "eastsuit2"
 	item_state = "eastsuit2"
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
 
 //craftable variation of eastsuit, essentially requiring the presence of a tailor with relevant materials
 //still weak against blunt

--- a/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
@@ -141,5 +141,5 @@
 		/obj/item/clothing/suit/roguetown/armor/basiceast = 1,
 		)
 	tools = list(/obj/item/needle)
-	craftdiff = 5
+	craftdiff = 3
 	


### PR DESCRIPTION
## About The Pull Request

Gave the dobo robe upgrade, the decorated dobo robes, an integrity upgrade instead of nothing. Also reduced the skincrafting skill needed from master, to journeyman.

Why not an armor upgrade? Because the base robe already has this:

```
#define ARMOR_SPELLSINGER list("blunt" = 70, "slash" = 70, "stab" = 50, "piercing" = 30, "fire" = 0, "acid" = 0)
```

vs basic leather, studded, and good (hardened):

```
#define ARMOR_LEATHER list("blunt" = 60, "slash" = 50, "stab" = 40, "piercing" = 20, "fire" = 0, "acid" = 0)
#define ARMOR_LEATHER_GOOD list("blunt" = 100, "slash" = 70, "stab" = 50, "piercing" = 30, "fire" = 0, "acid" = 0)
#define ARMOR_LEATHER_STUDDED list("blunt" = 80, "slash" = 80, "stab" = 60, "piercing" = 20, "fire" = 0, "acid" = 0)
```

## Testing Evidence

<details>

<img width="430" height="285" alt="dreamseeker_r9sZpM5WuR" src="https://github.com/user-attachments/assets/903eb04e-4782-4a6e-ac03-e771c239ee6e" />
<img width="648" height="396" alt="dreamseeker_yXCPLfLCK1" src="https://github.com/user-attachments/assets/b850194f-9214-4d05-a2de-0bdd01ed6657" />
<img width="472" height="297" alt="dreamseeker_kNVB2Z1eg8" src="https://github.com/user-attachments/assets/12895c52-6de0-4faa-baf9-8958c29494b7" />
<img width="469" height="311" alt="dreamseeker_jgoZFJsrlT" src="https://github.com/user-attachments/assets/8b9ef3fa-b7ec-4fd4-9b5e-7261a5f4edd0" />
<img width="425" height="359" alt="dreamseeker_0YQLEDOV5I" src="https://github.com/user-attachments/assets/ef9731e3-b910-4d31-a617-f29762fe7fff" />

</details>

## Why It's Good For The Game

Oversight bad.
