### PR TITLE
Lets licker not have CritRes

### DIFF
--- a/code/modules/vampire_neu/vampire.dm
+++ b/code/modules/vampire_neu/vampire.dm
@@ -149,6 +149,9 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	owner.current.set_bloodpool(owner.current.maxbloodpool / 100 * INITIAL_BLOODPOOL_PERCENTAGE)
 	add_antag_hud(antag_hud_type, antag_hud_name, owner.current)
 
+	if(HAS_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE))
+		REMOVE_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
+
 /datum/antagonist/vampire/on_removal()
 	remove_antag_hud(antag_hud_type, owner.current)
 	if(ishuman(owner.current))


### PR DESCRIPTION
## About The Pull Request

Fixes the fact that it's pretty easy to abuse Lycker by culling out one of the few ways to kill them (silver, crit, bloodloss).

## Testing Evidence

Tested.

## Why It's Good For The Game

No powergaming

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
