### PR TITLE
Mortar exploit fix

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/mortarpestle.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/mortarpestle.dm
@@ -160,7 +160,7 @@
 		return
 	var/recipe = find_recipe(I)
 	if(recipe == null && I.grind_results == null && I.juice_results == null)
-		to_chat(user, "<span class='warning'>[I] can't be grind!!</span>")
+		to_chat(user, "<span class='warning'>[I] can't be ground!!</span>")
 		return
 	if(!user.transferItemToLoc(I,src))
 		to_chat(user, "<span class='warning'>[I] is stuck to my hand!</span>")


### PR DESCRIPTION
## About The Pull Request

At the moment, you can put a spear, a sword, and other things in the mortar that obviously shouldn't go in there... I've noticed how people abuse it by shoving a huge sword into their mortar and stuffing it into their inventory.

I made it so that only what could be grinnd could be put in the mortar.

## Testing Evidence

<img width="224" height="37" alt="image" src="https://github.com/user-attachments/assets/c296ee1d-7336-4785-8e20-6ce6b27d8d16" />

(I changed grind to ground, but I'm too lazy to take a new screenshot...)
## Why It's Good For The Game

No one will carry a few halberds in their bag.
