### PR TITLE
Quick smoke for Artillery Fireball.

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -18,7 +18,6 @@
 	var/lifetime = 5
 	var/opaque = 1 //whether the smoke can block the view when in enough amount
 
-
 /obj/effect/particle_effect/smoke/proc/fade_out(frames = 16)
 	if(alpha == 0) //Handle already transparent case
 		return
@@ -267,3 +266,11 @@
 	smoke.effect_type = smoke_type
 	smoke.set_up(range, location)
 	smoke.start()
+
+/datum/effect_system/smoke_spread/fast
+	effect_type = /obj/effect/particle_effect/smoke/fast
+
+// Very quick smoke meant for artillery fireball
+/obj/effect/particle_effect/smoke/fast
+	lifetime = 1
+

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball_artillery.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball_artillery.dm
@@ -72,7 +72,7 @@
 	// The visuals are here, the lava is just for visuals and doesn't ACTUALLY damage you! Just looks cool and indicates what is structures will be damaged.
 	for(var/turf/open/visual in view(radius, fallzone))
 		var/obj/effect/temp_visual/lavastaff/Lava = new /obj/effect/temp_visual/lavastaff(visual)
-		var/datum/effect_system/smoke_spread/S = new /datum/effect_system/smoke_spread // SMOKE EFFECT
+		var/datum/effect_system/smoke_spread/S = new /datum/effect_system/smoke_spread/fast // SMOKE EFFECT
 		animate(Lava, alpha = 255, time = 5)
 		S.set_up(radius, fallzone)
 		S.start()


### PR DESCRIPTION
## About The Pull Request
- Swap the smoke on the artillery fireball for one that quickly dissipates

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![NVIDIA_Overlay_poWpHSbLOt](https://github.com/user-attachments/assets/c64b1711-e88c-447b-a19c-7177d3a3d8f4)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Retain the soul of the original spell and let it obscure things on explosion, without making it hell to deal with in PVE because it obscures the screen for an extensive period of time which only affect PC.

(Asked Toaster if this is OK to make)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
