### PR TITLE
Wildshape Trait tweaks & hunger/thirst transfer

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -50,12 +50,10 @@
 			w_BP.add_wound(wound.type)
 			c_BP.remove_wound(wound.type)
 
-	//removing damage from our сurrent body
 	W.adjustBruteLoss(getBruteLoss())
 	W.adjustFireLoss(getFireLoss())
 	W.adjustOxyLoss(getOxyLoss())
 
-	//transfering damage/bleedings/blood volume/thirst/hunger to our new body
 	src.adjustBruteLoss(-src.getBruteLoss())
 	src.adjustFireLoss(-src.getFireLoss())
 	src.adjustOxyLoss(-src.getOxyLoss())
@@ -74,7 +72,7 @@
 	W.base_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB)
 	W.update_a_intents()
 
-	//temporal traits so our body won't die or snore
+	// temporal traits so our body won't die or snore
 	ADD_TRAIT(src, TRAIT_NOSLEEP, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_NOBREATH, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_NOPAIN, TRAIT_SOURCE_WILDSHAPE)
@@ -82,7 +80,7 @@
 	ADD_TRAIT(src, TRAIT_NOHUNGER, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_SOURCE_WILDSHAPE)
 	ADD_TRAIT(src, TRAIT_PACIFISM, TRAIT_SOURCE_WILDSHAPE) // just an extra layer of protection in case something will go wrong
-	src.status_flags |= GODMODE // so they won't die in any means
+	src.status_flags |= GODMODE // so they won't die by any means
 	invisibility = oldinv
 
 	W.gain_inherent_skills()
@@ -125,12 +123,10 @@
 			w_BP.add_wound(wound.type)
 			c_BP.remove_wound(wound.type)
 
-	//removing damage from our body
 	W.adjustBruteLoss(getBruteLoss())
 	W.adjustFireLoss(getFireLoss())
 	W.adjustOxyLoss(getOxyLoss())
 
-	//transfering damage/bleeding/blood/thirst/hunger volume to our new body
 	src.adjustBruteLoss(-src.getBruteLoss())
 	src.adjustFireLoss(-src.getFireLoss())
 	src.adjustOxyLoss(-src.getOxyLoss())


### PR DESCRIPTION
## About The Pull Request

I guess it's the last one for now. Thirst & Hunger transfers between forms and some tweaks to your invisible body for it to not die. Also now these traits got other sources so untransform won't take your generic ones like deathless or fatal insomnia.

During the bugfix process I also found out that druidic death sequence were followed by werefolf's untransform. Why? I've got no clue. But now it's fixed, so now all bruises and shit will be transfered to body after death in wild form.

## Testing Evidence

https://youtu.be/Fets3yDpUZ4

And yeah, godmode works fine, damage transfers correctly and etc.

## Why It's Good For The Game

I mean, it's better not to die than to die. Expecially when your body is laying defendless somewhere, still urging for food, water and oxygen.
