### PR TITLE
Mage Duke Spell Point Adjustment

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -189,8 +189,8 @@ GLOBAL_LIST_EMPTY(lord_titles)
 
 /**
 	Mage Lord subclass. Prince mage is a thing.
-	Light on skills, has some combat skills mage normally doesn't have. 18 pts so people don't complain they are better.
-	Stats is better than mage associate and magic heir. +12 total.
+	Light on skills, has some combat skills mage normally doesn't have.
+	Stats are better than mage associate and magic heir. +12 total.
 	Mage armor and no armor training.
 
 
@@ -208,7 +208,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		STATKEY_PER = 2,
 		STATKEY_WIL = 1,
 	)
-	subclass_spellpoints = 18
+	subclass_spellpoints = 24
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

The Mage Lord subclass for Duke's starting spell points are increased to 24, up from 18.

## Testing Evidence

It compiles

## Why It's Good For The Game

Warrior Lord and Merchant Lord (Duke subclasses) both have starting skills of Expert in a chosen weapon class: Swords for Warrior Lord and Crossbows for Merchant. In addition, both classes have armor training of Medium Tier or higher. Mage Lord, by contrast, has no armor training, and only a Journeyman skill in Arcane. It makes sense for Mage Lord to have no armor training, as some spells rely on the wearer not being armored, but it does not make sense for Mage Lord to be weaker in it's respective strength, Arcane, than Warrior or Merchant are in their own weapon of choice. 

So why adjust spell points rather than increase Arcane? Because the difference between Arcane as a combat skill and other weapon skills is not one to one. Arcane grants a 5% cast time reduction with each rank, which is useful, but also will not be the main source of cast time reduction a mage has. I would argue the true measure of power potential for mage classes is in how many spell points they start with at round start. And also because I don't think the Duke needs to necessarily have power on par with a Wretch mage because of the advantage they already have as the Duke. They'll have access to better equipment and (ideally) people defending them. But when you compare them against other mage classes, you'll realize that they're actually balanced at around an Apprentice level of power, or somewhere in-between Apprentice and Journeyman.

Let's look at the spell points with other mage classes that have access to T3 spells (Antags and Court Mage excluded): 

- Wretch (Hedge Mage) has 27 spell points to spend, and in fact also has Expert level Arcane. This is in line with the other Wretch subclasses also having Expert level training in their respective weapon skills, if they have a weapon skill.
- Mage Associate has 21 spell points to spend, and has Journeyman Arcane.
- Mage Apprentice, Alchemist Apprentice, and Mage Adventurer (Sorcerer) both have 18 spell points to spend. This is something of an Apprentice level of spell point spread.

It just doesn't make sense from a gameplay perspective to have the Duke be limited to a Mage _Apprentice_ level of power potential. I think at _minimum_ the Duke should have 21 spell points, but ideally, I think they should also be better than the standard Mage Associate. Not necessarily better than Wretch, but certainly better than the average towner of adventurer mage. I don't think their current spell point allotment makes sense from a flavor perspective either. The class flavor description reads: "Now you rule not only by crown and steel, but by spell and wit, show those who doubted your time buried in books was well spent how wrong they were." I fail to see how you can adequately demonstrate spellcasting prowess if you're realistically limited to about 3 or 4 other spells after taking the two armor spells (6 points) to keep yourself from dying to a couple of stray arrows. Or if you're only able to cast as many different spells as an Apprentice. I think you should also be able to support your guard and yourself with some buffing spells, and have a spell or two to engage in defensive combat with if the enemy breaks through your guard to target you.

And let's be honest - if you enjoy the magic style of combat, and are considering playing a Duke, looking into Mage Lord is going to turn you away at present - especially given the recent change to make the Duke unrevivable. Which is a change I support, as an aside, but ask yourself: would you really, honestly want to play a Duke, who is no doubt going to be the target of bandits and other antagonists, and only have the same mechanical skill level of a Squire - arguably less than a Squire - to defend yourself with? I absolutely would not. It's my hope that this can encourage some new Duke players, or that it can revive interest in Mage Lord in people that tried it in the past.

And just to address a counterargument I'm sure will arise...

"But just take Arcane Potential!"
That doesn't fix the problem of them being inherently **much** weaker in their specialization than the other duke subclasses, and also forces the player into taking a Virtue as a band-aid fix to the needlessly low spell point count which could be spent elsewhere for flavor/RP or on a hybrid build. Which I assume the design of this subclass is supposed to allow for, given that Mage Lord has apprentice level training in Swords and Knife-fighting. Arcane Potential also only gives you 3 points, which will translate to one spell or possibly two less powerful/utility spells. 


## Changelog

:cl:
balance: Adjusted Mage Lord Duke's starting spell points to 24.
/:cl:
