### PR TITLE
Fix: Crafting system honors can_craft_with() when consuming ingredients

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -380,6 +380,9 @@
 		for(var/A in R.reqs)
 			amt = R.reqs[A]
 			surroundings = get_environment(user)
+			for(var/obj/item/I in surroundings)
+				if(!I.can_craft_with())
+					surroundings -= I
 			for(var/atom/movable/IS in surroundings)
 				if(!R.subtype_reqs && (IS.type in subtypesof(A)))
 					surroundings.Remove(IS)


### PR DESCRIPTION
## About The Pull Request

This PR resolves a critical logic flaw where the crafting system's ingredient consumption procedure ignored item availability rules, resulting in the destruction of blocked items during quantity crafting.

* **Problem:** When performing quantity crafting (using 1/5/10/Max buttons), the consumption procedure (`del_reqs`) accessed an unfiltered list of surrounding items.
* **Result:** Items explicitly blocked via `/obj/item/proc/can_craft_with()` (e.g., a full `/obj/item/storage/roguebag`) were consumed/destroyed after all available ingredients of that type were used up.
* **Root Cause:** Desynchronization between the item display/check logic (which used `can_craft_with()`) and the item deletion logic (which did not).
* **Fix:** A filter loop was added to `del_reqs` to ensure it only processes items that return `TRUE` from `can_craft_with()`. 

---

## Testing Evidence

1.  **Setup:** Tested with a recipe requiring a `roguebag`. Placed one empty (Allowed) and one full (Blocked) `roguebag` near the crafting station.
2.  **Pre-Fix Behavior:** Attempting to craft 2 items successfully consumes the empty bag, then consumes and destroys the full bag.
3.  **Post-Fix Behavior:** Attempting to craft 2 items consumes the empty bag, then stops. The full bag remains intact and protected, as the filter prevents its consumption.

https://github.com/user-attachments/assets/c87a5c61-79c3-4924-bdf1-859c794abdb3


## Why It's Good For The Game

This is a necessary fix for consistency, stability, and integrity:

* **Consistency:** It ensures that the game's rules for ingredient availability (`can_craft_with`) are honored in **all** stages of the crafting process (UI, checks, and consumption).
* **Prevents Item Loss:** It prevents players from unintentionally destroying filled storage items, written documents, or other state-dependent objects during routine mass-crafting operations.
* **Stability:** It closes a critical logical vulnerability that could potentially affect any recipe requiring an item with a complex state.

---

## Changelog
:cl:
fix: Items that are explicitly blocked from being used as ingredients (e.g., full storage bags, written paper, etc.) will no longer be consumed when performing multi-quantity crafting.
code: Synchronized the item consumption logic with the `can_craft_with()` check, making the crafting system more robust against complex item states.
/:cl: