### PR TITLE
Handfeeding an animal slightly heals them

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -286,7 +286,7 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		move_to_delay = initial(move_to_delay)
 		return
 	var/health_deficiency = getBruteLoss() + getFireLoss()
-	if(health_deficiency >= ( maxHealth - (maxHealth*0.75) ))
+	if(health_deficiency >= ( maxHealth - (maxHealth*0.50) ))
 		move_to_delay = initial(move_to_delay) + 2
 	else
 		move_to_delay = initial(move_to_delay)


### PR DESCRIPTION
## About The Pull Request
* Handfeeding an animal heals them by 10-20.
* Animals slow down when they miss 50% of their health instead of 75%.

## Testing Evidence
fed a wounded animal, it heals

## Why It's Good For The Game
non-magical way to heal your mounts

makes wildlife slightly more intimidating to fight, makes mounts a bit more durable 
