### PR TITLE
Garrison Bell and Watchmen Garriscom

### DIFF
--- a/code/game/objects/structures/roguetown/bell.dm
+++ b/code/game/objects/structures/roguetown/bell.dm
@@ -73,7 +73,7 @@
 				if("The Inquisition")
 					rolestonotify = list("Inquisitor", "Orthodoxist", "Absolver")
 				if("Garrison")
-					rolestonotify = list("Man at Arms", "Sergeant", "Dungeoneer")
+					rolestonotify = list("Man at Arms", "Sergeant", "Dungeoneer", "Watchman")
 			send_ooc_note(("I hear the distant sounds of [src] ringing. I'm being called to the [localarea]."), job = rolestonotify)
 
 /obj/structure/standingbell/proc/reset_cooldown()

--- a/code/game/objects/structures/roguetown/bell.dm
+++ b/code/game/objects/structures/roguetown/bell.dm
@@ -72,6 +72,8 @@
 					rolestonotify = list("Bathmaster", "Bathhouse Attendant")
 				if("The Inquisition")
 					rolestonotify = list("Inquisitor", "Orthodoxist", "Absolver")
+				if("Garrison")
+					rolestonotify = list("Man at Arms", "Sergeant", "Dungeoneer")
 			send_ooc_note(("I hear the distant sounds of [src] ringing. I'm being called to the [localarea]."), job = rolestonotify)
 
 /obj/structure/standingbell/proc/reset_cooldown()

--- a/code/modules/roguetown/roguemachine/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm.dm
@@ -150,7 +150,7 @@
 /obj/structure/roguemachine/scomm/MiddleClick(mob/living/carbon/human/user)
 	if(.)
 		return
-	if((HAS_TRAIT(user, TRAIT_GUARDSMAN) || (user.job == "Warden") || (user.job == "Squire") || (user.job == "Marshal") || (user.job == "Grand Duke") || (user.job == "Knight Captain") || (user.job == "Grand Duchess")))
+	if((HAS_TRAIT(user, TRAIT_GUARDSMAN) || (user.job == "Watchman") || (user.job == "Warden") || (user.job == "Squire") || (user.job == "Marshal") || (user.job == "Grand Duke") || (user.job == "Knight Captain") || (user.job == "Grand Duchess")))
 		if(alert("Would you like to swap lines or connect to a jabberline?",, "swap", "jabberline") != "jabberline")
 			garrisonline = !garrisonline
 			to_chat(user, span_info("I [garrisonline ? "connect to the garrison SCOMline" : "connect to the general SCOMLINE"]"))


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
The garrison building has this neato front lobby and I've never really seen it used. This puts one of those nifty zone summon bells here for the garrison, Maa / Sergeant / Dungeoneer so they have some excuse to say "not it!" on the houndSCOM whenever it rings.

Also touches garrison scom to let "Watchmen" convert roles turn them on and off. Maybe this niche feature will be used once per year.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="2554" height="902" alt="image" src="https://github.com/user-attachments/assets/fd5062e6-3388-4b77-9663-d244c84f08cf" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Who really talks to garrison characters, anyway?

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
