### PR TITLE
makes heretic armors properly unrepairable

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -158,6 +158,8 @@
 	icon_state = "matthiosarmor"
 	max_integrity = ARMOR_INT_CHEST_PLATE_ANTAG	
 	peel_threshold = 5	//-Any- weapon will require 5 peel hits to peel coverage off of this armor.
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/matthios/Initialize()
 	. = ..()
@@ -175,6 +177,8 @@
 	icon_state = "zizoplate"
 	max_integrity = ARMOR_INT_CHEST_PLATE_ANTAG
 	peel_threshold = 5	//-Any- weapon will require 5 peel hits to peel coverage off of this armor.
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/zizo/Initialize()
 	. = ..()

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -272,6 +272,8 @@
 	desc = "Gilded tombs do worm enfold."
 	icon_state = "matthiosboots"
 	armor = ARMOR_ASCENDANT
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/shoes/roguetown/boots/armor/matthios/Initialize()
 	. = ..()
@@ -289,6 +291,8 @@
 	desc = "Plate boots. Called forth from the edge of what should be known. In Her name."
 	icon_state = "zizoboots"
 	armor = ARMOR_ASCENDANT
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/shoes/roguetown/boots/armor/zizo/Initialize()
 	. = ..()

--- a/code/modules/clothing/rogueclothes/gloves/plate.dm
+++ b/code/modules/clothing/rogueclothes/gloves/plate.dm
@@ -54,6 +54,8 @@
 	desc = "Many a man his life hath sold,"
 	icon_state = "matthiosgloves"
 	max_integrity = ARMOR_INT_SIDE_ANTAG
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/gloves/roguetown/plate/matthios/Initialize()
 	. = ..()
@@ -71,6 +73,9 @@
 	desc = "avantyne plate gauntlets. Called forth from the edge of what should be known. In Her name."
 	icon_state = "zizogauntlets"
 	max_integrity = ARMOR_INT_SIDE_ANTAG
+	anvilrepair = null
+	sewrepair = FALSE
+
 
 /obj/item/clothing/gloves/roguetown/plate/zizo/Initialize()
 	. = ..()

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -621,6 +621,8 @@
 	bloody_icon = 'icons/effects/blood64.dmi'
 	experimental_inhand = FALSE
 	experimental_onhip = FALSE
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/head/roguetown/helmet/heavy/graggar
 	name = "vicious helmet"
@@ -661,6 +663,8 @@
 	max_integrity = ARMOR_INT_HELMET_ANTAG
 	peel_threshold = 4
 	var/frogstyle = FALSE
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/head/roguetown/helmet/heavy/zizo/MiddleClick(mob/user)
 	frogstyle = !frogstyle

--- a/code/modules/clothing/rogueclothes/pants/plate.dm
+++ b/code/modules/clothing/rogueclothes/pants/plate.dm
@@ -65,6 +65,8 @@
 	icon_state = "matthioslegs"
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_PICK)
 	armor = ARMOR_ASCENDANT
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/under/roguetown/platelegs/matthios/Initialize()
 	. = ..()
@@ -85,6 +87,8 @@
 	icon_state = "zizocloth"
 	armor = ARMOR_ASCENDANT
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_PICK)
+	anvilrepair = null
+	sewrepair = FALSE
 
 /obj/item/clothing/under/roguetown/platelegs/zizo/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

- Just makes it so you can't repair the heretic armors(except graggar as intended) through the edge case of mending
- Also theoretically covers my ass incase someone finds some weird way to remove them(yet unfound...)

## Testing Evidence

trust

## Why It's Good For The Game

this was always intended and was bypassed by an un-thought of workaround. 

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
