### PR TITLE
Fixing flips after grabs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -618,8 +618,6 @@
 	if(pulling)
 		if(ismob(pulling))
 			var/mob/living/M = pulling
-			if(pulledby && pulledby == pulling)
-				reset_offsets("pulledby")
 			M.reset_offsets("pulledby")
 			reset_pull_offsets(pulling)
 			if(HAS_TRAIT(M, TRAIT_GARROTED))


### PR DESCRIPTION
## About The Pull Request

If two people grab each other and one of them puts the other on the ground, then one of them turned over. This fixes it. 
This was fixed by Surikat2k, one of the coders from our Twilight Axis server.

## Testing Evidence

It's working...

## Why It's Good For The Game

Finally, there won't be hundreds of tickets asking for "FLIP MY CHARACTER, PLEASE, ADMINS!!!"
