### PR TITLE
Fixes Peasant Rebel & Aspraint Rolling

### DIFF
--- a/code/modules/antagonists/roguetown/villain/aspirant.dm
+++ b/code/modules/antagonists/roguetown/villain/aspirant.dm
@@ -65,10 +65,10 @@
 
 /datum/antagonist/aspirant/ruler/greet() // No alert for the ruler to always keep them guessing.
 
-/datum/antagonist/prebel/can_be_owned(datum/mind/new_owner)
+/datum/antagonist/aspirant/can_be_owned(datum/mind/new_owner)
 	. = ..()
 	if(.)
-		if(!(new_owner.assigned_role in GLOB.noble_positions) || !(new_owner.assigned_role in GLOB.garrison_positions))
+		if(!((new_owner.assigned_role in GLOB.noble_positions) || (new_owner.assigned_role in GLOB.garrison_positions) || (new_owner.assigned_role in GLOB.courtier_positions)))
 			return FALSE
 
 /datum/antagonist/aspirant/on_gain()

--- a/code/modules/events/antagonist/solo/minor/aspirant.dm
+++ b/code/modules/events/antagonist/solo/minor/aspirant.dm
@@ -37,7 +37,7 @@
 	for(var/datum/mind/antag_mind as anything in setup_minds)
 		add_datum_to_mind(antag_mind, antag_mind.current)
 
-	var/list/helping = list("Consort" ,"Hand" ,"Prince" ,"Captain" ,"Steward" ,"Court Magician ","Archivist", "Royal Knight", "Town Crier","Veteran")
+	var/list/helping = list("Consort" ,"Hand" ,"Suitor" ,"Prince" ,"Captain" ,"Steward" ,"Court Magician ","Archivist", "Knight", "Knight Captain", "Marshal", "Councillor", "Town Crier","Veteran")
 	var/list/possible_helpers = list()
 	for(var/mob/living/living in GLOB.human_list)
 		if(!living.client)

--- a/code/modules/events/antagonist/solo/rebels.dm
+++ b/code/modules/events/antagonist/solo/rebels.dm
@@ -11,6 +11,8 @@
 	base_antags = 1
 	maximum_antags = 3
 
+	denominator = 50 // adds 1 possible rebel for every 50 players
+
 	max_occurrences = 1
 
 	earliest_start = 0 SECONDS
@@ -18,7 +20,7 @@
 	typepath = /datum/round_event/antagonist/solo/rebel
 	antag_datum = /datum/antagonist/prebel/head
 
-	weight = 2
+	weight = 1
 
 	restricted_roles = list(
 		"Grand Duke",
@@ -35,6 +37,7 @@
 		"Templar",
 		"Councillor",
 		"Bandit",
+		"Servant",
 		"Prince",
 		"Princess",
 		"Hand",
@@ -44,6 +47,7 @@
 		"Captain",
 		"Archivist",
 		"Knight",
+		"Knight Captain",
 		"Court Magician",
 		"Inquisitor",
 		"Orthodoxist",


### PR DESCRIPTION
## About The Pull Request

Ports this PR as suggested by PR's author. https://github.com/Scarlet-Reach/Scarlet-Reach/pull/625

Makes Aspirant roll properly, fixes peasant rebel rolling, and decreased the weight of peasant rebel as a catch-all just to try and make it rarer incase.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Fixes unintended errors. If people don't like peasant rebel, set its max occurrences to 0. Simple as.
