### PR TITLE
Removes the ability for AI to get sleepy

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -83,7 +83,8 @@ SUBSYSTEM_DEF(nightshift)
 		if(!cmode)
 			SSdroning.play_area_sound(areal, src.client)
 		SSdroning.play_loop(areal, src.client)
-
+	if(mode != NPC_AI_OFF)
+		return
 	switch(todd)
 		if("day")
 			if(HAS_TRAIT(src, TRAIT_VAMP_DREAMS))


### PR DESCRIPTION
## About The Pull Request

Removes the ability for mobs that are AI controlled to get sleepy.

## Testing Evidence

Tested downstream

## Why It's Good For The Game

Was debugging subsystems on downstream live server when came across this:

<img width="626" height="1053" alt="image" src="https://github.com/user-attachments/assets/5446797f-2f10-4997-bb48-d84f610affa1" />

That's 1285 lines of sleepy debuffs milord, or 71% of the fast processing subsystem. This is probably why the RNG dungeon makes the server lag, even though the AI itself is disabled.