### PR TITLE
Just one more retinue PR to save the Peaks trust

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/brigandine.dm
+++ b/code/modules/clothing/rogueclothes/armor/brigandine.dm
@@ -47,13 +47,13 @@
 			pic.color = get_detail_color()
 		add_overlay(pic)
 
-/obj/item/clothing/suit/roguetown/armor/brigandine/sheriff/Initialize()
+/obj/item/clothing/suit/roguetown/armor/brigandine/retinue/Initialize()
 	. = ..()
 	if(GLOB.lordprimary)
 		lordcolor(GLOB.lordprimary,GLOB.lordsecondary)
 	GLOB.lordcolor += src
 
-/obj/item/clothing/suit/roguetown/armor/brigandine/sheriff/lordcolor(primary,secondary)
+/obj/item/clothing/suit/roguetown/armor/brigandine/retinue/lordcolor(primary,secondary)
 	detail_tag = "_det"
 	detail_color = primary
 	update_icon()
@@ -61,7 +61,7 @@
 		var/mob/L = loc
 		L.update_inv_armor()
 
-/obj/item/clothing/suit/roguetown/armor/brigandine/sheriff/Destroy()
+/obj/item/clothing/suit/roguetown/armor/brigandine/retinue/Destroy()
 	GLOB.lordcolor -= src
 	return ..()
 
@@ -74,7 +74,7 @@
 	armor_class = ARMOR_CLASS_HEAVY
 	max_integrity = ARMOR_INT_CHEST_PLATE_BRIGANDINE + 50
 
-/obj/item/clothing/suit/roguetown/armor/brigandine/sheriff/coat
+/obj/item/clothing/suit/roguetown/armor/brigandine/retinue/coat
 	name = "coat of the commander"
 	desc = "A thick boiled leather surcoat with enough plates concealed within the folds to offer superior protection. It weighs a ton and takes a great man to wear."
 	icon_state = "leathercoat"
@@ -83,7 +83,7 @@
 	sleeved_detail = TRUE
 	boobed_detail = TRUE
 
-/obj/item/clothing/suit/roguetown/armor/brigandine/sheriff/coat/attack_right(mob/user)
+/obj/item/clothing/suit/roguetown/armor/brigandine/retinue/coat/attack_right(mob/user)
 	if(picked)
 		return
 	var/the_time = world.time
@@ -142,6 +142,24 @@
 		if(get_detail_color())
 			pic.color = get_detail_color()
 		add_overlay(pic)
+
+/obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue/Initialize()
+	. = ..()
+	if(GLOB.lordprimary)
+		lordcolor(GLOB.lordprimary,GLOB.lordsecondary)
+	GLOB.lordcolor += src
+
+/obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue/lordcolor(primary,secondary)
+	detail_tag = "_detail"
+	detail_color = primary
+	update_icon()
+	if(ismob(loc))
+		var/mob/L = loc
+		L.update_inv_armor()
+
+/obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue/Destroy()
+	GLOB.lordcolor -= src
+	return ..()
 
 /obj/item/clothing/suit/roguetown/armor/brigandine/captain
 	name = "captain's brigandine"

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -371,13 +371,13 @@
 		return
 	picked = TRUE
 
-/obj/item/clothing/cloak/tabard/knight/guard
+/obj/item/clothing/cloak/tabard/retinue
 	desc = "A tabard with the lord's heraldic colors."
 	color = CLOTHING_AZURE
-	detail_tag = "_spl"
+	detail_tag = "_quad"
 	detail_color = CLOTHING_WHITE
 
-/obj/item/clothing/cloak/tabard/knight/guard/attack_right(mob/user)
+/obj/item/clothing/cloak/tabard/retinue/attack_right(mob/user)
 	if(picked)
 		return
 	var/the_time = world.time
@@ -408,13 +408,25 @@
 		return
 	picked = TRUE
 
-/obj/item/clothing/cloak/tabard/knight/guard/Initialize()
+/obj/item/clothing/cloak/tabard/retinue/Initialize()
 	. = ..()
 	if(GLOB.lordprimary)
 		lordcolor(GLOB.lordprimary,GLOB.lordsecondary)
 	GLOB.lordcolor += src
 
-/obj/item/clothing/cloak/tabard/knight/guard/update_icon()
+/obj/item/clothing/cloak/tabard/retinue/lordcolor(primary,secondary)
+	color = primary
+	detail_color = secondary
+	update_icon()
+	if(ismob(loc))
+		var/mob/L = loc
+		L.update_inv_cloak()
+
+/obj/item/clothing/cloak/tabard/retinue/Destroy()
+	GLOB.lordcolor -= src
+	return ..()
+
+/obj/item/clothing/cloak/tabard/retinue/update_icon()
 	cut_overlays()
 	if(get_detail_tag())
 		var/mutable_appearance/pic = mutable_appearance(icon(icon, "[icon_state][detail_tag]"))
@@ -423,18 +435,8 @@
 			pic.color = get_detail_color()
 		add_overlay(pic)
 
-/obj/item/clothing/cloak/tabard/knight/guard/lordcolor(primary,secondary)
-	color = primary
-	detail_color = secondary
-	update_icon()
-	if(ismob(loc))
-		var/mob/L = loc
-		L.update_inv_cloak()
-
-/obj/item/clothing/cloak/tabard/knight/guard/Destroy()
-	GLOB.lordcolor -= src
-	return ..()
-
+/obj/item/clothing/cloak/tabard/retinue/captain //Because of his other snowflake cloak we can't actually use the naming normally.
+	name = "captain's tabard"
 
 //////////////////////////
 /// SOLDIER TABARD

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -51,8 +51,8 @@
 	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	beltl = /obj/item/rogueweapon/mace/cudgel
-	belt = /obj/item/storage/belt/rogue/leather/black
-	backr = /obj/item/storage/backpack/rogue/satchel/black
+	belt = /obj/item/storage/belt/rogue/leather
+	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/scomstone/bad/garrison
 
 // Melee goon
@@ -123,6 +123,22 @@
 	H.verbs |= /mob/proc/haltyell
 
 	if(H.mind)
+		var/armor_options = list("Brigandine Set", "Maille Set")
+		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMS") as anything in armor_options
+
+		switch(armor_choice)
+			if("Brigandine Set")
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+				wrists = /obj/item/clothing/wrists/roguetown/splintarms
+				pants = /obj/item/clothing/under/roguetown/splintlegs
+
+			if("Maille Set")
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+
 		var/helmets = list(
 		"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
 		"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
@@ -135,29 +151,6 @@
 		var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets
 		if(helmchoice != "None")
 			head = helmets[helmchoice]
-
-		var/armors = list(
-			"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
-			"Iron Hauberk"		= /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron,
-			"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
-		)
-		var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors
-		armor = armors[armorchoice]
-
-		var/arms = list(
-			"Brigandine Splint Arms"		= wrists = /obj/item/clothing/wrists/roguetown/splintarms,
-			"Steel Bracers"		= wrists = /obj/item/clothing/wrists/roguetown/bracers,
-			"Jack Chains"		= wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain,
-		)
-		var/armschoice = input(H, "Choose your arm protection.", "READY THYSELF") as anything in arms
-		wrists = arms[armschoice]
-
-		var/chausses = list(
-			"Brigandine Chausses"		= /obj/item/clothing/under/roguetown/splintlegs,
-			"Steel Chain Chausses"		= /obj/item/clothing/under/roguetown/chainlegs,
-		)
-		var/chausseschoice = input(H, "Choose your chausses.", "READY THYSELF") as anything in chausses
-		pants = chausses[chausseschoice]
 
 // Ranged weapons and daggers on the side - lighter armor, but fleet!
 /datum/advclass/manorguard/skirmisher
@@ -195,7 +188,7 @@
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	pants = /obj/item/clothing/under/roguetown/splintlegs
 	wrists = /obj/item/clothing/wrists/roguetown/splintarms
-	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 
 	H.adjust_blindness(-3)
@@ -221,7 +214,7 @@
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			if("Medium Armor")
-				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 		backpack_contents = list(
@@ -282,10 +275,6 @@
 
 /datum/outfit/job/roguetown/manorguard/cavalry/pre_equip(mob/living/carbon/human/H)
 	..()
-
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson		//Bit worse shirt protection than the archer -- as foot soldier.
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale			//Makes up for worse shirt protection with kinda better armor protection
-	pants = /obj/item/clothing/under/roguetown/chainlegs
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 
@@ -312,6 +301,22 @@
 			)
 		H.verbs |= /mob/proc/haltyell
 
+		var/armor_options = list("Brigandine Set", "Maille Set")
+		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMS") as anything in armor_options
+
+		switch(armor_choice)
+			if("Brigandine Set")
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+				wrists = /obj/item/clothing/wrists/roguetown/splintarms
+				pants = /obj/item/clothing/under/roguetown/splintlegs
+
+			if("Maille Set")
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+
 		var/helmets = list(
 		"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
 		"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
@@ -324,26 +329,3 @@
 		var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets
 		if(helmchoice != "None")
 			head = helmets[helmchoice]
-
-		var/armors = list(
-			"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
-			"Iron Hauberk"		= /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron,
-			"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
-		)
-		var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors
-		armor = armors[armorchoice]
-
-		var/arms = list(
-			"Brigandine Splint Arms"		= wrists = /obj/item/clothing/wrists/roguetown/splintarms,
-			"Steel Bracers"		= wrists = /obj/item/clothing/wrists/roguetown/bracers,
-			"Jack Chains"		= wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain,
-		)
-		var/armschoice = input(H, "Choose your arm protection.", "READY THYSELF") as anything in arms
-		wrists = arms[armschoice]
-
-		var/chausses = list(
-			"Brigandine Chausses"		= /obj/item/clothing/under/roguetown/splintlegs,
-			"Steel Chain Chausses"		= /obj/item/clothing/under/roguetown/chainlegs,
-		)
-		var/chausseschoice = input(H, "Choose your chausses.", "READY THYSELF") as anything in chausses
-		pants = chausses[chausseschoice]

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -50,10 +50,10 @@
 	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
-	belt = /obj/item/storage/belt/rogue/leather/black
+	belt = /obj/item/storage/belt/rogue/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
-	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backr = /obj/item/storage/backpack/rogue/satchel
 	head = /obj/item/clothing/head/roguetown/helmet/sallet/visored
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 	id = /obj/item/scomstone/garrison
@@ -133,7 +133,7 @@
 				l_hand = /obj/item/rogueweapon/scabbard/sword
 
 		var/armors = list(
-			"Lightweight Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/light,
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/retinue,
 			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
 			"Scalemail"	= /obj/item/clothing/suit/roguetown/armor/plate/scale,
 		)

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -79,7 +79,7 @@
 	)
 
 /datum/outfit/job/roguetown/marshal/classic/pre_equip(mob/living/carbon/human/H)
-	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/sheriff
+	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/retinue
 	cloak = /obj/item/clothing/cloak/stabard/surcoat/bailiff
 	backr = /obj/item/rogueweapon/mace/cudgel/justice
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold
@@ -116,7 +116,7 @@
 	)
 
 /datum/outfit/job/roguetown/marshal/kcommander/pre_equip(mob/living/carbon/human/H)
-	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/sheriff/coat
+	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/retinue/coat
 	backr = /obj/item/rogueweapon/sword/long/oathkeeper
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -43,14 +43,14 @@
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(istype(H.cloak, /obj/item/clothing/cloak/stabard))
+		if(istype(H.cloak, /obj/item/clothing/cloak/tabard/knight/guard)  || (istype(H.cloak, /obj/item/clothing/cloak/captain)))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")
 			if(index)
 				index = copytext(H.real_name, 1,index)
 			if(!index)
 				index = H.real_name
-			S.name = "Captain Tabard ([index])"
+			S.name = "Captain Tabard ([index])" //This doesn't even actually work but you know.
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
 		var/honorary = "Ser"
@@ -196,17 +196,17 @@
 		var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors
 		switch(armorchoice)
 			if("Brigandine")
-				armor = /obj/item/clothing/suit/roguetown/armor/brigandine
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/retinue
 				pants = /obj/item/clothing/under/roguetown/chainlegs
-				cloak = /obj/item/clothing/cloak/stabard
+				cloak = /obj/item/clothing/cloak/tabard/retinue/captain
 			if("Coat of Plates")
 				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates
 				pants = /obj/item/clothing/under/roguetown/chainlegs
-				cloak = /obj/item/clothing/cloak/stabard
+				cloak = /obj/item/clothing/cloak/tabard/retinue/captain
 			if("Fluted Cuirass")
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fluted
 				pants = /obj/item/clothing/under/roguetown/chainlegs
-				cloak = /obj/item/clothing/cloak/stabard
+				cloak = /obj/item/clothing/cloak/tabard/retinue/captain
 			if("Captain's armor")
 				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/captain
 				pants = /obj/item/clothing/under/roguetown/chainlegs/captain

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -37,7 +37,7 @@
 	..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(istype(H.cloak, /obj/item/clothing/cloak/stabard/surcoat/guard))
+		if(istype(H.cloak, /obj/item/clothing/cloak/tabard/retinue))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")
 			if(index)
@@ -60,7 +60,7 @@
 					H.mind.person_knows_me(MF)
 
 /datum/outfit/job/roguetown/knight
-	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
+	cloak = /obj/item/clothing/cloak/tabard/retinue
 	neck = /obj/item/clothing/neck/roguetown/bevor
 	gloves = /obj/item/clothing/gloves/roguetown/plate
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
@@ -155,7 +155,7 @@
 			head = helmets[helmchoice]
 
 		var/armors = list(
-			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/retinue,
 			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
 			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
 			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
@@ -241,7 +241,7 @@
 			head = helmets[helmchoice]
 
 		var/armors = list(
-			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/retinue,
 			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
 			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
 			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
@@ -351,7 +351,7 @@
 			head = helmets[helmchoice]
 
 		var/armors = list(
-			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
+			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine/retinue,
 			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
 			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
 			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
@@ -448,7 +448,7 @@
 			if("Medium Armor")
 				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 				pants = /obj/item/clothing/under/roguetown/chainlegs
-				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
 			if("Medium Cuirass")
 				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 				pants = /obj/item/clothing/under/roguetown/chainlegs


### PR DESCRIPTION
## About The Pull Request

Cuts down on the amount of clutter MAAs have to go through on spawn by slamming their selections into 2 options - Brigandine Set (what skirmisher already has on spawn) and Maille set (scale / haubergeon / bracers). Sergeant gets full brigandine.
Brigandines (light and medium) now copy the heraldry colours on spawn for easier identification.
Removed the black belt and satchel for garrison - it's a leftover from when the default heraldry colours were red and black.
Repathed knight tabards and put them back on knights - should help seperate them from garrison.

## Testing Evidence

<img width="227" height="419" alt="image" src="https://github.com/user-attachments/assets/d7d3cbd9-2658-4cc7-991f-43c53caaabfa" />

<img width="244" height="455" alt="image" src="https://github.com/user-attachments/assets/3ae51554-909d-43d6-b130-2ef9d2131eaf" />

<img width="85" height="103" alt="image" src="https://github.com/user-attachments/assets/15490d5d-32f4-4fe8-b279-e9203a80d063" />

## Why It's Good For The Game

Having to click through 6 windows just to play guard gets annoying after the 50th time even if it does limit customization.
Easier identification is nice besides it's in the code might as well use it.