### PR TITLE
Fixes compliant mode combat middleclick double-fire

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -111,6 +111,9 @@
 		var/mob/living/carbon/human/H = usr
 		H.print_levels(H)
 
+/atom/movable/screen/skills/should_click_on_mouse_up(var/atom/original_object)
+	return FALSE
+
 /atom/movable/screen/craft
 	name = "crafting menu"
 	icon_state = "craft"
@@ -633,6 +636,9 @@
 		else
 			L.toggle_cmode()
 			update_icon()
+
+/atom/movable/screen/cmode/should_click_on_mouse_up(var/atom/original_object)
+	return FALSE
 
 /atom/movable/screen/mov_intent
 	name = "run/walk toggle"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

/atom/proc/should_click_on_mouse_up was firing on middle-click for hud objects that didn't have special middle-mouse interactions, meaning that middle-click for combat mode compliant mode was toggling/untoggling in the same "input". Same with skills, double-showing with middle mouse click. This puts in some stopgap overloads to prevent that from happening.

## Testing Evidence


https://github.com/user-attachments/assets/b84230df-479f-45d5-a54f-f9adaf612956



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

A middle mouse click is a middle mouse click, you can't say it's only half.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
