### PR TITLE
Grants dullahan the deathless traits and zombie_immunity

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
@@ -16,7 +16,7 @@
 
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,MUTCOLORS_PARTSONLY)
 	default_features = MANDATORY_FEATURE_LIST
-	inherent_traits = list(TRAIT_EASYDECAPITATION)
+	inherent_traits = list(TRAIT_EASYDECAPITATION,TRAIT_NOHUNGER,TRAIT_NOBREATH,TRAIT_ZOMBIE_IMMUNE) //Given the deathless traits inherently as part of their nature as pseudo-undead.
 	use_skintones = 1
 	disliked_food = NONE
 	liked_food = NONE


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin.

- Revenants will spawn with No Hunger and No Breath inherently, meaning they do not need food or water and cannot drown.

- Deathless is functionally useless for them now.

- They do not raise from the dead as undead... undead, now, either.

## Testing Evidence
Tested all traits, fully functional on all three accounts.


## Why It's Good For The Game

The lore page for the Revenant race clearly states they do not actually require food, water, or rest as they are a peculiar pseudo-undead, which also are already raised from the dead and therefore shouldn't be turning into deadites. I believe these traits will have the race play a little more accurately to how they're described.

