### PR TITLE
Kill Contract Proximity Spawners

### DIFF
--- a/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
@@ -1,0 +1,55 @@
+/obj/effect/quest_spawn
+	name = "quest spawner"
+	icon = 'icons/effects/landmarks_static.dmi'
+	icon_state = "x"
+	anchored = TRUE
+	layer = MID_LANDMARK_LAYER
+	invisibility = INVISIBILITY_OBSERVER
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+	var/atom/movable/contained_atom
+	var/datum/proximity_monitor/proximity_monitor
+
+/obj/effect/quest_spawn/Initialize(mapload)
+	. = ..()
+	proximity_monitor = new(src, 7)
+
+/obj/effect/quest_spawn/Destroy(force)
+	. = ..()
+	QDEL_NULL(contained_atom)
+	proximity_monitor = null
+
+/obj/effect/quest_spawn/HasProximity(mob/nearby)
+	if(!contained_atom)
+		return
+
+	if(!istype(nearby))
+		return
+
+	var/datum/component/quest_object/quest_component = GetComponent(/datum/component/quest_object)
+	if(!istype(quest_component))
+		return
+
+	var/datum/quest/quest = quest_component.quest_ref?.resolve()
+	if(!istype(quest))
+		return
+
+	if(get_dist(get_turf(src), get_turf(quest.quest_scroll_ref?.resolve())) > 7)
+		return
+
+	var/image/I = image(icon = 'icons/effects/effects.dmi', loc = get_turf(src), icon_state = "mobwarning", layer = 18)
+	I.layer = 18
+	I.plane = 18
+	I.alpha = 125
+	I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	flick_overlay_view(I, 5 SECONDS)
+
+	contained_atom.forceMove(get_turf(src))
+	contained_atom = null
+
+	playsound(loc, "plantcross", 100, FALSE, 3)
+
+	qdel(src)
+
+/obj/effect/quest_spawn/ex_act()
+	return

--- a/code/modules/roguetown/roguemachine/questing/questing_components.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_components.dm
@@ -1,26 +1,29 @@
 /datum/component/quest_object
 	var/datum/weakref/quest_ref
 	var/is_mob = FALSE
+	var/no_outline = FALSE
+	var/override_compatibility = FALSE
 	var/outline_filter_id = "quest_item_outline"
 
 /datum/component/quest_object/Initialize(datum/quest/target_quest)
-	if(!isitem(parent) && !ismob(parent))
+	if(!override_compatibility && !isitem(parent) && !ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	quest_ref = WEAKREF(target_quest)
 	is_mob = ismob(parent)
 
-	if(is_mob)
-		var/mob/M = parent
-		M.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#ff0000", "size" = 0.5))
-		RegisterSignal(parent, COMSIG_MOB_DEATH, PROC_REF(on_target_death))
-		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_mob_examine))
-	else
-		var/obj/item/I = parent
-		I.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#008cff", "size" = 0.5))
-		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
-		RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_item_dropped))
-		RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_item_dropped))
+	if(!no_outline)
+		if(is_mob)
+			var/mob/M = parent
+			M.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#ff0000", "size" = 0.5))
+			RegisterSignal(parent, COMSIG_MOB_DEATH, PROC_REF(on_target_death))
+			RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_mob_examine))
+		else
+			var/obj/item/I = parent
+			I.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#008cff", "size" = 0.5))
+			RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
+			RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_item_dropped))
+			RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_item_dropped))
 
 	RegisterSignal(target_quest, COMSIG_PARENT_QDELETING, PROC_REF(on_quest_deleted))
 
@@ -189,3 +192,20 @@
 		Q.progress_current++
 		Q.on_progress_update()
 		return
+
+/// Component for kill quest spawners
+/datum/component/quest_object/mob_spawner
+	override_compatibility = TRUE
+	no_outline = TRUE
+
+/datum/component/quest_object/mob_spawner/Initialize(datum/quest/target_quest)
+	. = ..()
+	if(. == COMPONENT_INCOMPATIBLE)
+		return
+
+/datum/component/quest_object/mob_spawner/on_quest_deleted(datum/source)
+	if(QDELETED(parent))
+		return
+
+	qdel(parent)
+	qdel(src)

--- a/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
@@ -15,9 +15,12 @@
 		if(!spawn_turf)
 			continue
 
-		var/mob/living/new_mob = new target_mob_type(spawn_turf)
+		var/obj/effect/quest_spawn/spawn_effect = new /obj/effect/quest_spawn(spawn_turf)
+		var/mob/living/new_mob = new target_mob_type(spawn_effect)
 		new_mob.faction |= "quest"
 		new_mob.AddComponent(/datum/component/quest_object/kill, src)
+		spawn_effect.contained_atom = new_mob
+		spawn_effect.AddComponent(/datum/component/quest_object/mob_spawner, src)
 		add_tracked_atom(new_mob)
 		landmark.add_quest_faction_to_nearby_mobs(spawn_turf)
 		sleep(1)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2395,6 +2395,7 @@
 #include "code\modules\roguetown\roguemachine\questing\questing_landmarks.dm"
 #include "code\modules\roguetown\roguemachine\questing\items\parcel.dm"
 #include "code\modules\roguetown\roguemachine\questing\items\quest_scroll.dm"
+#include "code\modules\roguetown\roguemachine\questing\items\spawn_effect.dm"
 #include "code\modules\roguetown\roguemachine\questing\types\__quest.dm"
 #include "code\modules\roguetown\roguemachine\questing\types\__quest_list.dm"
 #include "code\modules\roguetown\roguemachine\questing\types\quest_courier.dm"


### PR DESCRIPTION
## About The Pull Request

- Kill contracts, such as Kill, Outlaw, Raid, and so forth, now use proximity monitors to spawn the mobs in. This means, upon taking a contract, the mob won't be on the playing field until the contract itself is brought close to it.

## Testing Evidence

https://github.com/user-attachments/assets/73a79851-0337-42c0-aec6-7bfb68c6eb66

## Why It's Good For The Game

The lands being flooded by enemies that kill you if you're just walking by unrelatedly is bad.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Kill contracts, such as Kill, Outlaw, Raid, and so forth, now use proximity monitors to spawn the mobs in. This means, upon taking a contract, the mob won't be on the playing field until the contract itself is brought close to it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
