### PR TITLE
Steward Crownstone

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -69,7 +69,7 @@
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold/steward
 	beltr = /obj/item/storage/keyring/steward
 	backr = /obj/item/storage/backpack/rogue/satchel
-	id = /obj/item/scomstone
+	id = /obj/item/scomstone/garrison
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
 	H.verbs |= /mob/living/carbon/human/proc/adjust_taxes


### PR DESCRIPTION
## About The Pull Request

- The Steward now gets a Crownstone instead of a regular Scomstone.

## Testing Evidence

It probably works.

## Why It's Good For The Game

After a discussion in dev-general, I've been informed it'd probably be a good idea for Steward to be able to speak with the Garrison, since the Steward handles the finances.