### PR TITLE
Fixes ITEM_SLOT_BACK macro escape

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -40,7 +40,7 @@
 #define ITEM_SLOT_DENYPOCKET	(1<<22) // this is to deny items with a w_class of WEIGHT_CLASS_SMALL or WEIGHT_CLASS_TINY to fit in pockets.
 #define ITEM_SLOT_BACKPACK		(1<<23)
 
-#define ITEM_SLOT_BACK			ITEM_SLOT_BACK_L | ITEM_SLOT_BACK_R
+#define ITEM_SLOT_BACK			(ITEM_SLOT_BACK_L | ITEM_SLOT_BACK_R)
 
 //SLOTS
 


### PR DESCRIPTION
## About The Pull Request

Puts the value macro's value between ( and )

## Testing Evidence

Tested downstream

## Why It's Good For The Game

This caused an issue for us downstream, when we tried to put a headgear onto a skeleton, namely a crown, and it got forced into the back slot because the if checked for

`if(!(I.slot_flags & ITEM_SLOT_BACK))`

Which got translated to

`if(!(I.slot_flags & 1<<15 | 1<<14))`

Thus unable to ever return a 0 value, and thus forcing everything to be equipped to the backs first