### PR TITLE
Sets the cloth payout price to 2 mammon

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile_rawmat.dm
+++ b/code/modules/roguetown/roguestock/stockpile_rawmat.dm
@@ -132,7 +132,7 @@
 	desc = "Lengths of cloth for sewing and tailoring."
 	item_type = /obj/item/natural/cloth
 	held_items = list(0, 2)
-	payout_price = 3
+	payout_price = 2
 	withdraw_price = 3
 	transport_fee = 2
 	export_price = 5


### PR DESCRIPTION
## About The Pull Request
1:1 with its fiber value, making it simply be a more efficient way to carry fiber around stockpile-value wise.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I'm not sure who thinks mowing ~35 grass for ~100 mammon and then autocrafting that for like 5 mins is "gaming the system", but now it'll be 50 grass and even longer crafting time. Real, chad grinders with Isolationist who have ripped the T key off of their keyboards on purpose won't really be affected.

There is literally nothing left to reduce beyond this, it's 1:1 Mammon to Fiber ratio. It's okay to be a Lawnmower for a living.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
