### PR TITLE
Make Katar 8 instead of 6 clickCD

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -10,7 +10,7 @@
 	chargetime = 0
 	swingdelay = 0
 	damfactor = 1.3
-	clickcd = CLICK_CD_INTENTCAP
+	clickcd = CLICK_CD_RAPID
 	item_d_type = "slash"
 
 /datum/intent/katar/thrust
@@ -22,7 +22,7 @@
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	penfactor = 40
 	chargetime = 0
-	clickcd = CLICK_CD_INTENTCAP
+	clickcd = CLICK_CD_RAPID
 	item_d_type = "stab"
 
 /datum/intent/lordbash


### PR DESCRIPTION
## About The Pull Request
Kinda based on a discovery from: https://github.com/Rotwood-Vale/Ratwood-2.0/pull/29
- Katar is now 8 clickCD in line with dagger / sabre instead of 6 clickCD

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I was not even aware that Katar has an additional +25% multiplicative clickCD on top of better damage than dagger, which would explain why it feels so damn busted in PVE. Luckily nothing happens so it wasn't abused widely in PVP, yet.

This still make Katar pretty damn good as it has access to very high cut damage multiplier and a stab better than rapier. It just isn't ultra absurd anymore.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
