### PR TITLE
Straw bed minijak

### DIFF
--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -323,7 +323,7 @@
 	name = "straw bed"
 	desc = "A rough bed of straw. It's scratchy, and probably hides lots of bugs, but at least it's dry and warm."
 	icon_state = "shitbed"
-	sleepy = 1
+	sleepy = 1.5
 
 /obj/structure/bed/rogue/post_buckle_mob(mob/living/M)
 	..()


### PR DESCRIPTION
## About The Pull Request

- Increase straw bed `sleepy` modifier from 1 to 1.5, causing it to cross threshold for falling asleep quicker as well as slightly buffing health recovery while sleeping on them

## Testing Evidence

Compiled.

## Why It's Good For The Game

People on discord asked for it. Main agrument was that straw bed is still a bed and falling asleep on it shouldn't take longer. It's still slightly weaker than bedroll, and only half as good as normal bed.

## Changelog

:cl:
balance: Straw beds are now considered beds when it comes to falling asleep time

/:cl:

