### PR TITLE
+2CON/-1FOR for nettlesome scamp

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -210,12 +210,11 @@
 	//Not standard weighted. Not intended to be considering the stat ceilings. -F
 	subclass_stats = list(
 	STATKEY_STR = -3,
-	STATKEY_CON = -3,
+	STATKEY_CON = -1,
 	STATKEY_SPD = 4,
 	STATKEY_PER = 2,
 	STATKEY_INT = 2,
-	STATKEY_WIL = 1,
-	STATKEY_LCK = 1,
+	STATKEY_WIL = 1
 	)
 	subclass_skills = list(
 		/datum/skill/misc/sneaking = SKILL_LEVEL_MASTER,


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.

## Testing Evidence

yes

## Why It's Good For The Game

Lets them not bleed out instantly. Probably should peek at how bleeding under X CON works, however.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
