### PR TITLE
bandaid maneater thing

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -44,7 +44,7 @@
 		produce_seed()
 		seednutrition = 0
 	if(!has_buckled_mobs())
-		if(world.time > last_eat + 50)
+		if(world.time > last_eat + 80)
 			var/list/around = view(1, src)
 			for(var/mob/living/M in around)
 				HasProximity(M)
@@ -63,7 +63,7 @@
 			STOP_PROCESSING(SSobj, src)
 			return TRUE
 	for(var/mob/living/L in buckled_mobs)
-		if(world.time > last_eat + 50)
+		if(world.time > last_eat + 100)
 			last_eat = world.time
 			L.flash_fullscreen("redflash3")
 			playsound(src.loc, list('sound/vo/mobs/plant/attack (1).ogg','sound/vo/mobs/plant/attack (2).ogg','sound/vo/mobs/plant/attack (3).ogg','sound/vo/mobs/plant/attack (4).ogg'), 100, FALSE, -1)


### PR DESCRIPTION
## About The Pull Request AND Why It's Good For The Game

for context, maneaters are _**literally**_ broken:

1. They cannot damage you if you are wearing armor. 
2. If you are wearing armor, they will often not damage the armor. 
3. Because of the way they work, they can sometimes pull you from multiple tiles away. 
4. The proximity monitor is super buggy and barely works. 
5. You can often walk over them without anything actually happening due to how they process.
6. Oftentimes, even if you escape the tile you are buckled on, they will continue to try to eat you.

Balance wise, they're also literally just a check? If you are a mage and you get grabbed by a man eater, it is GG. There's not really any skill involved here. You literally just die. If you are a medium or heavy armor or even light armored person, and you get grabbed, nothing happens.

I **was going to** fix the code, (and maybe have them do dmg or sap TRIUMPHs instead of ripping limbs off immediately) but looking at it made me physically ill, so I'm instead just putting a super bandaid fix on it that increases the amount of time it takes for them to start eating you. Yes, this severely decreases the threat they present. No, this isn't a bad thing.

## Testing Evidence




