### PR TITLE
Add alchemy recipe for turning clay into stone

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -190,6 +190,14 @@
 	craftdiff = 3
 	verbage_simple = "transmute"
 
+/datum/crafting_recipe/roguetown/alchemy/c2sto
+	name = "clay to stone"
+	category = "Transmutation"
+	result = list(/obj/item/natural/stone = 1)
+	reqs = list(/obj/item/natural/clay = 2)
+	craftdiff = 2
+	verbage_simple = "transmute"
+
 /datum/crafting_recipe/roguetown/alchemy/s2coa
 	name = "stone to coal"
 	category = "Transmutation"


### PR DESCRIPTION
## About The Pull Request

What it says on the tin - adds an alchemy crafting recipe for turning 2 clay into 1 stone with craftdiff 2.

## Testing Evidence

Complied, turned some clay into stone, had good times in my clay-free laboratory.
<img width="1119" height="845" alt="obraz" src="https://github.com/user-attachments/assets/96efc1f3-74ad-4e55-b11f-d3a94c323ae9" />

## Why It's Good For The Game

Having shit ton of useless clay near your alchemical laboratory is rather unsightly and annoying, this PR gives an option for utilizing said clay without turning every alchemist around into half-part potter. 
PR to help clean up the workspace and slightly reduce stone grind for alchemists. I'm open to raising the ratio to 3:1 or even 4:1 if 2:1 is considered too strong (again, made this change mainly as a way to get rid of clay laying around, not as a way to farm stones).
Craftdiff set to 2 should prevent people from using this as an easy entry into alchemy.
