### PR TITLE
Shields help in charges + charge immob is halved

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -1,4 +1,4 @@
-//These procs handle putting s tuff in my hands
+//These procs handle putting stuff in my hands
 //as they handle all relevant stuff like adding it to the player's screen and updating their overlays.
 
 //Returns the thing we're currently holding
@@ -10,6 +10,15 @@
 //So we're treating each "pair" of limbs as a team, so "both" refers to them
 /mob/proc/get_inactive_held_item()
 	return get_item_for_held_index(get_inactive_hand_index())
+
+
+//Returns a list of items in both hands
+/mob/proc/get_held_items()
+	var/list/obj/item/held_item = list()
+	held_item += get_active_held_item()
+	held_item += get_inactive_held_item()
+
+	return held_item
 
 
 //Finds the opposite index for the active one (eg: upper left arm will find the item in upper right arm)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -200,6 +200,17 @@
 			if(L.dir == get_dir(src, L))
 				self_points += 2
 
+			// Shields matter
+			var/list/obj/item/user_inhand = get_held_items()
+			var/list/obj/item/target_inhand = L.get_held_items()
+
+			for(var/obj/I in user_inhand)
+				if(istype(I, /obj/item/rogueweapon/shield))
+					self_points += 2
+			for(var/obj/I in target_inhand)
+				if(istype(I, /obj/item/rogueweapon/shield))
+					target_points += 2
+
 			// Randomize con roll from -1 to +1 to make it less consistent
 			self_points += rand(-1, 1)
 
@@ -225,7 +236,7 @@
 			if(self_points == target_points)
 				L.Knockdown(1)
 				Knockdown(30)
-			Immobilize(10)
+			Immobilize(5)
 			var/playsound = FALSE
 			if(L.apply_damage(15, BRUTE, "chest", L.run_armor_check("chest", "blunt", damage = 10)))
 				playsound = TRUE


### PR DESCRIPTION
## About The Pull Request

Having a shield (or two) helps the charger have a better chance in a successful charge. The enemy having a shield stacks it in their favour.

The immobilisation from a successful charge is now halved.

## Testing Evidence

Tested.

## Why It's Good For The Game

Shields charges were pretty common.
Halved immob makes charges a bit more viable to capitalise on.

NUFC: new proc `get_held_items()` that just returns a list of items in both hands. doesn't go by index.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Shields help charges. Whether for the charger or the opponent.
balance: Charge immobilisation is now halved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
