### PR TITLE
Makes fire stack decay scale to being prone and to amount.

### DIFF
--- a/code/datums/status_effects/firestacker.dm
+++ b/code/datums/status_effects/firestacker.dm
@@ -3,6 +3,8 @@
 #define MOB_BIG_FIRE_STACK_THRESHOLD 10
 /// How fast fire stacks decay (more - faster)
 #define STACK_DECAY_MULTIPLIER 1
+#define STACK_DECAY_SCALE_FACTOR 4 // Multiply the decay rate by dividing the amount of firestacks by this value
+#define STACK_DECAY_PRONE_MULTIPLIER 3 // If the mob is prone, decay stacks faster
 /datum/status_effect/fire_handler
 	id = "abstract"
 	alert_type = null
@@ -156,7 +158,11 @@
 	if(!on_fire)
 		return TRUE
 
-	adjust_stacks(owner.fire_stack_decay_rate * STACK_DECAY_MULTIPLIER * wait * 0.1)
+	var/decay_multiplier = stacks / STACK_DECAY_SCALE_FACTOR
+	if(!(owner.mobility_flags & MOBILITY_STAND))
+		decay_multiplier *= STACK_DECAY_PRONE_MULTIPLIER
+
+	adjust_stacks(decay_multiplier * owner.fire_stack_decay_rate * STACK_DECAY_MULTIPLIER * wait * 0.1)
 
 	if(stacks <= 0)
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request
Help people who get stuck in purgatory when they get hit by firestacks (hello infernal watcher) get back up a bit quicker by changing the scaling
- The amount of firestacks on a mob is divided by 4, which is then used to multiply the static decay rate of -0.05. I thought of making it scale directly to the amount of firestacks but I felt it would be too powerful.
- When a mob is prone, then this rate is further multiplied by *3, so being unconscious / sleeping / knocked out will quicken the speed you can recover.

The goal is to make purgatory easier to escape from without any material effects on firestacks in active combat.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Verily.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Make it so.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
