### PR TITLE
Caustic Bandage while moving port

### DIFF
--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -289,9 +289,9 @@
 	H.update_damage_overlays()
 
 	if(M == user)
-		user.visible_message(span_notice("[user] bandages [user.p_their()] [affecting]."), span_notice("I bandage my [affecting]."))
+		user.visible_message(span_notice("[user] bandages [user.p_their()] [affecting]."), span_notice("I bandage my [affecting.name]."))
 	else
-		user.visible_message(span_notice("[user] bandages [M]'s [affecting]."), span_notice("I bandage [M]'s [affecting]."))
+		user.visible_message(span_notice("[user] bandages [M]'s [affecting]."), span_notice("I bandage [M]'s [affecting.name]."))
 
 /obj/item/natural/thorn
 	name = "thorn"


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/wewman222/CC/pull/161:

> Title says it all; Allow users to bandage themselves whilst moving to allow bandage viability being something to be able to use mid-combat as opposed to only having recovery options post-combat. Not only does this allow people to tend to mortal wounds whilst running away to a slight degree, but this gives people a chance at surviving brutal combat.
> The speed of bandaging has been improved slightly as well by 0.5 seconds (at 10 SPD), due to the bandaging mechanic now also having a bonus from the users speed stat.
> 
> At 10 SPD, 0.5 seconds. At 20 SPD, 1 second faster, benefitting those who have a focus on mobility/light armor whilst also being a general QOL for the speed of bandaging for people who do not have Medicine skill.
> 
> You also cannot UNBANDAGE whilst moving; Thus only making this as a final resort, momentary solution, and not allowing you to re-apply an already soaked combat. Requiring you to actually take the time to heal yourself once you're in a more safe position.

- Also fixes an unnecessary "the" when bandaging

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="143" height="23" alt="dreamseeker_iUHljgITCf" src="https://github.com/user-attachments/assets/26fe27b4-e346-4bdf-8bf3-999dc616dd4a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes mid combat bandaging when you can disengage a viable techniquet to stem bleeding. Better than mid combat red chug.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
