### PR TITLE
explosion damage fix (alternative to #4827)

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -181,9 +181,9 @@ GLOBAL_LIST_EMPTY(explosions)
 			dist_epi = get_dist(L, epicenter)
 			if(dist_epi <= heavy_impact_range)
 				continue
-			if(L.mind) //min 60, max 150
-				burn = rand(40,90)
-				brute = rand(20,60)
+			if(L.mind) //min 30, max 60.
+				burn = rand(20,40)
+				brute = rand(10,20)
 				L.adjustFireLoss(burn)
 				L.adjustBruteLoss(brute)
 	EX_PREPROCESS_CHECK_TICK

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -373,8 +373,8 @@
 	light_outer_range =  2
 
 	//explosion values
-	var/exp_heavy = 0
-	var/exp_light = 2
+	var/exp_heavy = -1
+	var/exp_light = -1
 	var/exp_flash = 3
 	var/exp_fire = 2
 

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/meteor_storm.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/meteor_storm.dm
@@ -54,8 +54,8 @@
 	plane = GAME_PLANE
 	light_outer_range = 2
 	duration = 9
-	var/exp_heavy = 0
-	var/exp_light = 2
+	var/exp_heavy = -1
+	var/exp_light = -1
 	var/exp_flash = 2
 	var/exp_fire = 1
 	var/explode_sound = list('sound/misc/explode/incendiary (1).ogg','sound/misc/explode/incendiary (2).ogg')

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -26,8 +26,8 @@
 
 /obj/projectile/magic/aoe/fireball/rogue
 	name = "fireball"
-	exp_heavy = 0
-	exp_light = 0
+	exp_heavy = -1
+	exp_light = -1
 	exp_flash = 0
 	exp_fire = 1
 	damage = 60

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball_artillery.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball_artillery.dm
@@ -37,8 +37,8 @@
 
 /obj/projectile/magic/aoe/fireball/rogue/artillery
 	name = "Artillery Fireball"
-	exp_heavy = 0
-	exp_light = 0
+	exp_heavy = -1
+	exp_light = -1
 	exp_flash = 0
 	exp_fire = 1
 	damage = 50 // 10 less damage than actual fireball on direct fire

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/greater_fireball.dm
@@ -25,8 +25,8 @@
 
 /obj/projectile/magic/aoe/fireball/rogue/great
 	name = "fireball"
-	exp_heavy = 0
-	exp_light = 1
+	exp_heavy = -1
+	exp_light = -1
 	exp_flash = 2
 	exp_fire = 2
 	damage = 90 // This is gonna fucking HURT

--- a/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
@@ -38,8 +38,8 @@
 
 /obj/projectile/magic/aoe/fireball/spitfire
 	name = "Spitfire"
-	exp_heavy = 0
-	exp_light = 0
+	exp_heavy = -1
+	exp_light = -1
 	exp_flash = 0
 	exp_fire = 0
 	damage = 20


### PR DESCRIPTION
## About The Pull Request
greatly reduces light explosion's damage. removes explosion damage entirely from mage spells, functionally reverting them to the pre-bomberman pr (no more 1 shotting plate creechurs)

## Testing Evidence

seemed like it worked i wasnt one shotting myself

## Why It's Good For The Game

maybe already often used spells shouldnt be one shotting people
explosion damage remains because the few difficult sources of achieving non-light explosions deserve to hurt

:cl:
balance: spells once again no longer deal explosion damage
balance: light explosions (being at the edge of a big bomb, being hit with a bottlebomb, etc) are FAR less lethal. bigger explosions remain unchanged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
