### PR TITLE
makes it so that shophands and clerks can also do the merchant/steward quest handler bonus gold thing

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/clerk.dm
@@ -9,6 +9,7 @@
 	allowed_races = ACCEPTED_RACES
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
+	is_quest_giver = TRUE
 
 	tutorial = "Clerk, tax-collector, blessed fool. You help the Steward with anything they need and perform their tasks when they are unavailable. Although you aren't a noble, it's not the worst position. The caveat? If money is misplaced or goes missing, a noble could probably weasel out of the stockades as punishment. You? Eh...well, Etrusca is lovely this time of year."
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
@@ -9,6 +9,7 @@
 	allowed_races = ACCEPTED_RACES
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
+	is_quest_giver = TRUE
 
 	tutorial = "You work the largest store in the Peaks by grace of the Merchant who has shackled you to this drudgery. The work of stocking shelves and taking inventory for your employer is mind-numbing and repetitive--but at least you have a roof over your head and comfortable surroundings. With time, perhaps you will one day be more than a glorified servant."
 


### PR DESCRIPTION
## About The Pull Request

makes it so that shophands and clerks can also do the merchant/steward quest handler bonus gold thing

## Testing Evidence

1 liner

## Why It's Good For The Game

letting ppl play more towner roles is good actually. there r characters that don't necessarily fit IC'ly as steward or merchant, locking them out of that thing specifically seems quite strange, especially given that it doesn't seem like it'd be so. seems more like an oversight, idk

## Changelog

:cl:
qol: shophands and clerks can now give out quests
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
