### PR TITLE
makes manabloom alchemical

### DIFF
--- a/code/game/objects/items/rogueitems/magic/magic_resources.dm
+++ b/code/game/objects/items/rogueitems/magic/magic_resources.dm
@@ -63,6 +63,7 @@
 	name = "mana bloom"
 	icon_state = "manabloom"
 	desc = "Dense mana that has taken the form of plant life."
+	seed = /obj/item/herbseed/manabloom
 	resistance_flags = FLAMMABLE
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_grind_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_grind_recipes.dm
@@ -293,8 +293,3 @@
 	name = "Herb Seed (Rosa)"
 	valid_input = /obj/item/alch/rosa
 	valid_outputs = list(/obj/item/herbseed/rosa = 1)
-
-/datum/alch_grind_recipe/manabloom_seed
-	name = "Herb Seed (Manabloom)"
-	valid_input = /obj/item/reagent_containers/food/snacks/grown/manabloom
-	valid_outputs = list(/obj/item/herbseed/manabloom = 1)

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_grind_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_grind_recipes.dm
@@ -171,6 +171,12 @@
 	valid_outputs = list(/obj/item/alch/berrypowder = 1)
 	bonus_chance_outputs = list(/obj/item/alch/waterdust = 25)
 
+/datum/alch_grind_recipe/manabloompowder
+	name = "Manabloom Powder"
+	valid_input = /obj/item/reagent_containers/food/snacks/grown/manabloom
+	valid_outputs = list(/obj/item/alch/manabloompowder = 1)
+	bonus_chance_outputs = list(/obj/item/alch/manabloompowder = 25)
+
 // Start of gem dust section - I've included gold dust as an additional product because of lesser alchemy, grinding up a gem should give you a bit extra (I mean come on it's a gem)
 
 /datum/alch_grind_recipe/mineraldustyellow  // costs two gold to make

--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -233,7 +233,7 @@
 	if(alert("Do you wish to change your self?", "Dust of Self", "Yes", "No") != "Yes")
 		return
 	user.visible_message(
-		span_warn("[user] begins to use [src]."), 
+		span_warn("[user] begins to use [src]."),
 		span_warn("I begin to apply [src] on myself.")
 	)
 	if(!do_after(user, 5 SECONDS))
@@ -397,6 +397,14 @@
 	major_pot = /datum/alch_cauldron_recipe/lck_potion
 	med_pot = /datum/alch_cauldron_recipe/spd_potion
 	minor_pot = /datum/alch_cauldron_recipe/health_potion
+
+/obj/item/alch/manabloompowder
+	name = "manabloom powder"
+	icon_state = "bluepowder"
+
+	major_pot = /datum/alch_cauldron_recipe/mana_potion
+	med_pot = /datum/alch_cauldron_recipe/int_potion
+	minor_pot = /datum/alch_cauldron_recipe/big_mana_potion
 
 /obj/item/alch/rosa
 	name = "rosa"


### PR DESCRIPTION
## About The Pull Request

Adds a "manabloom powder" alchemy item for brewing simple mana potions with (or big ones if you have enough other ingredients).

Adds a grind recipe in the mortar to turn manablooms into manabloom powder.

edit: THIS REMOVES THE MORTAR GRIND RECIPE FOR MANABLOOM SEEDS. YOU MUST NOW SMACK THEM WITH A BLUNT-INTENT OBJECT TO OBTAIN SEEDS. Blame mortars not allowing multiple different options for crafting.

## Testing Evidence

<img width="356" height="269" alt="image" src="https://github.com/user-attachments/assets/71b082f7-4895-495d-b2d3-0562bef463c2" />
<img width="297" height="188" alt="image" src="https://github.com/user-attachments/assets/d75fb7d3-faf0-4132-9ef6-61f0e3500ea1" />

(I forgot to take pictures of this part) Manabloom seeds can be extracted from manabloom produce with blunt-intent strikes. Manabloom seeds can be planted properly as herbs. Planted manabloom grows properly and can be properly harvested.

## Why It's Good For The Game

There are literally only two ingredients in the entire game that can provide basic mana potions. Now you don't have to go kill wolves for a simple potion, while the big boy mana potion remains marginally more difficult to access, mirroring healing potions.