### PR TITLE
More Mage Associate Slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -3,8 +3,8 @@
 	flag = MAGEAPPRENTICE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 6
+	spawn_positions = 6
 
 	allowed_races = ACCEPTED_RACES
 	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation)


### PR DESCRIPTION
## About The Pull Request

- Increased Mage Associate slots from 4 to 6.

## Testing Evidence

I didn't.

## Why It's Good For The Game

The university is quite large, with varying roles to fulfill, from alchemy, to summoning, to roleplaying, to going on fetchquests for ingredients. I believe it can facilitate more slots.
