### PR TITLE
Pork roast fix

### DIFF
--- a/modular/Neu_Food/code/raw/raw_meat.dm
+++ b/modular/Neu_Food/code/raw/raw_meat.dm
@@ -46,6 +46,7 @@
 	name = "raw pigflesh"
 	icon_state = "pork"
 	color = "#f093c3"
+	fried_type = /obj/item/reagent_containers/food/snacks/rogue/meat/fatty/roast
 	slices_num = 2
 	slice_path = /obj/item/reagent_containers/food/snacks/rogue/meat/bacon
 	chopping_sound = TRUE


### PR DESCRIPTION
Now we can roast pork, previously we couldn't

## About The Pull Request

For some reson pork just couldn't be fried even tho there are recipies that require it. Now everyone can enjoy some juicy pigmeat.

## Testing Evidence

Trust me its a single line of code.

## Why It's Good For The Game

Pork is tasty. Also makes it possible to make pork with rice and cucumbers giving them some more meaning and diversifying diet of nobles i think. Its good, man.