### PR TITLE
Miner Skill switching polearms to maces

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -20,7 +20,7 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

Changes Miner's journeyman polearm skills to journeyman mace skills.

## Testing Evidence

Just changing a skill value.

## Why It's Good For The Game

I think it's more fitting for Miners to be good at smashing things with big blunt objects than for them to be good at using spears. They're already good at using pickaxes and axes. When swinging a pickaxe, an axe, or a mace, it all generally uses the same motions and muscles. Maces are also a typical weapon used by conscripted footmen, right after spears, but we have farmers and spear-hunters for spear militia.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
