### PR TITLE
Huge massive buff that will save Azure Peak - Adds the Fireproof tag to some of the leather tier hats that were missing it

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
@@ -81,6 +81,7 @@
 	worn_x_dimension = 64
 	worn_y_dimension = 64
 	sewrepair = TRUE
+	resistance_flags = FIRE_PROOF
 
 // Grenzel unique drip head. Pretend it is a secrete (A type of hat with a hidden helmet underneath). Same stats as kettle
 /obj/item/clothing/head/roguetown/grenzelhofthat
@@ -99,6 +100,7 @@
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST)
 	armor = ARMOR_SPELLSINGER // spellsinger hat stats
 	sewrepair = TRUE
+	resistance_flags = FIRE_PROOF
 	var/picked = FALSE
 	color = "#262927"
 	detail_color = "#FFFFFF"
@@ -156,3 +158,4 @@
 	sewrepair = TRUE
 	flags_inv = HIDEEARS
 	body_parts_covered = HEAD|HAIR|EARS|NOSE|EYES
+	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
## About The Pull Request
All the light helmets in Light Helmets asides from the three that were not parented to the Leather Helmet had a fireproof tag, this brings some of the other unique class/job specific items in line with their leather helmet counterparts.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
trust
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Getting set on fire already ignores armor and does damage directly to you, this prevents it from ALSO destroying your drip entirely as well. In addition the hats that had the tag added to them were also either EXTREMELY difficult to get replaced (Grenzelhoftian Hat and Spellslinger for example require Master sewing which only a tailor really has.) or is entirely unreplaceable (The worn bamboo hat for example)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
