### PR TITLE
Changes warhammer intents

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -24,6 +24,9 @@
 	icon_state = "insmash"
 	item_d_type = "blunt"
 
+/datum/intent/mace/smash/warhammer
+	damfactor = 1.3
+
 /datum/intent/mace/smash/flataxe
 	damfactor = 1.2
 	clickcd = 10
@@ -475,7 +478,7 @@
 
 /obj/item/rogueweapon/mace/warhammer
 	force = 20
-	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/warhammer/pick)
+	possible_item_intents = list(/datum/intent/mace/warhammer/stab, /datum/intent/mace/smash/warhammer)
 	gripped_intents = null
 	name = "warhammer"
 	desc = "Made to punch through armor and skull alike."
@@ -498,7 +501,7 @@
 
 /obj/item/rogueweapon/mace/warhammer/steel
 	force = 25
-	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/warhammer/pick, /datum/intent/mace/warhammer/stab)
+	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash/warhammer, /datum/intent/mace/warhammer/stab)
 	name = "steel warhammer"
 	desc = "A fine steel warhammer, makes a satisfying sound when paired with a knight's helm."
 	icon_state = "swarhammer"


### PR DESCRIPTION
## About The Pull Request

Removes pick intent from Warhammers and gives them an edited smash intent instead. Also replaces the strike intent of the iron ones with just stab to remove the redundancy of a second +damage modified intent, giving the two types a method to pierce armor

## Testing Evidence

<img width="263" height="200" alt="codestuff1" src="https://github.com/user-attachments/assets/e53415bf-ea6a-4174-a364-d8e8b168be46" />
<img width="344" height="219" alt="codestuff2" src="https://github.com/user-attachments/assets/59b2768d-fb63-4fba-8b53-6bee43505e43" />


I don't have a pic for the iron ones intents because it was a change done after testing was already started, but they have stab now, it's just a one line path change.

## Why It's Good For The Game

Pick intent has always been a bane to any armor user, easily going through a good chunk easily. Two birds with one stone: Remove the ridiculous strength of these weapons, and gives them a stronger damage option similar to maces to make use of that hammer.

Might change up the PR and add an edited Peel intent when I wake up, but for now it's in a good spot.