### PR TITLE
Ruma Spangle ✨

### DIFF
--- a/code/__DEFINES/armor_defines.dm
+++ b/code/__DEFINES/armor_defines.dm
@@ -113,5 +113,6 @@
 #define ARMOR_ZIZOCONCSTRUCT list("blunt" = 60, "slash" = 70, "stab" = 70, "piercing" = 60, "fire" = 40, "acid" = 10)
 #define ARMOR_DRAGONHIDE list("blunt" = 30, "slash" = 30, "stab" = 30, "piercing" = 30, "fire" = 40, "acid" = 0) // snowflake armor for dragonhide, fire resist but lower other values from the ring since more integ
 #define ARMOR_FATEWEAVER list("blunt" = 10, "slash" = 100, "stab" = 100, "piercing" = 100, "fire" = 0, "acid" = 0)
+#define ARMOR_RUMACLAN	list("blunt" = 5,"slash" = 90, "stab" = 90, "piercing" = 50, "fire" = 0, "acid" = 0)
 // Blocks every hit, at least once
 #define ARMOR_GRONN_LIGHT list("blunt" = 80, "slash" = 80, "stab" = 30, "piercing" = 30, "fire" = 0, "acid" = 0)

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -677,8 +677,7 @@
 	resistance_flags = FIRE_PROOF
 	icon_state = "easttats"
 	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR
-	armor = list("blunt" = 30, "slash" = 50, "stab" = 50, "piercing" = 20, "fire" = 0, "acid" = 0)
-	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
+	armor = ARMOR_RUMACLAN
 	body_parts_covered = COVERAGE_FULL
 	body_parts_inherent = COVERAGE_FULL
 	icon = 'icons/roguetown/clothing/shirts.dmi'
@@ -687,11 +686,11 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	allowed_race = NON_DWARVEN_RACE_TYPES
-	max_integrity = 600 //Bad armor protection and very basic crit protection, but incredibly hard to break completely
+	max_integrity = 250
 	flags_inv = null //free the breast
 	surgery_cover = FALSE // cauterize and surgery through it.
-	var/repair_amount = 6 //The amount of integrity the tattoos will repair themselves
-	var/repair_time = 20 SECONDS //The amount of time between each repair
+	var/repair_amount = 25 //The amount of integrity the tattoos will repair themselves
+	var/repair_time = 30 SECONDS //The amount of time between each repair
 	var/last_repair //last time the tattoos got repaired
 
 /obj/item/clothing/suit/roguetown/shirt/undershirt/easttats/Initialize(mapload)
@@ -710,6 +709,7 @@
 	if(obj_integrity < max_integrity)
 		START_PROCESSING(SSobj, src)
 		return
+	src.last_repair = world.time + src.repair_time
 
 /obj/item/clothing/suit/roguetown/shirt/undershirt/easttats/process()
 	if(obj_integrity >= max_integrity)

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -671,7 +671,7 @@
 	allowed_race = NON_DWARVEN_RACE_TYPES
 
 //tattoo code
-/obj/item/clothing/suit/roguetown/shirt/undershirt/easttats
+/obj/item/clothing/suit/roguetown/armor/regenerating/easttats
 	name = "bouhoi bujeog tattoos"
 	desc = "A mystic style of tattoos adopted by the Ruma Clan, emulating a practice performed by warrior monks of the Xinyi Dynasty. They are your way of identifying fellow clan members, an sign of companionship and secretive brotherhood. These are styled into the shape of clouds, created by a mystical ink which shifts and moves in ripples like a pond to harden where your skin is struck. It's movement causes you to shudder."
 	resistance_flags = FIRE_PROOF
@@ -686,40 +686,27 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	allowed_race = NON_DWARVEN_RACE_TYPES
-	max_integrity = 175
+	max_integrity = 195
 	flags_inv = null //free the breast
 	surgery_cover = FALSE // cauterize and surgery through it.
-	var/repair_amount = 25 //The amount of integrity the tattoos will repair themselves
-	var/repair_time = 30 SECONDS //The amount of time between each repair
-	var/last_repair //last time the tattoos got repaired
 
-/obj/item/clothing/suit/roguetown/shirt/undershirt/easttats/Initialize(mapload)
+	repairmsg_begin = "The tattoos begin to slowly mend its abuse.."
+	repairmsg_continue = "The tattoos mend some of its abuse.."
+	repairmsg_stop = "The tattoos stops mending from the onslaught!"
+	repairmsg_end = "The tattoos flow more calmly, as they finish resting and regain their strength."
+
+	interrupt_damount = 25
+	repair_time = 35 SECONDS
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/easttats/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/suit/roguetown/shirt/easttats/easttats/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/suit/roguetown/armor/regenerating/easttats/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return
 	qdel(src)
-
-
-/obj/item/clothing/suit/roguetown/shirt/undershirt/easttats/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
-	. = ..()
-	if(obj_integrity < max_integrity)
-		START_PROCESSING(SSobj, src)
-		return
-	src.last_repair = world.time + src.repair_time
-
-/obj/item/clothing/suit/roguetown/shirt/undershirt/easttats/process()
-	if(obj_integrity >= max_integrity)
-		STOP_PROCESSING(SSobj, src)
-		src.visible_message(span_notice("The [src] flow more calmly, as they finish resting and regain their strength."), vision_distance = 1)
-		return
-	else if(world.time > src.last_repair + src.repair_time)
-		src.last_repair = world.time
-		obj_integrity = min(obj_integrity + src.repair_amount, src.max_integrity)
-	..()
 
 /obj/item/clothing/suit/roguetown/shirt/dress/maid
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -686,7 +686,7 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	allowed_race = NON_DWARVEN_RACE_TYPES
-	max_integrity = 150
+	max_integrity = 175
 	flags_inv = null //free the breast
 	surgery_cover = FALSE // cauterize and surgery through it.
 	var/repair_amount = 25 //The amount of integrity the tattoos will repair themselves

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -686,7 +686,7 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	allowed_race = NON_DWARVEN_RACE_TYPES
-	max_integrity = 250
+	max_integrity = 150
 	flags_inv = null //free the breast
 	surgery_cover = FALSE // cauterize and surgery through it.
 	var/repair_amount = 25 //The amount of integrity the tattoos will repair themselves

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
@@ -36,7 +36,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/scabbard/sword/kazengun/steel
 	beltl = /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench
-	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/easttats
+	shirt = /obj/item/clothing/suit/roguetown/armor/regenerating/easttats
 	cloak = /obj/item/clothing/cloak/eastcloak1
 	armor = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2
@@ -82,7 +82,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/quiver/arrows
 	beltl = /obj/item/flashlight/flare/torch/lantern
-	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/easttats
+	shirt = /obj/item/clothing/suit/roguetown/armor/regenerating/easttats
 	cloak = /obj/item/clothing/cloak/eastcloak1
 	armor = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/seonjang.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/seonjang.dm
@@ -44,7 +44,7 @@
 	H.adjust_blindness(-3)
 
 	if(should_wear_masc_clothes(H))
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/easttats
+		shirt = /obj/item/clothing/suit/roguetown/armor/regenerating/easttats
 		cloak = /obj/item/clothing/cloak/eastcloak1
 		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
 		gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
@@ -55,6 +55,6 @@
 		H.dna.species.soundpack_m = new /datum/voicepack/male/evil()
 	else if(should_wear_femme_clothes(H))
 		armor = /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/easttats
+		shirt = /obj/item/clothing/suit/roguetown/armor/regenerating/easttats
 		shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	H.merctype = 9


### PR DESCRIPTION
## About The Pull Request
- Changes their skin armor to be more closer to plate armor (better, actually), but have low durability.
- Getting struck will reset the regen timer, meaning it can only regen outside of combat.
- It now regens 25 integrity every 30 seconds.

It's now similar to that uhh dragon-thingy that mages get, just sorta inherent to the shirt slot.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
By partial request / suggestion / inspired by the AC Wrangle PR.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance:Ruma Clan tattoos are now tankier.
balance:Ruma Clan tattoos regeneration increased. The regen timer resets when taking enough damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
