### PR TITLE
Makes the typing indicator start appearing on the first word.

### DIFF
--- a/code/modules/client/verbs/typing.dm
+++ b/code/modules/client/verbs/typing.dm
@@ -5,8 +5,8 @@
 	src << output('html/typing_indicator.html', "commandbar_spy")
 
 /client/proc/handle_commandbar_typing(href_list)
-	// Check if user has any text typed (argument_length > 0)
-	if(length(href_list["verb"]) < 1 || text2num(href_list["argument_length"]) < 1)
+	// Check if user has any text typed
+	if(length(href_list["verb"]) < 1)
 		if(commandbar_typing)
 			commandbar_typing = FALSE
 			stop_typing()


### PR DESCRIPTION
## About The Pull Request
Makes the typing indicator start appearing on the first word.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![TabTip_b2spfSqX4K](https://github.com/user-attachments/assets/8e0cfc41-bf65-46e7-bd6f-f579a1479beb)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Currently it only appear on the second word, makes it start appearing on the first word.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
