### PR TITLE
Gives Specials IFF, Specials Buffs

### DIFF
--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -436,8 +436,9 @@ SPECIALS START HERE
 	post_icon_state = "sweep_fx"
 	pre_icon_state = "trap"
 	sfx_post_delay = 'sound/combat/shin_swipe.ogg'
-	delay = 0.7 SECONDS
-	cooldown = 15 SECONDS
+	delay = 0.5 SECONDS
+	cooldown = 20 SECONDS
+	stamcost = 15
 	var/eff_dur = 5	//We do NOT want to use SECONDS macro here.
 	var/dam
 
@@ -451,6 +452,7 @@ SPECIALS START HERE
 	for(var/mob/living/L in get_hearers_in_view(0, T))
 		if(L != howner)
 			L.Slowdown(eff_dur)
+			L.apply_status_effect(/datum/status_effect/debuff/hobbled)	//-2 SPD for 8 seconds
 			if(L.mobility_flags & MOBILITY_STAND)
 				apply_generic_weapon_damage(L, dam, "stab", pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), bclass = BCLASS_CUT)
 	..()

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -422,10 +422,11 @@ SPECIALS START HERE
 
 /datum/special_intent/side_sweep/apply_hit(turf/T)
 	for(var/mob/living/L in get_hearers_in_view(0, T))
-		L.apply_status_effect(/datum/status_effect/debuff/exposed, eff_dur)
-		if(L.mobility_flags & MOBILITY_STAND)
-			var/obj/item/rogueweapon/W = iparent
-			apply_generic_weapon_damage(L, dam, W.d_type, t_zone, bclass = BCLASS_CUT)
+		if(L != howner)
+			L.apply_status_effect(/datum/status_effect/debuff/exposed, eff_dur)
+			if(L.mobility_flags & MOBILITY_STAND)
+				var/obj/item/rogueweapon/W = iparent
+				apply_generic_weapon_damage(L, dam, W.d_type, t_zone, bclass = BCLASS_CUT)
 	..()
 
 /datum/special_intent/shin_swipe
@@ -448,9 +449,10 @@ SPECIALS START HERE
 
 /datum/special_intent/shin_swipe/apply_hit(turf/T)	//This is applied PER tile, so we don't need to do a big check.
 	for(var/mob/living/L in get_hearers_in_view(0, T))
-		L.Slowdown(eff_dur)
-		if(L.mobility_flags & MOBILITY_STAND)
-			apply_generic_weapon_damage(L, dam, "stab", pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), bclass = BCLASS_CUT)
+		if(L != howner)
+			L.Slowdown(eff_dur)
+			if(L.mobility_flags & MOBILITY_STAND)
+				apply_generic_weapon_damage(L, dam, "stab", pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), bclass = BCLASS_CUT)
 	..()
 
 //Hard to hit, freezes you in place. Offbalances & slows the targets hit. If they're already offbalanced they get knocked down.
@@ -462,13 +464,13 @@ SPECIALS START HERE
 	pre_icon_state = "trap"
 	use_doafter = TRUE
 	respect_adjacency = FALSE
-	delay = 0.7 SECONDS
+	delay = 0.6 SECONDS
 	cooldown = 20 SECONDS
 	var/slow_dur = 5	//We do NOT want to use SECONDS macro here. Slowdown() takes in an int and turns it into seconds already.
 	var/KD_dur = 2 SECONDS
 	var/Offb_dur = 5 SECONDS
 	var/Offbself_dur = 1.5 SECONDS
-	var/dam = 80
+	var/dam = 200
 
 //We play the pre-sfx here because it otherwise it gets played per tile. Sounds funky.
 /datum/special_intent/ground_smash/on_create()
@@ -478,21 +480,22 @@ SPECIALS START HERE
 
 /datum/special_intent/ground_smash/apply_hit(turf/T)
 	for(var/mob/living/L in get_hearers_in_view(0, T))
-		//We fling the target sideways from the attacker
-		var/targetdir = get_dir(L, howner)
-		var/throwdir = turn(targetdir, prob(50) ? 90 : 270)
-		var/dist = rand(1, 3)
-		var/turf/current_turf = get_turf(L)
-		var/turf/target_turf = get_ranged_target_turf(current_turf, throwdir, dist)
-		L.safe_throw_at(target_turf, dist, 1, howner, force = MOVE_FORCE_EXTREMELY_STRONG)
-		//We slow them down
-		L.Slowdown(slow_dur)
-		//We offbalance them OR knock them down if they're already offbalanced
-		if(L.IsOffBalanced())
-			L.Knockdown(KD_dur)
-		else
-			L.OffBalance(Offb_dur)
-		apply_generic_weapon_damage(L, dam, "blunt", BODY_ZONE_CHEST, bclass = BCLASS_BLUNT, no_pen = TRUE)
+		if(L != howner)
+			//We fling the target sideways from the attacker
+			var/targetdir = get_dir(L, howner)
+			var/throwdir = turn(targetdir, prob(50) ? 90 : 270)
+			var/dist = rand(1, 3)
+			var/turf/current_turf = get_turf(L)
+			var/turf/target_turf = get_ranged_target_turf(current_turf, throwdir, dist)
+			L.safe_throw_at(target_turf, dist, 1, howner, force = MOVE_FORCE_EXTREMELY_STRONG)
+			//We slow them down
+			L.Slowdown(slow_dur)
+			//We offbalance them OR knock them down if they're already offbalanced
+			if(L.IsOffBalanced())
+				L.Knockdown(KD_dur)
+			else
+				L.OffBalance(Offb_dur)
+			apply_generic_weapon_damage(L, dam, "blunt", BODY_ZONE_CHEST, bclass = BCLASS_BLUNT, no_pen = TRUE)
 	var/sfx = pick('sound/combat/ground_smash1.ogg','sound/combat/ground_smash2.ogg','sound/combat/ground_smash3.ogg')
 	playsound(T, sfx, 100, TRUE)
 	..()
@@ -523,10 +526,11 @@ SPECIALS START HERE
 
 /datum/special_intent/flail_sweep/apply_hit(turf/T)
 	for(var/mob/living/L in get_hearers_in_view(0, T))
-		if(L.mobility_flags & MOBILITY_STAND)
-			victim_count++
-			addtimer(CALLBACK(src, PROC_REF(apply_effect), L), 0.1 SECONDS)	//We need to count them all up first so this is an unfortunate (& janky) requirement.
-	..()																//An alternative could be a spatial grid count from howner called once.
+		if(L != howner)
+			if(L.mobility_flags & MOBILITY_STAND)
+				victim_count++
+				addtimer(CALLBACK(src, PROC_REF(apply_effect), L), 0.1 SECONDS)	//We need to count them all up first so this is an unfortunate (& janky) requirement.
+	..()																		//An alternative could be a spatial grid count from howner called once.
 
 ///This will apply the actual effect, as we need some way to count all the mobs in the zone first.
 /datum/special_intent/flail_sweep/proc/apply_effect(mob/living/victim)
@@ -573,10 +577,10 @@ SPECIALS START HERE
 	pre_icon_state = "trap"
 	use_doafter = TRUE
 	respect_adjacency = FALSE
-	delay = 0.6 SECONDS
+	delay = 0.5 SECONDS
 	cooldown = 25 SECONDS
-	var/immob_dur = 3 SECONDS
-	var/exposed_dur = 5 SECONDS
+	var/immob_dur = 3.5 SECONDS
+	var/exposed_dur = 6 SECONDS
 	var/dam
 
 /datum/special_intent/axe_swing/_reset()
@@ -585,7 +589,7 @@ SPECIALS START HERE
 /datum/special_intent/axe_swing/process_attack()
 	tile_coordinates = list()
 	var/obj/item/rogueweapon/W = iparent
-	dam = W.force_dynamic * (howner.STASTR / 10)
+	dam = (W.force_dynamic * (howner.STASTR / 10)) + 50
 	if(howner.used_hand == 1)	//We mirror it if it's the left arm.
 		tile_coordinates += AXE_SWING_GRID_MIRROR
 	else
@@ -599,10 +603,11 @@ SPECIALS START HERE
 
 /datum/special_intent/axe_swing/apply_hit(turf/T)
 	for(var/mob/living/L in get_hearers_in_view(0, T))
-		L.apply_status_effect(/datum/status_effect/debuff/exposed, exposed_dur)
-		L.Immobilize(immob_dur)
-		if(L.mobility_flags & MOBILITY_STAND)
-			apply_generic_weapon_damage(L, dam, "slash", pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), bclass = BCLASS_CHOP)
+		if(L != howner)
+			L.apply_status_effect(/datum/status_effect/debuff/exposed, exposed_dur)
+			L.Immobilize(immob_dur)
+			if(L.mobility_flags & MOBILITY_STAND)
+				apply_generic_weapon_damage(L, dam, "slash", pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), bclass = BCLASS_CHOP)
 	var/sfx = pick('sound/combat/sp_axe_swing1.ogg','sound/combat/sp_axe_swing2.ogg','sound/combat/sp_axe_swing3.ogg')
 	playsound(T, sfx, 100, TRUE)
 	..()
@@ -629,9 +634,10 @@ SPECIALS START HERE
 /datum/special_intent/whip_coil/apply_hit(turf/T)
 	var/whiffed = TRUE
 	for(var/mob/living/L in get_hearers_in_view(0, T))
-		L.Immobilize(immob_dur)
-		apply_generic_weapon_damage(L, dam, "slash", pick(BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT), bclass = BCLASS_LASHING)
-		whiffed = FALSE
+		if(L != howner)
+			L.Immobilize(immob_dur)
+			apply_generic_weapon_damage(L, dam, "slash", pick(BODY_ZONE_PRECISE_L_FOOT, BODY_ZONE_PRECISE_R_FOOT), bclass = BCLASS_LASHING)
+			whiffed = FALSE
 	if(!whiffed)
 		playsound(T, 'sound/combat/sp_whip_hit.ogg', 100, TRUE)
 	else
@@ -686,11 +692,12 @@ SPECIALS START HERE
 
 /datum/special_intent/greatsword_swing/apply_hit(turf/T)
 	for(var/mob/living/L in get_hearers_in_view(0, T))
-		L.Slowdown(slow_dur)
-		if(L.mobility_flags & MOBILITY_STAND)
-			apply_generic_weapon_damage(L, ((hitcount > 1) ? (dam * 1.5) : dam), "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT)
-		var/sfx = 'sound/combat/sp_gsword_hit.ogg'
-		playsound(T, sfx, 100, TRUE)
+		if(L != howner)
+			L.Slowdown(slow_dur)
+			if(L.mobility_flags & MOBILITY_STAND)
+				apply_generic_weapon_damage(L, ((hitcount > 1) ? (dam * 1.5) : dam), "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT)
+			var/sfx = 'sound/combat/sp_gsword_hit.ogg'
+			playsound(T, sfx, 100, TRUE)
 	..()
 
 #undef GAREN_WAVE1

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -465,7 +465,8 @@ SPECIALS START HERE
 	use_doafter = TRUE
 	respect_adjacency = FALSE
 	delay = 0.6 SECONDS
-	cooldown = 20 SECONDS
+	cooldown = 25 SECONDS
+	stamcost = 25
 	var/slow_dur = 5	//We do NOT want to use SECONDS macro here. Slowdown() takes in an int and turns it into seconds already.
 	var/KD_dur = 2 SECONDS
 	var/Offb_dur = 5 SECONDS
@@ -579,6 +580,7 @@ SPECIALS START HERE
 	respect_adjacency = FALSE
 	delay = 0.5 SECONDS
 	cooldown = 25 SECONDS
+	stamcost = 15
 	var/immob_dur = 3.5 SECONDS
 	var/exposed_dur = 6 SECONDS
 	var/dam
@@ -662,7 +664,7 @@ SPECIALS START HERE
 	delay = 0.7 SECONDS
 	cooldown = 30 SECONDS
 	stamcost = 25	//Stamina cost
-	var/dam = 50
+	var/dam = 60
 	var/slow_dur = 2
 	var/hitcount = 0
 	var/self_debuffed = FALSE


### PR DESCRIPTION
## About The Pull Request
- Every melee weapon special was given IFF -- they won't affect the user of the Special.

I'm still not sure on this one, do not consider it precedent for any new ones, or for it to stay this way! It's likely going to be on a case-by-case basis. Though a visual distinction between IFF and Not would be neat. Like a red "!" instead of yellow or something.

- Axe, Ground Smash and Greatsword Specials were given more damage and slightly quicker deployment time.
- But they were also given a stamina cost now. Yeah, they were free to use before. Mostly because they were so unwieldy. More wieldy = more costly.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tried to groundsmash myself, failed!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It was a suggestion made by a few players. The IFF part. The jaks are mostly just me. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance:Specials do not affect the user of the Special.
balance:Axe, Greatsword & Mace Specials received buffs to damage.
balance:Shin Prod (arming sword, rapier) Special has a more potent slow now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
