### PR TITLE
Massive Aubergine balancejak (It uses Tomato now)

### DIFF
--- a/modular/Neu_Food/code/cooked/cooked_veggies.dm
+++ b/modular/Neu_Food/code/cooked/cooked_veggies.dm
@@ -185,7 +185,7 @@
 
 /obj/item/reagent_containers/food/snacks/rogue/eggplantmeat
 	name = "unfinished stuffed aubergine"
-	desc = "An eggplant stuffed with raw meat, ready to be topped with...apple!?"
+	desc = "An eggplant stuffed with raw meat, ready to be topped with a tomato."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_veggies.dmi'
 	icon_state = "eggplantraw"
 	rotprocess = SHELFLIFE_LONG
@@ -193,7 +193,7 @@
 /obj/item/reagent_containers/food/snacks/rogue/eggplantmeat/attackby(obj/item/I, mob/living/user, params)
 	var/found_table = locate(/obj/structure/table) in (loc)
 	update_cooktime(user)
-	if(istype(I, /obj/item/reagent_containers/food/snacks/grown/apple))
+	if(istype(I, /obj/item/reagent_containers/food/snacks/grown/fruit/tomato))
 		if(isturf(loc)&& (found_table))
 			playsound(get_turf(user), 'sound/foley/dropsound/gen_drop.ogg', 30, TRUE, -1)
 			to_chat(user, "Topping tomatos onto the aubergine...")
@@ -207,19 +207,19 @@
 
 /obj/item/reagent_containers/food/snacks/rogue/eggplantstuffedraw
 	name = "raw stuffed aubergine"
-	desc = "A stuffed aubergine with raw meat and tomato (apple), ready to be cooked."
+	desc = "A stuffed aubergine with raw meat and tomato (Real tomato!), ready to be cooked."
 	icon = 'modular/Neu_Food/icons/cooked/cooked_veggies.dmi'
 	icon_state = "eggplantrawtom"
 	rotprocess = SHELFLIFE_LONG
 	cooked_type = /obj/item/reagent_containers/food/snacks/rogue/preserved/eggplantstuffed
 
 /obj/item/reagent_containers/food/snacks/rogue/preserved/eggplantstuffed
-	list_reagents = list(/datum/reagent/consumable/nutriment = SNACK_DECENT)
+	list_reagents = list(/datum/reagent/consumable/nutriment = MEAL_MEAGRE)
 	name = "stuffed aubergine"
-	desc = "Eggplant stuffed with raw meat and apple. Delicious!"
+	desc = "Eggplant stuffed with raw meat and tomato. Delicious!"
 	icon = 'modular/Neu_Food/icons/cooked/cooked_veggies.dmi'
 	icon_state = "stuffedeggplant"
-	tastes = list("meat" = 1, "apple" = 1, "aubergine" = 1)
+	tastes = list("meat" = 1, "tomato" = 1, "aubergine" = 1)
 	faretype = FARE_FINE
 	rotprocess = SHELFLIFE_LONG
 	eat_effect = /datum/status_effect/buff/foodbuff
@@ -227,7 +227,7 @@
 /obj/item/reagent_containers/food/snacks/rogue/preserved/eggplantstuffed/attackby(obj/item/I, mob/living/user, params)
 	var/found_table = locate(/obj/structure/table) in (loc)
 	update_cooktime(user)
-	if(istype(I, /obj/item/reagent_containers/food/snacks/rogue/cheddarwedge))
+	if(istype(I, /obj/item/reagent_containers/food/snacks/rogue/cheddarslice))
 		if(isturf(loc)&& (found_table))
 			playsound(get_turf(user), 'sound/foley/dropsound/gen_drop.ogg', 30, TRUE, -1)
 			to_chat(user, "Laying down a blanket of cheese...")
@@ -240,7 +240,7 @@
 		return ..()
 
 /obj/item/reagent_containers/food/snacks/rogue/preserved/eggplantstuffedcheese
-	list_reagents = list(/datum/reagent/consumable/nutriment = SNACK_NUTRITIOUS)
+	list_reagents = list(/datum/reagent/consumable/nutriment = MEAL_AVERAGE)
 	name = "stuffed aubergine with cheese"
 	desc = "Stuffed aubergine with cheese on top. Fit for a king!"
 	icon = 'modular/Neu_Food/icons/cooked/cooked_veggies.dmi'


### PR DESCRIPTION
## About The Pull Request

This replaces the apple in the aubergine recipe with an actual tomato and the cheese wedge it's topped with with a cheese slice since it's more appropriate. This also significantly increases the nutrition value of the meal, since it's a complex and expensive recipe that was barely any better than a cake slice.
## Testing Evidence

<img width="575" height="376" alt="image" src="https://github.com/user-attachments/assets/3e820300-e733-43d2-95ff-558bd539c418" />

(I realize the examine text screenshot I posted is for a raw stuffed aubergine-.. and  the aubergine on the ground is a cooked and cheesed one, this may create a misleading illusion that I am examining the cooked aubergine and it is appearing as raw. That is not the case I just examined a raw one earlier for that part of the screenshot pleasedon'tkillme)

## Why It's Good For The Game

See above, using an actual tomato is better than an apple that gets flavoured as one.
Complex recipe that only makes one item, it should have good nutrition. Probably doesn't need to also cost a whole cheese wedge.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Stuffed Aubergine now uses an apple instead of Tomato
balance: Stuffed Aubergine only requires a cheese slice instead of a wedge
balance: Stuffed Aubergine provides more nutrition when eaten.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
