### PR TITLE
Missionary Parity with other Holy Casters

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -587,7 +587,7 @@
 			cloak = /obj/item/clothing/suit/roguetown/shirt/robe //placeholder, anyone who doesn't have cool patron drip sprites just gets generic robes
 			head = /obj/item/clothing/head/roguetown/roguehood
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)	//Minor regen, capped to T3.
+	C.grant_miracles(H, cleric_tier = CLERIC_T3, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_3)	//Minor regen, capped to T3, parity with other Holy and/or Arcyne caster - no others spend 15 minutes idling only to unlock their entire potencial.
 	if(H.mind)
 		var/weapons = list("Woodstaff", "Quarterstaff")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons


### PR DESCRIPTION
## About The Pull Request

Increase the base/roundjoin Miracle tier of the Missionary adventurer(which is also their maximum Miracle Tier)
Change the base Miracle Tier of Missionaries from T1 to T3(maximum tier unchanged)

## Testing Evidence

my computer didn't blow up so this is a good sign, this isn't so hard after all!
<img width="1902" height="1041" alt="image" src="https://github.com/user-attachments/assets/6a8351de-58e7-45e1-9c7b-f95feafb1699" />


## Why It's Good For The Game

Long are gone the daes when the magos had their noses stuck in theis books accumulating spellpoints and arcyne power.
So too shall the Divine Heralds follow their examples.
