### PR TITLE
Orc mob nerf 2.0

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
@@ -32,10 +32,10 @@
 			r_hand = /obj/item/rogueweapon/shield/wood // Help preserve integrity
 		if(3)
 			l_hand = /obj/item/rogueweapon/mace/cudgel/copper
-	H.STASTR = 12
+	H.STASTR = 11
 	H.STASPD = 8
-	H.STACON = 12
-	H.STAWIL = 12
+	H.STACON = 11
+	H.STAWIL = 11
 	H.STAINT = 4 // Very dumb
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
@@ -70,10 +70,10 @@
 			l_hand = /obj/item/rogueweapon/greataxe
 		if(5)
 			l_hand = /obj/item/rogueweapon/pick/militia
-	H.STASTR = 14 // GAGGER GAGGER GAGGER
+	H.STASTR = 12 // GAGGER GAGGER GAGGER
 	H.STASPD = 8
-	H.STACON = 13
-	H.STAWIL = 13
+	H.STACON = 12
+	H.STAWIL = 10
 	H.STAINT = 4
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
@@ -104,10 +104,10 @@
 			l_hand = /obj/item/rogueweapon/huntingknife/idagger
 		if(2)
 			l_hand = /obj/item/rogueweapon/pick/militia
-	H.STASTR = 16 // GAGGER GAGGER GAGGER
+	H.STASTR = 13 // GAGGER GAGGER GAGGER
 	H.STASPD = 10 // Fast, for an orc
-	H.STACON = 16
-	H.STAWIL = 13
+	H.STACON = 12
+	H.STAWIL = 12
 	H.STAINT = 1 // Minmax department
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
@@ -145,11 +145,11 @@
 		if(6)
 			l_hand = /obj/item/rogueweapon/sword/short/falchion
 			r_hand = /obj/item/rogueweapon/sword/short/falchion // intrusive thoughts
-	H.STASTR = 16 // GAGGER GAGGER GAGGER
+	H.STASTR = 14 // GAGGER GAGGER GAGGER
 	H.STASPD = 10 // Fast, for an orc
-	H.STACON = 16
-	H.STAWIL = 13
-	H.STAINT = 1 // Minmax department
+	H.STACON = 12
+	H.STAWIL = 12
+	H.STAINT = 1
 	H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
@@ -161,4 +161,3 @@
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, INNATE_TRAIT)


### PR DESCRIPTION
## About The Pull Request
Revival of https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3379 

I'm still of the belief post loot nerf that the Orc Mobs are far too cracked for the risk vs rewards ratio and until / unless loot is tweaked with a major PR from me they should be downtuned a bit. This is relatively mild and just cut down 3 - 6 statpoints on average, alongside removing Crit Res from Warlord (Which are already cracked)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Nae

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Nerfing Omniwound bleed rate for orcs does not measurably improve the experience because kiting and bleeding out mobs is not a viable PVE tactic and more of a PVP tactic that take place over 3 minutes  - generally not feasible nor fun in close quarter. 

Orcs are utterly cracked but it was fine under the old balance where the dungeons were highly rewarding. Now it is a high risk high difficulty dungeon for the average PVE-r with low rewards. This tune it down slightly in line with the rewards.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
