### PR TITLE
Gives sextons patron-dependent amulets

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/sexton.dm
+++ b/code/modules/jobs/job_types/roguetown/church/sexton.dm
@@ -84,7 +84,7 @@
 		if(/datum/patron/divine/ravox)
 			neck = /obj/item/clothing/neck/roguetown/psicross/ravox
 		if(/datum/patron/divine/xylix)
-			neck = /obj/item/clothing/neck/roguetown/psicross/xylix
+			neck = /obj/item/clothing/neck/roguetown/luckcharm
 		else
 			neck = /obj/item/clothing/neck/roguetown/psicross/undivided
 


### PR DESCRIPTION
## About The Pull Request

It gives sextons an amulet based on their patron, instead of a psycross which they had for some reason?

## Testing Evidence

<img width="990" height="512" alt="image" src="https://github.com/user-attachments/assets/76a5e1d7-1c8a-4936-a42b-b2e4d1e0e709" />

## Why It's Good For The Game

whyd they have a psycross

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:Hollyhock
add: Gave sextons cool amulets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
