### PR TITLE
Port Vanderlin 2838 - Load Client Music Lag.

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -75,7 +75,12 @@
 #undef FTPDELAY
 #undef ADMIN_FTPDELAY_MODIFIER
 
-/proc/pathwalk(path)
+/**
+ * Takes a directory and returns every file within every sub directory.
+ * If extensions_filter is provided then only files that end in that extension are given back.
+ * If extensions_filter is a list, any file that matches at least one entry is given back.
+ */
+/proc/pathwalk(path, extensions_filter)
 	var/list/jobs = list(path)
 	var/list/filenames = list()
 
@@ -85,9 +90,20 @@
 		for(var/new_filename in new_filenames)
 			// if filename ends in / it is a directory, append to currdir
 			if(findtext(new_filename, "/", -1))
-				jobs += current_dir + new_filename
+				jobs += "[current_dir][new_filename]"
+				continue
+			// filename extension filtering
+			if(extensions_filter)
+				if(islist(extensions_filter))
+					for(var/allowed_extension in extensions_filter)
+						if(endswith(new_filename, allowed_extension))
+							filenames += "[current_dir][new_filename]"
+							break
+				else if(endswith(new_filename, extensions_filter))
+					filenames += "[current_dir][new_filename]"
 			else
 				filenames += current_dir + new_filename
+				filenames += "[current_dir][new_filename]"
 	return filenames
 
 /proc/pathflatten(path)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -914,3 +914,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 /proc/sanitize_css_class_name(name)
 	var/static/regex/regex = new(@"[^a-zA-Z0-9]","g")
 	return replacetext(name, regex, "")
+
+/proc/endswith(input_text, ending)
+	var/input_length = LAZYLEN(ending)
+	return !!findtext(input_text, ending, -input_length)

--- a/code/controllers/subsystem/sounds.dm
+++ b/code/controllers/subsystem/sounds.dm
@@ -23,9 +23,17 @@ SUBSYSTEM_DEF(sounds)
 	/// higher reserve position - decremented and incremented to reserve sound channels, anything above this is reserved. The channel at this index is the highest unreserved channel.
 	var/channel_reserve_high
 
+	/// all sound files
+	var/list/all_sounds = list()
+	/// all music files
+	var/list/all_music_sounds = list()
+
 /datum/controller/subsystem/sounds/Initialize()
 	setup_available_channels()
-	return ..()
+	find_all_available_sounds()
+	. = ..()
+
+	preload_music_for_clients()
 
 /datum/controller/subsystem/sounds/proc/setup_available_channels()
 	channel_list = list()
@@ -36,6 +44,33 @@ SUBSYSTEM_DEF(sounds)
 		channel_list += i
 	channel_random_low = 1
 	channel_reserve_high = length(channel_list)
+
+/datum/controller/subsystem/sounds/proc/find_all_available_sounds()
+	all_sounds = list()
+	// Put more common extensions first to speed this up a bit
+	var/static/list/valid_file_extensions = list(
+		".ogg",
+		".wav",
+		".mid",
+		".midi",
+		".mod",
+		".it",
+		".s3m",
+		".xm",
+		".oxm",
+		".raw",
+		".wma",
+		".aiff",
+	)
+
+	all_sounds = pathwalk("sound/", valid_file_extensions)
+
+	all_music_sounds = pathwalk("sound/ambience/", valid_file_extensions)
+	all_music_sounds += pathwalk("sounds/music/", valid_file_extensions)
+
+/datum/controller/subsystem/sounds/proc/preload_music_for_clients()
+	for(var/client/player as anything in GLOB.clients)
+		player.preload_music()
 
 /// Removes a channel from using list.
 /datum/controller/subsystem/sounds/proc/free_sound_channel(channel)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1197,3 +1197,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		log_admin("COMMEND: [ckey] commends [theykey].")
 	return
 
+/client/proc/preload_music()
+	if(SSsounds.initialized == TRUE)
+		for(var/sound_path as anything in SSsounds.all_music_sounds)
+			src << load_resource(sound_path, -1)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -92,6 +92,8 @@
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
 	enable_client_mobs_in_contents(client)
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
+	if(client)
+		client.preload_music()
 
 /**
   * Checks if the attached client is an admin and may deadmin them


### PR DESCRIPTION
## About The Pull Request
https://github.com/Monkestation/Vanderlin/pull/2838 - Load music into memory to remove client side music lag when transitioning areas or such. 

Also port a function ported by Flieeeppy / Chen Marisa

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Logged in game, turned on music.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yippee

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
