### PR TITLE
Slight Magejack

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -115,7 +115,7 @@
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/airblade)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/conjure_weapon)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mending)
 	H.cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
 	if(H.mind)
 		var/weapons = list("Longsword", "Falchion & Wooden Shield", "Messer & Wooden Shield", "Hwando") // Much smaller selection with only three swords. You will probably want to upgrade.
@@ -189,7 +189,7 @@
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/conjure_weapon)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mending)
 	H.cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)


### PR DESCRIPTION
## About The Pull Request

With the recent change regarding conjure weapon, not that it was breaking the economy because a real steel weapon will always be superior to a conjured one. it is now a spell that provides worse weapon that these classes starting loadout.

## Testing Evidence

it just works

## Why It's Good For The Game

Conjure weapon was a good early option and now is only serviceable and or in last resort if your weapon break.
Replacing it with mending that provide active support while allowing you to continue fighting with **non-iron** level of damage and integrity rewarding spellblades and spellsingers that upgrade their equipment.

## Changelog
Replace Conjure weapon spells with Mending in both Spellblade and Spellsinger starting spell loadout, both spells have the same spellpoint cost so not changing their starting spellpoint pool and now their current lineup of spells reward them for interacting with the economy by upgrading their gears.
/:cl: