### PR TITLE
Dendor's wildshape damage transferring tweak/bugfix

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -4,18 +4,14 @@
 /mob/living/carbon/human/proc/wildshape_transformation(shapepath)
 	if(!mind)
 		log_runtime("NO MIND ON [src.name] WHEN TRANSFORMING")
-
 	Paralyze(1, ignore_canstun = TRUE)
-
 	for(var/obj/item/I in src)
 		dropItemToGround(I)
-
 	regenerate_icons()
 	icon = null
 	var/oldinv = invisibility
 	invisibility = INVISIBILITY_MAXIMUM
 	cmode = FALSE
-
 	if(client)
 		SSdroning.play_area_sound(get_area(src), client)
 
@@ -85,7 +81,6 @@
 		return
 	if(!mind)
 		log_runtime("NO MIND ON [src.name] WHEN UNTRANSFORMING")
-
 	Paralyze(1, ignore_canstun = TRUE)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)


### PR DESCRIPTION
## About The Pull Request

Damage, blood volume and bleeding now transfers between dendor wildshape forms (including human form).
Previously damage delt to human form transferred to wild form, but stayed the same after healing in wild form, so you've had to heal twice. Also you could bled out while in wild form, so you'd die instantly after switching back to human.

## Testing Evidence

https://www.youtube.com/watch?v=PA20G-A8hgE

## Why It's Good For The Game

1. A much more clear logic of transferring damage between forms.
2. You will no longer die if you've got bleeding during human form and spent some time while in wild form. (yeah I guess it's a bug)
3. Now you'll be able to heal your wounds in any form, without the need to switch back to human one.