### PR TITLE
Fisher spear skill increase

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
@@ -24,7 +24,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE) //Wrestling down those nasty carp.
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE) //Fishermen know how to spearfish and harpoon bigger aquatic threats like sea goblins and deep ones.
 	H.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)


### PR DESCRIPTION
## About The Pull Request
FISHER POWER CREEP INCOMING

Fishing spears have existed in the game for a while and now a trident also exists, I think it makes complete sense for fishermen to be decently capable spear conscripts if called to arms.

## Testing Evidence

It's just one number being changed.

## Why It's Good For The Game

It makes complete sense to me that fishermen would be capable of using spears to defend their homes if the town is under attack since spearfishing is a method of getting fish in-game. Being able to nail something as difficult to hit as an eel or similarly small fish in the water would translate fairly well to being able to harpoon land-based threats if needed. Also, bronze tridents exist now and they would be THE iconic weapon of fisherfolk if called to arms. Also also, polearms were generally just the common weapon of conscripts in times of conflict.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->