### PR TITLE
Temp-Fix for the Grenzelhoftian Hipshirt.

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -143,7 +143,7 @@
 	body_parts_covered = COVERAGE_ALL_BUT_LEGS
 	icon_state = "grenzelshirt"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
-	boobed = TRUE
+	boobed = FALSE // Temporary fix, set to FALSE because for some reason boobed and details don't want to work together, removing the ability to dye it or it's details for the onmob
 	detail_tag = "_detail"
 	detail_color = CLOTHING_WHITE
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM


### PR DESCRIPTION
## About The Pull Request
While working on another project I realized that for some reason, when BOOBED was set to true for the Grenzel Hipshirt, it was preventing the female sprite onmob from having details. I had this issue before when I was remaking the Jester outfit to be dyable, for some reason Boobed and Details don't want to work together.

This is a bandaid fix until someone far smarter than I can look into the carbon/living/update_icons and figure out why the _boob and _detail don't want to work together.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Pre-Fix and Post-Fix
<img width="175" height="195" alt="pre" src="https://github.com/user-attachments/assets/35ffe8ab-cf3e-4023-87a4-c5bce109a8ee" />
<img width="172" height="191" alt="post" src="https://github.com/user-attachments/assets/2bdfc091-5fde-40a1-9a3c-a55cdc5d908f" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fixes bugs.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
