### PR TITLE
Aasimar Update (+Revenant)

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -37,6 +37,7 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 	apply_charflaw_equipment(character, player)
 	apply_prefs_special(character, player)
 	apply_prefs_virtue(character, player)
+	apply_prefs_race_bonus(character, player)
 	if(player.prefs.dnr_pref)
 		apply_dnr_trait(character, player)
 	if(player.prefs.loadout)
@@ -77,6 +78,25 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 			apply_virtue(character, virtuetwo_type)
 		else
 			to_chat(character, "Incorrect Second Virtue parameters! (Heretic virtue on a non-heretic) It will not be applied.")
+
+/proc/apply_prefs_race_bonus(mob/living/carbon/human/character, client/player)
+	if (!player)
+		player = character.client
+	if (!player)
+		return
+	if (!player.prefs)
+		return
+	if (!player.prefs.race_bonus || player.prefs.race_bonus == "None")
+		return
+	var/bonus = player.prefs.race_bonus
+	if(ispath(bonus))	//The bonus is a real path
+		if(ispath(bonus, /datum/virtue))
+			var/datum/virtue/v = bonus
+			apply_virtue(character, new v)
+	if(bonus in MOBSTATS)
+		character.change_stat(bonus, 1) //atm it only supports one stat getting a +1
+	if(bonus in GLOB.roguetraits)
+		ADD_TRAIT(character, bonus, TRAIT_GENERIC)
 
 /proc/virtue_check(var/datum/virtue/V, heretic = FALSE)
 	if(V)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -200,6 +200,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 	var/tgui_pref = TRUE
 
+	var/race_bonus
+
 /datum/preferences/New(client/C)
 	parent = C
 	migrant  = new /datum/migrant_pref(src)
@@ -367,6 +369,16 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 			dat += "<BR>"
 			dat += "<b>Race:</b> <a href='?_src_=prefs;preference=species;task=input'>[pref_species.name]</a>[spec_check(user) ? "" : " (!)"]<BR>"
+			if(length(pref_species.custom_selection))
+				var/race_bonus_display
+				if(race_bonus)
+					for(var/bonus in pref_species.custom_selection)
+						if(pref_species.custom_selection[bonus] == race_bonus)
+							race_bonus_display = bonus
+							break
+				dat += "<b>Race Bonus:</b> <a href='?_src_=prefs;preference=race_bonus_select;task=input'>[race_bonus_display ? "[race_bonus_display]" : "None"]</a><BR>"
+			else
+				race_bonus = null
 
 			// LETHALSTONE EDIT BEGIN: add statpack selection
 			dat += "<b>Statpack:</b> <a href='?_src_=prefs;preference=statpack;task=input'>[statpack.name]</a><BR>"
@@ -404,6 +416,11 @@ GLOBAL_LIST_EMPTY(chosen_names)
 //				dat += "<a href='?_src_=prefs;preference=toggle_random;random_type=[RANDOM_AGE_ANTAG]'>When Antagonist: [(randomise[RANDOM_AGE_ANTAG]) ? "Yes" : "No"]</A>"
 
 //			dat += "<b><a href='?_src_=prefs;preference=name;task=random'>Random Name</A></b><BR>"
+			if(length(pref_species.restricted_virtues))
+				if(virtue.type in pref_species.restricted_virtues)
+					virtue = "None"
+				if(virtuetwo.type in pref_species.restricted_virtues)
+					virtuetwo = "None"
 			dat += "<b>Virtue:</b> <a href='?_src_=prefs;preference=virtue;task=input'>[virtue]</a><BR>"
 			if(statpack.name == "Virtuous")
 				dat += "<b>Second Virtue:</b> <a href='?_src_=prefs;preference=virtuetwo;task=input'>[virtuetwo]</a><BR>"
@@ -1985,9 +2002,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 							continue
 						if (istype(V, /datum/virtue/heretic) && !istype(selected_patron, /datum/patron/inhumen))
 							continue
-						if (istype(V, /datum/virtue/utility/noble) && ((pref_species == /datum/species/construct/metal) || (pref_species ==/datum/species/dullahan)))		//Stops bypass of nobility for constructs.
-							continue
-						if (istype(V, /datum/virtue/utility/resident) && (pref_species == /datum/species/dullahan))
+						if(length(pref_species.restricted_virtues) && (V.type in pref_species.restricted_virtues))
 							continue
 						virtue_choices[V.name] = V
 					virtue_choices = sort_list(virtue_choices)
@@ -2006,11 +2021,9 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 							continue
 						if (V.name == virtue.name || V.name == virtuetwo.name)
 							continue
+						if(length(pref_species.restricted_virtues) && (V in pref_species.restricted_virtues))
+							continue
 						if (istype(V, /datum/virtue/heretic) && !istype(selected_patron, /datum/patron/inhumen))
-							continue
-						if (istype(V, /datum/virtue/utility/noble) && ((pref_species == /datum/species/construct/metal) || (pref_species ==/datum/species/dullahan)))		//Stops bypass of nobility for constructs.
-							continue
-						if (istype(V, /datum/virtue/utility/resident) && (pref_species == /datum/species/dullahan))
 							continue
 						virtue_choices[V.name] = V
 					virtue_choices = sort_list(virtue_choices)
@@ -2033,6 +2046,12 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						charflaw = C
 						if(charflaw.desc)
 							to_chat(user, "<span class='info'>[charflaw.desc]</span>")
+
+				if("race_bonus_select")
+					if(length(pref_species.custom_selection))
+						var/choice = tgui_input_list(user, "What has faith blessed your race with?", "BONUS", pref_species.custom_selection)
+						if(choice)
+							race_bonus = pref_species.custom_selection[choice]
 
 				if("body_size")
 					var/new_body_size = tgui_input_number(user, "Choose your desired sprite size:\n([BODY_SIZE_MIN*100]%-[BODY_SIZE_MAX*100]%), Warning: May make your character look distorted", "Character Preference", features["body_size"]*100)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -418,9 +418,9 @@ GLOBAL_LIST_EMPTY(chosen_names)
 //			dat += "<b><a href='?_src_=prefs;preference=name;task=random'>Random Name</A></b><BR>"
 			if(length(pref_species.restricted_virtues))
 				if(virtue.type in pref_species.restricted_virtues)
-					virtue = "None"
+					virtue = new /datum/virtue/none
 				if(virtuetwo.type in pref_species.restricted_virtues)
-					virtuetwo = "None"
+					virtuetwo = new /datum/virtue/none
 			dat += "<b>Virtue:</b> <a href='?_src_=prefs;preference=virtue;task=input'>[virtue]</a><BR>"
 			if(statpack.name == "Virtuous")
 				dat += "<b>Second Virtue:</b> <a href='?_src_=prefs;preference=virtuetwo;task=input'>[virtuetwo]</a><BR>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2049,7 +2049,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 				if("race_bonus_select")
 					if(length(pref_species.custom_selection))
-						var/choice = tgui_input_list(user, "What has faith blessed your race with?", "BONUS", pref_species.custom_selection)
+						var/choice = tgui_input_list(user, "What has fate blessed your race with?", "BONUS", pref_species.custom_selection)
 						if(choice)
 							race_bonus = pref_species.custom_selection[choice]
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2021,7 +2021,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 							continue
 						if (V.name == virtue.name || V.name == virtuetwo.name)
 							continue
-						if(length(pref_species.restricted_virtues) && (V in pref_species.restricted_virtues))
+						if(length(pref_species.restricted_virtues) && (V.type in pref_species.restricted_virtues))
 							continue
 						if (istype(V, /datum/virtue/heretic) && !istype(selected_patron, /datum/patron/inhumen))
 							continue

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -418,12 +418,14 @@ GLOBAL_LIST_EMPTY(chosen_names)
 //			dat += "<b><a href='?_src_=prefs;preference=name;task=random'>Random Name</A></b><BR>"
 			if(length(pref_species.restricted_virtues))
 				if(virtue.type in pref_species.restricted_virtues)
-					virtue = new /datum/virtue/none
+					virtue = GLOB.virtues[/datum/virtue/none]
 				if(virtuetwo.type in pref_species.restricted_virtues)
-					virtuetwo = new /datum/virtue/none
+					virtuetwo = GLOB.virtues[/datum/virtue/none]
 			dat += "<b>Virtue:</b> <a href='?_src_=prefs;preference=virtue;task=input'>[virtue]</a><BR>"
 			if(statpack.name == "Virtuous")
 				dat += "<b>Second Virtue:</b> <a href='?_src_=prefs;preference=virtuetwo;task=input'>[virtuetwo]</a><BR>"
+			else
+				virtuetwo = GLOB.virtues[/datum/virtue/none]
 			dat += "<b>Vice:</b> <a href='?_src_=prefs;preference=charflaw;task=input'>[charflaw]</a><BR>"
 			var/datum/faith/selected_faith = GLOB.faithlist[selected_patron?.associated_faith]
 			dat += "<b>Faith:</b> <a href='?_src_=prefs;preference=faith;task=input'>[selected_faith?.name || "FUCK!"]</a><BR>"
@@ -1998,7 +2000,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						var/datum/virtue/V = GLOB.virtues[path]
 						if (!V.name)
 							continue
-						if (V.name == virtue.name || V.name == virtuetwo.name)
+						if ((V.name == virtue.name || V.name == virtuetwo.name) && !istype(V, /datum/virtue/none))
 							continue
 						if (istype(V, /datum/virtue/heretic) && !istype(selected_patron, /datum/patron/inhumen))
 							continue
@@ -2019,7 +2021,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						var/datum/virtue/V = GLOB.virtues[path]
 						if (!V.name)
 							continue
-						if (V.name == virtue.name || V.name == virtuetwo.name)
+						if ((V.name == virtue.name || V.name == virtuetwo.name) && !istype(V, /datum/virtue/none))
 							continue
 						if(length(pref_species.restricted_virtues) && (V.type in pref_species.restricted_virtues))
 							continue

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -371,6 +371,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			pref_species = new default_species.type()
 	else
 		pref_species = new default_species.type()
+	if(pref_species.custom_selection)
+		S["race_bonus"] >> race_bonus
 
 /datum/preferences/proc/_load_flaw(S)
 	var/charflaw_type
@@ -761,6 +763,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["statpack"] , statpack.type)
 	WRITE_FILE(S["virtue"] , virtue.type)
 	WRITE_FILE(S["virtuetwo"], virtuetwo.type)
+	WRITE_FILE(S["race_bonus"], race_bonus)
 	WRITE_FILE(S["combat_music"], combat_music.type)
 	WRITE_FILE(S["body_size"] , features["body_size"])
 	if(loadout)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -154,6 +154,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	/// List all of body markings that the player can choose from in customization. Body markings from sets get added to here
 	var/list/body_markings
 	var/list/languages = list(/datum/language/common)
+
+	var/list/restricted_virtues
+
+	var/list/custom_selection
+
 	/// Some species have less than standard gender locks
 	var/gender_swapping = FALSE
 	var/stress_examine = FALSE

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -83,6 +83,8 @@
 		/datum/body_marking/construct_psyclops_eye,
 	)
 
+	restricted_virtues = list(/datum/virtue/utility/noble)
+
 /datum/species/construct/metal/check_roundstart_eligible()
 	return TRUE
 	

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -20,7 +20,13 @@
 	skinned_type = /obj/item/ingot/steel
 	disliked_food = NONE
 	liked_food = NONE
-	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_BLOODLOSS_IMMUNE, TRAIT_NOBREATH, TRAIT_NOSLEEP)
+	inherent_traits = list(
+		TRAIT_NOHUNGER,
+		TRAIT_BLOODLOSS_IMMUNE,
+		TRAIT_NOBREATH,
+		TRAIT_EASYDISMEMBER,
+		TRAIT_ZOMBIE_IMMUNE
+		)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mcom.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/fcom.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -83,7 +83,7 @@
 		/datum/body_marking/construct_psyclops_eye,
 	)
 
-	restricted_virtues = list(/datum/virtue/utility/noble)
+	restricted_virtues = list(/datum/virtue/utility/noble, /datum/virtue/utility/deathless)
 
 /datum/species/construct/metal/check_roundstart_eligible()
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
@@ -16,7 +16,7 @@
 
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,MUTCOLORS_PARTSONLY)
 	default_features = MANDATORY_FEATURE_LIST
-	inherent_traits = list(TRAIT_EASYDECAPITATION)
+	inherent_traits = list(TRAIT_EASYDECAPITATION, TRAIT_NOHUNGER, TRAIT_NOBREATH, TRAIT_ZOMBIE_IMMUNE) //Given the deathless traits inherently as part of their nature as pseudo-undead.
 	use_skintones = 1
 	disliked_food = NONE
 	liked_food = NONE
@@ -115,6 +115,8 @@
 	languages = list(
 		/datum/language/common,
 	)
+
+	restricted_virtues = list(/datum/virtue/utility/noble, /datum/virtue/utility/deathless, /datum/virtue/utility/resident)
 
 	stress_examine = TRUE
 	stress_desc = span_red("Accursed. I should keep my distance...")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -13,7 +13,7 @@
 	Because of their upbringing, they make for natural conduits for godly powers. \
 	Azure Peak's populace holds them with a mixture of uneasy mixture of fear and respect. \
 	Due to their celestial nature, it is widely believed that an Aasimar's death is a bad omen...<br>\
-	(+1 Fortune)"
+	(+1 Stat of their choice, or Deathless Virtue)"
 
 	skin_tone_wording = "Craft"
 
@@ -43,7 +43,7 @@
 		OFFSET_NECK_F = list(0,-1), OFFSET_MOUTH_F = list(0,-1), OFFSET_PANTS_F = list(0,0), \
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		)
-	race_bonus = list(STAT_FORTUNE = 1)
+	race_bonus = list()
 	enflamed_icon = "widefire"
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,
@@ -77,6 +77,17 @@
 		/datum/language/common,
 		/datum/language/celestial
 	)
+
+	custom_selection = list(
+		"+1 FOR" = STATKEY_LCK,
+		"+1 INT" = STATKEY_INT,
+		"+1 CON" = STATKEY_CON,
+		"+1 WIL" = STATKEY_WIL,
+		"+1 PER" = STATKEY_PER,
+		"Deathless" = /datum/virtue/utility/deathless
+	)
+
+	restricted_virtues = list(/datum/virtue/utility/deathless)
 
 /datum/species/aasimar/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -13,7 +13,7 @@
 	Because of their upbringing, they make for natural conduits for godly powers. \
 	Azure Peak's populace holds them with a mixture of uneasy mixture of fear and respect. \
 	Due to their celestial nature, it is widely believed that an Aasimar's death is a bad omen...<br>\
-	(+1 Stat of their choice, or Deathless Virtue)"
+	(+1 Stat of their choice, or Lack of Hunger & Thirst)"
 
 	skin_tone_wording = "Craft"
 
@@ -84,10 +84,8 @@
 		"+1 CON" = STATKEY_CON,
 		"+1 WIL" = STATKEY_WIL,
 		"+1 PER" = STATKEY_PER,
-		"Deathless" = /datum/virtue/utility/deathless
+		"No Hunger & Thirst" = TRAIT_NOHUNGER
 	)
-
-	restricted_virtues = list(/datum/virtue/utility/deathless)
 
 /datum/species/aasimar/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()


### PR DESCRIPTION
## About The Pull Request
- Adds a race bonus variable to species, which can be a path, a trait or a statkey (at the moment)
   - this frankly warrants datumization but my injury isnt letting me code enough for this
- Aasimars now get to pick their +1 STAT (No STR / SPD) OR Foodless trait (no hunger / thirst)
![sryprxEIF9](https://github.com/user-attachments/assets/f79f437d-6bc5-454f-956c-775769a0a3fe)

- Adds `restricted_virtues` list to species that prevents those virtues from being picked by that race.
   - Revenants get Resident, Deathless and Nobility on that list
   - Metal Constructs get Deathless, Nobility
- It resets those virtues if they were already selected (to prevent unintended behaviour)
![687zM1EYeB](https://github.com/user-attachments/assets/c581c2d3-a4b6-4f92-a726-50fbfacd4c7b)

- Revenants get Deathless traits as part of their race now, same as #4070
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
By popular request for both species, also adds a framework for different types of race customization
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
