### PR TITLE
Donor sword fix

### DIFF
--- a/modular_azurepeak/code/game/objects/items/donator_fluff_items.dm
+++ b/modular_azurepeak/code/game/objects/items/donator_fluff_items.dm
@@ -66,8 +66,8 @@
 	mob_overlay_icon = 'modular_azurepeak/icons/clothing/onmob/donor_clothes.dmi'
 	sleeved = 'modular_azurepeak/icons/clothing/onmob/donor_sleeves_armor.dmi' //No sleeves
 
-//Eiren's donator item - custom greatsword
-/obj/item/rogueweapon/greatsword/eiren
+//Eiren's donator item - custom zweihander
+/obj/item/rogueweapon/greatsword/zwei/eiren
 	name = "Regret"
 	desc = "People bring the small flames of their wishes together... to keep them from burning out, we cast our own flames into the biggest fire we can find. But you know... I didn't bring a flame with me. As for me, maybe I just wandered up to the campfire to warm myself a little..."
 	icon_state = "eiren"

--- a/modular_azurepeak/code/game/objects/items/donator_modkit.dm
+++ b/modular_azurepeak/code/game/objects/items/donator_modkit.dm
@@ -70,5 +70,5 @@
 //Eiren - Custom zweihander type
 /obj/item/enchantingkit/eiren
 	name = "'Regret' morphing elixir"
-	target_items = list(/obj/item/rogueweapon/greatsword)		//Takes any type of GREATSWORD so estoc etc
-	result_item = /obj/item/rogueweapon/greatsword/eiren
+	target_items = list(/obj/item/rogueweapon/greatsword/zwei)		//now only takes the zwei and nothing else
+	result_item = /obj/item/rogueweapon/greatsword/zwei/eiren


### PR DESCRIPTION
## About The Pull Request

changed the item path to only apply to the zwei, not all greatswords so i don't morph my knight zwei into greatsword stats

## Testing Evidence

tested on local, didn't catch fire...yet

## Why It's Good For The Game

removes the ability to get something i'd have to buy from the smith
