### PR TITLE
Campfire Nerf

### DIFF
--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -802,9 +802,9 @@
 			if(!human.has_status_effect(/datum/status_effect/buff/healing/campfire))
 				to_chat(human, "The warmth of the fire comforts me, affording me a short rest.")
 			// Astrata followers get enhanced fire healing
-			var/buff_strength = 1
+			var/buff_strength = 0.5
 			if(human.patron?.type == /datum/patron/divine/astrata || human.patron?.type == /datum/patron/inhumen/matthios) //Fire and the fire-stealer
-				buff_strength = 2
+				buff_strength = 1
 			human.apply_status_effect(/datum/status_effect/buff/healing/campfire, buff_strength)
 			human.add_stress(/datum/stressevent/campfire)
 


### PR DESCRIPTION
## About The Pull Request

- Nerfed campfires. It heals half as much and healing is blocked if you have combat mode enabled.

## Testing Evidence
a

## Why It's Good For The Game

Campfires are supposed to grant respite when resting, it shouldn't be deployed in-combat so you can heal while you fight.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Nerfed campfires. It heals half as much and healing is blocked if you have combat mode enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
