### PR TITLE
cleans up chaos storm code, fixes bug

### DIFF
--- a/code/datums/magic_items/mythical_items/mythic.dm
+++ b/code/datums/magic_items/mythical_items/mythic.dm
@@ -1,6 +1,7 @@
 #define INFERNAL_FLAME_COOLDOWN 20 SECONDS
 #define FREEZING_COOLDOWN 20 SECONDS
 #define REWIND_COOLDOWN 20 SECONDS
+#define CHAOS_COOLDOWN 10 SECONDS
 
 //T4 Enchantments
 /datum/magic_item/mythic/infernalflame
@@ -129,9 +130,9 @@
 	var/last_used
 
 /datum/magic_item/mythic/chaos_storm/on_hit(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
-	if(world.time < (src.last_used[source] + (10 SECONDS)))
+	.=..()
+	if(world.time < (src.last_used + CHAOS_COOLDOWN))
 		return
-
 	if(isliving(target))
 		var/mob/living/L = target
 		switch(rand(1,5))
@@ -153,4 +154,4 @@
 			if(5)
 				L.confused += 2 SECONDS
 				to_chat(L, span_warning("Chaotic energy scrambles your thoughts!"))
-	last_used[source] = world.time
+		src.last_used = world.time


### PR DESCRIPTION
## About The Pull Request

i spend my entire round making funny sword only for sword to not sword. this make angry. now my minecraft enchants work

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="551" height="211" alt="image" src="https://github.com/user-attachments/assets/751d2bd0-713c-4166-9cd2-15a472b04954" />

it rolls both storms seperately if you stack them i tested it it just happened to land on the same thing in the screenshot

## Why It's Good For The Game

code working as intended is good
if a mage spends the time to make a hard enchant it should function
