### PR TITLE
Radial Campfires

### DIFF
--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -770,6 +770,7 @@
 	cookonme = TRUE
 	max_integrity = 30
 	soundloop = /datum/looping_sound/fireloop
+	var/healing_range = 2
 
 /obj/machinery/light/rogue/campfire/process()
 	..()
@@ -777,6 +778,20 @@
 		var/turf/open/O = loc
 		if(IS_WET_OPEN_TURF(O))
 			extinguish()
+
+	var/list/hearers_in_range = SSspatial_grid.orthogonal_range_search(src, SPATIAL_GRID_CONTENTS_TYPE_HEARING, healing_range)
+	for(var/mob/living/carbon/human/human in hearers_in_range)
+		var/distance = get_dist(src, human)
+		if(distance > healing_range)
+			continue
+		if(!human.has_status_effect(/datum/status_effect/buff/healing/campfire))
+			to_chat(human, "The warmth of the fire comforts me, affording me a short rest.")
+		// Astrata followers get enhanced fire healing
+		var/buff_strength = 1
+		if(human.patron?.type == /datum/patron/divine/astrata || human.patron?.type == /datum/patron/inhumen/matthios) //Fire and the fire-stealer
+			buff_strength = 2
+		human.apply_status_effect(/datum/status_effect/buff/healing/campfire, buff_strength)
+		human.add_stress(/datum/stressevent/campfire)
 
 /obj/machinery/light/rogue/campfire/onkick(mob/user)
 	if(isliving(user) && on)
@@ -793,18 +808,6 @@
 		var/mob/living/carbon/human/H = user
 		if(ishuman(H))
 			H.visible_message("<span class='info'>[H] warms [user.p_their()] hand near the fire.</span>")
-			var/first_go = TRUE
-			while(do_after(H, 105, target = src) && on)
-				// Astrata followers get enhanced fire healing
-				var/buff_strength = 1
-				if(H.patron?.type == /datum/patron/divine/astrata || H.patron?.type == /datum/patron/inhumen/matthios) //Fire and the fire-stealer
-					buff_strength = 2
-				H.apply_status_effect(/datum/status_effect/buff/healing/campfire, buff_strength)
-				H.add_stress(/datum/stressevent/campfire)
-				if(first_go)
-					to_chat(H, span_good("The warmth of the fire comforts me, affording me a short rest."))
-					first_go = FALSE
-		return TRUE //fires that are on always have this interaction with lmb unless its a torch
 
 /obj/machinery/light/rogue/campfire/densefire
 	icon_state = "densefire1"
@@ -819,6 +822,7 @@
 	pass_flags = LETPASSTHROW
 	bulb_colour = "#eea96a"
 	max_integrity = 60
+	healing_range = 4
 
 /obj/machinery/light/rogue/campfire/densefire/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSTABLE))


### PR DESCRIPTION
## About The Pull Request

- Campfires now heal in a range. Normal campfires heal when you're within two tiles of it, greater campfires heal within four tiles.

## Testing Evidence

Two tile range limit:
<img width="507" height="405" alt="image" src="https://github.com/user-attachments/assets/e8b422bf-f4eb-416a-8484-41e9e011e380" />

Four tile range limit:
<img width="334" height="411" alt="image" src="https://github.com/user-attachments/assets/8bda8901-bb52-4761-a5a9-0313d7999ddd" />

Out of range:
<img width="412" height="499" alt="image" src="https://github.com/user-attachments/assets/64bb96e2-a5e6-49a3-b40d-21423dcc1cf1" />

## Why It's Good For The Game

I really like the vibe that campfires give, and resting next to one should feel natural. Being forced to click on it and stay there feels a bit unnatural. Also gives greater campfires a greater purpose.
