### PR TITLE
Minor Guarded Virtue Update

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -239,7 +239,7 @@
 			if(L.STAINT > 9 && L.STAPER > 9)
 				. += span_redtext("<i>[m1] critically fragile!</i>")
 
-	if(user != src && HAS_TRAIT(user, TRAIT_MATTHIOS_EYES))
+	if(user != src && HAS_TRAIT(user, TRAIT_MATTHIOS_EYES) && (!HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS)))
 		var/atom/item = get_most_expensive()
 		if(item)
 			. += span_notice("You get the feeling [m2] most valuable possession is \a [item].")

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -123,12 +123,14 @@
 	if(ishuman(targets[1]))
 		var/vice_found
 		var/mob/living/carbon/human/H = targets[1]
-		if(HAS_TRAIT(H, TRAIT_DECEIVING_MEEKNESS) && user.get_skill_level(/datum/skill/magic/holy) > SKILL_LEVEL_NOVICE)
+		if(HAS_TRAIT(H, TRAIT_DECEIVING_MEEKNESS) && user.get_skill_level(/datum/skill/magic/holy) <= SKILL_LEVEL_NOVICE)
 			if(!(H in fake_vices))
 				fake_vices[H] = pick(GLOB.character_flaws)
 				vice_found = fake_vices[H]
 			else
 				vice_found = fake_vices[H]
+			if(prob(50 + ((H.STAPER - 10) * 10)))
+				to_chat(H, span_warning("A pair of prying eyes were laid on me..."))
 		if(!vice_found)
 			vice_found = H.charflaw.name
 		to_chat(user, span_info("They are... [span_warning("a [vice_found]")]"))

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -31,6 +31,11 @@
 /obj/effect/proc_holder/spell/invoked/appraise/cast(list/targets, mob/living/user)
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/target = targets[1]
+		if(HAS_TRAIT(target, TRAIT_DECEIVING_MEEKNESS) && target != user)
+			to_chat(user, "<font color='yellow'>I cannot tell...</font>")
+			if(prob(50 + ((target.STAPER - 10) * 10)))
+				to_chat(target, span_warning("A pair of prying eyes were laid on me..."))
+			return
 		var/mammonsonperson = get_mammons_in_atom(target)
 		var/mammonsinbank = SStreasury.bank_accounts[target]
 		var/totalvalue = mammonsinbank + mammonsonperson

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -123,6 +123,7 @@
 /datum/virtue/combat/guarded
 	name = "Guarded"
 	desc = "I have long kept my true capabilities and vices a secret. Sometimes being deceptively weak can save one's lyfe."
+	custom_text = "Obfuscates information about you from all sorts of effects, including patron abilities & passives, Assess and other virtues."
 	added_traits = list(TRAIT_DECEIVING_MEEKNESS)
 
 /*/datum/virtue/combat/impervious


### PR DESCRIPTION
## About The Pull Request
- Works against Matthios eyes and secular appraise
- Works against Baotha's vice vision as intended (bugfix)
- Either of those now has a chance to tell the target they were getting oogled at if they have Guarded
- Updated description
<img width="510" height="171" alt="dreamseeker_04C6ONl5rr" src="https://github.com/user-attachments/assets/f34a424b-048c-4e9d-ab5d-42fd5ad8d6a4" />

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
virtue functioning as intended vs information based features

feel free to comment with any other things it should interact with
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
