### PR TITLE
Stemming QoL

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -96,16 +96,22 @@
 		I = r_grab
 	else
 		I = l_grab
+
+	var/bleed_message = ""
 	if(I)
 		used_limb = parse_zone(I.sublimb_grabbed)
+		if(I.limb_grabbed.get_bleed_rate())
+			bleed_message = ", thereby stemming some bleeding"
 
 	if(used_limb)
-		target.visible_message(span_danger("[src] grabs [target]'s [span_userdanger(used_limb)]."), \
-						span_danger("[src] grabs my [span_userdanger(used_limb)]!"), span_hear("I hear shuffling."), null, src)
-		to_chat(src, span_danger("I grab [target]'s [span_userdanger(used_limb)]."))
+		target.visible_message(span_danger("[src] grabs [target]'s [span_userdanger(used_limb)][bleed_message]."),
+			span_danger("[src] grabs my [span_userdanger(used_limb)][bleed_message]!"),
+			span_hear("I hear shuffling."), null, src)
+		to_chat(src, span_danger("I grab [target]'s [span_userdanger(used_limb)][bleed_message]."))
 	else
-		target.visible_message(span_danger("[src] grabs [target]."), \
-						span_userdanger("[src] grabs me!"), span_hear("I hear shuffling."), null, src)
+		target.visible_message(span_danger("[src] grabs [target]."),
+			span_userdanger("[src] grabs me!"),
+			span_hear("I hear shuffling."), null, src)
 		to_chat(src, span_danger("I grab [target]."))
 
 	if(used_limb && target.client && target.hud_used && target.hud_used.zone_select)
@@ -119,19 +125,25 @@
 		I = user.r_grab
 	else
 		I = user.l_grab
+
+	var/bleed_message = ""
 	if(I)
 		used_limb = parse_zone(I.sublimb_grabbed)
+		if(I.limb_grabbed.get_bleed_rate())
+			bleed_message = ", thereby stemming more bleeding"
 
-	if(HAS_TRAIT(user, TRAIT_NOTIGHTGRABMESSAGE))	
+	if(HAS_TRAIT(user, TRAIT_NOTIGHTGRABMESSAGE))
 		return
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		visible_message("<span class='danger'>[user] firmly grips [src]'s [used_limb]!</span>",
-						"<span class='danger'>[user] firmly grips my [used_limb]!</span>", "<span class='hear'>I hear aggressive shuffling!</span>", null, user)
-		to_chat(user, "<span class='danger'>I firmly grip [src]'s [used_limb]!</span>")
+		visible_message(span_danger("[user] firmly grips [src]'s [used_limb][bleed_message]!"),
+			span_danger("[user] firmly grips my [used_limb][bleed_message]!"),
+			span_hear("I hear aggressive shuffling!"), null, user)
+		to_chat(user, span_danger("I firmly grip [src]'s [used_limb][bleed_message]!"))
 	else
-		visible_message("<span class='danger'>[user] tightens [user.p_their()] grip on [src]'s [used_limb]!</span>", \
-						"<span class='danger'>[user] tightens [user.p_their()] grip on my [used_limb]!</span>", "<span class='hear'>I hear aggressive shuffling!</span>", null, user)
-		to_chat(user, "<span class='danger'>I tighten my grip on [src]'s [used_limb]!</span>")
+		visible_message(span_danger("[user] tightens [user.p_their()] grip on [src]'s [used_limb][bleed_message]!"),
+			span_danger("[user] tightens [user.p_their()] grip on my [used_limb][bleed_message]!"),
+			span_hear(">I hear aggressive shuffling!"), null, user)
+		to_chat(user, span_danger("I tighten my grip on [src]'s [used_limb][bleed_message]!"))
 
 /mob/living/carbon/proc/precise_attack_check(zone, obj/item/bodypart/affecting) //for striking eyes, throat, etc
 	if(zone && affecting)

--- a/code/modules/surgery/bodyparts/bodypart_examine.dm
+++ b/code/modules/surgery/bodyparts/bodypart_examine.dm
@@ -158,7 +158,7 @@
 					status += span_danger("[medium_brute_msg]")
 				else
 					status += span_warning("[light_brute_msg]")
-		
+
 		if(burn >= DAMAGE_PRECISION)
 			switch(burn/max_damage)
 				if(0.75 to INFINITY)
@@ -169,14 +169,14 @@
 					status += span_danger("[medium_burn_msg]")
 				else
 					status += span_warning("[light_burn_msg]")
-	
+
 	var/bleed_rate = get_bleed_rate()
 	if(bleed_rate)
 		if(bleed_rate > 1) //Totally arbitrary value
 			status += span_bloody("<B>BLEEDING</B>")
 		else
 			status += span_bloody("BLEEDING")
-	
+
 	var/crazy_infection = FALSE
 	var/list/wound_strings = list()
 	for(var/datum/wound/wound as anything in wounds)
@@ -212,6 +212,12 @@
 
 	if(disabled)
 		status += span_deadsay("CRIPPLED")
+
+	// Is this bodypart being stemmed, and if so, by how many grabs? Only show this if we're bleeding on that limb.
+	if(bleed_rate)
+		var/stemmed_number = length(grabbedby)
+		if(stemmed_number) // If the wound is being stemmed by a grab, add that to status.
+			status += span_boldgreen("STEMMED*[stemmed_number]")
 
 	return status
 


### PR DESCRIPTION
## About The Pull Request

This introduces some more player feedback for stemming. You can see by how many hands a bleeding wound is being stemmed by if you check yourself for injuries, and grab messages onto a bleeding limb now include an anecdote that the grab is slowing the bleeding on that limb. 

## Testing Evidence

Inspecting yourself for injuries while being stemmed yields this additional notifier in the limb status. In this case, the bleeding limb is being stemmed by two grabs. You can also see the modified grab messages here.
<img width="470" height="359" alt="image" src="https://github.com/user-attachments/assets/ab311a7f-d05c-445b-a822-7f69481369d8" />

## Why It's Good For The Game

Stemming as a mechanic isn't really broadcast anywhere as is, which is funny considering how big of a deal blood loss is. This gives players better feedback about a life-saving mechanic, and should help avoid any confusion around why someone is grabbing you when the game explains in the relevant message that it's stemming a wound.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
