### PR TITLE
Fix: Pipes crafting

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -475,12 +475,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/pipe/crafted/Initialize()
 	. = ..()
+	src.packeditem = 0
+	src.smoketime = 0
 	if(prob(50))
-		name = "westman pipe"
-		icon_state = "longpipeoff"
-		item_state = "longpipeoff"
-		icon_on = "longpipeon"
-		icon_off = "longpipeoff"
+		var/atom/current_loc = loc
+		var/obj/item/clothing/mask/cigarette/pipe/westman/W = new /obj/item/clothing/mask/cigarette/pipe/westman(current_loc)
+		W.packeditem = 0
+		W.smoketime = 0
+		qdel(src)
+		return INITIALIZE_HINT_QDEL
 
 /obj/item/clothing/mask/cigarette/pipe/Destroy()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
## Testing Evidence

1.  **Chance Craft/Replacement Test:** After crafting, both resulting pipe types (`crafted` and `westman`) function correctly and retain their state and appearance after use (packing, cleaning, extinguishing), proving that the "type masquerade" issue is fully resolved.
2.  **"Ashes on Craft" Test:** A pipe was crafted and its variables were inspected: `packeditem` = 0, `smoketime` = 0. The pipe was successfully packed immediately, confirming it starts empty.

https://github.com/user-attachments/assets/c9429163-f314-4d48-838a-99c39837ffad

https://github.com/user-attachments/assets/9b750eba-dcd8-4159-a787-e1fe55db5ab9


---

## Why It's Good For The Game

This PR significantly improves stability and content functionality:

1.  **Fixes Broken Content:** Ensures that the long pipes, which are crafter-exclusive, are fully functional.
2.  **Guarantees Correct Initialization:** Resolves the bug where crafted items appeared in an incorrect, pre-used state.

https://github.com/user-attachments/assets/127702c4-1cb3-4735-87d4-0474577d5b07


https://github.com/user-attachments/assets/8ce6ede5-10e2-47ae-8935-f28756e59fff


---

## Changelog

:cl:
fix: Fixed the "type masquerade" issue for crafted long pipes, which previously caused them to have flickering sprites and break after cleaning.
fix: Fixed a bug where crafted pipes would start with residual "ashes".
/:cl:
```