### PR TITLE
Fixes lensdump links

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2720,7 +2720,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 		reset_all_customizer_accessory_colors()
 
 /proc/valid_headshot_link(mob/user, value, silent = FALSE, list/valid_extensions = list("jpg", "png", "jpeg"))
-	var/static/link_regex = regex("i.gyazo.com|a.l3n.co|b.l3n.co|c.l3n.co|images2.imgbox.com|thumbs2.imgbox.com|files.catbox.moe") //gyazo, discord, lensdump, imgbox, catbox
+	var/static/link_regex = regex(@"i\.gyazo.com|.\.l3n\.co|images2\.imgbox\.com|thumbs2\.imgbox\.com|files\.catbox\.moe") //gyazo, discord, lensdump, imgbox, catbox
 
 	if(!length(value))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

This is a fix I have pushed on other ss13 servers to allow a wider range of lensdump links by using wildcard regex in place of listing every lensdump prefix as they roll them out (eg "d.l3n.co")

Lensdump is a good image hosting service, highly recommend.

## Testing Evidence

Tested on other servers, works fine

## Why It's Good For The Game

Bug fix