### PR TITLE
Campfire cooking with no skill now have an actual 33% fail chance.

### DIFF
--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -127,17 +127,19 @@
 					var/prob2spoil = 33
 					if(user.get_skill_level(/datum/skill/craft/cooking))
 						prob2spoil = 1
+					var/already_rolled = FALSE
 					user.visible_message("<span class='notice'>[user] starts to cook [W] over [src].</span>")
 					for(var/i in 1 to 6)
 						if(do_after(user, 30 / cooktime_divisor, target = src))
 							var/obj/item/reagent_containers/food/snacks/S = W
 							var/obj/item/C
-							if(prob(prob2spoil))
+							if(prob(prob2spoil) && !already_rolled)
 								user.visible_message("<span class='warning'>[user] burns [S].</span>")
 								if(user.client?.prefs.showrolls)
 									to_chat(user, "<span class='warning'>Critfail... [prob2spoil]%.</span>")
 								C = S.cooking(1000, 1000, null)
 							else
+								already_rolled = TRUE
 								C = S.cooking(S.cooktime/4, S.cooktime/4, src)
 							if(C)
 								user.dropItemToGround(S, TRUE)


### PR DESCRIPTION
## About The Pull Request
- Campfire cooking with no skill now have an actual 33% fail chance.
- Campfire cooking with 0 skills were basically a trap due to the fact it rolls up to 6 times with 33% chance to burn which adds up to somewhere around 9% chance of successfully cooking, meaning that any 0 skill cooking should always be done with building an oven or hearth instead. That's kinda dumb. I can cook better than that.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="134" height="194" alt="dreamseeker_MCrZSqKNXi" src="https://github.com/user-attachments/assets/423b9bcf-0657-4fb6-a93c-1c171a7c1329" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Campfire cooking with no skill now have an actual 33% fail chance.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
