### PR TITLE
[COMMISSION] Gives veteran a choice between longsword and sabre

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -82,6 +82,9 @@
 
 // Normal veteran start, from the olden days.
 
+/datum/outfit/job/roguetown/vet/battlemaster
+	has_loadout = TRUE
+
 /datum/outfit/job/roguetown/vet/battlemaster/pre_equip(mob/living/carbon/human/H)
 	neck = /obj/item/clothing/neck/roguetown/bevor
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
@@ -89,7 +92,6 @@
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	beltr = /obj/item/storage/keyring/guardcastle
-	beltl = /obj/item/rogueweapon/scabbard/sword
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	cloak = /obj/item/clothing/cloak/half/vet
 	belt = /obj/item/storage/belt/rogue/leather/black
@@ -97,13 +99,16 @@
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
+	H.verbs |= /mob/proc/haltyell
+
+/datum/outfit/job/roguetown/vet/battlemaster/choose_loadout(mob/living/carbon/human/H)
+	. = ..()
 	if(H.age == AGE_OLD)
 		H.adjust_skillrank_up_to(/datum/skill/combat/swords, 6, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/combat/maces, 6, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 		H.change_stat(STATKEY_WIL, 1)
 
-	H.verbs |= /mob/proc/haltyell
 	H.adjust_blindness(-3)
 	if(H.mind)
 		var/weapons = list("Longsword","Sabre")
@@ -111,9 +116,11 @@
 		H.set_blindness(0)
 		switch(weapon_choice)
 			if("Longsword")
-				r_hand = /obj/item/rogueweapon/sword/long
+				H.put_in_hands(new /obj/item/rogueweapon/sword/long)
+				H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_L)
 			if("Sabre")
-				r_hand = /obj/item/rogueweapon/sword/sabre
+				H.put_in_hands(new /obj/item/rogueweapon/sword/sabre)
+				H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_L)
 
 /datum/advclass/veteran/footman
 	name = "Retired Footman"


### PR DESCRIPTION
## About The Pull Request
- Gives battlemaster a choice between sabre or longsword

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled, son. It worked, son.
<img width="290" height="246" alt="image" src="https://github.com/user-attachments/assets/8583ec2c-0cc7-4bea-961d-db30cc52ff0b" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Soul. Allow me to be real: it doesn't fit. A retired, plate-armored warrior like this should be carrying around a proper, universally effective weapon like a longsword. There's a precedent for it and I think it'd lead to more people playing veteran. Not a joke.

But it's also reasonable that people who like the sabre should be able to take the sabre, because certain types of masterful warriors might have different tastes in weaponry. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
