### PR TITLE
Merchantry mercenary weapon pricing

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
@@ -4,6 +4,11 @@
 	crate_name = "merchant guild's crate"
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
+/datum/supply_pack/rogue/merc_weapons/navaja
+	name = "Navaja"
+	cost = 80
+	contains = list(/obj/item/rogueweapon/huntingknife/idagger/navaja)
+
 /datum/supply_pack/rogue/merc_weapons/saildagger
 	name = "Sail Dagger"
 	cost = 80
@@ -11,68 +16,68 @@
 
 /datum/supply_pack/rogue/merc_weapons/erapier
 	name = "Etruscan Rapier"
-	cost = 80
+	cost = 120
 	contains = list(/obj/item/rogueweapon/sword/rapier/vaquero)
+
+/datum/supply_pack/rogue/merc_weapons/etruscanlongsword
+	name = "Etruscan Longsword"
+	cost = 409 // 409 because the Flos Duellatorum was written between 1400-1409 & Fiore is part of the reason frei gets an etruscan class
+	contains = list(/obj/item/rogueweapon/sword/long/etruscan)
 
 /datum/supply_pack/rogue/merc_weapons/shamshir
 	name = "Shamshir"
-	cost = 80
+	cost = 140
 	contains = list(/obj/item/rogueweapon/sword/sabre/shamshir)
-
-/datum/supply_pack/rogue/merc_weapons/beardedaxe
-	name = "Bearded Axe"
-	cost = 80
-	contains = list(/obj/item/rogueweapon/stoneaxe/woodcut/steel/atgervi)
 
 /datum/supply_pack/rogue/merc_weapons/naledistaff
 	name = "Naledi Warstaff"
-	cost = 80
+	cost = 140
 	contains = list(/obj/item/rogueweapon/woodstaff/naledi)
+
+/datum/supply_pack/rogue/merc_weapons/grenzelstaff
+	name = "Grenzelhoftian Blacksteel Staff"
+	cost = 140
+	contains = list(/obj/item/rogueweapon/woodstaff/emerald/blacksteelstaff)
+
+/datum/supply_pack/rogue/merc_weapons/glaive
+	name = "Glaive"
+	cost = 200
+	contains = list(/obj/item/rogueweapon/halberd/glaive)
 
 /datum/supply_pack/rogue/merc_weapons/pulaxe
 	name = "Pulaski Axe"
-	cost = 80
+	cost = 140
 	contains = list(/obj/item/rogueweapon/stoneaxe/woodcut/pick)
 
 /datum/supply_pack/rogue/merc_weapons/nagaika
 	name = "Nagaika Whip"
-	cost = 80
+	cost = 120
 	contains = list(/obj/item/rogueweapon/whip/nagaika)
-
-/datum/supply_pack/rogue/merc_weapons/navaja
-	name = "Navaja"
-	cost = 80
-	contains = list(/obj/item/rogueweapon/huntingknife/idagger/navaja)
 
 /datum/supply_pack/rogue/merc_weapons/naginata
 	name = "Naginata"
-	cost = 80
+	cost = 140
 	contains = list(/obj/item/rogueweapon/spear/naginata)
 
 /datum/supply_pack/rogue/merc_weapons/katana
 	name = "Kazengun Hwando"
-	cost = 80
+	cost = 120
 	contains = list(/obj/item/rogueweapon/sword/sabre/mulyeog)
+
+/datum/supply_pack/rogue/merc_weapons/kazengunhookblade
+	name = "Kazengun Hook Sword"
+	cost = 150
+	contains = list(/obj/item/rogueweapon/sword/sabre/hook)
 
 /datum/supply_pack/rogue/merc_weapons/kazengunscabbard
 	name = "Kazengun Scabbard"
 	cost = 250
 	contains = list(/obj/item/rogueweapon/scabbard/sword/kazengun)
 
-/datum/supply_pack/rogue/merc_weapons/kazengunhookblade
-	name = "Kazengun Hook Sword"
-	cost = 100
-	contains = list(/obj/item/rogueweapon/sword/sabre/hook)
-
-/datum/supply_pack/rogue/merc_weapons/glaive
-	name = "Glaive"
-	cost = 120
-	contains = list(/obj/item/rogueweapon/halberd/glaive)
-
-/datum/supply_pack/rogue/merc_weapons/etruscanlongsword
-	name = "Etruscan Longsword"
-	cost = 409 // 409 because the Flos Duellatorum was written between 1400-1409 & Fiore is part of the reason frei gets an etruscan class
-	contains = list(/obj/item/rogueweapon/sword/long/etruscan)
+/datum/supply_pack/rogue/merc_weapons/beardedaxe
+	name = "Bearded Axe"
+	cost = 140
+	contains = list(/obj/item/rogueweapon/stoneaxe/woodcut/steel/atgervi)
 
 /datum/supply_pack/rogue/merc_weapons/handclaw_iron
 	name = "Gronnic Iron Claw"
@@ -83,8 +88,3 @@
 	name = "Gronnic Steel Claw"
 	cost = 200
 	contains = list(/obj/item/rogueweapon/handclaw/steel)
-
-/datum/supply_pack/rogue/merc_weapons/grenzelstaff
-	name = "Grenzelhoftian Blacksteel Staff"
-	cost = 100
-	contains = list(/obj/item/rogueweapon/woodstaff/emerald/blacksteelstaff)


### PR DESCRIPTION
## About The Pull Request

Reshufles the gold/silverface for merchant in the foreign weapon category to be closer to eachother rather than being thrown around randomly. Increases prices across the board (except gronnite claws / etruscan longsword).

## Testing Evidence

Line changes.

## Why It's Good For The Game

While most of these aren't exactly an upgrade over regular versions, they shouldn't be as simple to get.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Merchantry mercenary weapon shop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
