### PR TITLE
Fixes PsyMusicbox exploit

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -821,7 +821,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(altgripped || wielded)
 			ungrip(user, FALSE)
 	if(twohands_required)
-		if(slot == SLOT_HANDS)
+		if(slot == ITEM_SLOT_HANDS)
 			wield(user)
 		else
 			ungrip(user)


### PR DESCRIPTION
## About The Pull Request

You can no longer 1-hand the music box if you're given it.

## Testing Evidence

Tested.

## Why It's Good For The Game

Exploitfix.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
