### PR TITLE
Post Grenzel Mage release analysis - Just a little tuning

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -261,6 +261,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/conjure_armor)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/counterspell)
+		H.mind?.adjust_spellpoints(3)
 	if(H.age == AGE_OLD) // FEAR the old man in a profession where men die young, or something corny like that.
 		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 5, TRUE)
 		H.change_stat(STATKEY_SPD, -1)


### PR DESCRIPTION
## About The Pull Request
After having a literal dream about it, and after some communication/feedback/critiques I feel maybe adding a few spell points (3 points) for folk to play with will bring the class in line with something like Hierophant. Hierophant were the most compared class overall and looking back over between the two, they not only have more arcyne skill than Grenzel mage, but also more overall spell points (total value of their spell points is 33). Overall Grenzel will still have a total value of 30 SP, however they get the unique spell so it SHOULD balance out, and the addition should let people vary their playstyle just a little bit.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
trust
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Just a bit of post-merge perspective on improving the class. Small tweak.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
