### PR TITLE
Crusader Templars (Polearms) Are Now Strapped

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -356,7 +356,7 @@
 			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		if("Spear")
 			H.put_in_hands(new /obj/item/rogueweapon/spear/holysee(H), TRUE)
-			H.put_in_hands(new /obj/item/rogueweapon/scabbard/gwstrap(H), TRUE)
+			H.put_in_hands(new /obj/item/rogueweapon/scabbard/gwstrap(H), FALSE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 		if("Flail")
 			H.put_in_hands(new /obj/item/rogueweapon/flail/sflail(H), TRUE)
@@ -388,7 +388,7 @@
 			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		if("Summer Scythe")
 			H.put_in_hands(new /obj/item/rogueweapon/halberd/bardiche/scythe(H), TRUE)
-			H.put_in_hands(new /obj/item/rogueweapon/scabbard/gwstrap(H), TRUE)
+			H.put_in_hands(new /obj/item/rogueweapon/scabbard/gwstrap(H), FALSE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE) // again, needs skill to actually use the weapon
 		if("Cackle Lash")
 			H.put_in_hands(new /obj/item/rogueweapon/whip/xylix(H), TRUE)


### PR DESCRIPTION
## About The Pull Request

- Crusader Templars that pick a polearm (Spear, Summer Scythe), now get a greatweapon strap too.

## Testing Evidence

<img width="1227" height="632" alt="image" src="https://github.com/user-attachments/assets/8efb457e-2fd0-4a30-ac01-143678a0b1e9" />

## Why It's Good For The Game

Lets 'em free up their hands for roleplay purposes.
