### PR TITLE
Make regenerating armour its own thing

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -1,4 +1,4 @@
-//gambeson family
+// GAMBESON ARMOUR
 
 /obj/item/clothing/suit/roguetown/armor/gambeson
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
@@ -216,53 +216,3 @@
 	icon_state = "shadowrobe"
 	armor = ARMOR_PADDED_GOOD
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM + 30 //280
-
-//
-/obj/item/clothing/suit/roguetown/armor/gambeson/disciple
-	name = "disciple's skin"
-	desc = "It's far more than just an oath. </br>'AEON, PSYDON, ADONAI - ENTROPY, HUMENITY, DIVINITY. A TRINITY THAT IS ONE, YET THREE; KNOWN BY ALL, YET FORGOTTEN TO TYME.' </br>'A CORPSE. I AM LIVING ON A FUCKING CORPSE. HE IS THE WORLD, AND THE WORLD IS ROTTING AWAY. HEAVEN CLOSED ITS GATES TO US, LONG AGO.' </br>'YET, HIS CHILDREN PERSIST; AND AS LONG AS THEY DO, SO MUST I. HAPPINESS MUST BE FOUGHT FOR.'"
-	resistance_flags = FIRE_PROOF
-	icon_state = null
-	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR
-	armor = list("blunt" = 30, "slash" = 50, "stab" = 50, "piercing" = 20, "fire" = 0, "acid" = 0) //Custom value; padded gambeson's slash- and stab- armor.
-	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
-	body_parts_covered = COVERAGE_FULL
-	body_parts_inherent = COVERAGE_FULL
-	max_integrity = 300
-	flags_inv = null //Exposes the chest and-or breasts. Should allow for a Disciple's thang to swang.
-	surgery_cover = FALSE //Should permit surgery and other invasive processes.
-	var/repair_time = 20 SECONDS
-	var/reptimer
-
-/obj/item/clothing/suit/roguetown/armor/gambeson/disciple/Initialize(mapload)
-	..()
-	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
-
-/obj/item/clothing/suit/roguetown/armor/gambeson/disciple/dropped(mob/living/carbon/human/user)
-	..()
-	if(QDELETED(src))
-		return
-	qdel(src)
-
-/obj/item/clothing/suit/roguetown/armor/gambeson/disciple/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
-	..()
-	if(reptimer)
-		visible_message(span_notice("My [name] stops mending from the onslaught!"), vision_distance = 1)
-		deltimer(reptimer)
-
-	visible_message(span_notice("My [name] begins to slowly mend its abuse.."), vision_distance = 1)
-	reptimer = addtimer(CALLBACK(src, PROC_REF(skin_repair)), repair_time, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
-
-/obj/item/clothing/suit/roguetown/armor/gambeson/disciple/proc/skin_repair(var/repair_percent = 0.2 * max_integrity)
-	if(obj_integrity >= max_integrity)
-		visible_message(span_notice("My [name] has become taut with newfound vigor!"), vision_distance = 1)
-		if(reptimer)
-			deltimer(reptimer)
-		return
-
-	visible_message(span_notice("My [name] begins to mends some of its abuse.."), vision_distance = 1)
-	obj_integrity = min(obj_integrity + repair_percent, max_integrity)
-	if(obj_broken)
-		obj_fix(full_repair = FALSE)
-	reptimer = addtimer(CALLBACK(src, PROC_REF(skin_repair)), repair_time, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
-

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -1,0 +1,107 @@
+// REGENERATING ARMOUR
+
+/obj/item/clothing/suit/roguetown/armor/regenerating
+	name = "regenerating armour"
+	desc = "Abstract parent. Contact developer if you see this."
+	icon_state = null
+	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR
+
+	/// Feedback messages
+	var/repairmsg_begin = "My armour begins to slowly mend its abuse.."
+	var/repairmsg_continue = "My armour mends some of its abuse.."
+	var/repairmsg_stop = "My armour stops mending from the onslaught!"
+	var/repairmsg_end = "My armour has become taut with newfound vigor!"
+
+	/// Time taken for regeneration
+	var/repair_time
+	/// Holder for timer
+	var/reptimer
+
+	/// Regen interrupt vars
+	var/interrupt_damount
+	var/interrupt_dtype
+	var/interrupt_dflag
+	var/interrupt_ddir
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
+	..()
+	if(reptimer)
+		if(!regen_interrupt(damage_amount, damage_type, damage_flag, attack_dir))
+			return
+		to_chat(loc, span_notice(repairmsg_stop))
+		deltimer(reptimer)
+
+	to_chat(loc, span_notice(repairmsg_begin))
+	reptimer = addtimer(CALLBACK(src, PROC_REF(armour_regen)), repair_time, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/proc/armour_regen(var/repair_percent = 0.2 * max_integrity)
+	if(obj_integrity >= max_integrity)
+		to_chat(loc, span_notice(repairmsg_end))
+		if(reptimer)
+			deltimer(reptimer)
+		return
+
+	to_chat(loc, span_notice(repairmsg_continue))
+	obj_integrity = min(obj_integrity + repair_percent, max_integrity)
+	if(obj_broken)
+		obj_fix(full_repair = FALSE)
+	reptimer = addtimer(CALLBACK(src, PROC_REF(armour_regen)), repair_time, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/proc/regen_interrupt(damage_amount, damage_type, damage_flag, attack_dir)
+	if(interrupt_damount && interrupt_damount > damage_amount)
+		return FALSE
+	if(interrupt_dtype && interrupt_dtype != damage_type)
+		return FALSE
+	if(interrupt_dflag && interrupt_dflag != damage_flag)
+		return FALSE
+	if(interrupt_ddir && interrupt_ddir != attack_dir)
+		return FALSE
+	return TRUE
+
+
+// SKIN ARMOUR
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin
+	name = "regenerating skin"
+	break_sound = 'sound/foley/cloth_rip.ogg'
+	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
+
+	resistance_flags = FIRE_PROOF
+	body_parts_covered = COVERAGE_FULL
+	body_parts_inherent = COVERAGE_FULL
+	flags_inv = null //Exposes the chest and-or breasts.
+	surgery_cover = FALSE //Should permit surgery and other invasive processes.
+	r_sleeve_status = SLEEVE_NORMAL
+	l_sleeve_status = SLEEVE_NORMAL
+	armor_class = ARMOR_CLASS_LIGHT
+	blocksound = SOFTUNDERHIT
+	blade_dulling = DULLING_BASHCHOP
+	armor = ARMOR_PADDED
+
+	repairmsg_begin = "My skin begins to slowly mend its abuse.."
+	repairmsg_continue = "My skin mends some of its abuse.."
+	repairmsg_stop = "My skin stops mending from the onslaught!"
+	repairmsg_end = "My skin has become taut with newfound vigor!"
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/Initialize(mapload)
+	..()
+	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/dropped(mob/living/carbon/human/user)
+	..()
+	if(QDELETED(src))
+		return
+	qdel(src)
+
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple
+	name = "disciple's skin"
+	desc = "It's far more than just an oath. </br>'AEON, PSYDON, ADONAI - ENTROPY, HUMENITY, DIVINITY. A TRINITY THAT IS ONE, \
+	YET THREE; KNOWN BY ALL, YET FORGOTTEN TO TYME.' </br>'A CORPSE. \
+	I AM LIVING ON A FUCKING CORPSE. HE IS THE WORLD, AND THE WORLD IS ROTTING AWAY. \
+	HEAVEN CLOSED ITS GATES TO US, LONG AGO.' </br>'YET, HIS CHILDREN PERSIST; AND AS LONG AS THEY DO, SO MUST I. \
+	HAPPINESS MUST BE FOUGHT FOR.'"
+	armor = list("blunt" = 30, "slash" = 50, "stab" = 50, "piercing" = 20, "fire" = 0, "acid" = 0) //Custom value; padded gambeson's slash- and stab- armor.
+	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
+	max_integrity = 300
+	repair_time = 20 SECONDS

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -45,7 +45,7 @@
 	gloves = /obj/item/clothing/gloves/roguetown/chain/psydon
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
 	id = /obj/item/clothing/ring/signet/silver
-	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/disciple
+	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple
 	backl = /obj/item/storage/backpack/rogue/satchel/otavan
 	mask = /obj/item/clothing/head/roguetown/helmet/blacksteel/psythorns
 	head = /obj/item/clothing/head/roguetown/roguehood/psydon

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1456,6 +1456,7 @@
 #include "code\modules\clothing\rogueclothes\armor\leather.dm"
 #include "code\modules\clothing\rogueclothes\armor\misc.dm"
 #include "code\modules\clothing\rogueclothes\armor\plate.dm"
+#include "code\modules\clothing\rogueclothes\armor\regenerating.dm"
 #include "code\modules\clothing\rogueclothes\armor\unique.dm"
 #include "code\modules\clothing\rogueclothes\gloves\_gloves.dm"
 #include "code\modules\clothing\rogueclothes\gloves\angle.dm"


### PR DESCRIPTION
## About The Pull Request

Completely NUFC.

Makes a very simple n basic framework for regenerating armour for use. Skin is a child of it (for use with disciple skin, and future werewolf n anymore). New file and moves it out of gambeson.

I thought of snowflaking a `regenerating` factor instead of this but this should be cleaner and better/longterm served for any type of armour (skin or otherwise) that should specially be regenerating.

Framework allows for repair time, repair messages, and regen interrupts on factors of direction/damage type/amount/flags if wanted for anything specific. should be fine.

## Testing Evidence

Disciple skin works.

## Why It's Good For The Game

Clean code good. 

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
