### PR TITLE
silver standardization (balancejak)

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -429,8 +429,8 @@
 	name = "psydonic war axe"
 	desc = "An ornate battle axe, plated in a ceremonial veneer of silver. The premiere instigator of conflict against elven attachees."
 	icon_state = "psyaxe"
-	force = 20
-	force_wielded = 25
+	force = 25
+	force_wielded = 30
 	minstr = 11
 	wdefense = 6
 	blade_dulling = DULLING_SHAFT_METAL
@@ -554,8 +554,8 @@
 	)
 
 /obj/item/rogueweapon/greataxe/psy
-	force = 15
-	force_wielded = 25
+	force = 25
+	force_wielded = 30
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/mace/strike) //When possible, add the longsword's 'alternate grip' mechanic to let people flip this around into a Mace-scaling weapon with swapped damage.
 	gripped_intents = list(/datum/intent/axe/cut/battle/greataxe, /datum/intent/axe/chop/battle/greataxe, /datum/intent/mace/rangedthrust, /datum/intent/mace/strike) //Axe-equivalent to the Godendag or Grand Mace.
 	name = "psydonic poleaxe"

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -159,8 +159,8 @@
 	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/rogueweapon/mace/steel/silver
-	force = 30
-	force_wielded = 35
+	force = 20
+	force_wielded = 27
 	name = "silver mace"
 	desc = "A heavy flanged mace, forged from pure silver. For a lord, it's the perfect symbol of authority; a decorative piece for the courts. For a paladin, however, there's no better implement for shattering avantyne-maille into a putrid pile of debris."
 	icon_state = "silvermace"
@@ -243,8 +243,8 @@
 /obj/item/rogueweapon/mace/cudgel/psy
 	name = "psydonic handmace"
 	desc = "A shorter variant of the flanged silver mace, rebalanced for one-handed usage. It isn't uncommon for these sidearms to mysteriously 'vanish' from an Adjudicator's belt, only to be 'rediscovered' - and subsequently kept - by a Confessor."
-	force = 25
-	force_wielded = 30
+	force = 22
+	force_wielded = 25
 	minstr = 9
 	wdefense = 5
 	wbalance = WBALANCE_SWIFT
@@ -480,8 +480,8 @@
 	name = "psydonic mace"
 	desc = "An ornate mace, plated in a ceremonial veneer of silver. Even the unholy aren't immune to discombobulation."
 	icon_state = "psymace"
-	force = 30
-	force_wielded = 35
+	force = 15
+	force_wielded = 30
 	minstr = 12
 	wdefense = 6
 	wbalance = WBALANCE_HEAVY
@@ -573,8 +573,8 @@
 	name = "silver warhammer"
 	desc = "A heavy warhammer, forged from pure silver. It follows the Otavan design of a 'lucerene'; a shortened polehammer with a pronounced spike, rebalanced for one-handed usage. Resplendent in presentation, righteous in purpose."
 	icon_state = "silverhammer"
-	force = 30
-	force_wielded = 30
+	force = 20
+	force_wielded = 20
 	minstr = 10
 	wdefense = 5
 	smeltresult = /obj/item/ingot/silver

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -120,13 +120,13 @@
 	minstr = 5
 
 /obj/item/rogueweapon/flail/sflail/silver
-	force = 35
+	force = 25
 	icon_state = "silverflail"
 	name = "silver morningstar"
 	possible_item_intents = list(/datum/intent/flail/strike, /datum/intent/mace/smash/flailrange)
-	desc = "A heavy, silver flail. It follows the Grenzelhoftian design of a 'morning star', utilizing a longer chain to extend its reach. While stronger than a steel flail, it requires far more strength to effectively swing."
+	desc = "A heavy, silver flail. It follows the Grenzelhoftian design of a 'morning star', utilizing a longer chain to extend its reach. While weaker than a steel flail, it'll sunder accursed beings."
 	smeltresult = /obj/item/ingot/silver
-	minstr = 12
+	minstr = 5
 	is_silver = TRUE
 
 /obj/item/rogueweapon/flail/sflail/silver/ComponentInitialize()
@@ -144,7 +144,7 @@
 	name = "swift journey"
 	desc = "The striking head is full of teeth, rattling viciously with ever strike, with every rotation. Each set coming from one the wielder has laid to rest. Carried alongside them as a great show of respect."
 	icon_state = "necraflail"
-	force = 35
+	force = 30
 	is_silver = TRUE
 
 /obj/item/rogueweapon/flail/sflail/necraflail/ComponentInitialize()
@@ -162,8 +162,8 @@
 	name = "psydonic flail"
 	desc = "An ornate flail, plated in a ceremonial veneer of silver. Its flanged head can crumple even the toughest of darksteel-maille."
 	icon_state = "psyflail"
-	force = 35
-	minstr = 10
+	force = 30
+	minstr = 5
 	wdefense = 0
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -389,8 +389,8 @@
 	name = "psydonic spear"
 	desc = "An ornate spear, plated in a ceremonial veneer of silver. The barbs pierce your palm, and - for just a moment - you see red. Never forget that you are why Psydon wept."
 	icon_state = "psyspear"
-	force = 15
-	force_wielded = 25
+	force = 20
+	force_wielded = 30
 	minstr = 11
 	wdefense = 6
 	resistance_flags = FIRE_PROOF	//It's meant to be smacked by a "lamptern", and is special enough to warrant overriding the spear weakness

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -755,8 +755,8 @@
 	desc = "A finely made longsword, plated in a ceremonial veneer of ornate silver - made for felling men and monsters alike. </br>'Psydon will deliver those who were mindful of Him to their place of ultimate triumph. No evil will touch them, nor will they grieve.'"
 	icon_state = "psysword"
 	sheathe_icon = "psysword"
-	force = 20
-	force_wielded = 25
+	force = 25
+	force_wielded = 30
 	minstr = 9
 	wdefense = 6
 	dropshrink = 1
@@ -968,8 +968,8 @@
 	desc = "Otavan smiths worked with Grenzelhoftian artificers, and an esoteric sidearm was born: a shortsword with an unique design, dismissing a crossguard in favor of a hollow beak to hook and draw harm away from its user. Short in length, yet lethally light in weight."
 	icon_state = "psyswordshort"
 	sheathe_icon = "psyswordshort"
-	force = 20
-	force_wielded = 20
+	force = 25
+	force_wielded = 25
 	minstr = 7
 	wdefense = 3
 	wbalance = WBALANCE_SWIFT


### PR DESCRIPTION
## About The Pull Request
This pr standardizes the silver weapons' values to stay consistent across its own tier of weapons. While also giving the inquisition / nercra's flail to be the exception to these rules, to make those silver weapons ignore the downsides of the crafted ones. Seeing as it's sort of their special **thing**

Plus, I wouldn't want these classes to throw away their cool unique weapon for steel. 

TLDR; psydonian sharp weapons went up to steel damage, psydonian blunt weapons went down to steel damage
crafted steel blunt weapons lost some force.
<details>
<summary>details</summary>
Here's how silver works right now
<img width="1040" height="780" alt="silver1" src="https://github.com/user-attachments/assets/4c23aefd-9475-467e-8aa9-bd995abf2961" />


Silver weapons currently are **direct upgrades** for blunt weapons. While being decent sidegrades for sharp weapons
This pr changes it to be more like this
<img width="1040" height="780" alt="silver2" src="https://github.com/user-attachments/assets/89b4f5ed-9a1f-4d16-a24f-b48609641694" />

Detail wise, blunt **silver weapons** go down 5 force, while anything **psydonite** becomes **the same force** as it's standerd steel counterpart. This turns the Psydonite weapons less into superweapons (the cudgel had 35 force, that's higher then the Grand mace!) more into weapons with **better defenses, integ, and the ability to apply sunder with full force of any other weapon**

</details>

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

**WARNING. BALANCEJAKKING PAST THIS POINT**
<details>
<summary>dente. why?</summary>



How silver weapons currently work, anything that is **blunt** has 5 more force, while anything that's **sharp** has 5 less force.

Why is this a problem?

1. This isn't explain to anyone ever, you have to code dive / read the descripton of the silver flail to figure this out. This means, if you were say playing Adjudicator and taking the psydonian greatsword, your weapon was doing 5 less damage than a normal sword. **While if you picked the flail, you were doing 5 more then a standerd flail**. My issue with this, is that it's the same **kind** of weapon. 

For instance, this would be like if **decrepit swords** were better than **steel swords** but **decrepit maces** were worse then **steel maces**

It's confusing for anyone that doesn't code dive, and doesn't really make any sense in terms of a videogame, or a roleplaying game. 

2. Direct upgrades < sidegrades
It's more interesting on a gameplay level to have to make the decison agaisnt a sunder-applying weapon or a raw damage weapon. It's also, way more thematic as the point of silverd weapons is **to kill monsters** throughout.. Most, fiction. I'd say? 

**"steel for humans, silver for monsters."** isn't the case with these weapons. It's always silver.


</details>

somehow this has alot of pushback. I'm going to hit some points I got sent earlyer, sorry if I'm putting words in your mouth, person.

<details>
<summary>but dente!</summary>
"Blunts bad, swords can peel and stab and these weapons need this."
This isn't a problem with silver. This applys to every blunt weapon. **these weapons** specifically being outliars does not **suddenly make blunt good**, if blunt is bad, these weapons having randomly inflated values does **not make blunt good**, go make blunt good

"How come no one complains about this?"
azure peak is pretty bad about finding overpowerd shit, as we usually play pretty safe/in good faith. Other servers nerfed these weapons far more then I am when porting over the silver rework.

"Why does this matter?"
it sets a bad standerd. people can point to this as a reason to buff things arbitrarily. (plus things should just be consistant man)

"but silvers rare like blacksteel weapons"
yeah so the inquistion spawns with these, which is my biggest issue. secondly, dude i've seen the keep mass produce steel weapons it's not arbitrarly limited like blacksteel 

secondly. if silver is designed to be **rare** and **better then steel** the swords and spears and axes **should be better then steel** I want to make it known,** i'm super okay with doing this**, but the lack of consistantcy baffles my brain.

if you want to make a 'super blacksteel flail' that's awesome we can do that. but why should it be silver


'dente did you need to autism hyperfocus on this thing for a day that doesn't even really matter that much balance wise at the current moment?'
no, probably not. but I feel like I have a good point somewhere here.
</details>

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
