### PR TITLE
Spell Runes are transparent to mouse + 128 Alpha

### DIFF
--- a/code/game/objects/items/rogueweapons/intent_alert.dm
+++ b/code/game/objects/items/rogueweapons/intent_alert.dm
@@ -7,3 +7,4 @@
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = 100
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	alpha = 128


### PR DESCRIPTION
## About The Pull Request
- Set mouse opacity to false on spell runes.
- Set Alpha to 128 (Experimental)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Set mouse opacity to false on spell runes.
<img width="271" height="243" alt="NVIDIA_Overlay_1wNO7ttygE" src="https://github.com/user-attachments/assets/a75b3480-7339-4758-8158-917a07a9e515" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Set mouse opacity to false on spell runes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
