### PR TITLE
More item equip fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -639,7 +639,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				return FALSE
 			return TRUE
 		if(SLOT_BACK)
-			if(H.back)
+			if(H.backr && H.backl)
 				return FALSE
 			if( !(I.slot_flags & ITEM_SLOT_BACK) )
 				return FALSE

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -51,7 +51,12 @@
 	var/not_handled = FALSE
 	switch(slot)
 		if(SLOT_BACK)
-			back = I
+			if(!backl && (I.slot_flags & ITEM_SLOT_BACK_L))
+				backl = I
+			else if(!backr && (I.slot_flags & ITEM_SLOT_BACK_R))
+				backr = I
+			else
+				not_handled = TRUE
 			update_inv_back()
 		if(SLOT_WEAR_MASK)
 			wear_mask = I

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -281,6 +281,15 @@
 		overlays_standing[BACK_LAYER] = back.build_worn_icon(default_layer = BACK_LAYER, default_icon_file = 'icons/mob/clothing/back.dmi')
 		update_hud_back(back)
 
+	if(backl)
+		overlays_standing[BACK_LAYER] = backl.build_worn_icon(default_layer = BACK_LAYER, default_icon_file = 'icons/mob/clothing/back.dmi')
+		update_hud_backl(back)
+	
+	if(backr)
+		overlays_standing[BACK_LAYER] = backr.build_worn_icon(default_layer = BACK_LAYER, default_icon_file = 'icons/mob/clothing/back.dmi')
+		update_hud_backl(back)
+
+
 	apply_overlay(BACK_LAYER)
 
 /mob/living/carbon/update_inv_head(hide_nonstandard = FALSE)


### PR DESCRIPTION
## About The Pull Request

But we aren't done yet! Found an another bug with the whole proc chain that the floor clothes equipper is using, which is that items that DO want to go into the back, end up in the actual, depricated ss13 back slot, instead of the back_l or back_r roguecode slots. Fixed that, by trying to equip them to left, then right slots, if they aren't already taken and has the slot to go there. The re-rendering is shitcode that I have no idea how to do properly, but it DOES work so who really knows maybe that's how you are supposed to do it

## Testing Evidence

Tested downstream

## Why It's Good For The Game

More bufixes
