### PR TITLE
Tightens crafting.dm del_req loop to not eat filled sacks or bottles

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -92,6 +92,8 @@
 /obj/item/proc/can_craft_with()
 	if(craft_blocked)
 		return FALSE
+	if(istype(src, /obj/item/storage/roguebag) && src.contents.len > 0) //for bait bags
+		return FALSE
 	return TRUE
 
 /datum/component/personal_crafting/proc/get_surroundings(mob/user)
@@ -115,7 +117,11 @@
 				if(RC.is_drainable())
 					for(var/datum/reagent/A in RC.reagents.reagent_list)
 						.["other"][A.type] += A.volume
-			.["other"][I.type] += 1
+				// Only count the container itself as a valid crafting item if it's empty
+				if(!RC.reagents || RC.reagents.total_volume == 0)
+					.["other"][I.type] += 1
+			else
+				.["other"][I.type] += 1
 
 /datum/component/personal_crafting/proc/check_tools(mob/user, datum/crafting_recipe/R, list/contents)
 	if(!R.tools.len)
@@ -433,6 +439,17 @@
 						Deletion += I
 						surroundings -= I
 						amt--
+			else if(ispath(A, /obj/item/reagent_containers)) //Don't eat bottles with reagents in them
+				var/atom/movable/I
+				while(amt > 0)
+					I = locate(A) in surroundings
+					var/obj/item/reagent_containers/RC = I
+					if(RC.reagents?.total_volume > 0)
+						surroundings -= I
+						continue
+					Deletion += I
+					surroundings -= I
+					amt--
 			else
 				var/atom/movable/I
 				while(amt > 0)


### PR DESCRIPTION
## About The Pull Request

Crafting del_reqs is a little hungry hippo, so it will eat sacks and bottles without regard for what may be inside them. This code tightens up the logic around what gets considered as a possible crafting item, omitting sacks that have contents and bottles that have reagents inside them. Unfortunately this solution prevents the single-bottle alchemy of water to wine / distillation. Now we need an empty bottle, always, to make something.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence


https://github.com/user-attachments/assets/919b699d-76cc-4e32-b9f8-85a84f947019



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Apothecaries and hunters around the world, rejoice.

Recommend a test merge for a bit to see if there's any wacky exploits that come from the reagent bottle tallying change.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
