### PR TITLE
Disciple's Skin bugfix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1455,7 +1455,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	to_chat(M, "\The [src] BREAKS...!")
 
-/obj/item/obj_fix()
+/obj/item/obj_fix(mob/user, full_repair = TRUE)
 	..()
 	update_damaged_state()
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -239,9 +239,10 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	balloon_alert_to_viewers("<font color = '#bb2b2b'>[src]<br>breaks!</font>")
 
 /// Called after obj is repaired (needle/hammer for items). Do not call unless obj_broken is true to avoid breaking armor.
-/obj/proc/obj_fix(mob/user)
+/obj/proc/obj_fix(mob/user, full_repair = TRUE)
 	obj_broken = FALSE
-	obj_integrity = max_integrity
+	if(full_repair)
+		obj_integrity = max_integrity
 	SEND_SIGNAL(src, COMSIG_ITEM_OBJFIX)
 
 ///what happens when the obj's integrity reaches zero.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -340,7 +340,7 @@
 			armorlist[x] = 0
 	..()
 
-/obj/item/clothing/obj_fix()
+/obj/item/clothing/obj_fix(mob/user, full_repair = TRUE)
 	..()
 	armor = original_armor
 

--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -228,36 +228,33 @@
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 	body_parts_covered = COVERAGE_FULL
 	body_parts_inherent = COVERAGE_FULL
-	max_integrity = 600 //Difficult to completely break.
+	max_integrity = 300
 	flags_inv = null //Exposes the chest and-or breasts. Should allow for a Disciple's thang to swang.
 	surgery_cover = FALSE //Should permit surgery and other invasive processes.
-	var/repair_amount = 6 
 	var/repair_time = 20 SECONDS
-	var/last_repair 
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/disciple/Initialize(mapload)
-	. = ..()
+	..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/disciple/dropped(mob/living/carbon/human/user)
-	. = ..()
+	..()
 	if(QDELETED(src))
 		return
 	qdel(src)
 
-
-/obj/item/clothing/suit/roguetown/armor/gambeson/disciple/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
-	. = ..()
-	if(obj_integrity < max_integrity)
-		START_PROCESSING(SSobj, src)
-		return
-
-/obj/item/clothing/suit/roguetown/armor/gambeson/disciple/process()
-	if(obj_integrity >= max_integrity) 
-		STOP_PROCESSING(SSobj, src)
-		src.visible_message(span_notice("[src] tautens with newfound vigor, before relaxing once more."), vision_distance = 1)
-		return
-	else if(world.time > src.last_repair + src.repair_time)
-		src.last_repair = world.time
-		obj_integrity = min(obj_integrity + src.repair_amount, src.max_integrity)
+/obj/item/clothing/suit/roguetown/armor/gambeson/disciple/obj_break(damage_flag)
 	..()
+	visible_message(span_notice("My [src] begins to tauten with newfound vigor, before relaxing once more.."), vision_distance = 1)
+	addtimer(CALLBACK(src, PROC_REF(skin_repair)), repair_time, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
+
+/obj/item/clothing/suit/roguetown/armor/gambeson/disciple/proc/skin_repair(var/repair_percent = 0.2 * max_integrity)
+	if(obj_integrity >= max_integrity) 
+		return
+
+	obj_integrity = min(obj_integrity + repair_percent, max_integrity)
+	visible_message(span_notice("My [src] slowly mends its abuse.."), vision_distance = 1)
+	if(obj_broken)
+		obj_fix(full_repair = FALSE)
+	addtimer(CALLBACK(src, PROC_REF(skin_repair)), repair_time, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
+


### PR DESCRIPTION
## About The Pull Request

The disciple skin now auto-repairs 20% every 20s once it breaks. It also partial-repairs, which means that it begins protecting once more, after the first repair (instead of needing to repaired to 100% at 100s before providing armour again)

Sets its integrity to 300 from 600 (since it can be broken and be fine now)

NUFC: Added partial-repairability. Should probably make that the default instead of 100%->Usability

## Testing Evidence

Tested.

## Why It's Good For The Game

Bugfix and now the disciple's skin works like spartan energy shield.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
