### PR TITLE
Let peel-stacks decrease step-by-step with mending

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -35,7 +35,7 @@
 		to_chat(user, span_warning("Not even magic can mend this item!"))
 		revert_cast()
 		return
-	if(I.obj_integrity >= I.max_integrity && I.body_parts_covered_dynamic == I.body_parts_covered)
+	if(I.obj_integrity >= I.max_integrity && I.body_parts_covered_dynamic == I.body_parts_covered && !I.peel_count)
 		to_chat(user, span_info("[I] appears to be in perfect condition."))
 		revert_cast()
 		return
@@ -51,9 +51,13 @@
 	if(I.obj_integrity >= I.max_integrity)
 		if(I.obj_broken)
 			I.obj_fix()
-		if(I.body_parts_covered_dynamic != I.body_parts_covered)
-			I.repair_coverage()
-			to_chat(user, span_info("[I]'s shorn layers mend together."))
+		if(I.peel_count)
+			I.peel_count--
+			to_chat(user, span_info("[I]'s shorn layers mend together. ([I.peel_count])."))
+		else
+			if(I.body_parts_covered_dynamic != I.body_parts_covered)
+				I.repair_coverage()
+				to_chat(user, span_info("[I]'s shorn layers mend together, completely."))
 
 
 /obj/effect/proc_holder/spell/invoked/mending/lesser


### PR DESCRIPTION
## About The Pull Request

Mending no longer full-fixes your armour coverage. It now decreases it per peel-stack

## Testing Evidence

Tested.

## Why It's Good For The Game

Not that easy to fix armour on the go

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
