### PR TITLE
More scabbard cleanup stuff

### DIFF
--- a/modular_azurepeak/code/game/objects/items/scabbard.dm
+++ b/modular_azurepeak/code/game/objects/items/scabbard.dm
@@ -27,10 +27,16 @@
 
 	COOLDOWN_DECLARE(shield_bang)
 
+	/// Weapon path and its children that are allowed
 	var/obj/item/rogueweapon/valid_blade
+	/// Specific weapons that are allowed. Bypasses valid_blade
 	var/list/obj/item/rogueweapon/valid_blades
+	/// Specific weapons that are not allowed. Bypassed valid_blade
 	var/list/obj/item/rogueweapon/invalid_blades
+
+	/// Stores weapon
 	var/obj/item/rogueweapon/sheathed
+
 	var/sheathe_time = 0.1 SECONDS
 	var/sheathe_sound = 'sound/foley/equip/scabbard_holster.ogg'
 
@@ -53,7 +59,7 @@
 		to_chat(user, span_warning("The sheath is occupied!"))
 		return FALSE
 	if(valid_blade && !istype(A, valid_blade))
-		to_chat(user, span_warning("[A] won't fit in there.."))
+		to_chat(user, span_warning("[A] won't fit in there."))
 		return FALSE
 	if(valid_blades)
 		if(!(A.type in valid_blades))
@@ -61,7 +67,7 @@
 			return FALSE
 	if(invalid_blades)
 		if(A.type in invalid_blades)
-			to_chat(user, span_warning("[A] won't fit in there.."))
+			to_chat(user, span_warning("[A] won't fit in there."))
 			return FALSE
 	return TRUE
 
@@ -124,7 +130,9 @@
 	..()
 	var/mob/living/M = usr
 
-	if(!M.incapacitated() && (loc == M || loc.loc == M) && istype(over, /atom/movable/screen/inventory/hand))
+	if(!Adjacent(M))
+		return
+	if(!M.incapacitated() && istype(over, /atom/movable/screen/inventory/hand))
 		var/atom/movable/screen/inventory/hand/H = over
 		if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
 			add_fingerprint(usr)
@@ -141,6 +149,7 @@
 	if(!sheathed)
 		if(!eat_sword(user, I))
 			return ..()
+
 
 /obj/item/rogueweapon/scabbard/examine(mob/user)
 	. = ..()
@@ -265,6 +274,16 @@
 	max_integrity = 500
 	sellprice = 2
 
+	invalid_blades = list(
+		/obj/item/rogueweapon/huntingknife/idagger/silver/stake
+	)
+
+/obj/item/rogueweapon/scabbard/sheath/weapon_check(mob/living/user, obj/item/A)
+	. = ..()
+	if(.)
+		if(!sheathe_icon)
+			return FALSE
+
 /obj/item/rogueweapon/scabbard/sheath/getonmobprop(tag)
 	..()
 
@@ -378,7 +397,6 @@
 	max_integrity = 0
 	sellprice = 15
 
-
 /obj/item/rogueweapon/scabbard/gwstrap/weapon_check(mob/living/user, obj/item/A)
 	. = ..()
 	if(.)
@@ -389,7 +407,6 @@
 				return TRUE
 		if(!istype(A, /obj/item/clothing/neck/roguetown/psicross)) //snowflake that bypasses the valid_blades that i made. i will commit seppuku eventually
 			return FALSE
-
 
 /obj/item/rogueweapon/scabbard/gwstrap/update_icon(mob/living/user)
 	if(sheathed)
@@ -484,13 +501,19 @@
 
 	valid_blade = /obj/item/rogueweapon/sword
 	invalid_blades = list(
-		/obj/item/rogueweapon/sword/long/exe
+		/obj/item/rogueweapon/sword/long/exe,
+		/obj/item/rogueweapon/sword/long/martyr
 	)
 
 	force = 7
 	max_integrity = 750
 	sellprice = 3
 
+/obj/item/rogueweapon/scabbard/sheath/weapon_check(mob/living/user, obj/item/A)
+	. = ..()
+	if(.)
+		if(!sheathe_icon)
+			return FALSE
 
 /*
 	KAZENGUN


### PR DESCRIPTION
## About The Pull Request

1. Martyr sword and silver stake are unsheathable.
2. You can pick up full scabbards from the floor by dragging them to your hands.
3. Catchall check for weapons who don't have `sheath_icon`. (I should make this better soon by just doing overlays lol)

## Testing Evidence

Tested.

## Why It's Good For The Game

I'm bad at coding

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
