### PR TITLE
Finish commandbar typing indicator port.

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -146,6 +146,9 @@ GLOBAL_LIST_EMPTY(respawncounts)
 		show_chronicle(tab)
 		return
 
+	if(href_list["commandbar_typing"])
+		handle_commandbar_typing(href_list)
+
 	switch(href_list["_src_"])
 		if("holder")
 			hsrc = holder
@@ -264,6 +267,8 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 	GLOB.clients += src
 	GLOB.directory[ckey] = src
+
+	initialize_commandbar_spy()
 
 	GLOB.ahelp_tickets.ClientLogin(src)
 	var/connecting_admin = FALSE //because de-admined admins connecting should be treated like admins.

--- a/code/modules/client/verbs/typing.dm
+++ b/code/modules/client/verbs/typing.dm
@@ -1,5 +1,3 @@
-#define IC_VERBS list("say", "me", "whisper", "subtle")
-
 /client/var/commandbar_thinking = FALSE
 /client/var/commandbar_typing = FALSE
 
@@ -7,25 +5,58 @@
 	src << output('html/typing_indicator.html', "commandbar_spy")
 
 /client/proc/handle_commandbar_typing(href_list)
+	// Check if user has any text typed (argument_length > 0)
+	if(length(href_list["verb"]) < 1 || text2num(href_list["argument_length"]) < 1)
+		if(commandbar_typing)
+			commandbar_typing = FALSE
+			stop_typing()
 
+		if(commandbar_thinking)
+			commandbar_thinking = FALSE
+			stop_thinking()
+		return
+
+	if(!commandbar_thinking)
+		commandbar_thinking = TRUE
+		start_thinking()
+
+	if(!commandbar_typing)
+		commandbar_typing = TRUE
+		start_typing()
+
+/** Sets the mob as "thinking" - displays typing indicator and adds trait */
+/client/proc/start_thinking()
+	if(!mob)
+		return FALSE
+	ADD_TRAIT(mob, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
+	mob.display_typing_indicator()
+
+/** Removes typing/thinking indicators and clears the trait */
+/client/proc/stop_thinking()
+	if(!mob)
+		return FALSE
+	REMOVE_TRAIT(mob, TRAIT_THINKING_IN_CHARACTER, CURRENTLY_TYPING_TRAIT)
+	mob.clear_typing_indicator()
 
 /**
  * Handles the user typing. After a brief period of inactivity,
  * signals the client mob to revert to the "thinking" icon.
  */
-/client/proc/start_typing(channel)
+/client/proc/start_typing()
+	if(!mob || !HAS_TRAIT(mob, TRAIT_THINKING_IN_CHARACTER))
+		return FALSE
 	var/mob/client_mob = mob
 	client_mob.display_typing_indicator()
-	addtimer(CALLBACK(src, PROC_REF(stop_typing), channel), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
+	addtimer(CALLBACK(src, PROC_REF(stop_typing)), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
 
 /**
  * Callback to remove the typing indicator after a brief period of inactivity.
  * If the user was typing IC, the thinking indicator is shown.
  */
-/client/proc/stop_typing(channel)
+/client/proc/stop_typing()
 	if(isnull(mob))
 		return FALSE
+	if(!HAS_TRAIT(mob, TRAIT_THINKING_IN_CHARACTER))
+		return FALSE
 	var/mob/client_mob = mob
-	client_mob.clear_typing_indicator()
-
-#undef IC_VERBS
+	client_mob.display_typing_indicator()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -45,6 +45,15 @@ window "mainwindow"
 		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
+	elem "commandbar_spy"
+		type = BROWSER
+		is-default = false
+		pos = 0,0
+		size = 200x200
+		anchor1 = -1,-1
+		anchor2 = -1,-1
+		is-visible = false
+		saved-params = ""
 
 window "mapwindow"
 	elem "mapwindow"


### PR DESCRIPTION
## About The Pull Request
Finishes an incomplete port of https://github.com/tgstation/tgstation/pull/83081
- Typing in commandbar now show a proper typing indicator with a short delay

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![TabTip_hOeybUMSrM](https://github.com/user-attachments/assets/4b1fe475-37ed-4be3-a930-8bf6323ba25f)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This makes typebaiting FUNCTIONALLY USELESS NOW....

for like the 3 players on AP (including myself) who type in command bar

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
