### PR TITLE
Fix: footstep sounds

### DIFF
--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -69,8 +69,6 @@
 	if(steps % 2)
 		return
 
-	if(steps != 0) // don't need to step as often when you hop around
-		return
 	return T
 
 /datum/component/footstep/proc/play_simplestep()


### PR DESCRIPTION
## About The Pull Request

Originally this check was
```	
if(steps != 0 && !LM.has_gravity(T))
    return
```
And that made sense. Without gravity check though, this makes no sense and causes footsteps to be played only on sixth turf.

## Testing Evidence

https://github.com/user-attachments/assets/9c716b33-9878-4e87-9a6d-a89318a06544

## Why It's Good For The Game

Uhhh I think I need those bugs gone