### PR TITLE
Fix of Heavy Gronn mercenary

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -632,7 +632,7 @@
 	swingsound = BLUNTWOOSH_HUGE
 	slot_flags = null//No.
 	smelt_bar_num = 2
-	minstr = 14
+	minstr = 13
 	wdefense = 2
 	wdefense_wbonus = 1 //3
 	demolition_mod = 1.25 //Oh, yes...


### PR DESCRIPTION
## About The Pull Request

Fixing #4876
Well, I think giving that class 14 strength will be imbalance. So, we are going another way and change maul requiring strength 14->13
Does this allow more classes to use the maul? Probably. Does it change the overall balance? I'm not sure (though I'm afraid the random bathhouse attendant will take a +2 str statpack in addition to base 11 str and start whacking clients in the balls with a maul)

## Testing Evidence

Trust me, this just 1 line of code

## Why It's Good For The Game

Fixing class issues 

## Changelog

:cl:
balance: decrease required strength of maul from 14 to 13
fix: now heavy gronn mercenary can wield his maul without additional statpacks or race bonuses, as intended
/:cl:
