### PR TITLE
Stuffing tails into pants

### DIFF
--- a/code/modules/clothing/rogueclothes/pants/_pants.dm
+++ b/code/modules/clothing/rogueclothes/pants/_pants.dm
@@ -41,3 +41,13 @@
 #else
 	return
 #endif
+
+/obj/item/clothing/under/roguetown/MiddleClick(mob/user)
+	var/mob/living/carbon/H = user
+	if(!ishuman(user))
+		return
+	if(flags_inv & HIDETAIL)
+		flags_inv &= ~HIDETAIL
+	else
+		flags_inv |= HIDETAIL
+	H.update_inv_pants()


### PR DESCRIPTION
## About The Pull Request
- Adds the ability to hide your tail when middle-clicking on any sort of pants
You could do this to helmets to hide your ears. Now you can do it to pants
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/f96768de-f70e-4f4a-bcfa-614380493d93


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Sometimes I stuff my tail into my pants and pretend like it's a little jerking instrument so this helps with immersion.

A lot of garments that might feasibly cover the tail do not, and it would be nice to determine whether or not they do at one's own convenience instead of giving them all the flag.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
