### PR TITLE
Wildshift tweaks & TRAIT_WILD_EATER bugfix

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
@@ -13,8 +13,8 @@
 /mob/living/carbon/human/species/wildshape/saiga/gain_inherent_skills()
 	. = ..()
 	if(src.mind)
-		src.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-		src.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+		src.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		src.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 		src.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
 		src.adjust_skillrank(/datum/skill/misc/athletics, 5, TRUE)
 
@@ -24,7 +24,7 @@
 		src.STASPD = 13
 
 		AddSpell(new /obj/effect/proc_holder/spell/self/saigahoofs)
-		real_name = "Saiga ([stored_mob.real_name])" //So we don't get a random name
+		real_name = "saiga doe" //So we don't get a random name
 
 // SAIGA SPECIES DATUM //
 /datum/species/shapesaiga
@@ -100,7 +100,7 @@
 /datum/intent/simple/saiga //Like a less defense dagger
 	name = "hoof"
 	icon_state = "instrike"
-	blade_class = BCLASS_CUT
+	blade_class = BCLASS_BLUNT
 	attack_verb = list("hits", "mauls", "bashes")
 	animname = "strike"
 	hitsound = "punch_hard"
@@ -110,11 +110,11 @@
 	miss_text = "kicks the air!"
 	miss_sound = "bluntswoosh"
 	item_d_type = "blunt"
-	swingdelay = 10
-	clickcd = 14
+	swingdelay = 8
+	clickcd = 10
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR // I'm evil
 
-/obj/item/rogueweapon/saiga_hoof //Like a less defense dagger
+/obj/item/rogueweapon/saiga_hoof //Like a mace
 	name = "saiga hoof"
 	desc = ""
 	item_state = null
@@ -132,7 +132,7 @@
 	wbalance = WBALANCE_NORMAL
 	w_class = WEIGHT_CLASS_NORMAL
 	can_parry = TRUE //I just think this is cool as fuck, sue me
-	sharpness = FALSE
+	sharpness = IS_BLUNT
 	demolition_mod = 1.5
 	swingsound = list('sound/vo/mobs/saiga/attack (1).ogg','sound/vo/mobs/saiga/attack (2).ogg')
 	possible_item_intents = list(/datum/intent/simple/saiga)

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/spider.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/spider.dm
@@ -25,7 +25,7 @@
 		AddSpell(new /obj/effect/proc_holder/spell/self/spiderfangs)
 		AddSpell(new /obj/effect/proc_holder/spell/self/createhoney)
 		AddSpell(new /obj/effect/proc_holder/spell/self/weaveweb)
-		real_name = "Beespider ([stored_mob.real_name])"
+		real_name = "beespider"
 		faction += "spiders" // It IS a spider
 
 // CAT SPECIES DATUM //
@@ -44,6 +44,7 @@
 		TRAIT_BREADY, //Ambusher
 		TRAIT_ORGAN_EATER,
 		TRAIT_PIERCEIMMUNE, //Prevents weapon dusting and caltrop effects when killed/stepping on shards, also 8 legs.
+		TRAIT_DODGEEXPERT,
 		TRAIT_LONGSTRIDER
 	)
 	inherent_biotypes = MOB_HUMANOID

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/volf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/volf.dm
@@ -22,7 +22,7 @@
 		src.STASPD = 13
 
 		AddSpell(new /obj/effect/proc_holder/spell/self/wolfclaws)
-		real_name = "Volf ([stored_mob.real_name])" //So we don't get a random name
+		real_name = "volf" //So we don't get a random name
 		faction += "wolfs" // It IS a wolf
 
 // WOLF SPECIES DATUM //

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -125,7 +125,7 @@
 
 /datum/reagent/water/gross/on_mob_life(mob/living/carbon/M)
 	..()
-	if(HAS_TRAIT(M, TRAIT_NASTY_EATER)) // lets orcs and goblins drink bogwater
+	if(HAS_TRAIT(M, TRAIT_NASTY_EATER) || HAS_TRAIT(M, TRAIT_WILD_EATER)) // lets orcs, goblins and dendorites drink bogwater
 		return
 	M.adjustToxLoss(1)
 	M.add_nausea(12) //Over 8 units will cause puking


### PR DESCRIPTION
## About The Pull Request

Dendor wildshift changes:
1. All beast forms lost their real_name links
2. Saiga got it hoofs updated to be more mace'y/speedy & got it wrestling/unnarmed skills raised up to apprecience.
3. Beespider got dodge expert trait

Wild Eater Trait changes:
1. Now it allows you to drink gross water (as stated in description)

## Testing Evidence

Local testing, fighting with mobs as saiga/beespider, drinking water from pond while in beast form, transforming into each affected form (saiga, wolf, beespider)

## Why It's Good For The Game

1. Beespider's pain threshold is low, so I guess theese changes will make 'em more tenacious since they got the weakest leather armor. Small amounts of stamina balances it so it's ain't OP.
2. Saiga's hoofs are kinda cringe. Long CD/delay between sweeps, low accuracy, no real defence. Also it's fightings skill way below wolf or spider. I guess it's not really assault form, but as I think it skills may be higher, so here we are. Higher than before, lower than it could be. Also now we've got all combat diversity. Cut, stab and blunt
3. Name changes: roleplay-sided it's just strange that you could definitely say that this beespider is Helix the Druid. Also it may now be possible to jumpscare random wanderers and got shot pointblank. Just a step towards Among Us gameplay.
4. Speaking about Wild Eater trait - I guess it's just a bug. It's said you are able to drink shittier water - so now you are.
