### PR TITLE
makes invisibility's chat warning actually tied to its duration

### DIFF
--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -77,7 +77,7 @@
 		animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
 		target.mob_timers[MT_INVISIBILITY] = world.time + dur SECONDS
 		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), dur SECONDS)
-		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), 15 SECONDS)
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), dur SECONDS)
 		return TRUE
 	revert_cast()
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
for some reason it was hardcoded at 15 seconds, despite the actual duration being variable based on your relevant caster skill. if you had over 3 (journeyman) skill, this would mean people would get warned of your appearance pre-emptively, which is, you know, bad.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

despite being a one line pr change i tested it anyways and thought it was somehow broken and was really frustrated for an entire hour (!!) until with outside assistance (!!!) i came to the realization that my byond was out of date and so my vsc wasnt actually building my new version properly and so i updated it except i overupdated it because byond is super finnicky and so then that didnt work again and i had to downgrade my byond but not TOO far and then it finally built and the actual fix worked

i think all this experience revealled is that im pretty bad with computers but the bugs fixed now yay. i dont really know what the moral of the story is. dont fix bugs at 6 am? dont be stupid?

anyways the thing isnt really screenshottable and i dont want to open up obs but it works trust
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

spells should do what theyre supposed to do i think 


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
