### PR TITLE
Removes color saturation limit

### DIFF
--- a/code/_globalvars/customization/organ_customization.dm
+++ b/code/_globalvars/customization/organ_customization.dm
@@ -17,23 +17,10 @@ GLOBAL_LIST_INIT(customizers, build_customizers())
 		.[type] = new type()
 	return .
 
-/proc/color_pick_sanitized(mob/user, description, title, default_value, min_tag = 0.07, max_tag = 0.80)
+/proc/color_pick_sanitized(mob/user, description, title, default_value)
 	var/color = input(user, description, title, default_value) as color|null
-	var/good = TRUE
 	if(!color)
 		return
 	color = sanitize_hexcolor(color)
-	var/list/hsl = rgb2hsl(hex2num(copytext(color,1,3)),hex2num(copytext(color,3,5)),hex2num(copytext(color,5,7)))
-	if(hsl[3] < min_tag)
-		to_chat(user, span_warning("The picked color is too dark! Raising Luminosity to minimum 20%."))
-		hsl[3] = min_tag
-		good = FALSE
-	if(hsl[2] > max_tag)
-		to_chat(user, span_warning("The picked color is too bright! Lowering Saturation to maximum 80%."))
-		hsl[2] = max_tag
-		good = FALSE
-	if(!good)
-		var/list/rgb = hsl2rgb(arglist(hsl))
-		color = sanitize_hexcolor("[num2hex(rgb[1])][num2hex(rgb[2])][num2hex(rgb[3])]")
 
 	return color


### PR DESCRIPTION
## About The Pull Request
It wasn't turning out to be very effective at its intended goal, but did impede gingers / blondes.

This PR does NOT mean your sparkledog isn't going to get bwoinked, it's moreso an admittance that your sparkledog could've been just as sparkly even with this code.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="172" height="192" alt="YIpltFt1OW" src="https://github.com/user-attachments/assets/5cc2c270-9677-4a58-b8e3-91da79b91a93" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The idea of allowing full RGB color selection but limiting the color range isn't the way to go.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del:Color saturation limits were removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
