### PR TITLE
Consolidates carbon human variables

### DIFF
--- a/code/datums/character_flaw/addiction.dm
+++ b/code/datums/character_flaw/addiction.dm
@@ -1,7 +1,3 @@
-
-/mob/living/carbon/human
-	var/datum/charflaw/charflaw
-
 /mob/proc/sate_addiction()
 	return
 

--- a/code/datums/gods/_curses.dm
+++ b/code/datums/gods/_curses.dm
@@ -1,13 +1,3 @@
-/mob/living/carbon/human
-	var/list/curses = list()
-	COOLDOWN_DECLARE(priest_announcement)
-	COOLDOWN_DECLARE(guildmaster_announcement) //This is not for priest but if you are looking for GUILDMASTER announcements it's here, more so convinence than anything.
-	COOLDOWN_DECLARE(priest_sermon)
-	COOLDOWN_DECLARE(priest_apostasy)
-	COOLDOWN_DECLARE(priest_excommunicate)
-	COOLDOWN_DECLARE(priest_curse)
-	COOLDOWN_DECLARE(priest_change_miracles)
-
 /mob/living/carbon/human/proc/handle_curses()
 	for(var/curse in curses)
 		var/datum/curse/C = curse

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -7,9 +7,6 @@
 	/// Determines whether this intent can be used during click cd
 	var/bypasses_click_cd = FALSE
 
-/mob/living/carbon/human
-	var/bait_stacks
-
 /mob/living/carbon/human/on_cmode()
 	if(!cmode)	//We just toggled it off.
 		addtimer(CALLBACK(src, PROC_REF(purge_bait)), 30 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -1,6 +1,3 @@
-/mob/living/carbon/human
-	var/mob/stored_mob = null
-
 /datum/antagonist/werewolf/on_life(mob/user)
 	if(!user) return
 	var/mob/living/carbon/human/H = user

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -144,3 +144,26 @@
 
 	/// Assoc list of culinary preferences of the mob
 	var/list/culinary_preferences = list()
+
+	var/datum/charflaw/charflaw
+
+	// curse list and cooldown
+	var/list/curses = list()
+	COOLDOWN_DECLARE(priest_announcement)
+	COOLDOWN_DECLARE(guildmaster_announcement) //This is not for priest but if you are looking for GUILDMASTER announcements it's here, more so convinence than anything.
+	COOLDOWN_DECLARE(priest_sermon)
+	COOLDOWN_DECLARE(priest_apostasy)
+	COOLDOWN_DECLARE(priest_excommunicate)
+	COOLDOWN_DECLARE(priest_curse)
+	COOLDOWN_DECLARE(priest_change_miracles)
+
+	// bait stacks for aimed intent
+	var/bait_stacks
+
+	// werewolf mob storage (this is bad and probably causes hard dels)
+	var/mob/stored_mob = null
+
+	var/mob/living/carbon/human/hostagetaker //Stores the person that took us hostage in a var, allows us to force them to attack the mob and such
+	var/mob/living/carbon/human/hostage //What hostage we have
+
+	fovangle = FOV_DEFAULT

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -135,10 +135,6 @@
 		return
 	qdel(src)
 
-/mob/living/carbon/human
-	var/mob/living/carbon/human/hostagetaker //Stores the person that took us hostage in a var, allows us to force them to attack the mob and such
-	var/mob/living/carbon/human/hostage //What hostage we have
-
 /mob/living/carbon/human/proc/attackhostage()
 	if(!istype(hostagetaker.get_active_held_item(), /obj/item/rogueweapon))
 		return

--- a/code/modules/mob/vision_cone.dm
+++ b/code/modules/mob/vision_cone.dm
@@ -7,9 +7,6 @@
 /mob
 	var/fovangle
 
-/mob/living/carbon/human
-	fovangle = FOV_DEFAULT
-
 //Procs
 /atom/proc/InCone(atom/center = usr, dir = NORTH)
 	if(get_dist(center, src) == 0 || src == center) return 0


### PR DESCRIPTION
Currently working on a PR that adds stuff to the carbon human datum and I could not handle the fact it got redefined like seven times for menial variables so I consolidated them all back into the original datum declaration. Might help with compile time but it's mostly for organizational purposes.