### PR TITLE
fixes bathhhouse bug

### DIFF
--- a/code/modules/roguetown/roguemachine/bathmaster.dm
+++ b/code/modules/roguetown/roguemachine/bathmaster.dm
@@ -206,7 +206,7 @@ SUBSYSTEM_DEF(BMtreasury)
 	var/list/vault_accounting = list()
 
 /datum/controller/subsystem/BMtreasury/proc/add_to_vault(var/obj/item/I)
-	if(I.get_real_price() <= 0 || istype(I, /obj/item/roguecoin))
+	if(I.get_real_price() <= 0 || istype(I, /obj/item/roguecoin) || istype(I, /obj/item/storage))
 		return
 	if(I.type in vault_accounting)
 		vault_accounting[I.type] *= multiple_item_penalty


### PR DESCRIPTION
## About The Pull Request
apparently my for loop broke shit, again. this should fix it by not allowing any kind of storage item to count as stuff. if there's another kind of bag or some shit, i don't know. this is my best attempt rn i dont have time for any better checks and idk i could just remove the loop but it'd suck for qol.

if there r any better solutions to this lmk asap. i've been thinking about actually splitting the real_value proc and whatever else from the examine proc and using some sort of fake value system so that you have to still sell shit individually but, again, idfk.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- runs. i put stuff in the bath vault and it gave me a percentage of what Wasnt in bags or whatever so i assume it works. idk how to mnaually fire the subsystem to check so this is the best i can do.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
