### PR TITLE
Virtue for a bandit camp, Matthios patron only

### DIFF
--- a/virtues/utility.dm
+++ b/virtues/utility.dm
@@ -333,3 +333,14 @@
 	name = "Mountable"
 	desc = "You have trained and become fit enough to function as a suitable mount. People may ride you as they would a saiga."
 	added_traits = list(TRAIT_MOUNTABLE)
+
+/datum/virtue/heretic/bandit_camp
+    name = "The land between"
+    desc = "My brothers in Matthios told me about free territory in these lands. I'm just a guest here."
+    custom_text = "Gives you access to bandit camp. Dont use it for validhunt. Only for Matthios worshipers"
+
+/datum/virtue/heretic/bandit_camp/handle_traits(mob/living/carbon/human/recipient)
+    if(istype(recipient.patron, /datum/patron/inhumen/matthios))
+        ADD_TRAIT(recipient, TRAIT_BANDITCAMP, TRAIT_GENERIC)
+    else
+        to_chat(recipient, "I forgot all about! What were these bastards talkin' about?")


### PR DESCRIPTION


## About The Pull Request

This will add virtue for Ascendants pull, but only Matthiosites will get camp access trait. They cant use dragon, don't worry.

## Testing Evidence

Just believe me, trust me. Just look at these little code piece
<img width="426" height="156" alt="Снимок экрана 2025-12-07 170726" src="https://github.com/user-attachments/assets/eb9957eb-aa65-46df-9544-d34c37836f3d" />


## Why It's Good For The Game

Bandits are VERY VERY RARE. This virtue will give players a chance to play as a mini antag with access to crowns and cool ass camp. Like Keyholder, you know.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:

add: virtue, yeah.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
