### PR TITLE
Makes ranged weapons fail to draw if clicking the quiver

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -135,8 +135,8 @@
 				if(mob.next_rmove > world.time)
 					return
 			mob.used_intent = mob.o_intent
-			if(mob.used_intent.get_chargetime() && mob.mmb_intent.can_charge() && !AD.blockscharging && !mob.in_throw_mode)
-				updateprogbar()
+			if(mob.used_intent.get_chargetime() && mob.mmb_intent.can_charge(object) && !AD.blockscharging && !mob.in_throw_mode)
+				updateprogbar(object)
 			else
 				mouse_pointer_icon = 'icons/effects/mousemice/human_attack.dmi'
 			return
@@ -156,12 +156,12 @@
 		if(!mob.mmb_intent)
 			mouse_pointer_icon = 'icons/effects/mousemice/human_looking.dmi'
 		else
-			if(mob.mmb_intent.get_chargetime() && mob.mmb_intent.can_charge() && !AD.blockscharging)
+			if(mob.mmb_intent.get_chargetime() && mob.mmb_intent.can_charge(object) && !AD.blockscharging)
 				if(mob.buckled)
 					mob.buckled.face_atom(object, location, control, params)
 				else
 					mob.face_atom(object, location, control, params)
-				updateprogbar()
+				updateprogbar(object)
 			else
 				mouse_pointer_icon = mob.mmb_intent.pointer
 		return
@@ -179,7 +179,7 @@
 		mob.atkswinging = "left"
 		mob.used_intent = mob.a_intent
 		if(mob.used_intent.get_chargetime() && !AD.blockscharging && !mob.in_throw_mode)
-			updateprogbar()
+			updateprogbar(object)
 		else
 			mouse_pointer_icon = 'icons/effects/mousemice/human_attack.dmi'
 		return
@@ -249,13 +249,13 @@
 	if(!isliving(mob))
 		return
 
-/client/proc/updateprogbar()
+/client/proc/updateprogbar(atom/clicked_object)
 	if(!mob)
 		return
 	if(!isliving(mob))
 		return
 	var/mob/living/L = mob
-	if(!L.used_intent.can_charge())
+	if(!L.used_intent.can_charge(clicked_object))
 		return
 	L.used_intent.prewarning()
 

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -152,7 +152,7 @@
 /datum/intent/proc/rmb_ranged(atom/target, mob/user)
 	return
 
-/datum/intent/proc/can_charge()
+/datum/intent/proc/can_charge(atom/clicked_object)
 	return TRUE
 
 /datum/intent/proc/afterchange()

--- a/code/game/objects/items/rogueweapons/mmb/spell.dm
+++ b/code/game/objects/items/rogueweapons/mmb/spell.dm
@@ -6,7 +6,7 @@
 	warnie = "aimwarn"
 	warnoffset = 0
 
-/datum/intent/spell/can_charge()
+/datum/intent/spell/can_charge(atom/clicked_object)
 	var/obj/effect/proc_holder/spell/spell_ability = mastermob.ranged_ability
 	if(istype(spell_ability) && !spell_ability.charge_check(mastermob, TRUE))
 		to_chat(mastermob, span_warning("This spell needs time to recharge!"))

--- a/code/game/objects/items/rogueweapons/ranged/bows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/bows.dm
@@ -5,11 +5,13 @@
 	chargedrain = 2
 	charging_slowdown = 3
 
-/datum/intent/shoot/bow/can_charge()
+/datum/intent/shoot/bow/can_charge(atom/clicked_object)
 	if(mastermob)
 		if(mastermob.get_num_arms(FALSE) < 2)
 			return FALSE
 		if(mastermob.get_inactive_held_item())
+			return FALSE
+		if(istype(clicked_object, /obj/item/quiver) && istype(mastermob.get_active_held_item(), /obj/item/gun/ballistic))
 			return FALSE
 	return TRUE
 
@@ -42,11 +44,13 @@
 	chargedrain = 2
 	charging_slowdown = 3
 
-/datum/intent/arc/bow/can_charge()
+/datum/intent/arc/bow/can_charge(atom/clicked_object)
 	if(mastermob)
 		if(mastermob.get_num_arms(FALSE) < 2)
 			return FALSE
 		if(mastermob.get_inactive_held_item())
+			return FALSE
+		if(istype(clicked_object, /obj/item/quiver) && istype(mastermob.get_active_held_item(), /obj/item/gun/ballistic))
 			return FALSE
 	return TRUE
 

--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -47,11 +47,13 @@
 	chargedrain = 0 //no drain to aim a crossbow
 	basetime = 20
 
-/datum/intent/shoot/crossbow/can_charge()
+/datum/intent/shoot/crossbow/can_charge(atom/clicked_object)
 	if(mastermob)
 		if(mastermob.get_num_arms(FALSE) < 2)
 			return FALSE
 		if(mastermob.get_inactive_held_item())
+			return FALSE
+		if(istype(clicked_object, /obj/item/quiver) && istype(mastermob.get_active_held_item(), /obj/item/gun/ballistic))
 			return FALSE
 	return TRUE
 
@@ -81,11 +83,13 @@
 
 
 
-/datum/intent/arc/crossbow/can_charge()
+/datum/intent/arc/crossbow/can_charge(atom/clicked_object)
 	if(mastermob)
 		if(mastermob.get_num_arms(FALSE) < 2)
 			return FALSE
 		if(mastermob.get_inactive_held_item())
+			return FALSE
+		if(istype(clicked_object, /obj/item/quiver) && istype(mastermob.get_active_held_item(), /obj/item/gun/ballistic))
 			return FALSE
 	return TRUE
 

--- a/code/game/objects/items/rogueweapons/ranged/slings.dm
+++ b/code/game/objects/items/rogueweapons/ranged/slings.dm
@@ -5,7 +5,10 @@
 	chargedrain = 2
 	charging_slowdown = 3
 
-/datum/intent/swing/sling/can_charge() //checks for arms and spare empty hand removed since it can fire with one hand
+/datum/intent/swing/sling/can_charge(atom/clicked_object) //checks for arms and spare empty hand removed since it can fire with one hand
+	if(mastermob)
+		if(istype(clicked_object, /obj/item/quiver) && istype(mastermob.get_active_held_item(), /obj/item/gun/ballistic))
+			return FALSE
 	return TRUE
 
 /datum/intent/swing/sling/prewarning()
@@ -32,7 +35,10 @@
 	chargedrain = 2
 	charging_slowdown = 3
 
-/datum/intent/arc/sling/can_charge() //checks for arms and spare empty hand removed since it can fire with one hand
+/datum/intent/arc/sling/can_charge(atom/clicked_object) //checks for arms and spare empty hand removed since it can fire with one hand
+	if(mastermob)
+		if(istype(clicked_object, /obj/item/quiver) && istype(mastermob.get_active_held_item(), /obj/item/gun/ballistic))
+			return FALSE
 	return TRUE
 
 /datum/intent/arc/sling/prewarning()


### PR DESCRIPTION
## About The Pull Request

As title. If you click on a quiver with any ranged weapon, it will not begin to draw. This is intended to resolve an awkward interaction in which, by nocking an arrow onto a bow or sling, you also trigger the prewarning proc for the weapon and began to draw or sling it, before having to do that again to fire it.

No crossbow allows you to load bolts directly from the quiver as far as I know, but I've retained the logic on the off-chance that's ever implemented.

## Testing Evidence

<img width="418" height="189" alt="image" src="https://github.com/user-attachments/assets/c80ef79b-645f-400d-8984-e59347c66d03" />

<img width="385" height="87" alt="image" src="https://github.com/user-attachments/assets/95752e66-21fd-484d-a543-f867205f0c2d" />

I also tested magic since it runs off the same charge logic, and nothing seems off.

## Why It's Good For The Game

This is pure QoL, it just removes one slightly unintuitive message and sound in an interaction where it shouldn't appear.

The code feels messy to me and I'm fairly sure I've missed something, I've needed to drag the clicked item across multiple arguments, but nothing seems to have broken on testing with either magic or any ranged weapons.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Slings and bows are no longer drawn when clicked on a quiver to nock an arrow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
