### PR TITLE
Fix riding commands not applying pleasure to rider

### DIFF
--- a/code/datums/sexcon/sex_actions/sex/anal_ride_sex.dm
+++ b/code/datums/sexcon/sex_actions/sex/anal_ride_sex.dm
@@ -29,17 +29,17 @@
 	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] rides [target]."))
 	playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE)
 
-	if(target.sexcon.considered_limp())
-		user.sexcon.perform_sex_action(target, 1.2, 4, TRUE)
-	else
-		user.sexcon.perform_sex_action(target, 2.4, 9, TRUE)
-	user.sexcon.handle_passive_ejaculation()
-
-	user.sexcon.perform_sex_action(target, 2, 4, FALSE)
+	target.sexcon.perform_sex_action(target, 2, 0, TRUE)
 	if(target.sexcon.check_active_ejaculation())
 		target.visible_message(span_love("[target] cums into [user]'s butt!"))
 		target.sexcon.cum_into()
 		target.virginity = FALSE
+
+	if(target.sexcon.considered_limp())
+		target.sexcon.perform_sex_action(user, 1.2, 4, FALSE)
+	else
+		target.sexcon.perform_sex_action(user, 2.4, 9, FALSE)
+	user.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/anal_ride_sex/on_finish(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	user.visible_message(span_warning("[user] gets off [target]."))

--- a/code/datums/sexcon/sex_actions/sex/vaginal_ride_sex.dm
+++ b/code/datums/sexcon/sex_actions/sex/vaginal_ride_sex.dm
@@ -33,19 +33,19 @@
 	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] rides [target]."))
 	playsound(target, 'sound/misc/mat/segso.ogg', 50, TRUE, -2, ignore_walls = FALSE)
 
-	if(target.sexcon.considered_limp())
-		user.sexcon.perform_sex_action(target, 1.2, 3, TRUE)
-	else
-		user.sexcon.perform_sex_action(target, 2.4, 7, TRUE)
-	user.sexcon.handle_passive_ejaculation()
-
-	user.sexcon.perform_sex_action(target, 2, 4, FALSE)
+	target.sexcon.perform_sex_action(target, 2, 0, TRUE)
 	if(target.sexcon.check_active_ejaculation())
 		target.visible_message(span_love("[target] cums into [user]'s cunt!"))
 		target.sexcon.cum_into()
 		target.try_impregnate(user)
 		target.virginity = FALSE
 		user.virginity = FALSE
+
+	if(target.sexcon.considered_limp())
+		target.sexcon.perform_sex_action(user, 1.2, 3, FALSE)
+	else
+		target.sexcon.perform_sex_action(user, 2.4, 7, FALSE)
+	user.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/vaginal_ride_sex/on_finish(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	user.visible_message(span_warning("[user] gets off [target]."))


### PR DESCRIPTION
## About The Pull Request

This PR addresses an oversight with the sex commands, `ride them` and `ride them anally`.

Both of these commands would not mechanically give pleasure to the ridden character - this PR fixes that.

## Testing Evidence

I have tested this locally and confirm it works.

## Why It's Good For The Game

This fixes an oversight/bug.