### PR TITLE
Actors list runtime fix

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1619,7 +1619,7 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 	for(var/mob_id in GLOB.actors_list)
 		var/list/actor_data = GLOB.actors_list[mob_id]
 		if(!sorted_ckey_to_actor_data[mob_id])
-			sorted_ckey_to_actor_data[mob_id] = list("data" = actor_data["data"], "category" = "Nobodies")
+			sorted_ckey_to_actor_data[mob_id] = list("data" = actor_data, "category" = "Nobodies")
 
 	return sorted_ckey_to_actor_data
 


### PR DESCRIPTION
## About The Pull Request

If the user had rank = "Migrant" (or any other, but most often it is "Migrant") in GLOB.actors_list, then this violated everything, and the manifest stopped opening, causing a runtime crash. I fixed it.

## Testing Evidence

<img width="349" height="401" alt="image" src="https://github.com/user-attachments/assets/cc13c714-b248-4604-885e-04f29427e6ab" />

## Why It's Good For The Game

A manifest that opens is better than a manifest that doesn't work.