### PR TITLE
[Bishop] Fully unlocks bishop faith.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -248,6 +248,33 @@ GLOBAL_LIST_EMPTY(heretical_players)
 			H.mind?.AddSpell(new chosen_miracle)
 			t3.Remove(t3_choice)
 			t3_count--
+	// -- Start of section for god specific bonuses --
+	if(H.patron?.type == /datum/patron/divine/undivided)
+		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+	if(H.patron?.type == /datum/patron/divine/astrata)
+		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+		H.cmode_music = 'sound/music/cmode/church/combat_astrata.ogg'
+	if(H.patron?.type == /datum/patron/divine/noc)
+		H.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
+		if(H.mind)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+		ADD_TRAIT(H, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
+	if(H.patron?.type == /datum/patron/divine/abyssor)
+		ADD_TRAIT(H, TRAIT_WATERBREATHING, TRAIT_GENERIC)
+	if(H.patron?.type == /datum/patron/divine/necra)
+		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
+		H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
+	if(H.patron?.type == /datum/patron/divine/pestra)
+		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+	if(H.patron?.type == /datum/patron/divine/eora)
+		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+		H.cmode_music = 'sound/music/cmode/church/combat_eora.ogg'
+	if(H.patron?.type == /datum/patron/divine/malum)
+		ADD_TRAIT(H, TRAIT_SMITHING_EXPERT, TRAIT_GENERIC)
+	if(H.patron?.type == /datum/patron/divine/ravox)
+		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 
 /datum/job/priest/vice //just used to change the priest title
 	title = "Vice Priest"


### PR DESCRIPTION
## About The Pull Request
Allows bishops to pick any faith.
Also gives bishops master physiker trait, as it was downgrading their medical from master to expert on spawn.
Bishops now get patron traits but no additional bonuses based on their patron of choice.
Bishops spawn with solar vestments and mask. Undivided cloak, undivided amulet in satchel, and their chosen faith's robes on their body so they can choose what to wear and what to discard.
Ability to choose a T3/T4 spell of choice remains.

## Testing Evidence
<img width="1920" height="1075" alt="image" src="https://github.com/user-attachments/assets/b6959fd7-8710-4a67-abfc-6228d665b7ae" />

## Why It's Good For The Game
Witty okay'd (though give him a moment to review the PR)
Tiny comm for SquidQueen.

Unlocks the faith of bishops again. You can play your monogod faith flavored bishops again, for player freedom.
The flavor text of the role remains, with additional emphasis that despite your chosen patron, your goal is to harmonize the 10 faiths, not to cause dissent.

## Changelog

:cl:
add: Priest faith is unlocked
/:cl:

