### PR TITLE
[Balance] Crimson aril buff

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -1009,22 +1009,30 @@
 	icon_state = "crimson"
 	effect_desc = "This fruit heals for a blood price."
 
-	var/heal_amount = 45
+	var/heal_amount = 35
 	var/blood_loss = 225
 
+/obj/item/reagent_containers/food/snacks/eoran_aril/crimson/Initialize()
+	. = ..()
+	blood_loss = BLOOD_VOLUME_NORMAL * 0.04
+
 /obj/item/reagent_containers/food/snacks/eoran_aril/crimson/apply_effects(mob/living/carbon/eater)
-	//Instant heal, but you can only eat 2 before the next will make you pass out.
+	//Instant heal, but you can only eat a couple before the next will make you pass out.
 	var/list/wCount = eater.get_wounds()
 	//No undead because they kinda don't have blood to give for this.
 	if(!eater.construct && !(eater.mob_biotypes & MOB_UNDEAD))
+		var/current_brute_loss = eater.getBruteLoss()
+		blood_loss += (eater.blood_volume * 0.1)
 		if(wCount.len > 0)
-			eater.heal_wounds(heal_amount)
+			eater.heal_wounds(heal_amount + (current_brute_loss * 0.12))
 			eater.update_damage_overlays()
+		// blood loss is equal to 4% max blood volume + 10% of current blood volume
+		// Regular healing is equal to 35 damage + 12% of current damage
 		eater.blood_volume = max(0, eater.blood_volume - blood_loss)
-		eater.adjustBruteLoss(-heal_amount, 0)
-		eater.adjustFireLoss(-heal_amount, 0)
-		eater.adjustOxyLoss(-heal_amount, 0)
-		eater.adjustToxLoss(-heal_amount, 0)
+		eater.adjustBruteLoss(-(heal_amount + (current_brute_loss * 0.12)), 0)
+		eater.adjustFireLoss(-(heal_amount + (eater.getFireLoss() * 0.12)), 0)
+		eater.adjustToxLoss(-(heal_amount + (eater.getToxLoss() * 0.12)), 0)
+		eater.adjustOxyLoss(-(heal_amount + (eater.getOxyLoss() * 0.12)), 0)
 		eater.adjustOrganLoss(ORGAN_SLOT_BRAIN, -heal_amount)
 		eater.adjustCloneLoss(-heal_amount, 0)
 


### PR DESCRIPTION
## About The Pull Request
Crimson arils haven't been touched since before omniwounds were added, and trading your blood for an instant heal was rather low cost. They've been reworked as a result!

Change :
Instead of taking 50% of your blood to heal 45 flat damage they now.
Heal 35 flat damage and 12% of your current wounds.
Take 4% of the max of the bloodpool (22 blood) and 10% of your current bloodpool.

This should hopefully make it possible to use an aril in combat, especially against weaponry that inflict little bleeding. Though the main intent remains to help eorans heal people up as long as they have arils.

## Testing Evidence
Tested. Found out bruteloss variable doesn't represent bruteloss and you must use the getter, which returns bruteloss and that actually works but don't ask me why because the variable is always 0? What the-

## Why It's Good For The Game
Arils should be impactful.

## Changelog

:cl:
balance: Crimson arils heal more on average, and are less deadly now
/:cl:

