### PR TITLE
Stop Grenzelhoft Merc name collision.

### DIFF
--- a/code/datums/migrants/migrant_waves/grenzel_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/grenzel_noble_roles.dm
@@ -1,5 +1,5 @@
 #define CTAG_GRENZEL_ENVOY "grenzel_envoy"
-#define CTAG_GRENZEL_DOPPEL "grenzel_doppel"
+#define CTAG_GRENZEL_GUARD "grenzel_guard"
 #define CTAG_GRENZEL_PRIEST "grenzel_priest"
 
 /datum/migrant_role/grenzel/envoy
@@ -65,17 +65,17 @@
 	H.grant_language(/datum/language/grenzelhoftian)
 
 /datum/migrant_role/grenzel/bodyguard
-	name = "Doppelsoldner"
-	greet_text = "You are a dilligent soldier in employ of the Envoy for protection and to assure that their mission goes as planned."
+	name = "Leibwachter"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
-	advclass_cat_rolls = list(CTAG_GRENZEL_DOPPEL = 20)
+	advclass_cat_rolls = list(CTAG_GRENZEL_GUARD = 20)
 
-/datum/advclass/grenzel_doppel
-	name = "Doppelsoldner"
+/datum/advclass/grenzel_guard
+	name = "Leibwachter"
+	tutorial = "You are a dilligent soldier in employ of the Envoy for protection and to assure that their mission goes as planned."
 	outfit = /datum/outfit/job/roguetown/grenzel/doppel
 	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_STEELHEARTED)
-	category_tags = list(CTAG_GRENZEL_DOPPEL)
+	category_tags = list(CTAG_GRENZEL_GUARD)
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
@@ -124,14 +124,14 @@
 	H.grant_language(/datum/language/grenzelhoftian)
 
 /datum/migrant_role/grenzel/priest
-	name = "Priest"
+	name = "Envoy Priest"
 	greet_text = "Nominally the envoy's spiritual advisor, your real power extends beyond religious matters. Protect interests of the Holy See of the Ten."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	advclass_cat_rolls = list(CTAG_GRENZEL_PRIEST = 20)
 
 /datum/advclass/grenzel_priest
-	name = "Priest"
+	name = "Envoy Priest"
 	outfit = /datum/outfit/job/roguetown/grenzel/doppel
 	traits_applied = list(TRAIT_CHOSEN, TRAIT_RITUALIST, TRAIT_GRAVEROBBER)
 	category_tags = list(CTAG_GRENZEL_PRIEST)
@@ -171,5 +171,5 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)
 
 #undef CTAG_GRENZEL_ENVOY
-#undef CTAG_GRENZEL_DOPPEL
+#undef CTAG_GRENZEL_GUARD
 #undef CTAG_GRENZEL_PRIEST


### PR DESCRIPTION
## About The Pull Request
- When the Grenzelhoft Migrant Wave were ported, a name collision with Doppelsoldner Merc caused the wrong information to be displayed, leading to misinformation that Grenzelhoft Doppel is now a 13 point class instead of 9 points
- This changes the bodyguard's name to "Leibwachter" for Bodyguard / Lifeguard to avoid name collision.
- Name of some classes too, were changed (Priest -> Envoy Priest) to avoid future collision

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="454" height="439" alt="NVIDIA_Overlay_cvMbEaTFuM" src="https://github.com/user-attachments/assets/530cc6c2-ea1c-4595-9e9a-316d542317d2" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gonna hit someone with 3 tiles glaive chop if I get told Doppel is 13 points again.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
