### PR TITLE
Crafting Menu Optimizations

### DIFF
--- a/tgui/packages/tgui/interfaces/MiaCraft.js
+++ b/tgui/packages/tgui/interfaces/MiaCraft.js
@@ -10,152 +10,212 @@ import {
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
 
-// Keep these function outside to prevent re-render
-const CraftingCategory = ({ crafties, key3, onlyCraftable, craftability, key, actfunc, searchText }) => {
-    const visibleElements = useMemo(() => {
-      return Object.entries(crafties).filter(([key2, item2]) => !onlyCraftable || 
-      craftability.some(object => object[0] === item2.name && object[1] === 1))
-      .sort(([, aVal], [, bVal]) => String(aVal.name).localeCompare(String(bVal.name)))
-      .filter(([id, item]) => 
-      { return item.name.toLowerCase().includes(searchText); });
-    }, [crafties, onlyCraftable, craftability, searchText]);
-    return (visibleElements.length > 0 ? 
-        <Collapsible title={key3}>
-          {visibleElements.map(([key2, item2]) => (
-            <CraftingRecipe recipe={item2} key={key2} craftability={craftability} actfunc={actfunc} />
-          ))}
-          
-        </Collapsible> 
-      : null);
-  };
+/* ---------------------------------------------
+ * CraftingRecipe (optimized)
+ * --------------------------------------------- */
+const CraftingRecipe = ({ recipe, craftableSet, actfunc }) => {
+  const isCraftable = craftableSet.has(recipe.name);
 
-  const CraftingRecipe = ({ recipe, key, craftability, actfunc }) => {
-    return(
-      <Stack>
-        <Stack.Item>
-          <Button content="🛠" onClick={() => {
+  return (
+    <Stack>
+      <Stack.Item>
+        <Button
+          content="🛠"
+          onClick={() =>
             actfunc('craft', {
-              item : recipe.path,
-            });
-          }}
-          />
-        </Stack.Item>
-        <Stack.Item basis="80%">
-          <Collapsible title={recipe.name} style={{ backgroundColor: craftability.some(object => object[0] === recipe.name && object[1] === 1) ? "" : "grey" }}>
-            <LabeledList >
-              <LabeledList.Item label="Ingredients" style={{ 'margin-left': '20px' }}>
-                {recipe.req_text}
+              item: recipe.path,
+            })
+          }
+        />
+      </Stack.Item>
+
+      <Stack.Item basis="80%">
+        <Collapsible
+          title={recipe.name}
+          style={{ backgroundColor: isCraftable ? '' : 'grey' }}
+        >
+          <LabeledList>
+            <LabeledList.Item label="Ingredients" style={{ marginLeft: 20 }}>
+              {recipe.req_text}
+            </LabeledList.Item>
+
+            <LabeledList.Item label="Difficulty" style={{ marginLeft: 20 }}>
+              {recipe.craftingdifficulty}
+            </LabeledList.Item>
+
+            {recipe.tool_text && (
+              <LabeledList.Item label="Tool" style={{ marginLeft: 20 }}>
+                {recipe.tool_text}
               </LabeledList.Item>
-              <LabeledList.Item label="Difficulty" style={{ 'margin-left': '20px' }}>
-                {recipe.craftingdifficulty}
+            )}
+
+            {recipe.catalyst_text && (
+              <LabeledList.Item label="Catalyst" style={{ marginLeft: 20 }}>
+                {recipe.catalyst_text}
               </LabeledList.Item>
-              { recipe.tool_text &&
-                <LabeledList.Item label="Tool" style={{ 'margin-left': '20px' }}>
-                  {recipe.tool_text}
-                </LabeledList.Item>
-              }
-              {recipe.catalyst_text && 
-                  <LabeledList.Item label="Catalyst" style={{ 'margin-left': '20px' }}>
-                    {recipe.catalyst_text}
-                  </LabeledList.Item>
-              }
-              <LabeledList.Item label="Sell Price" style={{ 'margin-left': '20px' }}>
-                {recipe.sellprice}
-              </LabeledList.Item>
-              <LabeledList.Item label="Craft it!" style={{ 'margin-left': '20px', 'gap': '4px' }}>
-                <Button content="1x" onClick={() => {
-                  actfunc('craft', {
-                    item : recipe.path,
-                  });
-                }}
+            )}
+
+            <LabeledList.Item label="Sell Price" style={{ marginLeft: 20 }}>
+              {recipe.sellprice}
+            </LabeledList.Item>
+
+            <LabeledList.Item
+              label="Craft it!"
+              style={{ marginLeft: 20, gap: '4px' }}
+            >
+              {[1, 2, 3, 5].map((amount) => (
+                <Button
+                  key={amount}
+                  content={`${amount}x`}
+                  onClick={() =>
+                    actfunc('craft', {
+                      item: recipe.path,
+                      amount,
+                    })
+                  }
                 />
-                <Button content="2x" onClick={() => {
+              ))}
+
+              <Button
+                content="∞"
+                onClick={() =>
                   actfunc('craft', {
                     item: recipe.path,
-                    amount: 2,
-                  });
-                }}
-                />
-                <Button content="3x" onClick={() => {
-                  actfunc('craft', {
-                    item: recipe.path,
-                    amount: 3,
-                  });
-                }}
-                />
-                <Button content="5x" onClick={() => {
-                  actfunc('craft', {
-                    item: recipe.path,
-                    amount: 5,
-                  });
-                }}
-                />
-                <Button content="∞" onClick={() => {
-                  actfunc('craft', {
-                    item : recipe.path,
                     auto: true,
-                  });
-                }}
-                />
-              </LabeledList.Item>
-            </LabeledList>
-          </Collapsible>
-        </Stack.Item>
-      </Stack>
-    );
-  };
+                  })
+                }
+              />
+            </LabeledList.Item>
+          </LabeledList>
+        </Collapsible>
+      </Stack.Item>
+    </Stack>
+  );
+};
 
-export const MiaCraft = (props, context) => {
+/* ---------------------------------------------
+ * CraftingCategory (optimized)
+ * --------------------------------------------- */
+const CraftingCategory = ({
+  crafties,
+  title,
+  onlyCraftable,
+  craftableSet,
+  actfunc,
+  searchText,
+}) => {
+  const visibleElements = useMemo(() => {
+    const searchLower = searchText.toLowerCase();
+
+    return Object.entries(crafties)
+      .filter(([_, item]) => {
+        if (onlyCraftable && !craftableSet.has(item.name)) return false;
+        return item.name.toLowerCase().includes(searchLower);
+      })
+      .sort(([, a], [, b]) => a.name.localeCompare(b.name));
+  }, [crafties, onlyCraftable, craftableSet, searchText]);
+
+  if (!visibleElements.length) return null;
+
+  return (
+    <Collapsible title={title}>
+      {visibleElements.map(([key, item]) => (
+        <CraftingRecipe
+          key={key}
+          recipe={item}
+          craftableSet={craftableSet}
+          actfunc={actfunc}
+        />
+      ))}
+    </Collapsible>
+  );
+};
+
+/* ---------------------------------------------
+ * Main Component
+ * --------------------------------------------- */
+export const MiaCraft = () => {
   const { act, data } = useBackend();
-  const busy = data.busy;
-  const [category, setCategory] = useState();
-  const [subcategory, setSubcategory] = useState();
-  const craftability = Object.entries(data.craftability);
-  const [crafting_recipes] = useState(data.crafting_recipes);
-  let onlyCraftable = data.showonlycraftable;
-  const [searchText, setSearchText] = useState("");
+  const craftabilityEntries = Object.entries(data.craftability);
 
-  function ToggleOnlyCraftable() {
-    act('checkboxonlycraftable', { state : !onlyCraftable });
-  }
+  // Local UI state
+  const [searchText, setSearchText] = useState('');
 
-  function SearchTextModify(val) {
-    setSearchText(val);
-  }
+  // Pull once & never reassign
+  const crafting_recipes = data.crafting_recipes;
 
-  const renderColumn = () => {
-    return (
-      <Stack vertical>
-          <Stack.Item style={{ 'position': 'sticky' }}>
-              <Stack>
-                <Stack.Item>
-                  <Input placeholder="Search..." autoFocus value={searchText} onInput={(e) => SearchTextModify(e.target.value.toLowerCase())} />
-                </Stack.Item>
-                <Stack.Item>
-                  <label>Show only craftables</label>
-                  <input type="checkbox" checked={onlyCraftable} onClick={() => ToggleOnlyCraftable()} />
-                </Stack.Item>
-              </Stack>
-          </Stack.Item>
-          <Stack.Item>
-            {
-              Object.entries(crafting_recipes).sort(([a], [b]) => String(a).localeCompare(String(b))).map(([key, item]) => (
-                <CraftingCategory crafties={item} key3={key} onlyCraftable={onlyCraftable} craftability={craftability} key={key} actfunc={act} searchText={searchText} />
-              ))
-            }
-          </Stack.Item>
-      </Stack>
+  // Controlled checkbox state lives in backend
+  const onlyCraftable = data.showonlycraftable;
+
+  // O(1) lookup of craftable items
+  const craftableSet = useMemo(() => {
+    return new Set(
+      craftabilityEntries
+        .filter(([_, can]) => can === 1)
+        .map(([name]) => name)
     );
-  };
-  
-  return(
-    <Window title='Crafting' width={340} height={600} resizeable>
+  }, [craftabilityEntries]);
+
+  // Pre-sorted categories
+  const sortedCategories = useMemo(() => {
+    return Object.entries(crafting_recipes).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+  }, [crafting_recipes]);
+
+  return (
+    <Window title="Crafting" width={340} height={600} resizable>
       <Window.Content scrollable>
         <Stack horizontal>
-          {renderColumn()}
+          <Stack vertical>
+
+            {/* Search + Filter */}
+            <Stack.Item style={{ position: 'sticky' }}>
+              <Stack>
+                <Stack.Item>
+                  <Input
+                    placeholder="Search..."
+                    autoFocus
+                    value={searchText}
+                    onChange={(e) =>
+                      setSearchText(e.target.value.toLowerCase())
+                    }
+                  />
+                </Stack.Item>
+
+                <Stack.Item>
+                  <label>Show only craftables</label>
+                  <input
+                    type="checkbox"
+                    checked={onlyCraftable}
+                    onChange={() =>
+                      act('checkboxonlycraftable', {
+                        state: !onlyCraftable,
+                      })
+                    }
+                  />
+                </Stack.Item>
+              </Stack>
+            </Stack.Item>
+
+            {/* Categories */}
+            <Stack.Item>
+              {sortedCategories.map(([key, items]) => (
+                <CraftingCategory
+                  key={key}
+                  title={key}
+                  crafties={items}
+                  onlyCraftable={onlyCraftable}
+                  craftableSet={craftableSet}
+                  actfunc={act}
+                  searchText={searchText}
+                />
+              ))}
+            </Stack.Item>
+
+          </Stack>
         </Stack>
       </Window.Content>
     </Window>
   );
-
-  };
+};


### PR DESCRIPTION
## About The Pull Request

- Optimized the Crafting Menu, it should render a bit faster now.

## Testing Evidence

https://github.com/user-attachments/assets/d67fdfcc-e02a-4a21-967a-8d253a51e08a


## Why It's Good For The Game

faster is good

I literally just ran this through ChatGPT. I figured it'd have an insane amount of data to pull from open source React repos. Ran it on local, everything worked, could still craft, and it felt faster.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Optimized the crafting menu, it should load ever so slightly faster now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
