### PR TITLE
Removed door repair after kick

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -66,7 +66,7 @@
 /obj/structure/mineral_door/onkick(mob/user)
 	if(isSwitchingStates)
 		return
-	if(brokenstate == 1)
+	if(brokenstate)
 		return
 	if(door_opened)
 		playsound(src, 'sound/combat/hits/onwood/woodimpact (1).ogg', 100)


### PR DESCRIPTION
## About The Pull Request

Now our doors can be fixed in a very funny way. You take a completely broken door and hit it twice, and it gets fixed. This bug has been around for over a year... I just made it so that the kicks don't work on the broken door.

## Testing Evidence

It's working...

## Why It's Good For The Game

Crazy Diamond from Jo Jo will no longer fix your doors.
