### PR TITLE
Adjusts armour text colour on inspect

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -558,6 +558,6 @@ BLIND     // can't see anything
 				str += " | "
 		str += "</font>"
 
-	//This makes it appear a faint off-blue from the rest of examine text. Draws the cursor to it like to a Wetsquires.rt link.
+	//This makes it appear darker than the rest of examine text. Draws the cursor to it like to a Wetsquires.rt link.
 	examine_text = "<font color = '#808080'>[examine_text]</font>"
 	return SPAN_TOOLTIP_DANGEROUS_HTML(str, examine_text)


### PR DESCRIPTION
## About The Pull Request

This slightly adjusts the off-blue colour of armour on inspect as implemented in https://github.com/Azure-Peak/Azure-Peak/pull/4523, as I found it very difficult to differentiate the very subtle shade from the bulk of the text as a colourblind (deuteranopia) player. 

## Testing Evidence

Old shade:
<img width="400" height="64" alt="image" src="https://github.com/user-attachments/assets/404c7e0d-ec49-4c56-92a6-ff4639ff7d2e" />
New shade:
<img width="218" height="59" alt="image" src="https://github.com/user-attachments/assets/dc02a08d-8597-457c-89af-8a819fa4d4fa" />

## Why It's Good For The Game

Colourblind accessibility is good!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
