### PR TITLE
[SR] Kick auto targeting and Choking changes

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/kick.dm
+++ b/code/game/objects/items/rogueweapons/mmb/kick.dm
@@ -5,7 +5,7 @@
 	chargetime = 0
 	chargedrain = 0
 	noaa = FALSE
-	swingdelay = 4
+	swingdelay = 5
 	misscost = 20
 	unarmed = TRUE
 	animname = "kick"
@@ -33,9 +33,15 @@
 	// play the attack animation even when kicking non-mobs
 	if(mmb_intent) // why this would be null and not INTENT_KICK i have no clue, but the check already existed
 		do_attack_animation_simple(A, visual_effect_icon = mmb_intent.animname)
+
+	var/atom/target = A
+	if(isturf(A))
+		for(var/mob/living/M in A)
+			target = M
+			break
 	// but the rest of the logic is pretty much mob-only
-	if(ismob(A) && mmb_intent)
-		var/mob/living/M = A
+	if(ismob(target) && mmb_intent)
+		var/mob/living/M = target
 		sleep(mmb_intent.swingdelay)
 		if(M.has_status_effect(/datum/status_effect/buff/clash) && ishuman(M))
 			var/mob/living/carbon/human/HT = M
@@ -56,7 +62,7 @@
 		else
 			M.onkick(src)
 	else
-		A.onkick(src)
+		target.onkick(src)
 	OffBalance(3 SECONDS)
 	return TRUE
 

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -212,27 +212,32 @@
 				user.stop_pulling()
 				return FALSE
 			if(limb_grabbed && grab_state > 0) //this implies a carbon victim
-				if(iscarbon(M) && M != user)
-					user.stamina_add(rand(1,3))
+				if(iscarbon(M))
+					playsound(src.loc, 'sound/foley/struggle.ogg', 100, FALSE, -1)
+					user.stamina_add(7)
 					var/mob/living/carbon/C = M
-					if(get_location_accessible(C, BODY_ZONE_PRECISE_NECK))
+					var/choke_damage
+					if(user.STASTR > STRENGTH_SOFTCAP)
+						choke_damage = STRENGTH_SOFTCAP
+					else
+						choke_damage = user.STASTR * 0.75
+					if(chokehold)
+						choke_damage *= 1.2		//Slight bonus
+					if(C.pulling == user && C.grab_state >= GRAB_AGGRESSIVE)
+						choke_damage *= 0.95	//Slight malice
+					var/neck_armor = C.run_armor_check(BODY_ZONE_PRECISE_NECK, "slash")
+					var/reduction = (neck_armor / 100) * 0.66
+					reduction = min(max(reduction, 0), 1)
+					choke_damage *= (1 - reduction)
+					if(!HAS_TRAIT(C, TRAIT_NOBREATH))
+						if(C.stamina < C.max_stamina)
+							C.stamina_add(choke_damage*1.5)
 						if(prob(25))
 							C.emote("choke")
-						var/choke_damage
-						if(user.STASTR > STRENGTH_SOFTCAP)
-							choke_damage = STRENGTH_SOFTCAP
-						else
-							choke_damage = user.STASTR * 0.75
-						if(chokehold)
-							choke_damage *= 1.2		//Slight bonus
-						if(C.pulling == user && C.grab_state >= GRAB_AGGRESSIVE)
-							choke_damage *= 0.95	//Slight malice
-						C.adjustOxyLoss(choke_damage)
-						C.visible_message(span_danger("[user] [pick("chokes", "strangles")] [C][chokehold ? " with a chokehold" : ""]!"), \
-								span_userdanger("[user] [pick("chokes", "strangles")] me[chokehold ? " with a chokehold" : ""]!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE, user)
-						to_chat(user, span_danger("I [pick("choke", "strangle")] [C][chokehold ? " with a chokehold" : ""]!"))
-					else
-						to_chat(user, span_warning("I can't reach [C]'s throat!"))
+					C.adjustOxyLoss(choke_damage)
+					C.visible_message(span_danger("[user] [pick("chokes", "strangles")] [C][chokehold ? " with a chokehold" : ""]!"), \
+							span_userdanger("[user] [pick("chokes", "strangles")] me[chokehold ? " with a chokehold" : ""]!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE, user)
+					to_chat(user, span_danger("I [pick("choke", "strangle")] [C][chokehold ? " with a chokehold" : ""]!"))
 					user.changeNext_move(CLICK_CD_GRABBING)	//Stops spam for choking.
 		if(/datum/intent/grab/hostage)
 			if(user.buckled)


### PR DESCRIPTION
## About The Pull Request
`kicks will autotarget whatever mob is on the tile if you kick at the floor`

`strangling will drain the target's stamina, so they will stam out before actually passing out`

`can strangle through armour now, with a malus of 66% damage reduction from the neck armor's slash protection`

Ports https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1687
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Kicks becoming auto targeted actually carries quite a few consequences, however it does NOT work like swingdelay. It cares about what's on the actual tile that was targeted. You know, the normal, sensible way of doing it.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance:kicks will autotarget whatever mob is on the tile if you kick at the floor
balance:strangling will drain the target's stamina, so they will stam out before actually passing out
balance:can strangle through armour now, with a malus of 66% damage reduction from the neck armor's slash protection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
