### PR TITLE
Gives Arbalist a Psydonic Cuirass instead of a generic Lightweight Brigandine

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -65,9 +65,9 @@
 				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/confessor
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/inq
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
-			if("Arbalist - Crossbow, Lightweight Brigandine")
+			if("Arbalist - Crossbow, Psydonic Chestplate")
 				head = /obj/item/clothing/head/roguetown/headband/bloodied
-				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/half/fencer/psydon
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 				REMOVE_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 5, TRUE)


### PR DESCRIPTION
## About The Pull Request

Title.

## Testing Evidence

Uhhhh, it's a path change. 

## Why It's Good For The Game

It's technically-technically worse armor because it only has half durability compared to the lightweight brigandine - but it actually stops stabs and is actually marked as an inquisitorial item so identifying arbalist confessors is easier. It's not a massive difference.