### PR TITLE
grab actions now do fortune rolls

### DIFF
--- a/code/modules/mob/living/combat/accuracy_checks.dm
+++ b/code/modules/mob/living/combat/accuracy_checks.dm
@@ -87,11 +87,14 @@
 	if(!(mobility_flags & MOBILITY_STAND))
 		return FALSE
 	if(user.badluck(4))
-		var/list/usedp = list("Critical miss!", "Damn! Critical miss!", "No! Critical miss!", "It can't be! Critical miss!", "Xylix laughs at me! Critical miss!", "Bad luck! Critical miss!", "Curse creation! Critical miss!", "What?! Critical miss!")
-		to_chat(user, span_boldwarning("[pick(usedp)]"))
-		flash_fullscreen("blackflash2")
-		user.aftermiss()
+		badluckmessage(user)
 		return TRUE
+
+/proc/badluckmessage(mob/living/user)
+	var/static/list/usedp = list("Critical miss!", "Damn! Critical miss!", "No! Critical miss!", "It can't be! Critical miss!", "Xylix laughs at me! Critical miss!", "Bad luck! Critical miss!", "Curse creation! Critical miss!", "What?! Critical miss!")
+	to_chat(user, span_boldwarning("[pick(usedp)]"))
+	user.flash_fullscreen("blackflash2")
+	user.aftermiss()
 
 /proc/ranged_zone_difficulty(zone)
 	switch(zone)

--- a/code/modules/mob/living/combat/shared.dm
+++ b/code/modules/mob/living/combat/shared.dm
@@ -21,3 +21,14 @@
 	else
 		return 0
 
+/// Gets the "true" value of a stat on a human mob by eliminating all status effect modifiers that affect that stat.
+/mob/living/proc/get_true_stat(stat)
+	var/fakestat = get_stat(stat)
+	if(status_effects.len)
+		for(var/S in status_effects)
+			var/datum/status_effect/status = S
+			if(status.effectedstats.len)
+				if(status.effectedstats[stat])
+					if(status.effectedstats[stat] > 0)
+						fakestat -= status.effectedstats[stat]
+	return fakestat

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -203,7 +203,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(7))
+			if(user.badluck(5))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -257,7 +257,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(7))
+			if(user.badluck(5))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -389,7 +389,7 @@
 				return
 
 /obj/item/grabbing/proc/twistlimb(mob/living/user) //implies limb_grabbed and sublimb are things
-	if(user.badluck(7))
+	if(user.badluck(5))
 		badluckmessage(user)
 		user.stop_pulling()
 		return
@@ -514,7 +514,7 @@
 /obj/item/grabbing/attack_turf(turf/T, mob/living/user)
 	if(!valid_check())
 		return
-	if(user.badluck(7))
+	if(user.badluck(5))
 		badluckmessage(user)
 		user.stop_pulling()
 		return
@@ -550,7 +550,7 @@
 /obj/item/grabbing/attack_obj(obj/O, mob/living/user)
 	if(!valid_check())
 		return
-	if(user.badluck(7))
+	if(user.badluck(5))
 		badluckmessage(user)
 		user.stop_pulling()
 		return

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -203,7 +203,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(10))
+			if(user.badluck(7))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -257,7 +257,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(10))
+			if(user.badluck(7))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -389,7 +389,7 @@
 				return
 
 /obj/item/grabbing/proc/twistlimb(mob/living/user) //implies limb_grabbed and sublimb are things
-	if(user.badluck(10))
+	if(user.badluck(7))
 		badluckmessage(user)
 		user.stop_pulling()
 		return
@@ -514,6 +514,10 @@
 /obj/item/grabbing/attack_turf(turf/T, mob/living/user)
 	if(!valid_check())
 		return
+	if(user.badluck(7))
+		badluckmessage(user)
+		user.stop_pulling()
+		return
 	user.changeNext_move(CLICK_CD_GRABBING)
 	switch(user.used_intent.type)
 		if(/datum/intent/grab/move)
@@ -545,6 +549,10 @@
 
 /obj/item/grabbing/attack_obj(obj/O, mob/living/user)
 	if(!valid_check())
+		return
+	if(user.badluck(7))
+		badluckmessage(user)
+		user.stop_pulling()
 		return
 	user.changeNext_move(CLICK_CD_GRABBING)
 	if(user.used_intent.type == /datum/intent/grab/smash)

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -191,7 +191,11 @@
 
 	if(chokehold)
 		combat_modifier += 0.15
-
+	if(ishuman(user))
+		var/mob/living/carbon/human/HU = user
+		if(user.badluck(10, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
+			badluckmessage(user)
+			return
 	switch(user.used_intent.type)
 		if(/datum/intent/grab/upgrade)
 			if(!(M.status_flags & CANPUSH) || HAS_TRAIT(M, TRAIT_PUSHIMMUNE))
@@ -358,6 +362,11 @@
 				return
 
 /obj/item/grabbing/proc/twistlimb(mob/living/user) //implies limb_grabbed and sublimb are things
+	if(ishuman(user))
+		var/mob/living/carbon/human/HU = user
+		if(user.badluck(10, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
+			badluckmessage(user)
+			return
 	var/mob/living/carbon/C = grabbed
 	var/armor_block = C.run_armor_check(limb_grabbed, "slash")
 	var/damage = user.get_punch_dmg()
@@ -527,6 +536,11 @@
 
 
 /obj/item/grabbing/proc/smashlimb(atom/A, mob/living/user) //implies limb_grabbed and sublimb are things
+	if(ishuman(user))
+		var/mob/living/carbon/human/HU = user
+		if(user.badluck(10, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
+			badluckmessage(user)
+			return
 	var/mob/living/carbon/C = grabbed
 	var/armor_block = C.run_armor_check(limb_grabbed, d_type, armor_penetration = BLUNT_DEFAULT_PENFACTOR)
 	var/damage = user.get_punch_dmg()

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -191,11 +191,6 @@
 
 	if(chokehold)
 		combat_modifier += 0.15
-	if(ishuman(user))
-		var/mob/living/carbon/human/HU = user
-		if(user.badluck(10, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
-			badluckmessage(user)
-			return
 	switch(user.used_intent.type)
 		if(/datum/intent/grab/upgrade)
 			if(!(M.status_flags & CANPUSH) || HAS_TRAIT(M, TRAIT_PUSHIMMUNE))
@@ -207,6 +202,10 @@
 		if(/datum/intent/grab/choke)
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
+				return FALSE
+			if(user.badluck(10))
+				badluckmessage(user)
+				user.stop_pulling()
 				return FALSE
 			if(limb_grabbed && grab_state > 0) //this implies a carbon victim
 				if(iscarbon(M) && M != user)
@@ -235,6 +234,10 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
+			if(user.badluck(10))
+				badluckmessage(user)
+				user.stop_pulling()
+				return FALSE
 			if(limb_grabbed && grab_state > GRAB_PASSIVE) //this implies a carbon victim
 				if(ishuman(M) && M != user)
 					var/mob/living/carbon/human/H = M
@@ -254,6 +257,10 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
+			if(user.badluck(10))
+				badluckmessage(user)
+				user.stop_pulling()
+				return FALSE
 			if(limb_grabbed && grab_state > 0) //this implies a carbon victim
 				if(iscarbon(M))
 					user.stamina_add(rand(3,8))
@@ -261,6 +268,10 @@
 		if(/datum/intent/grab/twistitem)
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
+				return FALSE
+			if(user.badluck(10))
+				badluckmessage(user)
+				user.stop_pulling()
 				return FALSE
 			if(limb_grabbed && grab_state > 0) //this implies a carbon victim
 				if(ismob(M))
@@ -270,6 +281,10 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
+			if(user.badluck(10))
+				badluckmessage(user)
+				user.stop_pulling()
+				return FALSE
 			user.stamina_add(rand(3,13))
 			if(isitem(sublimb_grabbed))
 				removeembeddeditem(user)
@@ -278,6 +293,10 @@
 		if(/datum/intent/grab/shove)
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
+				return FALSE
+			if(user.badluck(10))
+				badluckmessage(user)
+				user.stop_pulling()
 				return FALSE
 			if(!(user.mobility_flags & MOBILITY_STAND))
 				to_chat(user, span_warning("I must stand.."))
@@ -312,6 +331,10 @@
 						M.visible_message(span_danger("[user] pins [M] to the ground!"), \
 							span_userdanger("[user] pins me to the ground!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
 			else
+				if(user.badluck(10))
+					badluckmessage(user)
+					user.stop_pulling()
+					return FALSE
 				user.stamina_add(rand(5,15))
 				if(M.compliance || prob(clamp((((4 + (((user.STASTR - M.STASTR)/2) + skill_diff)) * 10 + rand(-5, 5)) * combat_modifier), 5, 95)))
 					M.visible_message(span_danger("[user] shoves [M] to the ground!"), \
@@ -321,6 +344,10 @@
 					M.visible_message(span_warning("[user] tries to shove [M]!"), \
 									span_danger("[user] tries to shove me!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
 		if(/datum/intent/grab/disarm)
+			if(user.badluck(10))
+				badluckmessage(user)
+				user.stop_pulling()
+				return FALSE
 			var/obj/item/I
 			if(sublimb_grabbed == BODY_ZONE_PRECISE_L_HAND && M.active_hand_index == 1)
 				I = M.get_active_held_item()
@@ -362,11 +389,10 @@
 				return
 
 /obj/item/grabbing/proc/twistlimb(mob/living/user) //implies limb_grabbed and sublimb are things
-	if(ishuman(user))
-		var/mob/living/carbon/human/HU = user
-		if(user.badluck(10, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
-			badluckmessage(user)
-			return
+	if(user.badluck(10))
+		badluckmessage(user)
+		user.stop_pulling()
+		return
 	var/mob/living/carbon/C = grabbed
 	var/armor_block = C.run_armor_check(limb_grabbed, "slash")
 	var/damage = user.get_punch_dmg()
@@ -536,11 +562,10 @@
 
 
 /obj/item/grabbing/proc/smashlimb(atom/A, mob/living/user) //implies limb_grabbed and sublimb are things
-	if(ishuman(user))
-		var/mob/living/carbon/human/HU = user
-		if(user.badluck(10, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
-			badluckmessage(user)
-			return
+	if(user.badluck(10))
+		badluckmessage(user)
+		user.stop_pulling()
+		return
 	var/mob/living/carbon/C = grabbed
 	var/armor_block = C.run_armor_check(limb_grabbed, d_type, armor_penetration = BLUNT_DEFAULT_PENFACTOR)
 	var/damage = user.get_punch_dmg()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1216,6 +1216,11 @@
 	resist_chance *= combat_modifier
 	resist_chance = clamp(resist_chance, 5, 95)
 
+	if(!L.compliance || !compliance)
+		if(badluck(7))
+			badluckmessage(src)
+			return
+
 	if(L.compliance)
 		resist_chance = 100
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -212,9 +212,8 @@
 	for(var/obj/item/grabbing/G in grabbedby)
 		if(G.chokehold == TRUE)
 			combat_modifier += 0.15
-	var/mob/living/carbon/human/HU = user
 	if(!instant && !surrendering && !restrained() && !compliance)
-		if(user.badluck(10, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
+		if(user.badluck(10))
 			badluckmessage(user)
 			return
 	var/probby
@@ -235,7 +234,7 @@
 		user.changeNext_move(2 SECONDS)
 		src.Immobilize(1 SECONDS)
 		src.changeNext_move(1 SECONDS)
-		if(user.badluck(5, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
+		if(user.badluck(5))
 			badluckmessage(user)
 			user.stop_pulling()
 		return

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -212,7 +212,11 @@
 	for(var/obj/item/grabbing/G in grabbedby)
 		if(G.chokehold == TRUE)
 			combat_modifier += 0.15
-
+	var/mob/living/carbon/human/HU = user
+	if(!instant && !surrendering && !restrained() && !compliance)
+		if(user.badluck(10, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
+			badluckmessage(user)
+			return
 	var/probby
 	if(!compliance)
 		probby = clamp((((4 + (((user.STASTR - STASTR)/2) + skill_diff)) * 10 + rand(-5, 5)) * combat_modifier), 5, 95)
@@ -231,6 +235,9 @@
 		user.changeNext_move(2 SECONDS)
 		src.Immobilize(1 SECONDS)
 		src.changeNext_move(1 SECONDS)
+		if(user.badluck(5, (HU.statpack.type == /datum/statpack/physical/struggler) ? TRUE : FALSE))
+			badluckmessage(user)
+			user.stop_pulling()
 		return
 
 	if(!instant)

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -278,7 +278,8 @@
 /mob/living/proc/badluck(multi = 3, ignore_effects = FALSE)
 	if(ignore_effects)
 		var/truefor = get_true_stat(STATKEY_LCK)
-		return prob((10 - truefor) * multi)
+		if(truefor < 10)
+			return prob((10 - truefor) * multi)
 	else if(STALUC < 10)
 		return prob((10 - STALUC) * multi)
 

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -275,8 +275,11 @@
 	else
 		return 0
 
-/mob/living/proc/badluck(multi = 3)
-	if(STALUC < 10)
+/mob/living/proc/badluck(multi = 3, ignore_effects = FALSE)
+	if(ignore_effects)
+		var/truefor = get_true_stat(STATKEY_LCK)
+		return prob((10 - truefor) * multi)
+	else if(STALUC < 10)
 		return prob((10 - STALUC) * multi)
 
 /mob/living/proc/goodluck(multi = 3)


### PR DESCRIPTION
## About The Pull Request
10% per FOR under 10, failure for most* of these actions will result in the grab being dropped
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="495" height="172" alt="dreamseeker_CHEqGngdJ2" src="https://github.com/user-attachments/assets/fa2aa4c1-afc0-4cae-b117-31264aa5775c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
FOR, negative in particular, affects exactly this -- every action taken, except once in a grab it was ignored, now FOR influences grab upgrades, tackles, twists, smashes, etc as if it was a regular action 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
