### PR TITLE
Fixes for flipping during grabs(again) and occlusion

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -2,7 +2,6 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 150
 	anchored = TRUE
-	plane = GAME_PLANE_UPPER
 
 /obj/structure/flora/Initialize()
 	. = ..()

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -12,6 +12,7 @@
 	blade_dulling = DULLING_CUT
 	pixel_x = -16
 	layer = 4.81
+	plane = GAME_PLANE_UPPER
 	attacked_sound = 'sound/misc/woodhit.ogg'
 	destroy_sound = 'sound/misc/woodhit.ogg'
 	debris = list(/obj/item/grown/log/tree/stick = 2)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -637,8 +637,6 @@
 				var/obj/item/grabbing/I = get_inactive_held_item()
 				if(I.grabbed == pulling)
 					dropItemToGround(I, silent = FALSE)
-	reset_offsets("pulledby")
-	reset_pull_offsets(src)
 
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request

Another piece of code has been removed that was not working correctly and was flipping character sprites. I also fixed the fact that the characters for third parties were under them when passing through the bushes.

## Testing Evidence

<img width="309" height="306" alt="image" src="https://github.com/user-attachments/assets/4c10e3dc-8796-4bb2-97b4-9d8462dbbc56" />


## Why It's Good For The Game

I hope that now there won't be any flipping of sprites at all and there won't be any problems with layers either.
