### PR TITLE
Gives black oak pariah the wretch bounty hook

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/blackoak.dm
@@ -68,4 +68,4 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/conjure_weapon)
-
+	wretch_select_bounty(H)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Black Oak Pariah lacked the wretch bounty hook on spawn rollout, this one-liner slaps it in.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="803" height="420" alt="image" src="https://github.com/user-attachments/assets/b7526e0d-c3cb-44cf-bbfe-4bbb0b6c468c" />


## Why It's Good For The Game
go forth my chud son
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
