### PR TITLE
Port Vanderlin's "oz" to "ligulae / ligula" changes

### DIFF
--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -1,3 +1,5 @@
+#define UNIT_FORM_STRING(amount) (amount == 1 ? "ligula" : "ligulae")
+
 /proc/chem_recipes_do_conflict(datum/chemical_reaction/r1, datum/chemical_reaction/r2)
 	//do the non-list tests first, because they are cheaper
 	if(r1.required_container != r2.required_container)

--- a/code/datums/brewing_recipes/_brewing_recipe_base.dm
+++ b/code/datums/brewing_recipes/_brewing_recipe_base.dm
@@ -81,11 +81,11 @@
 		html += "<h3>Liquids Required</h3>"
 		for(var/atom/path as anything in needed_reagents)
 			var/count = needed_reagents[path]
-			html += "[FLOOR(count / 3, 1)] oz of [initial(path.name)]<br>"
+			html += "[FLOOR(count, 1)] [UNIT_FORM_STRING(FLOOR(count, 1))] of [initial(path.name)]<br>"
 		html += "<br>"
 
 	if(brewed_amount)
-		html += "Produces: [FLOOR((per_brew_amount * brewed_amount) / 3, 1)] oz of [name]"
+		html += "Produces: [FLOOR((per_brew_amount * brewed_amount), 1)] [UNIT_FORM_STRING(FLOOR((per_brew_amount * brewed_amount), 1))] of [name]"
 	if(brewed_item)
 		html += "Produces:[icon2html(new brewed_item, user)] [(brewed_item_count)] [initial(brewed_item.name)]"
 	html += {"

--- a/code/datums/brewing_recipes/_brewing_recipe_base.dm
+++ b/code/datums/brewing_recipes/_brewing_recipe_base.dm
@@ -19,7 +19,7 @@
 	///amount of brewed creations used when either canning or bottling
 	var/brewed_amount = 1
 	///each bottle or canning gives how this much reagents
-	var/per_brew_amount = 48
+	var/per_brew_amount = 50
 	///helpful hints
 	var/helpful_hints
 	///if we have a secondary name some do if you want to hide the ugly info

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -85,7 +85,7 @@
 		var/count = reqs[path]
 		if(ispath(path, /datum/reagent))
 			var/datum/reagent/R = path
-			html += "- [CEILING(count / 3, 1)] oz of [initial(R.name)]<br>" // Cuz we're weird and don't use it under chem catalyst and we don't want icon crash 
+			html += "- [FLOOR(count, 1)] [UNIT_FORM_STRING(FLOOR(count, 1))] of [initial(R.name)]<br>"
 		else if(ispath(path, /obj)) // Prevent a runtime from happening w/ datum atm until it is
 			var/atom/atom = path
 			if(subtype_reqs)
@@ -124,7 +124,7 @@
 			  "}
 		for(var/atom/path as anything in chem_catalysts)
 			var/count = chem_catalysts[path]
-			html += "[CEILING(count / 3, 1)] oz of [initial(path.name)]<br>"
+			html += "[FLOOR(count, 1)] [UNIT_FORM_STRING(FLOOR(count, 1))] of [initial(path.name)]<br>"
 		html += {"
 			</div>
 		<div>

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -417,22 +417,22 @@
 				if(user.can_see_reagents() || (user.Adjacent(src) && (user.get_skill_level(/datum/skill/craft/alchemy) >= 2 || HAS_TRAIT(user, TRAIT_CICERONE)))) //Show each individual reagent
 					. += "It contains:"
 					for(var/datum/reagent/R in reagents.reagent_list)
-						. += "[round(R.volume / 3, 0.1)] oz of <font color=[R.color]>[R.name]</font>"
+						. += "[round(R.volume, 0.1)] [UNIT_FORM_STRING(round(R.volume, 0.1))] of <font color=[R.color]>[R.name]</font>"
 				else //Otherwise, just show the total volume
 					var/total_volume = 0
 					var/reagent_color
 					for(var/datum/reagent/R in reagents.reagent_list)
 						total_volume += R.volume
 					reagent_color = mix_color_from_reagents(reagents.reagent_list)
-					if(total_volume / 3 < 1)
-						. += "It contains less than 1 oz of <font color=[reagent_color]>something.</font>"
+					if(total_volume < 1)
+						. += "It contains less than 1 [UNIT_FORM_STRING(1)] of <font color=[reagent_color]>something.</font>"
 					else
-						. += "It contains [round(total_volume / 3)] oz of <font color=[reagent_color]>something.</font>"
+						. += "It contains [round(total_volume)] [UNIT_FORM_STRING(round(total_volume))] of <font color=[reagent_color]>something.</font>"
 			else
 				. += "Nothing."
 		else if(reagents.flags & AMOUNT_VISIBLE)
 			if(reagents.total_volume)
-				. += span_notice("It has [round(reagents.total_volume / 3)] oz left.")
+				. += span_notice("It has [round(reagents.total_volume)] [UNIT_FORM_STRING(round(reagents.total_volume))] left.")
 			else
 				. += span_danger("It's empty.")
 

--- a/code/game/objects/items/rogueitems/ceramics.dm
+++ b/code/game/objects/items/rogueitems/ceramics.dm
@@ -18,7 +18,7 @@
 	desc = "A ceramic bottle." //The sprite was anything but small
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "claybottlecook"
-	volume = 65 // Larger than glass bottle
+	volume = 75 // Larger than glass bottle
 	sellprice = 6
 	reagent_flags = OPENCONTAINER	//So it doesn't appear through
 

--- a/code/game/objects/items/rogueitems/waterskin.dm
+++ b/code/game/objects/items/rogueitems/waterskin.dm
@@ -2,9 +2,9 @@
 	name = "waterskin"
 	desc = "A leather waterskin."
 	icon_state = "waterskin"
-	amount_per_transfer_from_this = 6
-	possible_transfer_amounts = list(3,6,9)
-	volume = 64
+	amount_per_transfer_from_this = 10
+	possible_transfer_amounts = list(5, 10)
+	volume = 75 // 3 cups
 	dropshrink = 1
 	sellprice = 10
 	closed = FALSE

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -1,5 +1,5 @@
 #define MIN_STEW_TEMPERATURE 374 // For cooking
-#define VOLUME_PER_STEW_COOK 32 // Volume to cook per ingredient
+#define VOLUME_PER_STEW_COOK 30 // Volume to cook per ingredient
 #define VOLUME_PER_STEW_COOK_AFTER 1 // Volume to deduct after the sleep is over
 #define DEEP_FRY_TIME 5 SECONDS // Default deep fry time
 #define OIL_CONSUMED 5 // Amount of oil consumed per deep fry (1 fat = 4 fry)

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -6,9 +6,10 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/rt/wisdoms.txt"))
 	desc = "A bottle with a cork."
 	icon = 'icons/roguetown/items/cooking.dmi'
 	icon_state = "clear_bottle1"
-	amount_per_transfer_from_this = 6
-	possible_transfer_amounts = list(6)
-	volume = 48
+	amount_per_transfer_from_this = 10
+	amount_per_gulp = 5
+	possible_transfer_amounts = list(10)
+	volume = 50
 	fill_icon_thresholds = list(0, 25, 50, 75, 100)
 	dropshrink = 0.8
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -212,9 +212,9 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 5
 	throwforce = 10
-	amount_per_transfer_from_this = 33
-	possible_transfer_amounts = list(33)
-	volume = 99
+	amount_per_transfer_from_this = 25
+	possible_transfer_amounts = list(25)
+	volume = 100
 	flags_inv = HIDEHAIR
 	reagent_flags = OPENCONTAINER
 	obj_flags = CAN_BE_HIT

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipe_base.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipe_base.dm
@@ -35,7 +35,7 @@
 			var/count = output_reagents[path]
 			if(ispath(path, /datum/reagent))
 				var/datum/reagent/R = path
-				html += "[CEILING(count / 3, 1)] oz of [initial(R.name)]<br>"
+				html += "[FLOOR(count, 1)] [UNIT_FORM_STRING(FLOOR(count, 1))] of [initial(R.name)]<br>"
 		html += "</div>"
 
 	if(output_items.len)

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
@@ -1,110 +1,110 @@
 /datum/alch_cauldron_recipe/antidote
 	name = "Antidote"
 	smells_like = "wet moss"
-	output_reagents = list(/datum/reagent/medicine/antidote = 81)
+	output_reagents = list(/datum/reagent/medicine/antidote = 90)
 
 /datum/alch_cauldron_recipe/strong_antidote
 	name = "Antidote (Strong)"
 	smells_like = "purity"
-	output_reagents = list(/datum/reagent/medicine/strong_antidote = 81)
+	output_reagents = list(/datum/reagent/medicine/strong_antidote = 90)
 
 /datum/alch_cauldron_recipe/berrypoison
 	name = "Poison (Berry)"
 	smells_like = "death"
 	skill_required = SKILL_LEVEL_JOURNEYMAN // Basic poison should be harder to handle
-	output_reagents = list(/datum/reagent/berrypoison = 81)
+	output_reagents = list(/datum/reagent/berrypoison = 90)
 
 /datum/alch_cauldron_recipe/doompoison
 	name = "Poison (Doom)"
 	smells_like = "doom"
 	skill_required = SKILL_LEVEL_EXPERT // Strong poison should be more difficult to make
-	output_reagents = list(/datum/reagent/berrypoison = 81,/datum/reagent/additive = 81)
+	output_reagents = list(/datum/reagent/berrypoison = 90,/datum/reagent/additive = 90)
 
 /datum/alch_cauldron_recipe/stam_poison
 	name = "Stamina Poison"
 	smells_like = "a slow breeze"
 	skill_required = SKILL_LEVEL_JOURNEYMAN // Basic poison should be harder to handle
-	output_reagents = list(/datum/reagent/stampoison = 81)
+	output_reagents = list(/datum/reagent/stampoison = 90)
 
 /datum/alch_cauldron_recipe/big_stam_poison
 	name = "Stamina Poison (Strong)"
 	smells_like = "stagnant air"
 	skill_required = SKILL_LEVEL_EXPERT // Strong poison should be more difficult to make
-	output_reagents = list(/datum/reagent/stampoison = 81,/datum/reagent/additive = 81)
+	output_reagents = list(/datum/reagent/stampoison = 90,/datum/reagent/additive = 90)
 
 //Healing potions
 /datum/alch_cauldron_recipe/health_potion
 	name = "Elixir of Health"
 	smells_like = "sweet berries"
-	output_reagents = list(/datum/reagent/medicine/healthpot = 81)
+	output_reagents = list(/datum/reagent/medicine/healthpot = 90)
 
 /datum/alch_cauldron_recipe/big_health_potion
 	name = "Elixir of Health (Strong)"
 	smells_like = "berry pie"
 	skill_required = SKILL_LEVEL_JOURNEYMAN // If it has "Strong", lock it roundstart for Apothecary or above
-	output_reagents = list(/datum/reagent/medicine/healthpot = 81,/datum/reagent/additive = 81)
+	output_reagents = list(/datum/reagent/medicine/healthpot = 90,/datum/reagent/additive = 90)
 
 /datum/alch_cauldron_recipe/mana_potion
 	name = "Elixir of Mana"
 	smells_like = "power"
-	output_reagents = list(/datum/reagent/medicine/manapot = 81)
+	output_reagents = list(/datum/reagent/medicine/manapot = 90)
 
 /datum/alch_cauldron_recipe/big_mana_potion
 	name = "Elixir of Mana (Strong)"
 	smells_like = "fear"
 	skill_required = SKILL_LEVEL_JOURNEYMAN
-	output_reagents = list(/datum/reagent/medicine/manapot = 81,/datum/reagent/additive = 81)
+	output_reagents = list(/datum/reagent/medicine/manapot = 90,/datum/reagent/additive = 90)
 
 /datum/alch_cauldron_recipe/stamina_potion
 	name = "Elixir of Stamina"
 	smells_like = "fresh air"
-	output_reagents = list(/datum/reagent/medicine/stampot = 81)
+	output_reagents = list(/datum/reagent/medicine/stampot = 90)
 
 /datum/alch_cauldron_recipe/big_stamina_potion
 	name = "Elixir of Stamina (Strong)"
 	smells_like = "clean winds"
 	skill_required = SKILL_LEVEL_JOURNEYMAN
-	output_reagents = list(/datum/reagent/medicine/stampot = 81,/datum/reagent/additive = 81)
+	output_reagents = list(/datum/reagent/medicine/stampot = 90,/datum/reagent/additive = 90)
 
 //S.P.E.C.I.A.L. potions - Expert or above (roundstart Witch etc.)
 /datum/alch_cauldron_recipe/str_potion
 	name = "Potion of Mountain Muscles"
 	smells_like = "petrichor"
 	skill_required = SKILL_LEVEL_EXPERT
-	output_reagents = list(/datum/reagent/buff/strength = 27)
+	output_reagents = list(/datum/reagent/buff/strength = 30)
 
 /datum/alch_cauldron_recipe/per_potion
 	name = "Potion of Keen Eye"
 	smells_like = "fire"
 	skill_required = SKILL_LEVEL_EXPERT
-	output_reagents = list(/datum/reagent/buff/perception = 27)
+	output_reagents = list(/datum/reagent/buff/perception = 30)
 
 /datum/alch_cauldron_recipe/end_potion
 	name = "Potion of Enduring Fortitude"
 	smells_like = "mountain air"
 	skill_required = SKILL_LEVEL_EXPERT
-	output_reagents = list(/datum/reagent/buff/endurance = 27)
+	output_reagents = list(/datum/reagent/buff/endurance = 30)
 
 /datum/alch_cauldron_recipe/con_potion
 	name = "Potion of Stone Flesh"
 	smells_like = "earth"
 	skill_required = SKILL_LEVEL_EXPERT
-	output_reagents = list(/datum/reagent/buff/constitution = 27)
+	output_reagents = list(/datum/reagent/buff/constitution = 30)
 
 /datum/alch_cauldron_recipe/int_potion
 	name = "Potion of Keen Mind"
 	smells_like = "water"
 	skill_required = SKILL_LEVEL_EXPERT
-	output_reagents = list(/datum/reagent/buff/intelligence = 27)
+	output_reagents = list(/datum/reagent/buff/intelligence = 30)
 
 /datum/alch_cauldron_recipe/spd_potion
 	name = "Potion of Fleet Foot"
 	smells_like = "clean air"
 	skill_required = SKILL_LEVEL_EXPERT
-	output_reagents = list(/datum/reagent/buff/speed = 27)
+	output_reagents = list(/datum/reagent/buff/speed = 30)
 
 /datum/alch_cauldron_recipe/lck_potion
 	name = "Potion of Seven Clovers"
 	smells_like = "calming"
 	skill_required = SKILL_LEVEL_EXPERT
-	output_reagents = list(/datum/reagent/buff/fortune = 27)
+	output_reagents = list(/datum/reagent/buff/fortune = 30)

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_items.dm
@@ -3,10 +3,10 @@
 	desc = "A cute bottle that can hold three swigs of liquid, which is useful for both miserly business practices and preventing accidental overdosing. This one lacks a cork."
 	icon = 'icons/roguetown/misc/alchemy.dmi'
 	icon_state = "vial_bottle"
-	amount_per_transfer_from_this = 9
-	amount_per_gulp = 9
-	possible_transfer_amounts = list(9)
-	volume = 27
+	amount_per_transfer_from_this = 10
+	amount_per_gulp = 10
+	possible_transfer_amounts = list(10)
+	volume = 30
 	fill_icon_thresholds = list(0, 33, 66, 100)
 	w_class = WEIGHT_CLASS_TINY
 	experimental_onhip = FALSE

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -157,7 +157,7 @@
 	However it meant that putting it in an alchemical vial was a trap as it sipped 9 units instead of 5 units that is the required minimum.
 	And removed any excessive potion inside the body. This has been changed to apply a 3 seconds buff to the mob, but have much lower
 	metabolization rate, so that the duration of the buff depends on how long you last. 
-	Roughly tested. At Metabolization Rate 1. 9 units sip (1/3 of a vial) last 20 seconds.
+	Roughly tested. At Metabolization Rate 1. 10 units sip (1/3 of a vial) last 20 seconds.
 	To make this somewhat equal to the old system, base metabolization rate is 0.1 - making it last 200 seconds - 600 seconds if you sip an entire vial.
 	This is 2x on weaker potions (Intelligence, Fortune). However, overdose threshold is now 30 units so you can only drink one vial at once.
 	And potion stacking is not possible without neutralizing itself.
@@ -166,7 +166,7 @@
 	description = ""
 	reagent_state = LIQUID
 	metabolization_rate = REAGENTS_METABOLISM * 0.1
-	overdose_threshold = 30
+	overdose_threshold = 33
 
 /datum/reagent/buff/overdose_process(mob/living/carbon/M)
 	. = ..()

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -1,38 +1,38 @@
 
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot
-	list_reagents = list(/datum/reagent/medicine/healthpot = 48)
+	list_reagents = list(/datum/reagent/medicine/healthpot = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/healthpotnew
-	list_reagents = list(/datum/reagent/medicine/stronghealth = 48)
+	list_reagents = list(/datum/reagent/medicine/stronghealth = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/manapot
-	list_reagents = list(/datum/reagent/medicine/manapot = 48)
+	list_reagents = list(/datum/reagent/medicine/manapot = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/poison
 	list_reagents = list(/datum/reagent/toxin/killersice = 1)
 
 /obj/item/reagent_containers/glass/bottle/rogue/water
-	list_reagents = list(/datum/reagent/water = 48)
+	list_reagents = list(/datum/reagent/water = 50)
 
 
 /obj/item/reagent_containers/glass/bottle/mercury
-	list_reagents = list(/datum/reagent/mercury = 48)
+	list_reagents = list(/datum/reagent/mercury = 50)
 
 //vanderlin potion stuff//
 /obj/item/reagent_containers/glass/bottle/rogue/strongmanapot
-	list_reagents = list(/datum/reagent/medicine/strongmana = 48)
+	list_reagents = list(/datum/reagent/medicine/strongmana = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/stampot
-	list_reagents = list(/datum/reagent/medicine/stampot = 48)
+	list_reagents = list(/datum/reagent/medicine/stampot = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/strongstampot
-	list_reagents = list(/datum/reagent/medicine/strongstam = 48)
+	list_reagents = list(/datum/reagent/medicine/strongstam = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/antidote
-	list_reagents = list(/datum/reagent/medicine/antidote = 48)
+	list_reagents = list(/datum/reagent/medicine/antidote = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/strong_antidote
-	list_reagents = list(/datum/reagent/medicine/strong_antidote = 48)
+	list_reagents = list(/datum/reagent/medicine/strong_antidote = 50)
 
 /obj/item/reagent_containers/glass/bottle/rogue/berrypoison
 	list_reagents = list(/datum/reagent/berrypoison = 15)
@@ -47,40 +47,40 @@
 	list_reagents = list(/datum/reagent/strongstampoison = 15)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/strpot
-	list_reagents = list(/datum/reagent/buff/strength = 27)
+	list_reagents = list(/datum/reagent/buff/strength = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/perpot
-	list_reagents = list(/datum/reagent/buff/perception = 27)
+	list_reagents = list(/datum/reagent/buff/perception = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/endpot
-	list_reagents = list(/datum/reagent/buff/endurance = 27)
+	list_reagents = list(/datum/reagent/buff/endurance = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/conpot
-	list_reagents = list(/datum/reagent/buff/constitution = 27)
+	list_reagents = list(/datum/reagent/buff/constitution = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/intpot
-	list_reagents = list(/datum/reagent/buff/intelligence = 27)
+	list_reagents = list(/datum/reagent/buff/intelligence = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/spdpot
-	list_reagents = list(/datum/reagent/buff/speed = 27)
+	list_reagents = list(/datum/reagent/buff/speed = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/lucpot
-	list_reagents = list(/datum/reagent/buff/fortune = 27)
+	list_reagents = list(/datum/reagent/buff/fortune = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/healthpot
-	list_reagents = list(/datum/reagent/medicine/healthpot = 27)
+	list_reagents = list(/datum/reagent/medicine/healthpot = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew
-	list_reagents = list(/datum/reagent/medicine/stronghealth = 27)
+	list_reagents = list(/datum/reagent/medicine/stronghealth = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/blessedwater
-	list_reagents = list(/datum/reagent/water/blessed = 27)	
+	list_reagents = list(/datum/reagent/water/blessed = 30)	
 
 /obj/item/reagent_containers/glass/bottle/alchemical/manapot
-	list_reagents = list(/datum/reagent/medicine/manapot = 27)
+	list_reagents = list(/datum/reagent/medicine/manapot = 30)
 
 /obj/item/reagent_containers/glass/bottle/alchemical/strongmanapot
-	list_reagents = list(/datum/reagent/medicine/strongmana = 27)	
+	list_reagents = list(/datum/reagent/medicine/strongmana = 30)	
 
 //////////////////////////
 /// ALCOHOLIC BOTTLES ///
@@ -88,154 +88,154 @@
 
 // BEER - Cheap, Plentiful, Saviours of Family Life
 /obj/item/reagent_containers/glass/bottle/rogue/beer
-	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 50)
 	desc = "A bottle that contains a generic housebrewed small-beer. It has an improvised corkseal made of hardened clay."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/zagul
-	list_reagents = list(/datum/reagent/consumable/ethanol/zagul = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/zagul = 50)
 	desc = "A bottle with the coastal zagul cork-seal. An extremely cheap lager hailing from a local brewery."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/blackgoat
-	list_reagents = list(/datum/reagent/consumable/ethanol/blackgoat = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/blackgoat = 50)
 	desc = "A bottle with the black goat kriek cork-seal. A fruit-sour beer brewed with jackberries for a tangy taste."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/ratkept
-	list_reagents = list(/datum/reagent/consumable/ethanol/onion = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/onion = 50)
 	desc = "A bottle with surprisingly no cork-seal. On the glass is carved the word \"ONI-N\", the 'O' seems to have been scratched out completely. Dubious. On the glass is a paper glued to it showing an illustration of rats guarding a cellar filled with bottles against a hoard of beggars."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/hagwoodbitter
-	list_reagents = list(/datum/reagent/consumable/ethanol/hagwoodbitter = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/hagwoodbitter = 50)
 	desc = "A bottle with the hagwood bitters cork-seal. The least bitter thing to be exported from the Grenzelhoft occupied state of Zorn."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/aurorian
-	list_reagents = list(/datum/reagent/consumable/ethanol/aurorian = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/aurorian = 50)
 	desc = "A bottle with the aurorian brewhouse cork-seal. An Elvish beer brewed from an herbal gruit."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/fireleaf
-	list_reagents = list(/datum/reagent/consumable/ethanol/fireleaf= 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/fireleaf= 50)
 	desc = "A bottle with a generic leaf cork-seal. An Elvish beer formed by distilling cabbages. You're pretty sure you can make your own with certainly higher quality."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/butterhairs
-	list_reagents = list(/datum/reagent/consumable/ethanol/butterhairs = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/butterhairs = 50)
 	desc = "A bottle with the Dwarven Federation Trade Alliance cork-seal. This beer, known as butterhairs: is widely considered one of the greatest exported by the Dwarves."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/stonebeardreserve
-	list_reagents = list(/datum/reagent/consumable/ethanol/stonebeards = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/stonebeards = 50)
 	desc = "A bottle with the House Stoutenson cork-seal. Stonebeards Reserve is one of the most legendary beers in existence, with only a few hundred barrels made every year."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/sazdistal
-	list_reagents = list(/datum/reagent/consumable/ethanol/sazdistal = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/sazdistal = 50)
 	desc = "A bottle with the House Stoutenson cork-seal. This strange liquid is considered as the most spicy and alcoholic drink in all the Mountainhomes. Bought by nobles of all ages, mostly those with a deathwish."	
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/voddena
-	list_reagents = list(/datum/reagent/consumable/ethanol/voddena = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/voddena = 50)
 	desc = "A bottle with the City of Norwandine cork-seal. It contains a respectably pure, clean voddena."
 
 // WINES - Expensive, Nobleblooded
 /obj/item/reagent_containers/glass/bottle/rogue/wine
-	list_reagents = list(/datum/reagent/consumable/ethanol/wine = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/wine = 50)
 	desc = "A bottle that contains a generic red-wine, likely from Raneshen. It has a red-clay cork-seal."
 
 /obj/item/reagent_containers/glass/bottle/rogue/wine/sourwine
-	list_reagents = list(/datum/reagent/consumable/ethanol/sourwine = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/sourwine = 50)
 	desc = "A bottle that contains a Grenzelhoftian classic with a black ink cork-seal.. An extremely sour wine that is watered down with mineral water."
 
 /obj/item/reagent_containers/glass/bottle/rogue/redwine
-	list_reagents = list(/datum/reagent/consumable/ethanol/redwine = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/redwine = 50)
 	desc = "A bottle with the Otavan Merchant Guild cork-seal. This one appears to be labelled as a relatively young red-wine from the coinlord state."
 
 /obj/item/reagent_containers/glass/bottle/rogue/whitewine
-	list_reagents = list(/datum/reagent/consumable/ethanol/whitewine = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/whitewine = 50)
 	desc = "A bottle with the Otavan Merchant Guild cork-seal. This one appears to be labelled as a sweet wine from the colder northern regions."
 
 /obj/item/reagent_containers/glass/bottle/rogue/elfred
-	list_reagents = list(/datum/reagent/consumable/ethanol/elfred = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/elfred = 50)
 	desc = "A bottle gilded with a silver cork-seal. It appears to be labelled as an elvish red wine from Otava. Likely worth more than what an entire village makes!"
 
 /obj/item/reagent_containers/glass/bottle/rogue/elfblue
-	list_reagents = list(/datum/reagent/consumable/ethanol/elfblue = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/elfblue = 50)
 	desc = "A bottle gilded with a golden cork-seal. This is the legendary Valmora Blue from the Vineyard of Valmora, headed by a sainted Dark-Elf swordsmaster. This bottle would swoon Gods over!"
 
 //AZURE DRINKS
 /obj/item/reagent_containers/glass/bottle/rogue/beer/jagdtrunk
-	list_reagents = list(/datum/reagent/consumable/ethanol/jagdtrunk = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/jagdtrunk = 50)
 	desc = "A bottle with a Saigabuck cork-seal. This dark liquid is the strongest alcohol coming out of Grenzelhoft available. A herbal schnapps, sure to burn out any disease."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/apfelweinheim
-	list_reagents = list(/datum/reagent/consumable/ethanol/apfelweinheim = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/apfelweinheim = 50)
 	desc = "A bottle with the Apfelweinheim cork-seal. A cider from the Grenzelhoftian town of Apfelweinheim. Well received for its addition of pear, alongside crisp apples."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/rtoper
-	list_reagents = list(/datum/reagent/consumable/ethanol/rtoper = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/rtoper = 50)
 	desc = "A bottle with the Lirvas-crest cork-seal. An especially tart cider from the petty kingdom of Lirvas. Myths say the brewers let the barrels age in the bog, which results in that especially stong flavour."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/nred
-	list_reagents = list(/datum/reagent/consumable/ethanol/nred = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/nred = 50)
 	desc = "A bottle with the City of Norwandine cork-seal. A red ale brewed to perfection in the lands of Hammerhold."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/gronnmead
-	list_reagents = list(/datum/reagent/consumable/ethanol/gronnmead = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/gronnmead = 50)
 	desc = "A bottle with a Shieldmaiden Berewrey cork-seal. A deep red honey-wine, refined with the red berries native to Gronns highlands."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/avarmead
-	list_reagents = list(/datum/reagent/consumable/ethanol/avarmead = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/avarmead = 50)
 	desc = "A bottle with a simple cork-seal. A golden honey-wine brewed in the Avar Steppes. Manages to keep a proper taste while staying strong."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/avarrice
-	list_reagents = list(/datum/reagent/consumable/ethanol/avarrice = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/avarrice = 50)
 	desc = "A bottle with a simple cork-seal. A murky, white wine made from rice grown in the steppes of Avar."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/saigamilk
-	list_reagents = list(/datum/reagent/consumable/ethanol/saigamilk = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/saigamilk = 50)
 	desc = "A bottle with a Running Saiga cork-seal. A form of alcohol brewed from the milk of a saiga and salt. Common drink of the nomads living in the steppe."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/kgunlager
-	list_reagents = list(/datum/reagent/consumable/ethanol/kgunlager = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/kgunlager = 50)
 	desc = "A bottle with a Yamaguchi Brewery cork-seal. A pale lager brewed in the far-away lands of Kazengun, refined with green tea for an unique flavour-profile. Even lighter than elven-brew!"
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/kgunsake
-	list_reagents = list(/datum/reagent/consumable/ethanol/kgunsake = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/kgunsake = 50)
 	desc = "A bottle with a Golden Swan cork-seal. A translucient, pale-blue liquid made from rice. A favourite drink of the warlords and nobles of Kazengun."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/kgunplum
-	list_reagents = list(/datum/reagent/consumable/ethanol/kgunplum = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/kgunplum = 50)
 	desc = "A bottle with a Golden Swan cork-seal. A reddish-golden alcohol made from a fruit commonly found on the Kazengun-isles. A favourite of the commoners."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/kgunshochu
-	list_reagents = list(/datum/reagent/consumable/ethanol/kgunshochu = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/kgunshochu = 50)
 	desc = "A bottle with a Golden Swan cork-seal. A clean alcohol made by distilling rice. With a dry and clean finish. Popular amongst the warrior caste of Kazengun."
 
 // Zhongese Drinks
 /obj/item/reagent_containers/glass/bottle/rogue/beer/huangjiu
-	list_reagents = list(/datum/reagent/consumable/ethanol/huangjiu = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/huangjiu = 50)
 	desc = "A bottle with a red seal. A strong, sweet yellow rice wine that is often used in cooking."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/baijiu
-	list_reagents = list(/datum/reagent/consumable/ethanol/baijiu = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/baijiu = 50)
 	desc = "A bottle with a red seal. A strong, clear liquor made from fermented sorghum or rice. The favored drink of wandering warriors."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/yaojiu
-	list_reagents = list(/datum/reagent/consumable/ethanol/yaojiu = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/yaojiu = 50)
 	desc = "A bottle with a red seal. A strong, sweet rice wine infused with medicinal herbs, including Ginseng. Often prescribed as a medicine on the Zhongese mainland."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/shejiu
-	list_reagents = list(/datum/reagent/consumable/ethanol/shejiu = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/shejiu = 50)
 	desc = "A bottle with a red seal. A strong rice wine with a dead snake inside. In the land of Zhong, It is believed that drinking this will improve one's virility and blood circulation."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/murkwine
-	list_reagents = list(/datum/reagent/consumable/ethanol/murkwine = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/murkwine = 50)
 	desc = "A bottle with a Possumtail Brewery mark. A special brew made from murky water and swampweed. A Heartfelt special."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/nocshine
-	list_reagents = list(/datum/reagent/consumable/ethanol/nocshine = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/nocshine = 50)
 	desc = "A bottle with a blue, Crescent moon mark. A special brew that is extremely potent and toxic, but strengthen the body. If you dare."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/whipwine
-	list_reagents = list(/datum/reagent/consumable/ethanol/whipwine = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/whipwine = 50)
 	desc = "A strange bottle with a concerningly brown color. It bears the seal of a snake's head over a leaf. Markings indicate the contents are supposed to be good for health..."
 
 /obj/item/reagent_containers/glass/bottle/rogue/beer/komuchisake
-	list_reagents = list(/datum/reagent/consumable/ethanol/komuchisake = 48)
+	list_reagents = list(/datum/reagent/consumable/ethanol/komuchisake = 50)
 	desc = "A dusty, ancient bottle with a red-ochre coloring. It bears an intricately detailed golden skull seal, and the markings on it are clearly of the Shogunate. It looks to be filled with herbs inside."
 
 		//////////////////////////
@@ -243,25 +243,25 @@
 		//////////////////////////
 
 /obj/item/reagent_containers/glass/bottle/claybottle/wine
-	list_reagents = list(/datum/reagent/consumable/ethanol/wine = 65)
+	list_reagents = list(/datum/reagent/consumable/ethanol/wine = 75)
 	desc = "A clay bottle that contains a generic red-wine, likely from Raneshen. It has a red-clay cork-seal."
 
 /obj/item/reagent_containers/glass/bottle/claybottle/water
-	list_reagents = list(/datum/reagent/water = 65)
+	list_reagents = list(/datum/reagent/water = 75)
 	desc = "A clay bottle with no markings."
 
 /obj/item/reagent_containers/glass/bottle/claybottle/beer
-	list_reagents = list(/datum/reagent/consumable/ethanol = 65)
+	list_reagents = list(/datum/reagent/consumable/ethanol = 75)
 	desc = "A clay bottle that contains a generic housebrewed small-beer. It has an improvised corkseal made of hardened clay."
 
 /obj/item/reagent_containers/glass/bottle/claybottle/nred
-	list_reagents = list(/datum/reagent/consumable/ethanol/nred = 65)
+	list_reagents = list(/datum/reagent/consumable/ethanol/nred = 75)
 	desc = "A clay bottle with the City of Norwandine cork-seal. A red ale brewed to perfection in the lands of Hammerhold."
 
 /obj/item/reagent_containers/glass/bottle/claybottle/gronnmead
-	list_reagents = list(/datum/reagent/consumable/ethanol/gronnmead = 65)
+	list_reagents = list(/datum/reagent/consumable/ethanol/gronnmead = 75)
 	desc = "A clay bottle with a Shieldmaiden Berewrey cork-seal. A deep red honey-wine, refined with the red berries native to Gronns highlands."
 
 /obj/item/reagent_containers/glass/bottle/claybottle/whitewine
-	list_reagents = list(/datum/reagent/consumable/ethanol/whitewine = 65)
+	list_reagents = list(/datum/reagent/consumable/ethanol/whitewine = 75)
 	desc = "A bottle with the Otavan Merchant Guild cork-seal. This one appears to be labelled as a sweet wine from the colder northern regions."

--- a/code/modules/roguetown/roguejobs/mages/rituals/_ritual.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/_ritual.dm
@@ -170,7 +170,7 @@ GLOBAL_LIST_INIT(t4enchantmentrunerituallist,generate_t4enchantment_rituallist()
 			var/count = required_atoms[path]
 			if(ispath(path, /datum/reagent))
 				var/datum/reagent/R = path
-				html += "- [CEILING(count / 3, 1)] oz of [initial(R.name)]<br>"
+				html += "- [FLOOR(count, 1)] [UNIT_FORM_STRING(FLOOR(count, 1))] of [initial(R.name)]<br>"
 			else
 				html += "- [count] counts of [initial(path.name)]<br>"
 

--- a/modular/Neu_Food/code/cookware/bowl.dm
+++ b/modular/Neu_Food/code/cookware/bowl.dm
@@ -12,7 +12,7 @@
 	possible_transfer_amounts = list(7)
 	dropshrink = 1
 	w_class = WEIGHT_CLASS_NORMAL
-	volume = 33
+	volume = 30
 	obj_flags = CAN_BE_HIT
 	sellprice = 1
 	drinksounds = list('sound/items/drink_cup (1).ogg','sound/items/drink_cup (2).ogg','sound/items/drink_cup (3).ogg','sound/items/drink_cup (4).ogg','sound/items/drink_cup (5).ogg')

--- a/modular/Neu_Food/code/cookware/cup.dm
+++ b/modular/Neu_Food/code/cookware/cup.dm
@@ -14,7 +14,7 @@
 	dropshrink = 0.8
 	w_class = WEIGHT_CLASS_NORMAL
 	experimental_inhand = FALSE
-	volume = 24
+	volume = 25
 	obj_flags = CAN_BE_HIT
 	sellprice = 1
 	drinksounds = list('sound/items/drink_cup (1).ogg','sound/items/drink_cup (2).ogg','sound/items/drink_cup (3).ogg','sound/items/drink_cup (4).ogg','sound/items/drink_cup (5).ogg')

--- a/modular/Neu_Food/code/cookware/pot.dm
+++ b/modular/Neu_Food/code/cookware/pot.dm
@@ -15,7 +15,7 @@
 	reagent_flags = OPENCONTAINER
 	throwforce = 10
 	dropshrink = 1 // Override for bucket
-	volume = 198
+	volume = 200
 
 /obj/item/reagent_containers/glass/bucket/pot/update_icon()
 	cut_overlays()
@@ -45,14 +45,14 @@
 	name = "decrepit pot"
 	desc = "A kettle of wrought bronze. One could only imagine what the stews of millenia prior must've tasted like; do you suppose they knew of seasonings-and-spices, too?"
 	icon_state = "apote"
-	volume = 99
+	volume = 100
 	color = "#bb9696"
 	sellprice = 25
 
 /obj/item/reagent_containers/glass/bucket/pot/stone
 	name = "stone pot"
 	desc = "A pot made out of stone. It can hold less than a metal pot."
-	volume = 99 // 99 is the max volume for a stone pot
+	volume = 100 // 99 is the max volume for a stone pot
 
 /obj/item/reagent_containers/glass/bucket/pot/kettle
 	name = "kettle"
@@ -61,7 +61,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 32
 	grid_height = 64
-	volume = 99
+	volume = 100
 
 /obj/item/reagent_containers/glass/bucket/pot/copper
 	name = "copper pot"
@@ -73,7 +73,7 @@
 	desc = "A teapot made out of ceramic. Used to serve tea, it can hold a lot of liquid. It can still spill, however."
 	dropshrink = 0.7
 	icon_state = "teapot"
-	volume = 99
+	volume = 100
 	sellprice = 20
 
 /obj/item/reagent_containers/glass/bucket/pot/teapot/examine()


### PR DESCRIPTION
## About The Pull Request
Port of https://github.com/Monkestation/Vanderlin/pull/3060
- Replaces mention of "Oz" with "Ligulae / Ligula", an old roman unit that is kinda close to 10 ml. No more desync between in code and out of code units.
- Normalized reagent container & transfer amount where noted. Bucket / Pot -> 100 / 200 from 99 to 200. Cups to 25 from 24. Bowl is now 30. Stew Recipe generates 30 instead of 32 units. Bottle is now 50 units, Alchemical Vial is now 30 units. Potion recipe is 90 / 30. Overdose threshold for potion buff is now 33 instead of 30. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="859" height="694" alt="dreamseeker_y6i4PywPMH" src="https://github.com/user-attachments/assets/937aa968-a660-4636-b0cb-08b91c5d73ef" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Finally no more fucking desync of OOC and code units

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
