### PR TITLE
Lets Anthrax Assassins choose a second sabre instead of a bow and arrow

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/anthrax.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/anthrax.dm
@@ -63,7 +63,7 @@
 	mask = /obj/item/clothing/mask/rogue/facemask/shadowfacemask
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
 	backr = /obj/item/rogueweapon/shield/tower/spidershield
-	beltr = /obj/item/rogueweapon/whip/spiderwhip
+	beltr = /obj/item/rogueweapon/whip/spiderwhip	
 	beltl = /obj/item/rope/chain
 
 	if(H.mind)
@@ -73,12 +73,13 @@
 			if("I'm a spider rider (your pet with you)")
 				l_hand = /obj/item/bait/spider
 			if("I walk on my legs (+1 for athletics)")
-				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_MASTER, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_MASTER, TRUE)		
 
 	H.merctype = 15
 
 /datum/advclass/mercenary/anthrax/assasin
-	name = "Anthrax Assasin"
+	name = "Anthrax Assassin"
+	tutorial = "Black Venom's infamous killers for hire, it is said a single cut from their poison tipped blades is enough to send their victim to an early grave. You are one of those assassins, use your trusty bow and arrow to bring your targets' demise from afar or take a second sabre and weave a beautiful dance of death. All that matters is that your contract is fulfilled and your pockets heavy with mammon."
 	outfit = /datum/outfit/job/roguetown/mercenary/anthrax/assasin
 	traits_applied = list(TRAIT_DARKVISION, TRAIT_DODGEEXPERT)
 	subclass_stats = list(
@@ -88,8 +89,6 @@
 		STATKEY_SPD = 2,
 	)
 	subclass_skills = list(
-		/datum/skill/combat/bows = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, 
@@ -97,13 +96,11 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/traps = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/bows = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/bows = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
@@ -122,8 +119,22 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 	mask = /obj/item/clothing/mask/rogue/shepherd/shadowmask/delf
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
-	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/short
-	beltr = /obj/item/quiver/poisonarrows
 	beltl = /obj/item/rogueweapon/scabbard/sword
 	r_hand = /obj/item/rogueweapon/sword/sabre/stalker
+
+	if(H.mind)
+		var/weapon = list("Bow and Arrow", "Dual Sabres")
+		var/weaponchoice = input(H, "Choose your WEAPON.", "PICK YOUR INSTRUMENTS.") as anything in weapon
+		switch(weaponchoice)
+			if("Bow and Arrow")
+				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/short
+				beltr = /obj/item/quiver/poisonarrows
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
+			if("Dual Sabres")
+				l_hand = /obj/item/rogueweapon/sword/sabre/stalker
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				backr = null
+				ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC)
+				
+	H.merctype = 15	
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
@@ -21,6 +21,7 @@
 	class_categories = TRUE
 	job_subclasses = list(
 		/datum/advclass/mercenary/anthrax,
+		/datum/advclass/mercenary/anthrax/assasin,
 		/datum/advclass/mercenary/atgervi,
 		/datum/advclass/mercenary/atgervi/shaman,
 		/datum/advclass/mercenary/condottiero,


### PR DESCRIPTION
## About The Pull Request

Anthrax Assassins now get the choice between a second stalker sabre or the bow and arrow they currently spawn with. They loose their expert skill in bows by default, but choosing the bow option will bump it back up.
Picking the second sabre will give them the dual wielder trait so they can actually make use of it.
Also made it so Anthrax Assassins appear as an option when previewing mercenary classes and gives them an unique description.

## Testing Evidence

<img width="372" height="572" alt="image" src="https://github.com/user-attachments/assets/f273351a-7186-4746-b6a2-c0b210d098c1" />
<img width="453" height="395" alt="image" src="https://github.com/user-attachments/assets/8f215d29-70de-4400-9abd-1ae185ab59be" />
<img width="161" height="264" alt="image" src="https://github.com/user-attachments/assets/ed912767-1f76-4f84-ab70-e813bd38118c" />


## Why It's Good For The Game

Dual wielding is just about drowest thing there is, so it makes sense for the drow subclass to offer it as an option.

