### PR TITLE
Make ironclad not a fraud

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -344,12 +344,15 @@
 			if("Sword")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				beltr = /obj/item/rogueweapon/sword/short
+				gloves = /obj/item/clothing/gloves/roguetown/chain
 			if("Cudgel")
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				beltr = /obj/item/rogueweapon/mace/cudgel
+				gloves = /obj/item/clothing/gloves/roguetown/chain
 			if("Double Shield")
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/rogueweapon/shield/tower/metal
+				gloves = /obj/item/clothing/gloves/roguetown/chain
 			if("Plate Gloves")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/plate


### PR DESCRIPTION
## About The Pull Request

Now Ironclad is A MESS. Stats and skills are worse than battlemaster's and knight errant's, but you know what? Ironclad has a plate training and is comparable to knight errant, that: Has same skill levels, slightly buffed stats, riding skill with a free horse, NOBILITY, and also ROUNDSTART STEEL ARMOR. 

So, I changed Ironclad to be a bit less fraud it is now...

1. All armor is steel.
2. Choses between full plate + gambeson and half plate + hauberk.
3. Has Journeyman shield skill and kite shield. 
4. Choses between short sword, cudgel, plate gauntlets and unarmed journeyman, and SECOND KITE SHIELD WITH SHIELDS EXPERT.

