### PR TITLE
Fixes Mapping Oversight Runtimes

### DIFF
--- a/_maps/dungeon_generator/room/Bathhouse Dungeon.dmm
+++ b/_maps/dungeon_generator/room/Bathhouse Dungeon.dmm
@@ -1020,7 +1020,9 @@
 /area/rogue/under/tomb/sewer)
 "vb" = (
 /obj/structure/closet/crate/roguecloset/crafted,
-/obj/item/storage/fancy/candle_box,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/royal)

--- a/_maps/dungeon_generator/room/SteamCastle.dmm
+++ b/_maps/dungeon_generator/room/SteamCastle.dmm
@@ -1087,7 +1087,7 @@
 	STASTR = 15;
 	STASPD = 15;
 	STACON = 14;
-	STAEND = 14;
+	STAWIL = 14;
 	STALUC = 12;
 	candodge = 0
 	},
@@ -1173,7 +1173,7 @@
 	STASTR = 15;
 	STASPD = 15;
 	STACON = 14;
-	STAEND = 14;
+	STAWIL = 14;
 	STALUC = 12;
 	candodge = 0
 	},
@@ -2371,10 +2371,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
-"Cm" = (
-/mob/living/carbon/human/species/skeleton/npc/hardspread,
-/turf/open/floor/carpet/red,
-/area/rogue/under/tomb/indoors)
 "Co" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -2863,7 +2859,7 @@
 	STASTR = 15;
 	STASPD = 15;
 	STACON = 14;
-	STAEND = 14;
+	STAWIL = 14;
 	STALUC = 12;
 	candodge = 0
 	},
@@ -3934,7 +3930,7 @@
 /mob/living/carbon/human/species/orc/npc/berserker{
 	STASTR = 20;
 	STACON = 15;
-	STAEND = 15;
+	STAWIL = 15;
 	STASPD = 15;
 	STAINT = 5;
 	STAPER = 8;
@@ -8264,7 +8260,7 @@ rk
 pT
 cR
 cR
-Cm
+tO
 cR
 cA
 cR

--- a/_maps/dungeon_generator/room/Thelastbreath.dmm
+++ b/_maps/dungeon_generator/room/Thelastbreath.dmm
@@ -508,7 +508,7 @@
 	STALUC = 14;
 	STAPER = 14;
 	STAINT = 15;
-	STAEND = 12;
+	STAWIL = 12;
 	STACON = 12
 	},
 /obj/item/clothing/suit/roguetown/shirt/robe/courtmage,
@@ -1429,7 +1429,7 @@
 	STASPD = 15;
 	STASTR = 15;
 	STACON = 12;
-	STAEND = 12;
+	STAWIL = 12;
 	candodge = 0
 	},
 /obj/item/rogueweapon/sword/decorated,

--- a/_maps/dungeon_generator/room/goblincamp.dmm
+++ b/_maps/dungeon_generator/room/goblincamp.dmm
@@ -47,7 +47,7 @@
 /obj/effect/mapping_helpers/floor_clothing_equipper,
 /mob/living/carbon/human/species/goblin/npc{
 	STACON = 20;
-	STAEND = 20;
+	STAWIL = 20;
 	STAINT = 20;
 	STALUC = 20;
 	STAPER = 20;

--- a/_maps/dungeon_generator/room/graveend.dmm
+++ b/_maps/dungeon_generator/room/graveend.dmm
@@ -134,7 +134,7 @@
 /mob/living/simple_animal/hostile/rogue/haunt{
 	name = "Bonetaker";
 	STACON = 15;
-	STAEND = 15;
+	STAWIL = 15;
 	STAINT = 15;
 	STALUC = 15;
 	STAPER = 15;


### PR DESCRIPTION
## About The Pull Request

Fixes a few mapping oversight runtimes relating to new dungeon generator.

Mobs no longer have STAEND and instead properly have STAWIL; it was run timing BOTH the mob AND the crash reporting of it, funnily

And removed the legacy candle package for instead just 3 regular unlit candles. The package is using a legacy storage system that doesn't work.

## Testing Evidence

Yep, compiles.

## Why It's Good For The Game

This made trying to F5 debug test a nightmare of 5 minutes pressing 'skip, skip' every time it runtimed.

There's still turf runtimes and vampire ones but this cut down on the most annoying constantly firing ones during map generation.