### PR TITLE
Slurbow Penetration Decrease + Addition of Pen Factor Code to Ranged Weapons

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -157,7 +157,8 @@
 
 		BB.accuracy += accfactor * (user.STAPER - 8) * 3 // 8+ PER gives +3 per level. Exponential.
 		BB.bonus_accuracy += (user.STAPER - 8) // 8+ PER gives +1 per level. Does not decrease over range.
-		BB.bonus_accuracy += (user.get_skill_level(/datum/skill/combat/crossbows) * 5) // +5 per XBow level.
+		BB.bonus_accuracy += (user.get_skill_level(/datum/skill/combat/crossbows) * 5) // +5 per XBow level.'
+		BB.armor_penetration *= penfactor
 		BB.damage *= damfactor
 	cocked = FALSE
 	if(user.has_status_effect(/datum/status_effect/buff/clash) && ishuman(user))
@@ -202,4 +203,5 @@
 	hasloadedsprite = TRUE
 	movingreload = TRUE
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_HIP
+	penfactor = 0.5		//Bolts have 50 pen, this decreases to 25. Should only pen armor with less than 67 protection.
 

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -12,6 +12,7 @@
 	istrainable = TRUE // For the moment I'll allow these to be traineable until a proper way to level up bows and crossbows is coded. - Foxtrot
 	var/damfactor = 1 // Multiplier for projectile damage. Used by bows and crossbows.
 	var/accfactor = 1 // Multiplier for projectile accuracy. Used by bows and crossbows.
+	var/penfactor = 1 // Multiplier for projectile penetration. Used by crossbows, meant for any compressed-bow types.
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/attackby(obj/item/A, mob/user, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Basically acts as a framework for future ranged weapon additions since slurbow is kind of annoying right now.

Also sort of a slur-bow nerf but it's needed one. I'll break down the calculation for simplicity here.

Slurbow current:
42 damage, 50 pen = bypassing any armor with less than ~92 pierce protection. (Paddy gamby is only 80)

Slurbow after adjustment:
42 damage, 25 pen = bypassing any armor with less than ~67 pierce protection. (Basically only padded gamby is above that)

## Testing Evidence

Need to test, but it's just numbers adjustment. Code existed already, just wasn't set up to call on bows the same way damage does.

## Why It's Good For The Game

Slurbows had the annoying issue where you would reload really fast and it ignored all armor. The ~50% damage decrease from a regular crossbow didn't matter given you could crit due to the 42 damage you were doing and still do a hefty sum of damage, more than some melee weapons, really easily with a good range.

Now padded gambesons will properly protect against slur bows at least. Can tune pen up or down as needed, maybe add this to different bow types, but hey now padded gamby isn't useless vs all bolts. (Still useless vs crossbow but at least that has a high reload time.)