### PR TITLE
Port Intent indices memorization from Scarlet-Reach PR #1583

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -141,6 +141,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/datum/skill/associated_skill
 
 	var/list/possible_item_intents = list(/datum/intent/use)
+	var/saved_intent_index = 1 // Stores the last selected intent index when item is dropped
 
 	var/bigboy = FALSE //used to center screen_loc when in hand
 	var/wielded = FALSE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -459,11 +459,17 @@
 			if(numb > possible_a_intents.len)
 				return
 			else
+				var/obj/item/held_item = get_active_held_item()
+				if(held_item)
+					held_item.saved_intent_index = numb
+				else
+					if(active_hand_index == 1)
+						l_ua_index = numb
+					else
+						r_ua_index = numb
 				if(active_hand_index == 1)
-					l_ua_index = numb
 					l_index = numb
 				else
-					r_ua_index = numb
 					r_index = numb
 				a_intent = possible_a_intents[numb]
 		else
@@ -493,9 +499,9 @@
 			intents = Masteritem.alt_intents
 	else
 		if(active_hand_index == 1)
-			r_index = r_ua_index
-		else
 			l_index = l_ua_index
+		else
+			r_index = r_ua_index
 		intents = base_intents.Copy()
 	for(var/defintent in intents)
 		if(Masteritem)
@@ -511,9 +517,9 @@
 			intents = Masteritem.alt_intents
 	else
 		if(active_hand_index == 1)
-			l_index = l_ua_index
-		else
 			r_index = r_ua_index
+		else
+			l_index = l_ua_index
 		intents = base_intents.Copy()
 	for(var/defintent in intents)
 		if(Masteritem)
@@ -525,17 +531,25 @@
 			hud_used.action_intent.update_icon(possible_a_intents,possible_offhand_intents,oactive)
 		else
 			hud_used.action_intent.update_icon(possible_offhand_intents,possible_a_intents,oactive)
-	if(active_hand_index == 1)
-		if(l_index <= possible_a_intents.len)
-			rog_intent_change(l_index)
+	var/obj/item/active_item = get_active_held_item()
+	if(active_item && active_item.saved_intent_index > 0 && active_item.saved_intent_index <= possible_a_intents.len)
+		if(active_hand_index == 1)
+			l_index = active_item.saved_intent_index
 		else
-			rog_intent_change(1)
+			r_index = active_item.saved_intent_index
+	if(active_hand_index == 1)
+		if(l_index > possible_a_intents.len)
+			l_index = 1
+		if(r_index > possible_offhand_intents.len)
+			r_index = 1
+		rog_intent_change(l_index)
 		rog_intent_change(r_index, 1)
 	else
-		if(r_index <= possible_a_intents.len)
-			rog_intent_change(r_index)
-		else
-			rog_intent_change(1)
+		if(r_index > possible_a_intents.len)
+			r_index = 1
+		if(l_index > possible_offhand_intents.len)
+			l_index = 1
+		rog_intent_change(r_index)
 		rog_intent_change(l_index, 1)
 
 /mob/verb/mmb_intent_change(input as text)


### PR DESCRIPTION
## About The Pull Request
Port https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1583
> Intent indices not being tracked properly. Items will now remember their intents, and your hands will remember the last intent you had selected with that hand when it was empty. Now you won't get switched back to touch mode every time someone resists out of a grab.

Separated from my batch port in case this goes wrong. I'd consider this a feature, honestly.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested briefly locally.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yae

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Item will remember the last intent you have selected when it is dropped, and your hands will remember the last intent you had selected with that hand when it was empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
