### PR TITLE
Balance campfire for resting

### DIFF
--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -804,7 +804,7 @@
 			// Astrata followers get enhanced fire healing
 			var/buff_strength = 1
 			if(human.patron?.type == /datum/patron/divine/astrata || human.patron?.type == /datum/patron/inhumen/matthios) //Fire and the fire-stealer
-				buff_strength = 2
+				buff_strength = 1.5
 			human.apply_status_effect(/datum/status_effect/buff/healing/campfire, buff_strength)
 			human.add_stress(/datum/stressevent/campfire)
 


### PR DESCRIPTION
## About The Pull Request

Rebalance campfire healing aura to fit the "resting and gathering around"

## Testing Evidence

trust me, half as big "twice" as potent.

## Why It's Good For The Game

Campfires are not and should not provide near inexistent utility nor too great, hitting the middle point.
You are meant to rest around it, not floating within vague warmth radius.


## Changelog

Balance : campfire are for resting and not being vaguely around, restore healing values(to a certain degree), cut radius in half.
/:cl: