### PR TITLE
Heavy Helmets Now Require Medium-Armor Training

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -11,6 +11,7 @@
 	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
 	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL
+	armor_class = ARMOR_CLASS_MEDIUM	//Heavy helmets require at least medium armor training. Stops no-armor training plate-headgear users.
 
 /obj/item/clothing/head/roguetown/helmet/heavy/aalloy
 	name = "decrepit barbute"

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -543,6 +543,7 @@
 	block2add = FOV_BEHIND
 	smeltresult = /obj/item/ingot/steel
 	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL - ARMOR_INT_HELMET_HEAVY_ADJUSTABLE_PENALTY
+	armor_class = null	//Needs no armor class, snowflake merc gear.
 
 /obj/item/clothing/head/roguetown/helmet/heavy/volfplate/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, (HEAD|EARS|HAIR), (HIDEEARS|HIDEHAIR), null, 'sound/items/visor.ogg', null, UPD_HEAD)	//Standard helmet


### PR DESCRIPTION
## About The Pull Request

pointed this out a few times, people said: "I'm fine with this tbh, mages/dodge users shouldn't be wearing knight helmets"

so here you go

limits heavy helmets, aka Savoyards, 'knight' helms (pig-face bacinet isn't mind you), and the high-end plate helmets to require medium armor trait otherwise suffer the consequences.

why do this? simple - seeing people limited to studded leather but wearing big knight helmets, blacksteel helms, etc is silly and counter to the point of builds.

some builds have no armor training but master swords - you're supposed to surrender the gamer-gear for that.
dodge expert? you have dodge expert, you're a dodge build, you shouldn't be slamming your head around in the big ol' knight helmet
mages? yeah, self-explanitory

this is an attempt to not screw-over the medium armor classes, but these are **HEAVY** helmets, by PATH. Just make them heavy-er than a normal helmet. It'll make people use sallets, kettles, etc more instead of insta-upgrading to "erm smithy full knight helmet for my Frieslettmanngrenzelhoftelfenstompher" as light/crit-resist/non-armored classes.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

being told "well real mages in my opinion don't do that so . . ." isn't a selling point to the issue. 

i was considering doing this to plate gauntlets and plate boots too but im not gonna go full adolf hitler of code (yet).
