### PR TITLE
touches it/its gender clothes spawn to associate from mob/carbon

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -462,10 +462,10 @@
 
 // LETHALSTONE EDIT: Helper functions for pronoun-based clothing selection
 /proc/should_wear_masc_clothes(mob/living/carbon/human/H)
-	return (H.pronouns == HE_HIM || H.pronouns == THEY_THEM || H.pronouns == IT_ITS || H.pronouns == SHE_HER_M)
+	return (H.pronouns == HE_HIM || H.pronouns == THEY_THEM || H.pronouns == SHE_HER_M || (H.pronouns == IT_ITS && H.gender == MALE))
 
 /proc/should_wear_femme_clothes(mob/living/carbon/human/H)
-	return (H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F || H.pronouns == HE_HIM_F)
+	return (H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F || H.pronouns == HE_HIM_F || (H.pronouns == IT_ITS && H.gender == FEMALE))
 // LETHALSTONE EDIT END
 
 /datum/job/proc/get_informed_title(mob/mob)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Touches the should wear masc/femme clothes helpers for loadout validation, in special consideration to it/its pronouns, to reference mob/carbon gender between masculine/feminine.

Basically a caveat to allow for feminine body barbarians using it/its to get the femme loadout.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
it/its with body type feminine
<img width="2200" height="703" alt="image" src="https://github.com/user-attachments/assets/d54c2c61-8228-4181-9595-48e7253f3013" />

it/its with body type masculine
<img width="2511" height="727" alt="image" src="https://github.com/user-attachments/assets/8e15367d-7a54-403e-9f12-6f787124b889" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Feels better than putting an it/its (masc) and it/its (femme) into the pronoun system.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
