### PR TITLE
Adding A Second Coat (Of Primer) - Fixes a minor plot hole that I was informed about, roughly two hours ago.

### DIFF
--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -152,7 +152,7 @@ More recently, unsettling rumors have arose of an ancient cult, nestled deep wit
 	</details>
 
 	<details>
-		<summary><strong> Enlightenment - 352 AP to 922 AP </strong></summary>
+		<summary><strong> Enlightenment - 352 AP to ??? AP </strong></summary>
 		<br>
 		Kingdoms arise, with the Holy Celestial Empire - a communion of both Man and God - reigning above them all. The snow-elves, though cursed with infertility, were nevertheless blessed the most with Noc's wisdom. By their hands, many mechanical marvels are developed: some still exist today, such as the SCOM and MEISTERS.
 		<br><br>
@@ -163,7 +163,7 @@ More recently, unsettling rumors have arose of an ancient cult, nestled deep wit
 	</details>
 
 	<details>
-		<summary><strong> Sundering - 923 to 1313 AP </strong></summary>
+		<summary><strong> Sundering - ???, between 923 and 1313 AP </strong></summary>
 		<br>
 		At the height of Psydonia's prosperity, a snow-elven archmage discovers a way to dispel the curse that has led to their race's endangerment. A great machine is constructed, yet its activation results in a cataclysm beyond compare. Explosions ripple throughout Psydonia's leylines, and every single snow-elve simultaneously evaporates into piles of gore and ash.
 		<br><br>
@@ -174,7 +174,7 @@ More recently, unsettling rumors have arose of an ancient cult, nestled deep wit
 	</details>
 
 	<details>
-		<summary><strong> Decay - 1311 to 1512 AP </strong></summary>
+		<summary><strong> Decay - ??? to 1512 AP </strong></summary>
 		<br>
 		In the ashes of Celestia, a new deity arose - Zizo. She is followed by Baotha, Graggar, and Matthios, who have now fully resurfaced. Their presence gave way to the birth of Ascendanism, for they gifted His children with a revelation: they were all but mortals, once, who had discovered how to obtain divinity for themselves. A schism forms in the churches, and the Ecclesial is born.
 		<br><br>


### PR DESCRIPTION
## About The Pull Request

Very brief, but this should amend a _small_ plot hole I was just reminded of.
When I initially wrote the Primer, I took pretty much everything from the Wiki entry. This includes the specific date for Zizo's ascension, 923 AP. As it _turns out_, however, this was actually a fairly recent change.

Beforehand, for most of Azure's existence, the actual date of Zizo's ascension was implied to be 1311-1313 AP _(as the Ascendant's 'church', the Ecclesiarch, was said to've existed for around two hundred years by 1513 AP - and had explicitly formed in the wake of Zizo's ascension and Celestia's collapse.)_

Considering this plothole _(alongside the recent moves to respect Nightmare's wishes with removing his lore?)_, I've decided to make this patch as a quick bandaid. '923' is replaced with 'not long ago' in the opening scrawl, and the specific date behind the 'Sundering' era has now been extended from 923-1313 AP.

This should hopefully fix the plothole and ensure both sides of the aisle aren't retroactively retconned.
_(At least, for now.)_

## Testing Evidence

Just a couple one-liner changes in the .txt file. Nothing too important.

## Why It's Good For The Game

A _(relatively)_ coherent timeline is good. Ensuring that previous characters aren't retroactively retconned due to less-than-publicized changes in a fairly important date is also good.

## Changelog

:cl:
fix: Repairs the timeline.
/:cl: