### PR TITLE
Counterspell Glow-up (literally c:)

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_single_target/counterspell.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/counterspell.dm
@@ -19,6 +19,8 @@
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 	overlay_state = "rune2"
 
+#define FILTER_COUNTERSPELL "counterspell_glow"
+
 /obj/effect/proc_holder/spell/invoked/counterspell/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))
 		var/mob/living/carbon/target = targets[1]
@@ -28,6 +30,7 @@
 			return
 		ADD_TRAIT(target, TRAIT_SPELLCOCKBLOCK, MAGIC_TRAIT)
 		ADD_TRAIT(target, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
+		target.add_filter(FILTER_COUNTERSPELL, 2, list("type" = "outline", "color" = "#FFFFFF", "alpha" = 30, "size" = 1))
 		to_chat(target, span_warning("I feel as if my connection to the Arcyne disappears entirely. The air feels still..."))
 		target.visible_message("[target]'s arcyne aura seems to fade.")
 		addtimer(CALLBACK(src, PROC_REF(remove_buff), target), wait = 20 SECONDS)
@@ -37,5 +40,8 @@
 /obj/effect/proc_holder/spell/invoked/counterspell/proc/remove_buff(mob/living/carbon/target)
 	REMOVE_TRAIT(target, TRAIT_SPELLCOCKBLOCK, MAGIC_TRAIT)
 	REMOVE_TRAIT(target, TRAIT_ANTIMAGIC, MAGIC_TRAIT)
+	target.remove_filter(FILTER_COUNTERSPELL)
 	to_chat(target, span_warning("I feel my connection to the arcyne surround me once more."))
 	target.visible_message("[target]'s arcyne aura seems to return once more.")
+
+#undef FILTER_COUNTERSPELL

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/counterspell.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/counterspell.dm
@@ -4,7 +4,7 @@
 	cost = 3
 	releasedrain = 35
 	chargedrain = 1
-	chargetime = 15
+	chargetime = 0
 	recharge_time = 80 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE


### PR DESCRIPTION
## About The Pull Request
Counterspell is often unpicked by most mages due to how situational it is. Something I've learned while playing Grenzelmage has shown that the charge time for it is often way too long for it to actually be useful.

In order to bring it in line to being a EFFICIENT mage on mage violence weapon, I have removed the charge time of it, allowing you to use it as a reaction as if it were D&D!

A note: A reminder for what exactly Counterspell does, It adds BOTH Spell-immunity as WELL as prevents the target from casting. It's a double edged sword for a mage. You can prevent them from casting a big fireball or anything for 20 seconds, however your spells will fizzle for the next 20 seconds as well.

It also still has an 80 second recharge time so you can't CHAIN it.

ANOTHER reminder, most HIGH LEVEL spell based antags (Lich, VL) have a way to prevent counterspell to not cockblock their entire gimmick. (Counter Counterspell trait)

oh shit oh fuck, right I also added a glow to it, I made you glow slightly white. It's neigh unnoticeable but other buff/debuff spells do similar stuff so fuck it why not counterspell.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
bread 👍 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
might make a underused spell more used <|:^)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
