### PR TITLE
Increase penalty for parrying in armor you're not trained for

### DIFF
--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -1,4 +1,6 @@
 #define STAM_DRAIN_PER_STR_DIFF_HEAVY_BAL -2
+#define MAX_PARRY_CHANCE_NO_ARMOR_TRAINING 40 // Tank their parry
+#define PARRY_STAM_DRAIN_PEN_NO_ARMOR_TRAINING 10 // Extra stam drain for not training armor
 
 /mob/living/proc/attempt_parry(datum/intent/intenty, mob/living/user)
 	var/prob2defend = user.defprob
@@ -128,8 +130,8 @@
 	if(HAS_TRAIT(user, TRAIT_HARDSHELL) && H.client)	//Dwarf-merc specific limitation w/ their armor on in pvp
 		prob2defend = clamp(prob2defend, 5, 70)
 	if(!H?.check_armor_skill())
-		prob2defend = clamp(prob2defend, 5, 75)			//Caps your max parry to 75 if using armor you're not trained in. Bad dexerity.
-		drained = drained + 5							//More stamina usage for not being trained in the armor you're using.
+		prob2defend = clamp(prob2defend, 5, MAX_PARRY_CHANCE_NO_ARMOR_TRAINING)			//Caps your max parry to 40 if using armor you're not trained in. Bad dexerity.
+		drained = drained + PARRY_STAM_DRAIN_PEN_NO_ARMOR_TRAINING						//More stamina usage for not being trained in the armor you're using.
 
 	//Dual Wielding
 	var/defender_dualw
@@ -310,3 +312,6 @@
 			record_round_statistic(STATS_PARRIES)
 		playsound(get_turf(src), pick(parry_sound), 100, FALSE)
 		return TRUE
+
+#undef MAX_PARRY_CHANCE_NO_ARMOR_TRAINING
+#undef PARRY_STAM_DRAIN_PEN_NO_ARMOR_TRAINING


### PR DESCRIPTION
## About The Pull Request
Replacement for https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/4421 once I was reminded that dreamwalker and lich actually exists as crit resist class WITH armor.
- Parrying chance is tanked to 40% instead of 70% when you parry w/o training while in armor you are not trained for (This should hit even infinite stamina class)
- Stamina drain is increased from 5 to 10.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Nae

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Death to powerful gamers

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
