### PR TITLE
Prieststacking

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -479,6 +479,9 @@ GLOBAL_LIST_EMPTY(heretical_players)
 
 		return TRUE
 
+	if (inputty in GLOB.excommunicated_players)
+		return //No stacking	
+
 	if (H.real_name == inputty)
 		if (!COOLDOWN_FINISHED(src, priest_apostasy))
 			to_chat(src, span_warning("You must wait until you can mark another."))
@@ -552,6 +555,9 @@ GLOBAL_LIST_EMPTY(heretical_players)
 				else
 					return
 		return
+
+	if (inputty in GLOB.apostasy_players)//This is an abysmal way of doing this but uhhhhhhhhhhhhhhhhhh yeah
+		return //No stacking
 
 	if (H.real_name == inputty)
 		if (!COOLDOWN_FINISHED(src, priest_excommunicate))
@@ -635,6 +641,10 @@ code\modules\admin\verbs\divinewrath.dm has a variant with all the gods so keep 
 
 			if (!COOLDOWN_FINISHED(src, priest_curse))
 				to_chat(src, span_warning("You must wait before invoking a curse again."))
+				return
+
+			if (H.mind.has_antag_datum(/datum/antagonist))
+				to_chat(src, span_warning("They are outside your grasp."))
 				return
 
 			//Check if we can curse this person.


### PR DESCRIPTION
## About The Pull Request

Removes ability to stack excommunication and apostasy on one person, can no longer curse proper antagonists (doesn't apply to wretches for they are antag lite)
More or less remake of this https://github.com/Azure-Peak/Azure-Peak/pull/3534

## Testing Evidence

Tested in that PR

## Why It's Good For The Game

Meant to be like this for long while but I simply didn't remake the PR
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Priest Apostasy/Excommunication stacking
fix: Priest Curse working on antagonists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
