### PR TITLE
HUGBOX PEAK: the return of vampire deconvert

### DIFF
--- a/code/modules/vampire_neu/clan/_base_clan.dm
+++ b/code/modules/vampire_neu/clan/_base_clan.dm
@@ -252,8 +252,11 @@ And it also helps for the character set panel
 
 	UnregisterSignal(vampire, COMSIG_HUMAN_LIFE)
 
+	var/datum/action/clan_menu/clan_action = locate(/datum/action/clan_menu) in vampire.actions
+	QDEL_NULL(clan_action)
+
 	// Remove unique Clan feature traits
-	for (var/trait in clane_traits)
+	for(var/trait in clane_traits)
 		REMOVE_TRAIT(vampire, trait, "clan")
 
 	vampire.update_body()
@@ -267,6 +270,8 @@ And it also helps for the character set panel
 	if(disguise_comp)
 		qdel(disguise_comp)
 
+	vampire.verbs -= /mob/living/carbon/human/proc/disguise_verb
+
 	clan_members -= vampire
 
 	if(vampire.clan_position)
@@ -274,6 +279,10 @@ And it also helps for the character set panel
 
 	for(var/datum/coven/coven as anything in clane_covens)
 		vampire.remove_coven(coven)
+
+	// Bloodheal coven has snowflake behavior since it is added to all vampires. So - snowflake removal.
+	var/datum/coven/bloodheal/bloodheal = locate(/datum/coven/bloodheal) in vampire.covens
+	vampire.remove_coven(bloodheal)
 
 	var/list/spells_to_remove = list(
 		/datum/action/clan_menu,

--- a/code/modules/vampire_neu/clan/clan_leader.dm
+++ b/code/modules/vampire_neu/clan/clan_leader.dm
@@ -56,9 +56,7 @@
 /datum/clan_leader/proc/remove_leader(mob/living/carbon/human/H)
 	REMOVE_TRAIT(H, TRAIT_CLAN_LEADER, "clan")
 	for(var/spell_type in lord_spells)
-		var/datum/action/spell_instance = locate(spell_type) in H.actions
-		if(spell_instance)
-			spell_instance.Remove(H)
+		H.mind?.RemoveSpell(spell_type)
 
 	for(var/verb_path in lord_verbs)
 		H.verbs -= verb_path

--- a/modular_azurepeak/code/game/objects/items/quicksilver.dm
+++ b/modular_azurepeak/code/game/objects/items/quicksilver.dm
@@ -129,11 +129,30 @@
 			M.Jitter(30)
 			return
 
-	else if(Vamp) //We're the vampire, we can't be saved.
-		to_chat(M, span_userdanger("This wretched silver weighs heavy on my brow. An insult I shall never forget, for as long as I die."))
-		user.visible_message(span_danger("The silver poultice boils away from [M]'s brow, viscerally rejecting the divine anointment."))
+	else if(Vamp) //We're the vampire, WE CAN BE SAVED BECAUSE WE ARE THE HUGBOX PEAK!!! YIPPE, FRIEND, MAGIC, RAINBWOS AND SPARKLEDOGS~~~
+		if(tgui_alert(M, "Resist the curse?", "Silver Poultice", list("YES", "NO")) != "YES")
+			to_chat(M, span_userdanger("This wretched silver weighs heavy on my brow. An insult I shall never forget, for as long as I die."))
+			user.visible_message(span_danger("The silver poultice boils away from [M]'s brow, viscerally rejecting the divine anointment."))
+			M.Stun(30)
+			M.Knockdown(30)
+			return
+
+		to_chat(M, span_userdanger("THE FOUL SILVER! MY BODY RENDS ITSELF ASUNDER!"))
+		Vamp.on_removal()
 		M.Stun(30)
 		M.Knockdown(30)
+		M.Jitter(30)
+		for(var/trait in list(
+			TRAIT_EASYDISMEMBER, 
+			TRAIT_NOPAIN, 
+			TRAIT_NOPAINSTUN, 
+			TRAIT_NOBREATH, 
+			TRAIT_TOXIMMUNE, 
+			TRAIT_ZOMBIE_IMMUNE, 
+			TRAIT_ROTMAN, 
+			TRAIT_SILVER_WEAK
+		))
+			ADD_TRAIT(M, trait, TRAIT_GENERIC)
 		return
 //A letter to give info on how to make this thing.
 /obj/item/paper/inquisition_poultice_info


### PR DESCRIPTION
## About The Pull Request

Before somebody else inevitably makes this but with worse implementation.

Vampire deconversion wia quicksilver poultice.
**Deconversion, unsurprisingly, is OPT IN.**

Adds all rotcured traits to the deconverted vampire.

You can opt out of conversion, deconversion, next - I'll add the option to opt out of combat, mechanics and even death. Because player-agency matters and HRP is about giving players unlimited choices.


## Testing Evidence

<img width="431" height="320" alt="image" src="https://github.com/user-attachments/assets/4724861c-710e-4b2f-b36a-44cc345e314c" />

## Why It's Good For The Game

![i (18)](https://github.com/user-attachments/assets/a580b320-8bc0-4a1f-80e2-cc975a040da6)
