### PR TITLE
Re-enter Corpse Ghosting

### DIFF
--- a/code/modules/client/verbs/ghost.dm
+++ b/code/modules/client/verbs/ghost.dm
@@ -50,12 +50,14 @@ GLOBAL_LIST_INIT(ghost_verbs, list(
 	set name = "Leave Your Body"
 
 	if(mob.stat == DEAD && isliving(mob))
-		mob.make_me_an_observer(TRUE)
+		message_admins("[key_name_admin(usr)] is ghosting from their dead body.")
+		mob.ghostize(TRUE, ignore_zombie = TRUE)
 
 /client/proc/reenter_corpse()
 	set category = "Spirit"
 	set name = "Reenter Corpse"
 	if(isobserver(mob))
+		message_admins("[key_name_admin(usr)] has re-entered their dead body.")
 		var/mob/dead/observer/O = mob
 		O.reenter_corpse()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -348,7 +348,7 @@ Transfer_mind is there to check if mob is being deleted/not going to have a body
 Works together with spawning an observer, noted above.
 */
 
-/mob/proc/ghostize(can_reenter_corpse = 1, force_respawn = FALSE, admin = FALSE, drawskip)
+/mob/proc/ghostize(can_reenter_corpse = 1, force_respawn = FALSE, admin = FALSE, drawskip, ignore_zombie = FALSE)
 	if(!key)
 		return
 	stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now
@@ -374,8 +374,8 @@ Works together with spawning an observer, noted above.
 	ghost.key = key
 	return ghost
 
-/mob/living/carbon/human/ghostize(can_reenter_corpse = 1, force_respawn = FALSE, admin = FALSE, drawskip = FALSE)
-	if(mind)
+/mob/living/carbon/human/ghostize(can_reenter_corpse = 1, force_respawn = FALSE, admin = FALSE, drawskip = FALSE, ignore_zombie = FALSE)
+	if(mind && !ignore_zombie)
 		if(mind.has_antag_datum(/datum/antagonist/zombie))
 			if(force_respawn)
 				mind.remove_antag_datum(/datum/antagonist/zombie)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -3,6 +3,8 @@
 	..()
 	if(client)
 		client.update_ooc_verb_visibility()
+		if(stat == DEAD)
+			client.verbs.Add(GLOB.ghost_verbs)
 	//Mind updates
 	sync_mind()
 	mind.show_memory(src, 0)
@@ -27,7 +29,7 @@
 
 	if(ranged_ability)
 		ranged_ability.deactivate()
-	
+
 	set_ssd_indicator(FALSE)
 
 /mob/living/proc/login_fade()


### PR DESCRIPTION
## About The Pull Request

- You can now re-enter your body after using the 'Leave Your Body' option.
- Leaving and Re-entering your body now shows admin-logs. Don't abuse this!

## Testing Evidence

:D

## Why It's Good For The Game

I think it's nice to be able to look around and see if anyone's going to save you before you log off and go play Half Sword.
