### PR TITLE
[PORT] Add river controller from Twilight Axis

### DIFF
--- a/code/controllers/subsystem/rivers.dm
+++ b/code/controllers/subsystem/rivers.dm
@@ -1,0 +1,31 @@
+SUBSYSTEM_DEF(rivers)
+	name = "Rivers"
+	flags = SS_KEEP_TIMING | SS_NO_INIT
+	wait = 0.5 SECONDS
+	var/list/processing = list()
+	var/list/currentrun = list()
+
+/datum/controller/subsystem/rivers/stat_entry()
+	..("ACTIVE RIVER TILES:[processing.len]")
+
+
+/datum/controller/subsystem/rivers/fire(resumed = 0)
+	if (!resumed || !src.currentrun.len)
+		src.currentrun = processing.Copy()
+
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+
+	while(currentrun.len)
+		var/turf/open/water/river/thing = currentrun[currentrun.len]
+		currentrun.len--
+		if(!QDELETED(thing))
+			thing.process_river()
+		else
+			processing -= thing
+		if (MC_TICK_CHECK)
+			return
+
+/datum/controller/subsystem/rivers/Recover()
+	if (istype(SSrivers.processing))
+		processing = SSrivers.processing

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -195,7 +195,7 @@
 				playsound(AM, pick('sound/foley/watermove (1).ogg','sound/foley/watermove (2).ogg'), 100, FALSE)
 			if(istype(oldLoc, type) && (get_dir(src, oldLoc) != SOUTH))
 				water_overlay.layer = ABOVE_MOB_LAYER
-				water_overlay.plane = water_overlay.plane = GAME_PLANE_HIGHEST
+				water_overlay.plane = GAME_PLANE_HIGHEST
 			else
 				spawn(6)
 					if(AM.loc == src)
@@ -507,7 +507,6 @@
 	slowdown = 5
 	wash_in = TRUE
 	swim_skill = TRUE
-	var/river_processing
 	swimdir = TRUE
 
 /turf/open/water/river/flow
@@ -539,12 +538,12 @@
 /turf/open/water/river/Entered(atom/movable/AM, atom/oldLoc)
 	. = ..()
 	if(isliving(AM))
-		if(!river_processing)
-			river_processing = addtimer(CALLBACK(src, PROC_REF(process_river)), 5, TIMER_STOPPABLE)
+		START_PROCESSING(SSrivers, src)
 
 /turf/open/water/river/get_heuristic_slowdown(mob/traverser, travel_dir)
-	var/const/UPSTREAM_PENALTY = 2
-	var/const/DOWNSTREAM_BONUS = -2
+	var/const/UPSTREAM_PENALTY = 4
+	var/const/DOWNSTREAM_BONUS = -1
+	var/const/SIDESTREAM_PENALTY = 2
 	. = ..()
 	if(traverser.is_floor_hazard_immune())
 		return
@@ -555,9 +554,10 @@
 		. += DOWNSTREAM_BONUS // faster!
 	else if(travel_dir == GLOB.reverse_dir[dir]) // upriver
 		. += UPSTREAM_PENALTY // slower
+	else 
+		. += SIDESTREAM_PENALTY // sidestream walking isn't free, bro
 
 /turf/open/water/river/proc/process_river()
-	river_processing = null
 	for(var/atom/movable/A in contents)
 		for(var/obj/structure/S in src)
 			if(S.obj_flags & BLOCK_Z_OUT_DOWN)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -367,6 +367,7 @@
 #include "code\controllers\subsystem\ping.dm"
 #include "code\controllers\subsystem\pollution.dm"
 #include "code\controllers\subsystem\radio.dm"
+#include "code\controllers\subsystem\rivers.dm"
 #include "code\controllers\subsystem\rogueroundsplayed.dm"
 #include "code\controllers\subsystem\runechat.dm"
 #include "code\controllers\subsystem\server_maint.dm"


### PR DESCRIPTION
## About The Pull Request

We had a very high load on the Twilight Axis at the timer controller. We couldn't figure out why for a long time, but it turns out that every time a mob steps into the water, it triggers a timer. Now imagine... A RAT that goes against the current without stopping, because its AI believes that tiles with water can be easily passed. When we removed such a rat, the server stopped lagging...

Now the rivers have a separate controller to avoid this.

Port from: https://github.com/Twilight-Fortress-SS13/Twilight-Axis/pull/414
 
 That's what a single rat walking against the river could do.
<img width="538" height="69" alt="image" src="https://github.com/user-attachments/assets/b2d5563f-aa4d-4f68-b5e4-1ba26084c19a" />
<img width="450" height="58" alt="image" src="https://github.com/user-attachments/assets/d5b27cd1-0b0f-4758-9f60-505cf318a34c" />

These lags passed after we removed just one rat...

## Testing Evidence

<img width="569" height="70" alt="image" src="https://github.com/user-attachments/assets/f6b0db7d-0593-487d-bf05-ec64376d0023" />

## Why It's Good For The Game

<img width="856" height="1199" alt="image" src="https://github.com/user-attachments/assets/4b0f2dbf-7dff-46df-a7b5-8630b8d2e5f5" />


## Changelog
:cl:
fix: fixed a few things
code: changed some code
/:cl:

