### PR TITLE
Reduces Silver Shovel Bar Cost To 1

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/tools.dm
@@ -352,9 +352,9 @@
 	createditem_num = 3
 
 /datum/anvil_recipe/tools/silver/shovel
-	name = "Shovel, Silver (+1 Silver, +1 Small Log)"
+	name = "Shovel, Silver (+1 Small Log)"
 	req_bar = /obj/item/ingot/silver
-	additional_items = list(/obj/item/ingot/silver, /obj/item/grown/log/tree/small)
+	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/shovel/silver
 
 // --------- GOLD RECIPES-----------


### PR DESCRIPTION
## About The Pull Request

I reduced the cost of the silver shovel from 2 bars of silver, to 1.

## Testing Evidence

<img width="722" height="407" alt="dreamseeker_Xx3ZNHIL6Y" src="https://github.com/user-attachments/assets/61ecc9b5-6ff2-401b-9cce-b3819a593c5d" />
<img width="322" height="306" alt="dreamseeker_VRvN3RRYDY" src="https://github.com/user-attachments/assets/3e8f15d6-9e56-4e82-bbc0-335cee586aeb" />

## Why It's Good For The Game

The silver whip, and other weapons like the quarterstaff, only use one silver bar. The shovel costing two bars when it isn't even a proper weapon is a little silly.
