### PR TITLE
Lancer Squire Sheathes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -89,6 +89,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 	backr = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch,
 		/obj/item/clothing/neck/roguetown/chaincoif,


### PR DESCRIPTION
## About The Pull Request

- Lancer squires now spawn with a greatweapon sheath.

## Testing Evidence

<img width="1912" height="819" alt="image" src="https://github.com/user-attachments/assets/f251eb3f-3656-4007-8eb8-9ac6ec5feaf3" />

## Why It's Good For The Game

Lets them roleplay a bit easier by being able to sheathe their spears.
