### PR TITLE
Stew cooks 30 instead of 31. Bucekt holds 120 and Pot holds 240.

### DIFF
--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -1,5 +1,5 @@
 #define MIN_STEW_TEMPERATURE 374 // For cooking
-#define VOLUME_PER_STEW_COOK 30 // Volume to cook per ingredient
+#define VOLUME_PER_STEW_COOK 29 // Volume to cook per ingredient
 #define VOLUME_PER_STEW_COOK_AFTER 1 // Volume to deduct after the sleep is over
 #define DEEP_FRY_TIME 5 SECONDS // Default deep fry time
 #define OIL_CONSUMED 5 // Amount of oil consumed per deep fry (1 fat = 4 fry)

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -21,7 +21,7 @@
 			to_chat(user, span_warning("[W] is full."))
 			return
 		if(do_after(user, 1 SECONDS, target = src))
-			var/list/waterl = list(/datum/reagent/water = 200)
+			var/list/waterl = list(/datum/reagent/water = 250)
 			W.reagents.add_reagent_list(waterl)
 			to_chat(user, "<span class='notice'>I fill [W] from [src].</span>")
 			playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 80, FALSE)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -214,7 +214,7 @@
 	throwforce = 10
 	amount_per_transfer_from_this = 25
 	possible_transfer_amounts = list(25)
-	volume = 100
+	volume = 120
 	flags_inv = HIDEHAIR
 	reagent_flags = OPENCONTAINER
 	obj_flags = CAN_BE_HIT

--- a/modular/Neu_Food/code/cookware/pot.dm
+++ b/modular/Neu_Food/code/cookware/pot.dm
@@ -15,7 +15,7 @@
 	reagent_flags = OPENCONTAINER
 	throwforce = 10
 	dropshrink = 1 // Override for bucket
-	volume = 200
+	volume = 240
 
 /obj/item/reagent_containers/glass/bucket/pot/update_icon()
 	cut_overlays()
@@ -45,14 +45,14 @@
 	name = "decrepit pot"
 	desc = "A kettle of wrought bronze. One could only imagine what the stews of millenia prior must've tasted like; do you suppose they knew of seasonings-and-spices, too?"
 	icon_state = "apote"
-	volume = 100
+	volume = 120
 	color = "#bb9696"
 	sellprice = 25
 
 /obj/item/reagent_containers/glass/bucket/pot/stone
 	name = "stone pot"
 	desc = "A pot made out of stone. It can hold less than a metal pot."
-	volume = 100 // 99 is the max volume for a stone pot
+	volume = 120 // 99 is the max volume for a stone pot
 
 /obj/item/reagent_containers/glass/bucket/pot/kettle
 	name = "kettle"
@@ -61,7 +61,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	grid_width = 32
 	grid_height = 64
-	volume = 100
+	volume = 120
 
 /obj/item/reagent_containers/glass/bucket/pot/copper
 	name = "copper pot"
@@ -73,7 +73,7 @@
 	desc = "A teapot made out of ceramic. Used to serve tea, it can hold a lot of liquid. It can still spill, however."
 	dropshrink = 0.7
 	icon_state = "teapot"
-	volume = 100
+	volume = 120
 	sellprice = 20
 
 /obj/item/reagent_containers/glass/bucket/pot/teapot/examine()


### PR DESCRIPTION
## About The Pull Request
- Stew cook 30 per ingredient for an even number
- Bucket now holds 120
- Pot holds 240. Worse pot (Stone) holds 120.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="287" height="291" alt="NVIDIA_Overlay_36WMOfHtRH" src="https://github.com/user-attachments/assets/8f82f7c7-d721-40a1-b8d1-68ed54875658" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Number now goes even after the dram PR instead of having leftover water.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
