### PR TITLE
Add more skin tones for revenant + change ages

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
@@ -13,6 +13,7 @@
 	// Stat balancing. Per-server decision. Preferably keep neutral until analysis post testmerges.
 	//race_bonus = list(STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 1)
 	skin_tone_wording = "Catalyst"
+	max_age = "???"
 
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY,MUTCOLORS)
 	default_features = MANDATORY_FEATURE_LIST
@@ -163,6 +164,29 @@
 
 /datum/species/dullahan/get_skin_list()
 	return list(
+		"Timber-Gronn" = SKIN_COLOR_TIMBER_GRONN,
+		"Giza-Azure" = SKIN_COLOR_GIZA_AZURE,
+		"Walnut-Stine" = SKIN_COLOR_WALNUT_STINE,
+		"Etrustcan-Dandelion" = SKIN_COLOR_ETRUSTCAN_DANDELION,
+		"Naledi-Born" = SKIN_COLOR_NALEDI_BORN,
+		"Naledi-Southerner" = SKIN_COLOR_NALEDI_LIGHT,
+		"Kaze-Lotus" = SKIN_COLOR_KAZE_LOTUS,
+		"Grenzel-Azuria" = SKIN_COLOR_GRENZEL_WOODS,
+		"Etrusca-Lirvas" = SKIN_COLOR_ETRUSCA_LIRVAS,
+		"Free Roamers" = SKIN_COLOR_FREE_FOLK,
+		"Aavnic"	= SKIN_COLOR_AVAR_BORNE,
+		"Shalvine Roamer" = SKIN_COLOR_SHALVINE_AZURE,
+		"Lalve-Steppes" = SKIN_COLOR_LALVE_NALEDI,
+		"Naledi-Otava" = SKIN_COLOR_NALEDI_OTAVA,
+		"Grezel-Aavnic" = SKIN_COLOR_GRENZEL_AVAR,
+		"Hammer-Gronn" = SKIN_COLOR_HAMMER_GRONN,
+		"Commorah" = SKIN_COLOR_COMMORAH,
+		"Gloomhaven" = SKIN_COLOR_GLOOMHAVEN,
+		"Darkpila" = SKIN_COLOR_DARKPILA,
+		"Sshanntynlan" = SKIN_COLOR_SSHANNTYNLAN,
+		"Llurth Dreir" = SKIN_COLOR_LLURTH_DREIR,
+		"Tafravma" = SKIN_COLOR_TAFRAVMA,
+		"Yuethindrynn" = SKIN_COLOR_YUETHINDRYNN,
 		"Grenzelhoft" = SKIN_COLOR_PALE_GRENZELHOFT,
 		"Hammerhold" = SKIN_COLOR_PALE_HAMMERHOLD,
 		"Ebon" = SKIN_COLOR_PALE_EBON,
@@ -171,14 +195,7 @@
 		"Arlenneth" = SKIN_COLOR_ARLENNETH,
 		"Nessyss" = SKIN_COLOR_NESSYSS,
 		"Helixia" = SKIN_COLOR_HELIXIA,
-		"Nymsea" = SKIN_COLOR_NYMSEA,
-		"Commorah" = SKIN_COLOR_COMMORAH,
-		"Gloomhaven" = SKIN_COLOR_GLOOMHAVEN,
-		"Darkpila" = SKIN_COLOR_DARKPILA,
-		"Sshanntynlan" = SKIN_COLOR_SSHANNTYNLAN,
-		"Llurth Dreir" = SKIN_COLOR_LLURTH_DREIR,
-		"Tafravma" = SKIN_COLOR_TAFRAVMA,
-		"Yuethindrynn" = SKIN_COLOR_YUETHINDRYNN
+		"Nymsea" = SKIN_COLOR_NYMSEA
 	)
 
 /datum/species/dullahan/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -38,6 +38,7 @@
 	They typically trace their beginnings to how their progenator died before being raised."
 */
 	skin_tone_wording = "Origin City-State"
+	max_age = 850
 
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,OLDGREY)
 	allowed_taur_types = list(

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfs.dm
@@ -20,6 +20,7 @@
 	(+1 Speed)"
 
 	skin_tone_wording = "Tribal Identity"
+	max_age = 850
 
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,OLDGREY)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -16,6 +16,7 @@
 	(+1 Stat of their choice, or Lack of Hunger & Thirst)"
 
 	skin_tone_wording = "Craft"
+	max_age = "???"
 
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -18,6 +18,8 @@
 	(+1 Constitution, +1 Perception)" 
 
 	skin_tone_wording = "Identity"
+	max_age = 250
+
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,STUBBLE,OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP)


### PR DESCRIPTION
## About The Pull Request

**Age Changes**
- Revenants / Aasimar max age is now '???'
- Elf/Dark Elf max age is now '850'
- Half Elf max age is now '250'

**Skintone changes**
- Revenants get access to more skin-tones.

## Testing Evidence

Tested.

## Why It's Good For The Game

Likely lore-accurate max-ages? Inform if incorrect. 
More skin tones for Revs.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
