### PR TITLE
Druid exploit fix (wildshape changes) + fungal illum nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -15,8 +15,6 @@
 	if(client)
 		SSdroning.play_area_sound(get_area(src), client)
 
-	fully_heal(FALSE) //If we don't do this, even a single cut will mean the player's real body will die in the void while they run around wildshaped
-	
 	var/mob/living/carbon/human/species/wildshape/W = new shapepath(loc) //We crate a new mob for the wildshaping player to inhabit
 
 	W.set_patron(src.patron)
@@ -37,6 +35,19 @@
 	W.voice_color = voice_color
 	W.cmode_music_override = cmode_music_override
 	W.cmode_music_override_name = cmode_music_override_name
+
+	var/list/datum/wound/woundlist = get_wounds()
+	if(woundlist.len)
+		for(var/datum/wound/wound in woundlist)
+			var/obj/item/bodypart/c_BP = get_bodypart(wound.bodypart_owner.body_zone)
+			var/obj/item/bodypart/w_BP = W.get_bodypart(wound.bodypart_owner.body_zone)
+			w_BP.add_wound(wound.type)
+			c_BP.remove_wound(wound.type)
+
+	W.adjustBruteLoss(getBruteLoss())
+	W.adjustFireLoss(getFireLoss())
+	W.adjustOxyLoss(getOxyLoss())
+
 	mind.transfer_to(W)
 	skills?.known_skills = list()
 	skills?.skill_experience = list()
@@ -68,6 +79,18 @@
 
 	if(dead)
 		W.death()
+
+	var/list/datum/wound/woundlist = get_wounds()
+	if(woundlist.len)
+		for(var/datum/wound/wound in woundlist)
+			var/obj/item/bodypart/c_BP = get_bodypart(wound.bodypart_owner.body_zone)
+			var/obj/item/bodypart/w_BP = W.get_bodypart(wound.bodypart_owner.body_zone)
+			w_BP.add_wound(wound.type)
+			c_BP.remove_wound(wound.type)
+
+	W.adjustBruteLoss(getBruteLoss())
+	W.adjustFireLoss(getFireLoss())
+	W.adjustOxyLoss(getOxyLoss())
 
 	W.forceMove(get_turf(src))
 

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -84,7 +84,13 @@
 	devotion_cost = 30
 
 /obj/effect/proc_holder/spell/targeted/conjure_glowshroom/cast(list/targets, mob/user = usr)
-	. = ..()
+	..()
+
+	to_chat(user, span_notice("I begin enriching the soil around me!"))
+	if(!do_after(user, 2 SECONDS, progress = TRUE))
+		revert_cast()
+		return FALSE
+
 	var/turf/T = user.loc
 	for(var/X in GLOB.cardinals)
 		var/turf/TT = get_step(T, X)

--- a/code/modules/spells/spell_types/wildshape.dm
+++ b/code/modules/spells/spell_types/wildshape.dm
@@ -41,6 +41,10 @@
 
 			var/new_wildshape_type = input(M, "Choose Your Animal Form!", "It's Morphing Time!", null) as null|anything in sortList(animal_list)
 
+			if(!new_wildshape_type)
+				revert_cast()
+				return FALSE
+
 			for(var/crecher in possible_shapes) //Second pass to fetch the mob type itself and send it on wildshape_transformation
 				var/mob/living/carbon/human/species/wildshape/B = crecher
 				if(new_wildshape_type == B.name)


### PR DESCRIPTION
## About The Pull Request

1. Changing back and forth from your wildshape now transfers your damage across forms.
2. Fungal Illumination has a 2s delay before the shrooms pop up.
3. Cancelling beastform select does not charge you devotion nor does it trigger cooldown.

## Testing Evidence

Tested.

## Why It's Good For The Game

Utilising beastform for a free aheal isn't good. Bug exploit fixed.
Fungal Illum's been often used as a no-esc tactic, considering how powerful a paralyse and knockdown is.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
