### PR TITLE
Ported Mage Lord from Caustic Cove, a subclass for the Duke! Also gave them a satchel. 

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -37,6 +37,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	job_subclasses = list(
 		/datum/advclass/lord/warrior,
 		/datum/advclass/lord/merchant,
+		/datum/advclass/lord/mage,
 		/datum/advclass/lord/inbred
 	)
 
@@ -180,6 +181,46 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	l_hand = /obj/item/rogueweapon/lordscepter
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
+
+/** 
+	Mage Lord subclass. Prince mage is a thing.
+	Light on skills, has some combat skills mage normally doesn't have. 18 pts so people don't complain they are better.
+	Stats is better than mage associate and magic heir. +12 total.
+	Mage armor and no armor training.
+
+
+	King's addition: Porting this to Azure after a long time. May adjust later to compromise with other vision for the role. Also gave them a fucking satchel.
+*/
+/datum/advclass/lord/mage
+	name = "Mage Lord"
+	tutorial = "Despite spending your younger years focused on reading and the wonders of the arcyne, it came the time for you to take the throne. Now you rule not only by crown and steel, but by spell and wit, show those who doubted your time buried in books was well spent how wrong they were."
+	outfit = /datum/outfit/job/roguetown/lord/mage
+	category_tags = list(CTAG_LORD)
+	traits_applied = list(TRAIT_NOBLE, TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3)
+	subclass_stats = list(
+		STATKEY_LCK = 5,
+		STATKEY_INT = 4,
+		STATKEY_PER = 2,
+		STATKEY_WIL = 1,
+	)
+	subclass_spellpoints = 18
+	subclass_skills = list(
+		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+	)
+
+/datum/outfit/job/roguetown/lord/mage/pre_equip(mob/living/carbon/human/H)
+	..()
+	backr = /obj/item/storage/backpack/rogue/satchel
+
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/roguegem/amethyst = 1, /obj/item/spellbook_unfinished/pre_arcyne = 1)
 
 /** 
 	Inbred Lord subclass. A joke class, evolution of the Inbred Wastrel.


### PR DESCRIPTION
## About The Pull Request

- This ports the Mage Lord subclass for the Grand Duke from Caustic Cove. It's intended to be a follow-up class to the Mage Prince/ss role. 
- It features T3 magic, middling arcyne skills, zero ability to wear armor and overall shouldn't be a particularly potent combat caster. 
- Ideally best for those who enjoy a sorcerous overlord.

## Testing Evidence

Compiles, runs, and no spells broke the game.

## Why It's Good For The Game

It is my earnest belief that having a mage duke will only lead to more flavorful dukes as opposed to fraggers, nor do I think will this in any way replace Court Mage as it exists. Many people have desired a magical slash scholarly alternative for the Duke to match the classes of the Heirs so I think this is more than fair. Also, it's not particularly strong. If needed it can be weakened further.


