### PR TITLE
taur fix - makes it so that hits to the taur's feet are actually blocked by their leg armor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -201,7 +201,7 @@
 		hitpush = FALSE
 		skipcatch = TRUE
 		blocked = TRUE
-	
+
 	//Thrown item deflection -- this RETURNS if successful!
 	var/obj/item/W = get_active_held_item()
 	if(!blocked && I && cmode)
@@ -337,7 +337,7 @@
 		if(!affecting)
 			affecting = get_bodypart(BODY_ZONE_CHEST)
 		var/ap = (M.d_type == "blunt") ? BLUNT_DEFAULT_PENFACTOR : M.armor_penetration
-		var/armor = run_armor_check(affecting, M.d_type, armor_penetration = ap, damage = damage)
+		var/armor = run_armor_check(get_armor_zone_for_bodypart(affecting, dam_zone), M.d_type, armor_penetration = ap, damage = damage)
 		next_attack_msg.Cut()
 
 		var/nodmg = FALSE
@@ -770,7 +770,7 @@
 		if(arm_clothes)
 			torn_items |= arm_clothes
 
-	//LEGS & FEET//
+        //LEGS & FEET//
 	if(!def_zone || def_zone == BODY_ZONE_L_LEG || def_zone == BODY_ZONE_R_LEG)
 		var/obj/item/clothing/leg_clothes = null
 		if(shoes)
@@ -807,6 +807,11 @@
 						protection = val
 						used = C
 	return used
+
+/mob/living/carbon/human/proc/get_armor_zone_for_bodypart(obj/item/bodypart/affecting, def_zone)
+	if(affecting?.body_zone == BODY_ZONE_TAUR && def_zone && def_zone in affecting.subtargets)
+		return def_zone
+	return affecting
 
 /mob/living/carbon/human/on_fire_stack(seconds_per_tick, datum/status_effect/fire_handler/fire_stacks/fire_handler)
 	//SEND_SIGNAL(src, COMSIG_HUMAN_BURNING)


### PR DESCRIPTION
## About The Pull Request

previously, you could entirely bypass a taur's armor by simply targeting their toes; it correctly targeted their taur parts but did not do the armor calculation. this fixes that.

_**PLEASE TM THIS BEFORE FULLMERGING, IT TOUCHES VERY IMPORTANT CODE AND I AM NOT CONFIDENT IN MY ABILITY.**_

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

so, first off; taurs are objectively still weaker with this change, as wanted. they only have one armor pool for their entire lower half; less body parts means a piece of armor will be taking more damage no matter where you're aiming. so this shouldn't lead to a massive uptick in them. i don't think anyone actually realized this based off of how rare they were, period

also, bugfixes are nice

## Changelog


:cl:
fix: attacks targeting feet on taurs will no longer ignore their armor
/:cl: