### PR TITLE
Kill speedfactor from swim skill

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -323,9 +323,7 @@
 
 /turf/open/water/get_slowdown(mob/user)
 	var/returned = slowdown
-	returned = returned - (user.get_skill_level(/datum/skill/misc/swimming))
 	if(ishuman(user))
-		returned = max(returned, 0.5)
 		var/mob/living/carbon/human/H = user
 		var/ac = H.highest_ac_worn()
 		switch(ac)


### PR DESCRIPTION
## About The Pull Request

Swimming skill no longer dictates your speed in water. Only how much stamina is spent per movement in water tile.

## Testing Evidence

Tested.

## Why It's Good For The Game

No more swim grinding cheese.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
