### PR TITLE
Updates screen_loc bounds for mouseover maptext

### DIFF
--- a/code/_onclick/hud/mouseover.dm
+++ b/code/_onclick/hud/mouseover.dm
@@ -243,8 +243,8 @@
 		maptext_y = 28
 		maptext_x = -32
 
-	if(text2num(screen_loc_X[1]) <= 0)
-		screen_loc_X[1] = 1
+	if(text2num(screen_loc_X[1]) <= -3)
+		screen_loc_X[1] = -3
 	if(text2num(screen_loc_Y[1]) <= 0)
 		screen_loc_Y[1] = 1
 


### PR DESCRIPTION
## About The Pull Request

Ok so when I forced mouseover maptext to be constrained by 1,1 bounds (the infamous pine tree problem), I forgot that our inventory is actually on the main window, not in a separate one
Thus minimal X screen_loc should be -3, not 1

## Testing Evidence

<img width="1475" height="1269" alt="image" src="https://github.com/user-attachments/assets/bd119e6a-c518-48a6-9d5b-915bff609685" />

## Why It's Good For The Game

bug