### PR TITLE
Actually kills the KC's glaive option

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -124,7 +124,6 @@
 	if(H.mind)
 		var/weapons = list(
 			"Edict & Aegis (Sabre & Buckler)",
-			"Deliverance (Glaive)",
 			"Claymore",
 			"Great Mace",
 			"Battle Axe",


### PR DESCRIPTION
## About The Pull Request

3 reach high AP option that goes through plate. Very overpowered. Literally inculcates bad KC habits.

The only other weapon with 3 reach is whips (blunt) and lance (blunt with high CD). The glaive's very very strong and only usable by noobs, frankly.

## Testing Evidence

Yep.

## Why It's Good For The Game

So people stop selecting it.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
