### PR TITLE
Make shield smash a subtype of mace smash.

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -2,8 +2,8 @@
 #define SHIELD_BLOCK		/datum/intent/shield/block
 #define SHIELD_BASH_METAL 	/datum/intent/shield/bash/metal
 #define SHIELD_BLOCK_METAL 	/datum/intent/shield/block/metal
-#define SHIELD_SMASH 		/datum/intent/shield/smash
-#define SHIELD_SMASH_METAL 	/datum/intent/shield/smash/metal
+#define SHIELD_SMASH 		/datum/intent/mace/smash/shield
+#define SHIELD_SMASH_METAL 	/datum/intent/mace/smash/shield/metal
 #define SHIELD_BANG_COOLDOWN (3 SECONDS)
 
 /obj/item/rogueweapon/shield
@@ -97,17 +97,10 @@
 /datum/intent/shield/block/metal
 	hitsound = list('sound/combat/parry/shield/metalshield (1).ogg')
 
-/datum/intent/shield/smash
-	name = "smash"
-	blade_class = BCLASS_SMASH
-	attack_verb = list("smashes")
-	icon_state = "insmash"
+/datum/intent/mace/smash/shield
 	hitsound = list('sound/combat/shieldbash_wood.ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
-	damfactor = 1.5
-	swingdelay = 10
 
-/datum/intent/shield/smash/metal
+/datum/intent/mace/smash/shield/metal
 	hitsound = list('sound/combat/parry/shield/metalshield (1).ogg')
 
 /obj/item/rogueweapon/shield/wood


### PR DESCRIPTION
## About The Pull Request
Makes shield smash a subtype of mace smash, allowing it to access the new smash feature.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_f1ey580iw9](https://github.com/user-attachments/assets/714a8703-8e39-4086-99b7-b345c1fb9383)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I said so.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
