### PR TITLE
Conjure Weapon only spawns iron weapons

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
@@ -1,7 +1,7 @@
 /obj/effect/proc_holder/spell/invoked/conjure_weapon
 	name = "Conjure Weapon"
 	desc = "Conjure a weapon of your choice in your hand. The weapon will be unsummoned should you conjure a new one or unbind the spell.\n\
-	At 12 int or above, conjure steel-tier weapons, otherwise conjure iron-tier weapons. Melee weapons only."
+	Melee weapons only."
 	overlay_state = "conjure_weapon"
 	sound = list('sound/magic/whiteflame.ogg')
 
@@ -26,39 +26,19 @@
 
 	var/obj/item/rogueweapon/conjured_weapon = null
 
-	var/list/iron_weapons = list(
-		"Iron Short Sword" = /obj/item/rogueweapon/sword/short/iron,
-		"Iron Messer" = /obj/item/rogueweapon/sword/short/messer/iron,
-		"Claymore" = /obj/item/rogueweapon/greatsword/zwei,
+	var/list/weapons = list(
+		"Short Sword" = /obj/item/rogueweapon/sword/short/iron,
+		"Hunting Sword" = /obj/item/rogueweapon/sword/short/messer/iron,
+		"Arming Sword" = /obj/item/rogueweapon/sword/iron,
 		"Cudgel" = /obj/item/rogueweapon/mace/cudgel,
-		"Iron Warhammer" = /obj/item/rogueweapon/mace/warhammer,
-		"Iron Dagger" = /obj/item/rogueweapon/huntingknife/idagger,
-		"Iron Axe" = /obj/item/rogueweapon/stoneaxe/woodcut,
-		"Iron Greataxe" = /obj/item/rogueweapon/greataxe,
-		"Iron Flail" = /obj/item/rogueweapon/flail,
-		"Iron Spear" = /obj/item/rogueweapon/spear,
-		"Whip" = /obj/item/rogueweapon/whip,
-	)
-	// There's no way I am putting Lucerne in iron tier I am gonna misclassify it as steel on purpose
-
-	// Trying to keep the list manageable so 1 / 2 iconic thing from each family is fine
-	var/list/steel_weapons = list(
-		"Steel Sabre" = /obj/item/rogueweapon/sword/sabre,
-		"Steel Rapier" = /obj/item/rogueweapon/sword/rapier,
-		"Longsword" = /obj/item/rogueweapon/sword/long,
-		"Zweihander" = /obj/item/rogueweapon/greatsword/grenz,
-		"Battle Axe" = /obj/item/rogueweapon/stoneaxe/battle,
-		"Steel Dagger" = /obj/item/rogueweapon/huntingknife/idagger/steel,
-		"Halberd" = /obj/item/rogueweapon/halberd,
-		"Steel Warhammer" = /obj/item/rogueweapon/mace/warhammer/steel,
-		"Steel Flail" = /obj/item/rogueweapon/flail/sflail,
+		"Warhammer" = /obj/item/rogueweapon/mace/warhammer,
+		"Dagger" = /obj/item/rogueweapon/huntingknife/idagger,
+		"Axe" = /obj/item/rogueweapon/stoneaxe/woodcut,
+		"Flail" = /obj/item/rogueweapon/flail,
 		"Whip" = /obj/item/rogueweapon/whip,
 	)
 
 /obj/effect/proc_holder/spell/invoked/conjure_weapon/cast(list/targets, mob/living/user = usr)
-	var/list/weapons = iron_weapons
-	if(user.STAINT >= 12)
-		weapons = steel_weapons
 	var/weapon_choice = input(user, "Choose a weapon", "Conjure Weapon") as anything in weapons
 	if(!weapon_choice)
 		return


### PR DESCRIPTION
## About The Pull Request

The Conjure Weapon spell only spawns iron weapons, and does not spawn greatweapons of any kind. INT does not factor into what weapons you can spawn anymore.

## Testing Evidence

<img width="445" height="350" alt="image" src="https://github.com/user-attachments/assets/424ec02b-f843-466b-9d4c-93501128c39a" />
<img width="207" height="143" alt="image" src="https://github.com/user-attachments/assets/a34f5a97-0b4b-40cb-ac37-9a7423ff93bd" />
<img width="452" height="243" alt="image" src="https://github.com/user-attachments/assets/072f9da6-ddd3-4b14-9ee2-24c923f50f02" />


## Why It's Good For The Game

Conversation with folks about "The Problems with Mages". Mages can largely ignore the economy by equipping themselves with steel longswords/halberds/zweihanders.

Instead of removing the spell outright, it now only spawns iron weapons. Mages can still use spells like force enchantment to turn their conjured iron arming sword into something as strong as a steel longsword though.
