### PR TITLE
Meteor storm 'fix'

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_aoe/meteor_storm.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/meteor_storm.dm
@@ -19,14 +19,14 @@
 	var/turf/T = get_turf(targets[1])
 //	var/list/affected_turfs = list()
 	playsound(T,'sound/magic/meteorstorm.ogg', 80, TRUE)
-	sleep(2)
+	T.visible_message(span_boldwarning("Fire rains from the sky!"))
+	sleep(30)
 	create_meteors(T)
 
 //meteor storm and lightstorm.
 /obj/effect/proc_holder/spell/invoked/meteor_storm/proc/create_meteors(atom/target)
 	if(!target)
 		return
-	target.visible_message(span_boldwarning("Fire rains from the sky!"))
 	var/turf/targetturf = get_turf(target)
 	for(var/turf/turf as anything in RANGE_TURFS(6,targetturf))
 		if(prob(20))
@@ -49,23 +49,22 @@
 
 /obj/effect/temp_visual/target
 	icon = 'icons/mob/actions/actions_spells.dmi'
-	icon_state = "sniper_zoom"
+	icon_state = "projectile"
 	layer = BELOW_MOB_LAYER
 	plane = GAME_PLANE
 	light_outer_range = 2
 	duration = 9
 	var/exp_heavy = 0
 	var/exp_light = 2
-	var/exp_flash = 0
-	var/exp_fire = 3
-	var/exp_hotspot = 0
+	var/exp_flash = 2
+	var/exp_fire = 1
 	var/explode_sound = list('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg')
 
 /obj/effect/temp_visual/target/Initialize(mapload, list/flame_hit)
 	. = ..()
 	INVOKE_ASYNC(src, PROC_REF(fall), flame_hit)
 
-/obj/effect/temp_visual/target/proc/fall(list/flame_hit)	//Potentially minor explosion at each impact point
+/obj/effect/temp_visual/target/proc/fall(list/flame_hit)
 	var/turf/T = get_turf(src)
 	playsound(T,'sound/magic/meteorstorm.ogg', 80, TRUE)
 	new /obj/effect/temp_visual/fireball(T)
@@ -74,13 +73,35 @@
 		var/turf/closed/mineral/M = T
 		M.gets_drilled()
 	new /obj/effect/hotspot(T)
-	for(var/mob/living/L in T.contents)
-		if(islist(flame_hit) && !flame_hit[L])
-			L.adjustFireLoss(40)
-			L.adjust_fire_stacks(8)
-			L.ignite_mob()
-			to_chat(L, span_userdanger("You're hit by a meteor!"))
-			flame_hit[L] = TRUE
-		else
-			L.adjustFireLoss(10) //if we've already hit them, do way less damage
+	for(var/turf/nearby in RANGE_TURFS(3, T))
+		var/dist = get_dist(T, nearby)
+		if(dist > 3)
+			continue
+
+		for(var/mob/living/L in nearby.contents)
+			if(islist(flame_hit) && flame_hit[L]) // already hit by this meteor
+				L.adjustFireLoss(5)
+				continue
+
+			switch(dist)
+				if(0) // Direct impact
+					L.adjustFireLoss(40)
+					L.adjust_fire_stacks(8)
+					L.ignite_mob()
+					to_chat(L, span_userdanger("You're hit by a meteor!"))
+				if(1) // Very close
+					L.adjustFireLoss(20)
+					L.adjust_fire_stacks(4)
+					L.ignite_mob()
+					to_chat(L, span_danger("Heat from the meteor sears you!"))
+				if(2) // Nearby
+					L.adjustFireLoss(10)
+					L.adjust_fire_stacks(2)
+					to_chat(L, span_warning("You feel the scorching blast!"))
+				if(3) // Edge of the blast
+					L.adjustFireLoss(5)
+					L.adjust_fire_stacks(1)
+
+			if(islist(flame_hit))
+				flame_hit[L] = TRUE
 	explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, soundin = explode_sound)

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/sundering_lightning.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/sundering_lightning.dm
@@ -78,5 +78,5 @@
 	for(var/mob/living/L in T.contents)
 		if(L.anti_magic_check())
 			continue
-		L.electrocute_act(50)
+		L.electrocute_act(65)	//a little over half the damage of thunderstrike, but doesn't degrade on each subsequent ring.
 		to_chat(L, span_userdanger("You're hit by lightning!!!"))


### PR DESCRIPTION
## About The Pull Request
Meteorstorm explosion no longer has obscene fire range
Meteor storms impact marker now correctly applied
Increases sundering strikes damage impact to be a bit more. still a fair bit Less then thunderstrike, but it's damage doesn't fall off like thunderstrikes does.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
When I ported over Meteor storm, I was not aware Azure Peak had unified Hotspots and fire in the explosion code, supposedly as a port from vanderlin. This lead to what I had intended as applying firestacks to mobs near impact sites instead having the ENTIRE area near an impact covered in hotspots. 

This new version of the meteor storm instead only creates a single hotspot on the impact zone, while mobs within certain distances get varying firestacks added on. The random and unspecific method of this, as well as the sizable cooldown leave meteor storm worse then greater fireball for individual and small scale fights, while having meteorstorm work as an intended siege weapon, or a wide spread AOE for large scale fights.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
