### PR TITLE
Awe now applies a status effect, Awestruck, instead of simply making someone walk towards you.

### DIFF
--- a/code/modules/vampire_neu/covens/coven_powers/presence.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/presence.dm
@@ -70,8 +70,8 @@
 	id = "awestruck"
 	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/awestruck
-	var/mob/living/awe_user
-	var/mob/living/awe_target
+	var/mob/living/carbon/human/awe_user
+	var/mob/living/carbon/human/awe_target
 
 /atom/movable/screen/alert/status_effect/awestruck
 	name = "Awestruck"
@@ -84,10 +84,12 @@
 	if(!awe_target.can_see_cone(awe_user))
 		awe_target.playsound_local(awe_target, 'sound/magic/heartbeat.ogg', 100)
 		awe_target.Immobilize(10 SECONDS)
+		awe_target.freakout_hud_skew()
 		awe_target.visible_message("<span class='warning'>[awe_target] goes still for a moment, their movements suddenly halted.</span>", "<span class='warning'>You were just beholding their presence.. Where are they? WHERE ARE THEY!?</span>")
 	if(awe_target.can_see_cone(awe_user) && dist > 4)
 		awe_target.playsound_local(awe_target, 'sound/magic/heartbeat.ogg', 100)
 		awe_target.Immobilize(10 SECONDS)
+		awe_target.freakout_hud_skew()
 		awe_target.visible_message("<span class='warning'>[awe_target] goes still for a moment, their movements suddenly halted.</span>", "<span class='warning'>Their presence.. you need to be closer, to admire it. YOU NEED TO BE CLOSER!!</span>")
 
 	else


### PR DESCRIPTION
## About The Pull Request
This makes it so that Awe doesn't call walk_to() (or whatever the proc actually is) on the target, but instead applies a debuff called Awestruck. It cannot be applied more than once to a single target at a time. 

Awestruck makes it so that you are immobilized for 10 seconds (up to change by maintainer request) if you cannot see the caster in your vision cone prior to the effect ending OR if you can see them but stray farther than 4 tiles away.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
A lot of the text, sound, etc in this clip are WIP and have been changed prior to making this PR. The effect works though.

https://github.com/user-attachments/assets/b895294c-034e-4aab-bcfd-42bb91a49d3c


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This feels a lot more fair, and adds more tactical considerations that go beyond just hijacking someone's movement. For the user, it could be a good ability for crowd control, especially if you fight in a closed space like the forest. 

I tried to nerf Awe in a really stupid way before, but I think this is a better approach. It forces the target to be aggressive, while retaining the Presence CC utility. It's an interesting risk-reward dynamic in my opinion.

All numbers are able to be changed.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
