### PR TITLE
A Peon's Primer - Ports over a slimmed-down, Azurified version of Vanderlin's in-game lore primer!

### DIFF
--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -1,7 +1,7 @@
 <p><strong><em><span style="font-size:115%"> Welcome to Azure Peak! </span></em></strong></p>
 <p> This lore primer serves as an introduction to Azure Peak's setting.
 <br><br>
-As always, note that this lore primer shouldn't be treated as gospel. After all, there's plenty of room in Psydonia for characters with their own interpretations of faith-and-truth. Contradicting the established narrative is an excellent way to invoke conflict between clergymen and countrymen alike.
+As always, note that this lore primer shouldn't be treated as gospel. After all, there's plenty of room in Psydonia for characters with their own interpretations of faith-and-truth - no matter how contradictory they might appear to be. Get creative!
 <br><br>
 Only the broadest strokes have been applied onto this canvas. There's plenty of supplemental lore hidden throughout Azure Peak: level a keen eye towards the dungeons, tomes, events, and descriptions of examined items, if you wish to uncover Psydonia's secrets. 
 <br><br>
@@ -41,6 +41,160 @@ Don't be afraid to check out Azure Peak's Wiki - https://azurepeak.miraheze.org/
 
 
 <p><strong><em><span style="font-size:115%"> ... </span></em></strong></p>
+
+
+<details>
+	<summary><strong><span style="font-size:130%"> TIMELINE OF PSYDONIA </span></strong></summary>
+
+	<strong><span style="font-size:115%"> NOTEWORTHY EVENTS </span></strong>
+	<br><br>
+	<details>
+		<summary><strong> Calamity - -66 PR to -1 PR  </strong></summary>
+		<br>
+		The Archdevil, a force beyond reality, invades the still-nurtured world of Psydonia. Though shaken by the newfound concepts of sin and murder, Psydon's children nevertheless rally to defend their home. Bronze-armored legionnaires clash against devils and deadites alike, while Psydon struggles to keep His world from falling apart. His angels take up the mantle as the first kings: divine commanders.
+		<br><br>
+		Psydon's intervention is minimal, due to a terrible ploy enacted by the Archdevil: Vheslyn's entryway - a rift in the worldly filament - sucks in the souls of those slain, condemning them to eternal suffering. Psydon focuses most of His energy to try and seal the rift from growing any larger, leaving Him unable to directly assist His children in battle.
+		<br><br>
+		Within a generation, the Archdevil destroys most of Psydonia. Raging cyclones and thunderstorms blot out the starless skies, as many settlements are swallowed whole by the Archdevil's fatigueless march. The remnants of His children - reduced to the paltry thousands - are evacuated to the highest mountains by His angels, in preparation for their final stand.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Sacrifice - -1 PR  </strong></summary>
+		<br>
+		Psydon, moved by the desperate prayers of His children and angels, weeps. His attention finally turns away from the rift, which - without any force to oppose it - begins to consume the world itself. Vheslyn, personally leading the army of darkness, confronts His children. Before the last of men-and-mer can be culled, however, a blinding light pierces the storm-clouded skies.
+		<br><br>
+		The Archdevil's haughtiness turns into petrification, as the mere presence of Psydon-upon-the-world evaporates every summited devil within a heartbeat. The deities take to the skies, and the ensuing clash is felt throughout all of Psydonia. Though Vheslyn eventually gains the advantage, even It could not foresee Psydon's willingness to save His world.
+		<br><br>
+		Empowered by the hopes and dreams of His children, Psydon channels all of His divine might into a singular missile: the Comet Syon. The impact engulfs both Psydon and Vheslyn in a massive explosion: one that not only destroys the Archdevil's world-consuming rift, but also drowns most of the ruined world. From the mountaintops, His children are left with nothing but deathly silence.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Providence - 0 AP to 351 AP </strong></summary>
+		<br>
+		Though Psydonia was saved, it had come at a grave cost. Both Psydon and Vheslyn had vanished, and most of the world had been rendered uninhabitable by the Calamity. Knowing the importance of discovering Psydon's fate above all else, most of His angels leave Psydonia to begin their search: the starless skies, at last, finally reignite.
+		<br><br>
+		Shortly afterwards, the Pantheon makes itself known to Psydonia's survivors: Abyssor recedes the floodwaters back into the ocean, Dendor rekindles growth amongst the ruined ecosystems, and Necra shepherds Psydonia's lingering souls to rest. Blinding light envelops the sky, so that Astrata can guide His children down from the mountaintops.
+		<br><br>
+		With the Pantheon's nurturing, Psydonia gradually recovers from its nigh-apocalyptic state. Noc shepherds in the gentle night, halving Astrata's burden of reigning over His world - and in the dreams of His children, Noc whispers knowledge for them to seize. Ravox, Eora, Pestra, Malum, and Xylix intermingle with men-and-mer alike, spawning many fables and legends.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Enlightenment - 352 AP to 922 AP </strong></summary>
+		<br>
+		Kingdoms arise, with the Holy Celestial Empire - a communion of both Man and God - reigning above them all. The snow-elves, though cursed with infertility, were nevertheless blessed the most with Noc's wisdom. By their hands, they created many technological marvels that still exist today: namely, the mechanisms used for Thrones, Meisters, and the SCOM. 
+		<br><br>
+		Gradually, the Pantheon's presence in day-to-day life recedes, so that man-and-mer could continue to grow on their own. Clashes between kingdoms are infrequent, but present: most tend to end with mediation by the Holy Celestial Empire. Beyond that, Psydonia is otherwise uncontested - and for centuries to come, His children live in prosperity.
+		<br><br>
+		At this point, almost all of Psydonia now worships the Pantheon. Unlike today, however, the Psydonic minority isn't ostracized: instead, they're still treated as spiritual equals. The resting place of the Comet Syon is rediscovered, and a lesser kingdom is erected upon its coast: the Grand Duchy of Azure Peak. Azuria becomes a holy site for Psydonic worshippers.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Sundering - 923 AP </strong></summary>
+		<br>
+		At the height of Psydonia's prosperity, a snow-elven archmage discovers a way to dispel the curse that has led to their race's endangerment. A great machine is constructed, yet its activation results in a cataclysm beyond compare. Explosions ripple throughout Psydonia's leylines, and every single snow-elve simultaneously evaporates into piles of gore and ash.
+		<br><br>
+		Within a single night, an entire race had been erased from the face of the earth. The fractured leylines delved a mortal wound to Psydonia itself, causing the very forces of nature to turn on itself. Those, killed in the ensuing chaos, are resurrected as gibbering deadites - and like a plague, mania spreads throughout the Holy Celestial Empire.
+		<br><br>
+		Under the Psydonic churches, a crusade - ill-informed yet yearning for vengeance - descends upon Celestia, sealing the capital's fate. The Pantheon's own churches, believing the sudden calamity to've been caused by the raiding Psydonians, react with violence. It is only through Astrata's direct intervention that both sides didn't destroy one-another.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Decay - 924-1512 AP </strong></summary>
+		<br>
+		In the ashes of Celestia, a new deity arose - Zizo, accompanied by the trinity of Baotha, Graggar, and Matthios. Their presence gave way to the birth of Ascendanism, for they gifted His children with a revelation: they were all but mortals, once, who had discovered how to obtain divinity for themselves. A schism forms in the churches, and the Ecclesial is born.
+		<br><br>
+		With the Holy Celestial Empire in ruins, His children are forever marred. The Pantheon's church resettles in the central kingdom of Grenzelhoft, and becomes known as the Holy See - likewise, the Psydonic crusaders mournfully return to the Orthodoxy. Both leaders of these opposing churches now blame one-another for inadvertently destroying the Holy Celestial Empire.
+		<br><br>
+		Prosperity ends, and decay sets in. Divisions in faith, born in the Sundering, are now set in stone. Many worshippers have turned their backs on both Psydon and the Pantheon, in favor of the Ascendants. Men-and-mer alike are now far more vulnerable to depression, oft-coping through indulgence in vices or outbursts of uncontrollable emotions.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Now - 1513 AP </strong></summary>
+		<br>
+		The world is dying, yet it is not like the Calamity or Sundering. It is slow, prolonged, and creeping: like rot upon wood. Starvation and strife aren't the norm, but signs of a struggle have become clear. The wheat is less bountiful, the stars glimmer less in the night sky, and - more concerningly - more villains have crept out to prowl once more.
+		<br><br>
+		Yet, His children persist. Some might not even know of the world's circumstance: much less so in Azuria, which has since flourished. It's believed that its connection - both physical and spiritual - to the Comet Syon has granted it some clemency from more worldly hardships: a thought that has driven many refugees and pilgrims to its harbors.
+		<br><br>
+		Churchbells chime throughout Azuria, christening the start of a new week. Some lament about strange-and-prophetic dreams from the nights prior, though they oft-brush it off as nothing more than that: something spawned from a crumb of spoiled mustard, rather than anything divine. Others simply groan, rise from their cots, and prepare for the labors-to-come.
+		<br><br>
+		What about you?
+	</details>
+	<br><br>
+</details>
+
+
+<details>
+	<summary><strong><span style="font-size:130%"> MYTHOS OF PSYDONIA </span></strong></summary>
+
+	<strong><span style="font-size:115%"> OVERVIEW OF THE DIVINE </span></strong>
+	<br><br>
+	<details>
+		<summary><strong> THE FATHER </strong></summary>
+		<br>
+		<span style="display:block; color:#007fff; font-size:115%"> "..." </span>
+		<br>
+		Psydon is worshipped as the creator of ontological reality, and the only true force of goodness that Psydonia ever knew. It was He who gifted man-and-mer with not only existence, but the capacity to emote like Him. When the Archdevil tore open reality and threatened to destroy Psydonia, it was Him who undertook the ultimate sacrifice to save the world He had come to love. 
+<br><br>
+Nowadays, most believe that Psydon is gone: yet, an ardent minority continues to remain loyal in the hopes that He may yet return to save His world once more. His children might be bereft of miracles and answers, but they continue to endure - even at the end of the world.
+<br><br>
+		Psydonic worshippers are in the minority, and are generally ostracized by most kingdoms. The Orthodoxy teaches the most widespread form of Psydonic worship, though there are countless other forms practiced throughout the world. 
+<br><br>
+Azuria currently houses a cohort of the Holy Psydonic Inquisition, as part of a diplomatic affair with Otava. In addition, Azuria - due to its proximity to Syon's resting place - is considered a 'holy site' by the Orthodoxy. Such has made it common for pilgrims throughout all of Psydonia to visit the lesser kingdom, in the hopes that they may be blessed by what remains of the divine comet.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> THE PANTHEON </strong></summary>
+		<br>
+		<span style="display:block; color:#ffd700; font-size:115%"> "WITH ORDER, WE REIGN; AND WITH FAITH, WE PROSPER." </span>
+		<br>
+		The Pantheon are the successors to Psydon: ten deities who have taken up the mantle of guiding His children along. After the Comet Syon had seemingly destroyed both Psydon and the Archdevil, the ruined world's survivors wept for guidence. 
+<br><br>
+Though most of His angels had left Psydonia in search of answers only woven into the stars, there remained a cohort of ten who - whether through guilt or newfound purpose - remained behind to pick up the pieces. Adopting more heavenly forms to ensure His children would not be afraid, Astrata and Her nine siblings finally descended from the reignited skies to answer their prayers: and from there, the rest was history.
+		<br><br>
+		Pantheonic worshippers are in the majority, and have remained as such for over a millenium's time. Almost every kingdom in Psydonia houses a church that preaches the Pantheon's teachings, taken directly from the Holy See's tomes.
+<br><br>
+Azuria is no different, with its duchal patrons being Astrata, Dendor, and Abyssor. While Astrata is traditionally worshipped as the Pantheon's supreme deity, the Holy See oft-emphasizes that all ten deities should be given equal reverance. Hence, it isn't uncommon to see an Astratan praying to Ravox for courage in the midst of battle, nor to witness a Malumite cursing out Dendor for overmuddying a carriage's intended pathway. 
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> THE ASCENDANTS </strong></summary>
+		<br>
+		<span style="display:block; color:#800080; font-size:115%"> "WHAT IS A GOD, IF NOT A MAN WHO HAS RECOGNIZED THE FOLLY OF MORTALITY?" </span>
+		<br>
+		The Ascendants are the youngest of all deities, and - as alleged by its worshippers - the true heirs to Psydon's mantle. Unlike the Pantheon, these four deities were never divine to begin with: instead, they were mortals who had managed to achieve godhood through mythical exploits. 
+<br><br>
+Zizo offers progress, Baotha offers bliss, Graggar offers freedom, and Matthios offers wealth - yet, their worshippers seldom know the price that must be paid to obtain such luxuries. While the Holy See has desperately tried to cover up the truth being the Ascendants, a recent schism has led to many of His children embracing the concept of apotheosis.
+		<br><br>
+		Ascendant worshippers vary from region-to-region. Most inner kingdoms revile the concept of Ascendanism, and - thanks to its demonization by the Holy See - oft-hunt down those who openly praise the four-who-ascended. 
+<br><br>
+The outermost kingdoms are much different, however: Gronn, Fjall, Raneshen, and Lirvas happen to welcome the Ascendants, albeit in forms that might be considered 'esoteric' and 'unusual' by more-recent convertees. Owing to the individualistic nature of Ascendanism, most worshippers - save for those who've completely embraced the concept of 'obtaining godhood' - tend to secularly worship one deity in particular.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> THE ARCHDEVIL </strong></summary>
+		<br>
+		<span style="display:block; color:#ff0000; font-size:115%"> "FROM THE ASHES, WE ROSE! AND TO THE ASHES, WE WILL ALL RETURN!" </span>
+		<br>
+		Vheslyn. The primordial essence, the manifestation of ontological evil, and - for the longest time - the lone inhabitant of ur-existence. Psydon had created reality within the void: an act of unforeseen interlopage that drove Vheslyn into a blithering rage. 
+<br><br>
+It was Vheslyn who introduced sin into the hearts of His children, who formed an army of darkness to march upon Psydonia, and created Hell to forever-torment those who were slain in the ensuing rampage. Before His world could be destroyed, however, Psydon undertook the ultimate sacrifice to stop Vheslyn's rampage: a final blow that sundered both body-and-spirit. In the Comet Syon's explosion, both had vanished.
+		<br><br>
+		Yet, Vheslyn's influence did not fully leave Psydonia. The few devils who had survived the Comet Syon's impact, now left powerless and tethered to Psydonia, would eventually learn to embrace goodness: and by communing with His children, the first Tieflings would be made. 
+<br><br>
+More recently, unsettling rumors have arose of an ancient cult, nestled deep within the Fjallic wastes - one that seeks to resurrect Vheslyn, in order to finally destroy Psydonia and return everything to nothingness. Most believe such rumors to be nothing more than that: a rumor. Even so, one must wonder why Psydonia's northern skies have taken on such vivid auroras, lately.
+		<br>
+	</details>
+	<br><br>
+</details>
 
 
 <details>
@@ -297,78 +451,10 @@ Even so, their reputation is mercifully softened by the fact that they grow some
 
 
 <details>
-	<summary><strong><span style="font-size:130%"> MYTHOS OF PSYDONIA </span></strong></summary>
-
-	<strong><span style="font-size:115%"> OVERVIEW OF THE DIVINE </span></strong>
-	<br><br>
-	<details>
-		<summary><strong> THE FATHER </strong></summary>
-		<br>
-		<span style="display:block; color:#007fff; font-size:115%"> "..." </span>
-		<br>
-		Psydon is worshipped as the creator of ontological reality, and the only true force of goodness that Psydonia ever knew. It was He who gifted man-and-mer with not only existence, but the capacity to emote like Him. When the Archdevil tore open reality and threatened to destroy Psydonia, it was Him who undertook the ultimate sacrifice to save the world He had come to love. 
-<br><br>
-Nowadays, most believe that Psydon is gone: yet, an ardent minority continues to remain loyal in the hopes that He may yet return to save His world once more. His children might be bereft of miracles and answers, but they continue to endure - even at the end of the world.
-<br><br>
-		Psydonic worshippers are in the minority, and are generally ostracized by most kingdoms. The Orthodoxy teaches the most widespread form of Psydonic worship, though there are countless other forms practiced throughout the world. 
-<br><br>
-Azuria currently houses a cohort of the Holy Psydonic Inquisition, as part of a diplomatic affair with Otava. In addition, Azuria - due to its proximity to Syon's resting place - is considered a 'holy site' by the Orthodoxy. Such has made it common for pilgrims throughout all of Psydonia to visit the lesser kingdom, in the hopes that they may be blessed by what remains of the divine comet.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> THE PANTHEON </strong></summary>
-		<br>
-		<span style="display:block; color:#ffd700; font-size:115%"> "WITH ORDER, WE REIGN; AND WITH FAITH, WE PROSPER." </span>
-		<br>
-		The Pantheon are the successors to Psydon: ten deities who have taken up the mantle of guiding His children along. After the Comet Syon had seemingly destroyed both Psydon and the Archdevil, the ruined world's survivors wept for guidence. 
-<br><br>
-Though most of His angels had left Psydonia in search of answers only woven into the stars, there remained a cohort of ten who - whether through guilt or newfound purpose - remained behind to pick up the pieces. Adopting more heavenly forms to ensure His children would not be afraid, Astrata and Her nine siblings finally descended from the reignited skies to answer their prayers: and from there, the rest was history.
-		<br><br>
-		Pantheonic worshippers are in the majority, and have remained as such for over a millenium's time. Almost every kingdom in Psydonia houses a church that preaches the Pantheon's teachings, taken directly from the Holy See's tomes.
-<br><br>
-Azuria is no different, with its duchal patrons being Astrata, Dendor, and Abyssor. While Astrata is traditionally worshipped as the Pantheon's supreme deity, the Holy See oft-emphasizes that all ten deities should be given equal reverance. Hence, it isn't uncommon to see an Astratan praying to Ravox for courage in the midst of battle, nor to witness a Malumite cursing out Dendor for overmuddying a carriage's intended pathway. 
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> THE ASCENDANTS </strong></summary>
-		<br>
-		<span style="display:block; color:#800080; font-size:115%"> "WHAT IS A GOD, IF NOT A MAN WHO HAS RECOGNIZED THE FOLLY OF MORTALITY?" </span>
-		<br>
-		The Ascendants are the youngest of all deities, and - as alleged by its worshippers - the true heirs to Psydon's mantle. Unlike the Pantheon, these four deities were never divine to begin with: instead, they were mortals who had managed to achieve godhood through mythical exploits. 
-<br><br>
-Zizo offers progress, Baotha offers bliss, Graggar offers freedom, and Matthios offers wealth - yet, their worshippers seldom know the price that must be paid to obtain such luxuries. While the Holy See has desperately tried to cover up the truth being the Ascendants, a recent schism has led to many of His children embracing the concept of apotheosis.
-		<br><br>
-		Ascendant worshippers vary from region-to-region. Most inner kingdoms revile the concept of Ascendanism, and - thanks to its demonization by the Holy See - oft-hunt down those who openly praise the four-who-ascended. 
-<br><br>
-The outermost kingdoms are much different, however: Gronn, Fjall, Raneshen, and Lirvas happen to welcome the Ascendants, albeit in forms that might be considered 'esoteric' and 'unusual' by more-recent convertees. Owing to the individualistic nature of Ascendanism, most worshippers - save for those who've completely embraced the concept of 'obtaining godhood' - tend to secularly worship one deity in particular.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> THE ARCHDEVIL </strong></summary>
-		<br>
-		<span style="display:block; color:#ff0000; font-size:115%"> "FROM THE ASHES, WE ROSE! AND TO THE ASHES, WE WILL ALL RETURN!" </span>
-		<br>
-		Vheslyn. The primordial essence, the manifestation of ontological evil, and - for the longest time - the lone inhabitant of ur-existence. Psydon had created reality within the void: an act of unforeseen interlopage that drove Vheslyn into a blithering rage. 
-<br><br>
-It was Vheslyn who introduced sin into the hearts of His children, who formed an army of darkness to march upon Psydonia, and created Hell to forever-torment those who were slain in the ensuing rampage. Before His world could be destroyed, however, Psydon undertook the ultimate sacrifice to stop Vheslyn's rampage: a final blow that sundered both body-and-spirit. In the Comet Syon's explosion, both had vanished.
-		<br><br>
-		Yet, Vheslyn's influence did not fully leave Psydonia. The few devils who had survived the Comet Syon's impact, now left powerless and tethered to Psydonia, would eventually learn to embrace goodness: and by communing with His children, the first Tieflings would be made. 
-<br><br>
-More recently, unsettling rumors have arose of an ancient cult, nestled deep within the Fjallic wastes - one that seeks to resurrect Vheslyn, in order to finally destroy Psydonia and return everything to nothingness. Most believe such rumors to be nothing more than that: a rumor. Even so, one must wonder why Psydonia's northern skies have taken on such vivid auroras, lately.
-		<br>
-	</details>
-	<br><br>
-</details>
-
-<details>
 	<summary><strong><span style="font-size:130%"> GLOSSARY OF PSYDONIA </span></strong></summary>
-
+	<details>
 	<strong><span style="font-size:115%"> NOTEWORTHY CONCEPTS </span></strong>
 	<br><br>
-	<details>
 		<p><strong> Psydonia </strong> - The world that Azuria takes place in. Named after its creator, Psydon. </p>
 		<p><strong> Enigma </strong> - A more agnostic term for Psydonia, preferred by the Holy See and Ascendants. Not to be confused with the Isle of Enigma. </p>
 		<p><strong> Comet Syon </strong> - A divine star, sent down by Psydon to destroy the Archdevil. Its core had come to rest just off of Azuria's coast. </p>
@@ -384,12 +470,13 @@ More recently, unsettling rumors have arose of an ancient cult, nestled deep wit
 		<br>
 	</details>
 
+	<details>
 	<strong><span style="font-size:115%"> NOTEWORTHY TERMS </span></strong>
 	<br><br>
-	<details>
 		<p><strong> Miracle </strong> - Holy magicka. Unlike the arcyne, miracles are powered by one's faith and devotion to their chosen deity. </p>
 		<p><strong> Lux </strong> - The physical condensation of soulmatter, present along the heart. It's said to tether one's spirit to their body. </p>
 		<p><strong> Deadite </strong> - Luxless corpses, resurrected through unholy means. Interchangeably used to describe both zombies and skeletons. </p>
+		<p><strong> Nitebeast </strong> - Monsters who rely on night-and-darkness to prowl. Primarily references werewolves, but can reference vampires as well. </p>
 		<p><strong> Lycker </strong> - Vampires. These luxless revenants are said to drink the blood of the living, and are empowered with unholy magicks. </p>
 		<p><strong> Avantyne </strong> - A so-called 'evil' alloy, wielded by Zizo's most devoted worshippers. More commonly known as 'darksteel'.</p>
 		<p><strong> Saiga </strong> - Large antelopes, and Psydonia's most popular choice for cavalrymen and travelers. Analogous to the far-rarer horse. </p>
@@ -407,92 +494,6 @@ More recently, unsettling rumors have arose of an ancient cult, nestled deep wit
 		<p><strong> PR </strong> - The previous calender-era, lasting from the beginning of recorded history to the Comet Syon's impact - and Psydon's absence. </p>
 		<p><strong> AP </strong> - The current calender-era, which started after the end of Psydonic supremacy. The current date, as mentioned, is 1513 AP. </p>
 		<br>
-	</details>
-	<br><br>
-</details>
-
-
-<details>
-	<summary><strong><span style="font-size:130%"> TIMELINE OF PSYDONIA </span></strong></summary>
-
-	<strong><span style="font-size:115%"> NOTEWORTHY EVENTS </span></strong>
-	<br><br>
-	<details>
-		<summary><strong> Calamity - -66 PR to -1 PR  </strong></summary>
-		<br>
-		The Archdevil, a force beyond reality, invades the still-nurtured world of Psydonia. Though shaken by the newfound concepts of sin and murder, Psydon's children nevertheless rally to defend their home. Bronze-armored legionnaires clash against devils and deadites alike, while Psydon struggles to keep His world from falling apart. His angels take up the mantle as the first kings: divine commanders.
-		<br><br>
-		Psydon's intervention is minimal, due to a terrible ploy enacted by the Archdevil: Vheslyn's entryway - a rift in the worldly filament - sucks in the souls of those slain, condemning them to eternal suffering. Psydon focuses most of His energy to try and seal the rift from growing any larger, leaving Him unable to directly assist His children in battle.
-		<br><br>
-		Within a generation, the Archdevil destroys most of Psydonia. Raging cyclones and thunderstorms blot out the starless skies, as many settlements are swallowed whole by the Archdevil's fatigueless march. The remnants of His children - reduced to the paltry thousands - are evacuated to the highest mountains by His angels, in preparation for their final stand.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Sacrifice - -1 PR  </strong></summary>
-		<br>
-		Psydon, moved by the desperate prayers of His children and angels, weeps. His attention finally turns away from the rift, which - without any force to oppose it - begins to consume the world itself. Vheslyn, personally leading the army of darkness, confronts His children. Before the last of men-and-mer can be culled, however, a blinding light pierces the storm-clouded skies.
-		<br><br>
-		The Archdevil's haughtiness turns into petrification, as the mere presence of Psydon-upon-the-world evaporates every summited devil within a heartbeat. The deities take to the skies, and the ensuing clash is felt throughout all of Psydonia. Though Vheslyn eventually gains the advantage, even It could not foresee Psydon's willingness to save His world.
-		<br><br>
-		Empowered by the hopes and dreams of His children, Psydon channels all of His divine might into a singular missile: the Comet Syon. The impact engulfs both Psydon and Vheslyn in a massive explosion: one that not only destroys the Archdevil's world-consuming rift, but also drowns most of the ruined world. From the mountaintops, His children are left with nothing but deathly silence.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Providence - 0 AP to 351 AP </strong></summary>
-		<br>
-		Though Psydonia was saved, it had come at a grave cost. Both Psydon and Vheslyn had vanished, and most of the world had been rendered uninhabitable by the Calamity. Knowing the importance of discovering Psydon's fate above all else, most of His angels leave Psydonia to begin their search: the starless skies, at last, finally reignite.
-		<br><br>
-		Shortly afterwards, the Pantheon makes itself known to Psydonia's survivors: Abyssor recedes the floodwaters back into the ocean, Dendor rekindles growth amongst the ruined ecosystems, and Necra shepherds Psydonia's lingering souls to rest. Blinding light envelops the sky, so that Astrata can guide His children down from the mountaintops.
-		<br><br>
-		With the Pantheon's nurturing, Psydonia gradually recovers from its nigh-apocalyptic state. Noc shepherds in the gentle night, halving Astrata's burden of reigning over His world - and in the dreams of His children, Noc whispers knowledge for them to seize. Ravox, Eora, Pestra, Malum, and Xylix intermingle with men-and-mer alike, spawning many fables and legends.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Enlightenment - 352 AP to 922 AP </strong></summary>
-		<br>
-		Kingdoms arise, with the Holy Celestial Empire - a communion of both Man and God - reigning above them all. The snow-elves, though cursed with infertility, were nevertheless blessed the most with Noc's wisdom. By their hands, they created many technological marvels that still exist today: namely, the mechanisms used for Thrones, Meisters, and the SCOM. 
-		<br><br>
-		Gradually, the Pantheon's presence in day-to-day life recedes, so that man-and-mer could continue to grow on their own. Clashes between kingdoms are infrequent, but present: most tend to end with mediation by the Holy Celestial Empire. Beyond that, Psydonia is otherwise uncontested - and for centuries to come, His children live in prosperity.
-		<br><br>
-		At this point, almost all of Psydonia now worships the Pantheon. Unlike today, however, the Psydonic minority isn't ostracized: instead, they're still treated as spiritual equals. The resting place of the Comet Syon is rediscovered, and a lesser kingdom is erected upon its coast: the Grand Duchy of Azure Peak. Azuria becomes a holy site for Psydonic worshippers.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Sundering - 923 AP </strong></summary>
-		<br>
-		At the height of Psydonia's prosperity, a snow-elven archmage discovers a way to dispel the curse that has led to their race's endangerment. A great machine is constructed, yet its activation results in a cataclysm beyond compare. Explosions ripple throughout Psydonia's leylines, and every single snow-elve simultaneously evaporates into piles of gore and ash.
-		<br><br>
-		Within a single night, an entire race had been erased from the face of the earth. The fractured leylines delved a mortal wound to Psydonia itself, causing the very forces of nature to turn on itself. Those, killed in the ensuing chaos, are resurrected as gibbering deadites - and like a plague, mania spreads throughout the Holy Celestial Empire.
-		<br><br>
-		Under the Psydonic churches, a crusade - ill-informed yet yearning for vengeance - descends upon Celestia, sealing the capital's fate. The Pantheon's own churches, believing the sudden calamity to've been caused by the raiding Psydonians, react with violence. It is only through Astrata's direction intervention that both sides didn't destroy one-another.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Decay - 924-1512 AP </strong></summary>
-		<br>
-		In the ashes of Celestia, a new deity arose - Zizo, accompanied by the trinity of Baotha, Graggar, and Matthios. Their presence gave way to the birth of Ascendanism, for they gifted His children with a revelation: they were all but mortals, once, who had discovered how to obtain divinity for themselves. A schism forms in the churches, and the Ecclesial is born.
-		<br><br>
-		With the Holy Celestial Empire in ruins, His children are forever marred. The Pantheon's church resettles in the central kingdom of Grenzelhoft, and becomes known as the Holy See - likewise, the Psydonic crusaders mournfully return to the Orthodoxy. Both leaders of these opposing churches now blame one-another for inadvertently destroying the Holy Celestial Empire.
-		<br><br>
-		Prosperity ends, and decay sets in. Divisions in faith, born in the Sundering, are now set in stone. Many worshippers have turned their backs on both Psydon and the Pantheon, in favor of the Ascendants. Men-and-mer alike are now far more vulnerable to depression, oft-coping through indulgence in vices or outbursts of uncontrollable emotions.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Now - 1513 AP </strong></summary>
-		<br>
-		The world is dying, yet it is not like the Calamity or Sundering. It is slow, prolonged, and creeping: like rot upon wood. Starvation and strife aren't the norm, but signs of a struggle have become clear. The wheat is less bountiful, the stars glimmer less in the night sky, and - more concerningly - more villains have crept out to prowl once more.
-		<br><br>
-		Yet, His children persist. Some might not even know of the world's circumstance: much less so in Azuria, which has since flourished. It's believed that its connection - both physical and spiritual - to the Comet Syon has granted it some clemency from more worldly hardships: a thought that has driven many refugees and pilgrims to its harbors.
-		<br><br>
-		Churchbells chime throughout Azuria, christening the start of a new week. Some lament about strange-and-prophetic dreams from the nights prior, though they oft-brush it off as nothing more than that: something spawned from a crumb of spoiled mustard, rather than anything divine. Others simply groan, rise from their cots, and prepare for the labors-to-come.
-		<br><br>
-		What about you?
 	</details>
 	<br><br>
 </details>

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -1,7 +1,7 @@
 <p><strong><em><span style="font-size:115%"> Welcome to Azure Peak! </span></em></strong></p>
 <p> This lore primer serves as an introduction to Azure Peak's setting.
 <br><br>
-As always, note that this lore primer shouldn't be treated as gospel. After all, there's plenty of room in Psydonia for characters with their own interpretations of faith-and-truth - no matter how contradictory they might appear to be. Get creative!
+As always, note that this lore primer shouldn't be treated as gospel. Don't stress too much about trying to "get it all right" - it's far more fun to spark conflict through contradiction, and to explore the many unique interpretations that characters can have.
 <br><br>
 Only the broadest strokes have been applied onto this canvas. There's plenty of supplemental lore hidden throughout Azure Peak: level a keen eye towards the dungeons, tomes, events, and descriptions of examined items, if you wish to uncover Psydonia's secrets. 
 <br><br>
@@ -41,92 +41,6 @@ Don't be afraid to check out Azure Peak's Wiki - https://azurepeak.miraheze.org/
 
 
 <p><strong><em><span style="font-size:115%"> ... </span></em></strong></p>
-
-
-<details>
-	<summary><strong><span style="font-size:130%"> TIMELINE OF PSYDONIA </span></strong></summary>
-
-	<strong><span style="font-size:115%"> NOTEWORTHY EVENTS </span></strong>
-	<br><br>
-	<details>
-		<summary><strong> Calamity - -66 PR to -1 PR  </strong></summary>
-		<br>
-		The Archdevil, a force beyond reality, invades the still-nurtured world of Psydonia. Though shaken by the newfound concepts of sin and murder, Psydon's children nevertheless rally to defend their home. Bronze-armored legionnaires clash against devils and deadites alike, while Psydon struggles to keep His world from falling apart. His angels take up the mantle as the first kings: divine commanders.
-		<br><br>
-		Psydon's intervention is minimal, due to a terrible ploy enacted by the Archdevil: Vheslyn's entryway - a rift in the worldly filament - sucks in the souls of those slain, condemning them to eternal suffering. Psydon focuses most of His energy to try and seal the rift from growing any larger, leaving Him unable to directly assist His children in battle.
-		<br><br>
-		Within a generation, the Archdevil destroys most of Psydonia. Raging cyclones and thunderstorms blot out the starless skies, as many settlements are swallowed whole by the Archdevil's fatigueless march. The remnants of His children - reduced to the paltry thousands - are evacuated to the highest mountains by His angels, in preparation for their final stand.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Sacrifice - -1 PR  </strong></summary>
-		<br>
-		Psydon, moved by the desperate prayers of His children and angels, weeps. His attention finally turns away from the rift, which - without any force to oppose it - begins to consume the world itself. Vheslyn, personally leading the army of darkness, confronts His children. Before the last of men-and-mer can be culled, however, a blinding light pierces the storm-clouded skies.
-		<br><br>
-		The Archdevil's haughtiness turns into petrification, as the mere presence of Psydon-upon-the-world evaporates every summited devil within a heartbeat. The deities take to the skies, and the ensuing clash is felt throughout all of Psydonia. Though Vheslyn eventually gains the advantage, even It could not foresee Psydon's willingness to save His world.
-		<br><br>
-		Empowered by the hopes and dreams of His children, Psydon channels all of His divine might into a singular missile: the Comet Syon. The impact engulfs both Psydon and Vheslyn in a massive explosion: one that not only destroys the Archdevil's world-consuming rift, but also drowns most of the ruined world. From the mountaintops, His children are left with nothing but deathly silence.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Providence - 0 AP to 351 AP </strong></summary>
-		<br>
-		Though Psydonia was saved, it had come at a grave cost. Both Psydon and Vheslyn had vanished, and most of the world had been rendered uninhabitable by the Calamity. Knowing the importance of discovering Psydon's fate above all else, most of His angels leave Psydonia to begin their search: the starless skies, at last, finally reignite.
-		<br><br>
-		Shortly afterwards, the Pantheon makes itself known to Psydonia's survivors: Abyssor recedes the floodwaters back into the ocean, Dendor rekindles growth amongst the ruined ecosystems, and Necra shepherds Psydonia's lingering souls to rest. Blinding light envelops the sky, so that Astrata can guide His children down from the mountaintops.
-		<br><br>
-		With the Pantheon's nurturing, Psydonia gradually recovers from its nigh-apocalyptic state. Noc shepherds in the gentle night, halving Astrata's burden of reigning over His world - and in the dreams of His children, Noc whispers knowledge for them to seize. Ravox, Eora, Pestra, Malum, and Xylix intermingle with men-and-mer alike, spawning many fables and legends.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Enlightenment - 352 AP to 922 AP </strong></summary>
-		<br>
-		Kingdoms arise, with the Holy Celestial Empire - a communion of both Man and God - reigning above them all. The snow-elves, though cursed with infertility, were nevertheless blessed the most with Noc's wisdom. By their hands, they created many technological marvels that still exist today: namely, the mechanisms used for Thrones, Meisters, and the SCOM. 
-		<br><br>
-		Gradually, the Pantheon's presence in day-to-day life recedes, so that man-and-mer could continue to grow on their own. Clashes between kingdoms are infrequent, but present: most tend to end with mediation by the Holy Celestial Empire. Beyond that, Psydonia is otherwise uncontested - and for centuries to come, His children live in prosperity.
-		<br><br>
-		At this point, almost all of Psydonia now worships the Pantheon. Unlike today, however, the Psydonic minority isn't ostracized: instead, they're still treated as spiritual equals. The resting place of the Comet Syon is rediscovered, and a lesser kingdom is erected upon its coast: the Grand Duchy of Azure Peak. Azuria becomes a holy site for Psydonic worshippers.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Sundering - 923 AP </strong></summary>
-		<br>
-		At the height of Psydonia's prosperity, a snow-elven archmage discovers a way to dispel the curse that has led to their race's endangerment. A great machine is constructed, yet its activation results in a cataclysm beyond compare. Explosions ripple throughout Psydonia's leylines, and every single snow-elve simultaneously evaporates into piles of gore and ash.
-		<br><br>
-		Within a single night, an entire race had been erased from the face of the earth. The fractured leylines delved a mortal wound to Psydonia itself, causing the very forces of nature to turn on itself. Those, killed in the ensuing chaos, are resurrected as gibbering deadites - and like a plague, mania spreads throughout the Holy Celestial Empire.
-		<br><br>
-		Under the Psydonic churches, a crusade - ill-informed yet yearning for vengeance - descends upon Celestia, sealing the capital's fate. The Pantheon's own churches, believing the sudden calamity to've been caused by the raiding Psydonians, react with violence. It is only through Astrata's direct intervention that both sides didn't destroy one-another.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Decay - 924-1512 AP </strong></summary>
-		<br>
-		In the ashes of Celestia, a new deity arose - Zizo, accompanied by the trinity of Baotha, Graggar, and Matthios. Their presence gave way to the birth of Ascendanism, for they gifted His children with a revelation: they were all but mortals, once, who had discovered how to obtain divinity for themselves. A schism forms in the churches, and the Ecclesial is born.
-		<br><br>
-		With the Holy Celestial Empire in ruins, His children are forever marred. The Pantheon's church resettles in the central kingdom of Grenzelhoft, and becomes known as the Holy See - likewise, the Psydonic crusaders mournfully return to the Orthodoxy. Both leaders of these opposing churches now blame one-another for inadvertently destroying the Holy Celestial Empire.
-		<br><br>
-		Prosperity ends, and decay sets in. Divisions in faith, born in the Sundering, are now set in stone. Many worshippers have turned their backs on both Psydon and the Pantheon, in favor of the Ascendants. Men-and-mer alike are now far more vulnerable to depression, oft-coping through indulgence in vices or outbursts of uncontrollable emotions.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> Now - 1513 AP </strong></summary>
-		<br>
-		The world is dying, yet it is not like the Calamity or Sundering. It is slow, prolonged, and creeping: like rot upon wood. Starvation and strife aren't the norm, but signs of a struggle have become clear. The wheat is less bountiful, the stars glimmer less in the night sky, and - more concerningly - more villains have crept out to prowl once more.
-		<br><br>
-		Yet, His children persist. Some might not even know of the world's circumstance: much less so in Azuria, which has since flourished. It's believed that its connection - both physical and spiritual - to the Comet Syon has granted it some clemency from more worldly hardships: a thought that has driven many refugees and pilgrims to its harbors.
-		<br><br>
-		Churchbells chime throughout Azuria, christening the start of a new week. Some lament about strange-and-prophetic dreams from the nights prior, though they oft-brush it off as nothing more than that: something spawned from a crumb of spoiled mustard, rather than anything divine. Others simply groan, rise from their cots, and prepare for the labors-to-come.
-		<br><br>
-		What about you?
-	</details>
-	<br><br>
-</details>
 
 
 <details>
@@ -192,6 +106,94 @@ It was Vheslyn who introduced sin into the hearts of His children, who formed an
 <br><br>
 More recently, unsettling rumors have arose of an ancient cult, nestled deep within the Fjallic wastes - one that seeks to resurrect Vheslyn, in order to finally destroy Psydonia and return everything to nothingness. Most believe such rumors to be nothing more than that: a rumor. Even so, one must wonder why Psydonia's northern skies have taken on such vivid auroras, lately.
 		<br>
+	</details>
+	<br><br>
+</details>
+
+
+<details>
+	<summary><strong><span style="font-size:130%"> TIMELINE OF PSYDONIA </span></strong></summary>
+
+	<strong><span style="font-size:115%"> NOTEWORTHY EVENTS </span></strong>
+	<br><br>
+	<details>
+		<summary><strong> Calamity - -66 PR to -1 PR  </strong></summary>
+		<br>
+		The Archdevil, a force beyond reality, invades the still-nurtured world of Psydonia. Though shaken by the newfound concepts of sin and murder, Psydon's children nevertheless rally to defend their home. Bronze-armored legionnaires clash against devils and deadites alike, while Psydon struggles to keep His world from falling apart. His angels take up the mantle as the first kings: divine commanders.
+		<br><br>
+		Psydon's intervention is minimal, due to a terrible ploy enacted by the Archdevil: Vheslyn's entryway - a rift in the worldly filament - sucks in the souls of those slain, condemning them to eternal suffering. Psydon focuses most of His energy to try and seal the rift from growing any larger, leaving Him unable to directly assist His children in battle.
+		<br><br>
+		Within a generation, the Archdevil destroys most of Psydonia. Raging cyclones and thunderstorms blot out the starless skies, as many settlements are swallowed whole by the Archdevil's fatigueless march. The remnants of His children - reduced to the paltry thousands - are evacuated to the highest mountains by His angels, in preparation for their final stand.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Sacrifice - -1 PR  </strong></summary>
+		<br>
+		Psydon, moved by the desperate prayers of His children and angels, weeps. His attention finally turns away from the rift, which - without any force to oppose it - begins to consume the world itself. Vheslyn, personally leading the army of darkness, confronts His children. Before the last of men-and-mer can be culled, however, a blinding light pierces the storm-clouded skies.
+		<br><br>
+		The Archdevil's haughtiness turns into petrification, as the mere presence of Psydon-upon-the-world evaporates every summited devil within a heartbeat. The deities take to the skies, and the ensuing clash is felt throughout all of Psydonia. Though Vheslyn eventually gains the advantage, even It could not foresee Psydon's willingness to save His world.
+		<br><br>
+		Empowered by the hopes and dreams of His children, Psydon channels all of His divine might into a singular missile: the Comet Syon. The impact engulfs both Psydon and Vheslyn in a massive explosion: one that not only destroys the Archdevil's world-consuming rift, but also drowns most of the ruined world. From the mountaintops, His children are left with nothing but deathly silence.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Providence - 0 AP to 351 AP </strong></summary>
+		<br>
+		Though Psydonia was saved, it had come at a grave cost. Both Psydon and Vheslyn had vanished, and most of the world had been rendered uninhabitable by the Calamity. Knowing the importance of discovering Psydon's fate above all else, most of His angels leave Psydonia to begin their search: the starless skies, at last, finally reignite.
+		<br><br>
+		Shortly afterwards, the Pantheon makes itself known to Psydonia's survivors: Abyssor recedes the floodwaters back into the ocean, Dendor rekindles growth amongst the ruined ecosystems, and Necra shepherds Psydonia's lingering souls to rest. Blinding light envelops the sky, so that Astrata can guide His children down from the mountaintops.
+		<br><br>
+		With the Pantheon's nurturing, Psydonia gradually recovers from its nigh-apocalyptic state. Noc shepherds in the gentle night, halving Astrata's burden of reigning over His world - and in the dreams of His children, Noc whispers knowledge for them to seize. Ravox, Eora, Pestra, Malum, and Xylix intermingle with men-and-mer alike, spawning many fables and legends.
+		<br><br>
+		Baotha, Graggar, and Matthios briefly gain widespread traction through their exploits against the divine. In retaliation, the Pantheon attempts to completely damn their presence from the world's memory. This suppression-of-knowledge keeps the innermost kingdoms blissfully unaware for several centuries, up until Zizo's ascension.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Enlightenment - 352 AP to 922 AP </strong></summary>
+		<br>
+		Kingdoms arise, with the Holy Celestial Empire - a communion of both Man and God - reigning above them all. The snow-elves, though cursed with infertility, were nevertheless blessed the most with Noc's wisdom. By their hands, many mechanical marvels are developed: some still exist today, such as the SCOM and MEISTERS.
+		<br><br>
+		Gradually, the Pantheon's presence in day-to-day life recedes, so that man-and-mer could continue to grow on their own. Clashes between kingdoms are infrequent, but present: most tend to end with mediation by the Holy Celestial Empire. Beyond that, Psydonia is otherwise uncontested - and for centuries to come, His children live in prosperity.
+		<br><br>
+		At this point, almost all of Psydonia now worships the Pantheon. Unlike today, however, the Psydonic minority isn't ostracized: instead, they're still treated as spiritual equals. The resting place of the Comet Syon is rediscovered, and a lesser kingdom is erected upon its coast: the Grand Duchy of Azure Peak. Azuria becomes a holy site for Psydonic worshippers.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Sundering - 923 AP </strong></summary>
+		<br>
+		At the height of Psydonia's prosperity, a snow-elven archmage discovers a way to dispel the curse that has led to their race's endangerment. A great machine is constructed, yet its activation results in a cataclysm beyond compare. Explosions ripple throughout Psydonia's leylines, and every single snow-elve simultaneously evaporates into piles of gore and ash.
+		<br><br>
+		Within a single night, an entire race had been erased from the face of the earth. The fractured leylines delved a mortal wound to Psydonia itself, causing the very forces of nature to turn on itself. Those, killed in the ensuing chaos, are resurrected as gibbering deadites - and like a plague, mania spreads throughout the Holy Celestial Empire.
+		<br><br>
+		Under the Psydonic churches, a crusade - ill-informed yet yearning for vengeance - descends upon Celestia, sealing the capital's fate. The Pantheon's own churches, believing the sudden calamity to've been caused by the raiding Psydonians, react with violence. It is only through Astrata's direct intervention that both sides didn't destroy one-another.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Decay - 924-1512 AP </strong></summary>
+		<br>
+		In the ashes of Celestia, a new deity arose - Zizo. She is followed by Baotha, Graggar, and Matthios, who have now resurfaced. Their presence gave way to the birth of Ascendanism, for they gifted His children with a revelation: they were all but mortals, once, who had discovered how to obtain divinity for themselves. A schism forms in the churches, and the Ecclesial is born.
+		<br><br>
+		With the Holy Celestial Empire in ruins, His children are forever marred. The Pantheon's church resettles in the central kingdom of Grenzelhoft, and becomes known as the Holy See - likewise, the Psydonic crusaders mournfully return to the Orthodoxy. Both leaders of these opposing churches now blame one-another for inadvertently destroying the Holy Celestial Empire.
+		<br><br>
+		Prosperity ends, and decay sets in. Divisions in faith, born in the Sundering, are now set in stone. Many worshippers have turned their backs on both Psydon and the Pantheon, in favor of the Ascendants. Men-and-mer alike are now far more vulnerable to depression, oft-coping through indulgence in vices or outbursts of uncontrollable emotions.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Now - 1513 AP </strong></summary>
+		<br>
+		The world is dying, yet it is not like the Calamity or Sundering. It is slow, prolonged, and creeping: like rot upon wood. Starvation and strife aren't the norm, but signs of a struggle have become clear. The wheat is less bountiful, the stars glimmer less in the night sky, and - more concerningly - more villains have crept out to prowl once more.
+		<br><br>
+		Yet, His children persist. Some might not even know of the world's circumstance: much less so in Azuria, which has since flourished. It's believed that its connection - both physical and spiritual - to the Comet Syon has granted it some clemency from more worldly hardships: a thought that has driven many refugees and pilgrims to its harbors.
+		<br><br>
+		Churchbells chime throughout Azuria, christening the start of a new week. Some lament about strange-and-prophetic dreams from the nights prior, though they oft-brush it off as nothing more than that: something spawned from a crumb of spoiled mustard, rather than anything divine. Others simply groan, rise from their cots, and prepare for the labors-to-come.
+		<br><br>
+		What about you?
 	</details>
 	<br><br>
 </details>
@@ -437,7 +439,7 @@ Their proximity to the Terrorbog, however, means that they're also oft-beleaguer
 	</details>
 
 	<details>
-		<summary><strong> SCARLETIA </strong></summary>
+		<summary><strong> RUDMARSCH </strong></summary>
 		<br>
 		<em>The Reach, Kingdom of Sanguine Fields</em>
 		<br><br>

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -1,24 +1,498 @@
-<b>The year is 1513.</b> There is a Grand Duchy built on traditional elven homelands, and in that Duchy there is the capital of Azure Peak, and it is the end of the world.
-<br>
-<br>
-Thousands of years ago, Psydon sent down the Comet Syon to defeat the rampaging Archdevil Vheslyn that scoured and pillaged the holy world of Psydonia. The Archdevil was slain, sent back to her home-plane- but Psydon was wounded, and fell into a deep, deep slumber (or into a shallow death?) from which he did not stir. The impact shattered him into his Ten children- Ten shards of him that guided humenity and the other races from the primordial era they were birthed from.
-<br>
-But times change.
-<br>
-<br>
-The Age of Enlightenment was a great period in the mortal races' years, where the Empire of the Holy Celestia, guided by the blessings of the Ten, brought there was unprecedented peace and prosperity across Psydonia. As the mortals expanded their power and understanding of the world around them, the Ten fell into the background, perhaps being overtaken by the same gradual sleep that plied Psydon. Great Wonders were built, and the mortal races learned. And the mortal races Ascended. In 1311, the archmage Zaelorion Crynsaris, proudest of the snow elves, ascended to Divinity. Mortals learned they could play Gods.
-<br>
-<br>
-And Mortals learned that they could ascend; that they could play Gods. And so ZIZO rose to the front of the Ascendants- mortals that had, in their own right, ascended to True Divinity. And so, the Age of Enlightenment ended with fire- the Snow Elf race exterminated, the holy Empire of the Ten extinguished, the advancements and knowledge of the eras so-shattered.
-<br>
-<br>
-Psydonia rots. Psydonia decays; scent of shit and pus and maggot-filth in the air. The Holy See controls diocese around the world that worship The Ten ever-so-faithfully...but trouble brews. Two-hundred years ago, the Church underwent a harsh schism in the dying embers of the Age of Enlightenment and of the fracturing of the empire. The Holy Ecclesial split, preaching the Ascendant. The Ten were weak, they said- and the Ascendant were what would save mortals upon this dying coil.
-<br>
-<br>
-<b>Children of the Ten, Psydonia is under attack by the Inhumen Ascendant and ever-creeping Archdevils-</b> will you lose your faith in the Ten that have guided and nurtured you?
-<br>
-<b>Glorious Ecclestials, Worshipper of Ascendants, the Ten are weak and the church is corrupt-</b> will you rise up and rewrite a world in your image, stronger and more resilient?
-<br>
-<b>Holy Lamb, Sacrificial Hero, Blessed Idiot, PSYDON endures-</b> will you yet endure as stoically and wilfully as he does, for all of humenkind?
-<br>
-<b>Lowly fool- will you save your world?</b>
+<p><strong><em><span style="font-size:115%"> Welcome to Azure Peak! </span></em></strong></p>
+<p> This lore primer serves as an introduction to Azure Peak's setting.
+<br><br>
+As always, note that this lore primer shouldn't be treated as gospel. After all, there's plenty of room in Psydonia for characters with their own interpretations of faith-and-truth. Contradicting the established narrative is an excellent way to invoke conflict between clergymen and countrymen alike.
+<br><br>
+Only the broadest strokes have been applied onto this canvas. There's plenty of supplemental lore hidden throughout Azure Peak: level a keen eye towards the dungeons, tomes, events, and descriptions of examined items, if you wish to uncover Psydonia's secrets. 
+<br><br>
+Don't be afraid to check out Azure Peak's Wiki - https://azurepeak.miraheze.org/ - for more information regarding the lore, mechanics, and more.</p>
+
+<details>
+	<summary><strong><span style="font-size:130%"> THE STORY SO FAR </span></strong></summary>
+
+	<p><strong> The year is 1513 AP. There is a Grand Duchy built on traditional elven homelands, and in that Duchy there is the capital of Azure Peak, and it is the end 	of the world.
+	<br><br>
+	A millennium ago, Psydon sent down the Comet Syon to defeat the rampaging Archdevil, which had arisen to destroy Psydonia. The Archdevil was destroyed under such 	divine might, yet a grave cost: for Psydon had collapsed into a deep sleep - (or into a shallow death?) - from which He did not stir. From the Comet Syon's impact, 	ten angels arose: a Pantheon of His divine will, who guided His children out of their primordial stupor and into enlightenment. From Psydonia's ruins, hope blossomed.
+	<br><br>
+	But times change.
+	<br><br>
+	The Age of Enlightenment brought forth prosperity throughout all of Psydonia. Guided by the Pantheon's blessings, the Holy Celestial Empire reclaimed 	Psydonia and 	shepherded in a millennium of peace. As the mortals expanded their power and understanding of the world around them, however, the Pantheon's interlopage waned - 	perhaps they, too, were being overtaken by the same gradual sleep that plied Psydon. Great Wonders were built, and the mortals learned. And..
+	<br><br>
+	..the mortal races Ascended.
+	<br><br> 
+	In 923 AP, the Age of Enlightment ended in fire. Zizo, the greatest archmage of the Holy Celestial Empire, had discovered the secrets to apotheosis: that which 	allowed Man to transmute itself into God. She created the Greatest Wonder, and - with it - Ascended with Her chosen acolytes into divinity. Psydonia's leylines 
+	ruptured with uncontrollable magicks, the entire snow-elven people were evaporated into lux-mist, and the Holy Celestial Empire collapsed into a raging inferno.
+	<br><br> 
+	And on that night - amidst the ashes - His children learned that they, too, could play the part of Gods.
+	<br><br> 
+	Psydonia rots. Psydonia decays: a gut-churning scent of shit and pus and maggot-filth, lingering in the air. The Holy See controls dioceses around the world that 
+	worship the Pantheon ever-so-faithfully, yet trouble still brews. Arising from the schism that followed the Holy Celestial Empire's collapse, the Ecclesial has since 	driven more-and-more of His children away from the Holy See's teachings: after all - what better-a-way to save this dying world than to ascend as well?
+	<br><br>
+	Children of the Pantheon: Psydonia is under attack by the Inhumen Ascendants - will you lose your faith in the Ten that have guided and nurtured you?
+	<br><br>
+	Glorious Ecclestials, Worshippers of the Ascendants: the Ten are weak and the Holy See is corrupt - will you rise up and rewrite a world in your image, stronger and more resilient?
+	<br><br>
+	Holy Lamb, Sacrificial Hero, Blessed Idiot: Psydon endures - will you yet endure as stoically and willfully as He does, for all of humenkind?
+	<br><br>
+	Lowly fool - will you save your world? Or do you watch the birth of a new one?</em><br></p>
+</details>
+<br><br>
+</details>
+
+
+<p><strong><em><span style="font-size:115%"> ... </span></em></strong></p>
+
+
+<details>
+	<summary><strong><span style="font-size:130%"> POWERS OF PSYDONIA </span></strong></summary>
+
+	<strong><span style="font-size:115%"> NOTEWORTHY KINGDOMS, FIEFS, AND RUINS </span></strong>
+	<br><br>
+	<details>
+		<summary><strong> AZURIA </strong></summary>
+		<br>
+		<em>The Grand Duchy of Azure Peak, Syon's Rest</em>
+		<br><br>
+		Azuria is a lesser kingdom, burrowed halfway into the ancient elvish mountainscapes that stand vigil over Psydonia's central oceans. Long ago, it held host to the final battle between Psydon and the Archdevil: nowadays, it's more well-known for its strong fishing economy and delicious salted trout pies. Owing to its nature as a welcoming refuge for both travelers and pilgrims alike, Azuria's population - both residential and temporary - happens to be unusually diverse. 
+<br><br>
+Not unlike the divine comet that has long since come to rest beneath its shores, so too does Azuria's foliage glimmer with brilliant hues of blue during the winter. Many believe that Azuria has been seeded with such energy, which is why it has been able to remain blissfully calm within a world that stands a mere tremor away from collapsing into utter chaos.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> GRENZELHOFT </strong></summary>
+		<br>
+		<em>The Empire, Seat of the Pantheon's Holy See</em>
+		<br><br>
+		Grenzelhoft has been around since the dawn of Psydonia, in one form or another, as its strongest kingdom. It is ruled both by an Emperor and, to a more spiritual extent, the Pope of the Holy See. Courtesy of its nigh-limitless might, Grenzelhoft has succeeded at proliferating the Pantheon's worship throughout most of Psydonia: a fact that has fueled the rivalry with its sister-kingdom, Otava, for the past millennium. 
+<br><br>
+Beyond its fabulously-dressed mercenaries and preference for bun-cradled sausages, Grenzelhoft is also praised for its hand in creating blacksteel - an alloy of near-mythical repute, coveted by all. Most recently, Grenzelhoft has taken the step to completely dismantle the practice of non-punitive slavery within its territories: a moral victory that had spurred threats of an embargo by Raneshen's slave-trading guilds.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> OTAVA </strong></summary>
+		<br>
+		<em>The Cathedral, Worshippers of the Weeping God</em>
+		<br><br>
+		Otava had broken off from Grenzelhoft, long ago, after the Comet Syon's impact had invoked a schism amongst the faithful. While Grenzelhoft embraced the Pantheon as heirs of Psydon's divine authority, Otava stubbornly clung to the notion that their now-absent God would yet return: and over a millennium later, they still believe it. 
+<br><br>
+It is the only kingdom of notable size that still worships Psydon, and - as a theocracy - is solely ruled by the Archbishop of its Orthodoxy. Despite its apostasy, Otava still exports enough value to warrant the begrudging respect of its neighbors: be it through silver, stone, or slayers. The latent paranoia amongst its faithful inhabitants has recently exploded into full-on hysteria, following their witnessing of the 'blue sun' phenomena: a purported sign that Psydon's return is nigh.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> NALEDI </strong></summary>
+		<br>
+		<em>The Caliphate, Apostates of Magicked Renown</em>
+		<br><br>
+		Naledi is a nation dominated by southern dunes, northern mountains that border Grenzelhoft, and lush savannas that cling to the coast. Governed by a Shah, who delegates the functions of their cities to politico-philosopher Caliphs and theocratic Cariye. With an emphasis on both academia and piety, Naledi is renowned for it’s warscholars, magickal institutions, and belief in Old Psydonic - a monotheistic denomination of Psydonians that believe He is the only God, and the Pantheon are different names of Him.
+<br><br> 
+Decades of invasion from Djinn, destabilized trade routes leaving towneships starved, and the exodus of warscholars in search for more opportunities has put Naledi in a gradual state of decline. More troubling, however, is the revelation that its star-speckled skies have abruptly turned into a colorless void.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> AAVNR </strong></summary>
+		<br>
+		<em>The Steppes, Nomadic Masters of Martiality</em>
+		<br><br>
+		Aavnr is an atypical nation, owing to its vast expanse of flatlands. In lieu of being ruled by a singular kingdom - similar to the bordering nations of Grenzelhoft and Otava, Aavnr instead holds host to a wide array of smaller villages, nomadic tribes, and orcish warbands. Most of Psydonia's saigas can trace their ancestry from these steppes. 
+<br><br>
+The most prominent lesser kingdom within Aavnr's boundries is the Potentate: a coalition of nomadic tribes, which have since settled down along the coast in order to create a naval-reliant nexus for tradesmen of all varieties. Owing to the constant struggles faced by most who live within the steppes, Aavnr has also cultivated some of the finest martialists in all of Psydonia: a trait that has led to many foreign warriors visiting the steppes in search of greater tutelage. 
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> HAMMERHOLD </strong></summary>
+		<br>
+		<em>The Fortress, Craftsmen of the Mountainscapes</em>
+		<br><br>
+		Hammerhold, similarly to Azuria, is perched within the northern mountainscapes. While Azuria resides near the northeastwardly coast, however, Hammerhold has firmly rooted itself within the northwestern peaks - those that make Mount Golgatha look diminutive in comparison. Beneath its snowy castles is a massive dwarven fortress, renowned for its legendary artificers and alchemists. 
+<br><br>
+They are believed to've been the first to successfully alchemize blastpowder: a highly expensive yet volatile ingredient for the rarely-seen handbombs and handgonnes. Alongside Azuria, Hammerhold holds one of the only known paths to the Underdark - a world-spanning labyrinth of subterranean caves and fae-nests, rumored to house both unimaginable horrors and yet-to-be-discovered treasures. Out of the many who've embarked into these depths, only a few've returned.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> GRONN </strong></summary>
+		<br>
+		<em>The Tundra, Raiders of the Frigid Pines</em>
+		<br><br>
+		Gronn reaches as far north as civilization dares to tread, though most would dare to contest whether such a nation could even be described as 'civil' in the first place. Similarly to the Aavnric steppes, Gronn lacks a singular kingdom to rule over the mountainous tundras - most signs of traditional civilization line the southern border, peppered with villages that oft-host foreign beasthunters. 
+<br><br>
+Fiercer warbands often venture outside of Gronn in order to raid neighboring lands and caravans for their riches: yet whenever a kingdom attempts to retaliate with an invasion of their own, they're usually stopped dead in their tracks by Gronn's inhospitably-violent blizzards. Some believe that they're the descendants of those who dared to venture beyond the Fjall - the northernmost deadlands of Psydonia.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> RANESHEN </strong></summary>
+		<br>
+		<em>The Autarchy, Merchants of Shifting Sands</em>
+		<br><br>
+		Raneshen - better known by its ancestral title, 'Zybantia' - resides across the ocean as Grenzelhoft's economic rival: a greater kingdom, founded long ago by ancient Naledian exiles. While topologically similar to Naledi, the Ranesheni people had built their nation upon a far different thought: since Psydon had created the world, it was only right that divine reverence shouldn't solely manifest in prayer, but through indulgence as well.
+<br><br>
+Such has led Raneshen to becoming Psydonia's wealthiest nation, with a stranglehold over the exportation of exotic spices, silks, and slaves. Yet, the one thing Raneshen takes pride in above all else is music - its composers are unmatched in skill, and have been the premiere choice for catering to extravagant ceremonies: the latest of which being the coronation of Grenzelhoft's newest Emperor. 
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> LIRVAS </strong></summary>
+		<br>
+		<em>The Plutocracy, Fiefdom of Sinners-And-Slaves</em>
+		<br><br>
+		Lirvas, nestled within a small isle just off of Raneshen's coast, is notorious for its guiltless worship of the Ascendants. The social strata of Livras is carved into the stone itself: a five-ringed kingdom, built around a temple of gold. Only those within the innermost rings can indulge in sin-and-excess, for the rest are all indebted - be it through coinage or slavery - to the wealthiest few. 
+<br><br>
+It is ruled not by a man, but a dragon: an ancient megabeast who's power has allowed Lirvas to remain unthreatened by foreign kingdoms. Yet, for as powerful as its draconic tyrant might be, even it can't stop the will of the people. A massive rebellion, spurred through a long-planned strike by the freedmen of the 'Forlorn Hope', threatens to tear Lirvas apart from the inside-out.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> KAZENGUN-LINGYUE </strong></summary>
+		<br>
+		<em>The Dynasty, Sister-Kingdoms of Mystique</em>
+		<br><br>
+		Kazengun and Lingyue reside upon the same halved continent as Raneshen, yet have remained isolated from most worldly affairs until recently. While little is known about these mysterious nations, scholars have been able to piece together a rough idea of what lies beyond Psydonia's central oceans: courtesy of the Kazengunese-and-Lingyuese mercenaries that've taken up residence in Azuria. 
+<br><br>
+They speak of a beautiful landscape, peppered with subtropical isles and accustomed to the fiercest storms imaginable. Such peace cannot be savored, however, as Kazengun and Lingyue are now locked within a brutal civil war - the consequence of long-standing territorial disputes and clashing beliefs in the esoteric. In order to better fund their militaries, both kingdoms have started to indulge far more in foreign economics.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> ETRUSCA </strong></summary>
+		<br>
+		<em>The Isle, Devotees of Gods-And-Country Alike</em>
+		<br><br>
+		Etrusca rests as the sole isle between Psydonia's halved continents: the intermediate point between the coasts of Azuria and Raneshen. It's said that no other kingdom is as beloved by its own people: a sense of national pride, so potent, that it can rival even the Pantheon's most zealous worshippers. Besides their love for pastas and romantic fables, Etrusca also happens to house Psydonia's strongest naval fleet. 
+<br><br>
+Most recently, it had been invaded by the full might of Raneshen's military: yet despite the numerical disadvantage, Etrusca's armada - and the efforts of the 'Vaquero', folkheroic guerilla fighters - was able to ultimately repel the Ranesheni aggressors. While still recovering from the invasion's damages, Etrusca is nevertheless basking in the afterflow of their triumph.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> FJALL </strong></summary>
+		<br>
+		<em>The Arctic, Ruins of Vheslyn-And-Celestia</em>
+		<br><br>
+		Fjall may not be a nation, but its relevance supersedes even the greatest kingdoms of today. In Psydonia's infancy, it was the staging ground for the Archdevil's invasion: a violation of reality that turned its savannahs into a volcanic mountainscape. Once the Archdevil fell and the magma cooled, civilization crept back in to reclaim it - a grandiose kingdom, erected upon the Archdevil's proverbial grave, as a proclamation of their triumph over evil. 
+<br><br>
+Yet, not a millennium later, there came Zizo's ascension: a calamity so profound that everything further north than Gronn's forests was irreversibly destroyed. Now, all that remains are twisting mountains, and the few who still live within its valleys. Even through Fjall's harshest blizzards, the winds of these fjords sing a haunting tune: one that foretells Psydonia's end.
+		<br>
+	</details>
+
+	<br>
+	<strong><span style="font-size:115%"> MISCELLANIOUS KINGDOMS, FIEFS, AND RUINS </span></strong>
+	<br><br>
+	<details>
+		<summary><strong> ROCKHILL </strong></summary>
+		<br>
+		<em>The Rogue's Town, Sister-Kingdom of Azuria</em>
+		<br><br>
+		Rockhill is the closest kingdom to Azuria, reachable within a half-day's journey on saigaback. Known for its cheap-yet-plentiful liquor and prolific pickpocketeers, the peasantry - while illiterate and Psydon-fearing - are surprisingly jovial. 
+<br><br>
+Though similar in size to Azuria, its self-contained nature means that it is more freely ruled by a king instead of a duke. Religious differences aside, Rockhill and Azuria have maintained a strong alliance for the better part of a century.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> VALORIA </strong></summary>
+		<br>
+		<em>The Republic, Cultivators of the Weeping God's Order</em>
+		<br><br>
+		Valoria is a lesser kingdom that straddles the western coasts, just a stone's throw away from Lyndvhar. They practice an optimistic variant of the Orthodoxy, and - though largely independent from Otava's influence - often helps out whenever the Archbishop calls for holy warfare. 
+<br><br>
+Residing within Valoria's walls is the Order of the Silver Psycross: a faith-militance that's renowned for its intoxicating mirth, adherence to chivalry, and remarkably delicious handpies. 
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> LYNDVHAR </strong></summary>
+		<br>
+		<em>The Port, Receiver of Psydonia's Merchant-Fleets</em>
+		<br><br>
+		Lyndvhar might be similar in size to Azuria, but has a far more vital presence in Psydonia's economic affairs. Due to their positioning on the western coast, they're considered the closest - and most neutral - port for nearly every major kingdom with a mercantile fleet. 
+<br><br>
+Fried salmoncakes, jellied eels, and pints of Fjall-iced liquor keep Lyndvhar's dockworkers strong: both when laboring at the harbor, and when rioting against the wealthy elite after a particularly close game of lampternball.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> VANDERLIN </strong></summary>
+		<br>
+		<em>The Progressive, Harnessers of Artificery</em>
+		<br><br>
+		Vanderlin - like Hammerhold - is one of the few kingdoms that has dabbled in the oft-misunderstood techniques of artificery. It's rumored that their plumbing exceeds even Grenzelhoft's own in terms of cleanliness, and that bronze spigots can ferry water where no bucket could normally reach in a timely manner.
+<br><br>
+Standing far above the king's manor is a massive clocktower, allegedly powered by a strange crystal that had been unearthed within their copper-and-tin mines.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> KINGSFIELD </strong></summary>
+		<br>
+		<em>The Overlooker, Duchy-Adherent to Azuria</em>
+		<br><br>
+		Kingsfield, as the name implies, houses a majority of Azuria's noblemen and peasantry: hence, why the duchy's streets might seem emptier than one might imagine. The streets oft-bustle with carriages that can quickly ferry its riders to the duchy itself, for a small price. 
+<br><br>
+Tethered to a clocktower of its own is Azuria's own airship: a so-called 'skyvessel' - one of the few known to exist - that has remained suspiciously ready for a yet-announced maiden voyage.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> BLASTENGHYLL </strong></summary>
+		<br>
+		<em>The Lost, Remains of a Martyred Farmtown</em>
+		<br><br>
+		Blastenghyll once stood as an agricultural community, neighboring the kingdoms of both Rockhill and Azuria. It had recently been subjected to a horrific tragedy, however: nearly every villager, ritualistically murdered by the forces of Zizo in order to invoke the greatest rituos. 
+<br><br>
+Though a force of Psydonic crusaders had managed to stop the ritual before its completion, it still came at a terrible cost. All that remains now, amongst overgrown logs and poppies, is a lone obelisk of stone.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> KAIZOKU </strong></summary>
+		<br>
+		<em>The Farlands, Kingdom of Fogged Legend</em>
+		<br><br>
+		Kaizoku occupies a smaller series of isles that're at the edge of known civilization, and - if the scholars are to be believed - is an ancestral relative to the twinned-empires of Kazengun and Lingyue. It is perpetually shrouded in fog, so thick that only its well-accustomed sailors could ever hope to safely navigate through it.
+<br><br>
+Mostly known for its exportation of the fogbeast: a prized hybrid of the saiga and horse, and the favored steed of Kingsfield's stout-postured knight-commander.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> BLACKSTONE </strong></summary>
+		<br>
+		<em>The Crater, Hole of Naught But Dust-And-Echoes</em>
+		<br><br>
+		While not originally named 'Blackstone', this fief was retroactively termed as such following a minor incident which - involving the accidental collision of two Syonic fragments in transit - had resulted it being completely vaporized. 
+<br><br>
+The remaining crater had left a curious surprise, however, for its survivors: a glassy surface, not unlike obsidian, that seems to glimmer with unnatural energy. As of now, a sect of the Holy Psydonic Inquisition garrisons the crater.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> ROTWOOD </strong></summary>
+		<br>
+		<em>The Vale, Laborers of the Terrorbog</em>
+		<br><br>
+		Originally formed as a camp for those overlooking the Terrorbog, the 'Rotwood Vale' - as it's most commonly known as now - has since grown into a lesser kingdom, renowned for hosting some of Psydonia's most battle-hardened Wardens. 
+<br><br>
+Their proximity to the Terrorbog, however, means that they're also oft-beleaguered by deadly plagues: a matter that has only served to further enforce the unusually high level of segregation between the noblemen and their peasantry.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> SCARLETIA </strong></summary>
+		<br>
+		<em>The Reach, Kingdom of Sanguine Fields</em>
+		<br><br>
+		Colloquially known as the 'Scarlet Reach', this lesser kingdom once had the misfortune of being in the middle of a century-long war between Grenzelhoft and Otava. While the fighting has long since ceased, its fields have forever retained an unnaturally red hue. 
+<br><br>
+Even so, their reputation is mercifully softened by the fact that they grow some of the highest-quality wheat and tea within Psydonia. They briefly came into conflict with Azuria over a salt mine that sat on contested territories.
+		<br>
+	</details>
+	<br><br>
+</details>
+
+
+<details>
+	<summary><strong><span style="font-size:130%"> MYTHOS OF PSYDONIA </span></strong></summary>
+
+	<strong><span style="font-size:115%"> OVERVIEW OF THE DIVINE </span></strong>
+	<br><br>
+	<details>
+		<summary><strong> THE FATHER </strong></summary>
+		<br>
+		<span style="display:block; color:#007fff; font-size:115%"> "..." </span>
+		<br>
+		Psydon is worshipped as the creator of ontological reality, and the only true force of goodness that Psydonia ever knew. It was He who gifted man-and-mer with not only existence, but the capacity to emote like Him. When the Archdevil tore open reality and threatened to destroy Psydonia, it was Him who undertook the ultimate sacrifice to save the world He had come to love. 
+<br><br>
+Nowadays, most believe that Psydon is gone: yet, an ardent minority continues to remain loyal in the hopes that He may yet return to save His world once more. His children might be bereft of miracles and answers, but they continue to endure - even at the end of the world.
+<br><br>
+		Psydonic worshippers are in the minority, and are generally ostracized by most kingdoms. The Orthodoxy teaches the most widespread form of Psydonic worship, though there are countless other forms practiced throughout the world. 
+<br><br>
+Azuria currently houses a cohort of the Holy Psydonic Inquisition, as part of a diplomatic affair with Otava. In addition, Azuria - due to its proximity to Syon's resting place - is considered a 'holy site' by the Orthodoxy. Such has made it common for pilgrims throughout all of Psydonia to visit the lesser kingdom, in the hopes that they may be blessed by what remains of the divine comet.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> THE PANTHEON </strong></summary>
+		<br>
+		<span style="display:block; color:#ffd700; font-size:115%"> "WITH ORDER, WE REIGN; AND WITH FAITH, WE PROSPER." </span>
+		<br>
+		The Pantheon are the successors to Psydon: ten deities who have taken up the mantle of guiding His children along. After the Comet Syon had seemingly destroyed both Psydon and the Archdevil, the ruined world's survivors wept for guidence. 
+<br><br>
+Though most of His angels had left Psydonia in search of answers only woven into the stars, there remained a cohort of ten who - whether through guilt or newfound purpose - remained behind to pick up the pieces. Adopting more heavenly forms to ensure His children would not be afraid, Astrata and Her nine siblings finally descended from the reignited skies to answer their prayers: and from there, the rest was history.
+		<br><br>
+		Pantheonic worshippers are in the majority, and have remained as such for over a millenium's time. Almost every kingdom in Psydonia houses a church that preaches the Pantheon's teachings, taken directly from the Holy See's tomes.
+<br><br>
+Azuria is no different, with its duchal patrons being Astrata, Dendor, and Abyssor. While Astrata is traditionally worshipped as the Pantheon's supreme deity, the Holy See oft-emphasizes that all ten deities should be given equal reverance. Hence, it isn't uncommon to see an Astratan praying to Ravox for courage in the midst of battle, nor to witness a Malumite cursing out Dendor for overmuddying a carriage's intended pathway. 
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> THE ASCENDANTS </strong></summary>
+		<br>
+		<span style="display:block; color:#800080; font-size:115%"> "WHAT IS A GOD, IF NOT A MAN WHO HAS RECOGNIZED THE FOLLY OF MORTALITY?" </span>
+		<br>
+		The Ascendants are the youngest of all deities, and - as alleged by its worshippers - the true heirs to Psydon's mantle. Unlike the Pantheon, these four deities were never divine to begin with: instead, they were mortals who had managed to achieve godhood through mythical exploits. 
+<br><br>
+Zizo offers progress, Baotha offers bliss, Graggar offers freedom, and Matthios offers wealth - yet, their worshippers seldom know the price that must be paid to obtain such luxuries. While the Holy See has desperately tried to cover up the truth being the Ascendants, a recent schism has led to many of His children embracing the concept of apotheosis.
+		<br><br>
+		Ascendant worshippers vary from region-to-region. Most inner kingdoms revile the concept of Ascendanism, and - thanks to its demonization by the Holy See - oft-hunt down those who openly praise the four-who-ascended. 
+<br><br>
+The outermost kingdoms are much different, however: Gronn, Fjall, Raneshen, and Lirvas happen to welcome the Ascendants, albeit in forms that might be considered 'esoteric' and 'unusual' by more-recent convertees. Owing to the individualistic nature of Ascendanism, most worshippers - save for those who've completely embraced the concept of 'obtaining godhood' - tend to secularly worship one deity in particular.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> THE ARCHDEVIL </strong></summary>
+		<br>
+		<span style="display:block; color:#ff0000; font-size:115%"> "FROM THE ASHES, WE ROSE! AND TO THE ASHES, WE WILL ALL RETURN!" </span>
+		<br>
+		Vheslyn. The primordial essence, the manifestation of ontological evil, and - for the longest time - the lone inhabitant of ur-existence. Psydon had created reality within the void: an act of unforeseen interlopage that drove Vheslyn into a blithering rage. 
+<br><br>
+It was Vheslyn who introduced sin into the hearts of His children, who formed an army of darkness to march upon Psydonia, and created Hell to forever-torment those who were slain in the ensuing rampage. Before His world could be destroyed, however, Psydon undertook the ultimate sacrifice to stop Vheslyn's rampage: a final blow that sundered both body-and-spirit. In the Comet Syon's explosion, both had vanished.
+		<br><br>
+		Yet, Vheslyn's influence did not fully leave Psydonia. The few devils who had survived the Comet Syon's impact, now left powerless and tethered to Psydonia, would eventually learn to embrace goodness: and by communing with His children, the first Tieflings would be made. 
+<br><br>
+More recently, unsettling rumors have arose of an ancient cult, nestled deep within the Fjallic wastes - one that seeks to resurrect Vheslyn, in order to finally destroy Psydonia and return everything to nothingness. Most believe such rumors to be nothing more than that: a rumor. Even so, one must wonder why Psydonia's northern skies have taken on such vivid auroras, lately.
+		<br>
+	</details>
+	<br><br>
+</details>
+
+<details>
+	<summary><strong><span style="font-size:130%"> GLOSSARY OF PSYDONIA </span></strong></summary>
+
+	<strong><span style="font-size:115%"> NOTEWORTHY CONCEPTS </span></strong>
+	<br><br>
+	<details>
+		<p><strong> Psydonia </strong> - The world that Azuria takes place in. Named after its creator, Psydon. </p>
+		<p><strong> Enigma </strong> - A more agnostic term for Psydonia, preferred by the Holy See and Ascendants. Not to be confused with the Isle of Enigma. </p>
+		<p><strong> Comet Syon </strong> - A divine star, sent down by Psydon to destroy the Archdevil. Its core had come to rest just off of Azuria's coast. </p>
+		<p><strong> Undermaiden </strong> - Death. The personification of Necra, who is said to ferry the deceased towards their chosen afterlife. </p>
+		<p><strong> Paradise </strong> - Heaven. Debatably created by either Psydon or Astrata, as a resting place for the faithful and virtuous. </p>
+		<p><strong> Underworld </strong> - Hell. A spiteful inversion of reality, created by the Archdevil. It is the home of devils, demons, and taxmen. </p>
+		<p><strong> Holy See </strong> - The premiere worshippers of the Pantheon, and the governing body of the Church. Ruled by a Pope.</p>
+		<p><strong> Ecclesial </strong> - A splinter-faction of the Holy See, which has instead embraced the Ascendants. Sporadically present in hidden enclaves. </p>
+		<p><strong> Orthodoxy </strong> - The Holy See's rival and occasional ally, whom gives praise to Psydon. Ruled by an Archbishop.</p>
+		<p><strong> Alotheos </strong> - A labyrinthian tomb, located within Azuria. Though its origins aren't known, its said to hold untold riches within. </p>
+		<p><strong> Arcyne </strong> - Magicka. A blessing of Noc, which allows for the manipulation of Psydonia's latent energies. </p>
+		<p><strong> Leyline </strong> - Channels of pure magicka, running across Psydonia like the arteries in a body. Most arcyne acts draw from these veins. </p>
+		<br>
+	</details>
+
+	<strong><span style="font-size:115%"> NOTEWORTHY TERMS </span></strong>
+	<br><br>
+	<details>
+		<p><strong> Miracle </strong> - Holy magicka. Unlike the arcyne, miracles are powered by one's faith and devotion to their chosen deity. </p>
+		<p><strong> Lux </strong> - The physical condensation of soulmatter, present along the heart. It's said to tether one's spirit to their body. </p>
+		<p><strong> Deadite </strong> - Luxless corpses, resurrected through unholy means. Interchangeably used to describe both zombies and skeletons. </p>
+		<p><strong> Lycker </strong> - Vampires. These luxless revenants are said to drink the blood of the living, and are empowered with unholy magicks. </p>
+		<p><strong> Avantyne </strong> - A so-called 'evil' alloy, wielded by Zizo's most devoted worshippers. More commonly known as 'darksteel'.</p>
+		<p><strong> Saiga </strong> - Large antelopes, and Psydonia's most popular choice for cavalrymen and travelers. Analogous to the far-rarer horse. </p>
+		<p><strong> Red </strong> - A healing potion - specifically, the regenerative juices inside. Additionally known as 'lifeblood'.  </p>
+		<p><strong> Blue </strong> - A fatigue potion - or, rather, the energy-boosting juices inside. Additionally known as 'manna'. </p>
+		<p><strong> Cackleberry </strong> - Eggs. The favored pronunciation amongst the peasantry and antiquated. </p>
+		<p><strong> Mammon </strong> - Currency. A copper zenny is one mammon, a silver ziliquae is five mammons, and a gold zenar is ten mammons. </p>
+		<p><strong> Scom </strong> - A rous-powered communication machine. Also functions as a verb, when used to describe 'calling' or 'contacting' someone. </p>
+		<p><strong> Meister </strong> - A coinage-machine that - with the cost of a bloodied finger - allows one to access their personal reserve of mammons. </p>
+		<p><strong> Nervemaster </strong> - The nexus that all coinage-machines are connected to. It can both deposit-and-tax mammons from all personal reserves.</p>
+		<p><strong> Vomitorium </strong> - A twin-throated chute that trails all the way to a city's stockpile. It both eats-and-vomits mammons and materials.</p>
+		<p><strong> Silverface </strong> - Toggleable vendors, drawing from the stockpile of local businesses. Far more expensive, yet quicker, than commissions.</p>
+		<p><strong> Excidium </strong> - The leyline of bounty-hunters: a machine that both tracks and redeems local bounties for a sum of coinage.</p>
+		<p><strong> Lampternball </strong> - A popular sport, where one maneuvers a rounded lamptern into either a hoop, goal, or a blaggard's face.</p>
+		<p><strong> PR </strong> - The previous calender-era, lasting from the beginning of recorded history to the Comet Syon's impact - and Psydon's absence. </p>
+		<p><strong> AP </strong> - The current calender-era, which started after the end of Psydonic supremacy. The current date, as mentioned, is 1513 AP. </p>
+		<br>
+	</details>
+	<br><br>
+</details>
+
+
+<details>
+	<summary><strong><span style="font-size:130%"> TIMELINE OF PSYDONIA </span></strong></summary>
+
+	<strong><span style="font-size:115%"> NOTEWORTHY EVENTS </span></strong>
+	<br><br>
+	<details>
+		<summary><strong> Calamity - -66 PR to -1 PR  </strong></summary>
+		<br>
+		The Archdevil, a force beyond reality, invades the still-nurtured world of Psydonia. Though shaken by the newfound concepts of sin and murder, Psydon's children nevertheless rally to defend their home. Bronze-armored legionnaires clash against devils and deadites alike, while Psydon struggles to keep His world from falling apart. His angels take up the mantle as the first kings: divine commanders.
+		<br><br>
+		Psydon's intervention is minimal, due to a terrible ploy enacted by the Archdevil: Vheslyn's entryway - a rift in the worldly filament - sucks in the souls of those slain, condemning them to eternal suffering. Psydon focuses most of His energy to try and seal the rift from growing any larger, leaving Him unable to directly assist His children in battle.
+		<br><br>
+		Within a generation, the Archdevil destroys most of Psydonia. Raging cyclones and thunderstorms blot out the starless skies, as many settlements are swallowed whole by the Archdevil's fatigueless march. The remnants of His children - reduced to the paltry thousands - are evacuated to the highest mountains by His angels, in preparation for their final stand.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Sacrifice - -1 PR  </strong></summary>
+		<br>
+		Psydon, moved by the desperate prayers of His children and angels, weeps. His attention finally turns away from the rift, which - without any force to oppose it - begins to consume the world itself. Vheslyn, personally leading the army of darkness, confronts His children. Before the last of men-and-mer can be culled, however, a blinding light pierces the storm-clouded skies.
+		<br><br>
+		The Archdevil's haughtiness turns into petrification, as the mere presence of Psydon-upon-the-world evaporates every summited devil within a heartbeat. The deities take to the skies, and the ensuing clash is felt throughout all of Psydonia. Though Vheslyn eventually gains the advantage, even It could not foresee Psydon's willingness to save His world.
+		<br><br>
+		Empowered by the hopes and dreams of His children, Psydon channels all of His divine might into a singular missile: the Comet Syon. The impact engulfs both Psydon and Vheslyn in a massive explosion: one that not only destroys the Archdevil's world-consuming rift, but also drowns most of the ruined world. From the mountaintops, His children are left with nothing but deathly silence.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Providence - 0 AP to 351 AP </strong></summary>
+		<br>
+		Though Psydonia was saved, it had come at a grave cost. Both Psydon and Vheslyn had vanished, and most of the world had been rendered uninhabitable by the Calamity. Knowing the importance of discovering Psydon's fate above all else, most of His angels leave Psydonia to begin their search: the starless skies, at last, finally reignite.
+		<br><br>
+		Shortly afterwards, the Pantheon makes itself known to Psydonia's survivors: Abyssor recedes the floodwaters back into the ocean, Dendor rekindles growth amongst the ruined ecosystems, and Necra shepherds Psydonia's lingering souls to rest. Blinding light envelops the sky, so that Astrata can guide His children down from the mountaintops.
+		<br><br>
+		With the Pantheon's nurturing, Psydonia gradually recovers from its nigh-apocalyptic state. Noc shepherds in the gentle night, halving Astrata's burden of reigning over His world - and in the dreams of His children, Noc whispers knowledge for them to seize. Ravox, Eora, Pestra, Malum, and Xylix intermingle with men-and-mer alike, spawning many fables and legends.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Enlightenment - 352 AP to 922 AP </strong></summary>
+		<br>
+		Kingdoms arise, with the Holy Celestial Empire - a communion of both Man and God - reigning above them all. The snow-elves, though cursed with infertility, were nevertheless blessed the most with Noc's wisdom. By their hands, they created many technological marvels that still exist today: namely, the mechanisms used for Thrones, Meisters, and the SCOM. 
+		<br><br>
+		Gradually, the Pantheon's presence in day-to-day life recedes, so that man-and-mer could continue to grow on their own. Clashes between kingdoms are infrequent, but present: most tend to end with mediation by the Holy Celestial Empire. Beyond that, Psydonia is otherwise uncontested - and for centuries to come, His children live in prosperity.
+		<br><br>
+		At this point, almost all of Psydonia now worships the Pantheon. Unlike today, however, the Psydonic minority isn't ostracized: instead, they're still treated as spiritual equals. The resting place of the Comet Syon is rediscovered, and a lesser kingdom is erected upon its coast: the Grand Duchy of Azure Peak. Azuria becomes a holy site for Psydonic worshippers.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Sundering - 923 AP </strong></summary>
+		<br>
+		At the height of Psydonia's prosperity, a snow-elven archmage discovers a way to dispel the curse that has led to their race's endangerment. A great machine is constructed, yet its activation results in a cataclysm beyond compare. Explosions ripple throughout Psydonia's leylines, and every single snow-elve simultaneously evaporates into piles of gore and ash.
+		<br><br>
+		Within a single night, an entire race had been erased from the face of the earth. The fractured leylines delved a mortal wound to Psydonia itself, causing the very forces of nature to turn on itself. Those, killed in the ensuing chaos, are resurrected as gibbering deadites - and like a plague, mania spreads throughout the Holy Celestial Empire.
+		<br><br>
+		Under the Psydonic churches, a crusade - ill-informed yet yearning for vengeance - descends upon Celestia, sealing the capital's fate. The Pantheon's own churches, believing the sudden calamity to've been caused by the raiding Psydonians, react with violence. It is only through Astrata's direction intervention that both sides didn't destroy one-another.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Decay - 924-1512 AP </strong></summary>
+		<br>
+		In the ashes of Celestia, a new deity arose - Zizo, accompanied by the trinity of Baotha, Graggar, and Matthios. Their presence gave way to the birth of Ascendanism, for they gifted His children with a revelation: they were all but mortals, once, who had discovered how to obtain divinity for themselves. A schism forms in the churches, and the Ecclesial is born.
+		<br><br>
+		With the Holy Celestial Empire in ruins, His children are forever marred. The Pantheon's church resettles in the central kingdom of Grenzelhoft, and becomes known as the Holy See - likewise, the Psydonic crusaders mournfully return to the Orthodoxy. Both leaders of these opposing churches now blame one-another for inadvertently destroying the Holy Celestial Empire.
+		<br><br>
+		Prosperity ends, and decay sets in. Divisions in faith, born in the Sundering, are now set in stone. Many worshippers have turned their backs on both Psydon and the Pantheon, in favor of the Ascendants. Men-and-mer alike are now far more vulnerable to depression, oft-coping through indulgence in vices or outbursts of uncontrollable emotions.
+		<br>
+	</details>
+
+	<details>
+		<summary><strong> Now - 1513 AP </strong></summary>
+		<br>
+		The world is dying, yet it is not like the Calamity or Sundering. It is slow, prolonged, and creeping: like rot upon wood. Starvation and strife aren't the norm, but signs of a struggle have become clear. The wheat is less bountiful, the stars glimmer less in the night sky, and - more concerningly - more villains have crept out to prowl once more.
+		<br><br>
+		Yet, His children persist. Some might not even know of the world's circumstance: much less so in Azuria, which has since flourished. It's believed that its connection - both physical and spiritual - to the Comet Syon has granted it some clemency from more worldly hardships: a thought that has driven many refugees and pilgrims to its harbors.
+		<br><br>
+		Churchbells chime throughout Azuria, christening the start of a new week. Some lament about strange-and-prophetic dreams from the nights prior, though they oft-brush it off as nothing more than that: something spawned from a crumb of spoiled mustard, rather than anything divine. Others simply groan, rise from their cots, and prepare for the labors-to-come.
+		<br><br>
+		What about you?
+	</details>
+	<br><br>
+</details>


### PR DESCRIPTION
## About The Pull Request

This is a follow-up to Free's pull request.
In short, it replaces our old _'lore primer'_ blurb with a dedicated text document. The original version was ported over from Vanderlin, though almost everything - save for the formatting - has been replaced.

Clicking the _'lore primer'_ button now directs you to a seperate page, which has..
* A handy little greeting, peppered with some important notes and a direct link to Azure Peak's wiki,
* 'THE STORY SO FAR', which uses a touched-up version of the original _'lore primer'_ blurb by Teabear,
* 'POWERS OF PSYDONIA', which offers a brief description for most major, minor, and miscellaneous settlements,
* 'MYTHOS OF PSYDONIA', which gives an overview of the major faiths and their respective deities,
* 'GLOSSARY OF PSYDONIA', which describes a bunch of setting-specific terms and nomenclature, and..
* 'TIMELINE OF PSYDONIA', which uses a heavily modified and slimmed-down version of Nightmare's original timeline.

I should clarify, first and foremost, that I am _not_ the best writer. The pacing might be off, and there will absolutely be some imperfections. My hope is that it's serviceable enough, however, to ensure that we can finally nip the year-long issue of _"people not knowing about where the lore or wiki is"_ in the butt.

With that being said, I've also made sure to keep everything _as_ close to the established lore - namely, stuff written on the wiki or explicitly cemented in the game - as possible. Some creative liberties have been taken in cases where little-to-no applicable information was available, though that's about it.

Otherwise, this should be good to go. Lore-developers are _(obviously)_ free to edit and tweak this to their heart's content, and to improve on the rudimentary stuff I've added. Thanks to how .txt files work, it should be _far_ easier for less experienced lore-developers to submit changes as needed, without having to fret about testing.

_(Disclaimer: I suck ass at writing long-form stuff like this. I pray I never have to touch a text document again. I openly invite any-and-all lore developers to rewrite whatever they want, here.)_

## Testing Evidence

<img width="1169" height="957" alt="61860a681adb2a3694a42365ba6cad3b" src="https://github.com/user-attachments/assets/773d3903-10ed-474a-aa8e-22a3fe746dcf" />
You can click the little arrows beside each title to uncover more information. Very intuitive!


## Why It's Good For The Game

Making it super easy for people to both discover Azure Peak's wiki _and_ get a crash course on the setting's lore _(through small and digestible entries)_ is good. 
Ensuring that lore-developers can easily codify their changes to the lore from here-on _(without having to worry too much about testing, beyond format-tweaks)_ is _also_ good.

On that note: credit to Monkberry, Bowlofcereal, Frok, and a handful of others - both for consultancy and contributions, in one way or another.
## Changelog

:cl:
add: Ports over a heavily-modified (and Azurified) version of Vanderlin's in-game lore primer.
/:cl:
add: Ports over a heavily-modified (and Azurified) version of Vanderlin's in-game lore primer.
