### PR TITLE
Kill unnecessary re-render on examine panels.

### DIFF
--- a/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Box, Button, Image, Section, Stack } from 'tgui-core/components';
 
 import { resolveAsset } from '../assets';
@@ -18,23 +18,21 @@ export const FlavorTextPage = (props) => {
   const [oocNotesIndex, setOocNotesIndex] = useState('SFW');
   const [flavorTextIndex, setFlavorTextIndex] = useState('SFW');
 
-  const flavorHTML = {
+  const flavorHTML = useMemo(() => ({
     __html: `<span className='Chat'>${flavor_text}</span>`,
-  };
+  }), [flavor_text]);
 
-  const nsfwHTML = {
+  const nsfwHTML = useMemo(() => ({
     __html: `<span className='Chat'>${flavor_text_nsfw}</span>`,
-  };
+  }), [flavor_text_nsfw]);
 
-  const oocHTML = {
+  const oocHTML = useMemo(() => ({
     __html: `<span className='Chat'>${ooc_notes}</span>`,
-  };
+  }), [ooc_notes]);
 
-  const oocnsfwHTML = {
+  const oocnsfwHTML = useMemo(() => ({
     __html: `<span className='Chat'>${ooc_notes_nsfw}</span>`,
-  };
-
-
+  }), [ooc_notes_nsfw]);
 
   return (
         <Stack fill>


### PR DESCRIPTION
## About The Pull Request
Requested by Free. 

This fixes the issue on the new FT not allowing text highlight because it was refreshing unnecessarily. This wraps the generated HTMLs in useMemo so a new object is not created every re-render which is then passed down to the box underneath triggering a re-render on the parent and rinse and repeat.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![jEO156Hvyi](https://github.com/user-attachments/assets/75966fd3-ffb8-4bf0-855a-447d6617ebce)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I do this for a living

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
