### PR TITLE
Ground Smash (Mace) and Great Swing (Gsword) Special tweaks

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/special.dm
+++ b/code/game/objects/items/rogueweapons/mmb/special.dm
@@ -21,6 +21,8 @@
 	if(user.has_status_effect(/datum/status_effect/debuff/specialcd))
 		return
 
+	user.face_atom(target)
+
 	var/obj/item/rogueweapon/W = user.get_active_held_item()
 	if(istype(W, /obj/item/rogueweapon) && W.special)
 		var/skillreq = W.associated_skill

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -122,6 +122,8 @@
 	if(user.has_status_effect(/datum/status_effect/debuff/specialcd))
 		return
 
+	user.face_atom(target)
+
 	var/obj/item/rogueweapon/W = user.get_active_held_item()
 	if(istype(W, /obj/item/rogueweapon) && W.special)
 		var/skillreq = W.associated_skill

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -312,7 +312,7 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 	if(ishuman(target))
 		var/mob/living/carbon/human/HT = target
 		var/obj/item/bodypart/affecting = HT.get_bodypart(zone)
-		var/armor_block = HT.run_armor_check(zone, d_type, 0, damage = dam, used_weapon = W, armor_penetration = -999)
+		var/armor_block = HT.run_armor_check(zone, d_type, 0, damage = dam, used_weapon = W, armor_penetration = (no_pen ? -999 : 0))
 		if(no_pen && armor_block)
 			armor_block = 999
 		if(HT.apply_damage(dam, W.damtype, affecting, armor_block))
@@ -664,7 +664,7 @@ SPECIALS START HERE
 	sfx_pre_delay = 'sound/combat/rend_hit.ogg'
 	respect_adjacency = FALSE
 	respect_dir = TRUE
-	delay = 0.6 SECONDS
+	delay = 0.7 SECONDS
 	cooldown = 30 SECONDS
 	stamcost = 25	//Stamina cost
 	var/dam = 60
@@ -672,8 +672,8 @@ SPECIALS START HERE
 	var/hitcount = 0
 	var/self_debuffed = FALSE
 	var/self_immob = 2.2 SECONDS
-	var/self_clickcd = 2 SECONDS
-	var/self_expose = 2.2 SECONDS
+	var/self_clickcd = 2.1 SECONDS
+	var/self_expose = 2.3 SECONDS
 
 /datum/special_intent/greatsword_swing/_reset()
 	hitcount = initial(hitcount)
@@ -707,8 +707,8 @@ SPECIALS START HERE
 					if(3)
 						hitdmg *= 2
 				apply_generic_weapon_damage(L, hitdmg, "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT)
-				if(hitcount == 3)	//Last hit deals an extra 90 damage to integrity only. Facetanking it is highly discouraged!
-					apply_generic_weapon_damage(L, (dam*1.5), "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT, no_pen = TRUE)
+				if(hitcount == 3)	//Last hit deals a bit of extra damage to integrity only. Facetanking it is highly discouraged!
+					apply_generic_weapon_damage(L, (dam * 0.8) "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT, no_pen = TRUE)
 			var/sfx = 'sound/combat/sp_gsword_hit.ogg'
 			playsound(T, sfx, 100, TRUE)
 	..()

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -314,7 +314,7 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 		var/obj/item/bodypart/affecting = HT.get_bodypart(zone)
 		var/armor_block = HT.run_armor_check(zone, d_type, 0, damage = dam, used_weapon = W, armor_penetration = 0)
 		if(no_pen)
-			armor_block = 100
+			armor_block = 999
 		if(HT.apply_damage(dam, W.damtype, affecting, armor_block))
 			affecting.bodypart_attacked_by(bclass, dam, howner, armor = armor_block, crit_message = TRUE, weapon = W)
 			msg += "<b> It pierces through to their flesh!</b>"
@@ -464,21 +464,20 @@ SPECIALS START HERE
 	tile_coordinates = list(list(0,0), list(0,1, 0.1 SECONDS), list(0,2, 0.2 SECONDS))
 	post_icon_state = "kick_fx"
 	pre_icon_state = "trap"
-	use_doafter = TRUE
-	respect_adjacency = FALSE
-	delay = 0.6 SECONDS
+	respect_adjacency = TRUE
+	delay = 0.7 SECONDS
 	cooldown = 25 SECONDS
 	stamcost = 25
 	var/slow_dur = 5	//We do NOT want to use SECONDS macro here. Slowdown() takes in an int and turns it into seconds already.
 	var/KD_dur = 2 SECONDS
 	var/Offb_dur = 5 SECONDS
-	var/Offbself_dur = 1.5 SECONDS
+	var/self_immob_dur = 1.1 SECONDS
 	var/dam = 200
 
 //We play the pre-sfx here because it otherwise it gets played per tile. Sounds funky.
 /datum/special_intent/ground_smash/on_create()
 	. = ..()
-	howner.OffBalance(Offbself_dur)
+	howner.Immobilize(self_immob_dur)
 	playsound(howner, 'sound/combat/ground_smash_start.ogg', 100, TRUE)
 
 /datum/special_intent/ground_smash/apply_hit(turf/T)
@@ -513,7 +512,7 @@ SPECIALS START HERE
 	sfx_pre_delay = 'sound/combat/flail_sweep.ogg'
 	use_doafter = TRUE
 	respect_adjacency = FALSE
-	delay = 0.8 SECONDS
+	delay = 0.7 SECONDS
 	cooldown = 25 SECONDS
 	var/victim_count = 0
 	var/slow_init = 2
@@ -648,7 +647,7 @@ SPECIALS START HERE
 		playsound(T, 'sound/combat/sp_whip_whiff.ogg', 100, TRUE)
 	..()
 
-#define GAREN_WAVE1 1 SECONDS
+#define GAREN_WAVE1 0.7 SECONDS
 #define GAREN_WAVE2 1.4 SECONDS
 
 /datum/special_intent/greatsword_swing
@@ -656,23 +655,24 @@ SPECIALS START HERE
 	desc = "Swing your greatsword all around you in a ring of Judgement."
 	tile_coordinates = list(
 		list(0,0), list(1,0), list(1,-1),list(1,-2),list(0,-2),list(-1,-2),list(-1,-1),list(-1,0),\
-		list(0,0, GAREN_WAVE1), list(1,0, GAREN_WAVE1), list(1,-1, GAREN_WAVE1),list(1,-2, GAREN_WAVE1),list(0,-2, GAREN_WAVE1),list(-1,-2, GAREN_WAVE1),list(-1,-1, GAREN_WAVE1),list(-1,0, GAREN_WAVE1),\
+		list(0,1, GAREN_WAVE1), list(1,1, GAREN_WAVE1), list(-1,1, GAREN_WAVE1),list(1,-3, GAREN_WAVE1),list(0,-3, GAREN_WAVE1),list(-1,-3, GAREN_WAVE1),list(-2,0, GAREN_WAVE1),list(-2,-1, GAREN_WAVE1),list(-2,-2, GAREN_WAVE1),list(2,0, GAREN_WAVE1),list(2,-1, GAREN_WAVE1),list(2,-2, GAREN_WAVE1),\
 		list(0,0, GAREN_WAVE2), list(1,0, GAREN_WAVE2), list(1,-1, GAREN_WAVE2),list(1,-2, GAREN_WAVE2),list(0,-2, GAREN_WAVE2),list(-1,-2, GAREN_WAVE2),list(-1,-1, GAREN_WAVE2),list(-1,0, GAREN_WAVE2)
 		)
 	post_icon_state = "sweep_fx"
 	pre_icon_state = "fx_trap_long"
 	sfx_pre_delay = 'sound/combat/rend_hit.ogg'
 	respect_adjacency = FALSE
-	delay = 0.7 SECONDS
+	respect_dir = TRUE
+	delay = 0.6 SECONDS
 	cooldown = 30 SECONDS
 	stamcost = 25	//Stamina cost
 	var/dam = 60
 	var/slow_dur = 2
 	var/hitcount = 0
 	var/self_debuffed = FALSE
-	var/self_immob = 3.5 SECONDS
-	var/self_clickcd = 3.5 SECONDS
-	var/self_expose = 5 SECONDS
+	var/self_immob = 2.2 SECONDS
+	var/self_clickcd = 2 SECONDS
+	var/self_expose = 2.2 SECONDS
 
 /datum/special_intent/greatsword_swing/_reset()
 	hitcount = initial(hitcount)
@@ -699,7 +699,15 @@ SPECIALS START HERE
 		if(L != howner)
 			L.Slowdown(slow_dur)
 			if(L.mobility_flags & MOBILITY_STAND)
-				apply_generic_weapon_damage(L, ((hitcount > 1) ? (dam * 1.5) : dam), "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT)
+				var/hitdmg = dam
+				switch(hitcount)
+					if(2)
+						hitdmg *= 1.5
+					if(3)
+						hitdmg *= 2
+				apply_generic_weapon_damage(L, hitdmg, "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT)
+				if(hitcount == 3)	//Last hit deals an extra 90 damage to integrity only. Facetanking it is highly discouraged!
+					apply_generic_weapon_damage(L, (dam*1.5), "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT, no_pen = TRUE)
 			var/sfx = 'sound/combat/sp_gsword_hit.ogg'
 			playsound(T, sfx, 100, TRUE)
 	..()

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -708,7 +708,7 @@ SPECIALS START HERE
 						hitdmg *= 2
 				apply_generic_weapon_damage(L, hitdmg, "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT)
 				if(hitcount == 3)	//Last hit deals a bit of extra damage to integrity only. Facetanking it is highly discouraged!
-					apply_generic_weapon_damage(L, (dam * 0.8) "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT, no_pen = TRUE)
+					apply_generic_weapon_damage(L, (dam * 0.8), "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT, no_pen = TRUE)
 			var/sfx = 'sound/combat/sp_gsword_hit.ogg'
 			playsound(T, sfx, 100, TRUE)
 	..()

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -312,8 +312,8 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 	if(ishuman(target))
 		var/mob/living/carbon/human/HT = target
 		var/obj/item/bodypart/affecting = HT.get_bodypart(zone)
-		var/armor_block = HT.run_armor_check(zone, d_type, 0, damage = dam, used_weapon = W, armor_penetration = 0)
-		if(no_pen)
+		var/armor_block = HT.run_armor_check(zone, d_type, 0, damage = dam, used_weapon = W, armor_penetration = -999)
+		if(no_pen && armor_block)
 			armor_block = 999
 		if(HT.apply_damage(dam, W.damtype, affecting, armor_block))
 			affecting.bodypart_attacked_by(bclass, dam, howner, armor = armor_block, crit_message = TRUE, weapon = W)
@@ -492,6 +492,7 @@ SPECIALS START HERE
 			L.safe_throw_at(target_turf, dist, 1, howner, force = MOVE_FORCE_EXTREMELY_STRONG)
 			//We slow them down
 			L.Slowdown(slow_dur)
+			L.apply_status_effect(/datum/status_effect/debuff/exposed, 2.5 SECONDS)
 			//We offbalance them OR knock them down if they're already offbalanced
 			if(L.IsOffBalanced())
 				L.Knockdown(KD_dur)


### PR DESCRIPTION
## About The Pull Request
- Both had their doafter (little dots chargeup) removed.
- They immobilize the user for a short time instead.
- Great Swing's timings adjusted to be more consistent.
- Ground Smash's timings adjusted to be more even.
- Great Swing has a new pattern.

![ezgif-442446d34b0d3d55](https://github.com/user-attachments/assets/fd93866b-df24-4c12-a001-4cd68fca754d)

- Fixed Ground Smash's damage penning armor. Oops!

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The doafters really just aren't working for Specials, and it has enough support to allow the user to simply be immobilized for the duration of the effect, which serves the same function without throwing off the timings. I need to rework how doafters work here, especially with multi-pattern Specials.

Beyond that, just tweaking things based on feedback / suggestions. The Gsword pattern might not stick, but it is a bit more engaging imo.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Greatsword and Mace Specials had their timings adjusted.
tweak: Greatsword Special (Great Swing) pattern has been changed.
tweak: Various other slight adjustments to Mace and Greatsword Specials.
fix: Unintended penetration on Specials.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
