### PR TITLE
Absolver revive sanity check

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -812,20 +812,35 @@
 /mob/living/proc/check_revive(mob/living/user)
 	if(src == user)
 		return FALSE
+	if(stat < DEAD)
+		to_chat(user, span_warning("Nothing happens."))
+		return FALSE
 	if(!mind)
 		return FALSE
 	if(!mind.active)
-		to_chat(user, span_warning("Astrata is not done with [src], yet."))
+		to_chat(user, span_warning("They are unresponsive to my attempts. For now."))
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_DNR))
-		to_chat(user, span_danger("None of the Ten have them. Their only chance is spent. Where did they go?"))
+		to_chat(user, span_danger("None of the divine have them. Their only chance is spent. Where did they go?"))
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_NECRAS_VOW))
 		to_chat(user, span_warning("This one has pledged themselves whole to Necra. They are Hers."))
 		return FALSE
-	if(stat < DEAD)
-		to_chat(user, span_warning("Nothing happens."))
+
+	var/obj/item/bodypart/head = get_bodypart("head")
+	var/obj/item/organ/brain/brain = getorganslot(ORGAN_SLOT_BRAIN)
+	var/obj/item/organ/heart/heart = getorganslot(ORGAN_SLOT_HEART)
+
+	if(!head)
+		to_chat(user, span_warning("[src] is missing their head!"))
 		return FALSE
+	if(!brain)
+		to_chat(user, span_warning("[src] is missing their brain!"))
+		return FALSE
+	if(!heart)
+		to_chat(user, span_warning("[src] is missing their heart!"))
+		return FALSE
+
 	return TRUE
 
 //Proc used to resuscitate a mob, for full_heal see fully_heal()

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -329,56 +329,42 @@
 	
 	// Special case for dead targets
 	if(H.stat >= DEAD)
-		// Check if the target has a head, brain, and heart
-		var/obj/item/bodypart/head = H.get_bodypart("head")
-		var/obj/item/organ/brain/brain = H.getorganslot(ORGAN_SLOT_BRAIN)
-		var/obj/item/organ/heart/heart = H.getorganslot(ORGAN_SLOT_HEART)
-		
-		if(head && brain && heart)
-			if(!H.mind)
-				revert_cast()
-				return FALSE
-			if(HAS_TRAIT(H, TRAIT_NECRAS_VOW))
-				to_chat(user, "This one has pledged themselves whole. There's nothing to ABSOLVE.")
-				revert_cast()
-				return FALSE	
-			if(alert(user, "REACH OUT AND PULL?", "THERE'S NO LUX IN THERE", "YES", "NO") != "YES")	
-				revert_cast()
-				return FALSE
-			to_chat(user, span_warning("You attempt to revive [H] by ABSOLVING them!"))
-			// Dramatic effect
-			user.visible_message(span_danger("[user] grabs [H] by the wrists, attempting to ABSOLVE them!"))
-			if(alert(H, "They want to ABSOLVE you. Will you let them?", "ABSOLUTION", "I'll allow it", "I refuse") != "I'll allow it")
-				H.visible_message(span_notice("Nothing happens."))
-				return FALSE
-			// Create visual effects
-			H.apply_status_effect(/datum/status_effect/buff/psyvived)
-			// Kill the caster
-			user.say("MY LYFE FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
-			user.death()
-			// Revive the target
-			H.revive(full_heal = TRUE, admin_revive = FALSE)
-			H.adjustOxyLoss(-H.getOxyLoss())
-			H.grab_ghost(force = TRUE) // even suicides
-			H.emote("breathgasp")
-			H.Jitter(100)
-			H.update_body()
-			record_round_statistic(STATS_LUX_REVIVALS)
-			ADD_TRAIT(H, TRAIT_IWASREVIVED, "[type]")
-			H.apply_status_effect(/datum/status_effect/buff/psyvived)
-			user.apply_status_effect(/datum/status_effect/buff/psyvived)
-			H.visible_message(span_notice("[H] is ABSOLVED!"), span_green("I awake from the void."))		
-			H.mind.remove_antag_datum(/datum/antagonist/zombie)
-			H.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-			H.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
-			return TRUE
-		else
-			to_chat(user, span_warning("[H] is missing vital organs and cannot be revived!"))
-			revert_cast(user)
+		if(!H.check_revive(user))
+			revert_cast()
 			return FALSE
-	
+		if(alert(user, "REACH OUT AND PULL?", "THERE'S NO LUX IN THERE", "YES", "NO") != "YES")	
+			revert_cast()
+			return FALSE
+		to_chat(user, span_warning("You attempt to revive [H] by ABSOLVING them!"))
+		// Dramatic effect
+		user.visible_message(span_danger("[user] grabs [H] by the wrists, attempting to ABSOLVE them!"))
+		if(alert(H, "They want to ABSOLVE you. Will you let them?", "ABSOLUTION", "I'll allow it", "I refuse") != "I'll allow it")
+			H.visible_message(span_notice("Nothing happens."))
+			return FALSE
+		// Create visual effects
+		H.apply_status_effect(/datum/status_effect/buff/psyvived)
+		// Kill the caster
+		user.say("MY LYFE FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
+		user.death()
+		// Revive the target
+		H.revive(full_heal = TRUE, admin_revive = FALSE)
+		H.adjustOxyLoss(-H.getOxyLoss())
+		H.grab_ghost(force = TRUE) // even suicides
+		H.emote("breathgasp")
+		H.Jitter(100)
+		H.update_body()
+		record_round_statistic(STATS_LUX_REVIVALS)
+		ADD_TRAIT(H, TRAIT_IWASREVIVED, "[type]")
+		H.apply_status_effect(/datum/status_effect/buff/psyvived)
+		user.apply_status_effect(/datum/status_effect/buff/psyvived)
+		H.visible_message(span_notice("[H] is ABSOLVED!"), span_green("I awake from the void."))		
+		H.mind.remove_antag_datum(/datum/antagonist/zombie)
+		H.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
+		H.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+		return TRUE
+
 	// Transfer afflictions from the target to the caster
-	
+
 	// Transfer damage
 	var/brute_transfer = H.getBruteLoss()
 	var/burn_transfer = H.getFireLoss()


### PR DESCRIPTION
## About The Pull Request

basic sanity checks like dnr and such.

## Testing Evidence

yeah

## Why It's Good For The Game

sanity checks using the `check_revive()` proc is cleaner

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
