### PR TITLE
Add skulldog snouts back to wild-kin

### DIFF
--- a/code/modules/client/customizer/customizers/organ/snout.dm
+++ b/code/modules/client/customizer/customizers/organ/snout.dm
@@ -266,6 +266,7 @@
 		/datum/sprite_accessory/snout/alienlizard,
 		/datum/sprite_accessory/snout/alienlizardteeth,
 		/datum/sprite_accessory/snout/skulldog,
+		/datum/sprite_accessory/snout/front/skulldog,
 		/datum/sprite_accessory/snout/hanubus,
 		/datum/sprite_accessory/snout/hpanda,
 		/datum/sprite_accessory/snout/hjackal,


### PR DESCRIPTION
## About The Pull Request
- This restores skulldog and skulldog (front) to wild-kin
- Also rename dullahan snout to dullahan snout instead of wild-kin snout.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="244" height="254" alt="uTLGpshpMG" src="https://github.com/user-attachments/assets/7fecd6b7-4d4c-4212-9371-e52eb15fa141" />
<img width="467" height="313" alt="dreamseeker_tOzocyIRV7" src="https://github.com/user-attachments/assets/a9d3b6f4-4cee-4ade-9bba-601a6ce7f53f" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I don't think it is a good idea to screw over another few wild-kin players and force them to play rev (or make them play elsewhere) atm.

This has approval from the admin who asked for the original PR to revert it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
