### PR TITLE
makes voidtouched enchantment not so bad a group of mages thought it was broken

### DIFF
--- a/code/datums/magic_items/greater_items/greater.dm
+++ b/code/datums/magic_items/greater_items/greater.dm
@@ -231,7 +231,7 @@
 	if(world.time < (src.last_used[source] + 10 SECONDS))
 		return
 
-	if(isliving(target))
+	if(isliving(target) && target != user) //self teleporting might be scary actually
 		var/mob/living/L = target
 		to_chat(L, span_warning("You feel reality warp around you!"))
 		var/list/possible_turfs = list()


### PR DESCRIPTION
## About The Pull Request

no rng proc, fixes the timer, vastly shortens the timer, can't proc on self hits

## Testing Evidence

i did it 👍 theres literally nothing to screenshot but i did it

## Why It's Good For The Game

voidstones are annoying and rng-based to acquire. getting TWO is actually pretty hard. voidtouched is an enchantment that is SUPPOSED to be able to occasionally teleport its target 3 tiles away, which is really not worth the effort but that's besides the point

in practice, you only get a chance to use it once every two minutes. and it only had a fifteen percent chance of activating. and REGASRDLESS of whether it activated or not it WENT BACK ON COOLDOWN.

this means, in practice, the effective cooldown was Eleven Minutes, assuming you hit something with it the Exact moment it comes off cooldown. this is on an effect that teleports you THREE TILES away you can literally just WASD back in LESS THAN A SECOND

anyways its guaranteed and every 10 seconds now. it STILL isnt very good for direct combat but theres some creative use potential here like sending ppl off cliffs or to the other side of a wall if u want to be funny
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: voidtouched is no longer borderline nonfunctional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
