### PR TITLE
Show Error on Spell Recharge

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -129,7 +129,7 @@
 				if(mob.next_rmove > world.time)
 					return
 			mob.used_intent = mob.o_intent
-			if(mob.used_intent.get_chargetime() && !AD.blockscharging && !mob.in_throw_mode)
+			if(mob.used_intent.get_chargetime() && mob.mmb_intent.can_charge() && !AD.blockscharging && !mob.in_throw_mode)
 				updateprogbar()
 			else
 				mouse_pointer_icon = 'icons/effects/mousemice/human_attack.dmi'
@@ -150,7 +150,7 @@
 		if(!mob.mmb_intent)
 			mouse_pointer_icon = 'icons/effects/mousemice/human_looking.dmi'
 		else
-			if(mob.mmb_intent.get_chargetime() && !AD.blockscharging)
+			if(mob.mmb_intent.get_chargetime() && mob.mmb_intent.can_charge() && !AD.blockscharging)
 				updateprogbar()
 			else
 				mouse_pointer_icon = mob.mmb_intent.pointer
@@ -248,13 +248,13 @@
 	L.used_intent.prewarning()
 
 	if(!charging) //This is for spell charging
-		charging = 1 
+		charging = 1
 		L.used_intent.on_charge_start()
 		L.update_charging_movespeed(L.used_intent)
 //		L.update_warning(L.used_intent)
-		progress = 0 
+		progress = 0
 
-//		if(L.used_intent.charge_invocation) 
+//		if(L.used_intent.charge_invocation)
 //			sections = 100/L.used_intent.charge_invocation.len
 //		else
 //			sections = null
@@ -288,7 +288,7 @@
 			chargedprog = ((progress / goal) * 100)
 			mouse_pointer_icon = 'icons/effects/mousemice/swang/acharging.dmi'
 		else //Fully charged spell
-			if(!doneset) 
+			if(!doneset)
 				doneset = 1
 				if(L.curplaying && !L.used_intent.keep_looping)
 					playsound(L, 'sound/magic/charged.ogg', 100, TRUE)

--- a/code/game/objects/items/rogueweapons/mmb/spell.dm
+++ b/code/game/objects/items/rogueweapons/mmb/spell.dm
@@ -6,6 +6,13 @@
 	warnie = "aimwarn"
 	warnoffset = 0
 
+/datum/intent/spell/can_charge()
+	var/obj/effect/proc_holder/spell/spell_ability = mastermob.ranged_ability
+	if(istype(spell_ability) && !spell_ability.charge_check(mastermob, TRUE))
+		to_chat(mastermob, span_warning("This spell needs time to recharge!"))
+		return FALSE
+	return TRUE
+
 /datum/intent/spell/on_mmb(atom/target, mob/living/user, params)
 	if(user.ranged_ability?.InterceptClickOn(user, params, target))
 		user.changeNext_move(clickcd)


### PR DESCRIPTION
## About The Pull Request

- Trying to charge a spell that's still recharging will now not show the psycross loading pointer, instead it'll show a useful error message in the chat. This should make it more obvious why the fireball isn't fireballing.

## Testing Evidence

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/ff3b0984-76b5-4686-8ca8-6ab87859e4d9" />

## Why It's Good For The Game

This confused the heck out of me, and I thought it was a bug.
