### PR TITLE
Don't uselessly check client for null twice for `update_mouse_pointer()`

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1899,8 +1899,12 @@
 			clear_fullscreen("remote_view", 0)
 
 /mob/living/update_mouse_pointer()
-	..()
-	if (client && ranged_ability && ranged_ability.ranged_mousepointer)
+	if(!client)
+		return
+	if(!client.charging && !atkswinging)
+		if(examine_cursor_icon && client.keys_held["Shift"]) //mouse shit is hardcoded, make this non hard-coded once we make mouse modifiers bindable
+			client.mouse_pointer_icon = examine_cursor_icon
+	if(ranged_ability && ranged_ability.ranged_mousepointer)
 		client.mouse_pointer_icon = ranged_ability.ranged_mousepointer
 
 /mob/living/vv_edit_var(var_name, var_value)


### PR DESCRIPTION
## About The Pull Request

### This is a port of a [PR made in another fork](https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1056)
Original description below

---

This PR makes an inline optimized for the proc `mob/living/update_mouse_pointer()`.

By only checking client once, it saves on a inherited proc call and additional null check, which makes a difference for hot code such as `update_mouse_pointer()`.

## Testing Evidence
Before:
<img width="818" height="134" alt="before" src="https://github.com/user-attachments/assets/cc454923-c999-409d-b76a-1240ceebc65e" />
After:
<img width="819" height="137" alt="after" src="https://github.com/user-attachments/assets/63b431ea-ff43-43f0-8ec2-0f988fd87676" />

The average calls is `828246` per round - this will save up to 1.3 seconds of processing time.

## Why It's Good For The Game

Optimizes the server in a small way.