### PR TITLE
Fixes two warnings from dullahan port + Possible zugfix

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -96,9 +96,8 @@
 			nodmg = TRUE
 			next_attack_msg += span_warning("Armor stops the damage.")
 
-	var/datum/wound/caused_wound
 	if(!nodmg)
-		caused_wound = affecting.bodypart_attacked_by(BCLASS_BITE, dam2do, user, user.zone_selected, crit_message = TRUE)
+		affecting.bodypart_attacked_by(BCLASS_BITE, dam2do, user, user.zone_selected, crit_message = TRUE)
 	visible_message(span_danger("[user] bites [src]'s [parse_zone(user.zone_selected)]![next_attack_msg.Join()]"), \
 					span_userdanger("[user] bites my [parse_zone(user.zone_selected)]![next_attack_msg.Join()]"))
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -60,15 +60,15 @@
 	. = list()
 
 	for(var/mob/M as anything in listeners)
-		var/turf/tocheck = get_turf(M)
+		var/turf/turf_check = get_turf(M)
 		// Check relay instead.
 		if(isdullahan(M))
 			var/mob/living/carbon/human = M
 			var/datum/species/dullahan/dullahan = human.dna.species
 			if(dullahan.headless)
-				tocheck = get_turf(dullahan.my_head)
+				turf_check = get_turf(dullahan.my_head)
 
-		if(get_dist(get_turf(M), turf_source) <= maxdistance)
+		if(get_dist(turf_check, turf_source) <= maxdistance)
 			if(animal_pref)
 				if(M.client?.prefs?.mute_animal_emotes)
 					continue


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.

<img width="1075" height="44" alt="NVIDIA_Overlay_3Hj9uBkLio" src="https://github.com/user-attachments/assets/3c74c3ca-8807-4a2b-9c2d-4f812f392018" />

First warning was for a misplaced `get_turf` check on a dullahan if their head is lopped off. So it also fixes a potential bug where a dullahan's body was still processing hearing even though their head was away.
Second warning was for a truly unused var.

## Testing Evidence

Does indeed work.

## Why Is It Good

idk


<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
