### PR TITLE
Primordial Spell Edit

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_primordial.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_primordial.dm
@@ -35,7 +35,7 @@
 
 	var/obj/item/sacrifice
 	for(var/obj/item/I in user.held_items)
-		if(istype(I, /obj/item/alch/waterdust)||istype(I, /obj/item/alch/airdust)|| istype(I, /obj/item/alch/firedust))
+		if(istype(I, /obj/item/magic/elementalshard)||istype(I, /obj/item/magic/iridescentscale)|| istype(I, /obj/item/magic/hellhoundfang))
 			sacrifice = I
 			break
 


### PR DESCRIPTION
## About The Pull Request

Upon testing myself and reading what people had to say on discord. Acquiring the ingredients to even use this spell is quite a pain in the ass to the point that its not even worth using. I can see why the original spell was only 4 points because the time requirement to even get one of these summons is crazy. 

So, I have changed the required ingredients to use items from our already existing summoning system. Do they match perfectly? No. Are they obtainable through the mage gameplay loop, making the spell actually useable? Yes. 

Fire Primordial Changed from Fire Dust to Hellhound Fang
Water Primordial Changed from Water Dust to Elemental Shard
Air Primordial Changed from Air Dust to Iridescent Scale

## Testing Evidence

Or not. Let me check this again.

## Why It's Good For The Game

As mentioned above, to use this spell requires you to really go out of your way to obtain the ingredients (Fire/Water/Air Dust) to summon one of these creatures which obtaining said ingredients is entirely RNG depending on spawns of certain flowers, grinding ingredients chances, etc. This instead makes spell more intertwined with our current summoning system while making the ingredients obtainable. 
