### PR TITLE
Properly fixes and cleans up mending

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -24,35 +24,36 @@
 	var/int_bonus = 0.00
 
 /obj/effect/proc_holder/spell/invoked/mending/cast(list/targets, mob/living/user)
-	if(istype(targets[1], /obj/item))
-		var/obj/item/I = targets[1]
-		if(!I.anvilrepair && !I.sewrepair)
-			to_chat(user, span_warning("Not even magic can mend this item!"))
-			revert_cast()
-			return
-
-		if(I.obj_integrity < I.max_integrity || I.body_parts_covered_dynamic != I.body_parts_covered)
-			int_bonus = (user.STAINT * 0.01)
-			repair_percent += int_bonus
-			repair_percent *= I.max_integrity
-			I.obj_integrity = min(I.obj_integrity + repair_percent, I.max_integrity)
-			user.visible_message(span_info("[I] glows in a faint mending light."))
-			playsound(I, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
-			if(I.obj_integrity >= I.max_integrity)
-				I.obj_integrity = I.max_integrity
-				if(I.obj_broken)
-					I.obj_fix()
-				else
-					I.repair_coverage()
-		else if(I.peel_count)
-			I.peel_count--
-			to_chat(user, span_info("[I]'s shorn layers mend together. ([I.peel_count])."))
-		else
-			to_chat(user, span_info("[I] appears to be in perfect condition."))
-			revert_cast()
-	else
+	if(!istype(targets[1], /obj/item))
 		to_chat(user, span_warning("There is no item here!"))
 		revert_cast()
+		return
+
+	var/obj/item/I = targets[1]
+
+	if(!I.anvilrepair && !I.sewrepair)
+		to_chat(user, span_warning("Not even magic can mend this item!"))
+		revert_cast()
+		return
+	if(I.obj_integrity >= I.max_integrity && I.body_parts_covered_dynamic == I.body_parts_covered)
+		to_chat(user, span_info("[I] appears to be in perfect condition."))
+		revert_cast()
+		return
+
+	int_bonus = (user.STAINT * 0.01)
+	repair_percent += int_bonus
+	repair_percent *= I.max_integrity
+
+	I.obj_integrity = min(I.obj_integrity + repair_percent, I.max_integrity)
+	user.visible_message(span_info("[I] glows in a faint mending light."))
+	playsound(I, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
+
+	if(I.obj_integrity >= I.max_integrity)
+		if(I.obj_broken)
+			I.obj_fix()
+		if(I.body_parts_covered_dynamic != I.body_parts_covered)
+			I.repair_coverage()
+			to_chat(user, span_info("[I]'s shorn layers mend together."))
 
 
 /obj/effect/proc_holder/spell/invoked/mending/lesser


### PR DESCRIPTION
## About The Pull Request

Bugfix. Mending no longer repairs to full for no reason.

Upon repair, if that repair hits maximum integrity, it fixes the object to its unbroken state and resets peel.

## Testing Evidence

Yes.

## Why It's Good For The Game

Fugbix/exploitfix.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
