### PR TITLE
Move Kick Cooldown to a status effect instead of offbalance.

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -511,6 +511,17 @@
 	icon_state = "debuff"
 	color ="#af9f9f"
 
+/datum/status_effect/debuff/kickcd
+	id = "kick_cooldown"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/kickcd
+	duration = 3 SECONDS
+
+/atom/movable/screen/alert/status_effect/debuff/kickcd
+	name = "Kick Cooldown"
+	desc = "I can't kick right now."
+	icon_state = "debuff"
+	color ="#c50b0b"
+
 ///////////////////////
 /// CLIMBING STUFF ///
 /////////////////////

--- a/code/game/objects/items/rogueweapons/mmb/kick.dm
+++ b/code/game/objects/items/rogueweapons/mmb/kick.dm
@@ -60,7 +60,7 @@
 			M.onkick(src)
 	else
 		A.onkick(src)
-	OffBalance(3 SECONDS)
+	apply_status_effect(/datum/status_effect/debuff/kickcd)
 	return TRUE
 
 /mob/living/proc/can_kick(atom/A, do_message = TRUE)
@@ -72,7 +72,7 @@
 		return FALSE
 	if(isliving(A) && !(mobility_flags & MOBILITY_STAND) && pulledby)
 		return FALSE
-	if(IsOffBalanced())
+	if(has_status_effect(/datum/status_effect/debuff/kickcd))
 		if(do_message)
 			to_chat(src, span_warning("I haven't regained my balance yet."))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
- Move kick cooldown to a status effect instead of offbalance

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1447" height="1114" alt="TabTip_BSAf1msZv4" src="https://github.com/user-attachments/assets/b09f4cc2-7756-4404-b3d3-aabc38ae191e" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Otherwise you can just jump into someone who kicked you outta defend intent and wreck them instantly.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
