### PR TITLE
Critical Resistance & Easydismember cancels eachother on spawn.

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -49,6 +49,16 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 	var/datum/job/assigned_job = SSjob.GetJob(character.mind?.assigned_role)
 	if(assigned_job)
 		assigned_job.clamp_stats(character)
+	check_trait_incompatibilities(character)
+
+/// Check for incompatible traits and remove one of them
+/proc/check_trait_incompatibilities(mob/living/carbon/human/H)
+	// Easy Dismemberment & Critical Resistance get both cancelled out
+	if(HAS_TRAIT(H, TRAIT_EASYDISMEMBER) && HAS_TRAIT(H, TRAIT_CRITICAL_RESISTANCE))
+		REMOVE_TRAIT(H, TRAIT_EASYDISMEMBER, null) // Doesn't care for source, they ARE getting canceled
+		REMOVE_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, null)
+		to_chat(H, span_warning("My limbs are too frail and my body too tough... the contradiction leaves me unable to resist critical wounds."))
+	return TRUE
 
 /proc/apply_prefs_virtue(mob/living/carbon/human/character, client/player)
 	if (!player)


### PR DESCRIPTION
## About The Pull Request
- When a class / virtue combo spawn with Easy Dismember and Critical Resistance, both trait cancels eachother out.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1190" height="702" alt="NVIDIA_Overlay_CqZutWnlCo" src="https://github.com/user-attachments/assets/d34193ce-89fc-489f-a224-fe49314838e2" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Cut down on a powergaming virtue-trait combo without invalidating character choice entirely.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
