### PR TITLE
Differing Systems - Reflavors 'AGEVET' into 'VERIFIED', clarifies how Azure's optional agevetting system works.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -329,7 +329,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 			var/agevetted = user.check_agevet()
 			dat += "<td style='width:33%;text-align:right'>"
-			dat += "<a href='?_src_=prefs;preference=agevet'><b>Age Vetted:</b></a> [agevetted ? "<font color='#1cb308'>Yes!</font>" : "<font color='#aa0202'>No.</font>"]"
+			dat += "<a href='?_src_=prefs;preference=agevet'><b>VERIFIED:</b></a> [agevetted ? "<font color='#74cde0'>YAE!</font>" : "<font color='#897472'>NAE?</font>"]"
 			dat += "</td>"
 
 			dat += "</table>"
@@ -1310,9 +1310,9 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 	else if(href_list["preference"] == "agevet")
 		if(!user.check_agevet())
-			to_chat(usr, span_warning("You are not age verified. Other players can see your age verification status. To become age verified, open a ticket in Azure Peak's community Discord server.</b>"))
+			to_chat(usr, span_info("- This value doesn't affect you, your whitelist, or your mechanics in <i>any</i> way. If you'd like to show others that you've verified your date-of-birth with a censored ID, however, just open a ticket in Azure Peak's #vet-here channel.</b>"))
 		else
-			to_chat(usr, span_nicegreen("You are already age verified. <b>Yippee!</b>"))
+			to_chat(usr, span_love("- You have been <i>successfully</i> verified! Go get some, champ!"))
 
 	else if(href_list["preference"] == "culinary")
 		show_culinary_ui(user)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1310,9 +1310,9 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 	else if(href_list["preference"] == "agevet")
 		if(!user.check_agevet())
-			to_chat(usr, span_info("This value doesn't affect you, your whitelist, or your mechanics in any way. If you'd like to show others that you've verified your date-of-birth with a censored ID, however, just open a ticket in Azure Peak's <b>#vet-here</b> channel."))
+			to_chat(usr, span_info("- You are a whitelisted player with full access to the server's features. If you'd like to show others that you've <b>VERIFIED</b> your date-of-birth with a censored ID, you can open a ticket in Azure Peak's <b>#vet-here</b> channel. Besides adding a special header to your flavortext, your <b>VERIFIED</b> status does not affect your whitelist or mechanics in any way."))
 		else
-			to_chat(usr, span_love("You have been successfully verified! Go get some, champ!"))
+			to_chat(usr, span_love("- You have been successfully <b>VERIFIED!</b>"))
 
 	else if(href_list["preference"] == "culinary")
 		show_culinary_ui(user)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1310,7 +1310,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 	else if(href_list["preference"] == "agevet")
 		if(!user.check_agevet())
-			to_chat(usr, span_info("- You are a whitelisted player with full access to the server's features. If you'd also like to show others that you've been <b>AGE-vERIFIED</b> with a censored ID, you can open a ticket in Azure Peak's <b>#vet-here</b> channel. Note that this is a purely optional process, and - besides awarding a special header for your flavortext - doesn't affect you in any other way."))
+			to_chat(usr, span_info("- You are a whitelisted player with full access to the server's features. If you'd also like to show others that you've been <b>AGE-VERIFIED</b> with a censored ID, you can open a ticket in Azure Peak's <b>#vet-here</b> channel. Note that this is a purely optional process, and - besides awarding a special header for your flavortext - doesn't affect you in any other way."))
 		else
 			to_chat(usr, span_love("- You have been successfully <b>AGE-VERIFIED!</b>"))
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1310,7 +1310,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 	else if(href_list["preference"] == "agevet")
 		if(!user.check_agevet())
-			to_chat(usr, span_info("- You are a whitelisted player with full access to the server's features. If you'd like to show others that you've <b>VERIFIED</b> your date-of-birth with a censored ID, you can open a ticket in Azure Peak's <b>#vet-here</b> channel. Besides adding a special header to your flavortext, your <b>VERIFIED</b> status does not affect your whitelist or mechanics in any way."))
+			to_chat(usr, span_info("- You are a whitelisted player with full access to the server's features. If you'd also like to show others that you've <b>VERIFIED</b> your date-of-birth with a censored ID, you can open a ticket in Azure Peak's <b>#vet-here</b> channel. Note that this is a <i>purely optional process</i> which - besides awarding a special header for your flavortext - doesn't affect your whitelist or mechanics in any way."))
 		else
 			to_chat(usr, span_love("- You have been successfully <b>VERIFIED!</b>"))
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1310,9 +1310,9 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 	else if(href_list["preference"] == "agevet")
 		if(!user.check_agevet())
-			to_chat(usr, span_info("- You are a whitelisted player with full access to the server's features. If you'd also like to show others that you've <b>VERIFIED</b> your date-of-birth with a censored ID, you can open a ticket in Azure Peak's <b>#vet-here</b> channel. Note that this is a <i>purely optional process</i> which - besides awarding a special header for your flavortext - doesn't affect your whitelist or mechanics in any way."))
+			to_chat(usr, span_info("- You are a whitelisted player with full access to the server's features. If you'd also like to show others that you've been <b>AGE-vERIFIED</b> with a censored ID, you can open a ticket in Azure Peak's <b>#vet-here</b> channel. Note that this is a purely optional process, and - besides awarding a special header for your flavortext - doesn't affect you in any other way."))
 		else
-			to_chat(usr, span_love("- You have been successfully <b>VERIFIED!</b>"))
+			to_chat(usr, span_love("- You have been successfully <b>AGE-VERIFIED!</b>"))
 
 	else if(href_list["preference"] == "culinary")
 		show_culinary_ui(user)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1310,9 +1310,9 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 	else if(href_list["preference"] == "agevet")
 		if(!user.check_agevet())
-			to_chat(usr, span_info("- This value doesn't affect you, your whitelist, or your mechanics in <i>any</i> way. If you'd like to show others that you've verified your date-of-birth with a censored ID, however, just open a ticket in Azure Peak's #vet-here channel.</b>"))
+			to_chat(usr, span_info("This value doesn't affect you, your whitelist, or your mechanics in any way. If you'd like to show others that you've verified your date-of-birth with a censored ID, however, just open a ticket in Azure Peak's <b>#vet-here</b> channel."))
 		else
-			to_chat(usr, span_love("- You have been <i>successfully</i> verified! Go get some, champ!"))
+			to_chat(usr, span_love("You have been successfully verified! Go get some, champ!"))
 
 	else if(href_list["preference"] == "culinary")
 		show_culinary_ui(user)

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -35,7 +35,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 			dat += "<center><i><font color = '#b9b9b9'; font size = 1>This is a LEGACY profile from the naive daes of Psydon!</font></i></center>"
 		var/agevetted = client.check_agevet()
 		if(agevetted)
-			dat += "<center><i><font color = '#74cde0'; font size = 1>This profile belongs to a VERIFIED traveler of Azuria!</font></i></center>"
+			dat += "<center><i><font color = '#74cde0'; font size = 1>This profile belongs to an AGE-VERIFIED traveler of Azuria!</font></i></center>"
 		if(valid_headshot_link(null, headshot_link, TRUE))
 			dat += ("<div align='center'><img src='[headshot_link]' width='325px' height='325px'></div>")
 		if(flavortext)

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -32,9 +32,10 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		if(legacy_check)	//If this is how a Legacy char was established, we save it.
 			client.prefs?.save_character()
 		if(is_legacy)
-			dat += "<center><i><font color = '#b9b9b9'; font size = 1>This is a LEGACY Profile from naive days of Psydon.</font></i></center>"
+			dat += "<center><i><font color = '#b9b9b9'; font size = 1>This is a LEGACY profile from the naive daes of Psydon!</font></i></center>"
 		var/agevetted = client.check_agevet()
-		dat += "<center>This person is [agevetted ? "<font color='#1cb308'>Age Vetted.</font>" : "<font color='#aa0202'>Not Age Vetted</font>"]</center>"
+		if(agevetted)
+			dat += "<center><i><font color = '#74cde0'; font size = 1>This profile belongs to a VERIFIED traveler of Azuria!</font></i></center>"
 		if(valid_headshot_link(null, headshot_link, TRUE))
 			dat += ("<div align='center'><img src='[headshot_link]' width='325px' height='325px'></div>")
 		if(flavortext)


### PR DESCRIPTION
## About The Pull Request

This is an addendum to a preceding pull request, [linked here](https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3986), which ported Scarlet Reach's verification system over to Azure Peak.
There's already been a bit of confusion from the community over _how_ this works, so I've decided to go in and manually edit the following..
- _'Agevet' is now _'VERIFIED'_, on the character creation menu.
- Changes _"No"_ and _"Yes"_ to _"NAE?"_ and _"YAE!"_, alongside their coloration.
- Alters the on-click description to explain the purely optional - and non-gamechanging - nature of this mechanic.
- Alters the blurb shown on the flavortexts of verified players.
- Ports the maintainer's change, [linked here](https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/4022), which fully removes the blurb from the flavortexts of unverified players.

## Testing Evidence

Changes the raw text and hexcodes of several lines, but otherwise leaves the _code_ itself untouched.

## Why It's Good For The Game

- Rethemes the system to better fit Azure Peak's expectations, while also making it look like a natural extension of its interface.
- Clarifies how this version of the system works, in order to prevent more confusion from returning- _(or non-code savvy)_ players.
- Prevents unwanted discrimination and stress for unverified players, while still making it easy to find verified players.

Azure Peak's whitelisting system is more rigorous than Scarlet Reach's whitelisting system, and being accepted is required to access the server in the first place. Our community's expectations and standards are fairly different _(and arguably higher)_, too, which helps to filter out a lot of potential bad actors.

Generally, most players here can be trusted to be - at the minimum - a relatively competent adult. They don't need to be singled out with bold red text if they don't want to share any personal information with the administration. They also don't need to worry about whether they'll lose access to certain mechanics _(like on Scarlet Reach)_, if they don't verify.

At the same time, however, this _also_ ensures that verified players can be easily spotted in the wild, for those who are otherwise uncomfortable with unverified scenes.