### PR TITLE
Adds subclass outfit preview

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -249,7 +249,7 @@
 //			backpack_contents.Insert(1, box)
 //			backpack_contents[box] = 1
 
-		if(backpack_contents)
+		if(backpack_contents && !visualsOnly)
 			for(var/path in backpack_contents)
 				var/number = backpack_contents[path]
 				if(!isnum(number))//Default to 1

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -35,7 +35,7 @@
 	/// Subclass stat bonuses.
 	var/list/subclass_stats
 
-	/// Subclass skills. Is NOT capped to the listed level, but instead gives that number of levels.. EX. list(/datum/skill = SKILL_LEVEL_JOURNEYMAN)
+	/// Subclass skills. Everything here is leveled UP TO using adjust_skillrank_up_to EX. list(/datum/skill = SKILL_LEVEL_JOURNEYMAN)
 	var/list/subclass_skills
 
 	/// Subclass languages.

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -47,14 +47,17 @@
 	/// Extra fluff added to the role explanation in class selection.
 	var/extra_context
 
-/datum/advclass/proc/equipme(mob/living/carbon/human/H)
+/datum/advclass/proc/equipme(mob/living/carbon/human/H, dummy = FALSE)
 	// input sleeps....
 	set waitfor = FALSE
 	if(!H)
 		return FALSE
 
 	if(outfit)
-		H.equipOutfit(outfit)
+		H.equipOutfit(outfit, dummy)
+
+		if(dummy)	//This means we're doing a Char Sheet preview. We don't need to equip the dummy with anything else, the outfits are likely to runtime on their own.
+			return
 
 	post_equip(H)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
@@ -55,15 +55,16 @@
 	id = /obj/item/mattcoin
 	H.adjust_blindness(-3)
 	var/weapons = list("Battleaxe & Cudgel","Flail & Shield")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Battleaxe & Cudgel") //one weapon to hurt people one weapon to kill people
-			backl= /obj/item/rogueweapon/stoneaxe/battle
-			beltr = /obj/item/rogueweapon/mace/cudgel
-		if("Flail & Shield") //plate users beware, you're in for a scare!
-			backl= /obj/item/rogueweapon/shield/wood
-			beltr = /obj/item/rogueweapon/flail
+	if(H.mind)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Battleaxe & Cudgel") //one weapon to hurt people one weapon to kill people
+				backl= /obj/item/rogueweapon/stoneaxe/battle
+				beltr = /obj/item/rogueweapon/mace/cudgel
+			if("Flail & Shield") //plate users beware, you're in for a scare!
+				backl= /obj/item/rogueweapon/shield/wood
+				beltr = /obj/item/rogueweapon/flail
 
 	if(!istype(H.patron, /datum/patron/inhumen/matthios))
 		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
@@ -53,37 +53,38 @@
 	id = /obj/item/mattcoin
 	H.adjust_blindness(-3)
 	var/weapons = list("Crossbow & Dagger", "Bow & Sword")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Crossbow & Dagger") //Rogue
-			backl= /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow //we really need to make this not a grenade launcher subtype
-			beltr = /obj/item/quiver/bolts
-			cloak = /obj/item/clothing/cloak/raincloak/mortus //cool cloak
-			beltl = /obj/item/rogueweapon/huntingknife/idagger/steel
-			backr = /obj/item/storage/backpack/rogue/satchel
-			backpack_contents = list(
-						/obj/item/needle/thorn = 1,
-						/obj/item/natural/cloth = 1,
-						/obj/item/lockpickring/mundane = 1,
-						/obj/item/flashlight/flare/torch = 1,
-						/obj/item/rogueweapon/scabbard/sheath = 1
-						) //rogue gets lockpicks
-			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
-		if("Bow & Sword") //Poacher
-			backl= /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-			l_hand = /obj/item/rogueweapon/sword/short
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			beltr = /obj/item/quiver/arrows
-			head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm //cool hat
-			backr = /obj/item/storage/backpack/rogue/satchel
-			backpack_contents = list(
-						/obj/item/needle/thorn = 1,
-						/obj/item/natural/cloth = 1,
-						/obj/item/restraints/legcuffs/beartrap = 2,
-						/obj/item/flashlight/flare/torch = 1,
-						) //poacher gets mantraps
-			H.adjust_skillrank(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
+	if(H.mind)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Crossbow & Dagger") //Rogue
+				backl= /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow //we really need to make this not a grenade launcher subtype
+				beltr = /obj/item/quiver/bolts
+				cloak = /obj/item/clothing/cloak/raincloak/mortus //cool cloak
+				beltl = /obj/item/rogueweapon/huntingknife/idagger/steel
+				backr = /obj/item/storage/backpack/rogue/satchel
+				backpack_contents = list(
+							/obj/item/needle/thorn = 1,
+							/obj/item/natural/cloth = 1,
+							/obj/item/lockpickring/mundane = 1,
+							/obj/item/flashlight/flare/torch = 1,
+							/obj/item/rogueweapon/scabbard/sheath = 1
+							) //rogue gets lockpicks
+				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
+			if("Bow & Sword") //Poacher
+				backl= /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+				l_hand = /obj/item/rogueweapon/sword/short
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				beltr = /obj/item/quiver/arrows
+				head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm //cool hat
+				backr = /obj/item/storage/backpack/rogue/satchel
+				backpack_contents = list(
+							/obj/item/needle/thorn = 1,
+							/obj/item/natural/cloth = 1,
+							/obj/item/restraints/legcuffs/beartrap = 2,
+							/obj/item/flashlight/flare/torch = 1,
+							) //poacher gets mantraps
+				H.adjust_skillrank(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
 
 	if(!istype(H.patron, /datum/patron/inhumen/matthios))
 		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
@@ -54,19 +54,20 @@
 	id = /obj/item/mattcoin
 	H.adjust_blindness(-3)
 	var/weapons = list("Spear & Crossbow","Sword & Buckler")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Spear & Crossbow") //Deserter watchman. Maybe should be shield and spear? spear and crossbow is kinda clumsy
-			backl= /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow //we really need to make this not a grenade launcher subtype
-			beltr = /obj/item/quiver/bolts
-			r_hand = /obj/item/rogueweapon/spear/billhook
-			head = /obj/item/clothing/head/roguetown/helmet/kettle
-		if("Sword & Buckler") //Mercenary on the wrong side of the law
-			backl= /obj/item/rogueweapon/shield/buckler
-			beltr = /obj/item/rogueweapon/sword //steel sword like literally every adventurer gets
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			head = /obj/item/clothing/head/roguetown/helmet/sallet
+	if(H.mind)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Spear & Crossbow") //Deserter watchman. Maybe should be shield and spear? spear and crossbow is kinda clumsy
+				backl= /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow //we really need to make this not a grenade launcher subtype
+				beltr = /obj/item/quiver/bolts
+				r_hand = /obj/item/rogueweapon/spear/billhook
+				head = /obj/item/clothing/head/roguetown/helmet/kettle
+			if("Sword & Buckler") //Mercenary on the wrong side of the law
+				backl= /obj/item/rogueweapon/shield/buckler
+				beltr = /obj/item/rogueweapon/sword //steel sword like literally every adventurer gets
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				head = /obj/item/clothing/head/roguetown/helmet/sallet
 
 	if(!istype(H.patron, /datum/patron/inhumen/matthios))
 		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -51,13 +51,14 @@
 		)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
-	var/weapons = list("Katar","Knuckle Dusters")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Katar")
-			backpack_contents += list(/obj/item/rogueweapon/katar = 1)
-		if("Knuckle Dusters")
-			backpack_contents += list(/obj/item/rogueweapon/knuckles/bronzeknuckles = 1)
+	if(H.mind)
+		var/weapons = list("Katar","Knuckle Dusters")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Katar")
+				backpack_contents += list(/obj/item/rogueweapon/katar = 1)
+			if("Knuckle Dusters")
+				backpack_contents += list(/obj/item/rogueweapon/knuckles/bronzeknuckles = 1)
 	H.cmode_music = 'sound/music/combat_holy.ogg' // left in bc i feel like monk players want their darktide
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
@@ -177,13 +178,14 @@
 		if(/datum/patron/old_god)
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted/ornate
 			cloak = /obj/item/clothing/cloak/psydontabard
-			var/helmets = list("Armet","Bucket Helm")
-			var/helmet_choice = input("Choose your Psydonian Helm", "WALK IN HIS LIGHT") as anything in helmets
-			switch(helmet_choice)
-				if("Bucket Helm")
-					head = /obj/item/clothing/head/roguetown/helmet/heavy/psybucket
-				if("Armet")
-					head = /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm
+			if(H.mind)
+				var/helmets = list("Armet","Bucket Helm")
+				var/helmet_choice = input("Choose your Psydonian Helm", "WALK IN HIS LIGHT") as anything in helmets
+				switch(helmet_choice)
+					if("Bucket Helm")
+						head = /obj/item/clothing/head/roguetown/helmet/heavy/psybucket
+					if("Armet")
+						head = /obj/item/clothing/head/roguetown/helmet/heavy/psydonhelm
 		if(/datum/patron/divine/astrata)
 			cloak = /obj/item/clothing/cloak/templar/astrata
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/astratan
@@ -220,25 +222,26 @@
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles.
-	var/weapons = list("Longsword","Mace","Flail")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Longsword")
-			if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
-				beltr = /obj/item/rogueweapon/sword/long/oldpsysword
-			else
-				beltr = /obj/item/rogueweapon/sword/long
-			r_hand = /obj/item/rogueweapon/scabbard/sword
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-		if("Mace")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
-				beltr = /obj/item/rogueweapon/mace/cudgel/psy/old
-			else
-				beltr = /obj/item/rogueweapon/mace
-		if("Flail")
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/flail
+	if(H.mind)
+		var/weapons = list("Longsword","Mace","Flail")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Longsword")
+				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
+					beltr = /obj/item/rogueweapon/sword/long/oldpsysword
+				else
+					beltr = /obj/item/rogueweapon/sword/long
+				r_hand = /obj/item/rogueweapon/scabbard/sword
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			if("Mace")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
+					beltr = /obj/item/rogueweapon/mace/cudgel/psy/old
+				else
+					beltr = /obj/item/rogueweapon/mace
+			if("Flail")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/flail
 	H.set_blindness(0)
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
@@ -352,24 +355,25 @@
 			cloak = /obj/item/clothing/cloak/templar/pestra
 		else
 			cloak = /obj/item/clothing/cloak/cape/crusader
-	var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
-	var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Harp")
-			backr = /obj/item/rogue/instrument/harp
-		if("Lute")
-			backr = /obj/item/rogue/instrument/lute
-		if("Accordion")
-			backr = /obj/item/rogue/instrument/accord
-		if("Guitar")
-			backr = /obj/item/rogue/instrument/guitar
-		if("Hurdy-Gurdy")
-			backr = /obj/item/rogue/instrument/hurdygurdy
-		if("Viola")
-			backr = /obj/item/rogue/instrument/viola
-		if("Vocal Talisman")
-			backr = /obj/item/rogue/instrument/vocals
+	if(H.mind)
+		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
+		var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Harp")
+				backr = /obj/item/rogue/instrument/harp
+			if("Lute")
+				backr = /obj/item/rogue/instrument/lute
+			if("Accordion")
+				backr = /obj/item/rogue/instrument/accord
+			if("Guitar")
+				backr = /obj/item/rogue/instrument/guitar
+			if("Hurdy-Gurdy")
+				backr = /obj/item/rogue/instrument/hurdygurdy
+			if("Viola")
+				backr = /obj/item/rogue/instrument/viola
+			if("Vocal Talisman")
+				backr = /obj/item/rogue/instrument/vocals
 
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
@@ -492,9 +496,9 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)	//Minor regen, capped to T3.
 	if(istype(H.patron, /datum/patron/divine))
 		// For now, only Tennites get this. Heretics can have a special treat later
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)
+		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)
 	if(istype(H.patron, /datum/patron/inhumen))
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast/unholyblast)
+		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast/unholyblast)
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
 			neck = /obj/item/clothing/neck/roguetown/psicross

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -40,24 +40,25 @@
 		/obj/item/flashlight/flare/torch/lantern,
 		)
 	H.set_blindness(0)
-	var/weapons = list("Naginata","Quarterstaff","Hwando")
-	var/weapon_choice = input("Choose your weapon", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Naginata")
-			r_hand = /obj/item/rogueweapon/spear/naginata
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
-			armor = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
-		if("Quarterstaff")
-			backr = /obj/item/rogueweapon/woodstaff/quarterstaff/steel
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
-			armor = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
-		if("Hwando")
-			beltl = /obj/item/rogueweapon/sword/sabre/mulyeog
-			beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
-			armor = /obj/item/clothing/suit/roguetown/armor/basiceast
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+	if(H.mind)
+		var/weapons = list("Naginata","Quarterstaff","Hwando")
+		var/weapon_choice = input("Choose your weapon", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Naginata")
+				r_hand = /obj/item/rogueweapon/spear/naginata
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
+				armor = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
+			if("Quarterstaff")
+				backr = /obj/item/rogueweapon/woodstaff/quarterstaff/steel
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
+				armor = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
+			if("Hwando")
+				beltl = /obj/item/rogueweapon/sword/sabre/mulyeog
+				beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
+				armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 
 /datum/advclass/foreigner/yoruku
 	name = "Eastern Assassin"
@@ -102,24 +103,25 @@
 	cloak = /obj/item/clothing/cloak/thief_cloak/yoruku
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	H.set_blindness(0)
-	var/weapons = list("Tanto","Kodachi")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Tanto")
-			beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun
-			beltl = /obj/item/rogueweapon/scabbard/sheath/kazengun
-			H.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
-		if("Kodachi")
-			beltr = /obj/item/rogueweapon/sword/short/kazengun
-			beltl = /obj/item/rogueweapon/scabbard/sword/kazengun/kodachi
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
-	var/masks = list("Oni","Kitsune")
-	var/mask_choice = input("Choose your mask.", "HIDE YOURSELF") as anything in masks
-	switch(mask_choice)
-		if("Oni")
-			mask = /obj/item/clothing/mask/rogue/facemask/yoruku_oni
-		if("Kitsune")
-			mask = /obj/item/clothing/mask/rogue/facemask/yoruku_kitsune
+	if(H.mind)
+		var/weapons = list("Tanto","Kodachi")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Tanto")
+				beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun
+				beltl = /obj/item/rogueweapon/scabbard/sheath/kazengun
+				H.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
+			if("Kodachi")
+				beltr = /obj/item/rogueweapon/sword/short/kazengun
+				beltl = /obj/item/rogueweapon/scabbard/sword/kazengun/kodachi
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+		var/masks = list("Oni","Kitsune")
+		var/mask_choice = input("Choose your mask.", "HIDE YOURSELF") as anything in masks
+		switch(mask_choice)
+			if("Oni")
+				mask = /obj/item/clothing/mask/rogue/facemask/yoruku_oni
+			if("Kitsune")
+				mask = /obj/item/clothing/mask/rogue/facemask/yoruku_kitsune
 
 /datum/advclass/foreigner/repentant
 	name = "Otavan Repentant"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -100,29 +100,30 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/conjure_weapon)
 	H.cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
-	var/weapons = list("Longsword", "Falchion & Wooden Shield", "Messer & Wooden Shield", "Hwando") // Much smaller selection with only three swords. You will probably want to upgrade.
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Longsword")
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/long
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-		if("Falchion & Wooden Shield")
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			backr = /obj/item/rogueweapon/shield/wood
-			r_hand = /obj/item/rogueweapon/sword/short/falchion
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_APPRENTICE, TRUE)
-		if("Messer & Wooden Shield")
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			backr = /obj/item/rogueweapon/shield/wood
-			r_hand = /obj/item/rogueweapon/sword/short/messer/iron
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_APPRENTICE, TRUE)
-		if("Hwando")
-			r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog // Meant to not have the special foreign scabbards.
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+	if(H.mind)
+		var/weapons = list("Longsword", "Falchion & Wooden Shield", "Messer & Wooden Shield", "Hwando") // Much smaller selection with only three swords. You will probably want to upgrade.
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Longsword")
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/long
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+			if("Falchion & Wooden Shield")
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				backr = /obj/item/rogueweapon/shield/wood
+				r_hand = /obj/item/rogueweapon/sword/short/falchion
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_APPRENTICE, TRUE)
+			if("Messer & Wooden Shield")
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				backr = /obj/item/rogueweapon/shield/wood
+				r_hand = /obj/item/rogueweapon/sword/short/messer/iron
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_APPRENTICE, TRUE)
+			if("Hwando")
+				r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog // Meant to not have the special foreign scabbards.
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				armor = /obj/item/clothing/suit/roguetown/armor/basiceast
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'
@@ -174,21 +175,22 @@
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'
-	var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
-	var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Harp")
-			backr = /obj/item/rogue/instrument/harp
-		if("Lute")
-			backr = /obj/item/rogue/instrument/lute
-		if("Accordion")
-			backr = /obj/item/rogue/instrument/accord
-		if("Guitar")
-			backr = /obj/item/rogue/instrument/guitar
-		if("Hurdy-Gurdy")
-			backr = /obj/item/rogue/instrument/hurdygurdy
-		if("Viola")
-			backr = /obj/item/rogue/instrument/viola
-		if("Vocal Talisman")
-			backr = /obj/item/rogue/instrument/vocals
+	if(H.mind)
+		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
+		var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Harp")
+				backr = /obj/item/rogue/instrument/harp
+			if("Lute")
+				backr = /obj/item/rogue/instrument/lute
+			if("Accordion")
+				backr = /obj/item/rogue/instrument/accord
+			if("Guitar")
+				backr = /obj/item/rogue/instrument/guitar
+			if("Hurdy-Gurdy")
+				backr = /obj/item/rogue/instrument/hurdygurdy
+			if("Viola")
+				backr = /obj/item/rogue/instrument/viola
+			if("Vocal Talisman")
+				backr = /obj/item/rogue/instrument/vocals

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -80,31 +80,32 @@
 
 /datum/outfit/job/roguetown/adventurer/knighte/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning("You are a knight from a distant land, a scion of a noble house visiting Azuria for one reason or another."))
-	var/helmets = list(
-		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
-		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
-		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
-		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
-		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Visored Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
-		"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
-		"Hounskull Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
-		"Etruscan Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-		"Slitted Kettle"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
-		"None"
-		)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+	if(H.mind)
+		to_chat(H, span_warning("You are a knight from a distant land, a scion of a noble house visiting Azuria for one reason or another."))
+		var/helmets = list(
+			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
+			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
+			"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
+			"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
+			"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
+			"Visored Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
+			"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+			"Hounskull Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
+			"Etruscan Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Slitted Kettle"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
+			"None"
+			)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/armors = list(
-		"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-		"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
-		"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
-		)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	armor = armors[armorchoice]
+		var/armors = list(
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
+			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
+			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
+			)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		armor = armors[armorchoice]
 
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	pants = /obj/item/clothing/under/roguetown/chainlegs
@@ -125,34 +126,35 @@
 	if(TU)
 		new /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled(TU)
 	H.set_blindness(0)
-	var/weapons = list("Longsword","Mace + Shield","Flail + Shield","Billhook","Battle Axe","Greataxe")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Longsword")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/sword/long
-			r_hand = /obj/item/rogueweapon/scabbard/sword
-		if("Mace + Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/mace
-			backr = /obj/item/rogueweapon/shield/tower/metal
-		if("Flail + Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/flail
-			backr = /obj/item/rogueweapon/shield/tower/metal
-		if("Billhook")
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			r_hand = /obj/item/rogueweapon/spear/billhook
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Battle Axe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			r_hand = /obj/item/rogueweapon/stoneaxe/battle
-		if("Greataxe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			r_hand = /obj/item/rogueweapon/greataxe
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
+	if(H.mind)
+		var/weapons = list("Longsword","Mace + Shield","Flail + Shield","Billhook","Battle Axe","Greataxe")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Longsword")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/sword/long
+				r_hand = /obj/item/rogueweapon/scabbard/sword
+			if("Mace + Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/mace
+				backr = /obj/item/rogueweapon/shield/tower/metal
+			if("Flail + Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/flail
+				backr = /obj/item/rogueweapon/shield/tower/metal
+			if("Billhook")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				r_hand = /obj/item/rogueweapon/spear/billhook
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Battle Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				r_hand = /obj/item/rogueweapon/stoneaxe/battle
+			if("Greataxe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				r_hand = /obj/item/rogueweapon/greataxe
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
 
 /datum/advclass/noble/squire
 	name = "Squire Errant"
@@ -194,19 +196,20 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/rogueweapon/hammer/iron = 1, /obj/item/rogueweapon/tongs = 1, /obj/item/recipe_book/survival = 1)
-	var/armors = list("Light Armor","Medium Armor")
-	var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armors
-	switch(armor_choice)
-		if("Light Armor")
-			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-			pants = /obj/item/clothing/under/roguetown/trou/leather
-			gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
-			beltr = /obj/item/rogueweapon/huntingknife/idagger
-			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-		if("Medium Armor")
-			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
-			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-			gloves = /obj/item/clothing/gloves/roguetown/chain/iron
-			beltr = /obj/item/rogueweapon/sword/iron
-			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+	if(H.mind)
+		var/armors = list("Light Armor","Medium Armor")
+		var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armors
+		switch(armor_choice)
+			if("Light Armor")
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+				pants = /obj/item/clothing/under/roguetown/trou/leather
+				gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+				beltr = /obj/item/rogueweapon/huntingknife/idagger
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			if("Medium Armor")
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+				pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+				gloves = /obj/item/clothing/gloves/roguetown/chain/iron
+				beltr = /obj/item/rogueweapon/sword/iron
+				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 	H.set_blindness(0)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -52,18 +52,19 @@
 		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
-	var/weapons = list("Recurve Bow","Crossbow")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Recurve Bow")
-			H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-			beltl = /obj/item/quiver/arrows
-		if("Crossbow")
-			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			beltl = /obj/item/quiver/bolts
+	if(H.mind)
+		var/weapons = list("Recurve Bow","Crossbow")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Recurve Bow")
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+				beltl = /obj/item/quiver/arrows
+			if("Crossbow")
+				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltl = /obj/item/quiver/bolts
 
 /datum/advclass/ranger/assassin
 	name = "Assassin"
@@ -207,38 +208,39 @@
 		/obj/item/flashlight/flare/torch/lantern = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
-	var/weapons = list("Recurve Bow","Billhook","Sling","Crossbow")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Recurve Bow")
-			H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-			beltl = /obj/item/quiver/arrows
-		if("Billhook") // Debatable here, but we love variety.
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			r_hand = /obj/item/rogueweapon/spear/billhook
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Sling")
-			H.adjust_skillrank_up_to(/datum/skill/combat/slings, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltl = /obj/item/quiver/sling/iron
-			r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
-		if("Crossbow") // Hunting crossbows were a thing in these times, shame we don't have an item for it.
-			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			beltl = /obj/item/quiver/bolts
-	var/armors = list("Light Armor","Medium Armor")
-	var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armors
-	switch(armor_choice)
-		if("Light Armor")
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
-			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-			gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
-			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-			H.change_stat(STATKEY_SPD, 1)
-		if("Medium Armor")
-			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
-			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-			gloves = /obj/item/clothing/gloves/roguetown/chain/iron
-			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-			H.change_stat(STATKEY_STR, 1)
-			H.set_blindness(0)
+	if(H.mind)
+		var/weapons = list("Recurve Bow","Billhook","Sling","Crossbow")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Recurve Bow")
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+				beltl = /obj/item/quiver/arrows
+			if("Billhook") // Debatable here, but we love variety.
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				r_hand = /obj/item/rogueweapon/spear/billhook
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Sling")
+				H.adjust_skillrank_up_to(/datum/skill/combat/slings, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltl = /obj/item/quiver/sling/iron
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
+			if("Crossbow") // Hunting crossbows were a thing in these times, shame we don't have an item for it.
+				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltl = /obj/item/quiver/bolts
+		var/armors = list("Light Armor","Medium Armor")
+		var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armors
+		switch(armor_choice)
+			if("Light Armor")
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+				gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+				H.change_stat(STATKEY_SPD, 1)
+			if("Medium Armor")
+				armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+				pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+				gloves = /obj/item/clothing/gloves/roguetown/chain/iron
+				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+				H.change_stat(STATKEY_STR, 1)
+				H.set_blindness(0)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -52,17 +52,18 @@
 		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
-	var/weapons = list("Sabre","Whip")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Sabre")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/sword/sabre
-			r_hand = /obj/item/rogueweapon/scabbard/sword
-		if("Whip")
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/whip
+	if(H.mind)
+		var/weapons = list("Sabre","Whip")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Sabre")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/sword/sabre
+				r_hand = /obj/item/rogueweapon/scabbard/sword
+			if("Whip")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/whip
 
 /datum/advclass/rogue/thief
 	name = "Thief"
@@ -168,24 +169,24 @@
 		)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
-	var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
-	var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Harp")
-			backr = /obj/item/rogue/instrument/harp
-		if("Lute")
-			backr = /obj/item/rogue/instrument/lute
-		if("Accordion")
-			backr = /obj/item/rogue/instrument/accord
-		if("Guitar")
-			backr = /obj/item/rogue/instrument/guitar
-		if("Hurdy-Gurdy")
-			backr = /obj/item/rogue/instrument/hurdygurdy
-		if("Viola")
-			backr = /obj/item/rogue/instrument/viola
-		if("Vocal Talisman")
-			backr = /obj/item/rogue/instrument/vocals
+		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
+		var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Harp")
+				backr = /obj/item/rogue/instrument/harp
+			if("Lute")
+				backr = /obj/item/rogue/instrument/lute
+			if("Accordion")
+				backr = /obj/item/rogue/instrument/accord
+			if("Guitar")
+				backr = /obj/item/rogue/instrument/guitar
+			if("Hurdy-Gurdy")
+				backr = /obj/item/rogue/instrument/hurdygurdy
+			if("Viola")
+				backr = /obj/item/rogue/instrument/viola
+			if("Vocal Talisman")
+				backr = /obj/item/rogue/instrument/vocals
 
 /datum/advclass/rogue/swashbuckler
 	name = "Swashbuckler"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/trader.dm
@@ -187,24 +187,25 @@
 		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
-	var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
-	var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Harp")
-			backr = /obj/item/rogue/instrument/harp
-		if("Lute")
-			backr = /obj/item/rogue/instrument/lute
-		if("Accordion")
-			backr = /obj/item/rogue/instrument/accord
-		if("Guitar")
-			backr = /obj/item/rogue/instrument/guitar
-		if("Hurdy-Gurdy")
-			backr = /obj/item/rogue/instrument/hurdygurdy
-		if("Viola")
-			backr = /obj/item/rogue/instrument/viola
-		if("Vocal Talisman")
-			backr = /obj/item/rogue/instrument/vocals
+	if(H.mind)
+		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
+		var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Harp")
+				backr = /obj/item/rogue/instrument/harp
+			if("Lute")
+				backr = /obj/item/rogue/instrument/lute
+			if("Accordion")
+				backr = /obj/item/rogue/instrument/accord
+			if("Guitar")
+				backr = /obj/item/rogue/instrument/guitar
+			if("Hurdy-Gurdy")
+				backr = /obj/item/rogue/instrument/hurdygurdy
+			if("Viola")
+				backr = /obj/item/rogue/instrument/viola
+			if("Vocal Talisman")
+				backr = /obj/item/rogue/instrument/vocals
 
 /datum/advclass/trader/peddler
 	name = "Peddler"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -32,63 +32,64 @@
 	to_chat(H, span_warning("You are a seasoned weapon specialist, clad in maille, with years of experience in warfare and battle under your belt."))
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	H.set_blindness(0)
-	var/weapons = list("Longsword","Mace","Billhook","Battle Axe","Short Sword & Iron Shield","Iron Saber & Wood Shield")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Longsword")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			backr = /obj/item/rogueweapon/sword/long
-			beltr = /obj/item/rogueweapon/scabbard/sword
-		if("Mace")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/mace
-		if("Billhook")
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
-			r_hand = /obj/item/rogueweapon/spear/billhook
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Battle Axe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
-			backr = /obj/item/rogueweapon/stoneaxe/battle
-		if("Short Sword & Iron Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			backr = /obj/item/rogueweapon/shield/iron
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/short/iron
-		if("Iron Saber & Wood Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			r_hand = /obj/item/rogueweapon/sword/saber/iron
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			backr = /obj/item/rogueweapon/shield/wood
-	var/armors = list("Chainmaille Set","Iron Breastplate","Gambeson & Helmet","Light Raneshi Armor")
-	var/armor_choice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	switch(armor_choice)
-		if("Chainmaille Set")
-			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
-			shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/random//giving them something to wear under their armors
-			pants = /obj/item/clothing/under/roguetown/chainlegs/iron
-			neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
-			gloves = /obj/item/clothing/gloves/roguetown/chain/iron
-		if("Iron Breastplate")
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
-			neck = /obj/item/clothing/neck/roguetown/coif/heavypadding
-			shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/random
-			pants = /obj/item/clothing/under/roguetown/splintlegs/iron
-			gloves = /obj/item/clothing/gloves/roguetown/angle
-		if("Gambeson & Helmet")
-			armor = /obj/item/clothing/suit/roguetown/armor/gambeson
-			neck = /obj/item/clothing/neck/roguetown/coif/padded//neck cover
-			shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/random
-			wrists = /obj/item/clothing/wrists/roguetown/splintarms/iron//adding it since this set feels far too weak compared to the other two, gets one helmet and arm cover at least
-			pants = /obj/item/clothing/under/roguetown/trou/leather
-			head = /obj/item/clothing/head/roguetown/helmet/kettle
-			gloves = /obj/item/clothing/gloves/roguetown/angle
-		if("Light Raneshi Armor")
-			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/raneshen
-			pants = /obj/item/clothing/under/roguetown/trou/leather/pontifex/raneshen
-			head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab
-			gloves = /obj/item/clothing/gloves/roguetown/angle
+	if(H.mind)
+		var/weapons = list("Longsword","Mace","Billhook","Battle Axe","Short Sword & Iron Shield","Iron Saber & Wood Shield")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Longsword")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				backr = /obj/item/rogueweapon/sword/long
+				beltr = /obj/item/rogueweapon/scabbard/sword
+			if("Mace")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/mace
+			if("Billhook")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/rogueweapon/spear/billhook
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Battle Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+				backr = /obj/item/rogueweapon/stoneaxe/battle
+			if("Short Sword & Iron Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				backr = /obj/item/rogueweapon/shield/iron
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/short/iron
+			if("Iron Saber & Wood Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				r_hand = /obj/item/rogueweapon/sword/saber/iron
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				backr = /obj/item/rogueweapon/shield/wood
+		var/armors = list("Chainmaille Set","Iron Breastplate","Gambeson & Helmet","Light Raneshi Armor")
+		var/armor_choice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		switch(armor_choice)
+			if("Chainmaille Set")
+				armor = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+				shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/random//giving them something to wear under their armors
+				pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+				neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
+				gloves = /obj/item/clothing/gloves/roguetown/chain/iron
+			if("Iron Breastplate")
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
+				neck = /obj/item/clothing/neck/roguetown/coif/heavypadding
+				shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/random
+				pants = /obj/item/clothing/under/roguetown/splintlegs/iron
+				gloves = /obj/item/clothing/gloves/roguetown/angle
+			if("Gambeson & Helmet")
+				armor = /obj/item/clothing/suit/roguetown/armor/gambeson
+				neck = /obj/item/clothing/neck/roguetown/coif/padded//neck cover
+				shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/random
+				wrists = /obj/item/clothing/wrists/roguetown/splintarms/iron//adding it since this set feels far too weak compared to the other two, gets one helmet and arm cover at least
+				pants = /obj/item/clothing/under/roguetown/trou/leather
+				head = /obj/item/clothing/head/roguetown/helmet/kettle
+				gloves = /obj/item/clothing/gloves/roguetown/angle
+			if("Light Raneshi Armor")
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/raneshen
+				pants = /obj/item/clothing/under/roguetown/trou/leather/pontifex/raneshen
+				head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab
+				gloves = /obj/item/clothing/gloves/roguetown/angle
 	belt = /obj/item/storage/belt/rogue/leather
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
@@ -130,17 +131,18 @@
 	..()
 	to_chat(H, span_warning("You are an esteemed swordsman who foregoes armor in exchange for a more nimble fighting style."))
 	H.set_blindness(0)
-	var/weapons = list("Rapier","Dagger")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Rapier")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			l_hand = /obj/item/rogueweapon/sword/rapier
-			r_hand = /obj/item/rogueweapon/scabbard/sword
-		if("Dagger")
-			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
-			r_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
-			beltr = /obj/item/rogueweapon/scabbard/sheath
+	if(H.mind)
+		var/weapons = list("Rapier","Dagger")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Rapier")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				l_hand = /obj/item/rogueweapon/sword/rapier
+				r_hand = /obj/item/rogueweapon/scabbard/sword
+			if("Dagger")
+				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
+				beltr = /obj/item/rogueweapon/scabbard/sheath
 	armor = /obj/item/clothing/suit/roguetown/armor/leather
 	head = /obj/item/clothing/head/roguetown/duelhat
 	mask = /obj/item/clothing/mask/rogue/duelmask
@@ -190,27 +192,28 @@
 /datum/outfit/job/roguetown/adventurer/mhunter/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
 	to_chat(H, span_warning("You specialize in hunting down monsters and the undead, carrying two blades - one of silver, one of steel."))
-	var/steel = list("Parrying Dagger","Sword","Dagger")
-	var/steel_choice = input("Choose your steel.", "PURGE THE LIVING") as anything in steel
-	switch(steel_choice)
-		if ("Parrying Dagger")
-			l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
-			beltr = /obj/item/rogueweapon/scabbard/sheath
-		if("Sword")
-			l_hand = /obj/item/rogueweapon/sword
-			beltr = /obj/item/rogueweapon/scabbard/sword
-		if ("Dagger")
-			l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
-			beltr = /obj/item/rogueweapon/scabbard/sheath
-	var/silver = list("Silver Sword","Silver Dagger")
-	var/silver_choice = input("Choose your silver.", "PURGE THE CURSED") as anything in silver
-	switch(silver_choice)
-		if("Silver Sword")
-			r_hand = /obj/item/rogueweapon/sword/silver
-			backr = /obj/item/rogueweapon/scabbard/sword
-		if ("Silver Dagger")
-			r_hand = /obj/item/rogueweapon/huntingknife/idagger/silver
-			backr = /obj/item/rogueweapon/scabbard/sheath
+	if(H.mind)
+		var/steel = list("Parrying Dagger","Sword","Dagger")
+		var/steel_choice = input("Choose your steel.", "PURGE THE LIVING") as anything in steel
+		switch(steel_choice)
+			if ("Parrying Dagger")
+				l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
+				beltr = /obj/item/rogueweapon/scabbard/sheath
+			if("Sword")
+				l_hand = /obj/item/rogueweapon/sword
+				beltr = /obj/item/rogueweapon/scabbard/sword
+			if ("Dagger")
+				l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
+				beltr = /obj/item/rogueweapon/scabbard/sheath
+		var/silver = list("Silver Sword","Silver Dagger")
+		var/silver_choice = input("Choose your silver.", "PURGE THE CURSED") as anything in silver
+		switch(silver_choice)
+			if("Silver Sword")
+				r_hand = /obj/item/rogueweapon/sword/silver
+				backr = /obj/item/rogueweapon/scabbard/sword
+			if ("Silver Dagger")
+				r_hand = /obj/item/rogueweapon/huntingknife/idagger/silver
+				backr = /obj/item/rogueweapon/scabbard/sheath
 	backl = /obj/item/storage/backpack/rogue/satchel/black
 	wrists = /obj/item/clothing/neck/roguetown/psicross/silver
 	armor = /obj/item/clothing/suit/roguetown/shirt/undershirt/puritan
@@ -267,28 +270,29 @@
 	to_chat(H, span_warning("You are a brutal warrior who foregoes armor in order to showcase your raw strength. You specialize in unarmed combat and wrestling."))
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	H.set_blindness(0)
-	var/weapons = list("Katar","Axe","Sword","Club","Spear","MY BARE HANDS!!!")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if ("Katar")
-			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/katar
-		if("Axe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/stoneaxe/boneaxe
-		if("Sword")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/short
-		if("Club")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/mace/woodclub
-		if("Spear")
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			r_hand = /obj/item/rogueweapon/spear/bonespear
-		if ("MY BARE HANDS!!!")
-			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
-			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+	if(H.mind)
+		var/weapons = list("Katar","Axe","Sword","Club","Spear","MY BARE HANDS!!!")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if ("Katar")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/katar
+			if("Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/stoneaxe/boneaxe
+			if("Sword")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/short
+			if("Club")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/mace/woodclub
+			if("Spear")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				r_hand = /obj/item/rogueweapon/spear/bonespear
+			if ("MY BARE HANDS!!!")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+				ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 	if(should_wear_masc_clothes(H))
 		H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 		head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm
@@ -340,38 +344,39 @@
 
 /datum/outfit/job/roguetown/adventurer/ironclad/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
-	to_chat(H, span_warning("You put your trust into your durable armor. The best offense is a good defense."))
-	var/helmets = list(
-		"Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/iron,
-		"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored/iron,
-		"Kettle Helmet"		= /obj/item/clothing/head/roguetown/helmet/kettle/iron,
-		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket/iron,
-		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/iron,
-		"None"
-		)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+	if(H.mind)
+		to_chat(H, span_warning("You put your trust into your durable armor. The best offense is a good defense."))
+		var/helmets = list(
+			"Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/iron,
+			"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored/iron,
+			"Kettle Helmet"		= /obj/item/clothing/head/roguetown/helmet/kettle/iron,
+			"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket/iron,
+			"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/iron,
+			"None"
+			)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/armors = list(
-		"Breastplate + Hauberk",
-		"Half-Plate + Light Gambeson"
-		)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	switch(armorchoice)
-		if("Breastplate + Hauberk")
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
-			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
-		if("Half-Plate + Light Gambeson")
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/iron
-			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
+		var/armors = list(
+			"Breastplate + Hauberk",
+			"Half-Plate + Light Gambeson"
+			)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		switch(armorchoice)
+			if("Breastplate + Hauberk")
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/half/iron
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
+			if("Half-Plate + Light Gambeson")
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/iron
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 
-	var/legs = list(
-		"Chain Chausses"	= /obj/item/clothing/under/roguetown/chainlegs/iron,
-		"Chain Kilt"		= /obj/item/clothing/under/roguetown/chainlegs/iron/kilt
-		)
-	var/legschoice = input("Choose your Pants.", "TAKE UP PANTS") as anything in legs
-	pants = legs[legschoice]
+		var/legs = list(
+			"Chain Chausses"	= /obj/item/clothing/under/roguetown/chainlegs/iron,
+			"Chain Kilt"		= /obj/item/clothing/under/roguetown/chainlegs/iron/kilt
+			)
+		var/legschoice = input("Choose your Pants.", "TAKE UP PANTS") as anything in legs
+		pants = legs[legschoice]
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 	neck = /obj/item/clothing/neck/roguetown/bevor/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
@@ -385,27 +390,28 @@
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	H.set_blindness(0)
-	var/weapons = list("Executioner's Sword","Warhammer + Shield","Flail + Shield","Lucerne","Greataxe")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Executioner's Sword")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			backr = /obj/item/rogueweapon/sword/long/exe
-		if("Warhammer + Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/mace/warhammer
-			backr = /obj/item/rogueweapon/shield/iron
-		if("Flail + Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltr = /obj/item/rogueweapon/flail
-			backr = /obj/item/rogueweapon/shield/iron
-		if("Lucerne")
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Greataxe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			r_hand = /obj/item/rogueweapon/greataxe
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
+	if(H.mind)
+		var/weapons = list("Executioner's Sword","Warhammer + Shield","Flail + Shield","Lucerne","Greataxe")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Executioner's Sword")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				backr = /obj/item/rogueweapon/sword/long/exe
+			if("Warhammer + Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/mace/warhammer
+				backr = /obj/item/rogueweapon/shield/iron
+			if("Flail + Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltr = /obj/item/rogueweapon/flail
+				backr = /obj/item/rogueweapon/shield/iron
+			if("Lucerne")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Greataxe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				r_hand = /obj/item/rogueweapon/greataxe
+				backr = /obj/item/rogueweapon/scabbard/gwstrap

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -34,14 +34,15 @@
 
 /datum/outfit/job/roguetown/adventurer/thug/pre_equip(mob/living/carbon/human/H)
 	..()
-	var/weapons = list("Knuckles","Cudgel")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Knuckles")
-			beltr = /obj/item/rogueweapon/knuckles/bronzeknuckles
-		if("Cudgel")
-			beltl = /obj/item/rogueweapon/mace/cudgel
+	if(H.mind)
+		var/weapons = list("Knuckles","Cudgel")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Knuckles")
+				beltr = /obj/item/rogueweapon/knuckles/bronzeknuckles
+			if("Cudgel")
+				beltl = /obj/item/rogueweapon/mace/cudgel
 	head = /obj/item/clothing/head/roguetown/roguehood/random 
 	belt = /obj/item/storage/belt/rogue/leather
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -54,30 +54,31 @@
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
-	var/weapons = list("Katar","Steel Knuckles","Punch Dagger","MY BARE HANDS!!!","Battle Axe","Mace","Sword")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if ("Katar")
-			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-			beltr = /obj/item/rogueweapon/katar
-		if ("Steel Knuckles")
-			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-			beltr = /obj/item/rogueweapon/knuckles
-		if ("Punch Dagger")
-			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-			beltr = /obj/item/rogueweapon/katar/punchdagger
-		if ("MY BARE HANDS!!!")
-			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
-		if ("Battle Axe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/stoneaxe/battle
-		if ("Mace")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/mace/goden/steel
-		if ("Sword")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/falx
-	wretch_select_bounty(H)
+	if(H.mind)
+		var/weapons = list("Katar","Steel Knuckles","Punch Dagger","MY BARE HANDS!!!","Battle Axe","Mace","Sword")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if ("Katar")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+				beltr = /obj/item/rogueweapon/katar
+			if ("Steel Knuckles")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+				beltr = /obj/item/rogueweapon/knuckles
+			if ("Punch Dagger")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+				beltr = /obj/item/rogueweapon/katar/punchdagger
+			if ("MY BARE HANDS!!!")
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+				ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+			if ("Battle Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/stoneaxe/battle
+			if ("Mace")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/mace/goden/steel
+			if ("Sword")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/falx
+		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -44,69 +44,70 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/charge)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
 
-	var/weapons = list(
-		"Estoc",
-		"Mace + Shield",
-		"Flail + Shield",
-		"Longsword + Shield", 
-		"Lucerne",
-		"Battle Axe",
-		"Lance + Kite Shield",
-		"Samshir",
-	)
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Estoc")
-			r_hand = /obj/item/rogueweapon/estoc
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Longsword + Shield")
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/long
-			backr = /obj/item/rogueweapon/shield/tower/metal
-		if("Mace + Shield")
-			beltr = /obj/item/rogueweapon/mace/steel
-			backr = /obj/item/rogueweapon/shield/tower/metal
-		if("Flail + Shield")
-			beltr = /obj/item/rogueweapon/flail/sflail
-			backr = /obj/item/rogueweapon/shield/tower/metal
-		if("Lucerne")
-			r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
-			backr = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Battle Axe")
-			backr = /obj/item/rogueweapon/stoneaxe/battle
-		if("Lance + Kite Shield")
-			r_hand = /obj/item/rogueweapon/spear/lance
-			backr = /obj/item/rogueweapon/shield/tower/metal
-		if("Samshir")
-			r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
-	var/helmets = list(
-		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
-		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
-		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
-		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
-		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Visored Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
-		"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
-		"Hounskull Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
-		"Etruscan Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-		"Slitted Kettle"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
-		"Kulah Khud"	= /obj/item/clothing/head/roguetown/helmet/sallet/raneshen,
-		"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+		var/weapons = list(
+			"Estoc",
+			"Mace + Shield",
+			"Flail + Shield",
+			"Longsword + Shield", 
+			"Lucerne",
+			"Battle Axe",
+			"Lance + Kite Shield",
+			"Samshir",
+		)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Estoc")
+				r_hand = /obj/item/rogueweapon/estoc
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Longsword + Shield")
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/long
+				backr = /obj/item/rogueweapon/shield/tower/metal
+			if("Mace + Shield")
+				beltr = /obj/item/rogueweapon/mace/steel
+				backr = /obj/item/rogueweapon/shield/tower/metal
+			if("Flail + Shield")
+				beltr = /obj/item/rogueweapon/flail/sflail
+				backr = /obj/item/rogueweapon/shield/tower/metal
+			if("Lucerne")
+				r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Battle Axe")
+				backr = /obj/item/rogueweapon/stoneaxe/battle
+			if("Lance + Kite Shield")
+				r_hand = /obj/item/rogueweapon/spear/lance
+				backr = /obj/item/rogueweapon/shield/tower/metal
+			if("Samshir")
+				r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
+		var/helmets = list(
+			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
+			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
+			"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
+			"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
+			"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
+			"Visored Sallet"			= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
+			"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+			"Hounskull Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
+			"Etruscan Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Slitted Kettle"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
+			"Kulah Khud"	= /obj/item/clothing/head/roguetown/helmet/sallet/raneshen,
+			"None"
+		)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/armors = list(
-		"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-		"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
-		"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,				
-		"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
-		"Scalemail"		= /obj/item/clothing/suit/roguetown/armor/plate/scale,
-	)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	armor = armors[armorchoice]
+		var/armors = list(
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
+			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
+			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,				
+			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+			"Scalemail"		= /obj/item/clothing/suit/roguetown/armor/plate/scale,
+		)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		armor = armors[armorchoice]
+		wretch_select_bounty(H)
 	gloves = /obj/item/clothing/gloves/roguetown/plate 
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	neck = /obj/item/clothing/neck/roguetown/bevor
@@ -125,7 +126,6 @@
 		)
 
 
-	wretch_select_bounty(H)
 
 /datum/advclass/wretch/deserter/maa
 	name = "Disgraced Man at Arms"
@@ -162,29 +162,30 @@
 	)
 /datum/outfit/job/roguetown/wretch/desertermaa/pre_equip(mob/living/carbon/human/H)
 	..()
-	var/weapons = list("Warhammer & Shield","Sabre & Shield","Axe & Shield","Billhook","Greataxe","Halberd",)
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Warhammer & Shield")
-			beltr = /obj/item/rogueweapon/mace/warhammer
-			backl = /obj/item/rogueweapon/shield/iron
-		if("Sabre & Shield")
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/sabre
-			backl = /obj/item/rogueweapon/shield/wood
-		if("Axe & Shield")
-			beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
-			backl = /obj/item/rogueweapon/shield/iron
-		if("Billhook")
-			r_hand = /obj/item/rogueweapon/spear/billhook 
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Halberd")
-			r_hand = /obj/item/rogueweapon/halberd
-			backl = /obj/item/rogueweapon/scabbard/gwstrap	
-		if("Greataxe")
-			r_hand = /obj/item/rogueweapon/greataxe
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
+	if(H.mind)
+		var/weapons = list("Warhammer & Shield","Sabre & Shield","Axe & Shield","Billhook","Greataxe","Halberd",)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Warhammer & Shield")
+				beltr = /obj/item/rogueweapon/mace/warhammer
+				backl = /obj/item/rogueweapon/shield/iron
+			if("Sabre & Shield")
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/sabre
+				backl = /obj/item/rogueweapon/shield/wood
+			if("Axe & Shield")
+				beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+				backl = /obj/item/rogueweapon/shield/iron
+			if("Billhook")
+				r_hand = /obj/item/rogueweapon/spear/billhook 
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Halberd")
+				r_hand = /obj/item/rogueweapon/halberd
+				backl = /obj/item/rogueweapon/scabbard/gwstrap	
+			if("Greataxe")
+				r_hand = /obj/item/rogueweapon/greataxe
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
 	H.verbs |= list(/mob/living/carbon/human/mind/proc/setorderswretch)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/retreat)
@@ -192,7 +193,29 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/brotherhood)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/charge)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
+		var/helmets = list(
+		"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+		"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+		"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
+		"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+		"None"
+		)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
+		var/masks = list(
+		"Steel Houndmask" 	= /obj/item/clothing/mask/rogue/facemask/steel/hound,
+		"Steel Mask"		= /obj/item/clothing/mask/rogue/facemask/steel,
+		"Wildguard"			= /obj/item/clothing/mask/rogue/wildguard,
+		"None"
+		)
+		var/maskchoice = input("Choose your Mask.", "MASK MASK MASK") as anything in masks // Run from it. MASK. MASK. MASK.
+		if(maskchoice != "None")
+			mask = masks[maskchoice]
+		
+		wretch_select_bounty(H)
 
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk	
@@ -207,31 +230,6 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 
 	backpack_contents = list(/obj/item/natural/cloth = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rogueweapon/scabbard/sheath = 1)
-	var/helmets = list(
-	"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
-	"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
-	"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
-	"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
-	"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
-	"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
-
-	var/masks = list(
-	"Steel Houndmask" 	= /obj/item/clothing/mask/rogue/facemask/steel/hound,
-	"Steel Mask"		= /obj/item/clothing/mask/rogue/facemask/steel,
-	"Wildguard"			= /obj/item/clothing/mask/rogue/wildguard,
-	"None"
-	)
-	var/maskchoice = input("Choose your Mask.", "MASK MASK MASK") as anything in masks // Run from it. MASK. MASK. MASK.
-	if(maskchoice != "None")
-		mask = masks[maskchoice]	
-
-
-
-	wretch_select_bounty(H)
 
 /obj/effect/proc_holder/spell/invoked/order
 	name = ""

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
@@ -59,4 +59,5 @@
 	if(H.age == AGE_OLD)
 		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_MASTER, TRUE)
 		H.mind?.adjust_spellpoints(6)
-	wretch_select_bounty(H)
+	if(H.mind)
+		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -36,22 +36,27 @@
 	to_chat(H, span_warning("You father your unholy cause through the most time-tested of ways: hard, heavy steel in both arms and armor."))
 	H.mind.current.faction += "[H.name]_faction"
 	H.set_blindness(0)
-	var/weapons = list("Longsword", "Mace", "Flail", "Axe")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Longsword")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/long
-		if("Mace")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/mace/steel
-		if("Flail")
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/flail/sflail
-		if("Axe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
-			beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+	if(H.mind)
+		var/weapons = list("Longsword", "Mace", "Flail", "Axe")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Longsword")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/long
+			if("Mace")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/mace/steel
+			if("Flail")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/flail/sflail
+			if("Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+		var/datum/devotion/C = new /datum/devotion(H, H.patron)
+		C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_4)	//Minor regen, can level up to T4.
+		wretch_select_bounty(H)
+
 	// You can convert those the church has shunned.
 	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
 	if (istype (H.patron, /datum/patron/inhumen/zizo))
@@ -80,10 +85,6 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
-	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_4)	//Minor regen, can level up to T4.
-	wretch_select_bounty(H)
-
 /datum/outfit/job/roguetown/wretch/heretic/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
 	switch(H.patron?.type)
@@ -217,26 +218,30 @@
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
 	H.cmode_music = 'sound/music/cmode/antag/combat_cutpurse.ogg'
-	var/weapons = list("Rapier","Dagger", "Bow", "Crossbow")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Rapier")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			l_hand = /obj/item/rogueweapon/sword/rapier
-		if("Dagger")
-			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
-			beltl = /obj/item/rogueweapon/scabbard/sheath
-			l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/special
-		if("Bow")
-			H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			beltl = /obj/item/quiver/arrows
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-		if("Crossbow")
-			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_JOURNEYMAN, TRUE) //have to specifically go into bows/crossbows unlike outlaw
-			beltr = /obj/item/quiver/bolts
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	if(H.mind)
+		var/weapons = list("Rapier","Dagger", "Bow", "Crossbow")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Rapier")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				l_hand = /obj/item/rogueweapon/sword/rapier
+			if("Dagger")
+				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
+				beltl = /obj/item/rogueweapon/scabbard/sheath
+				l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/special
+			if("Bow")
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltl = /obj/item/quiver/arrows
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			if("Crossbow")
+				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_JOURNEYMAN, TRUE) //have to specifically go into bows/crossbows unlike outlaw
+				beltr = /obj/item/quiver/bolts
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+		var/datum/devotion/C = new /datum/devotion(H, H.patron)
+		C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_4)	//Minor regen, can level up to T4.
+		wretch_select_bounty(H)
 
 	if (istype (H.patron, /datum/patron/inhumen/zizo))
 		if(H.mind)
@@ -245,9 +250,6 @@
 			H.mind.current.faction += "[H.name]_faction"
 		ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
 	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
-	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_4)	//Minor regen, can level up to T4.
-	wretch_select_bounty(H)
 
 /datum/outfit/job/roguetown/wretch/hereticspy/choose_loadout(mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -62,4 +62,4 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/necromancer)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
-	wretch_select_bounty(H)
+		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/outlaw.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/outlaw.dm
@@ -60,22 +60,23 @@
 		/obj/item/ammo_casing/caseless/rogue/bolt/water = 3,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
-	var/weapons = list("Rapier","Dagger", "Whip")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Rapier")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			l_hand = /obj/item/rogueweapon/sword/rapier
-		if("Dagger")
-			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
-			beltl = /obj/item/rogueweapon/scabbard/sheath
-			l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/special // Why were they spawning with an elven dagger in the first place??? Please LMK.
-		if ("Whip")
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
-			beltl = /obj/item/rogueweapon/whip
-	wretch_select_bounty(H)
+	if(H.mind)
+		var/weapons = list("Rapier","Dagger", "Whip")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Rapier")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				l_hand = /obj/item/rogueweapon/sword/rapier
+			if("Dagger")
+				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
+				beltl = /obj/item/rogueweapon/scabbard/sheath
+				l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/special // Why were they spawning with an elven dagger in the first place??? Please LMK.
+			if ("Whip")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
+				beltl = /obj/item/rogueweapon/whip
+		wretch_select_bounty(H)
 
 /datum/advclass/wretch/outlaw/marauder
 	name = "Marauder"
@@ -130,26 +131,27 @@
 		/obj/item/rope/chain = 1,
 		/obj/item/storage/roguebag = 1,
 		)
-	var/weapons = list("Just A Heater Shield","Dagger + Crossbow", "Militia Warpick + Heater Shield", "Militia Spear + Heater Shield")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Just An Iron Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			backr = /obj/item/rogueweapon/shield/iron
-		if("Dagger + Crossbow")
-			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
-			beltl = /obj/item/rogueweapon/scabbard/sheath
-			l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			beltr = /obj/item/quiver/bolts
-		if ("Militia Warpick + Heater Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
-			beltl = /obj/item/rogueweapon/pick/militia
-			backr = /obj/item/rogueweapon/shield/iron
-		if ("Militia Spear + Heater Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
-			l_hand = /obj/item/rogueweapon/spear/militia
-			backr = /obj/item/rogueweapon/shield/heater
-	wretch_select_bounty(H)
+	if(H.mind)
+		var/weapons = list("Just A Heater Shield","Dagger + Crossbow", "Militia Warpick + Heater Shield", "Militia Spear + Heater Shield")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Just An Iron Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				backr = /obj/item/rogueweapon/shield/iron
+			if("Dagger + Crossbow")
+				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
+				beltl = /obj/item/rogueweapon/scabbard/sheath
+				l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltr = /obj/item/quiver/bolts
+			if ("Militia Warpick + Heater Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+				beltl = /obj/item/rogueweapon/pick/militia
+				backr = /obj/item/rogueweapon/shield/iron
+			if ("Militia Spear + Heater Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
+				l_hand = /obj/item/rogueweapon/spear/militia
+				backr = /obj/item/rogueweapon/shield/heater
+		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/plaguebearer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/plaguebearer.dm
@@ -54,17 +54,18 @@
 		)
 	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
-	var/weapons = list("Archery", "LET THERE BE PLAGUE!!!")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Archery")
-			H.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-			beltl = /obj/item/quiver/poisonarrows
-		if("LET THERE BE PLAGUE!!!")
-			H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 4, TRUE)
-			backr = /obj/item/rogueweapon/woodstaff/toper
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/acidsplash)
-	wretch_select_bounty(H)
+	if(H.mind)
+		var/weapons = list("Archery", "LET THERE BE PLAGUE!!!")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Archery")
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+				beltl = /obj/item/quiver/poisonarrows
+			if("LET THERE BE PLAGUE!!!")
+				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 4, TRUE)
+				backr = /obj/item/rogueweapon/woodstaff/toper
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/acidsplash)
+		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
@@ -58,21 +58,22 @@
 		/obj/item/rope/chain = 1,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
-	var/weapons = list("Dagger","Axe", "Cudgel", "My Bow Is Enough")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Dagger")
-			H.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
-			beltr = /obj/item/rogueweapon/scabbard/sheath
-			r_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
-		if("Axe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
-			beltr = /obj/item/rogueweapon/stoneaxe/woodcut
-		if ("Cudgel")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
-			beltr = /obj/item/rogueweapon/mace/cudgel
-		if ("My Bow Is Enough")
-			H.adjust_skillrank_up_to(/datum/skill/combat/bows, 5, TRUE)
-			head = /obj/item/clothing/head/roguetown/duelhat
-	wretch_select_bounty(H)
+	if(H.mind)
+		var/weapons = list("Dagger","Axe", "Cudgel", "My Bow Is Enough")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Dagger")
+				H.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
+				beltr = /obj/item/rogueweapon/scabbard/sheath
+				r_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
+			if("Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
+				beltr = /obj/item/rogueweapon/stoneaxe/woodcut
+			if ("Cudgel")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
+				beltr = /obj/item/rogueweapon/mace/cudgel
+			if ("My Bow Is Enough")
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, 5, TRUE)
+				head = /obj/item/clothing/head/roguetown/duelhat
+		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
@@ -51,25 +51,26 @@
 		/obj/item/flint = 1,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
-	wretch_select_bounty(H)
-	var/weapons = list("Archery", "Crossbows", "LET THERE BE FLAME!!!")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Archery")
-			H.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-			beltl = /obj/item/quiver/pyroarrows
-		if("Crossbows")
-			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
-			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			beltl = /obj/item/quiver/pyrobolts
-		if("LET THERE BE FLAME!!!")
-			H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 2, TRUE)
-			backr = /obj/item/rogueweapon/woodstaff/toper
-			if(H.mind)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fireball)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/spitfire)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/rebuke)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stoneskin) // To not be instapaincritted if you accidentally hit yourself
+	if(H.mind)
+		var/weapons = list("Archery", "Crossbows", "LET THERE BE FLAME!!!")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Archery")
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+				beltl = /obj/item/quiver/pyroarrows
+			if("Crossbows")
+				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltl = /obj/item/quiver/pyrobolts
+			if("LET THERE BE FLAME!!!")
+				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 2, TRUE)
+				backr = /obj/item/rogueweapon/woodstaff/toper
+				if(H.mind)
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fireball)
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/spitfire)
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/rebuke)
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stoneskin) // To not be instapaincritted if you accidentally hit yourself
+		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/vigilante.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/vigilante.dm
@@ -37,18 +37,19 @@
 		/obj/item/rope/chain = 1,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
-	var/classes = list("The Watchman", "The Gadgeteer", "I AM JUSTICE INCARNATE!!!")
-	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
-	switch(classchoice)
-		if("The Watchman") //Face-to-face CQC. No crit resist. Pure aura. Rorschach. 
-			H.set_blindness(0)
-			watchman_equip(H)
-		if("The Gadgeteer") //Make gadgets, be precise and smart. Think ahead before you start swinging. Nite Owl. 
-			H.set_blindness(0)
-			owl_equip(H)
-		if("I AM JUSTICE INCARNATE!!!") //THROW SHIT AT PEOPLE. RANDOM BULLSHIT GO!!!! MOON KNIGHT. 
-			H.set_blindness(0)
-			bullshit_equip(H)
+	if(H.mind)
+		var/classes = list("The Watchman", "The Gadgeteer", "I AM JUSTICE INCARNATE!!!")
+		var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
+		switch(classchoice)
+			if("The Watchman") //Face-to-face CQC. No crit resist. Pure aura. Rorschach. 
+				H.set_blindness(0)
+				watchman_equip(H)
+			if("The Gadgeteer") //Make gadgets, be precise and smart. Think ahead before you start swinging. Nite Owl. 
+				H.set_blindness(0)
+				owl_equip(H)
+			if("I AM JUSTICE INCARNATE!!!") //THROW SHIT AT PEOPLE. RANDOM BULLSHIT GO!!!! MOON KNIGHT. 
+				H.set_blindness(0)
+				bullshit_equip(H)
 
 /datum/outfit/job/roguetown/wretch/vigilante/proc/watchman_equip(mob/living/carbon/human/H)
 	H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE) //No civilized barbarian. Sorry chud. Go play Berserker if you want that. 

--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -101,25 +101,26 @@
 	H.verbs |= /mob/proc/haltyell
 	H.set_blindness(0)
 
-	var/helmets = list(
-		"Path of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,
-		"Path of the Volf"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf,
-		"Path of the Ram"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/goat,
-		"Path of the Bear"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/bear,
-		"None"
-	)
-	var/helmchoice = input("Choose your Path.", "HELMET SELECTION") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+	if(H.mind)
+		var/helmets = list(
+			"Path of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,
+			"Path of the Volf"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf,
+			"Path of the Ram"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/goat,
+			"Path of the Bear"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/bear,
+			"None"
+		)
+		var/helmchoice = input("Choose your Path.", "HELMET SELECTION") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/hoods = list(
-		"Common Shroud" 	= /obj/item/clothing/head/roguetown/roguehood/warden,
-		"Antlered Shroud"		= /obj/item/clothing/head/roguetown/roguehood/warden/antler,
-		"None"
-	)
-	var/hoodchoice = input("Choose your Shroud.", "HOOD SELECTION") as anything in hoods
-	if(helmchoice != "None")
-		mask = hoods[hoodchoice]
+		var/hoods = list(
+			"Common Shroud" 	= /obj/item/clothing/head/roguetown/roguehood/warden,
+			"Antlered Shroud"		= /obj/item/clothing/head/roguetown/roguehood/warden/antler,
+			"None"
+		)
+		var/hoodchoice = input("Choose your Shroud.", "HOOD SELECTION") as anything in hoods
+		if(helmchoice != "None")
+			mask = hoods[hoodchoice]
 
 /datum/advclass/bogguardsman/forester
 	name = "Forester"
@@ -176,22 +177,23 @@
 	H.verbs |= /mob/proc/haltyell
 	H.set_blindness(0)
 
-	var/helmets = list(
-		"Path of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,
-		"Path of the Volf"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf,
-		"Path of the Ram"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/goat,
-		"Path of the Bear"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/bear,
-		"None"
-	)
-	var/helmchoice = input("Choose your Path.", "HELMET SELECTION") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+	if(H.mind)
+		var/helmets = list(
+			"Path of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,
+			"Path of the Volf"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf,
+			"Path of the Ram"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/goat,
+			"Path of the Bear"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/bear,
+			"None"
+		)
+		var/helmchoice = input("Choose your Path.", "HELMET SELECTION") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/hoods = list(
-		"Common Shroud" 	= /obj/item/clothing/head/roguetown/roguehood/warden,
-		"Antlered Shroud"		= /obj/item/clothing/head/roguetown/roguehood/warden/antler,
-		"None"
-	)
-	var/hoodchoice = input("Choose your Shroud.", "HOOD SELECTION") as anything in hoods
-	if(helmchoice != "None")
-		mask = hoods[hoodchoice]
+		var/hoods = list(
+			"Common Shroud" 	= /obj/item/clothing/head/roguetown/roguehood/warden,
+			"Antlered Shroud"		= /obj/item/clothing/head/roguetown/roguehood/warden/antler,
+			"None"
+		)
+		var/hoodchoice = input("Choose your Shroud.", "HOOD SELECTION") as anything in hoods
+		if(helmchoice != "None")
+			mask = hoods[hoodchoice]

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -99,22 +99,23 @@
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Warhammer & Shield","Axe & Shield","Halberd","Greataxe")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Warhammer & Shield")
-			beltr = /obj/item/rogueweapon/mace/warhammer
-			backl = /obj/item/rogueweapon/shield/iron
-		if("Axe & Shield")
-			beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
-			backl = /obj/item/rogueweapon/shield/iron
-		if("Halberd")
-			r_hand = /obj/item/rogueweapon/halberd
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Greataxe")
-			r_hand = /obj/item/rogueweapon/greataxe
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
+	if(H.mind)
+		var/weapons = list("Warhammer & Shield","Axe & Shield","Halberd","Greataxe")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Warhammer & Shield")
+				beltr = /obj/item/rogueweapon/mace/warhammer
+				backl = /obj/item/rogueweapon/shield/iron
+			if("Axe & Shield")
+				beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+				backl = /obj/item/rogueweapon/shield/iron
+			if("Halberd")
+				r_hand = /obj/item/rogueweapon/halberd
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Greataxe")
+				r_hand = /obj/item/rogueweapon/greataxe
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
 		/obj/item/rope/chain = 1,
@@ -124,41 +125,42 @@
 		)
 	H.verbs |= /mob/proc/haltyell
 
-	var/helmets = list(
-	"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
-	"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
-	"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
-	"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
-	"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
-	"Skull Cap"			= /obj/item/clothing/head/roguetown/helmet/skullcap,
-	"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+	if(H.mind)
+		var/helmets = list(
+		"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+		"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+		"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
+		"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+		"Skull Cap"			= /obj/item/clothing/head/roguetown/helmet/skullcap,
+		"None"
+		)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/armors = list(
-		"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
-		"Iron Hauberk"		= /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron,
-		"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
-	)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	armor = armors[armorchoice]
+		var/armors = list(
+			"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
+			"Iron Hauberk"		= /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron,
+			"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
+		)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		armor = armors[armorchoice]
 
-	var/arms = list(
-		"Brigandine Splint Arms"		= wrists = /obj/item/clothing/wrists/roguetown/splintarms,
-		"Steel Bracers"		= wrists = /obj/item/clothing/wrists/roguetown/bracers,
-		"Jack Chains"		= wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain,
-	)
-	var/armschoice = input("Choose your arm protection.", "READY THYSELF") as anything in arms
-	wrists = arms[armschoice]
+		var/arms = list(
+			"Brigandine Splint Arms"		= wrists = /obj/item/clothing/wrists/roguetown/splintarms,
+			"Steel Bracers"		= wrists = /obj/item/clothing/wrists/roguetown/bracers,
+			"Jack Chains"		= wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain,
+		)
+		var/armschoice = input("Choose your arm protection.", "READY THYSELF") as anything in arms
+		wrists = arms[armschoice]
 
-	var/chausses = list(
-		"Brigandine Chausses"		= /obj/item/clothing/under/roguetown/splintlegs,
-		"Steel Chain Chausses"		= /obj/item/clothing/under/roguetown/chainlegs,
-	)
-	var/chausseschoice = input("Choose your chausses.", "READY THYSELF") as anything in chausses
-	pants = chausses[chausseschoice]
+		var/chausses = list(
+			"Brigandine Chausses"		= /obj/item/clothing/under/roguetown/splintlegs,
+			"Steel Chain Chausses"		= /obj/item/clothing/under/roguetown/chainlegs,
+		)
+		var/chausseschoice = input("Choose your chausses.", "READY THYSELF") as anything in chausses
+		pants = chausses[chausseschoice]
 
 // Ranged weapons and daggers on the side - lighter armor, but fleet!
 /datum/advclass/manorguard/skirmisher
@@ -200,61 +202,62 @@
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Crossbow","Bow","Sling")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	var/armor_options = list("Light Armor", "Medium Armor")
-	var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armor_options
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Crossbow")
-			beltr = /obj/item/quiver/bolts
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-		if("Bow") // They can head down to the armory to sideshift into one of the other bows.
-			beltr = /obj/item/quiver/arrows
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-		if("Sling")
-			beltr = /obj/item/quiver/sling/iron
-			r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling // Both are belt slots and it's not worth setting where the cugel goes for everyone else, sad.
+	if(H.mind)
+		var/weapons = list("Crossbow","Bow","Sling")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		var/armor_options = list("Light Armor", "Medium Armor")
+		var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armor_options
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Crossbow")
+				beltr = /obj/item/quiver/bolts
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+			if("Bow") // They can head down to the armory to sideshift into one of the other bows.
+				beltr = /obj/item/quiver/arrows
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			if("Sling")
+				beltr = /obj/item/quiver/sling/iron
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling // Both are belt slots and it's not worth setting where the cugel goes for everyone else, sad.
 
-	switch(armor_choice)
-		if("Light Armor")
-			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-		if("Medium Armor")
-			pants = /obj/item/clothing/under/roguetown/chainlegs
-			armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
-			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+		switch(armor_choice)
+			if("Light Armor")
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			if("Medium Armor")
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
-	var/arms = list(
-		"Brigandine Splint Arms"		= wrists = /obj/item/clothing/wrists/roguetown/splintarms,
-		"Steel Bracers"		= wrists = /obj/item/clothing/wrists/roguetown/bracers,
-		"Jack Chains"		= wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain,
-	)
-	var/armschoice = input("Choose your arm protection.", "READY THYSELF") as anything in arms
-	wrists = arms[armschoice]
-
-	backpack_contents = list(
-		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
-		/obj/item/rope/chain = 1,
-		/obj/item/storage/keyring/guardcastle = 1,
-		/obj/item/rogueweapon/scabbard/sheath = 1,
-		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
+		var/arms = list(
+			"Brigandine Splint Arms"		= wrists = /obj/item/clothing/wrists/roguetown/splintarms,
+			"Steel Bracers"		= wrists = /obj/item/clothing/wrists/roguetown/bracers,
+			"Jack Chains"		= wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain,
 		)
-	H.verbs |= /mob/proc/haltyell
+		var/armschoice = input("Choose your arm protection.", "READY THYSELF") as anything in arms
+		wrists = arms[armschoice]
 
-	var/helmets = list(
-	"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
-	"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
-	"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
-	"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
-	"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
-	"Skull Cap"			= /obj/item/clothing/head/roguetown/helmet/skullcap,
-	"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+		backpack_contents = list(
+			/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+			/obj/item/rope/chain = 1,
+			/obj/item/storage/keyring/guardcastle = 1,
+			/obj/item/rogueweapon/scabbard/sheath = 1,
+			/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
+			)
+		H.verbs |= /mob/proc/haltyell
+
+		var/helmets = list(
+		"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+		"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+		"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
+		"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+		"Skull Cap"			= /obj/item/clothing/head/roguetown/helmet/skullcap,
+		"None"
+		)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
 		
 
@@ -301,59 +304,60 @@
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Bardiche","Sword & Shield")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Bardiche")
-			r_hand = /obj/item/rogueweapon/halberd/bardiche
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Sword & Shield")
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/sabre
-			backl = /obj/item/rogueweapon/shield/wood
-	
-	backpack_contents = list(
-		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
-		/obj/item/rope/chain = 1,
-		/obj/item/storage/keyring/guardcastle = 1,
-		/obj/item/rogueweapon/scabbard/sheath = 1,
-		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
+	if(H.mind)
+		var/weapons = list("Bardiche","Sword & Shield")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Bardiche")
+				r_hand = /obj/item/rogueweapon/halberd/bardiche
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Sword & Shield")
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/sabre
+				backl = /obj/item/rogueweapon/shield/wood
+		
+		backpack_contents = list(
+			/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+			/obj/item/rope/chain = 1,
+			/obj/item/storage/keyring/guardcastle = 1,
+			/obj/item/rogueweapon/scabbard/sheath = 1,
+			/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
+			)
+		H.verbs |= /mob/proc/haltyell
+
+		var/helmets = list(
+		"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+		"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+		"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
+		"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+		"Skull Cap"			= /obj/item/clothing/head/roguetown/helmet/skullcap,
+		"None"
 		)
-	H.verbs |= /mob/proc/haltyell
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/helmets = list(
-	"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
-	"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
-	"Bascinet Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet,
-	"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
-	"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
-	"Skull Cap"			= /obj/item/clothing/head/roguetown/helmet/skullcap,
-	"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+		var/armors = list(
+			"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
+			"Iron Hauberk"		= /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron,
+			"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
+		)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		armor = armors[armorchoice]
 
-	var/armors = list(
-		"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
-		"Iron Hauberk"		= /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron,
-		"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
-	)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	armor = armors[armorchoice]
+		var/arms = list(
+			"Brigandine Splint Arms"		= wrists = /obj/item/clothing/wrists/roguetown/splintarms,
+			"Steel Bracers"		= wrists = /obj/item/clothing/wrists/roguetown/bracers,
+			"Jack Chains"		= wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain,
+		)
+		var/armschoice = input("Choose your arm protection.", "READY THYSELF") as anything in arms
+		wrists = arms[armschoice]
 
-	var/arms = list(
-		"Brigandine Splint Arms"		= wrists = /obj/item/clothing/wrists/roguetown/splintarms,
-		"Steel Bracers"		= wrists = /obj/item/clothing/wrists/roguetown/bracers,
-		"Jack Chains"		= wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain,
-	)
-	var/armschoice = input("Choose your arm protection.", "READY THYSELF") as anything in arms
-	wrists = arms[armschoice]
-
-	var/chausses = list(
-		"Brigandine Chausses"		= /obj/item/clothing/under/roguetown/splintlegs,
-		"Steel Chain Chausses"		= /obj/item/clothing/under/roguetown/chainlegs,
-	)
-	var/chausseschoice = input("Choose your chausses.", "READY THYSELF") as anything in chausses
-	pants = chausses[chausseschoice]
+		var/chausses = list(
+			"Brigandine Chausses"		= /obj/item/clothing/under/roguetown/splintlegs,
+			"Steel Chain Chausses"		= /obj/item/clothing/under/roguetown/chainlegs,
+		)
+		var/chausseschoice = input("Choose your chausses.", "READY THYSELF") as anything in chausses
+		pants = chausses[chausseschoice]

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -113,34 +113,35 @@
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
 		)
 	H.adjust_blindness(-3)
-	var/weapons = list("Rhomphaia","Flail & Shield","Halberd","Sabre & Crossbow")	//Bit more unique than footsman, you are a jack-of-all-trades + slightly more 'elite'.
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Rhomphaia")			//Rare-ish anti-armor two hander sword. Kinda alternative of a bastard sword type. Could be cool.
-			backl = /obj/item/rogueweapon/scabbard/sword
-			l_hand = /obj/item/rogueweapon/sword/long/rhomphaia
-			beltr = /obj/item/rogueweapon/mace/cudgel
-		if("Flail & Shield")	//Tower-shield, higher durability wood shield w/ more coverage. Plus a steel flail; maybe.. less broken that a steel mace?
-			beltr = /obj/item/rogueweapon/flail/sflail
-			backl = /obj/item/rogueweapon/shield/tower
-		if("Halberd")			//Halberd - basically exact same as MAA. It's a really valid build. Spear thrust + sword chop + bash.
-			r_hand = /obj/item/rogueweapon/halberd
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-			beltr = /obj/item/rogueweapon/mace/cudgel
-		if("Sabre & Crossbow")	//Versetile skirmisher class. Considered other swords but sabre felt best without being too strong. (This one gets no cudgel, no space.)
-			beltr = /obj/item/quiver/bolts
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			r_hand = /obj/item/rogueweapon/sword/sabre
-			l_hand = /obj/item/rogueweapon/scabbard/sword
+	if(H.mind)
+		var/weapons = list("Rhomphaia","Flail & Shield","Halberd","Sabre & Crossbow")	//Bit more unique than footsman, you are a jack-of-all-trades + slightly more 'elite'.
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Rhomphaia")			//Rare-ish anti-armor two hander sword. Kinda alternative of a bastard sword type. Could be cool.
+				backl = /obj/item/rogueweapon/scabbard/sword
+				l_hand = /obj/item/rogueweapon/sword/long/rhomphaia
+				beltr = /obj/item/rogueweapon/mace/cudgel
+			if("Flail & Shield")	//Tower-shield, higher durability wood shield w/ more coverage. Plus a steel flail; maybe.. less broken that a steel mace?
+				beltr = /obj/item/rogueweapon/flail/sflail
+				backl = /obj/item/rogueweapon/shield/tower
+			if("Halberd")			//Halberd - basically exact same as MAA. It's a really valid build. Spear thrust + sword chop + bash.
+				r_hand = /obj/item/rogueweapon/halberd
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				beltr = /obj/item/rogueweapon/mace/cudgel
+			if("Sabre & Crossbow")	//Versetile skirmisher class. Considered other swords but sabre felt best without being too strong. (This one gets no cudgel, no space.)
+				beltr = /obj/item/quiver/bolts
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				r_hand = /obj/item/rogueweapon/sword/sabre
+				l_hand = /obj/item/rogueweapon/scabbard/sword
 
-	var/armors = list(
-		"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
-		"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
-		"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
-	)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	armor = armors[armorchoice]
+		var/armors = list(
+			"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
+			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
+			"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
+		)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		armor = armors[armorchoice]
 
 /obj/effect/proc_holder/spell/invoked/order
 	name = ""

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -136,15 +136,16 @@
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot
 	)
 	H.adjust_blindness(-3)
-	var/weapons = list("Iron Sword","Cudgel",)
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Iron Sword")
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/iron
-		if("Cudgel")	
-			beltr = /obj/item/rogueweapon/mace/cudgel
+	if(H.mind)
+		var/weapons = list("Iron Sword","Cudgel",)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Iron Sword")
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/iron
+			if("Cudgel")	
+				beltr = /obj/item/rogueweapon/mace/cudgel
 
 /datum/advclass/squire/skirmisher
 	name = "Irregular Squire"

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -240,24 +240,25 @@
 	H.verbs |= /mob/proc/haltyell
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Sword + Recurve Bow","Axe + Crossbow","Spear + Shield")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Sword + Recurve Bow")
-			r_hand = /obj/item/rogueweapon/sword/long
-			beltl = /obj/item/quiver/arrows
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+	if(H.mind)
+		var/weapons = list("Sword + Recurve Bow","Axe + Crossbow","Spear + Shield")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Sword + Recurve Bow")
+				r_hand = /obj/item/rogueweapon/sword/long
+				beltl = /obj/item/quiver/arrows
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 
-		if("Axe + Crossbow")
-			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut/steel
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			beltl = /obj/item/quiver/bolts
+			if("Axe + Crossbow")
+				r_hand = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltl = /obj/item/quiver/bolts
 
-		if ("Spear + Shield")
-			r_hand = /obj/item/rogueweapon/spear
-			backl = /obj/item/rogueweapon/shield/tower/metal
+			if ("Spear + Shield")
+				r_hand = /obj/item/rogueweapon/spear
+				backl = /obj/item/rogueweapon/shield/tower/metal
 
 /datum/advclass/veteran/merc
 	name = "Retired Mercenary"
@@ -328,19 +329,20 @@
 		H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 4, TRUE) // two handed weapons require a LOT of stamina.
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Zweihander","Halberd")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Zweihander")
-			r_hand = /obj/item/rogueweapon/greatsword/grenz
-			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Halberd")
-			r_hand = /obj/item/rogueweapon/halberd
-			H.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE) // SO, fun fact. The description of the grenzel halbardier says they specialize in axes, but they get no axe skill. Maybe this guy is where that rumor came from.
-			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+	if(H.mind)
+		var/weapons = list("Zweihander","Halberd")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Zweihander")
+				r_hand = /obj/item/rogueweapon/greatsword/grenz
+				H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Halberd")
+				r_hand = /obj/item/rogueweapon/halberd
+				H.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE) // SO, fun fact. The description of the grenzel halbardier says they specialize in axes, but they get no axe skill. Maybe this guy is where that rumor came from.
+				H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 
 /datum/advclass/veteran/scout
 	name = "Former Scout"

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -52,20 +52,21 @@
 		/obj/item/storage/belt/rogue/pouch/coins/poor
 		)
 	var/weapons = list("Heavy Mace","Shamshir and Shield","Spear and Shield")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Heavy Mace")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
-			backl = /obj/item/rogueweapon/mace/goden
-		if("Shamshir and Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
-			r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
-			backl = /obj/item/rogueweapon/shield/tower/raneshen
-		if("Spear and Shield")
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
-			r_hand = /obj/item/rogueweapon/spear
-			backl = /obj/item/rogueweapon/shield/tower/raneshen
+	if(H.mind)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Heavy Mace")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
+				backl = /obj/item/rogueweapon/mace/goden
+			if("Shamshir and Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+				r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
+				backl = /obj/item/rogueweapon/shield/tower/raneshen
+			if("Spear and Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
+				r_hand = /obj/item/rogueweapon/spear
+				backl = /obj/item/rogueweapon/shield/tower/raneshen
 
 	shoes = /obj/item/clothing/shoes/roguetown/shalal
 	belt = /obj/item/storage/belt/rogue/leather/shalal
@@ -124,23 +125,24 @@
 		/obj/item/storage/belt/rogue/pouch/coins/poor
 		)
 	var/weapons = list("Shamshir and Javelin","Whips and Knives", "Recurve Bow")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Shamshir and Javelin")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-			r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
-			backl = /obj/item/quiver/javelin/iron
-		if("Whips and Knives")	///They DO enslave people after all
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
-			r_hand = /obj/item/rogueweapon/whip
-			l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
-			backl = /obj/item/rogueweapon/scabbard/sheath
-		if("Recurve Bow")
-			H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
-			r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-			backl = /obj/item/quiver/arrows
+	if(H.mind)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Shamshir and Javelin")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
+				backl = /obj/item/quiver/javelin/iron
+			if("Whips and Knives")	///They DO enslave people after all
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_EXPERT, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/rogueweapon/whip
+				l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
+				backl = /obj/item/rogueweapon/scabbard/sheath
+			if("Recurve Bow")
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+				backl = /obj/item/quiver/arrows
 	shoes = /obj/item/clothing/shoes/roguetown/shalal
 	belt = /obj/item/storage/belt/rogue/leather/shalal
 	beltl = /obj/item/rogueweapon/scabbard/sword

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/freifechter.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/freifechter.dm
@@ -30,20 +30,21 @@
 	l_hand = /obj/item/rogueweapon/scabbard/sword
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fencer	//Experimental.
 	var/weapons = list("Modified Training Sword !!!CHALLENGE!!!", "Etruscan Longsword", "Kriegsmesser", "Field Longsword")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Modified Training Sword !!!CHALLENGE!!!")		//A sharp feder. Less damage, better defense. Definitely not a good choice.
-			r_hand = /obj/item/rogueweapon/sword/long/frei
-			beltr = /obj/item/rogueweapon/huntingknife/idagger
-		if("Etruscan Longsword")		//A longsword with a compound ricasso. Accompanied by a traditional flip knife.
-			r_hand = /obj/item/rogueweapon/sword/long/etruscan
-			beltr = /obj/item/rogueweapon/huntingknife/idagger/navaja
-		if("Kriegsmesser")		//Och- eugh- German!
-			r_hand = /obj/item/rogueweapon/sword/long/kriegmesser
-			beltr = /obj/item/rogueweapon/huntingknife/idagger
-		if("Field Longsword")		//A common longsword.
-			r_hand = /obj/item/rogueweapon/sword/long
-			beltr = /obj/item/rogueweapon/huntingknife/idagger
+	if(H.mind)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Modified Training Sword !!!CHALLENGE!!!")		//A sharp feder. Less damage, better defense. Definitely not a good choice.
+				r_hand = /obj/item/rogueweapon/sword/long/frei
+				beltr = /obj/item/rogueweapon/huntingknife/idagger
+			if("Etruscan Longsword")		//A longsword with a compound ricasso. Accompanied by a traditional flip knife.
+				r_hand = /obj/item/rogueweapon/sword/long/etruscan
+				beltr = /obj/item/rogueweapon/huntingknife/idagger/navaja
+			if("Kriegsmesser")		//Och- eugh- German!
+				r_hand = /obj/item/rogueweapon/sword/long/kriegmesser
+				beltr = /obj/item/rogueweapon/huntingknife/idagger
+			if("Field Longsword")		//A common longsword.
+				r_hand = /obj/item/rogueweapon/sword/long
+				beltr = /obj/item/rogueweapon/huntingknife/idagger
 	belt = /obj/item/storage/belt/rogue/leather/sash
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/freifechter
@@ -84,17 +85,18 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/freifechter
 	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	var/weapons = list("Graduate's Spear", "Boar Spear", "Lucerne")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Graduate's Spear")		//A steel spear with a cool-looking stick & a banner sticking out of it.
-			r_hand = /obj/item/rogueweapon/spear/boar/frei
-			l_hand = /obj/item/rogueweapon/katar/punchdagger/frei
-		if("Boar Spear")
-			r_hand = /obj/item/rogueweapon/spear/boar
-			wrists = /obj/item/rogueweapon/katar/punchdagger
-		if("Lucerne")		//A normal lucerne for the people that get no drip & no bitches.
-			r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
-			wrists = /obj/item/rogueweapon/katar/punchdagger
+	if(H.mind)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Graduate's Spear")		//A steel spear with a cool-looking stick & a banner sticking out of it.
+				r_hand = /obj/item/rogueweapon/spear/boar/frei
+				l_hand = /obj/item/rogueweapon/katar/punchdagger/frei
+			if("Boar Spear")
+				r_hand = /obj/item/rogueweapon/spear/boar
+				wrists = /obj/item/rogueweapon/katar/punchdagger
+			if("Lucerne")		//A normal lucerne for the people that get no drip & no bitches.
+				r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
+				wrists = /obj/item/rogueweapon/katar/punchdagger
 
 	belt = /obj/item/storage/belt/rogue/leather/sash
 	beltl = /obj/item/flashlight/flare/torch/lantern

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -38,15 +38,16 @@
 	to_chat(H, span_warning("You are a Doppelsoldner - \"Double-pay Mercenary\" - an experienced frontline swordsman trained by the Zenitstadt fencing guild."))
 	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate
-	var/weapons = list("Zweihander", "Kriegmesser & Buckler")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Zweihander")
-			r_hand = /obj/item/rogueweapon/greatsword/grenz
-		if("Kriegmesser & Buckler") // Buckler cuz they have no shield skill.
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/long/kriegmesser
-			l_hand = /obj/item/rogueweapon/shield/buckler
+	if(H.mind)
+		var/weapons = list("Zweihander", "Kriegmesser & Buckler")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Zweihander")
+				r_hand = /obj/item/rogueweapon/greatsword/grenz
+			if("Kriegmesser & Buckler") // Buckler cuz they have no shield skill.
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/long/kriegmesser
+				l_hand = /obj/item/rogueweapon/shield/buckler
 	//General gear regardless of class.
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	belt = /obj/item/storage/belt/rogue/leather
@@ -99,13 +100,14 @@
 	to_chat(H, span_warning("You're an experienced soldier skilled in the use of polearms and axes. Your equals make up the bulk of the mercenary guild's forces."))
 	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate
-	var/weapons = list("Halberd", "Partizan")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	switch(weapon_choice)
-		if("Halberd")
-			r_hand = /obj/item/rogueweapon/halberd
-		if("Partizan")
-			r_hand = /obj/item/rogueweapon/spear/partizan
+	if(H.mind)
+		var/weapons = list("Halberd", "Partizan")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Halberd")
+				r_hand = /obj/item/rogueweapon/halberd
+			if("Partizan")
+				r_hand = /obj/item/rogueweapon/spear/partizan
 	//General gear regardless of class.
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	belt = /obj/item/storage/belt/rogue/leather
@@ -164,13 +166,14 @@
 	beltr = /obj/item/quiver/bolts
 	beltl = /obj/item/rogueweapon/stoneaxe/woodcut/steel
 	r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-	var/armor_options = list("Light Brigandine", "Studded Leather Vest")
-	var/armor_choice = input("Choose your armor.", "DRESS UP") as anything in armor_options
-	switch(armor_choice)
-		if("Light Brigandine")
-			armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light	// find a smithy to fix it
-		if("Studded Leather Vest")
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded		// or maintain it yourself!
+	if(H.mind)
+		var/armor_options = list("Light Brigandine", "Studded Leather Vest")
+		var/armor_choice = input("Choose your armor.", "DRESS UP") as anything in armor_options
+		switch(armor_choice)
+			if("Light Brigandine")
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light	// find a smithy to fix it
+			if("Studded Leather Vest")
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/studded		// or maintain it yourself!
 	//General gear regardless of class.
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	belt = /obj/item/storage/belt/rogue/leather

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgebearer.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grudgebearer.dm
@@ -100,13 +100,14 @@
 			/obj/item/paper/scroll/grudge,
 			/obj/item/natural/feather,
 			)
-		var/weapons = list("Axe", "Mace")
-		var/wepchoice = input("Choose your weapon", "Available weapons") as anything in weapons
-		switch(wepchoice)
-			if("Axe")
-				backr = /obj/item/rogueweapon/stoneaxe/battle
-			if("Mace")
-				backr = /obj/item/rogueweapon/mace/goden/steel
+		if(H.mind)
+			var/weapons = list("Axe", "Mace")
+			var/wepchoice = input("Choose your weapon", "Available weapons") as anything in weapons
+			switch(wepchoice)
+				if("Axe")
+					backr = /obj/item/rogueweapon/stoneaxe/battle
+				if("Mace")
+					backr = /obj/item/rogueweapon/mace/goden/steel
 		H.merctype = 8
 
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/routier.dm
@@ -40,23 +40,24 @@
 	// CLASS ARCHETYPES
 	H.adjust_blindness(-3)
 	var/classes = list("Swordsman","Macebearer","Flailman", "Foot Lancer")
-	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
-	H.set_blindness(0)
-	to_chat(H, span_warning("You are a Knight of Otava, well experienced in the use of your chosen arms."))
-	switch(classchoice)
-		if("Swordsman")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			l_hand = /obj/item/rogueweapon/sword/short/falchion
-		if("Macebearer")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
-			beltl = /obj/item/rogueweapon/mace/steel/morningstar
-		if("Flailman")
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
-			beltl = /obj/item/rogueweapon/flail/sflail
-		if("Foot Lancer")
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
-			r_hand = /obj/item/rogueweapon/spear/lance
+	if(H.mind)
+		var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
+		H.set_blindness(0)
+		to_chat(H, span_warning("You are a Knight of Otava, well experienced in the use of your chosen arms."))
+		switch(classchoice)
+			if("Swordsman")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				l_hand = /obj/item/rogueweapon/sword/short/falchion
+			if("Macebearer")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
+				beltl = /obj/item/rogueweapon/mace/steel/morningstar
+			if("Flailman")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
+				beltl = /obj/item/rogueweapon/flail/sflail
+			if("Foot Lancer")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
+				r_hand = /obj/item/rogueweapon/spear/lance
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
@@ -42,137 +42,138 @@
 
 	// CLASS ARCHETYPES
 	H.adjust_blindness(-3)
-	var/classes = list("Szabrista - Saber Veteran", "Árkász - Elite Sapper", "Druzhina - Light Archer","Kozak - Light Infantry")
-	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
+	if(H.mind)
+		var/classes = list("Szabrista - Saber Veteran", "Árkász - Elite Sapper", "Druzhina - Light Archer","Kozak - Light Infantry")
+		var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
-	switch(classchoice)
-		if("Szabrista - Saber Veteran")	//Tl;dr - medium armor class for Mount and Blade larpers who still get a saiga. Akin to Vaquero with specific drip.
-			H.set_blindness(0)
-			to_chat(H, span_warning("The Szabristas are the elites of the southern steppes, veterans of conflict across the realm. Outfitted with a shishka and shield, these warriors sacrifice their swiftness for armor and civilized respect."))
-			shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot/steppesman
-			head = /obj/item/clothing/head/roguetown/helmet/sallet/shishak		//Needs a unique helmet + mask combo at some point. 	//Dragonfruits to the rescue! Unique helmet with neck protection and +50 durability.
-			gloves = /obj/item/clothing/gloves/roguetown/chain
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/scale/steppe	//Scale armor w/ better durability & unique sprite
-			cloak = /obj/item/clothing/cloak/raincloak/furcloak
-			wrists = /obj/item/clothing/wrists/roguetown/bracers
-			backl = /obj/item/rogueweapon/shield/iron/steppesman
-			beltl= /obj/item/rogueweapon/scabbard/sword
-			l_hand = /obj/item/rogueweapon/sword/sabre/steppesman
-			neck = /obj/item/clothing/neck/roguetown/chaincoif
-			H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
-			H.change_stat(STATKEY_STR, 2)
-			H.change_stat(STATKEY_WIL, 1)
-			H.change_stat(STATKEY_CON, 2)
-			H.change_stat(STATKEY_SPD, 1)
-			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-			H.dna.species.soundpack_m = new /datum/voicepack/male/evil() 	//Fits in my head all too well.
-			var/masks = list(
-			"Humen" 	= /obj/item/clothing/mask/rogue/facemask/steel/steppesman,
-			"Beast"		= /obj/item/clothing/mask/rogue/facemask/steel/steppesman/anthro,
-			"None"
-	)
-			var/maskchoice = input("What fits your face?", "MASK SELECTION") as anything in masks
-			if(maskchoice != "None")
-				mask = masks[maskchoice]
+		switch(classchoice)
+			if("Szabrista - Saber Veteran")	//Tl;dr - medium armor class for Mount and Blade larpers who still get a saiga. Akin to Vaquero with specific drip.
+				H.set_blindness(0)
+				to_chat(H, span_warning("The Szabristas are the elites of the southern steppes, veterans of conflict across the realm. Outfitted with a shishka and shield, these warriors sacrifice their swiftness for armor and civilized respect."))
+				shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot/steppesman
+				head = /obj/item/clothing/head/roguetown/helmet/sallet/shishak		//Needs a unique helmet + mask combo at some point. 	//Dragonfruits to the rescue! Unique helmet with neck protection and +50 durability.
+				gloves = /obj/item/clothing/gloves/roguetown/chain
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale/steppe	//Scale armor w/ better durability & unique sprite
+				cloak = /obj/item/clothing/cloak/raincloak/furcloak
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				backl = /obj/item/rogueweapon/shield/iron/steppesman
+				beltl= /obj/item/rogueweapon/scabbard/sword
+				l_hand = /obj/item/rogueweapon/sword/sabre/steppesman
+				neck = /obj/item/clothing/neck/roguetown/chaincoif
+				H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+				H.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
+				H.change_stat(STATKEY_STR, 2)
+				H.change_stat(STATKEY_WIL, 1)
+				H.change_stat(STATKEY_CON, 2)
+				H.change_stat(STATKEY_SPD, 1)
+				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+				H.dna.species.soundpack_m = new /datum/voicepack/male/evil() 	//Fits in my head all too well.
+				var/masks = list(
+				"Humen" 	= /obj/item/clothing/mask/rogue/facemask/steel/steppesman,
+				"Beast"		= /obj/item/clothing/mask/rogue/facemask/steel/steppesman/anthro,
+				"None"
+		)
+				var/maskchoice = input("What fits your face?", "MASK SELECTION") as anything in masks
+				if(maskchoice != "None")
+					mask = masks[maskchoice]
 
-		if("Árkász - Elite Sapper")	//Tl;dr - medium armor sappers with less mobility in exchange for their different statblock and equipment.
-			H.set_blindness(0)
-			to_chat(H, span_warning("The Árkászi are frontline sappers specialized in sowing chaos and confusion in tandem with the Szabristas, focused on raw strength and will over the company's swordsmen and archers."))
-			shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot/steppesman
-			head = /obj/item/clothing/head/roguetown/helmet/sallet/shishak
-			gloves = /obj/item/clothing/gloves/roguetown/chain
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/scale/steppe
-			wrists = /obj/item/clothing/wrists/roguetown/bracers
-			backl = /obj/item/rogueweapon/shield/iron/steppesman
-			l_hand = /obj/item/rogueweapon/stoneaxe/battle/steppesman
-			neck = /obj/item/clothing/neck/roguetown/chaincoif
-			H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/craft/carpentry, 2, TRUE)		//To avoid virtue cheese
-			H.adjust_skillrank_up_to(/datum/skill/craft/crafting, 2, TRUE)		//Ditto
-			H.adjust_skillrank_up_to(/datum/skill/labor/mining, 3, TRUE)		//Ditto
-			H.adjust_skillrank_up_to(/datum/skill/craft/traps, 3, TRUE)			//Ditto
-			H.change_stat(STATKEY_STR, 2)		//Statblock prone to revision. Probably will be revised. Currently weighted for 7 points and not 9.
-			H.change_stat(STATKEY_WIL, 3)
-			H.change_stat(STATKEY_CON, 2)
-			H.change_stat(STATKEY_PER, 2)
-			H.change_stat(STATKEY_SPD, -2)
-			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-			H.dna.species.soundpack_m = new /datum/voicepack/male/evil()
-			var/masks = list(
-			"Humen" 	= /obj/item/clothing/mask/rogue/facemask/steel/steppesman,
-			"Beast"		= /obj/item/clothing/mask/rogue/facemask/steel/steppesman/anthro,
-			"None"
-	)
-			var/maskchoice = input("What fits your face?", "MASK SELECTION") as anything in masks
-			if(maskchoice != "None")
-				mask = masks[maskchoice]
+			if("Árkász - Elite Sapper")	//Tl;dr - medium armor sappers with less mobility in exchange for their different statblock and equipment.
+				H.set_blindness(0)
+				to_chat(H, span_warning("The Árkászi are frontline sappers specialized in sowing chaos and confusion in tandem with the Szabristas, focused on raw strength and will over the company's swordsmen and archers."))
+				shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot/steppesman
+				head = /obj/item/clothing/head/roguetown/helmet/sallet/shishak
+				gloves = /obj/item/clothing/gloves/roguetown/chain
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale/steppe
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				backl = /obj/item/rogueweapon/shield/iron/steppesman
+				l_hand = /obj/item/rogueweapon/stoneaxe/battle/steppesman
+				neck = /obj/item/clothing/neck/roguetown/chaincoif
+				H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+				H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/craft/carpentry, 2, TRUE)		//To avoid virtue cheese
+				H.adjust_skillrank_up_to(/datum/skill/craft/crafting, 2, TRUE)		//Ditto
+				H.adjust_skillrank_up_to(/datum/skill/labor/mining, 3, TRUE)		//Ditto
+				H.adjust_skillrank_up_to(/datum/skill/craft/traps, 3, TRUE)			//Ditto
+				H.change_stat(STATKEY_STR, 2)		//Statblock prone to revision. Probably will be revised. Currently weighted for 7 points and not 9.
+				H.change_stat(STATKEY_WIL, 3)
+				H.change_stat(STATKEY_CON, 2)
+				H.change_stat(STATKEY_PER, 2)
+				H.change_stat(STATKEY_SPD, -2)
+				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+				H.dna.species.soundpack_m = new /datum/voicepack/male/evil()
+				var/masks = list(
+				"Humen" 	= /obj/item/clothing/mask/rogue/facemask/steel/steppesman,
+				"Beast"		= /obj/item/clothing/mask/rogue/facemask/steel/steppesman/anthro,
+				"None"
+		)
+				var/maskchoice = input("What fits your face?", "MASK SELECTION") as anything in masks
+				if(maskchoice != "None")
+					mask = masks[maskchoice]
 
-		if("Druzhina - Light Archer")	//Tl;dr - light armor class for Tatar-style archery. Has 'Druzhina' as a name cus czech/polish influence, couldn't think of better one.
-			H.set_blindness(0)
-			to_chat(H, span_warning("A Druzhina, a commoner of the Aavnic steppes made into a professional soldier. Hunters, herders, and various nomads from all walks of life. Equal in service, equal behind their bow, and ready to fight."))
-			shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot/steppesman
-			head = /obj/item/clothing/head/roguetown/helmet/sallet/shishak
-			gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/steppe
-			cloak = /obj/item/clothing/cloak/raincloak/furcloak
-			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-			beltr = /obj/item/quiver/javelin/iron
-			beltl = /obj/item/quiver/arrows
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/steppesman
-			neck = /obj/item/clothing/neck/roguetown/leather
-			H.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/tracking, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
-			H.change_stat(STATKEY_PER, 3)
-			H.change_stat(STATKEY_WIL, 2)
-			H.change_stat(STATKEY_SPD, 2)
-			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-		if("Kozak - Light Infantry")		//Tl;dr - Old Steppesman whip build, light armor, be the glass canon you always wanted to be. Live your life, king. 
-			H.set_blindness(0)
-			to_chat(H, span_warning("Being a Kozak is not a title one earns, nor is born with. It's a way of life. Known to be eccentric, living life on the edge - but living as free as possible. Skilled with whips, these madmen are the bane of civilized warriors."))
-			shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
-			head = /obj/item/clothing/head/roguetown/papakha	//No helm
-			gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/steppe
-			cloak = /obj/item/clothing/cloak/volfmantle			//Crazed man, gives the look.
-			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-			beltr = /obj/item/rogueweapon/shield/buckler		//Doesn't get good shield skill + no armor, so they get this to compensate for no parry on whip.
-			beltl = /obj/item/rogueweapon/whip
-			neck = /obj/item/clothing/neck/roguetown/bevor		//Better neckpiece for slightly less skill variety. Based it off a cool piece of art...
-			H.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)		//Bit high but he doesn't get huge strength boons so makes up for it. Same as a guard.
-			H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
-			H.change_stat(STATKEY_STR, 1)
-			H.change_stat(STATKEY_PER, 2)
-			H.change_stat(STATKEY_WIL, 1)
-			H.change_stat(STATKEY_SPD, 2)
-			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-			ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)
-			H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()		//Semi-crazed warrior vibe.
+			if("Druzhina - Light Archer")	//Tl;dr - light armor class for Tatar-style archery. Has 'Druzhina' as a name cus czech/polish influence, couldn't think of better one.
+				H.set_blindness(0)
+				to_chat(H, span_warning("A Druzhina, a commoner of the Aavnic steppes made into a professional soldier. Hunters, herders, and various nomads from all walks of life. Equal in service, equal behind their bow, and ready to fight."))
+				shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot/steppesman
+				head = /obj/item/clothing/head/roguetown/helmet/sallet/shishak
+				gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/steppe
+				cloak = /obj/item/clothing/cloak/raincloak/furcloak
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+				beltr = /obj/item/quiver/javelin/iron
+				beltl = /obj/item/quiver/arrows
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/steppesman
+				neck = /obj/item/clothing/neck/roguetown/leather
+				H.adjust_skillrank(/datum/skill/combat/bows, 5, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/knives, 4, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/misc/tracking, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
+				H.change_stat(STATKEY_PER, 3)
+				H.change_stat(STATKEY_WIL, 2)
+				H.change_stat(STATKEY_SPD, 2)
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			if("Kozak - Light Infantry")		//Tl;dr - Old Steppesman whip build, light armor, be the glass canon you always wanted to be. Live your life, king. 
+				H.set_blindness(0)
+				to_chat(H, span_warning("Being a Kozak is not a title one earns, nor is born with. It's a way of life. Known to be eccentric, living life on the edge - but living as free as possible. Skilled with whips, these madmen are the bane of civilized warriors."))
+				shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+				head = /obj/item/clothing/head/roguetown/papakha	//No helm
+				gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/steppe
+				cloak = /obj/item/clothing/cloak/volfmantle			//Crazed man, gives the look.
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+				beltr = /obj/item/rogueweapon/shield/buckler		//Doesn't get good shield skill + no armor, so they get this to compensate for no parry on whip.
+				beltl = /obj/item/rogueweapon/whip
+				neck = /obj/item/clothing/neck/roguetown/bevor		//Better neckpiece for slightly less skill variety. Based it off a cool piece of art...
+				H.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
+				H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)		//Bit high but he doesn't get huge strength boons so makes up for it. Same as a guard.
+				H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+				H.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
+				H.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
+				H.change_stat(STATKEY_STR, 1)
+				H.change_stat(STATKEY_PER, 2)
+				H.change_stat(STATKEY_WIL, 1)
+				H.change_stat(STATKEY_SPD, 2)
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+				ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)
+				H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()		//Semi-crazed warrior vibe.
 		
 	H.merctype = 11

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/vaquero.dm
@@ -31,7 +31,7 @@
 		/datum/skill/misc/music = SKILL_LEVEL_EXPERT,
 	)
 
-/datum/advclass/mercenary/vaquero/equipme(mob/living/carbon/human/H)
+/datum/advclass/mercenary/vaquero/equipme(mob/living/carbon/human/H, dummy)
 	if(should_wear_femme_clothes(H))
 		horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled
 	return ..()
@@ -62,24 +62,25 @@
 					/obj/item/roguekey/mercenary = 1,
 					/obj/item/rogueweapon/scabbard/sheath = 1
 					)
-	var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute")
-	var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Harp")
-			backr = /obj/item/rogue/instrument/harp
-		if("Lute")
-			backr = /obj/item/rogue/instrument/lute
-		if("Accordion")
-			backr = /obj/item/rogue/instrument/accord
-		if("Guitar")
-			backr = /obj/item/rogue/instrument/guitar
-		if("Hurdy-Gurdy")
-			backr = /obj/item/rogue/instrument/hurdygurdy
-		if("Viola")
-			backr = /obj/item/rogue/instrument/viola
-		if("Vocal Talisman")
-			backr = /obj/item/rogue/instrument/vocals
-		if("Flute")
-			backr = /obj/item/rogue/instrument/flute
+	if(H.mind)
+		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute")
+		var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Harp")
+				backr = /obj/item/rogue/instrument/harp
+			if("Lute")
+				backr = /obj/item/rogue/instrument/lute
+			if("Accordion")
+				backr = /obj/item/rogue/instrument/accord
+			if("Guitar")
+				backr = /obj/item/rogue/instrument/guitar
+			if("Hurdy-Gurdy")
+				backr = /obj/item/rogue/instrument/hurdygurdy
+			if("Viola")
+				backr = /obj/item/rogue/instrument/viola
+			if("Vocal Talisman")
+				backr = /obj/item/rogue/instrument/vocals
+			if("Flute")
+				backr = /obj/item/rogue/instrument/flute
 	H.merctype = 13

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -52,8 +52,6 @@
 		"MAROON" = "#5F1F34",
 		"BLACK" = "#242526"
 	))
-	detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
-	detailcolor = naledicolors[detailcolor]
 	to_chat(H, span_warning("You are a Naledi Hierophant, a magician who studied under cloistered sages, well-versed in all manners of arcyne. You prioritize enhancing your teammates and distracting foes while staying in the backline."))
 	if(H.age == AGE_OLD)
 		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 5, TRUE)
@@ -62,6 +60,8 @@
 		H.change_stat(STATKEY_PER, 1)
 		H.mind?.adjust_spellpoints(6)
 	if(H.mind)
+		detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
+		detailcolor = naledicolors[detailcolor]
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/giants_strength)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/longstrider)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)
@@ -138,10 +138,10 @@
 		"MAROON" = "#5F1F34",
 		"BLACK" = "#242526"
 	))
-	detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
-	detailcolor = naledicolors[detailcolor]
 	to_chat(H, span_warning("You are a Naledi Pontifex, a warrior trained into a hybridized style of movement-controlling magic and hand-to-hand combat. Though your abilities in magical fields are lacking, you are far more dangerous than other magi in a straight fight. You manifest your calm, practiced skill into a killing intent that takes the shape of an arcyne blade."))
 	if(H.mind)
+		detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
+		detailcolor = naledicolors[detailcolor]
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch) // In an attempt to make them less Possibly Wildly OP, they can't freely pick their spells. Casts at apprentice level, but doesn't get the spellbuy points it'd provide.
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/ensnare)
@@ -215,8 +215,6 @@
 		"MAROON" = "#5F1F34",
 		"BLACK" = "#242526"
 	))
-	detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
-	detailcolor = naledicolors[detailcolor]
 	to_chat(H, span_warning("You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though psydonians have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough."))
 	r_hand = /obj/item/rogueweapon/woodstaff/naledi
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/magered
@@ -246,6 +244,8 @@
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.
 	if(H.mind)
+		detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
+		detailcolor = naledicolors[detailcolor]
 		H.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/lesser_heal)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -125,116 +125,117 @@
 		/mob/living/carbon/human/mind/proc/setorders
 	)
 	H.adjust_blindness(-3)
-	var/weapons = list(
-		"Zweihander",
-		"Great Mace",
-		"Battle Axe",
-		"Greataxe",
-		"Estoc",
-		"Longsword",
-		"Flail",
-		"Sabre",
-		"Lance",
+	if(H.mind)
+		var/weapons = list(
+			"Zweihander",
+			"Great Mace",
+			"Battle Axe",
+			"Greataxe",
+			"Estoc",
+			"Longsword",
+			"Flail",
+			"Sabre",
+			"Lance",
+			)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Zweihander")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
+				r_hand = /obj/item/rogueweapon/greatsword/zwei
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Greataxe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
+				r_hand = /obj/item/rogueweapon/greataxe/steel/doublehead
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Estoc")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
+				r_hand = /obj/item/rogueweapon/estoc
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Battle Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
+				r_hand = /obj/item/rogueweapon/stoneaxe/battle
+			if("Great Mace")
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 5, TRUE)
+				r_hand = /obj/item/rogueweapon/mace/goden/steel
+			if("Longsword")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
+				r_hand = /obj/item/rogueweapon/sword/long
+				beltr = /obj/item/rogueweapon/scabbard/sword
+			if("Flail")
+				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 5, TRUE)
+				beltr = /obj/item/rogueweapon/flail/sflail
+			if("Sabre")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/sabre
+			if("Lance")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
+				r_hand = /obj/item/rogueweapon/spear/lance
+		if(weapon_choice in list("Battle Axe", "Great Mace", "Longsword", "Flail", "Sabre", "Lance"))
+			var/secondary = list(
+				"Kite Shield",
+				"Crossbow",
+				"Recurve Bow",
+			)
+			var/secondary_choice = input("Choose your secondary.", "TAKE UP ARMS") as anything in secondary
+			switch(secondary_choice)
+				if("Kite Shield")
+					backl = /obj/item/rogueweapon/shield/tower/metal
+				if("Crossbow")
+					H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
+					backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+					beltl = /obj/item/quiver/bolts
+				if("Recurve Bow")
+					H.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
+					beltl = /obj/item/quiver/arrows
+					backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+
+		var/armors = list(
+			"Brigandine",
+			"Coat of Plates",
+			"Steel Cuirass",
+			"Captain's armor"
 		)
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Zweihander")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-			r_hand = /obj/item/rogueweapon/greatsword/zwei
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Greataxe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
-			r_hand = /obj/item/rogueweapon/greataxe/steel/doublehead
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Estoc")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-			r_hand = /obj/item/rogueweapon/estoc
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Battle Axe")
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
-			r_hand = /obj/item/rogueweapon/stoneaxe/battle
-		if("Great Mace")
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, 5, TRUE)
-			r_hand = /obj/item/rogueweapon/mace/goden/steel
-		if("Longsword")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-			r_hand = /obj/item/rogueweapon/sword/long
-			beltr = /obj/item/rogueweapon/scabbard/sword
-		if("Flail")
-			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 5, TRUE)
-			beltr = /obj/item/rogueweapon/flail/sflail
-		if("Sabre")
-			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/sabre
-		if("Lance")
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
-			r_hand = /obj/item/rogueweapon/spear/lance
-	if(weapon_choice in list("Battle Axe", "Great Mace", "Longsword", "Flail", "Sabre", "Lance"))
-		var/secondary = list(
-			"Kite Shield",
-			"Crossbow",
-			"Recurve Bow",
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		switch(armorchoice)
+			if("Brigandine")
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				cloak = /obj/item/clothing/cloak/stabard
+			if("Coat of Plates")
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				cloak = /obj/item/clothing/cloak/stabard
+			if("Fluted Cuirass")
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				cloak = /obj/item/clothing/cloak/stabard
+			if("Captain's armor")
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/captain
+				pants = /obj/item/clothing/under/roguetown/chainlegs/captain
+				head = /obj/item/clothing/head/roguetown/helmet/heavy/captain
+				cloak = /obj/item/clothing/cloak/captain
+
+		if(armorchoice == "Captain's armor")
+			return // Get helmet from armor selection
+
+		var/helmets = list(
+			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
+			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
+			"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
+			"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
+			"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
+			"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
+			"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+			"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
+			"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Slitted Kettle"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
+			"None"
 		)
-		var/secondary_choice = input("Choose your secondary.", "TAKE UP ARMS") as anything in secondary
-		switch(secondary_choice)
-			if("Kite Shield")
-				backl = /obj/item/rogueweapon/shield/tower/metal
-			if("Crossbow")
-				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
-				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-				beltl = /obj/item/quiver/bolts
-			if("Recurve Bow")
-				H.adjust_skillrank_up_to(/datum/skill/combat/bows, 4, TRUE)
-				beltl = /obj/item/quiver/arrows
-				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-
-	var/armors = list(
-		"Brigandine",
-		"Coat of Plates",
-		"Steel Cuirass",
-		"Captain's armor"
-	)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	switch(armorchoice)
-		if("Brigandine")
-			armor = /obj/item/clothing/suit/roguetown/armor/brigandine
-			pants = /obj/item/clothing/under/roguetown/chainlegs
-			cloak = /obj/item/clothing/cloak/stabard
-		if("Coat of Plates")
-			armor = /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates
-			pants = /obj/item/clothing/under/roguetown/chainlegs
-			cloak = /obj/item/clothing/cloak/stabard
-		if("Fluted Cuirass")
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted
-			pants = /obj/item/clothing/under/roguetown/chainlegs
-			cloak = /obj/item/clothing/cloak/stabard
-		if("Captain's armor")
-			armor = /obj/item/clothing/suit/roguetown/armor/brigandine/captain
-			pants = /obj/item/clothing/under/roguetown/chainlegs/captain
-			head = /obj/item/clothing/head/roguetown/helmet/heavy/captain
-			cloak = /obj/item/clothing/cloak/captain
-
-	if(armorchoice == "Captain's armor")
-		return // Get helmet from armor selection
-
-	var/helmets = list(
-		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
-		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
-		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
-		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
-		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
-		"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
-		"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
-		"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-		"Slitted Kettle"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
-		"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
 /obj/effect/proc_holder/spell/self/convertrole
 	name = "Recruit Beggar"

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -111,58 +111,60 @@
 	H.verbs |= /mob/proc/haltyell
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Zweihander","Great Mace","Battle Axe","Greataxe","Estoc","Lucerne", "Partizan")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Zweihander")
-			r_hand = /obj/item/rogueweapon/greatsword/zwei
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Great Mace")
-			r_hand = /obj/item/rogueweapon/mace/goden/steel
-		if("Battle Axe")
-			r_hand = /obj/item/rogueweapon/stoneaxe/battle
-		if("Greataxe")
-			r_hand = /obj/item/rogueweapon/greataxe/steel
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Estoc")
-			r_hand = /obj/item/rogueweapon/estoc
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Lucerne")
-			r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-		if("Partizan")
-			r_hand = /obj/item/rogueweapon/spear/partizan
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
+	if(H.mind)
+		var/weapons = list("Zweihander","Great Mace","Battle Axe","Greataxe","Estoc","Lucerne", "Partizan")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Zweihander")
+				r_hand = /obj/item/rogueweapon/greatsword/zwei
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Great Mace")
+				r_hand = /obj/item/rogueweapon/mace/goden/steel
+			if("Battle Axe")
+				r_hand = /obj/item/rogueweapon/stoneaxe/battle
+			if("Greataxe")
+				r_hand = /obj/item/rogueweapon/greataxe/steel
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Estoc")
+				r_hand = /obj/item/rogueweapon/estoc
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Lucerne")
+				r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Partizan")
+				r_hand = /obj/item/rogueweapon/spear/partizan
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
 
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 
-	var/helmets = list(
-		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
-		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
-		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
-		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
-		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
-		"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
-		"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
-		"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-		"Slitted Kettle" = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
-		"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+	if(H.mind)
+		var/helmets = list(
+			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
+			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
+			"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
+			"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
+			"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
+			"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
+			"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+			"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
+			"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Slitted Kettle" = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
+			"None"
+		)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/armors = list(
-		"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-		"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
-		"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
-		"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
-	)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	armor = armors[armorchoice]
+		var/armors = list(
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
+			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
+			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
+			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+		)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		armor = armors[armorchoice]
 
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, 
@@ -204,50 +206,51 @@
 	H.verbs |= /mob/proc/haltyell
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Longsword","Flail","Warhammer","Sabre")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Longsword")
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			l_hand = /obj/item/rogueweapon/sword/long
-		if("Flail")
-			beltr = /obj/item/rogueweapon/flail/sflail
-		if ("Warhammer")
-			beltr = /obj/item/rogueweapon/mace/warhammer //Iron warhammer. This is one-handed and pairs well with shields. They can upgrade to steel in-round.
-		if("Sabre")
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			l_hand = /obj/item/rogueweapon/sword/sabre
+	if(H.mind)
+		var/weapons = list("Longsword","Flail","Warhammer","Sabre")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Longsword")
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				l_hand = /obj/item/rogueweapon/sword/long
+			if("Flail")
+				beltr = /obj/item/rogueweapon/flail/sflail
+			if ("Warhammer")
+				beltr = /obj/item/rogueweapon/mace/warhammer //Iron warhammer. This is one-handed and pairs well with shields. They can upgrade to steel in-round.
+			if("Sabre")
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				l_hand = /obj/item/rogueweapon/sword/sabre
 	
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	backl = /obj/item/rogueweapon/shield/tower/metal
+	if(H.mind)
+		var/helmets = list(
+			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
+			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
+			"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
+			"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
+			"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
+			"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
+			"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+			"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
+			"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Slitted Kettle"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
+			"None"
+		)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/helmets = list(
-		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
-		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
-		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
-		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
-		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
-		"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
-		"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
-		"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-		"Slitted Kettle"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
-		"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
-
-	var/armors = list(
-		"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-		"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
-		"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
-		"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
-	)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	armor = armors[armorchoice]
+		var/armors = list(
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
+			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
+			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
+			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+		)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		armor = armors[armorchoice]
 
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, 
@@ -293,69 +296,71 @@
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	H.verbs |= /mob/proc/haltyell
 
-	H.adjust_blindness(-3)
-	var/weapons = list(
-		"Longsword + Crossbow",
-		"Billhook + Recurve Bow",
-		"Grand Mace + Longbow", 
-		"Sabre + Recurve Bow",
-		"Lance + Kite Shield"
-	)
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Longsword + Crossbow")
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/long
-			beltr = /obj/item/quiver/bolts
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-		if("Billhook + Recurve Bow")
-			r_hand = /obj/item/rogueweapon/spear/billhook
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-			beltr = /obj/item/quiver/arrows
-			beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-		if("Grand Mace + Longbow")
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
-			beltr = /obj/item/quiver/arrows
-			beltl = /obj/item/rogueweapon/mace/goden/steel
-		if("Sabre + Recurve Bow")
-			l_hand = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/sabre
-			beltr = /obj/item/quiver/arrows
-			beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
-		if("Lance + Kite Shield")
-			r_hand = /obj/item/rogueweapon/spear/lance
-			backl = /obj/item/rogueweapon/shield/tower/metal
-			H.adjust_skillrank_up_to(/datum/skill/combat/shields, 2, TRUE) // Let them skip dummy hitting
+	if(H.mind)
+		H.adjust_blindness(-3)
+		var/weapons = list(
+			"Longsword + Crossbow",
+			"Billhook + Recurve Bow",
+			"Grand Mace + Longbow", 
+			"Sabre + Recurve Bow",
+			"Lance + Kite Shield"
+		)
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Longsword + Crossbow")
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/long
+				beltr = /obj/item/quiver/bolts
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+			if("Billhook + Recurve Bow")
+				r_hand = /obj/item/rogueweapon/spear/billhook
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				beltr = /obj/item/quiver/arrows
+				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			if("Grand Mace + Longbow")
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
+				beltr = /obj/item/quiver/arrows
+				beltl = /obj/item/rogueweapon/mace/goden/steel
+			if("Sabre + Recurve Bow")
+				l_hand = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/sabre
+				beltr = /obj/item/quiver/arrows
+				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			if("Lance + Kite Shield")
+				r_hand = /obj/item/rogueweapon/spear/lance
+				backl = /obj/item/rogueweapon/shield/tower/metal
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 2, TRUE) // Let them skip dummy hitting
 
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 
-	var/helmets = list(
-		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
-		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
-		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
-		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
-		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
-		"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
-		"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
-		"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-		"Slitted Kettle"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
-		"None"
-	)
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+	if(H.mind)
+		var/helmets = list(
+			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
+			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
+			"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
+			"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
+			"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
+			"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
+			"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+			"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
+			"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Slitted Kettle"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
+			"None"
+		)
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 
-	var/armors = list(
-		"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-		"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
-		"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
-		"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
-	)
-	var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
-	armor = armors[armorchoice]
+		var/armors = list(
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
+			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
+			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
+			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
+		)
+		var/armorchoice = input("Choose your armor.", "TAKE UP ARMOR") as anything in armors
+		armor = armors[armorchoice]
 
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, 
@@ -401,73 +406,74 @@
 	H.verbs |= /mob/proc/haltyell
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Rapier + Longbow","Estoc + Recurve Bow","Sabre + Buckler","Whip + Crossbow","Greataxe + Sling")
-	var/armor_options = list("Light Armor", "Medium Armor", "Medium Cuirass")
-	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-	var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armor_options
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Rapier + Longbow")
-			r_hand = /obj/item/rogueweapon/sword/rapier
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
-			beltr = /obj/item/quiver/arrows
+	if(H.mind)
+		var/weapons = list("Rapier + Longbow","Estoc + Recurve Bow","Sabre + Buckler","Whip + Crossbow","Greataxe + Sling")
+		var/armor_options = list("Light Armor", "Medium Armor", "Medium Cuirass")
+		var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		var/armor_choice = input("Choose your armor.", "TAKE UP ARMS") as anything in armor_options
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Rapier + Longbow")
+				r_hand = /obj/item/rogueweapon/sword/rapier
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
+				beltr = /obj/item/quiver/arrows
 
-		if("Estoc + Recurve Bow")
-			r_hand = /obj/item/rogueweapon/estoc
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-			beltr = /obj/item/quiver/arrows
-			beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			if("Estoc + Recurve Bow")
+				r_hand = /obj/item/rogueweapon/estoc
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				beltr = /obj/item/quiver/arrows
+				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			
+			if("Sabre + Buckler")
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/sabre
+				backl = /obj/item/rogueweapon/shield/buckler
+
+			if("Whip + Crossbow")
+				beltl = /obj/item/rogueweapon/whip
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltr = /obj/item/quiver/bolts
+			
+			if("Greataxe + Sling")
+				H.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
+				r_hand = /obj/item/rogueweapon/greataxe/steel
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				beltr = /obj/item/quiver/sling/iron
+				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
 		
-		if("Sabre + Buckler")
-			beltl = /obj/item/rogueweapon/scabbard/sword
-			r_hand = /obj/item/rogueweapon/sword/sabre
-			backl = /obj/item/rogueweapon/shield/buckler
+		switch(armor_choice)
+			if("Light Armor")
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+			if("Medium Armor")
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+			if("Medium Cuirass")
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted
 
-		if("Whip + Crossbow")
-			beltl = /obj/item/rogueweapon/whip
-			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-			beltr = /obj/item/quiver/bolts
+		var/helmets = list(
+			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
+			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
+			"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
+			"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
+			"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
+			"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
+			"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
+			"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
+			"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
+			"Slitted Kettle" = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
+			"None"
+		)
 		
-		if("Greataxe + Sling")
-			H.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE)
-			H.adjust_skillrank_up_to(/datum/skill/combat/axes, 4, TRUE)
-			r_hand = /obj/item/rogueweapon/greataxe/steel
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
-			beltr = /obj/item/quiver/sling/iron
-			beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
-	
-	switch(armor_choice)
-		if("Light Armor")
-			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-			armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-		if("Medium Armor")
-			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
-			pants = /obj/item/clothing/under/roguetown/chainlegs
-			armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
-		if("Medium Cuirass")
-			shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
-			pants = /obj/item/clothing/under/roguetown/chainlegs
-			armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted
-
-	var/helmets = list(
-		"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
-		"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
-		"Barred Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/sheriff,
-		"Bucket Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket,
-		"Knight Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-		"Visored Sallet"	= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
-		"Armet"				= /obj/item/clothing/head/roguetown/helmet/heavy/knight/armet,
-		"Hounskull Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
-		"Etruscan Bascinet" = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-		"Slitted Kettle" = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
-		"None"
-	)
-	
-	var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
-	if(helmchoice != "None")
-		head = helmets[helmchoice]
+		var/helmchoice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, 
 		/obj/item/rope/chain = 1, 

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -142,26 +142,27 @@
 		belt = /obj/item/storage/belt/rogue/leather/black
 		shoes = /obj/item/clothing/shoes/roguetown/sandals
 
-	var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute")
-	var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Harp")
-			backr = /obj/item/rogue/instrument/harp
-		if("Lute")
-			backr = /obj/item/rogue/instrument/lute
-		if("Accordion")
-			backr = /obj/item/rogue/instrument/accord
-		if("Guitar")
-			backr = /obj/item/rogue/instrument/guitar
-		if("Hurdy-Gurdy")
-			backr = /obj/item/rogue/instrument/hurdygurdy
-		if("Viola")
-			backr = /obj/item/rogue/instrument/viola
-		if("Vocal Talisman")
-			backr = /obj/item/rogue/instrument/vocals
-		if("Flute")
-			backr = /obj/item/rogue/instrument/flute
+	if(H.mind)
+		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute")
+		var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Harp")
+				backr = /obj/item/rogue/instrument/harp
+			if("Lute")
+				backr = /obj/item/rogue/instrument/lute
+			if("Accordion")
+				backr = /obj/item/rogue/instrument/accord
+			if("Guitar")
+				backr = /obj/item/rogue/instrument/guitar
+			if("Hurdy-Gurdy")
+				backr = /obj/item/rogue/instrument/hurdygurdy
+			if("Viola")
+				backr = /obj/item/rogue/instrument/viola
+			if("Vocal Talisman")
+				backr = /obj/item/rogue/instrument/vocals
+			if("Flute")
+				backr = /obj/item/rogue/instrument/flute
 
 /datum/advclass/nightmaiden/courtesan
 	name = "Courtesan"
@@ -228,26 +229,27 @@
 		belt = /obj/item/storage/belt/rogue/leather/black
 		shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/short
 
-	var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute")
-	var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
-	H.set_blindness(0)
-	switch(weapon_choice)
-		if("Harp")
-			backr = /obj/item/rogue/instrument/harp
-		if("Lute")
-			backr = /obj/item/rogue/instrument/lute
-		if("Accordion")
-			backr = /obj/item/rogue/instrument/accord
-		if("Guitar")
-			backr = /obj/item/rogue/instrument/guitar
-		if("Hurdy-Gurdy")
-			backr = /obj/item/rogue/instrument/hurdygurdy
-		if("Viola")
-			backr = /obj/item/rogue/instrument/viola
-		if("Vocal Talisman")
-			backr = /obj/item/rogue/instrument/vocals
-		if("Flute")
-			backr = /obj/item/rogue/instrument/flute
+	if(H.mind)
+		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute")
+		var/weapon_choice = input("Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Harp")
+				backr = /obj/item/rogue/instrument/harp
+			if("Lute")
+				backr = /obj/item/rogue/instrument/lute
+			if("Accordion")
+				backr = /obj/item/rogue/instrument/accord
+			if("Guitar")
+				backr = /obj/item/rogue/instrument/guitar
+			if("Hurdy-Gurdy")
+				backr = /obj/item/rogue/instrument/hurdygurdy
+			if("Viola")
+				backr = /obj/item/rogue/instrument/viola
+			if("Vocal Talisman")
+				backr = /obj/item/rogue/instrument/vocals
+			if("Flute")
+				backr = /obj/item/rogue/instrument/flute
 
 /obj/item/soap/bath
 	name = "herbal soap"

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -41,22 +41,21 @@
 	if(parent.is_new_player())
 		return
 //	last_preview_update = world.time
-	// Determine what job is marked as 'High' priority, and dress them up as such.
+	// Set up the dummy for its photoshoot
 	var/datum/job/previewJob
 	var/highest_pref = 0
 	for(var/job in job_preferences)
 		if(job_preferences[job] > highest_pref)
 			previewJob = SSjob.GetJob(job)
 			highest_pref = job_preferences[job]
-
-	// Set up the dummy for its photoshoot
 	var/mob/living/carbon/human/dummy/mannequin = generate_or_wait_for_human_dummy(DUMMY_HUMAN_SLOT_PREFERENCES)
 	copy_to(mannequin, 1, TRUE, TRUE)
 
-	if(previewJob)
+	if(preview_subclass && previewJob)
 		testing("previewjob")
 		mannequin.job = previewJob.title
-		previewJob.equip(mannequin, TRUE, preference_source = parent)
+		mannequin.patron = selected_patron
+		preview_subclass.equipme(mannequin, dummy = TRUE)
 
 	mannequin.rebuild_obscured_flags()
 	COMPILE_OVERLAYS(mannequin)


### PR DESCRIPTION
## About The Pull Request
![fghMV5hMkU](https://github.com/user-attachments/assets/b4c95fda-e64a-445b-8d95-5e4221352300)

It also respects patron choices, where applicable. Or tries to.
![omPDVQPuys](https://github.com/user-attachments/assets/55d6288c-2415-4c40-8da6-c2219b005634)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The class refactors SORT of allowed this. Unfortunately, every single input box needs to be gated behind a mind check until optional / user-chosen equipment is handled... somehow else. I'm not quite sure how yet. Probably migrated to the advclass datum as well in another tiring refactor.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
