### PR TITLE
Declare Outlaw: garrison edition

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -54,6 +54,7 @@
 #define TRAIT_POLYTHEIST "Polytheist"
 #define TRAIT_MONOTHEIST "Monotheist"
 #define TRAIT_GUARDSMAN "Vigilant Guardsman"
+#define TRAIT_GUARDSMAN_DISGRACED "Disgraced Guardsman"
 #define TRAIT_TAVERN_FIGHTER "Tavern Fighter"
 #define TRAIT_WOODSMAN "Talented Woodsman"
 #define TRAIT_DUNGEONMASTER "Ruthless Jailor"
@@ -241,7 +242,8 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_LEPROSY = span_necrosis("I'm a disgusting leper..."),
 	TRAIT_UNDIVIDED = span_info("I have seen past petty squabbles, and am a true follower of the Ten Undivided. I feel most comfortable around churchmen."),
 	TRAIT_TAVERN_FIGHTER = span_info("I am vigilant in my duties. The Tavern is my home, none shall dare oppose me or skip out on payment."),
-	TRAIT_GUARDSMAN = span_info("I am vigilant in my duties. In the town of Azure Peak, my abilities are sharper due to my routine and familiarity."),
+	TRAIT_GUARDSMAN = span_info("I am vigilant in my duties. My abilities are sharper due to my routine and familiarity."),
+	TRAIT_GUARDSMAN_DISGRACED = span_red("I have betrayed my oath."),
 	TRAIT_WOODSMAN = span_info("I am vigilant in my duties. In the grove and coast of Azure Peak, my abilities are sharper due to my routine and familiarity."),
 	TRAIT_DEATHBARGAIN = span_info("A horrible deal has been prepared in your name. May you never see it fulfilled..."),
 	TRAIT_RITUALIST = span_info("I am skilled in the holy arts. Using ritual chalk, I can more deftly channel my God's powers via runes."),

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -629,3 +629,13 @@
 	SIGNAL_HANDLER
 
 	INVOKE_ASYNC(carbon, TYPE_PROC_REF(/mob/living/carbon, liver_failure))
+
+/datum/status_effect/debuff/disgracedguardsman
+	id = "disgracedguardsman"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/disgracedguardsman
+	effectedstats = list(STATKEY_CON = -1, STATKEY_WIL = -1, STATKEY_SPD = -1, STATKEY_PER = -2)
+
+/atom/movable/screen/alert/status_effect/debuff/disgracedguardsman
+	name = "Disgraced Guardsman"
+	desc = "I betrayed my liege.."
+	icon_state = "debuff"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -360,11 +360,6 @@
 	playsound(owner, 'sound/magic/magearmorup.ogg', 75, FALSE)
 	owner.magearmor = 0
 
-/atom/movable/screen/alert/status_effect/buff/guardbuffone
-	name = "Vigilant Guardsman"
-	desc = "My home. I watch vigilantly and respond swiftly."
-	icon_state = "buff"
-
 /atom/movable/screen/alert/status_effect/buff/barkeepbuff
 	name = "Vigilant Tavernkeep"
 	desc = "My home. I watch vigilantly and respond swiftly."
@@ -402,22 +397,10 @@
 	if(!(our_area.tavern_area))
 		owner.remove_status_effect(/datum/status_effect/buff/barkeepbuff)
 
-/datum/status_effect/buff/guardbuffone
-	id = "guardbuffone"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/guardbuffone
-	effectedstats = list(STATKEY_CON = 1,STATKEY_WIL = 1, STATKEY_SPD = 1, STATKEY_PER = 2)
-
 /datum/status_effect/buff/dungeoneerbuff
 	id = "dungeoneerbuff"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/dungeoneerbuff
 	effectedstats = list(STATKEY_CON = 1,STATKEY_WIL = 1, STATKEY_STR = 2)//This only works in 2 small areas on the entire map
-
-/datum/status_effect/buff/guardbuffone/process()
-
-	.=..()
-	var/area/rogue/our_area = get_area(owner)
-	if(!(our_area.town_area))
-		owner.remove_status_effect(/datum/status_effect/buff/guardbuffone)
 
 /datum/status_effect/buff/wardenbuff/process()
 

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -24,8 +24,6 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 
 /area/rogue/Entered(mob/living/carbon/human/guy)
 	. = ..()
-	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_GUARDSMAN) && !guy.has_status_effect(/datum/status_effect/buff/guardbuffone)) //man at arms
-		guy.apply_status_effect(/datum/status_effect/buff/guardbuffone)
 	if((src.tavern_area == TRUE) && HAS_TRAIT(guy, TRAIT_TAVERN_FIGHTER) && !guy.has_status_effect(/datum/status_effect/buff/barkeepbuff)) // THE FIGHTER
 		guy.apply_status_effect(/datum/status_effect/buff/barkeepbuff)
 	if((src.warden_area == TRUE) && HAS_TRAIT(guy, TRAIT_WOODSMAN) && !guy.has_status_effect(/datum/status_effect/buff/wardenbuff)) // Warden

--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -50,8 +50,10 @@
 	category_tags = list(CTAG_DUNGEONEER)
 	subclass_stats = list(
 		STATKEY_STR = 2,
-		STATKEY_CON = 2,
-		STATKEY_WIL = 1
+		STATKEY_CON = 3,
+		STATKEY_WIL = 2,
+		STATKEY_SPD = 1,
+		STATKEY_PER = 2,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT,

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -64,10 +64,12 @@
 	category_tags = list(CTAG_MENATARMS)
 	traits_applied = list(TRAIT_MEDIUMARMOR)
 	subclass_stats = list(
-		STATKEY_STR = 2,// seems kinda lame but remember guardsman bonus!!
+		STATKEY_STR = 2,
 		STATKEY_INT = 1,
-		STATKEY_CON = 1,
-		STATKEY_WIL = 1
+		STATKEY_PER = 2,
+		STATKEY_CON = 2,
+		STATKEY_WIL = 2,
+		STATKEY_SPD = 1,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
@@ -161,9 +163,10 @@
 	category_tags = list(CTAG_MENATARMS)
 	//Garrison ranged/speed class. Time to go wild
 	subclass_stats = list(
-		STATKEY_SPD = 2,// seems kinda lame but remember guardsman bonus!!
-		STATKEY_PER = 2,
-		STATKEY_WIL = 1
+		STATKEY_SPD = 3,
+		STATKEY_PER = 4,
+		STATKEY_WIL = 2,
+		STATKEY_CON = 1,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
@@ -250,10 +253,12 @@
 	traits_applied = list(TRAIT_MEDIUMARMOR)
 	//Garrison mounted class; charge and charge often.
 	subclass_stats = list(
-		STATKEY_CON = 2,// seems kinda lame but remember guardsman bonus!!
-		STATKEY_WIL = 2,// Your name is speed, and speed is running.
+		STATKEY_CON = 3,
+		STATKEY_WIL = 3,
 		STATKEY_STR = 1,
-		STATKEY_INT = 1, // No strength to account for the nominally better weapons. We'll see.
+		STATKEY_INT = 1,
+		STATKEY_SPD = 1,
+		STATKEY_PER = 2,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -68,9 +68,10 @@
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_INT = 1,
-		STATKEY_CON = 1,
-		STATKEY_PER = 1, //Gets bow-skills, so give a SMALL tad of perception to aid in bow draw.
-		STATKEY_WIL = 1,
+		STATKEY_CON = 21,
+		STATKEY_PER = 3, //Gets bow-skills, so give a SMALL tad of perception to aid in bow draw.
+		STATKEY_WIL = 2,
+		STATKEY_SPD = 1,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -75,10 +75,11 @@
 	horse = /mob/living/simple_animal/hostile/retaliate/rogue/saiga/saigabuck/tame/saddled
 	subclass_stats = list(
 		STATKEY_STR = 2,
-		STATKEY_CON = 2,
-		STATKEY_WIL = 2,
+		STATKEY_CON = 3,
+		STATKEY_WIL = 3,
 		STATKEY_INT = 2,
-		STATKEY_PER = 1,
+		STATKEY_PER = 3,
+		STATKEY_SPD = 1,
 		STATKEY_LCK = 1
 	)
 	subclass_skills = list(

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -83,9 +83,9 @@
 	subclass_stats = list(
 		STATKEY_STR = 3,//Heavy hitters. Less con/end, high strength.
 		STATKEY_INT = 3,
-		STATKEY_CON = 1,
-		STATKEY_WIL = 1,
-		STATKEY_SPD = -1
+		STATKEY_CON = 2,
+		STATKEY_WIL = 2,
+		STATKEY_PER = 2,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT, //Polearms are pretty much explicitly a two-handed weapon, so I gave them a polearm option.
@@ -179,8 +179,10 @@
 	subclass_stats = list(
 		STATKEY_STR = 1,//Tanky, less strength, but high con/end.
 		STATKEY_INT = 1,
-		STATKEY_CON = 3,
-		STATKEY_WIL = 3,
+		STATKEY_CON = 4,
+		STATKEY_WIL = 4,
+		STATKEY_SPD = 1,
+		STATKEY_PER = 2,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
@@ -268,9 +270,10 @@
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_INT = 1,
-		STATKEY_CON = 1,
-		STATKEY_WIL = 1,
-		STATKEY_PER = 2
+		STATKEY_CON = 2,
+		STATKEY_WIL = 2,
+		STATKEY_PER = 4,
+		STATKEY_SPD = 1,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
@@ -376,8 +379,10 @@
 	subclass_stats = list(
 		STATKEY_STR = 1,
 		STATKEY_INT = 1,
-		STATKEY_WIL = 2,
-		STATKEY_SPD = 2
+		STATKEY_CON = 1,
+		STATKEY_WIL = 3,
+		STATKEY_SPD = 3,
+		STATKEY_PER = 2,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT, //Swords and knives class.

--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -351,18 +351,26 @@ GLOBAL_VAR_INIT(last_crown_announcement_time, -1000)
 	return make_outlaw(raw_message)
 
 /proc/make_outlaw(raw_message)
+	var/mob/living/carbon/human/found_human
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.real_name == raw_message)
+			found_human = H
 	if(raw_message in GLOB.outlawed_players)
 		GLOB.outlawed_players -= raw_message
 		priority_announce("[raw_message] is no longer an outlaw in the Azure Peak.", "The [SSticker.rulertype] Decrees", 'sound/misc/royal_decree.ogg', "Captain")
-		return FALSE
-	var/found = FALSE
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(H.real_name == raw_message)
-			found = TRUE
-	if(!found)
+		if(istype(found_human) && HAS_TRAIT(found_human, TRAIT_GUARDSMAN_DISGRACED))
+			REMOVE_TRAIT(found_human, TRAIT_GUARDSMAN_DISGRACED, TRAIT_GENERIC)
+			ADD_TRAIT(found_human, TRAIT_GUARDSMAN, JOB_TRAIT)
+			found_human.remove_status_effect(/datum/status_effect/debuff/disgracedguardsman)
+		return TRUE
+	if(!istype(found_human))
 		return FALSE
 	GLOB.outlawed_players += raw_message
 	priority_announce("[raw_message] has been declared an outlaw and must be captured or slain.", "The [SSticker.rulertype] Decrees", 'sound/misc/royal_decree2.ogg', "Captain")
+	if(HAS_TRAIT(found_human, TRAIT_GUARDSMAN))
+		REMOVE_TRAIT(found_human, TRAIT_GUARDSMAN, JOB_TRAIT)
+		ADD_TRAIT(found_human, TRAIT_GUARDSMAN_DISGRACED, TRAIT_GENERIC)
+		found_human.apply_status_effect(/datum/status_effect/debuff/disgracedguardsman)
 	return TRUE
 
 /proc/make_law(raw_message)


### PR DESCRIPTION
## About The Pull Request

- Removes vigilant guardian status effect that affected certain stats in town areas.
- Instead, all garrison members (who had TRAIT_GUARDSMAN) get vigilant guardian buff roundstart (aka rolled into their stats)
- Declaring somebody with TRAIT_GUARDSMAN an outlaw removes this trait, adds TRAIT_GUARDSMAN_DISGRACED, gives them a debuff - equal in stats to the old vigilant guardian buff.
``effectedstats = list(STATKEY_CON = -1, STATKEY_WIL = -1, STATKEY_SPD = -1, STATKEY_PER = -2)``
Effectively, this debuff nerfs knights to merc/wretch tier, MAAs - to adv tier.
- Pardoning an outlaw removes this debuff, removes TRAIT_GUARDSMAN_DISGRACED and returns TRAIT_GUARDSMAN

## Testing Evidence

<img width="2297" height="951" alt="image" src="https://github.com/user-attachments/assets/475ef20a-2a8d-4ba7-b890-ce88c26b18b9" />

## Why It's Good For The Game

Ok so area-based garrison buff was working in a very unfunny ways, just recall this buff working in hamlet buildings lol
Plus it is kinda unsovlful that the moment you step outside of town gates - you become as strong as an adventurer
Removes unsovl.

Allows the duke to punish ~~psydonian knights~~ traitors and rowdy garrison members