### PR TITLE
Old People In The Pews

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
@@ -8,7 +8,6 @@
 
 	allowed_races = ACCEPTED_RACES
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = list(AGE_ADULT)
 
 	tutorial = "Your family were zealots. They scolded you with a studded belt and prayed like sinners every waking hour of the day they weren't toiling in the fields. You escaped them by becoming a churchling--and a guaranteed education isn't so bad."
 


### PR DESCRIPTION
Expands age options for churchling.

## About The Pull Request

While others graduate from being a simple helping hand to that of a righteous templar, or a wise monk, you toil still. Though the gods have not seen fit to bestow upon you a fraction of their might, your old fingers do not falter in their work and your head remains bowed. Perhaps one dae, you may see the glimmer of their celestial power dance at your fingertips as you lie in bed and slip into Necra's embrace. Pray, Churchling. You may see fruit yet.

-Allows Middle-age and Elder to be Churchlings. 

## Testing Evidence

My environment a lil fucky rn and I have a hernia so I couldn't test the one line change pr but I have this doctor's note here you go :3c 

<img width="800" height="600" alt="hernia" src="https://github.com/user-attachments/assets/25033c8d-c082-471d-a6fd-c11d4999efcf" />


## Why It's Good For The Game

There was talk that players wanted such, and that other "youngfolk" classes actually don't have this restriction. You can now be a classic old gossiping nun running off delinquents and doting on the newcoining churchlings, secretly bitter that they may surpass you in miracle prowess. 

If you're reading this, I love you. Have a good day. 
