### PR TITLE
IRS: small upgrades to Azurian taxation

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -1,4 +1,4 @@
-/proc/priority_announce(text, title = "", sound, type , mob/living/sender = null, mob/living/receiver = null)
+/proc/priority_announce(text, title = "", sound, type , mob/living/sender = null, mob/living/receiver = null, strip_html = TRUE)
 	if(!text)
 		return
 
@@ -6,7 +6,10 @@
 
 	if (title && length(title) > 0)
 		announcement += "<h1 class='alert'>[title]</h1>"
-	announcement += "<br><span class='alert'>[STRIP_HTML_SIMPLE(text, MAX_MESSAGE_LEN)]</span>"
+	if(strip_html)
+		announcement += "<br><span class='alert'>[STRIP_HTML_SIMPLE(text, MAX_MESSAGE_LEN)]</span>"
+	else
+		announcement += "<br><span class='alert'>[text]</span>"
 
 	if (sender)
 		sender.log_talk(text, LOG_SAY, tag="priority announcement")

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -293,7 +293,7 @@ SUBSYSTEM_DEF(treasury)
 	church_fine_exemption = new_church_fine
 
 	if(yeomen_tax_value != new_yeomen_tax)
-		final_text += "<br>Yeomen tax: [new_yeomen_tax]%. "
+		final_text += "<br>Yeoman tax: [new_yeomen_tax]%. "
 	yeomen_tax_value = new_yeomen_tax
 	if(yeomen_fine_exemption != new_yeomen_fine)
 		final_text += "Yeomen are [new_yeomen_fine ? "now exempt from fines" : "no longer exempt from fines"]."

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -2,6 +2,11 @@
 #define TREASURY_TICK_AMOUNT 6 MINUTES
 #define EXPORT_ANNOUNCE_THRESHOLD 100
 
+#define TAX_CAT_NOBLE "Nobility"
+#define TAX_CAT_CHURCH "Church"
+#define TAX_CAT_YEOMEN "Yeomanry"
+#define TAX_CAT_PEASANTS "Peasantry"
+
 /proc/send_ooc_note(msg, name, job)
 	var/list/names_to = list()
 	if(name)
@@ -26,14 +31,13 @@ SUBSYSTEM_DEF(treasury)
 	name = "treasury"
 	wait = 1
 	priority = FIRE_PRIORITY_WATER_LEVEL
-	var/noble_tax_value = 0
-	var/noble_fine_exemption = TRUE
-	var/church_tax_value = 6
-	var/church_fine_exemption = TRUE
-	var/yeomen_tax_value = 12
-	var/yeomen_fine_exemption = FALSE
-	var/peasant_tax_value = 12
-	var/peasant_fine_exemption = FALSE
+	/// Assoc list of assoc lists for taxation settings. [category] = list("tax_percent" = num, "fine_exemption" = TRUE/FALSE)
+	var/list/taxation_cat_settings = list(
+		TAX_CAT_NOBLE = list("taxAmount" = 0, "fineExemption" = TRUE),
+		TAX_CAT_CHURCH = list("taxAmount" = 6, "fineExemption" = TRUE),
+		TAX_CAT_YEOMEN = list("taxAmount" = 12, "fineExemption" = FALSE),
+		TAX_CAT_PEASANTS = list("taxAmount" = 12, "fineExemption" = FALSE)
+	)
 	var/tax_value = 0.11
 	var/queens_tax = 0.10
 	var/treasury_value = 0
@@ -266,45 +270,14 @@ SUBSYSTEM_DEF(treasury)
 	return TRUE
 
 /// Boilerplate that sets taxes and announces it to the world. Only changed taxes are announced. 
-/datum/controller/subsystem/treasury/proc/set_taxes(
-	new_noble_tax = 0,
-	new_noble_fine = FALSE,
-	new_yeomen_tax = 0,
-	new_yeomen_fine = FALSE,
-	new_church_tax = 0,
-	new_church_fine = FALSE,
-	new_peasant_tax = 0,
-	new_peasant_fine = FALSE,
-)
+/datum/controller/subsystem/treasury/proc/set_taxes(list/categories, announcement_text)
 	var/final_text = null
-	if(noble_tax_value != new_noble_tax)
-		final_text += "<br>Noble tax: [new_noble_tax]%. "
-	noble_tax_value = new_noble_tax
-	if(noble_fine_exemption != new_noble_fine)
-		final_text += "The Nobility is [new_noble_fine ? "now exempt from fines" : "no longer exempt from fines"]."
-
-	noble_fine_exemption = new_noble_fine
-
-	if(church_tax_value != new_church_tax)
-		final_text += "<br>Church tax: [new_church_tax]%. "
-	church_tax_value = new_church_tax
-	if(church_fine_exemption != new_church_fine)
-		final_text += "The Church is [new_church_fine ? "now exempt from fines" : "no longer exempt from fines"]."
-	church_fine_exemption = new_church_fine
-
-	if(yeomen_tax_value != new_yeomen_tax)
-		final_text += "<br>Yeoman tax: [new_yeomen_tax]%. "
-	yeomen_tax_value = new_yeomen_tax
-	if(yeomen_fine_exemption != new_yeomen_fine)
-		final_text += "Yeomen are [new_yeomen_fine ? "now exempt from fines" : "no longer exempt from fines"]."
-	yeomen_fine_exemption = new_yeomen_fine
-
-	if(peasant_tax_value != new_peasant_tax)
-		final_text += "<br>Peasant tax: [new_peasant_tax]%. "
-	peasant_tax_value = new_peasant_tax
-	if(peasant_fine_exemption != new_peasant_fine)
-		final_text += "Peasants are [new_peasant_fine ? "now exempt from fines" : "no longer exempt from fines"]."
-	peasant_fine_exemption = new_peasant_fine
+	for(var/category in categories)
+		if(taxation_cat_settings[category]["taxAmount"] != categories[category]["taxAmount"])
+			final_text += "<br>[category] tax: [categories[category]["taxAmount"]]%. "
+		if(taxation_cat_settings[category]["fineExemption"] != categories[category]["fineExemption"])
+			final_text += "[category] is [categories[category]["fineExemption"] ? "now exempt from fines" : "no longer exempt from fines"]."
+		taxation_cat_settings[category] = categories[category]
 
 	if(isnull(final_text))
 		return
@@ -314,21 +287,21 @@ SUBSYSTEM_DEF(treasury)
 /// Returns correct tax (0, 100) for a living mob based on its traits & job
 /datum/controller/subsystem/treasury/proc/get_tax_value_for(mob/living/person)
 	if(HAS_TRAIT(person, TRAIT_NOBLE))
-		return noble_tax_value / 100
+		return taxation_cat_settings[TAX_CAT_NOBLE]["taxAmount"] / 100
 	else if(HAS_TRAIT(person, TRAIT_RESIDENT) || (person.job in GLOB.yeoman_positions))
-		return yeomen_tax_value / 100
+		return taxation_cat_settings[TAX_CAT_YEOMEN]["taxAmount"] / 100
 	else if(person.job in GLOB.church_positions)
-		return church_tax_value / 100
+		return taxation_cat_settings[TAX_CAT_CHURCH]["taxAmount"] / 100
 	else
-		return peasant_tax_value / 100
+		return taxation_cat_settings[TAX_CAT_PEASANTS]["taxAmount"] / 100
 
 /// Checks if a given mob can be fined, based on its traits & job. TRUE if can be fined, FALSE if protected by decrees
 /datum/controller/subsystem/treasury/proc/check_fine_exemption(mob/living/person)
 	if(HAS_TRAIT(person, TRAIT_NOBLE))
-		return noble_fine_exemption
+		return taxation_cat_settings[TAX_CAT_NOBLE]["fineExemption"]
 	else if(HAS_TRAIT(person, TRAIT_RESIDENT) || (person.job in GLOB.yeoman_positions))
-		return yeomen_fine_exemption
+		return taxation_cat_settings[TAX_CAT_NOBLE]["fineExemption"]
 	else if(person.job in GLOB.church_positions)
-		return church_fine_exemption
+		return taxation_cat_settings[TAX_CAT_CHURCH]["fineExemption"]
 	else
-		return peasant_fine_exemption
+		return taxation_cat_settings[TAX_CAT_PEASANTS]["fineExemption"]

--- a/code/datums/taxsetter.dm
+++ b/code/datums/taxsetter.dm
@@ -18,7 +18,7 @@
 
 /datum/taxsetter/ui_static_data(mob/user)
 	var/list/data = list("taxCategories")
-	for(var/category in temporary_tax_list)
+	for(var/category in SStreasury.taxation_cat_settings)
 		var/list/cat = list(
 			"categoryName" = category,
 			"taxAmount" = SStreasury.taxation_cat_settings[category]["taxAmount"],

--- a/code/datums/taxsetter.dm
+++ b/code/datums/taxsetter.dm
@@ -16,17 +16,15 @@
 		ui = new(user, src, "TaxSetter", "Set Taxes")
 		ui.open()
 
-/datum/taxsetter/ui_data(mob/user)
-	var/list/data = list(
-		"nobleTax" = SStreasury.noble_tax_value,
-		"nobleFine" = SStreasury.noble_fine_exemption,
-		"churchTax" = SStreasury.church_tax_value,
-		"churchFine" = SStreasury.church_fine_exemption,
-		"yeomenTax" = SStreasury.yeomen_tax_value,
-		"yeomenFine" = SStreasury.yeomen_fine_exemption,
-		"peasantTax" = SStreasury.peasant_tax_value,
-		"peasantFine" = SStreasury.peasant_fine_exemption,
-	)
+/datum/taxsetter/ui_static_data(mob/user)
+	var/list/data = list("taxCategories")
+	for(var/category in temporary_tax_list)
+		var/list/cat = list(
+			"categoryName" = category,
+			"taxAmount" = SStreasury.taxation_cat_settings[category]["taxAmount"],
+			"fineExemption" = SStreasury.taxation_cat_settings[category]["fineExemption"],
+		)
+		data["taxCategories"] += list(cat)
 	return data
 
 /datum/taxsetter/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -36,14 +34,7 @@
 	switch(action)
 		if("set_taxes")
 			SStreasury.set_taxes(
-				params["nobleTax"],
-				params["nobleFine"],
-				params["yeomenTax"],
-				params["yeomenFine"],
-				params["churchTax"],
-				params["churchFine"],
-				params["peasantTax"],
-				params["peasantFine"],
+				params["taxationCats"],
 				announcement_text
 			)
 

--- a/code/datums/taxsetter.dm
+++ b/code/datums/taxsetter.dm
@@ -1,0 +1,51 @@
+/**
+ * UI holder for interacting wtih SStreasury's tax values
+ */
+
+/// Since duke/steward have different announcements
+/datum/taxsetter/var/announcement_text = "The Generous Lord Decrees"
+
+/datum/taxsetter/New(announcement_text = null)
+	. = ..()
+	if(announcement_text)
+		src.announcement_text = announcement_text
+
+/datum/taxsetter/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "TaxSetter", "Set Taxes")
+		ui.open()
+
+/datum/taxsetter/ui_data(mob/user)
+	var/list/data = list(
+		"nobleTax" = SStreasury.noble_tax_value,
+		"nobleFine" = SStreasury.noble_fine_exemption,
+		"churchTax" = SStreasury.church_tax_value,
+		"churchFine" = SStreasury.church_fine_exemption,
+		"yeomenTax" = SStreasury.yeomen_tax_value,
+		"yeomenFine" = SStreasury.yeomen_fine_exemption,
+		"peasantTax" = SStreasury.peasant_tax_value,
+		"peasantFine" = SStreasury.peasant_fine_exemption,
+	)
+	return data
+
+/datum/taxsetter/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	if(..())
+		return TRUE
+
+	switch(action)
+		if("set_taxes")
+			SStreasury.set_taxes(
+				params["nobleTax"],
+				params["nobleFine"],
+				params["yeomenTax"],
+				params["yeomenFine"],
+				params["churchTax"],
+				params["churchFine"],
+				params["peasantTax"],
+				params["peasantFine"],
+				announcement_text
+			)
+
+/datum/taxsetter/ui_state(mob/user)
+	return GLOB.conscious_state

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -86,13 +86,5 @@ GLOBAL_VAR_INIT(steward_tax_cooldown, -50000) // Antispam
 	if(world.time < GLOB.steward_tax_cooldown + 600 SECONDS)
 		to_chat(src, span_warning("You must wait [round((GLOB.steward_tax_cooldown + 600 SECONDS - world.time)/600, 0.1)] minutes before adjusting taxes again! Think of the realm."))
 		return FALSE
-	var/newtax = input(src, "Set a new tax percentage (1-99)", src, SStreasury.tax_value*100) as null|num
-	if(newtax)
-		if(findtext(num2text(newtax), "."))
-			return
-		newtax = CLAMP(newtax, 1, 99)
-		if(stat)
-			return
-		SStreasury.tax_value = newtax / 100
-		priority_announce("The new tax in Azure Peak shall be [newtax] percent.", "The Steward Meddles", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
-		GLOB.steward_tax_cooldown = world.time
+	var/datum/taxsetter/taxsetter = new("The Steward Meddles")
+	taxsetter.ui_interact(src)

--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -176,6 +176,10 @@
 			return
 		for(var/mob/living/A in SStreasury.bank_accounts)
 			if(A == X)
+				if(SStreasury.check_fine_exemption(A))
+					say("By our Liege's mercy, they can not be fined!")
+					playsound(src, 'sound/misc/machineno.ogg', 100, FALSE, -1)
+					return
 				var/newtax = input(usr, "How much to fine [X]", src) as null|num
 				if(!usr.canUseTopic(src, BE_CLOSE) || locked)
 					return

--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -300,16 +300,8 @@ GLOBAL_VAR_INIT(last_crown_announcement_time, -1000)
 /obj/structure/roguemachine/titan/proc/give_tax_popup(mob/living/carbon/human/user)
 	if(!Adjacent(user))
 		return
-	var/newtax = input(user, "Set a new tax percentage (1-99)", src, SStreasury.tax_value*100) as null|num
-	if(newtax)
-		if(!Adjacent(user))
-			return
-		if(findtext(num2text(newtax), "."))
-			return
-		newtax = CLAMP(newtax, 1, 99)
-		SStreasury.tax_value = newtax / 100
-		priority_announce("The new tax in Azure Peak shall be [newtax] percent.", "The Generous Lord Decrees", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
-
+	var/datum/taxsetter/taxsetter = new("The Generous Lord Decrees")
+	taxsetter.ui_interact(user)
 
 /obj/structure/roguemachine/titan/proc/make_announcement(mob/living/user, raw_message)
 	if(!SScommunications.can_announce(user))

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -464,6 +464,7 @@
 #include "code\datums\skill_holder.dm"
 #include "code\datums\soullink.dm"
 #include "code\datums\spawners_menu.dm"
+#include "code\datums\taxsetter.dm"
 #include "code\datums\verbs.dm"
 #include "code\datums\weakrefs.dm"
 #include "code\datums\world_topic.dm"

--- a/tgui/packages/tgui/interfaces/TaxSetter.tsx
+++ b/tgui/packages/tgui/interfaces/TaxSetter.tsx
@@ -1,0 +1,147 @@
+import {
+  Button,
+  LabeledList,
+  NumberInput,
+  Section,
+  Stack,
+} from 'tgui-core/components';
+
+import { useBackend, useLocalState } from '../backend';
+import { Window } from '../layouts';
+
+interface Data {
+  nobleTax: number;
+  nobleFine: boolean;
+  churchTax: number;
+  churchFine: boolean;
+  yeomenTax: number;
+  yeomenFine: boolean;
+  peasantTax: number;
+  peasantFine: boolean;
+}
+
+export const TaxSetter = (props: any, context: any) => {
+  const { act, data } = useBackend<Data>();
+
+  const [nobleTax, setnobleTax] = useLocalState('nobleTax', data.nobleTax);
+  const [nobleFine, setnobleFine] = useLocalState('nobleFine', data.nobleFine);
+  const [churchTax, setchurchTax] = useLocalState('churchTax', data.churchTax);
+  const [churchFine, setchurchFine] = useLocalState(
+    'churchFine',
+    data.churchFine,
+  );
+  const [yeomenTax, setyeomenTax] = useLocalState('yeomenTax', data.yeomenTax);
+  const [yeomenFine, setyeomenFine] = useLocalState(
+    'yeomenFine',
+    data.yeomenFine,
+  );
+  const [peasantTax, setPeasantTax] = useLocalState(
+    'peasantTax',
+    data.peasantTax,
+  );
+  const [peasantFine, setpeasantFine] = useLocalState(
+    'peasantFine',
+    data.peasantFine,
+  );
+
+  return (
+    <Window width={530} height={300}>
+      <Window.Content>
+        <Stack vertical>
+          <Stack.Item>
+            <Stack>
+              <Stack.Item>
+                <TaxBlock
+                  title={'Noble tax'}
+                  taxAmount={nobleTax}
+                  fineExempt={nobleFine}
+                  onTaxChange={(value) => setnobleTax(value)}
+                  onFineChange={() => setnobleFine(!nobleFine)}
+                />
+                <TaxBlock
+                  title={'Church tax'}
+                  taxAmount={churchTax}
+                  fineExempt={churchFine}
+                  onTaxChange={(value) => setchurchTax(value)}
+                  onFineChange={() => setchurchFine(!churchFine)}
+                />
+              </Stack.Item>
+              <Stack.Item>
+                <TaxBlock
+                  title={'Yeomen tax'}
+                  taxAmount={yeomenTax}
+                  fineExempt={yeomenFine}
+                  onTaxChange={(value) => setyeomenTax(value)}
+                  onFineChange={() => setyeomenFine(!yeomenFine)}
+                />
+                <TaxBlock
+                  title={'Peasant tax'}
+                  taxAmount={peasantTax}
+                  fineExempt={peasantFine}
+                  onTaxChange={(value) => setPeasantTax(value)}
+                  onFineChange={() => setpeasantFine(!peasantFine)}
+                />
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+          <Stack.Item>
+            <Button.Confirm
+              fluid
+              color="good"
+              textAlign="Center"
+              onClick={() =>
+                act('set_taxes', {
+                  nobleTax: nobleTax,
+                  nobleFine: nobleFine,
+                  yeomenTax: yeomenTax,
+                  yeomenFine: yeomenFine,
+                  churchTax: churchTax,
+                  churchFine: churchFine,
+                  peasantTax: peasantTax,
+                  peasantFine: peasantFine,
+                })
+              }
+            >
+              MAKE IT SO
+            </Button.Confirm>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+interface TaxBlockProps {
+  title: string;
+  taxAmount: number;
+  fineExempt: boolean;
+  onTaxChange: (action: number) => void;
+  onFineChange: (action: boolean) => void;
+}
+
+export const TaxBlock = (props: TaxBlockProps) => {
+  const { title, taxAmount, fineExempt, onTaxChange, onFineChange } = props;
+
+  return (
+    <Section title={title}>
+      <LabeledList>
+        <LabeledList.Item label={<b>Tithe</b>}>
+          <NumberInput
+            step={1}
+            minValue={0}
+            maxValue={100}
+            value={taxAmount}
+            onChange={(value: number) => onTaxChange(value)}
+          />
+        </LabeledList.Item>
+        <LabeledList.Item label={<b>Fine exemption</b>}>
+          <Button
+            content={fineExempt ? 'by my mercy' : 'they shall pay'}
+            color={fineExempt ? 'bad' : 'good'}
+            onClick={() => onFineChange(!fineExempt)}
+          />
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

- Adds new pookie TGUI for setting taxes. Accessible via the titan itself or via steward's verbs.
- Adds four new taxation and fine categories. This can be tweaked by the duke/regent/steward, of course.
Nobility: 0% taxes roundstart, exempt from fines
Church: 6% taxes roundstart, exempt from fines
Yeomen: everyone with TRAIT_RESIDENT or with job in GLOB.yeoman_list ("Merchant", "Innkeeper", "Archivist", "Scribe", "Town Crier", "Bathmaster", "Guildmaster", "Guildsman", "Tailor"). 12% taxes, not exempt from fines
Peasants: everyone else. 12% taxes, not exempt from fines

## Testing Evidence

<img width="580" height="737" alt="ApplicationFrameHost_MKOp2bcGXz" src="https://github.com/user-attachments/assets/d07ded72-4d11-4ad8-b7f3-e15918c47a4e" />

## Why It's Good For The Game

Adds boilerplate.

Something about dukes having more control over the economy.
Copilot write me a justification for this PR thanks
