### PR TITLE
Cleans up #4818

### DIFF
--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -122,7 +122,7 @@
 			user.visible_message("<span class='warning'>[user] kicks [src]!</span>", \
 				"<span class='warning'>I kick [src]!</span>")
 
-/obj/machinery/light/rogue/campfire/wallfirecrafted
+/obj/machinery/light/rogue/campfire/wallfire
 	name = "fireplace"
 	desc = "A warm fire dances between a pile of half-burnt logs upon a bed of glowing embers."
 	icon_state = "wallfire1"
@@ -135,7 +135,7 @@
 	pixel_y = 32
 	healing_range = 2
 
-/obj/machinery/light/rogue/campfire/wallfirecrafted/attack_hand(mob/user)
+/obj/machinery/light/rogue/campfire/wallfire/fireplace/attack_hand(mob/user)
 	if(isliving(user) && on)
 		user.visible_message(span_warning("[user] snuffs [src]."))
 		burn_out()
@@ -147,7 +147,7 @@
 	desc = "Tiny flames flicker to the slightest breeze and offer enough light to see."
 	icon_state = "wallcandle1"
 	base_state = "wallcandle"
-	crossfire = FALSE
+	fueluse = 0
 	cookonme = FALSE
 	pixel_y = 32
 	soundloop = null
@@ -157,7 +157,6 @@
 	desc = "Cold wax sticks in sad half-melted repose. All they need is a spark."
 	icon_state = "wallcandle0"
 	base_state = "wallcandle"
-	crossfire = FALSE
 	cookonme = FALSE
 	light_outer_range = 0
 	pixel_y = 32

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -913,7 +913,7 @@
 /datum/crafting_recipe/roguetown/structure/fireplace
 	name = "Fireplace (North)"
 	category = "Misc"
-	result = /obj/machinery/light/rogue/campfire/wallfirecrafted
+	result = /obj/machinery/light/rogue/campfire/wallfire/fireplace
 	reqs = list(/obj/item/grown/log/tree/small = 1,
 				/obj/item/natural/stoneblock = 3)
 	verbage_simple = "build"


### PR DESCRIPTION
## About The Pull Request

- No more fuel usage for candles or fireplaces.

## Testing Evidence

Tested.

## Why It's Good For The Game

Candles/Fireplaces needing fuel was unintended. Also gets rid of an undefined parent.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fireplaces/Candles need no fuel anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
