### PR TITLE
Mend-Jelq

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -39,26 +39,26 @@
 		to_chat(user, span_info("[I] appears to be in perfect condition."))
 		revert_cast()
 		return
+	if(do_after(user, 7 SECONDS))
+		repair_percent = initial(repair_percent)
+		int_bonus = CLAMP((user.STAINT * 0.01), 0.01, 0.9)
+		repair_percent += int_bonus
+		repair_percent *= I.max_integrity
 
-	repair_percent = initial(repair_percent)
-	int_bonus = CLAMP((user.STAINT * 0.01), 0.01, 0.9)
-	repair_percent += int_bonus
-	repair_percent *= I.max_integrity
+		I.obj_integrity = min(I.obj_integrity + repair_percent, I.max_integrity)
+		user.visible_message(span_info("[I] glows in a faint mending light."))
+		playsound(I, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
 
-	I.obj_integrity = min(I.obj_integrity + repair_percent, I.max_integrity)
-	user.visible_message(span_info("[I] glows in a faint mending light."))
-	playsound(I, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
-
-	if(I.obj_integrity >= I.max_integrity)
-		if(I.obj_broken)
-			I.obj_fix()
-		if(I.peel_count)
-			I.peel_count--
-			to_chat(user, span_info("[I]'s shorn layers mend together. ([I.peel_count])."))
-		else
-			if(I.body_parts_covered_dynamic != I.body_parts_covered)
-				I.repair_coverage()
-				to_chat(user, span_info("[I]'s shorn layers mend together, completely."))
+		if(I.obj_integrity >= I.max_integrity)
+			if(I.obj_broken)
+				I.obj_fix()
+			if(I.peel_count)
+				I.peel_count--
+				to_chat(user, span_info("[I]'s shorn layers mend together. ([I.peel_count])."))
+			else
+				if(I.body_parts_covered_dynamic != I.body_parts_covered)
+					I.repair_coverage()
+					to_chat(user, span_info("[I]'s shorn layers mend together, completely."))
 
 
 /obj/effect/proc_holder/spell/invoked/mending/lesser


### PR DESCRIPTION
## About The Pull Request

- Adds a small do_after to mend, limiting its combat effectiveness
- You can still combat mend, though It'll immobilize you to complete, at the very least.

## Testing Evidence

one line jelq

## Why It's Good For The Game

- Mend currently removes a peel, alongside(at 10 int alone) restoring about 20% armor integrity(actually more, tested on lesser mending). This means alot when it's only on a 30(or 20, for big boy mend) second cd, comes out instantly, and repairs say, about 200 integrity on heretic armor sets and repairs peel stacks.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Mending now has a do_after timer on cast.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
