### PR TITLE
Blade Burst Fix

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_aoe/blade_burst.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/blade_burst.dm
@@ -71,7 +71,6 @@
 			if(L.anti_magic_check())
 				visible_message(span_warning("The blades dispel when they near [L]!"))
 				playsound(get_turf(L), 'sound/magic/magic_nulled.ogg', 100)
-				qdel(src)
 				continue
 			play_cleave = TRUE
 			L.adjustBruteLoss(damage)


### PR DESCRIPTION
## About The Pull Request

The Blade Burst spell disappeared from the spell list when used on a mimic. I fixed it.

## Testing Evidence

It's working...

## Why It's Good For The Game

Now the spell doesn't get destroyed if you use it on a mimic. It also doesn't deal damage, which is what it should do.
