### PR TITLE
Implement 2 seconds grace period for decap once knocked down.

### DIFF
--- a/code/__DEFINES/roguetown/combat.dm
+++ b/code/__DEFINES/roguetown/combat.dm
@@ -16,6 +16,7 @@ Medical defines
  Misc. Category. Spin it out if needed
 */
 #define CRIT_DISMEMBER_DAMAGE_THRESHOLD 0.75 // 75% damage threshold for dismemberment / crit
+#define STANDING_DECAP_GRACE_PERIOD 2 SECONDS // Time after falling prone where you still count as standing for decap purpose
 
 /*
 	Critical Resistance Defines 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1773,6 +1773,10 @@
 			should_be_lying = buckled.buckle_lying
 
 	if(should_be_lying)
+		// Track when we transition from standing to prone for dismemberment grace period
+		if(mobility_flags & MOBILITY_STAND) 
+			if(mob_timers)
+				mob_timers["last_standing"] = world.time
 		resting = TRUE
 		mobility_flags &= ~MOBILITY_STAND
 		if(buckled)

--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -30,7 +30,17 @@
 		if(zone_precise != BODY_ZONE_PRECISE_NECK)
 			return FALSE
 		if(!HAS_TRAIT(C, TRAIT_CRITICAL_WEAKNESS) && !HAS_TRAIT(C, TRAIT_EASYDISMEMBER))	//People with these traits can be decapped standing, or buckled, or however.
-			if(!isnull(C.mind) && (C.mobility_flags & MOBILITY_STAND) && !C.buckled) //Only allows upright decapitations if it's not a player. Unless they're buckled.
+			var/has_mind = TRUE  // DEBUG: Temporarily forced to TRUE for testing
+			var/not_buckled = !C.buckled
+
+			// Check if currently standing OR within grace period after being knocked down
+			var/can_stand = (C.mobility_flags & MOBILITY_STAND)
+			if(!can_stand && C.mob_timers && C.mob_timers["last_standing"])
+				// Within 2 seconds of being knocked down? Still count as standing
+				if(world.time < C.mob_timers["last_standing"] + STANDING_DECAP_GRACE_PERIOD)
+					can_stand = TRUE
+
+			if(has_mind && can_stand && not_buckled) //Only allows upright decapitations if it's not a player. Unless they're buckled.
 				return FALSE
 
 	if(body_zone != BODY_ZONE_HEAD)


### PR DESCRIPTION
## About The Pull Request
- When you're knocked down, set a mob timer for 2 seconds before you can be decapped
- This resolves the issue reported consistently since the addition of rend + lowering of dismemberment threshold that people are being standing decapped, which was caused by high damage attack instantly flooring the player, causing them to be decapped while "standing" before their icon update

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1196" height="785" alt="Discord_BFMAX4UEls" src="https://github.com/user-attachments/assets/99c40e84-4098-4d40-82ab-b1c1b1abb791" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Resolve a common source of player frustration for the past two months when faced with rend where they perceive they are decapitated when standing - and as far as the player are concerned, they ARE standing.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
