### PR TITLE
Add Launch Options & Move Config.txt out of gitignore into the actual folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ Temporary Items
 *.vscode/*
 !/.vscode/extensions.json
 !/.vscode/tasks.json
+!/.vscode/launch.json
 tools/MapAtmosFixer/MapAtmosFixer/obj/*
 tools/MapAtmosFixer/MapAtmosFixer/bin/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 ###Files and folders specified here will never be tracked.
 
+# Local overrides--you can use this to change the config for your dev environment (like setting up SQL) without worrying about committing it
+/config/dev_overrides.txt
+
 #Ignore everything in datafolder and subdirectories
 /data/**/*
 /tmp/**/*
@@ -222,6 +225,7 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 /config/*
 !/config/example/
 
+!/config/config.txt
 /config/jukebox_music/sounds/*
 !/config/jukebox_music/sounds/exclude
 /config/title_music/sounds/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamSeeker (Local Testing)",
+            "preLaunchTask": "Build All (Local Testing)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamSeeker",
+            "preLaunchTask": "Build All",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamDaemon (Local Testing)",
+            "preLaunchTask": "Build All (Local Testing)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamDaemon",
+            "preLaunchTask": "Build All",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamDaemon (unit tests)",
+            "preLaunchTask": "Build All (unit tests)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -103,5 +103,29 @@
 			"dependsOn": "dm: reparse",
 			"label": "Build All (low memory mode)"
 		},
+		{
+            "type": "process",
+            "command": "tools/build/build",
+            "args": ["-DUNIT_TESTS -DLOCALTEST"],
+            "windows": {
+                "command": ".\\tools\\build\\build.bat",
+                "args": ["-DUNIT_TESTS -DLOCALTEST"]
+            },
+            "options": {
+                "env": {
+                    "DM_EXE": "${config:dreammaker.byondPath}"
+                }
+            },
+            "problemMatcher": [
+                "$dreammaker",
+                "$tsc",
+                "$eslint-stylish"
+            ],
+            "group": {
+                "kind": "build"
+            },
+            "dependsOn": "dm: reparse",
+            "label": "Build All (unit tests)"
+        },
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,27 @@
 			"label": "Build All"
 		},
 		{
+			"type": "process",
+			"command": "tools/build/build.sh",
+			"args": ["-DLOCALTEST"],
+			"windows": {
+				"command": ".\\tools\\build\\build.bat",
+				"args": ["-DLOCALTEST"]
+			},
+			"options": {
+				"env": {
+					"DM_EXE": "${config:dreammaker.byondPath}"
+				}
+			},
+			"problemMatcher": ["$dreammaker", "$tsc", "$eslint-stylish"],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"dependsOn": "dm: reparse",
+			"label": "Build All (Local Testing)"
+		},
+		{
 			"type": "dreammaker",
 			"dme": "tgstation.dme",
 			"problemMatcher": ["$dreammaker"],

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -1,6 +1,11 @@
-#define MINIMUM_FLAVOR_TEXT		200
-#define MINIMUM_OOC_NOTES 		5 //Just put something in there
-
+#ifdef LOCALTEST
+	#define MINIMUM_FLAVOR_TEXT 0
+	#define MINIMUM_OOC_NOTES 0
+#endif
+#ifndef LOCALTEST
+	#define MINIMUM_FLAVOR_TEXT		200
+	#define MINIMUM_OOC_NOTES 		5 //Just put something in there
+#endif
 
 //Preference toggles
 #define SOUND_ADMINHELP			(1<<0)

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -47,6 +47,8 @@
 				for(var/J in legacy_configs)
 					LoadEntries(J)
 				break
+	if (fexists("[directory]/dev_overrides.txt"))
+		LoadEntries("dev_overrides.txt")
 	loadmaplist(CONFIG_MAPS_FILE)
 	LoadMOTD()
 	LoadPolicy()

--- a/config/config.txt
+++ b/config/config.txt
@@ -15,16 +15,16 @@ $include resources.txt
 # There are various options which are hard-locked for security reasons.
 
 ## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'tgstation' with the name of your choice.
-SERVERNAME Roguetown
+SERVERNAME AZURE PEAK
 
 ## Server tagline: This will appear right below the server's title.
-# SERVERTAGLINE A generic TG-based server
+# SERVERTAGLINE 18+ HRP Fantasy Server.
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
 # SERVERSQLNAME tgstation
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
-STATIONNAME Roguetown
+STATIONNAME AZURE PEAK
 
 ## Put on byond hub: Uncomment this to put your server on the byond hub.
 #HUB


### PR DESCRIPTION
## About The Pull Request
Ported from tg / vanderlin etc.

Some very very very very very long overdue improvements to our development workflow to bring us up to 2022 or 2025 standards:
- We now have a launch.json with five options for vscode (I don't think unit tests work yet), including a LOCALTEST mode (My version of low memory mode)
- Localtest mode currently just define minimum flavor text & ooc notes as 0 that's it. Now local run will actually run our build.sh with CBT etc.
- New mode may be added
- Five launch options: Dreamseeker w/ and w/o localtest, Dreamdaemon w/ and w/o local test, and unit tests. I don't think unit tests work but I CBA to continue today
- Added dev_overrides for local overrides
- Copied our example config.txt and put it in the actual folder, so that anyone who download the repo fresh will actually start with proper config and will be a localhost admin. Finally.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="782" height="368" alt="NVIDIA_Overlay_gAkucMGINX" src="https://github.com/user-attachments/assets/6589cd53-1410-4536-ad15-959369d3fa63" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Improves and modernize our development experience especially onboarding.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
