### PR TITLE
Small TGUI Improvements / Revert

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -9,7 +9,7 @@
 	set category = "IC"
 	
 	display_typing_indicator()
-	var/message = tgui_input_text(usr, "", "say", multiline = tgui_multiline, encode = FALSE)
+	var/message = input(usr, "", "say") as text|null
 	// If they don't type anything just drop the message.
 	clear_typing_indicator()
 	if(!length(message))
@@ -52,7 +52,7 @@
 	set category = "IC"
 
 	display_typing_indicator()
-	var/message = tgui_input_text(usr, "", "me", multiline = tgui_multiline, encode = FALSE)
+	var/message = input(usr, "", "me") as text|null
 	// If they don't type anything just drop the message.
 	clear_typing_indicator()		// clear it immediately!
 	if(!length(message))

--- a/code/modules/tgui_input/say_modal/modal.dm
+++ b/code/modules/tgui_input/say_modal/modal.dm
@@ -68,7 +68,7 @@
 
 	var/minimum_width = 360 //client?.prefs?.read_preference(/datum/preference/numeric/tgui_say_width) || 1
 	var/minimum_height = 1 /*(client?.prefs?.read_preference(/datum/preference/numeric/tgui_say_height) || 1)*/ * 20 + 10
-	winset(client, "tgui_say", "pos=410,400;is-visible=0;")
+	winset(client, "tgui_say", "is-visible=0;")
 
 	window.send_message("props", list(
 		"lightMode" = FALSE, //client?.prefs?.read_preference(/datum/preference/toggle/tgui_say_light),

--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -11,8 +11,9 @@
 	return TRUE
 
 /client/proc/get_looc()
-	var/msg = tgui_input_text(src, null, "looc \"text\"", encode = FALSE)
+	var/msg = input(src, "", "looc") as text|null
 	do_looc(msg, FALSE)
+	
 
 /client/verb/looc(msg as text)
 	set name = "LOOC"


### PR DESCRIPTION
## About The Pull Request
Targeted revert to revert some player painpoint with TGUI Inputs so I can take off the perma TM revert:
- Say, LOOC and Emote is now forced to use old input 
- TGUI say no longer force position to middle of the screen - at least once. It does reset position the second time though.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="474" height="287" alt="NVIDIA_Overlay_4yy3Z9wCYj" src="https://github.com/user-attachments/assets/248bc6fc-25c2-42d4-bdf4-502eaf12535c" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
yes

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
