### PR TITLE
Fixes fucky character preview for anthro species

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -414,6 +414,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 			dat += "<b>Unrevivable:</b> <a href='?_src_=prefs;preference=dnr;task=input'>[dnr_pref ? "Yes" : "No"]</a><BR>"
 
+			dat += "<b>Be a Familiar:</b><a href='?_src_=prefs;preference=familiar_prefs;task=input'>Familiar Preferences</a>"
+
 /*
 			dat += "<br><br><b>Special Names:</b><BR>"
 			var/old_group
@@ -500,8 +502,6 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			dat += "<br><b>Loadout Item II:</b> <a href='?_src_=prefs;preference=loadout_item2;task=input'>[loadout2 ? loadout2.name : "None"]</a>"
 
 			dat += "<br><b>Loadout Item III:</b> <a href='?_src_=prefs;preference=loadout_item3;task=input'>[loadout3 ? loadout3.name : "None"]</a>"
-
-			dat += "<br><b>Be a Familiar:</b><a href='?_src_=prefs;preference=familiar_prefs;task=input'>Familiar Preferences</a>"
 
 			dat += "</td>"
 
@@ -778,7 +778,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 	winshow(user, "preferencess_window", TRUE)
 	winset(user, "preferencess_window", "size=820x850")
-	winset(user, "preferencess_window", "pos=370,90")
+	winset(user, "preferencess_window", "pos=280,80")
 	var/datum/browser/noclose/popup = new(user, "preferences_browser", "<div align='center'>[used_title]</div>")
 	popup.set_window_options("can_close=0")
 	popup.set_content(dat.Join())

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -213,7 +213,7 @@ window "popupwindow"
 window "preferencess_window"
 	elem "preferencess_window"
 		type = MAIN
-		pos = 370,90
+		pos = 280,80
 		size = 820x850
 		anchor1 = -1,-1
 		anchor2 = -1,-1
@@ -231,7 +231,7 @@ window "preferencess_window"
 		saved-params = ""
 	elem "character_preview_map"
 		type = MAP
-		pos = 320,230
+		pos = 310,230
 		size = 172x192
 		anchor1 = 75,30
 		anchor2 = 100,20


### PR DESCRIPTION
## About The Pull Request

fixes this weird shit where the character preview is clipping with the text for anthro species & half-kin

<img width="481" height="507" alt="image" src="https://github.com/user-attachments/assets/5b2d9ee3-a5fe-4bb9-b38d-ce39f401bfd9" />

my bad

also properly centers the window

and moves familiar preferences to the left-side since there's a lot of empty space there and the right-side menu was getting kinda crowded

## Why It's Good For The Game

oops i messed up when resizing the char setup window