### PR TITLE
Buffs Sergeant, MaA spawn bank account

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -19,7 +19,7 @@
 	outfit = /datum/outfit/job/roguetown/manorguard
 	advclass_cat_rolls = list(CTAG_MENATARMS = 20)
 
-	give_bank_account = 22
+	give_bank_account = 120
 	min_pq = 3
 	max_pq = null
 	round_contrib_points = 2

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -18,7 +18,7 @@
 	outfit = /datum/outfit/job/roguetown/sergeant
 	advclass_cat_rolls = list(CTAG_SERGEANT = 20)
 
-	give_bank_account = 50
+	give_bank_account = 200
 	min_pq = 6
 	max_pq = null
 	cmode_music = 'sound/music/combat_ManAtArms.ogg'


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Cranks sergeant bank account and man-at-arms bank account up.
Sergeant: 50->200
MaA: 22->120

This represents them being "paid" already, "on spawn in", with a sum that in my experience is moderately generous towards letting the MaA focus on his task of being a guard - instead of hustling for funds, and not participating in the guard facade.

N.B. this does not increase the amount of money in the treasury on spawn, so that aspect of the economy is still a potential bottleneck.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="625" height="474" alt="image" src="https://github.com/user-attachments/assets/d508901f-ec6d-400b-ad93-88ef6c17ffc2" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

There is a strong disincentive for garrison role join on rounds of low steward, low keep, et cetera, for many different reasons. And no payment is one of them. I have seen garrison members create farms, or argue against economic adjustments like cloth to stockpile or lumberjacking, generally creating this idea of a "grind" for funds at the beginning of their round so that they can afford agency in the role: these problems emergent from not getting paid, apparently.

This is a naive solution of just cranking up MaA / Sergeant mammon on spawn, with the goal of: 1) lessening the urge to round-start money grind, and 2) lessening the disincentive of joining as garrison during an "inaccessible stewardry" round. I'll be the first to admit that this is the naive solution, and that these other problems have many other variables to them, and should be followed up in their own right in time. But for now, I think this would be a good band-aid.

In my opinion, only these roles (Sergeant, MAA) stand to benefit from such a paradigm shift. Squires and Knights have their own draws, and the Keep roles have their own agency in pursuing their "share of the pie". The pang is in the rank-and-file, the humble professional guardsman who has no such ambitions. This represents them having a good "nest egg" of credit built up in the city, and hopefully eases that problem of "no incentive" on sparser rounds.

As for Wardens: I dunno. Wardens are an enigma to me.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
