### PR TITLE
Bug-fix - Miacrafting now respects can_craft_here area proc

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -126,6 +126,10 @@
 	if(ishuman(usr))
 		var/mob/living/carbon/human/H = usr
 		if(modifiers["right"])
+			var/area/A = get_area(H)
+			if(!A.can_craft_here())
+				to_chat(H, span_warning("You cannot craft here."))
+				return
 			if(H.craftingthing && (H.mind?.lastrecipe != null))
 				last_craft = world.time
 				var/datum/component/personal_crafting/C = H.craftingthing

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -514,11 +514,23 @@
 	return data
 
 /datum/component/personal_crafting/ui_interact(mob/user, datum/tgui/ui)
+	var/area/A = get_area(user)
+	if(!A.can_craft_here())
+		to_chat(user, span_warning("You cannot craft here."))
+		if(ui) ui.close()
+		return
+
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "MiaCraft", "Crafting Menu", 700, 800)
 		ui.set_state(GLOB.not_incapacitated_turf_state)
 		ui.open()
+
+/datum/component/personal_crafting/ui_state(mob/user)
+	var/area/A = get_area(user)
+	if(!A.can_craft_here())
+		return UI_CLOSE
+	return ..()
 
 /datum/component/personal_crafting/ui_act(action, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Miacraft menu and 'repeat last recipe' right click function both now respect can_craft_here area proc.

This means you can't craft in areas that are supposed to prevent crafting.

## Testing Evidence

Tested locally, worked fine.

<img width="180" height="30" alt="image" src="https://github.com/user-attachments/assets/d5da176e-30a7-435f-a43d-2c2a5ceed159" />

## Why It's Good For The Game

It's a bugfix. You aren't really supposed to be able to craft around spawn zones/travel tiles or in certain dungeons. The new TGUI crafting menu doesn't currently check for can_craft_here.
