### PR TITLE
De-Vestments Cleric-Monk

### DIFF
--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -131,24 +131,31 @@
 	REMOVE_TRAIT(user, TRAIT_MONK_ROBE, TRAIT_GENERIC)
 	to_chat(user, span_notice("I must lay down my robes and rest; even God's chosen must rest.."))
 
+//This for adventurers. Base type, same armor. No holy-bonus.
 /obj/item/clothing/suit/roguetown/shirt/robe/monk
-	name = "monk vestments"
-	desc = "Nomadic vestments, worn by those who pursue faith above all else. The burlap is thickly-woven and padded, in order to ward off whatever threats may arise during one's pilgrimage: be it a biting chill or a volley of arrows."
+	name = "nomadic monk vestments"
+	desc = "Nomadic vestments, worn by those who pursue faith above all else. The red burlap is thickly-woven and padded, in order to ward off whatever threats may arise during one's pilgrimage: be it a biting chill or a volley of arrows."
 	icon_state = "monkvestments"
 	item_state = "monkvestments"
 	armor = ARMOR_PADDED_GOOD	//Equal to a padded gambeson, like before.
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_CHOP)	 //Ensures that this inherits the padded gambeson's resistances, too.
-	color = null
+	color = "#662315"
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 
-/obj/item/clothing/suit/roguetown/shirt/robe/monk/equipped(mob/living/user, slot)
+//This is for templars/psydonites. Gives a boon for wearing it to counter-act giving up plate and such.
+/obj/item/clothing/suit/roguetown/shirt/robe/monk/holy
+	name = "holy monk vestments"
+	desc = "Holy vestments, worn by those who pursue faith above all else. The burlap is thickly-woven, padded, and blessed in order to ward off whatever threats may arise during one's pilgrimage: be it a biting chill or a volley of arrows. Ble"
+	color = null	//Base sprite
+
+/obj/item/clothing/suit/roguetown/shirt/robe/monk/holy/equipped(mob/living/user, slot)
 	..()
 	if(!HAS_TRAIT(user, TRAIT_CIVILIZEDBARBARIAN))	//Requires this cus it's a monk-only thing.
 		return
 	ADD_TRAIT(user, TRAIT_MONK_ROBE, TRAIT_GENERIC)
 	to_chat(user, span_notice("With my vows to poverty and my vestments, I feel vigorous - empowered by my God!"))
 
-/obj/item/clothing/suit/roguetown/shirt/robe/monk/dropped(mob/living/user)
+/obj/item/clothing/suit/roguetown/shirt/robe/monk/holy/dropped(mob/living/user)
 	..()
 	REMOVE_TRAIT(user, TRAIT_MONK_ROBE, TRAIT_GENERIC)
 	to_chat(user, span_notice("I must lay down my robes and rest; even God's chosen must rest.."))

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -117,7 +117,7 @@
 			neck = /obj/item/clothing/neck/roguetown/psicross/malum
 			cloak = /obj/item/clothing/cloak/templar/malumite
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/priest
-	armor = /obj/item/clothing/suit/roguetown/shirt/robe/monk
+	armor = /obj/item/clothing/suit/roguetown/shirt/robe/monk/holy
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid

--- a/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
@@ -123,8 +123,8 @@
 	sellprice = 20
 
 /datum/crafting_recipe/roguetown/leather/unique/monkrobes
-	name = "monk vestments"
-	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/monk)
+	name = "holy monk vestments"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/monk/holy)
 	reqs = list(/obj/item/natural/hide/cured = 2,
 				/obj/item/reagent_containers/food/snacks/tallow = 1,
 				/obj/item/natural/fibers = 2)


### PR DESCRIPTION
## About The Pull Request

Removes the vestments that give the stamina regen perk from clerics. Lets them keep the vestments in a red color though without it; basically letting them keep it as unique good armor but without the perk attached.

## Testing Evidence

Works!!!!

## Why It's Good For The Game

I added monk vestments to cleric-monk when punches took more stamina, this was reversed so the entire point of giving monk adventurers this has been pretty - annoying given the increased stamina cost, the entire point of the vestments, is gone.

This technically is a nerf to monk-cleric but brings them back in-line with other adventurer types instead of whole-sale overshadowing them now.

Left the perk-vestments on Templar since I guess they can still use it since they're literally surrendering heavy armor for it so it's more justified at least.
