### PR TITLE
lets barbarbians and berserkers read

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -263,6 +263,7 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 	)
 
 /datum/outfit/job/roguetown/adventurer/barbarian/pre_equip(mob/living/carbon/human/H, visualsOnly)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -31,6 +31,7 @@
 		/datum/skill/craft/tanning = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 		/datum/skill/labor/butchering = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 	)
 
 /datum/outfit/job/roguetown/wretch/berserker/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

lets barbarians read

## Testing Evidence

should work just fine, 1 line change

## Why It's Good For The Game

The game has changed significantly to the point where not being able to read simply isn't a good idea. The quest system that adventurers interact with involves being able to read contracts. While it's true that you're able to get instructions by opening the scroll, the finer details are very often lost and result in you not being able to find the last mob you're trying to kill.

Also, you literally can't use silverface vendors, which is really fucked up.

(And don't say to simply get someone to do it for you, because needing to do this 10 times over the course of a round every time you play is actually just annoying. See: nobody playing barbarian)

Say barbarians not being able to read is 'SOVL' and call it Hugbox Peak and get a free Hakitapost
<img width="1080" height="195" alt="image" src="https://github.com/user-attachments/assets/b3162ce0-111b-481e-b1d4-81ee42fa7a77" />

