### PR TITLE
Smithing Quality Matters

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/smith_components.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smith_components.dm
@@ -208,7 +208,7 @@
 	material_quality = floor(material_quality/current_recipe.num_of_materials)-4
 	skill_quality = floor((skill_quality/current_recipe.num_of_materials)/1500)+material_quality
 	skill_quality -= floor(numberofhits * 0.25)
-	
+
 	var/modifier
 	switch(skill_quality)
 		if(BLACKSMITH_LEVEL_MIN to BLACKSMITH_LEVEL_SPOIL)
@@ -257,6 +257,11 @@
 					I.AddComponent(/datum/component/metal_glint)
 
 		I.sellprice *= modifier
+		I.max_integrity *= modifier
+		I.obj_integrity = I.max_integrity
+		I.max_blade_int *= modifier
+		I.blade_int = I.max_blade_int
+		I.sharpness_mod = round(1 / modifier, 0.01) // 1.3 modifier gives 0.76 sharpness mod, 0.3 modifier gives 3.3 sharpness mod
 		if(istype(I, /obj/item/lockpick))
 			var/obj/item/lockpick/L = I
 			L.picklvl = modifier


### PR DESCRIPTION
## About The Pull Request

- The quality of a smithed item now determines not just the selling price, but also the max integrity, max sharpness, and sharpness loss modifier. Ruined gives an overall x0.3 to stats, and a x3.3 sharpness loss modifier, while Masterwork gives x1.3 to stats and x0.76 to sharpness loss.

## Testing Evidence

<img width="1350" height="681" alt="image" src="https://github.com/user-attachments/assets/9fdb0ea0-0409-41f4-92bb-b53dc22512f0" />

## Why It's Good For The Game

I think it's weird that there's little to no incentive to using good quality materials and highly skilled artisans for armourpieces and weaponry.
