### PR TITLE
Being grabbed while in combat mode will cause you to automatically resist once, with a lessened stamina cost and no delay

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -476,8 +476,6 @@
 				C.grippedby(src)
 			if(!supress_message)
 				send_pull_message(target)
-			if(C.cmode)
-				C.resist_grab(reflexive = TRUE)
 		else
 			var/obj/item/grabbing/O = new()
 			O.name = "[target.name]"
@@ -497,6 +495,8 @@
 
 		update_pull_movespeed()
 		set_pull_offsets(target, state)
+		if(target.stat == CONSCIOUS && target.cmode)
+			target.resist_grab(reflexive = TRUE)
 	else
 		if(!supress_message)
 			var/sound_to_play = 'sound/combat/shove.ogg'

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -476,6 +476,8 @@
 				C.grippedby(src)
 			if(!supress_message)
 				send_pull_message(target)
+			if(C.cmode)
+				C.resist_grab(reflexive = TRUE)
 		else
 			var/obj/item/grabbing/O = new()
 			O.name = "[target.name]"
@@ -1167,10 +1169,10 @@
 	..()
 	update_charging_movespeed()
 
-/mob/proc/resist_grab(moving_resist)
+/mob/proc/resist_grab(reflexive = FALSE)
 	return TRUE //returning 0 means we successfully broke free
 
-/mob/living/resist_grab(moving_resist)
+/mob/living/resist_grab(reflexive = FALSE)
 	. = TRUE
 
 	var/wrestling_diff = 0
@@ -1215,9 +1217,10 @@
 	if(L.compliance)
 		resist_chance = 100
 
-	if(moving_resist && client) //we resisted by trying to move
-		client.move_delay = world.time + 20
-	stamina_add(rand(5,15))
+	if(!reflexive)
+		stamina_add(rand(5,15))
+	else
+		stamina_add(rand(1,5))
 
 	if(!prob(resist_chance))
 		var/rchance = ""


### PR DESCRIPTION

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

This is a lightweight balance change specifically intended to address grab spam cheese.

If you are grabbed while in combat mode (and while conscious, obviously) you will attempt to resist once reflexively. The stamina cost for this attempt is roughly 1/3, and it attempts the specific resist_grab() proc, rather than resist(), so you won't incur the delay for resisting from this first reflexive attempt.

No other aspects of grappling have been modified.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

I would like to make sure this isn't going to be wordlessly closed before I make the video demonstrating the before and after. I hate editing videos so this is an act of self-care.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

The current chain of effects of grabbing, resisting, movement inhibition, associated delays, and other soup in the combat slop means that a rippling tower of inhuman muscle can be totally paralyzed by two gnomes taking turns grabbing their ankles. This is a frankly ridiculous, immersion-shattering spectacle that is not uncommon.

This change would address that; it makes sense both from a gameplay and a realism perspective.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
