### PR TITLE
fixes what im 90% sure is a bug in the check boot stuff

### DIFF
--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -85,7 +85,7 @@
 		return FALSE
 	var/mob/living/carbon/human/H = user
 	var/obj/item/found_thing
-	if(H.get_stress_amount() > 0 && H.STALUC > 10)
+	if(H.get_stress_amount() < 0 && H.STALUC > 10)
 		found_thing = new /obj/item/roguecoin/gold
 	else if(H.STALUC == 10)
 		found_thing = new /obj/item/roguecoin/silver


### PR DESCRIPTION
## About The Pull Request
my oomf told me that check boot doesnt work 4 the gold coin and looking thru stress code afaik it's just pointed the wrong way round. it now chjecks if stress is LESS than wtv. im not 100% bc i cant tell the actual "stress value" without doing some bs to make a temporary var on my human mobs in my test server that c onstantly updates and i dont awnt 2 do that

so i just did ozium in game and saw that it gives u like -99 stres or w/e and now it c hecks to see if u have less than 0 stress instead of greater than
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- i didnt test it but i imagine it works now
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- bugfix(?)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
