### PR TITLE
Stop vampire frenzy runtime.

### DIFF
--- a/code/modules/vampire_neu/bloodsuck.dm
+++ b/code/modules/vampire_neu/bloodsuck.dm
@@ -13,6 +13,9 @@
 		return
 	if(world.time < last_drinkblood_use + 2 SECONDS)
 		return
+	if(!istype(victim))
+		to_chat(src, span_warning("I can only drink blood from living, intelligent beings!"))
+		return
 	if(victim.dna?.species && (NOBLOOD in victim.dna.species.species_traits))
 		to_chat(src, span_warning("Sigh. No blood."))
 		return


### PR DESCRIPTION
## About The Pull Request
Stop vampire frenzy runtime.

When vampire frenzy they can attempt to randomly grab and drink nearby living regardless of whether there is a limb or not which causes a runtime if they try to drink from a simple animal which has no DNA

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="489" height="227" alt="NVIDIA_Overlay_FxxiS0AqxC" src="https://github.com/user-attachments/assets/49f2fa1e-278c-4872-87fd-62e3e10f8562" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Stop vampire frenzy runtime.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
