### PR TITLE
Fix for Fill Songbook verb spam learning too many songs

### DIFF
--- a/code/controllers/subsystem/rogue/bardicinspiration.dm
+++ b/code/controllers/subsystem/rogue/bardicinspiration.dm
@@ -30,6 +30,7 @@ GLOBAL_LIST_INIT(learnable_songst3, (list(/obj/effect/proc_holder/spell/invoked/
 	var/tier1acquired = FALSE
 	var/tier2acquired = FALSE
 	var/tier3acquired = FALSE
+	var/learning_song = FALSE
 
 /datum/inspiration/Destroy(force)
 	. = ..()
@@ -132,9 +133,16 @@ GLOBAL_LIST_INIT(learnable_songst3, (list(/obj/effect/proc_holder/spell/invoked/
 	set name = "Fill Songbook"
 	set category = "Inspiration"
 
-
+	if(!inspiration)
+		return
+	if(inspiration.learning_song)
+		to_chat(src, span_warning("I'm already choosing a song!"))
+		return
 	if(!mind)
 		return
+
+	inspiration.learning_song = TRUE
+
 	var/list/songs = GLOB.learnable_songst1
 	var/list/choices = list()
 	var/choosablesongtiers = list()
@@ -160,6 +168,7 @@ GLOBAL_LIST_INIT(learnable_songst3, (list(/obj/effect/proc_holder/spell/invoked/
 	var/chosensongtier = tgui_input_list(src, "Choose a tier of song to add to your songbook", "SERENADE", choosablesongtiers)
 
 	if(!chosensongtier)
+		inspiration.learning_song = FALSE
 		return
 
 	switch(chosensongtier)
@@ -178,13 +187,16 @@ GLOBAL_LIST_INIT(learnable_songst3, (list(/obj/effect/proc_holder/spell/invoked/
 	var/obj/effect/proc_holder/spell/invoked/song/item = choices[choice]
 
 	if(!item)
+		inspiration.learning_song = FALSE
 		return     // user canceled;
 	if(alert(src, "[item.desc]", "[item.name]", "Learn", "Cancel") == "Cancel") //gives a preview of the spell's description to let people know what a spell does
+		inspiration.learning_song = FALSE
 		return
 
 	for(var/obj/effect/proc_holder/spell/knownsong in mind.spell_list)
 		if(knownsong.type == item.type)
 			to_chat(span_warning("You already know this one!"))
+			inspiration.learning_song = FALSE
 			return
 	var/obj/effect/proc_holder/spell/invoked/song/new_song = new item
 	mind.AddSpell(new_song)
@@ -196,5 +208,8 @@ GLOBAL_LIST_INIT(learnable_songst3, (list(/obj/effect/proc_holder/spell/invoked/
 			inspiration.tier2acquired = TRUE
 		if(3)
 			inspiration.tier3acquired = TRUE
+
+	inspiration.learning_song = FALSE
+
 	if(inspiration.songsbought >= inspiration.level)
 		verbs -= /mob/living/carbon/human/proc/picksongs


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

There was an exploit with hammering up a queue of Fill Songbook, allowing too many songs to be learned. This puts in a var tag-out that prevents it. Tested with all of the menu conditions, seems like it would be ok.

## Testing Evidence

https://github.com/user-attachments/assets/7943f4ab-6c50-4c3d-9f79-9c08e836fded


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Show me your greatest hits discography.

Now you may think, but what if the client disconnects or crashes out while selecting things. Won't the lock var be stuck on? In testing, the tgui stuff fails "safe" when the client disconnects, so everything seems to be ok in testing. I alt-f4'd a lot.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fill Songbook no longer spammable for all songs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
