### PR TITLE
statpack tweaks

### DIFF
--- a/modular_azurepeak/statpacks/agile.dm
+++ b/modular_azurepeak/statpacks/agile.dm
@@ -16,8 +16,8 @@
 
 /datum/statpack/agile/thug
 	name = "Thuggish"
-	desc = "Your robust physique and keen eyes oft been your most valuable friends in such trying times."
-	stat_array = list(STAT_STRENGTH = 2, STAT_PERCEPTION = 1, STAT_FORTUNE = 1, STAT_CONSTITUTION = -1, STAT_WILLPOWER = -1, STAT_SPEED = -1)
+	desc = "Your strong physique and keen eyes oft been your most valuable friends in such trying times."
+	stat_array = list(STAT_STRENGTH = 2, STAT_PERCEPTION = 1, STAT_FORTUNE = 1, STAT_WILLPOWER = -2, STAT_SPEED = -1)
 
 /datum/statpack/agile/wary
 	name = "Wary"

--- a/modular_azurepeak/statpacks/mental.dm
+++ b/modular_azurepeak/statpacks/mental.dm
@@ -27,7 +27,7 @@
 /datum/statpack/mental/aware
 	name = "Aware"
 	desc = "Your keen senses have not led you astray."
-	stat_array = list(STAT_PERCEPTION = 2, STAT_SPEED = 1, STAT_WILLPOWER = -1, STAT_CONSTITUTION = -1)
+	stat_array = list(STAT_PERCEPTION = 2, STAT_SPEED = 1, STAT_CONSTITUTION = -1, STAT_INTELLIGENCE = -1)
 
 /datum/statpack/mental/precise
 	name = "Precise"

--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -3,7 +3,7 @@
 /datum/statpack/physical/trained
 	name = "Trained"
 	desc = "Years honing your physique has left you with a physical edge, but your faculties have been somewhat neglected."
-	stat_array = list(STAT_STRENGTH = 1, STAT_CONSTITUTION = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1)
+	stat_array = list(STAT_STRENGTH = 1, STAT_CONSTITUTION = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1, STAT_FORTUNE = -1)
 
 /datum/statpack/physical/muscular
 	name = "Muscular"
@@ -13,7 +13,7 @@
 /datum/statpack/physical/tactician
 	name = "Alert"
 	desc = "You sharpened both your body and your mind as best you were able, and vigilance has been your reward."
-	stat_array = list(STAT_STRENGTH = 1, STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = -1, STAT_WILLPOWER = -1)
+	stat_array = list(STAT_STRENGTH = 1, STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = -2)
 
 /datum/statpack/physical/taut
 	name = "Taut"
@@ -28,9 +28,9 @@
 /datum/statpack/physical/struggler
 	name = "Struggler"
 	desc = "Lyfe's dealt you a poor hand, so you've opted to simply flip the table instead."
-	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 2, STAT_WILLPOWER = 2, STAT_INTELLIGENCE = -3, STAT_PERCEPTION = -3, STAT_FORTUNE = -2)
+	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 2, STAT_WILLPOWER = 2, STAT_INTELLIGENCE = -3, STAT_PERCEPTION = -3, STAT_FORTUNE = -3)
 
 /datum/statpack/physical/enduring
 	name = "Enduring"
 	desc = "You've spent yils willingly submitting your body through a most perilous journey. Stalwart in your faith, you've sworn to never flee again."
-	stat_array = list(STAT_CONSTITUTION = 3, STAT_WILLPOWER = 3, STAT_SPEED = -4)
+	stat_array = list(STAT_CONSTITUTION = 3, STAT_WILLPOWER = 3, STAT_SPEED = -3, STAT_INTELLIGENCE = -3)


### PR DESCRIPTION
## About The Pull Request
goals:
- get rid of CON / WIL combos in statpacks, both in cost and in gain
- if the combo is there, make it cost more
- +2 STR / SPD & CON / WIL combo statpacks should cost more
- weights are disregarded for this because most players do not perceive it at all even if they have spreadsheets to look at
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="965" height="917" alt="image" src="https://github.com/user-attachments/assets/b8c49032-4f50-4d27-9e66-4ea0f6b63e55" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- combo is very good as a benefit
- combo is debilitating as a cost
- they shouldn't be bundled together so frequently
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
