### PR TITLE
Hugbox Peak: NPC can't aim Neck anymore.

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -851,10 +851,11 @@
 	if(!(mobility_flags & MOBILITY_STAND))
 		aimheight_change(rand(1, 4)) // Go for the knees!
 		return
+	// Specifically excluding 12 - Neck to prevent decap
 	if(HAS_TRAIT(victim, TRAIT_BLOODLOSS_IMMUNE)) // Go for the head!
-		aimheight_change(rand(12, 19))
+		aimheight_change(rand(13, 19))
 		return
-	aimheight_change(pick(rand(5, 8), rand(9, 11), rand(12, 19))) // Arms, chest, head. Equal chance for each.
+	aimheight_change(pick(rand(5, 8), rand(9, 11), rand(13, 19))) // Arms, chest, head. Equal chance for each.
 
 // attack using a held weapon otherwise bite the enemy, then if we are angry there is a chance we might calm down a little
 /mob/living/carbon/human/proc/monkey_attack(mob/living/L)


### PR DESCRIPTION
## About The Pull Request
Specifically exclude Neck from NPC aiming zone. 

They can still nugget or chop the fuck outta you

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
None, actually.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Remove an accidental RR "help admin" clause from NPC without substantially affecting PVE difficulty since death is already a failure state.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
