### PR TITLE
Nerfs blood loss while in Yield condition

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -186,6 +186,8 @@
 			amt = amt / 2
 		if(HAS_TRAIT(src, TRAIT_CRITICAL_WEAKNESS))
 			amt = amt * 2
+	if(surrendering)
+		amt = amt / 4 // Helps yield condition not be a bloodloss failure state. Approx to grabbing all of your bodyparts at once
 	blood_volume = max(blood_volume - amt, 0)
 	record_round_statistic(STATS_BLOOD_SPILT, amt)
 	if(isturf(src.loc)) //Blood loss still happens in locker, floor stays clean


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

After discussion in dev, a thought came to reduce bleedout in yield condition. It's such a good idea that it's already in the code with the yield -> critical resistance bloodloss / 2, but maybe this isn't enough. So to make yield state not the "I shall now lay on the floor and bleed to death" choice in the combat matrix, 1/4ths the bleed rate while in the 60 second yield clumsy state.

So, effectively 1/8th blood loss while in the "can do nothing" 30s floored state, and then a subsequent 1/4th while in the 60s clumsy state. You're still kind of screwed if nobody is around to help you. Plus, someone can just come up and bind you while you're yieldmaxxing.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Bloodloss is very scary

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
