### PR TITLE
[Port] Makes Church Bell better (useful)

### DIFF
--- a/code/game/objects/items/rogueitems/bells.dm
+++ b/code/game/objects/items/rogueitems/bells.dm
@@ -84,17 +84,36 @@
 	if(ringing)
 		return
 	if(istype(used_item, /obj/item/rogueweapon/mace/church))
-		playsound(loc, 'sound/misc/bell.ogg', 50, 1)
-		for(var/mob/M in orange(150, src))
-			if(M.client)
-				to_chat(M, span_notice("The church bell rings, echoing solemnly through the area."))
+		playsound(loc, 'sound/misc/bell.ogg', 60, 1)
 		visible_message(span_notice("[user] uses the [used_item] to ring the [src]."))
+		ring_bell()
 		ringing = TRUE
 		sleep(cooldown)
 		ringing = FALSE
 	else
 
 		return ..()
+
+/obj/structure/stationary_bell/proc/ring_bell()
+	var/turf/origin_turf = get_turf(src)
+
+	for(var/mob/living/player in GLOB.player_list)
+		if(player.stat == DEAD)
+			continue
+		if(isbrain(player))
+			continue
+
+		var/distance = get_dist(player, origin_turf)
+		if(distance <= 7)
+			to_chat(player, span_notice("The church bell rings, echoing solemnly through the area."))
+			continue
+		if(distance <= 150)
+			to_chat(player, span_notice("The church bell rings, echoing solemnly through the area."))
+			player.playsound_local(get_turf(player), 'sound/misc/bell.ogg', 35, FALSE, pressure_affected = FALSE)
+			continue
+
+		to_chat(player, span_notice("The church bell rings, echoing distantly from afar."))
+		player.playsound_local(get_turf(player), 'sound/misc/bell.ogg', 35, FALSE, pressure_affected = FALSE)
 
 /obj/item/jingle_bells
 	name = "jingling bells"


### PR DESCRIPTION
## About The Pull Request

Ported from https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1659

Changes: church bell can ring across Z-levels and the distance of bell's sound increased.

## Testing Evidence

Works, trust me.

## Why It's Good For The Game

Stationary bell has literally no use currently but this PR makes it better and call people to the church for sermon or whatever.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Church bell is now working across Z-level as intented.
sound: Sound church bell is now global and everyone hear it. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
