### PR TITLE
Greatly increases the penalty for being revived.

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -332,14 +332,13 @@
 /datum/status_effect/debuff/revived
 	id = "revived"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/revived
-	/* The penalties below are tailor made to make someone revived very incapable in combat. -2 str, wil and con doesn't really 
-	 impact a melee class slightly, but the kicker is -8 Fortune which nukes your melee hit chance. Because Mage / Archer have an easier time
-	 getting around the old penalty of -1 across the board due to being ranged or having spells, the Perception and Int penalty is WAY harsher
-	 to make sure that they suffer heavily in damage scaling and spells / CDR scaling.
+	/* The penalties below are tailor made to make someone revived very incapable in combat. -2 str and wil doesn't really 
+	 impact a melee class slightly, but the kicker is -8 Fortune which nukes your melee hit chance. Archer eats a -6 Perception.
+	 Mage only gets -2 Intelligence, but -5 Constitution should make them glass cannon if they immediately re-engage.
 	 This is meant to solve or mitigate the treadmill problem of being revived and immediately running off to fight the antag again.
 	 Unless they pay the price of drinking a rot cure potion, which clears it instantly.
 	*/
-	effectedstats = list(STATKEY_STR = -2, STATKEY_PER = -6, STATKEY_INT = -8, STATKEY_WIL = -2, STATKEY_CON = -2, STATKEY_SPD = -2, STATKEY_LCK = -8)
+	effectedstats = list(STATKEY_STR = -2, STATKEY_PER = -6, STATKEY_INT = -2, STATKEY_WIL = -2, STATKEY_CON = -5, STATKEY_SPD = -2, STATKEY_LCK = -8)
 	duration = 30 MINUTES
 
 /atom/movable/screen/alert/status_effect/debuff/revived
@@ -351,7 +350,7 @@
 /datum/status_effect/debuff/rotted
 	id = "rotted_body"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/rotted
-	effectedstats = list(STATKEY_STR = -2, STATKEY_PER = -2, STATKEY_INT = -2, STATKEY_WIL = -2, STATKEY_CON = -2, STATKEY_SPD = -2, STATKEY_LCK = -2)
+	effectedstats = list(STATKEY_STR = -1, STATKEY_PER = -1, STATKEY_INT = -1, STATKEY_WIL = -1, STATKEY_CON = -1, STATKEY_SPD = -1, STATKEY_LCK = -1)
 	duration = 30 MINUTES	//Back to a temporary 30 min duration. It hurts.
 
 /atom/movable/screen/alert/status_effect/debuff/rotted


### PR DESCRIPTION
## About The Pull Request
- The revival sickness penalty has been increased from -1 to all stats and 15 minutes, to 30 minutes and:
- -2 Str, -6 Per, -2 Intelligence, -2 Wil, -5 Con, -8 Luck 
- 30 minutes instead of 15 minutes
- Now that the penalty is frontloaded for dying and being revived in the first place, the Rotted Body penalty has been reduced to -1 stats across the board instead of -2.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1140" height="644" alt="dreamseeker_fwAVXGMnHp" src="https://github.com/user-attachments/assets/006d9949-d45f-45b6-8cda-ad6d7d85a550" />
<img width="1135" height="645" alt="dreamseeker_IUj4kSpT8w" src="https://github.com/user-attachments/assets/5b8f31ed-f525-4be2-98b0-75ad56a303d2" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
We had a discussion about whether we want to port over Vanderlin's lux mechanics and the corresponding lore change of making lux extraction a much bigger deal, but I don't think that is the play because that mostly penalizes the reviver. It seems that the problem was that the previous revive penalty is easily ignored and town combat roles / advs can just run to immediately rejoin the fight with barely any consequences (-1 across the board doesn't really hurt that much). 

So instead, the penalty is greatly increased and I've added design notes on why I did it this particular way:
-2 across the board for random stats serves a small penalty
-5 to constitution means you are far less likely to survive in a fight you immediately re-engage in.
-8 to fortune tank melee hit chance massively 
-6 to perception is meant to particularly hit archer.
Previously, there was a -8 Intelligence debuff but it also hit towner / skills grinder so instead, it is a -2 and we relies on the -5 constitution instead.

This should have **very** low impact on actual true non-hunter towner who do economic roles and thug it out, because economic role efficiency is largely scaled to **skills** instead of stats, while hitting combat roles who run in harshly. If you want to treadmill the antag you will have more incentives to take a rotcure potion (Spending mammons = money sink!) or to wait out a longer and more meaningful one day duration.

I think this is better suited and tailored for our community that is unlikely to accept a revival limit and should help solve the gameplay problem at hand.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
