### PR TITLE
The PR to save Azure Peak - Removed the check for a stone being on the tile already when digging for stones.

### DIFF
--- a/code/modules/roguetown/roguejobs/gravedigger/hole.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/hole.dm
@@ -341,11 +341,10 @@
 				if(prob(25))
 					new /obj/item/natural/clay(T)
 		else
-			if(!(locate(/obj/item/natural/stone) in T) || !(locate(/obj/item/natural/clay) in T))
-				if(prob(23))
-					new /obj/item/natural/stone(T)
-				if(prob(18))	
-					new /obj/item/natural/clay(T)
+			if(prob(23))
+				new /obj/item/natural/stone(T)
+			if(prob(18))
+				new /obj/item/natural/clay(T)
 	return ..()
 
 /obj/structure/closet/dirthole/Destroy()


### PR DESCRIPTION
## About The Pull Request
Look, it's ass. It's always been ass.

This removes the check that see's if a stone is on the tile when you're digging before spawning another one. Essentially you would have to stop, switch hands, pick up the stone and drop it just to get a second stone to spawn. It was tedium for the sake of tedium. 
`
"BUT WHAT IF SOMEONE ABUSES IT TO MAKE A RIDDLE OF STEEL BY JUST DIGGING UP STONES"`, if someone wants to dig up 8,205 (give or take, fast maths) stones to make one riddle of steel when they could buy it for about 600 mammons (or like a dungeon and a half worth of work) then they deserve the riddle of steel. It's still a 23% chance to spawn on dig.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
dug hole 6 times, 1 rock appeared, dug hole 4 more times again with rock on tile, second rock appeared.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Tedium for the sake of tedium is bad.

P.O.V. me as a Court Magician making all of my associates dig holes until we get the required 8,000 rocks to make a riddle of steel
![im-tired](https://github.com/user-attachments/assets/e2ef4bff-12c4-4155-b572-6c9b6e7c2c28)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
