### PR TITLE
Visual report of headwear covering ears for coifs AND small visual tweak involving visored sallets for anthro ears

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -162,7 +162,7 @@
 	desc = "A steel helmet which protects the ears, nose, and eyes."
 	icon_state = "sallet_visor"
 	adjustable = CAN_CADJUST
-	flags_inv = HIDEFACE|HIDESNOUT|HIDEHAIR
+	flags_inv = HIDEEARS|HIDEFACE|HIDESNOUT|HIDEHAIR
 	flags_cover = HEADCOVERSEYES
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES
 	block2add = FOV_BEHIND
@@ -177,7 +177,7 @@
 	icon_state = "shishak"
 
 /obj/item/clothing/head/roguetown/helmet/sallet/visored/ComponentInitialize()
-	AddComponent(/datum/component/adjustable_clothing, (HEAD|EARS|HAIR), HIDEHAIR, null, 'sound/items/visor.ogg', null, UPD_HEAD)	//Sallet. Does not hide anything when opened.
+	AddComponent(/datum/component/adjustable_clothing, (HEAD|EARS|HAIR), HIDEEARS|HIDEHAIR, null, 'sound/items/visor.ogg', null, UPD_HEAD)	//Sallet. Hides ears at the very least since it's a helmet.
 
 /obj/item/clothing/head/roguetown/helmet/sallet/visored/attackby(obj/item/W, mob/living/user, params)
 	..()

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -27,7 +27,7 @@
 	icon_state = "coif"
 	item_state = "coif"
 	color = CLOTHING_BROWN
-	flags_inv = HIDEHAIR
+	flags_inv = HIDEEARS|HIDEHAIR
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	blocksound = SOFTHIT
 	body_parts_covered = NECK|HAIR|EARS|HEAD
@@ -43,7 +43,7 @@
 	icon_state = "ccoif"
 	item_state = "ccoif"
 	color = "#ad977d"
-	flags_inv = HIDEHAIR
+	flags_inv = HIDEEARS|HIDEHAIR
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	blocksound = SOFTHIT
 	body_parts_covered = NECK|HAIR|EARS|HEAD
@@ -78,7 +78,7 @@
 			adjustable = CADJUSTED
 			if(toggle_icon_state)
 				icon_state = "fullpadded_down"
-			flags_inv = HIDEHAIR
+			flags_inv = HIDEEARS|HIDEHAIR
 			body_parts_covered = NECK|HAIR|EARS|HEAD
 			if(ishuman(user))
 				var/mob/living/carbon/H = user
@@ -128,7 +128,7 @@
 	drop_sound = 'sound/foley/dropsound/chain_drop.ogg'
 	pickup_sound = 'sound/foley/equip/equip_armor_chain.ogg'
 	equip_sound = 'sound/foley/equip/equip_armor_chain.ogg'
-	flags_inv = HIDEHAIR
+	flags_inv = HIDEEARS|HIDEHAIR
 	armor = ARMOR_MAILLE
 	max_integrity = ARMOR_INT_SIDE_STEEL
 	resistance_flags = FIRE_PROOF
@@ -196,7 +196,7 @@
 			adjustable = CADJUSTED
 			if(toggle_icon_state)
 				icon_state = "chaincoif"
-			flags_inv = HIDEHAIR
+			flags_inv = HIDEEARS|HIDEHAIR
 			body_parts_covered = NECK|HAIR|EARS|HEAD
 			if(ishuman(user))
 				var/mob/living/carbon/H = user


### PR DESCRIPTION
## About The Pull Request

As the title states. This change involves mainly coifs head coverings and the visored sallet helmet type, both steel and iron. It will have the visored sallet behave like other visor or adjustable facemask style helmets like the pigface, etruscan bascinet, knight helmet, etc, where the helmet, when donned, covers the ears in both open visor and closed visor states by default.

The second part addresses the coifs of the game, where just by their design, should cover and protect at the very least, all but the front of the head. By the state the coifs are before this PR, the visual report implies that for whatever reason, ears are exposed and are not protected under the coif. The only time it will reveal the hair and ears is if the coif is adjusted to rest at the neck. This brings up the other small update where the second icon state for full coifs will now have the ears covered while the face exposed. See testing evidence for visual aid.

And for whatever reason, if you really really REALLY wish to have your ears visible through your helmet. I have discovered that simply clicking the helmet in your head slot with the MMB will show or hide your ears. Sadly, the process is quite jank for helmets that are adjustable, for EVERY time you lift or close the visor, it resets it to the default state; In the sallet's case, before this PR, this means your ears will show. Static helmets like kettle, regular sallet, etc do not have this problem and you can MMB with your heart's content on the state of your ears showing.

## Testing Evidence

Before the adjustment(current state before PR merge):

<img width="125" height="112" alt="image1before" src="https://github.com/user-attachments/assets/c15b6db3-3495-4d40-a765-ee0a3231f9d3" />

<img width="140" height="109" alt="image2before" src="https://github.com/user-attachments/assets/c484534c-20f8-4020-822a-475ebef4259a" />

<img width="109" height="107" alt="image3before" src="https://github.com/user-attachments/assets/20aa30e1-bbd0-45ab-ae99-e5ad8fec256b" />

<img width="130" height="125" alt="image4before" src="https://github.com/user-attachments/assets/e6b5dcf6-cf0e-4146-81c2-79bdfbb464ad" />

After adjustments:

<img width="144" height="119" alt="image1after" src="https://github.com/user-attachments/assets/a61aa766-210c-4860-b0a9-84788c57431c" />

<img width="140" height="128" alt="image1aafter" src="https://github.com/user-attachments/assets/fb60cf66-6cd5-407c-bf48-195676c700b3" />

<img width="133" height="117" alt="image2after" src="https://github.com/user-attachments/assets/ad0646e8-e83c-421b-81cf-4636660e1bed" />

<img width="124" height="128" alt="image3after" src="https://github.com/user-attachments/assets/a0910205-9172-4838-ad00-edb7cd257ee4" />

<img width="144" height="120" alt="image3afterstate2" src="https://github.com/user-attachments/assets/2c65b292-cb59-4928-add9-509728696ba3" />

<img width="131" height="127" alt="image3eafterstate3" src="https://github.com/user-attachments/assets/62d998a9-7081-419a-9351-7fbbde69bfef" />

<img width="157" height="125" alt="image4after" src="https://github.com/user-attachments/assets/ac3be2df-066b-4337-b25f-17a671f571aa" />

<img width="129" height="117" alt="image4state2" src="https://github.com/user-attachments/assets/5de984db-5120-40b0-b948-62f1b79261a1" />

<img width="144" height="117" alt="image4state3" src="https://github.com/user-attachments/assets/57322b5c-5785-4b6d-9ca7-41d68922ee13" />

Side shot of chainmail:

<img width="175" height="127" alt="sideimage4state1" src="https://github.com/user-attachments/assets/aa563dd5-bd59-4c07-8155-079241ceec4f" />

<img width="157" height="122" alt="sideimage4state2" src="https://github.com/user-attachments/assets/2e42691a-77a1-4d16-8c89-a7390b3bf4a9" />


## Why It's Good For The Game

Corrects visual inconsistencies with the head pieces mentioned above and in the title for a more immersive experience.