### PR TITLE
Fixes werewolf claws

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
@@ -43,27 +43,57 @@
 	antimagic_allowed = TRUE
 	recharge_time = 20 //2 seconds
 	ignore_cockblock = TRUE
-	var/extended = FALSE
+	var/list/extended_claw_record = list(FALSE, FALSE)
+	var/static/claw_type = /obj/item/rogueweapon/werewolf_claw
 
-/obj/effect/proc_holder/spell/self/claws/cast(mob/user = usr)
-	..()
-	var/obj/item/rogueweapon/werewolf_claw/left/l
-	var/obj/item/rogueweapon/werewolf_claw/right/r
+/obj/effect/proc_holder/spell/self/claws/cast(list/targets, mob/user)
+	. = ..()
+	var/list/current_hands = list(FALSE, FALSE)
+	current_hands[LEFT_HANDS] = user.get_item_for_held_index(LEFT_HANDS)
+	current_hands[RIGHT_HANDS] = user.get_item_for_held_index(RIGHT_HANDS)
+	var/extending_claws = FALSE
+	// note the potential (and intentional) double negative for having a hand for that index; if you're missing
+	// that arm, we need to return a truthy value to flip into a falsy value, so you don't try to extend claws
+	// if you're missing one arm and trying to free up the other hand from your current claws
+	if(!(current_hands[LEFT_HANDS] || !user.has_hand_for_held_index(LEFT_HANDS)) || !(current_hands[RIGHT_HANDS] || !user.has_hand_for_held_index(RIGHT_HANDS)))
+		extending_claws = TRUE
+	//LEFT_HANDS = 1, RIGHT_HANDS = 2, see code/__DEFINES/inventory.dm
+	for(var/hand_index = 1, hand_index < 3, hand_index++)
+		var/current_item = current_hands[hand_index]
+		if(extending_claws)
+			// don't try to force a claw into a hand holding something, like a succulent limb inconveniently
+			// attached to a victim
+			if(current_hands[hand_index])
+				continue
+			// don't try to force a claw into a hand that was detached from you, non-succulently
+			if(!user.has_hand_for_held_index(hand_index))
+				continue
+			var/new_claw
+			if(hand_index == LEFT_HANDS)
+				new_claw = new /obj/item/rogueweapon/werewolf_claw/left(user)
+				user.put_in_l_hand(new_claw)
+				extended_claw_record[LEFT_HANDS] = new_claw
+			else
+				new_claw = new /obj/item/rogueweapon/werewolf_claw/right(user)
+				user.put_in_r_hand(new_claw)
+				extended_claw_record[RIGHT_HANDS] = new_claw
+			continue
+		var/claw_entry = extended_claw_record[hand_index]
+		if(claw_entry && current_item != claw_entry)
+			var/msg = "[user] had a bug with their werewolf claws sheathing: Their\
+			 held item for their [(hand_index == LEFT_HANDS ? "left" : "right")] hand wasn't\
+			 the expected value! Expected: [claw_entry], Got: [current_item]"
+			log_admin(msg)
+			log_runtime(msg)
+			user.temporarilyRemoveItemFromInventory(I = claw_entry, force = TRUE)
+			qdel(claw_entry)
+		if(istype(current_item, claw_type))
+			user.temporarilyRemoveItemFromInventory(I = current_item, force = TRUE)
+			qdel(current_item)
+		extended_claw_record[hand_index] = FALSE
+	return TRUE
 
-	l = user.get_active_held_item()
-	r = user.get_inactive_held_item()
-	if(extended)
-		if(istype(user.get_active_held_item(), /obj/item/rogueweapon/werewolf_claw))
-			user.dropItemToGround(l, TRUE)
-			user.dropItemToGround(r, TRUE)
-			qdel(l)
-			qdel(r)
-			//user.visible_message("Your claws retract.", "You feel your claws retracting.", "You hear a sound of claws retracting.")
-			extended = FALSE
-	else
-		l = new(user,1)
-		r = new(user,2)
-		user.put_in_hands(l, TRUE, FALSE, TRUE)
-		user.put_in_hands(r, TRUE, FALSE, TRUE)
-		//user.visible_message("Your claws extend.", "You feel your claws extending.", "You hear a sound of claws extending.")
-		extended = TRUE
+	
+	
+	
+	

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
@@ -77,23 +77,25 @@
 				new_claw = new /obj/item/rogueweapon/werewolf_claw/right(user)
 				user.put_in_r_hand(new_claw)
 				extended_claw_record[RIGHT_HANDS] = new_claw
+			RegisterSignal(new_claw, COMSIG_QDELETING, PROC_REF(clear_claw_entry))
 			continue
 		var/claw_entry = extended_claw_record[hand_index]
 		if(claw_entry && current_item != claw_entry)
-			var/msg = "[user] had a bug with their werewolf claws sheathing: Their\
-			 held item for their [(hand_index == LEFT_HANDS ? "left" : "right")] hand wasn't\
-			 the expected value! Expected: [claw_entry], Got: [current_item]"
+			var/msg = "[user] held item wasn't extended_claw_entry as expected; Expected: [claw_entry], Got: [current_item]"
 			log_admin(msg)
 			log_runtime(msg)
-			user.temporarilyRemoveItemFromInventory(I = claw_entry, force = TRUE)
-			qdel(claw_entry)
 		if(istype(current_item, claw_type))
+			if(!claw_entry)
+				var/msg = "[user] had a werewolf claw that wasn't being tracked by the claw entries: [current_item]"
+				log_admin(msg)
+				log_runtime(msg)
 			user.temporarilyRemoveItemFromInventory(I = current_item, force = TRUE)
 			qdel(current_item)
-		extended_claw_record[hand_index] = FALSE
+		extended_claw_record[hand_index] = FALSE		
 	return TRUE
 
-	
-	
-	
-	
+/obj/effect/proc_holder/spell/self/claws/proc/clear_claw_entry(datum/source)
+	SIGNAL_HANDLER
+	var/claw_index = extended_claw_record.Find(source)
+	if(claw_index)
+		extended_claw_record[claw_index] = FALSE


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

This fixes werewolf claws. There is a slight modification to the behavior; if you have an empty hand, you will always attempt to extend a claw into that hand. You will only try to retract your claws if both hands are full. whether it's from holding something or that hand being unavailable.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->


https://github.com/user-attachments/assets/659de51b-6edf-48f2-b86a-d310e79642bb



## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

BUG: fix
VALID: KILL