### PR TITLE
Awe and Transfix now target willpower and not INT.

### DIFF
--- a/code/modules/vampire_neu/covens/coven_powers/presence.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/presence.dm
@@ -23,12 +23,13 @@
 	multi_activate = TRUE
 	cooldown_length = 60 SECONDS
 
-/datum/coven_power/presence/awe/pre_activation_checks(mob/living/target)
-	var/mypower = owner.STAINT
-	var/mob/living/carbon/human/H = target
-	var/theirpower = H.STAINT - 5
-	if((theirpower >= mypower))
-		to_chat(owner, span_warning("[target]'s mind is too powerful to sway!"))
+/datum/coven_power/presence/awe/pre_activation_checks(mob/living/carbon/human/target)
+	var/bloodskill = owner.get_skill_level(/datum/skill/magic/blood)
+	var/willpower = target.STAWIL-10
+	for(var/obj/item/clothing/neck/roguetown/psicross/silver/I in target.contents)
+		willpower += 2
+	if((willpower >= bloodskill))
+		to_chat(owner, span_warning("[target]'s will is too powerful to sway!"))
 		return FALSE
 
 	return TRUE

--- a/code/modules/vampire_neu/spells/transfix_neu.dm
+++ b/code/modules/vampire_neu/spells/transfix_neu.dm
@@ -11,8 +11,8 @@
 
 	/// Ignore crosses and give a different message
 	var/powerful = FALSE
-	/// Willpower divisor from INT
-	var/int_divisor = 3.3
+	/// Willpower divisor from WIL
+	var/wil_divisor = 3.3
 	/// Faces of blood die
 	var/blood_dice = 9
 	/// Faces of will die
@@ -63,7 +63,7 @@
 	for(var/mob/living/carbon/human/target as anything in targets)
 		if(target.cmode)
 			will_dice++
-		var/willpower = round(target.STAINT / int_divisor, 1)
+		var/willpower = round(target.STAWIL / wil_divisor, 1)
 		var/willroll = roll(willpower, will_dice)
 
 		// If the vampire failed badly
@@ -74,7 +74,7 @@
 				var/extra = "!"
 				if(knowledgable)
 					extra = ", I sense the caster was [user]!"
-				to_chat(target, "<font color='white'>The silver psycross shines and protect me from unholy magic[extra]</font>")
+				to_chat(target, "<font color='white'>The silver psycross shines and protects me from unholy magic[extra]</font>")
 				to_chat(user, span_userdanger("[target] has my BANE! It causes me to fail to ensnare their mind!"))
 				break
 


### PR DESCRIPTION
## About The Pull Request
Awe and Transfix now operate off of Blood Magic skill vs WIL as the comparison of stats.

Example:
Lickers start with 4 levels in blood magic skill. This means if they target someone with 12 WIL with Awe it'll be a comparison of 4 vs. 2. However, if they have a silver psycross on the target gets a +2 boost to their willpower for this comparison, meaning they would win the interaction. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
IDK it was too laggy on my test server to test. it's borderline line edits though. i had like 300+% tidi and IDK why.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
 Awe is genuinely vile to fight against in PVP as it stunlocks you for 3 seconds against vampires, but this levels the playing field.

Also, all the language for the target in Transfix is 'willpower' and not INT so this is just more consistent.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
