### PR TITLE
End of Matrix Blocking.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -94,11 +94,6 @@
 
 
 /mob/living/carbon/human/bullet_act(obj/projectile/P, def_zone = BODY_ZONE_CHEST)
-	if(istype(P, /obj/projectile/bullet))
-		if((P.damage_type == BURN) || (P.damage_type == BRUTE))
-			if(!P.nodamage && P.damage < src.health && isliving(P.firer))
-				retaliate(P.firer)
-
 	if(dna && dna.species)
 		var/spec_return = dna.species.bullet_act(P, src, def_zone)
 		if(spec_return)
@@ -112,7 +107,6 @@
 				return martial_art_result
 
 	if(!(P.original == src && P.firer == src)) //can't block or reflect when shooting yourself
-		retaliate(P.firer)
 		if(P.reflectable & REFLECT_NORMAL)
 			if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
 				visible_message(span_danger("The [P.name] gets reflected by [src]!"), \
@@ -143,6 +137,8 @@
 		if(check_shields(P, P.damage, "the [P.name]", PROJECTILE_ATTACK, P.armor_penetration))
 			P.on_hit(src, 100, def_zone)
 			return BULLET_ACT_HIT
+
+	retaliate(P.firer)
 	return ..(P, def_zone)
 
 /mob/living/carbon/human/proc/check_reflect(def_zone) //Reflection checks for anything in my l_hand, r_hand, or wear_armor based on the reflection chance of the object

--- a/code/modules/mob/vision_cone.dm
+++ b/code/modules/mob/vision_cone.dm
@@ -209,7 +209,10 @@
 	if(!isliving(src) || !isliving(L))
 		return
 	if(!client)
-		return TRUE
+		// NPCs without clients use simple directional vision cone
+		if(L.InCone(src, src.dir))
+			return TRUE
+		return FALSE
 	if(hud_used && hud_used.fov)
 		if(hud_used.fov.alpha != 0)
 			var/list/mobs2hide = list()


### PR DESCRIPTION
## About The Pull Request
- Mobs should no longer matrix and turn to block your arrow BEFORE it hits.
- And will no longer block 360 degrees regardless (Now it uses a simple vision cone instead of HUD based FOV cone - shoot them from behind)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="582" height="278" alt="NVIDIA_Overlay_sISkfTnnBK" src="https://github.com/user-attachments/assets/d4d437a9-8baf-476d-9d5b-11dcaf36bb5d" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It isn't fair when you flank a shield holder and then they block you anyway.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
