### PR TITLE
mob offsets now properly reset when you jump

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -702,6 +702,11 @@
 		animate(transform = prev_transform, time = 0)
 		throw_at(A, 1, 1, src, spin = FALSE)
 
+	if(mob_offsets)
+		for(var/o in mob_offsets)
+			if(mob_offsets[o])
+				reset_offsets(o)
+
 #undef FLIP_DIRECTION_CLOCKWISE
 #undef FLIP_DIRECTION_ANTICLOCKWISE
 


### PR DESCRIPTION
## About The Pull Request
makes it so your mob offsets properly reset when you jump while on a stump or window. i use acrobat to aura farm by harmlessly jumping out a window onto the ground.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
it works for stumps and windows
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
i put a crypto miner in
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
