### PR TITLE
Middle-aged balancejak

### DIFF
--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -64,6 +64,7 @@
 			if(AGE_MIDDLEAGED)
 				change_stat(STATKEY_SPD, -1)
 				change_stat(STATKEY_WIL, 1)
+				change_stat(STATKEY_LCK, 1)
 			if(AGE_OLD)
 				change_stat(STATKEY_STR, -1)
 				change_stat(STATKEY_SPD, -2)


### PR DESCRIPTION
## About The Pull Request

So, currently middle-aged gives you -1 weighted since SPD/STR weighs 2 points.
I suggest that middle-aged takes -1 SPD and gives +1 WIL +1 LCK instead.
Luck is a sleeper stat, so no, we will not have inflation of middle-aged characters.

## Testing Evidence

There's nothing to test but yeah 

## Why It's Good For The Game

This functionally makes young useless.