### PR TITLE
fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/gnome.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/gnome.dm
@@ -29,7 +29,7 @@ Even though they are of mixed blood and smaller than typical dwarves, most gnome
 	soundpack_m = /datum/voicepack/male/elf
 	soundpack_f = /datum/voicepack/female/elf
 	use_f = TRUE
-	use_m = TRUE
+	//use_m = TRUE
 	custom_clothes = TRUE
 	clothes_id = "dwarf"
 	offset_features = list(


### PR DESCRIPTION
## About The Pull Request
Fixes armor slots "floating" on gnomes because of the "use_m" option. I commented this out and things seem to fit fine. I missed this before, sorry.

## Testing Evidence

<img width="265" height="362" alt="image" src="https://github.com/user-attachments/assets/2c70fbd5-6ce0-49d3-afb1-343ade7fc7bb" />

This shows the armor fitting properly again

## Why It's Good For The Game

just fixes a graphic bug, one line

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
