### PR TITLE
[Balance] - Makes hoarder occur less often as heartbeasts get smarter

### DIFF
--- a/code/modules/roguetown/roguemachine/heartbeast/heart_quirks/quirk_hoarder.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_quirks/quirk_hoarder.dm
@@ -34,7 +34,7 @@
 
 	if(success)
 		convert_mammon_to_coins(withdrawal_amount, beast)
-		next_theft = (world.time + theft_cooldown) * beast.language_tier
+		next_theft = world.time + (theft_cooldown * beast.language_tier)
 		// Might satisfy itself when stealing
 		if(prob(5 * beast.language_tier))
 			beast.satisfied = TRUE

--- a/code/modules/roguetown/roguemachine/heartbeast/heart_quirks/quirk_hoarder.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_quirks/quirk_hoarder.dm
@@ -34,7 +34,7 @@
 
 	if(success)
 		convert_mammon_to_coins(withdrawal_amount, beast)
-		next_theft = world.time + theft_cooldown
+		next_theft = (world.time + theft_cooldown) * beast.language_tier
 		// Might satisfy itself when stealing
 		if(prob(5 * beast.language_tier))
 			beast.satisfied = TRUE


### PR DESCRIPTION
## About The Pull Request
Makes hoarder quirk cooldown scale with language tier. Instead of a flat 6 minutes cooldown.

**TIER SCALE**

1 - 6 minutes
2 - 12 minutes
3 - 18 minutes
4 - 24 minutes

## Testing Evidence
It's math, milord

## Why It's Good For The Game
Been getting a lot of complaints that a good keeper leveling up the beast quickly can drain the treasury too quickly, much to the frustration of stewards. This makes it more of a nuisance rather than something that can cripple rounds.

## Changelog
FUGH YEH WE HAVE CHANGELOGS NOW???

:cl:
balance: Heartbeast hoarder quirk now steals far less often as it grows smarter.
/:cl:
