### PR TITLE
Apothecary Starting Stock

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates_preloaded.dm
+++ b/code/game/objects/structures/crates_lockers/crates_preloaded.dm
@@ -1,0 +1,45 @@
+// Help apothecary kickstart, one of each seed. Don't want to make it too easy.
+/obj/structure/closet/crate/chest/old_crate/apothseed
+	name = "apothecary's herb seed crate"
+	desc = "A wooden crate used to store basic herbs."
+
+/obj/structure/closet/crate/chest/old_crate/apothseed/Initialize()
+	. = ..()
+	new /obj/item/herbseed/matricaria(src)
+	new /obj/item/herbseed/symphitum(src)
+	new /obj/item/herbseed/taraxacum(src)
+	new /obj/item/herbseed/atropa(src)
+	new /obj/item/herbseed/euphrasia(src)
+	new /obj/item/herbseed/paris(src)
+	new /obj/item/herbseed/calendula(src)
+	new /obj/item/herbseed/mentha(src)
+	new /obj/item/herbseed/urtica(src)
+	new /obj/item/herbseed/salvia(src)
+	new /obj/item/herbseed/hypericum(src)
+	new /obj/item/herbseed/benedictus(src)
+	new /obj/item/herbseed/valeriana(src)
+	new /obj/item/herbseed/artemisia(src)
+	new /obj/item/herbseed/rosa(src)
+	new /obj/item/seeds/swampweed(src)
+	new /obj/item/seeds/pipeweed(src)
+
+// Basic potion ingredients for initial supply of red & blue potions.
+// Everything else should be acquired by them.
+/obj/structure/closet/crate/chest/old_crate/apoth_initial_pot
+	name = "apothecary's potion ingredient crate"
+	desc = "Labeled: WEEKLY HERB SUPPLY."
+
+/obj/structure/closet/crate/chest/old_crate/apoth_initial_pot/Initialize()
+	. = ..()
+	new /obj/item/alch/calendula(src)
+	new /obj/item/alch/calendula(src)
+	new /obj/item/alch/calendula(src)
+	new /obj/item/alch/viscera(src)
+	new /obj/item/alch/viscera(src)
+	new /obj/item/alch/viscera(src)
+	new /obj/item/alch/bonemeal(src)
+	new /obj/item/alch/bonemeal(src)
+	new /obj/item/alch/bonemeal(src)
+	new /obj/item/alch/berrypowder(src)
+	new /obj/item/alch/berrypowder(src)
+	new /obj/item/alch/berrypowder(src)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1118,6 +1118,7 @@
 #include "code\game\objects\structures\beds_chairs\roguechair.dm"
 #include "code\game\objects\structures\crates_lockers\closets.dm"
 #include "code\game\objects\structures\crates_lockers\crates.dm"
+#include "code\game\objects\structures\crates_lockers\crates_preloaded.dm"
 #include "code\game\objects\structures\crates_lockers\cratestrapped.dm"
 #include "code\game\objects\structures\crates_lockers\roguetown.dm"
 #include "code\game\objects\structures\decorations\stone_path.dm"


### PR DESCRIPTION
## About The Pull Request
- Apothecary get 3 Cauldrons or something you crazy bastard. And 2 buckets instead of 1.
- The initial random herb seed crate removed, in favor of a **coded in subtype crate** of every single seed plus swampweed + pipeweed. One of each. Any extra, you have to pick yourself.
- They receive an initial crate of ingredients to brew 3 sets of red & blue for initial selling (they can go through it super quickly) so that they always have an initial stock and can establish themselves as the primary potion seller or something before the adventurers leave town for their first adventure (maybe).

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="249" height="201" alt="NVIDIA_Overlay_QYzgAzWL3r" src="https://github.com/user-attachments/assets/60877ffa-3343-4ed5-a367-9da96079f0da" />
<img width="479" height="491" alt="NVIDIA_Overlay_0QGsBncksT" src="https://github.com/user-attachments/assets/629f1f9f-57ff-45d5-ac58-ea84e02d418c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Most roles start with enough materials for some business initially before they have to resupply. Apothecary too, should function like this. I've elected not to give them enough for stat potions (for now) or any other potions, but selling red and blue should be basic functionalities they can perform at the start. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
