### PR TITLE
Painting Price Buff

### DIFF
--- a/code/game/objects/items/rogueitems/painting.dm
+++ b/code/game/objects/items/rogueitems/painting.dm
@@ -5,7 +5,7 @@
 	desc = ""
 	w_class = WEIGHT_CLASS_NORMAL
 	static_price = TRUE
-	sellprice = 200
+	sellprice = 100
 	icon = 'icons/roguetown/items/misc.dmi'
 	var/deployed_structure = /obj/structure/fluff/walldeco/painting
 
@@ -55,14 +55,14 @@
 	icon_state = "queenpainting"
 	desc = "It's Queen Samantha I of Psydonia. Her late husband would be so proud of what she has accomplished in his realm. These mass-reproduced paintings are unfortunately devalued."
 	dropshrink = 0.5
-	sellprice = 400
+	sellprice = 200
 	deployed_structure = /obj/structure/fluff/walldeco/painting/queen
 
 /obj/item/rogue/painting/seraphina
 	icon_state = "seraphinapainting"
 	desc = "It's holy priest Seraphina, first of her name, blessed be her name."
 	dropshrink = 0.5
-	sellprice = 400
+	sellprice = 200
 	deployed_structure = /obj/structure/fluff/walldeco/painting/seraphina
 
 /obj/structure/fluff/walldeco/painting/seraphina
@@ -73,7 +73,7 @@
 /obj/item/rogue/painting/skullzhg
 	icon_state = "skullpainting"
 	desc = "A moody scene depicting a skull and candles on a table. Memento mori."
-	sellprice = 400
+	sellprice = 200
 	deployed_structure = /obj/structure/fluff/walldeco/painting/skull
 
 /obj/structure/fluff/walldeco/painting/skull


### PR DESCRIPTION
## About The Pull Request

- Painting sell prices have been increased tenfold. Standard paintings sell for 100, while the more expensive ones sell for 200.

## Testing Evidence

Just tweaked the numbers.

## Why It's Good For The Game

Paintings take up a 3x3 space in your pack, so you can only feasibly escape with 1 or 2, leaving behind other loot in exchange for it. Plus, stealing a painting and making out like a bandit is peak thievery.