### PR TITLE
Adds shh silence spell to archivist

### DIFF
--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -436,3 +436,8 @@
 	timer = 10 MINUTES
 	stressadd = -2
 	desc = span_green("Since my magical accident, everything just seems so funny!")
+
+/datum/stressevent/archivist_shushed
+	timer = 1 MINUTES
+	stressadd = 4
+	desc = span_red("I was shushed by the archivist!")

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -108,6 +108,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/refocusstudies)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/takeapprentice)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/learn)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/silence/archivist_silence)
 	if(H.age == AGE_OLD)
 		H.change_stat(STATKEY_SPD, -1)
 		H.change_stat(STATKEY_INT, 1)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

A soulful joke made into a PR. Gives Archivist their own special Silence spell. Comes with shh emote and a stress moodlet. Ideally the archivist could shh someone on the brink of moodcrit and put them over the edge. Archivists don't get high arcane skill, so the silence isn't very long: approx. 20 seconds.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

https://github.com/user-attachments/assets/e1afc214-99d2-41f0-80ac-254e0e296f77


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Soulful clause. The moodlet is stiff enough to incentivize retaliation. This also makes archivist have a tiny bit of anti-mage to it, which will help it be in defense against the apprentices / the low level casters. Antag / wretch casters are already immune to silence, so no problems there. The cooldown / moodlet pain can change to whatever to let it merge.

Caveat, silence is an "evil zizo spell" that is nominally unavailable to any casters aside from heretics. I have personally never seen it used much. So this gimmick would be a good way of getting silence spell into the foray, without letting it escape its novelty by being widely accessible.
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Archivist gets a special version of the silence spell, as a gift.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
