### PR TITLE
Forces maptext to stay within 1,1 bounds

### DIFF
--- a/code/_onclick/hud/mouseover.dm
+++ b/code/_onclick/hud/mouseover.dm
@@ -245,6 +245,11 @@
 		maptext_y = 28
 		maptext_x = -32
 
+	if(text2num(screen_loc_X[1]) <= 0)
+		screen_loc_X[1] = 1
+	if(text2num(screen_loc_Y[1]) <= 0)
+		screen_loc_Y[1] = 1
+
 	screen_loc = "[screen_loc_X[1]]:[pix_X],[screen_loc_Y[1]]:[pix_Y]"
 
 	moved = screen_loc


### PR DESCRIPTION
## About The Pull Request

Forces maptext to stay within 1,1 screen_loc bounds

## Testing Evidence

https://github.com/user-attachments/assets/0317f199-1365-42fc-a02e-00ff636f84ab

## Why It's Good For The Game

Removes screen trickery-fuckery when hovering over big sprites