### PR TITLE
Massively nerfs the Eora ritual of pacification from 30 minutes to 5.

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -948,7 +948,7 @@
 /datum/status_effect/buff/pacify
 	id = "pacify"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/pacify
-	duration = 30 MINUTES
+	duration = 5 MINUTES
 
 /datum/status_effect/buff/pacify/on_apply()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Does what the title says. The Eora ritual had 30 minutes duration for total pacification, no need for a bud.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
N/A
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
30 minutes for a pacification ritual on SOMEONE ELSE could potentially fuck someone over really, really bad. Especially since it's not outright visible like other pacifying means like Eoran buds or the cursed mask.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
