### PR TITLE
Fixes cooking on burnt out fires

### DIFF
--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -110,7 +110,7 @@
 /obj/machinery/light/rogue/attackby(obj/item/W, mob/living/user, params)
 	var/datum/skill/craft/cooking/cs = user?.get_skill_level(/datum/skill/craft/cooking)
 	var/cooktime_divisor = get_cooktime_divisor(cs)
-	if(cookonme && fueluse > 0)
+	if(cookonme && on)
 		if(istype(W, /obj/item/reagent_containers/food/snacks))
 			if(istype(W, /obj/item/reagent_containers/food/snacks/egg))
 				to_chat(user, "<span class='warning'>I wouldn't be able to cook this over the fire...</span>")


### PR DESCRIPTION
## About The Pull Request

Makes it so that fires have to have to be on in order to cook on them

## Testing Evidence

Simple change

## Why It's Good For The Game

You can currently cook with good intentions and not much else
