### PR TITLE
Bringback kicks to break grabs

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/kick.dm
+++ b/code/game/objects/items/rogueweapons/mmb/kick.dm
@@ -70,8 +70,6 @@
 		return FALSE
 	if(A == src)
 		return FALSE
-	if(isliving(A) && pulledby)
-		return FALSE
 	if(IsOffBalanced())
 		if(do_message)
 			to_chat(src, span_warning("I haven't regained my balance yet."))


### PR DESCRIPTION
## About The Pull Request

So apparently the dullahan PR *also* disabled kicks when grabbed. Which means it was impossible to escape grabs like that.

Readded it again. Pleeease check your ports.

## Testing Evidence

Tested.

## Why It's Good For The Game

Intended feature.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
