### PR TITLE
Campfire Buff Tweak

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -500,6 +500,17 @@
 		owner.adjustCloneLoss(-healing_on_tick, 0)
 // Lesser miracle effect end
 
+/atom/movable/screen/alert/status_effect/buff/healing/campfire
+	name = "Warming Respite"
+	desc = "The warmth of a fire soothes my ails."
+	icon_state = "buff"
+
+/datum/status_effect/buff/healing/campfire
+	id = "healing_campfire"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/healing/campfire
+	examine_text = null
+	duration = 10 SECONDS
+
 #define BLOODHEAL_DUR_SCALE_PER_LEVEL 3 SECONDS
 #define BLOODHEAL_RESTORE_DEFAULT 5
 #define BLOODHEAL_RESTORE_SCALE_PER_LEVEL 2

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -776,28 +776,28 @@
 		L.visible_message("<span class='info'>[L] snuffs [src].</span>")
 		burn_out()
 
-/obj/machinery/light/rogue/campfire/attack_hand(mob/user, first_call = TRUE)
+/obj/machinery/light/rogue/campfire/attack_hand(mob/user)
 	. = ..()
 	if(.)
 		return
 
 	if(on)
 		var/mob/living/carbon/human/H = user
-
-		if(istype(H))
-			if(first_call)
-				H.visible_message("<span class='info'>[H] warms [user.p_their()] hand near the fire.</span>")
-
-			if(do_after(H, 105, target = src))
+		if(ishuman(H))
+			H.visible_message("<span class='info'>[H] warms [user.p_their()] hand near the fire.</span>")
+			var/first_go = TRUE
+			while(do_after(H, 105, target = src) && on)
 				// Astrata followers get enhanced fire healing
 				var/buff_strength = 1
 				if(H.patron?.type == /datum/patron/divine/astrata || H.patron?.type == /datum/patron/inhumen/matthios) //Fire and the fire-stealer
 					buff_strength = 2
-				H.apply_status_effect(/datum/status_effect/buff/healing, buff_strength)
+				H.apply_status_effect(/datum/status_effect/buff/healing/campfire, buff_strength)
 				H.add_stress(/datum/stressevent/campfire)
-				to_chat(H, "<span class='info'>The warmth of the fire comforts me, affording me a short rest.</span>")
-				attack_hand(H, FALSE) // Recursion
+				if(first_go)
+					to_chat(H, span_good("The warmth of the fire comforts me, affording me a short rest."))
+					first_go = FALSE
 		return TRUE //fires that are on always have this interaction with lmb unless its a torch
+
 /obj/machinery/light/rogue/campfire/densefire
 	icon_state = "densefire1"
 	base_state = "densefire"


### PR DESCRIPTION
## About The Pull Request

- Tweaked Campfire Healing recursion to work slightly differently, should have no player-facing changes.
- Examining someone healing at a campfire no longer shows the miracle healing text.

## Testing Evidence

I promise I tested I just didn't take a screenie.

## Why It's Good For The Game

Ports https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1276