### PR TITLE
CRASHES WOODWORKING ECONOMY WITH NO SURVIVORS

### DIFF
--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -387,6 +387,7 @@
 	max_integrity = 20
 	firefuel = 5 MINUTES
 	w_class = WEIGHT_CLASS_BULKY
+	sellprice = 4
 	bundletype = /obj/item/natural/bundle/plank
 	smeltresult = /obj/item/ash
 	


### PR DESCRIPTION
## About The Pull Request
- gives sell value to wood planks. u get 1 more value that u would get selling a normal log at the stockpile
- request
- you still cant sell them at the stockpile its merchant only
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- i booted it and sawed a log and a single one is worth 4 mammon. i don't think you can sell full stacks of them at the merchant but that's an entirely different beast and  last time i touched how merchant and stacks work and shit goblin heasd were no logner sellable and  i  Do Not Want 2 Touch That.
- also im not booting dun world and waiting 10 minutes 2 test it & i dont think dun test has a merchant zone???? i dont fucking know???? Please send mheplp  immediatelyt
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- request
- if an advent somehow abuses this i aint even got shit to say.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
