### PR TITLE
Bugfix: Adds fare types to carrot-steaks

### DIFF
--- a/modular/Neu_Food/code/cooked/cooked_meat_meal.dm
+++ b/modular/Neu_Food/code/cooked/cooked_meat_meal.dm
@@ -59,6 +59,7 @@
 	foodtype = MEAT
 	warming = 5 MINUTES
 	rotprocess = SHELFLIFE_DECENT
+	faretype = FARE_FINE
 	eat_effect = /datum/status_effect/buff/foodbuff
 	drop_sound = 'sound/foley/dropsound/gen_drop.ogg'
 
@@ -90,6 +91,7 @@
 	warming = 3 MINUTES
 	rotprocess = SHELFLIFE_DECENT
 	eat_effect = /datum/status_effect/buff/foodbuff
+	faretype = FARE_LAVISH
 
 /*	.................   Wiener Cabbage   ................... */
 /obj/item/reagent_containers/food/snacks/rogue/wienercabbage


### PR DESCRIPTION
## About The Pull Request

Adds a faretype to carrot steak and the carrot steak meal.

## Testing Evidence

One line change

## Why It's Good For The Game

They're fancy foods that nobles eat. Nobles should be able to eat them without throwing up.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Carrot steak and Carrot steal meal no longer make nobles throw up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
