### PR TITLE
Training Dummy Punching

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -974,19 +974,19 @@
 	icon = 'icons/roguetown/misc/structure.dmi'
 
 /obj/structure/fluff/statue/tdummy/attack_hand(mob/user)
-	if(!user.cmode || !user.mind || !isliving(user))
+	if(user.cmode || !user.mind || !isliving(user))
 		return ..()
 	practice(user, /datum/skill/combat/unarmed, ATTACK_EFFECT_PUNCH)
 
 /obj/structure/fluff/statue/tdummy/attackby(obj/item/attacking_weapon, mob/user, params)
-	if(!user.cmode || !attacking_weapon.associated_skill || !user.mind || !isliving(user))
+	if(user.cmode || !attacking_weapon.associated_skill || !user.mind || !isliving(user))
 		return ..()
 	if(attacking_weapon.max_blade_int)
 		attacking_weapon.remove_bintegrity(5)
-	if(istype(attacking_weapon.associated_skill, /datum/skill/combat))
-		practice(user, attacking_weapon.associated_skill, user.used_intent.animname)
-	else
+	if(!ispath(attacking_weapon.associated_skill, /datum/skill/combat))
 		to_chat(user, span_warning("I don't think this weapon's skill cannot be practiced on a dummy..."))
+		return
+	practice(user, attacking_weapon.associated_skill, user.used_intent.animname)
 
 /obj/structure/fluff/statue/tdummy/proc/practice(var/mob/living/living_mob, var/associated_skill, var/attack_animation)
 	living_mob.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
## About The Pull Request

- You can now punch a training dummy to practice your unarmed skill (up to apprentice).
- Non-combat skills can no longer be trained on a training dummy.

## Testing Evidence

:0

## Why It's Good For The Game

It's neat!
