### PR TITLE
Omniwound / Penetrative Weapon Tweak

### DIFF
--- a/code/datums/wounds/types/punctures.dm
+++ b/code/datums/wounds/types/punctures.dm
@@ -41,7 +41,7 @@
 	name = "puncture"
 	whp = 1
 	sewn_whp = 0
-	bleed_rate = 1
+	bleed_rate = 0.5 // Lower than usual to reflect that those are often penetrative weapons.
 	sewn_bleed_rate = 0.04
 	clotting_rate = 0.01
 	sewn_clotting_rate = 0.01
@@ -66,7 +66,7 @@
 #define PUNC_UPG_WHPRATE 0.5
 #define PUNC_UPG_SEWRATE 0.65
 #define PUNC_UPG_PAINRATE 0.05
-#define PUNC_UPG_CLAMP_ARMORED 0.75
+#define PUNC_UPG_CLAMP_ARMORED 0.375 // Bleed rate from penetrative damage upgrade is also capped
 #define PUNC_UPG_CLAMP_RAW 1.3
 #define PUNC_ARMORED_BLEED_CLAMP 6
 
@@ -91,7 +91,7 @@
 	name = "gouge"
 	whp = 1
 	sewn_whp = 0
-	bleed_rate = 1
+	bleed_rate = 0.25 // Lower than usual to reflect that these are often penetrative weapons.
 	sewn_bleed_rate = 0.04
 	clotting_rate = 0.01
 	sewn_clotting_rate = 0.01

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -35,9 +35,6 @@
 		if(used.blocksound)
 			playsound(loc, get_armor_sound(used.blocksound, blade_dulling), 100)
 		var/intdamage = damage
-		// Penetrative damage deals significantly less to the armor. Tentative.
-		if((damage + armor_penetration) > protection)
-			intdamage = (damage + armor_penetration) - protection
 		if(intdamfactor != 1)
 			intdamage *= intdamfactor
 		if(d_type == "blunt")


### PR DESCRIPTION
## About The Pull Request
- Penetrative weapons now deal **full damage** to armor again, removing that tentative changes
- Each puncture had a base bleed rate of 1, the same goes for pick - both were supposed to be weak because of penetrating but the base number contributed a lot to the bleed rate. Now, it is reduced to 0.5.
- Per additional puncture the upgrade of bleed rate is now clamped to 0.375 instead of 0.75.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yae

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Spear / Polearms / Estoc is frankly, far too powerful vs certain types of enemies for the "kite and bleed" game and is a pain to deal with. On the other hand, those weapon that are obscenely good vs humanoids are utterly useless vs skeletons or certain no blood loss vampire because penetrative damage no longer deal full damage to armor, therefore any stabbing weapon that cannot switch to cut suddenly become, as AP players say, "absymal dogshit" vs such. 

This PR halve the bleed rate to make bleed and kite a less overwhelming strategy and make stabbing polearm no longer a trap vs non-bleeding opponent when you need to break their armor.

Not touching blunt weapon since Onutsio has another PR up, even though I do not 100% agree (I don't have any idea myself)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
