### PR TITLE
Fix greatweaponstrap + Properly allow them to carry crosses

### DIFF
--- a/modular_azurepeak/code/game/objects/items/scabbard.dm
+++ b/modular_azurepeak/code/game/objects/items/scabbard.dm
@@ -384,8 +384,12 @@
 	if(.)
 		if(sheathed)
 			return FALSE
-		if(istype(A, /obj/item/rogueweapon) && A.w_class >= WEIGHT_CLASS_BULKY)
-			return TRUE
+		if(istype(A, /obj/item/rogueweapon))
+			if(A.w_class >= WEIGHT_CLASS_BULKY)
+				return TRUE
+		if(!istype(A, /obj/item/clothing/neck/roguetown/psicross)) //snowflake that bypasses the valid_blades that i made. i will commit seppuku eventually
+			return FALSE
+
 
 /obj/item/rogueweapon/scabbard/gwstrap/update_icon(mob/living/user)
 	if(sheathed)


### PR DESCRIPTION
## About The Pull Request

1. bugfix for anything going in gwstraps.
2. psycrosses can now be mounted on gwstraps (intended now)

## Testing Evidence

tested

## Why It's Good For The Game

fugbix also carrying crosses is kinda actually dope

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
