### PR TITLE
Message QoL + Projections

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/message.dm
+++ b/code/modules/spells/spell_types/wizard/utility/message.dm
@@ -87,7 +87,7 @@
 					to_chat(user, span_big("You whisper anonymously into [HL]'s mind: <font color=#[message_color]><i>\"[message]\"</i></font>"))
 				else
 					to_chat(HL, span_big("A brief vision suddenly flashes in my mind, originating from an unknown source: <font color=#[message_color]>\[<b>[message]</b>\]</font>"))
-					to_chat(user, span_big("You anonymously slip a brief vision into [HL]'s mind: <font color=#[message_color]>\[<b>[message]</b>\]</font>"))
+					to_chat(user, span_big("You slip a brief vision anonymously into [HL]'s mind: <font color=#[message_color]>\[<b>[message]</b>\]</font>"))
 
 			// Messages are whispered out loud, projections are just a silent murmur.
 			if(!is_projection)


### PR DESCRIPTION
## About The Pull Request

This expands the message spell in the following ways:

- You may now either issue a message or a projection to the recipient of the spell. Projections are brief visions, comprising visuals, smells, feelings, and anything else that isn't a spoken sentence.
- More feedback is implemented for the sender - you get a message confirming the success of the spell in addition to receiving the same noise as the recipient. 
- If not anonymous, messages appear in the text colour of the sender.

## Testing Evidence

<img width="470" height="192" alt="image" src="https://github.com/user-attachments/assets/2a4e434f-9648-48e6-b8a7-d3f1b0a47e6f" />

<img width="474" height="167" alt="image" src="https://github.com/user-attachments/assets/6669a0fd-43dd-47fc-a96a-f0ef967db7f3" />

## Why It's Good For The Game

Projections open up a lot of roleplay potential to the spell that isn't otherwise possible - there's a lot you can do with direct mind-to-mind communications that don't have to just be bound up in the format of dialogue. You can write prose! Obscure visions to interpret! Convince someone they're seeing the future! Get artsy!

Projections aren't whispered like messages are. This does theoretically open up the bad faith interaction of speaking normally into a projection just to avoid the message being whispered, but this is all adminlogged and it's a pretty particular scenario where it could be abused. Beyond that, the rest of this is just QoL.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
