### PR TITLE
increases reanimation time for pet semetary

### DIFF
--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -515,7 +515,7 @@
 
 /obj/effect/proc_holder/spell/invoked/resurrect/malum
 	name = "Diligent Revival"
-	desc = "Revive the target at a cost, cast on yourself to check.<br>Targets willpower and strenght will be sapped for a time."
+	desc = "Revive the target at a cost, cast on yourself to check.<br>Targets willpower and strength will be sapped for a time."
 	required_items = list(
 		/obj/item/ingot/iron = 3
 	)
@@ -524,7 +524,7 @@
 
 /obj/effect/proc_holder/spell/invoked/resurrect/ravox
 	name = "Just Revival"
-	desc = "Revive the target at a cost, cast on yourself to check.<br>Targets strenght and speed will be sapped for a time."
+	desc = "Revive the target at a cost, cast on yourself to check.<br>Targets strength and speed will be sapped for a time."
 	// The items here are somewhat hard to pick as it still has to be something a ravox acolyte would reasonably obtain.
 	// Bones insinuate that mayhaps, they went out there to delete some skeletons for justice?
 	required_items = list(

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
@@ -76,5 +76,5 @@ GLOBAL_LIST_INIT(animal_to_undead, list(
 
 /datum/component/deadite_animal_reanimation/proc/get_reanimation_time()
 	if(has_world_trait(/datum/world_trait/zizo_pet_cementery))
-		return 2 MINUTES
+		return 1.5 MINUTES
 	return ZOMBIE_REANIMATION_TIMER

--- a/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
+++ b/modular_azurepeak/code/modules/mob/living/simple_animal/rogue/creacher/undead_animal_helpers.dm
@@ -76,5 +76,5 @@ GLOBAL_LIST_INIT(animal_to_undead, list(
 
 /datum/component/deadite_animal_reanimation/proc/get_reanimation_time()
 	if(has_world_trait(/datum/world_trait/zizo_pet_cementery))
-		return 1 MINUTES
+		return 2 MINUTES
 	return ZOMBIE_REANIMATION_TIMER


### PR DESCRIPTION
## About The Pull Request
- pem sem time doubled (1 min -> 2)
- my spellcheck that was on another branch somehow got here but its fine probably
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- compiles
- i do not have the energy to stare at a corpse for 2 minutes after figuring out how to manually trigger thre storyteller event
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- constant complaints abt it
- actually valid now that butchery takes like 45 seconds to a minute to complete. u literally cant butcher animals in time rn. honestly it might be worth upping it to like 2 and 1/2 but this should be fine as a test value.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
