### PR TITLE
Physical Descriptor for revenant

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
@@ -100,9 +100,10 @@
 		/datum/body_marking/plain,
 	)
 	descriptor_choices = list(
+		/datum/descriptor_choice/trait,
+		/datum/descriptor_choice/stature,
 		/datum/descriptor_choice/height,
 		/datum/descriptor_choice/body,
-		/datum/descriptor_choice/stature,
 		/datum/descriptor_choice/face,
 		/datum/descriptor_choice/face_exp,
 		/datum/descriptor_choice/skin,


### PR DESCRIPTION
## About The Pull Request

The dullahan editor is very flexible, as is half-kin. But for some reason they don't have a "Physical Descriptor". I added it to them.

## Testing Evidence

<img width="698" height="335" alt="image" src="https://github.com/user-attachments/assets/8902f100-5010-4f71-a394-f09cca4e21c3" />

## Why It's Good For The Game

There is more opportunity to describe your revenant.
