### PR TITLE
Fix: Smeltery EXP exploit on ingot reinsertion (Fixes #4488)

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -144,6 +144,8 @@
 	user.dropItemToGround(smelting_item)
 	smelting_item.forceMove(src)
 	contained_items += smelting_item
+	if(smelting_item.smelted)
+		smelting_item.smelted = FALSE
 	if(!isliving(user) || !user.mind)
 		contained_items[smelting_item] = SMELTERY_LEVEL_SPOIL
 	else


### PR DESCRIPTION
## About The Pull Request

* Fixes an exploit that allowed for infinite Smelting EXP gain.
* The exploit occurred by repeatedly reinserting an already-smelted ingot into a furnace and immediately retrieving it with tongs.
* The fix introduces logic to reset the `smelted` flag when an ingot is placed back into the furnace.
* The item must now complete a new, full smelting cycle before it can grant EXP again.

https://github.com/user-attachments/assets/3f152f66-4f0e-4909-aa7f-05b8924e1e27

## Testing Evidence

* **Before Fix:** A single ingot could be cycled (put in and taken out of a lit furnace) repeatedly, granting instant EXP on each retrieval.
* **After Fix:** The ingot grants EXP once. Upon reinsertion, the subsequent retrieval grants no EXP until the furnace completes a new processing cycle (i.e., until the ingot is smelted again).

https://github.com/user-attachments/assets/c1d73e4a-02ce-462f-9724-75ffd70d73d6


## Why It's Good For The Game

* **Balance:** Eliminates a critical, unintended infinite EXP gain exploit that undermined the time and resource investment required for the Smelting skill.
* **Integrity:** Restores the intended progression curve for the Smelting skill, making it a properly time- and resource-gated craft.

## Changelog

:cl:
balance: Fixed an exploit that allowed infinite experience gain by repeatedly reinserting and retrieving a single ingot from a lit furnace.
fix: Ingot items now correctly reset their 'smelted' status when placed back into a furnace, requiring a full smelting cycle for new experience gain.
code: Updated `add_item` logic for smelters.
/:cl: