### PR TITLE
Sleepless Triumphs

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -83,19 +83,32 @@ SUBSYSTEM_DEF(nightshift)
 		if(!cmode)
 			SSdroning.play_area_sound(areal, src.client)
 		SSdroning.play_loop(areal, src.client)
-	if(todd == "day")
-		if(HAS_TRAIT(src, TRAIT_VAMP_DREAMS))
-			apply_status_effect(/datum/status_effect/debuff/vamp_dreams)
-		if(HAS_TRAIT(src, TRAIT_NIGHT_OWL))
-			apply_status_effect(/datum/status_effect/debuff/sleepytime)
 
-	if(todd == "night")
-		if(HAS_TRAIT(src, TRAIT_INFINITE_STAMINA))
-			return ..()
-		if(HAS_TRAIT(src, TRAIT_NOSLEEP))
-			return ..()
-		if(HAS_TRAIT(src, TRAIT_NIGHT_OWL))
-			add_stress(/datum/stressevent/night_owl)
-		else
-			apply_status_effect(/datum/status_effect/debuff/sleepytime)
-			add_stress(/datum/stressevent/sleepytime)
+	switch(todd)
+		if("day")
+			if(HAS_TRAIT(src, TRAIT_VAMP_DREAMS))
+				apply_status_effect(/datum/status_effect/debuff/vamp_dreams)
+			if(HAS_TRAIT(src, TRAIT_NIGHT_OWL))
+				apply_status_effect(/datum/status_effect/debuff/sleepytime)
+			if(HAS_TRAIT(src, TRAIT_INFINITE_STAMINA) || HAS_TRAIT(src, TRAIT_NOSLEEP))
+				handle_sleep_triumphs()
+		if("night")
+			if(HAS_TRAIT(src, TRAIT_INFINITE_STAMINA) || HAS_TRAIT(src, TRAIT_NOSLEEP))
+				return ..()
+			if(HAS_TRAIT(src, TRAIT_NIGHT_OWL))
+				add_stress(/datum/stressevent/night_owl)
+			else
+				apply_status_effect(/datum/status_effect/debuff/sleepytime)
+				add_stress(/datum/stressevent/sleepytime)
+
+/mob/living/carbon/human/proc/handle_sleep_triumphs()
+	if(!mind)
+		return
+	allmig_reward++
+	var/triumphs_to_add = 1
+	var/static/list/towner_jobs
+	towner_jobs = GLOB.peasant_positions | GLOB.yeoman_positions | GLOB.youngfolk_positions
+	if(mind.assigned_role != "Unassigned" && istype(mind.assigned_role, /datum/job) && (mind.assigned_role.title in towner_jobs)) //If you play a towner-related role, you get an additonal triumph
+		triumphs_to_add++
+	adjust_triumphs(triumphs_to_add)
+	to_chat(src, span_danger("Nights Survived: \Roman[allmig_reward]"))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(ticker)
 	/// Realm name, the location name of the current map
 	var/realm_name = "Azure Peak"
 	/// Reports the current ruler's display name
-	var/rulertype = "Grand Duke" 
+	var/rulertype = "Grand Duke"
 	/// The current ruling mob
 	var/rulermob = null
 	/// Current regent mob
@@ -195,7 +195,7 @@ SUBSYSTEM_DEF(ticker)
 				var/mob/dead/new_player/player = i
 				if(player.ready == PLAYER_READY_TO_PLAY)
 					++totalPlayersReady
-			
+
 			if(!gamemode_voted)
 				SSvote.initiate_vote("storyteller", "Psydon", timeLeft/2)
 				gamemode_voted = TRUE
@@ -313,7 +313,7 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/proc/setup()
 	message_admins(span_boldannounce("Starting game..."))
 	var/init_start = world.timeofday
-		
+
 	if(SSmapping.map_adjustment)
 		realm_name = SSmapping.map_adjustment.realm_name
 	CHECK_TICK

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -55,13 +55,7 @@
 				remove_stress(/datum/stressevent/sleepytime)
 				if(mind)
 					mind.sleep_adv.advance_cycle()
-					allmig_reward++
-					adjust_triumphs(1)
-					var/static/list/towner_jobs
-					towner_jobs = GLOB.peasant_positions | GLOB.yeoman_positions | GLOB.youngfolk_positions
-					if(mind.assigned_role.title in towner_jobs) //If you play a towner-related role, you get triumphs.
-						adjust_triumphs(1)
-					to_chat(src, span_danger("Nights Survived: \Roman[allmig_reward]"))
+					handle_sleep_triumphs()
 	if(leprosy == 1)
 		adjustToxLoss(2)
 	else if(leprosy == 2)
@@ -209,7 +203,7 @@
 					 		'sound/items/confessormask10.ogg')
 			playsound(src, mask_sound, 90, FALSE, 4, 0)
 			return
-			 	
+
 
 
 //This proc returns a number made up of the flags for body parts which you are protected on. (such as HEAD, CHEST, GROIN, etc. See setup.dm for the full list)


### PR DESCRIPTION
## About The Pull Request

- Characters with the Sleepless vice now gets their Triumphs once the night turns into day. This means Towner sleepless characters can still gain their round participation points, but they still lack the main ability of sleeping which is fatigue restoration and skill progression.

## Testing Evidence

<img width="746" height="264" alt="image" src="https://github.com/user-attachments/assets/b61f119d-ebdc-4104-a225-0147d23a39f9" />

## Why It's Good For The Game

I feel like them not gaining round participation points was an oversight.