### PR TITLE
No more mantrap / kneestinger ambush.

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -32,7 +32,6 @@
 
 		if(L.electrocute_act(30, src))
 			src.take_damage(15)
-			L.consider_ambush(always = TRUE)
 			if(L.throwing)
 				L.throwing.finalize(FALSE)
 //			if(mover.loc != loc && L.stat == CONSCIOUS)
@@ -82,7 +81,6 @@
 			var/mob/living/L = user
 			if(L.electrocute_act(30, src)) // The kneestingers will let you pass if you worship dendor, but they won't take your stupid ass hitting them.
 				L.emote("painscream")
-				L.consider_ambush(always = TRUE)
 				if(L.throwing)
 					L.throwing.finalize(FALSE)
 				return FALSE

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -49,7 +49,6 @@
 			BP.update_disabled()
 			C.apply_damage(trap_damage, BRUTE, def_zone)
 			C.update_sneak_invis(TRUE)
-			C.consider_ambush(always = TRUE)
 			return FALSE
 		else
 			var/used_time = 10 SECONDS
@@ -77,7 +76,6 @@
 				BP.update_disabled()
 				C.apply_damage(trap_damage, BRUTE, def_zone)
 				C.update_sneak_invis(TRUE)
-				C.consider_ambush(always = TRUE)
 				return FALSE
 	..()
 
@@ -90,7 +88,6 @@
 		if(isliving(user))
 			var/mob/living/L = user
 			L.update_sneak_invis(TRUE)
-			L.consider_ambush(always = TRUE)
 		return
 	..()
 
@@ -192,7 +189,6 @@
 						"<span class='danger'>I trigger \the [src]!</span>")
 				if(L.apply_damage(trap_damage, BRUTE, def_zone, L.run_armor_check(def_zone, "stab", damage = trap_damage)))
 					L.Stun(80)
-				L.consider_ambush(always = TRUE)
 	..()
 
 /obj/item/restraints/legcuffs/beartrap/dropped(mob/living/carbon/human/user)


### PR DESCRIPTION
## About The Pull Request
Kneestinger / Mantrap no longer trigger an ambush when triggered.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
As part of the warden ambush refactor, the ambush tile mechanics that prevented ambush from happening when kneestinger / mantrap were triggered were removed. This led to way more mantrap / kneestinger induced ambush which generally tends to be unfun.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
