### PR TITLE
Re-Adds Bandit Patron Requirement

### DIFF
--- a/code/modules/antagonists/roguetown/villain/bandit.dm
+++ b/code/modules/antagonists/roguetown/villain/bandit.dm
@@ -29,6 +29,8 @@
 /datum/antagonist/bandit/proc/finalize_bandit()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/music/traitor.ogg', 60, FALSE, pressure_affected = FALSE)
 	var/mob/living/carbon/human/H = owner.current
+	if(!istype(H.patron, (/datum/patron/inhumen/matthios || /datum/patron/inhumen/graggar || /datum/patron/inhumen/zizo || /datum/patron/inhumen/baotha)))
+		H.set_patron(/datum/patron/inhumen/matthios)	//If you aren't a heretical worshiper, forces you to Matthios worship. (All bandits follow Matthios.)
 	ADD_TRAIT(H, TRAIT_BANDITCAMP, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

PR that did this doesn't have in its name or desc the change of unrestricting bandits from ascendant lock - so I can't find it to link it here. Someone else feel free to do so.

Simple though - if you don't worship an Ascendant you get forced to Matthios follower if you roll bandit.

If you worship other ascendant, you get to live. Just will be force-converted if you play Iconoclast and it gives you an choice to convert still as the prior PR gave on all other classes.

## Testing Evidence

Worked. Forced my patron over to Matthios as an undivided follower.
<img width="1210" height="942" alt="image" src="https://github.com/user-attachments/assets/172cab06-e3ba-4ae8-b233-e1c058c92b3c" />

## Why It's Good For The Game

This was done before and, at the time, got lore approval when I re-instituted the lock. I'd argue bandits should force EVERYONE to Matthios worship given their descriptions, entire goal, and the fact everything goes to a Matthios idol for favor from Matthios, then is bought via the Matthiosan dragon - but hey I'm just putting it back to how it was instead of pushing for what makes sense.

Tennite bandits are incredibly silly. Psydonian bandits exist and don't need to play bandit antags - they're called the Inquisition.

Vampirelords are locked to Zizo, Lich is locked to Zizo, etc. It makes sense these guys would AT LEAST be locked to inhumen patrons.
