### PR TITLE
Fixes silver blessed stuff

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -42,10 +42,11 @@
 			if(used.armor?.getRating("blunt") > 0)
 				var/bluntrating = used.armor.getRating("blunt")
 				intdamage -= intdamage * ((bluntrating / 2) / 100)	//Half of the blunt rating reduces blunt damage taken by %-age.
-		if(istype(used_weapon) && used_weapon.is_silver && (used.smeltresult in list(/obj/item/ingot/aaslag, /obj/item/ingot/aalloy, /obj/item/ingot/purifiedaalloy)) || used.GetComponent(/datum/component/cursed_item))
-			/// Blessed silver delivers more int damage against "cursed" alloys, see component for multiplier values
-			var/datum/component/silverbless/bless = used_weapon?.GetComponent(/datum/component/silverbless)
-			intdamage = round(intdamage * bless?.cursed_item_intdamage)
+		if(istype(used_weapon) && used_weapon.is_silver && ((used.smeltresult in list(/obj/item/ingot/aaslag, /obj/item/ingot/aalloy, /obj/item/ingot/purifiedaalloy)) || used.GetComponent(/datum/component/cursed_item)))
+			// Blessed silver delivers more int damage against "cursed" alloys, see component for multiplier values
+			var/datum/component/silverbless/bless = used_weapon.GetComponent(/datum/component/silverbless)
+			// Default multiplier to 1 if no bless component is present
+			var/mult = bless ? bless.cursed_item_intdamage : 1
 		used.take_damage(intdamage, damage_flag = d_type, sound_effect = FALSE, armor_penetration = 100)
 	if(physiology)
 		protection += physiology.armor.getRating(d_type)


### PR DESCRIPTION


## About The Pull Request

Makes armor with a cursed_item component damageable again. Heretic armor is no longer invincible.

## Testing Evidence

Tested it with a normal sword, silver sword, blessed silver sword, unblessed psydonian sword, and blessed psydonian sword. All apply damage to the armors that were invincible before.

## Why It's Good For The Game

Invincible Graggar armor bad.
