### PR TITLE
Integrity Shushing 🤫

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -332,6 +332,7 @@ Medical defines
 */
 #define CRIT_DISMEMBER_DAMAGE_THRESHOLD 0.75 // 75% damage threshold for dismemberment / crit
 #define STANDING_DECAP_GRACE_PERIOD 2 SECONDS // Time after falling prone where you still count as standing for decap purpose
+#define INT_NOISE_DELAY 1 SECONDS
 
 /*
 	Critical Resistance Defines 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -532,8 +532,12 @@ BLIND     // can't see anything
 		chunkicon = "chunkfall3"
 		y_offset = 30
 	if(text)
-		new /obj/effect/temp_visual/armor_chunk(get_turf(src), 0.7 SECONDS, chunkcolor, chunkicon)
-		playsound(src, sfx, 100, TRUE)
+		if(isliving(loc))
+			var/mob/living/L = loc
+			if(L.last_integ_sound < world.time)
+				playsound(src, sfx, 100, TRUE)
+				L.last_integ_sound = world.time + INT_NOISE_DELAY
+			new /obj/effect/temp_visual/armor_chunk(get_turf(src), 0.7 SECONDS, chunkcolor, chunkicon)
 		filtered_balloon_alert(TRAIT_COMBAT_AWARE, text, -20, y_offset)
 	. = ..()
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -170,6 +170,8 @@
 
 	var/slowdown
 
+	var/last_integ_sound
+
 	var/last_dir_change = 0
 
 	var/list/death_trackers = list()


### PR DESCRIPTION
## About The Pull Request
Adds a delay for the integrity noise to mob defines. At least 1 second has to pass before a new sound is played, even if an item gets broken through a threshold. Doesn't apply to the full "broken" sounds.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
15 STR, Zweihander, swift intent, chest. Only heard one sound even though I was breaking through thresholds every hit.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I had the pleasure of hearing two people try to kill a skeleton and they were each hitting a different piece of armor at once and uh let's say ow ouch my ears.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
tweak:Integrity threshold noise frequency was reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
