### PR TITLE
Blackbags reduce garrote resist, NPCs are weaker to garrotes

### DIFF
--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -938,6 +938,8 @@ Inquisitorial armory down here
 		if(prob(40))
 			C.emote("choke")
 		C.adjustOxyLoss(choke_damage)
+		if(!C.mind) // NPCs can be choked out twice as fast
+			C.adjustOxyLoss(choke_damage)
 		C.visible_message(span_danger("[user] [pick("garrotes", "asphyxiates")] [C]!"), \
 		span_userdanger("[user] [pick("garrotes", "asphyxiates")] me!"), span_hear("I hear the sickening sound of cordage!"), COMBAT_MESSAGE_RANGE, user)
 		to_chat(user, span_danger("I [pick("garrote", "asphyxiate")] [C]!"))	

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1200,6 +1200,8 @@
 		if(!HAS_TRAIT(src, TRAIT_GARROTED))
 			combat_modifier -= 0.3
 		else
+			if(!src.mind)
+				combat_modifier -= 0.3
 			if(HAS_TRAIT(L, TRAIT_BLACKBAGGER))
 				combat_modifier -= 0.3
 				if(HAS_TRAIT(src, TRAIT_BAGGED))
@@ -1232,7 +1234,10 @@
 			if(!gcord)
 				gcord = L.get_inactive_held_item()
 			to_chat(pulledby, span_warning("[src] struggles against the [gcord]!"))
-			gcord.take_damage(25)
+			if(!src.mind) // NPCs do less damage to the garrote
+				gcord.take_damage(10)
+			else
+				gcord.take_damage(25)
 		if(!HAS_TRAIT(src, TRAIT_GARROTED))
 			visible_message(span_warning("[src] struggles to break free from [L]'s grip!"), \
 						span_warning("I struggle against [L]'s grip![rchance]"), null, null, L)


### PR DESCRIPTION
## About The Pull Request

Being black bagged makes it harder to escape a garrote. This is specifically only garroting and regular grabs are not any harder to escape.

## Testing Evidence
Without black bag:
<img width="457" height="176" alt="image" src="https://github.com/user-attachments/assets/ff357296-d35c-4928-b67c-60073de70708" />

With black bag:
<img width="470" height="121" alt="image" src="https://github.com/user-attachments/assets/09abab12-83a0-4091-851d-a47396ce9d4d" />


## Why It's Good For The Game

Unless you don't struggle at all, a single garrote can't choke someone out fast enough before it breaks because of the hard limit on its durability. Instead of making the garrote stronger, I've elected to make black bags work better with garrotes because they're less likely to be used in combat (and if you somehow manage to keep someone still for long enough to get a bag on their head, they're probably already getting ganked anyway.)

Influenced by a round where a confessor could not even subdue a maid and two garrotes snapped so they resorted to just choking them with their hands because that's somehow more effective.
