### PR TITLE
Containers on trays no longer spill their contents

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -172,6 +172,9 @@
 	for(var/mob/living/L in can_see_contents())
 		if(!L.CanReach(A))
 			hide_from(L)
+	spill_contents(A)
+
+/datum/component/storage/proc/spill_contents(atom/A)
 	for(var/obj/item/reagent_containers/I in A.contents)
 		if(I.reagents && I.spillable)
 			I.reagents.remove_all(3)

--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -186,6 +186,10 @@
 	dump_time = 40
 	collection_mode = COLLECT_SAME
 
+/datum/component/storage/concrete/tray/spill_contents(obj/A)
+	if (A.throwing)
+		. = ..()
+
 /datum/component/storage/concrete/tray/New(datum/P, ...)
 	. = ..()
 	can_hold = typecacheof(list(/obj/item/cooking, /obj/item/reagent_containers/glass/bowl, /obj/item/reagent_containers/glass/cup, /obj/item/kitchen, /obj/item/reagent_containers/food, /obj/item/reagent_containers/glass/bottle))

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -18,6 +18,9 @@
 	component_type = /datum/component/storage/concrete/tray
 	var/tray_display_dummies = list()
 
+/obj/item/storage/bag/tray/check_spill()
+	return
+
 /obj/item/storage/bag/tray/psy
 	name = "tray"
 	icon = 'icons/obj/food/containers.dmi'


### PR DESCRIPTION
## About The Pull Request

- Overrode `/obj/item/storage/proc/check_spill()` for trays causing them to no longer spill contents when moving around
- Separated `spill_contents` proc from `/datum/component/storage/proc/on_move()` and overrode it for trays causing them to no longer spill contents when being equipped/picked up. The default spill_contents is still called when a tray is thrown.

## Testing Evidence
Complied, walked around with some water in goblets on tray without spilling it all over myself.
<img width="1209" height="577" alt="obraz" src="https://github.com/user-attachments/assets/cda29d56-5546-426b-b39d-deba7b26a6bd" />


## Why It's Good For The Game
QoL/fix - trays are meant for carrying food and drinks around easier, now you can use them that way.

## Changelog

:cl:
qol: Containers on trays no longer spill their contents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
