### PR TITLE
Tiny tune down on Vizier healing.

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -133,7 +133,7 @@
 
 /obj/effect/proc_holder/spell/invoked/regression
 	name = "Regression"
-	desc = "Rewinds the target wounds, Healing them over time. If target is under Stasis heals them twice as much."
+	desc = "Rewinds the target wounds, Healing them over time."
 	overlay_state = "regression"
 	releasedrain = 30
 	chargedrain = 0
@@ -155,8 +155,6 @@
 		var/mob/living/target = targets[1]
 		target.visible_message(span_info("Order filled magic rewind [target]'s wounds!"), span_notice("My wounds, undone!"))
 		var/healing = 2.5
-		if(target.has_status_effect(/datum/status_effect/buff/stasis))
-			healing += 2.5
 		target.apply_status_effect(/datum/status_effect/buff/healing, healing)
 		return TRUE
 	revert_cast()


### PR DESCRIPTION
## About The Pull Request
As part of: https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/4289 I gave Vizier the ability to engage in some symbolic offensive. 

However their healing is still one of the strongest and most unique in game so this tune them down a little bit:
- Vizier's Convergence no longer synergize with stasis to further multiply their healing by 2.5x during stasis

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Nah

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This prevent their healing from being too overpowering (And they have an extremely powerful stasis niche) to the point I cannot give them budget elsewhere

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
