### PR TITLE
medicine experts can caut thru armor/clothes whateever

### DIFF
--- a/code/modules/surgery/surgeries/organic_steps.dm
+++ b/code/modules/surgery/surgeries/organic_steps.dm
@@ -103,7 +103,8 @@
 	success_sound = 'sound/surgery/cautery2.ogg'
 
 /datum/surgery_step/cauterize/validate_bodypart(mob/user, mob/living/carbon/target, obj/item/bodypart/bodypart, target_zone)
-	if(islist(user.status_traits) && ("Medicine Expert" in user.status_traits)) // If you have medicine expert, you can caut thru armor.
+	// If you have medicine expert, you can caut thru armor. Also fails if they're in cmode.
+	if(islist(user.status_traits) && ("Medicine Expert" in user.status_traits) && (target.cmode == 0)) 
 		ignore_clothes = TRUE
 	else // IDK if this is necessary but probably good 4 clarification.
 		ignore_clothes = FALSE

--- a/code/modules/surgery/surgeries/organic_steps.dm
+++ b/code/modules/surgery/surgeries/organic_steps.dm
@@ -103,6 +103,11 @@
 	success_sound = 'sound/surgery/cautery2.ogg'
 
 /datum/surgery_step/cauterize/validate_bodypart(mob/user, mob/living/carbon/target, obj/item/bodypart/bodypart, target_zone)
+	if(islist(user.status_traits) && ("Medicine Expert" in user.status_traits)) // If you have medicine expert, you can caut thru armor.
+		ignore_clothes = TRUE
+	else // IDK if this is necessary but probably good 4 clarification.
+		ignore_clothes = FALSE
+
 	. = ..()
 	if(!.)
 		return


### PR DESCRIPTION
## About The Pull Request
took ages figuring out how to bypass this shit until i realized there was an ignores_clothes flag i could've set if it was in the trait list. lmao. 
folk who have the expert medicine trait can now cauterize through armor. i considered adding a cmode check but i don't think it's worth it. if someone is doing this shit 2 powergame i aint even got shit 2 say. i can add it later idk i just felt like shit adding an if check and then it was anm or chec i i HAVE TO STOP ADDIGN CHECKS .PLEASE. OGHGHH MYG OD.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- it runs. i didnt tkae screenshots but on my test i stabbed myself w/ armor on/off, took the trait on/off. it works fine.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- i got paid 2 erp tokens by one person and a ksis on thge cheek by another
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
