### PR TITLE
Proper fix for roles not mouseoverable in player panel

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -247,6 +247,7 @@
 				else
 					M_job = "Ghost"
 
+			M_job = html_encode(M_job) // Encode so name like Magician's Apprentice don't break player panel
 			var/M_name = html_encode(M.name)
 			var/M_rname = html_encode(M.real_name)
 			var/M_key = html_encode(M.key)


### PR DESCRIPTION
## About The Pull Request
RW2 fixed the issue with Magician's Associate and Magician's Apprentice not showing up by removing the apostrophe. This is ported to SR.

This fixes it properly by using html_encode.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![NVIDIA_Overlay_gtkvTsfm1X](https://github.com/user-attachments/assets/e6304273-ed22-479d-bf58-1d5a273ad893)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yes

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
