### PR TITLE
Forlorn Buff - Medium Armor -> Nopain + Crit Rest. Militia Weapons Choice

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/forlorn.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/forlorn.dm
@@ -56,6 +56,12 @@
 		/obj/item/storage/belt/rogue/pouch/coins/poor
 		)
 	H.merctype = 5
+
+/datum/outfit/job/roguetown/mercenary/forlorn
+	has_loadout = TRUE
+
+/datum/outfit/job/roguetown/mercenary/forlorn/choose_loadout(mob/living/carbon/human/H)
+	. = ..()
 	var/weapons = list("Warhammer", // The OG
 	"Militia Steel Warpick", // Militia / Peasant weapons to slay the oppressors
 	"Maciejowski (Pair)", 
@@ -66,31 +72,31 @@
 	var/weapon_choice = input(H, "Choose your weapon.", "ARMS TO SLAY THE OPPRESSORS") as anything in weapons
 	switch(weapon_choice)
 		if("Warhammer")
-			beltl = /obj/item/rogueweapon/mace/warhammer/steel
-			backl = /obj/item/rogueweapon/shield/heater
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/mace/warhammer/steel, ITEM_SLOT_HANDS)
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/shield/heater, SLOT_BACK_L)
 			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT)
 		if("Militia Steel Warpick")
-			beltl = /obj/item/rogueweapon/pick/militia/steel // This is super good so you only get ONE
-			backl = /obj/item/rogueweapon/shield/heater
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/pick/militia/steel, SLOT_BELT_L) // This is super good so you only get ONE
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/shield/heater, SLOT_BACK_L)
 			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT)
 		if("Maciejowski (Pair)")
-			beltl = /obj/item/rogueweapon/sword/falchion/militia // I think this is really mid one handed so they get two
-			beltr = /obj/item/rogueweapon/sword/falchion/militia
-			backl = /obj/item/rogueweapon/shield/heater
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/sword/falchion/militia, SLOT_BELT_L) // I think this is really mid one handed so they get two
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/sword/falchion/militia, SLOT_BELT_R)
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/shield/heater, SLOT_BACK_L)
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT)
 		if("Militia Spear")
-			r_hand = /obj/item/rogueweapon/spear/militia // Find yer own wheat
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.put_in_hands(new /obj/item/rogueweapon/spear/militia)
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_L)
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT)
 		if("Militia War Axe")
-			r_hand = /obj/item/rogueweapon/greataxe/militia
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.put_in_hands(new /obj/item/rogueweapon/greataxe/militia)
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_L)
 			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT)
 		if("Militia Thresher")
-			r_hand = /obj/item/rogueweapon/flail/peasantwarflail
-			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.put_in_hands(new /obj/item/rogueweapon/flail/peasantwarflail)
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_L)
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT)
 		if("Militia Goedendag (Pair)")
-			r_hand = /obj/item/rogueweapon/woodstaff/militia
-			backl = /obj/item/rogueweapon/woodstaff/militia
+			H.put_in_hands(new /obj/item/rogueweapon/woodstaff/militia)
+			H.equip_to_slot_or_del(new /obj/item/rogueweapon/woodstaff/militia, SLOT_BACK_L)
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT)


### PR DESCRIPTION
## About The Pull Request
- Forlorn loses Medium Armor training, gains Nopain and Critical Resistance
- Forlorn Hope gain expanded weapon choice, including a decent selection of militia weapons. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="397" height="322" alt="NVIDIA_Overlay_TsF5mfFldX" src="https://github.com/user-attachments/assets/970c8c30-35ac-4fcd-9161-fb8af02aaf03" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Finally put the unhinged thoughts about buffing Forlorn I've had a while back to use. Since they got demoted to wearing only light armor, I thought it would create a better niche if I leaned into it by making them "Armed Barbarian" and gave them back crit resistance and nopain, instead of creating yet another medium armor legionnaire class. This give them a very unique niche / gimmick as a merc.

Militia Weapons are rather underused atm and I think there's no better class than a bunch of former slaves (Or maybe angry peasant adventurer class) to use them. 


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
