### PR TITLE
Freifechter Lancer WIL, Navaja fix, Fencing Jacket

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -642,7 +642,7 @@
 	force = 5
 	icon_state = "navaja_c"
 	item_state = "elfdag"
-	var/extended = 0
+	var/extended = FALSE
 	wdefense = 2
 	sellprice = 30 //shiny :o
 
@@ -651,7 +651,9 @@
 	playsound(src.loc, 'sound/blank.ogg', 50, TRUE)
 	if(extended)
 		force = 20
+		force_dynamic = 20
 		wdefense = 6
+		wdefense_dynamic = 6
 		w_class = WEIGHT_CLASS_NORMAL
 		throwforce = 23
 		icon_state = "navaja_o"
@@ -663,12 +665,14 @@
 		inv_storage_delay = initial(inv_storage_delay)
 	else
 		force = 5
+		force_dynamic = 5
 		w_class = WEIGHT_CLASS_SMALL
 		throwforce = 5
 		icon_state = "navaja_c"
 		attack_verb = list("stubbed", "poked")
 		sharpness = IS_BLUNT
 		wdefense = 2
+		wdefense_dynamic = 2
 		equip_delay_self = 0 SECONDS
 		unequip_delay_self = 0 SECONDS
 		inv_storage_delay = 0 SECONDS

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/freifechter.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/freifechter.dm
@@ -28,7 +28,6 @@
 	..()
 	to_chat(H, span_warning("You are a master in the arts of the longsword. Wielder of Psydonia's most versatile and noble weapon, you needn't anything else. You can choose a regional longsword."))
 	l_hand = /obj/item/rogueweapon/scabbard/sword
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fencer	//Experimental.
 	var/weapons = list("Modified Training Sword !!!CHALLENGE!!!", "Etruscan Longsword", "Kriegsmesser", "Field Longsword")
 	if(H.mind)
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
@@ -45,6 +44,15 @@
 			if("Field Longsword")		//A common longsword.
 				r_hand = /obj/item/rogueweapon/sword/long
 				beltr = /obj/item/rogueweapon/huntingknife/idagger
+
+		if(H.mind)
+			var/armors = list(
+				"Fencing Jacket"	= /obj/item/clothing/suit/roguetown/armor/leather/heavy/freifechter,
+				"Fencing Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fencer
+			)
+			var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors
+			armor = armors[armorchoice]
+
 	belt = /obj/item/storage/belt/rogue/leather/sash
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/freifechter
@@ -62,13 +70,11 @@
 	outfit = /datum/outfit/job/roguetown/mercenary/freelancer_lancer
 	subclass_languages = list(/datum/language/aavnic)//Your character could not have possibly "graduated" without atleast some basic knowledge of Aavnic.
 	traits_applied = list(TRAIT_BADTRAINER)
-	//To give you an edge in specialty moves like feints and stop you from being feinted
 	subclass_stats = list(
-		STATKEY_CON = 4,//This is going to need live testing, since I'm not sure they should be getting this much CON without using a statpack to spec. Revision pending.
+		STATKEY_CON = 2,
 		STATKEY_PER = 3,
-		STATKEY_SPD = 1, //We want to encourage backstepping since you no longer get an extra layer of armour. I don't think this will break much of anything.
 		STATKEY_STR = 1,
-		STATKEY_WIL = -2
+		STATKEY_WIL = 2
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_MASTER,	//This is the danger zone. Ultimately, the class won't be picked without this. I took the liberty of adjusting everything around to make this somewhat inoffensive, but we'll see if it sticks.


### PR DESCRIPTION
## About The Pull Request


* Freifechter Lancer now has 2 CON/WIL instead of 4 CON/-2 WIL, no SPE bonus. Wasn't updated after pain resist was moved to WIL instead of CON. Spoke to @Draganfrukts (The class' creator) about what to do with the class to get a second opinion.
* Navaja now updates its force and wdefense when opened. Was stuck as a 5 force knife before.
* Freifechter Fencer gets the option to choose between the cuirass and the fencing jacket. Just flavour stuff. The jacket is objectively worse statwise but looks nicer.

## Testing Evidence
Lancer
<img width="89" height="116" alt="image" src="https://github.com/user-attachments/assets/056c81a4-fa3e-4d12-90e8-78af656ae533" />

<img width="140" height="257" alt="image" src="https://github.com/user-attachments/assets/da05ee41-7587-4eed-985e-1f04d6335041" />

Freifechter armor selection
<img width="444" height="361" alt="image" src="https://github.com/user-attachments/assets/5f75b6c3-7926-4817-91cf-aa5027141161" />

<img width="257" height="455" alt="image" src="https://github.com/user-attachments/assets/c8eccc56-873f-4ea5-968e-07afc89cff18" />

<img width="237" height="447" alt="image" src="https://github.com/user-attachments/assets/853ed898-810b-445a-ad5f-cd5b7647c1c5" />

Navaja fix
<img width="439" height="263" alt="image" src="https://github.com/user-attachments/assets/d4e4dec1-414f-459d-bcba-25e390ca02b1" />

<img width="448" height="267" alt="image" src="https://github.com/user-attachments/assets/a8b39564-1e61-447c-a22c-a2cb3e2b2892" />



## Why It's Good For The Game

Freifechter Lancer has 14 CON but 8 WIL and immediately crumples due to pain upon getting hit. They also lost the steel cuirass they used to have so it's doubly punishing. Now, the class is slightly more usable as "guy with master polearms and nothing else".

Navaja was a bug. Fencing jacket is just extra options for clothing.