### PR TITLE
Small battlemaster buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -18,6 +18,7 @@
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/axes = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/shields = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

Adventure -> Warrior -> Battlemaster got it knife fighting skill up to apprentice.

## Testing Evidence

It's not like these changes may not work.

## Why It's Good For The Game

Experienced warrior can finally use the weapon that’s basically been their backup the whole time. No more weird situation where they can handle a bunch of weapons but not the one they should’ve been using the most. I mean, the Battlemaster literally starts with a hunting knife and still has no clue how to use it.
