### PR TITLE
Guidance Buff

### DIFF
--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/guidance.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/guidance.dm
@@ -50,10 +50,10 @@
 	var/outline_colour ="#f58e2d"
 	id = "guidance"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/guidance
-	duration = 1 MINUTES
+	duration = 5 MINUTES
 
 /datum/status_effect/buff/guidance/other
-	duration = 2 MINUTES
+	duration = 10 MINUTES
 
 /datum/status_effect/buff/guidance/on_apply()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

- Guidance now lasts 5 minutes when cast on yourself, 10 when cast on others.

## Testing Evidence

I didn't.

## Why It's Good For The Game

When playing the support role, I often felt my guidance spell was being wasted whenever I cast it, since it'd run out before anything really happened.
