### PR TITLE
fixes bathmatron vault revenue increment on end round screen

### DIFF
--- a/code/modules/roguetown/roguemachine/bathmaster.dm
+++ b/code/modules/roguetown/roguemachine/bathmaster.dm
@@ -238,8 +238,10 @@ SUBSYSTEM_DEF(BMtreasury)
 			for(var/obj/item/item in closet)
 				amt_to_generate += add_to_vault(item)
 
-	brassface.budget += round(amt_to_generate, 1) // goes directly into BRASSFACE rather than into any account.
+	amt_to_generate = round(amt_to_generate, 1)
+	brassface.budget += amt_to_generate // goes directly into BRASSFACE rather than into any account.
 	send_ooc_note("Income from smuggling hoard to the BRASSFACE: +[amt_to_generate]", job = "Bathmaster")
+	record_round_statistic(STATS_BATHMATRON_VAULT_TOTAL_REVENUE, amt_to_generate)
 
 
 /datum/controller/subsystem/BMtreasury/Destroy()


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<img width="343" height="109" alt="image" src="https://github.com/user-attachments/assets/ecef7bd5-1ba7-4333-ad61-2bdb1f1584df" />

Economy tab never had any sort of addition of STATS_BATHMATRON_VAULT_TOTAL_REVENUE. This adds it in the brassface's payout.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
+= 
## Why It's Good For The Game
Flex your interest
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
