### PR TITLE
sorry guys (trail mix hotfix + a wither fix)

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_aoe/blade_burst.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/blade_burst.dm
@@ -55,7 +55,7 @@
 		source_turf = get_step_multiz(source_turf, DOWN)
 
 	for(var/turf/affected_turf in get_hear(area_of_effect, T))
-		if(!(affected_turf in get_hear(area_of_effect, source_turf)))
+		if(!(affected_turf in get_hear(range, source_turf)))
 			continue
 		new /obj/effect/temp_visual/trap(affected_turf)
 	playsound(T, 'sound/magic/blade_burst.ogg', 80, TRUE, soundping = TRUE)
@@ -64,9 +64,9 @@
 	var/play_cleave = FALSE
 
 	for(var/turf/affected_turf in get_hear(area_of_effect, T))
-		new /obj/effect/temp_visual/blade_burst(affected_turf)
-		if(!(affected_turf in get_hear(area_of_effect, source_turf)))
+		if(!(affected_turf in get_hear(range, source_turf)))
 			continue
+		new /obj/effect/temp_visual/blade_burst(affected_turf)
 		for(var/mob/living/L in affected_turf.contents)
 			if(L.anti_magic_check())
 				visible_message(span_warning("The blades dispel when they near [L]!"))

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/snap_freeze.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/snap_freeze.dm
@@ -53,8 +53,8 @@
 	if(T.z < user.z)
 		source_turf = get_step_multiz(source_turf, DOWN)
 
-	for(var/turf/affected_turf in view(area_of_effect, T))
-		if(!(affected_turf in view(source_turf)))
+	for(var/turf/affected_turf in get_hear(area_of_effect, T))
+		if(!(affected_turf in get_hear(range, source_turf)))
 			continue
 		new /obj/effect/temp_visual/trapice(affected_turf)
 	playsound(T, 'sound/combat/wooshes/blunt/wooshhuge (2).ogg', 80, TRUE, soundping = TRUE) // it kinda sounds like cold wind idk
@@ -64,7 +64,7 @@
 
 	for(var/turf/affected_turf in get_hear(area_of_effect, T))
 		new /obj/effect/temp_visual/snap_freeze(affected_turf)
-		if(!(affected_turf in get_hear(area_of_effect, source_turf)))
+		if(!(affected_turf in get_hear(range, source_turf)))
 			continue
 		for(var/mob/living/L in affected_turf.contents)
 			if(L.anti_magic_check())

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/wither.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/wither.dm
@@ -53,10 +53,9 @@
 		if(L.anti_magic_check())
 			visible_message(span_warning("The magic fades away around you [L] "))  //antimagic needs some testing
 			playsound(damage_turf, 'sound/magic/magic_nulled.ogg', 100)
-			return
+			continue
 		L.adjustFireLoss(damage)
 		L.apply_status_effect(/datum/status_effect/buff/witherd/)
-		return
 
 
 /obj/effect/temp_visual/trap/wither


### PR DESCRIPTION
## About The Pull Request
accidentally used the wrong value in 2 of the spells which i didnt notice due to other factors in the test, causing them to deal 0 damage to anything not in aoe range _of the player_. anywaes they work now

while i was in there i fixed an early return on wither that caused it to only damage the first mob on each turf

## Testing Evidence

i opened the game and casted the spells on mobs and they died

## Why It's Good For The Game

sorry for party rocking

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: snap freeze and bladeburst now correctly function at range again. sorry
fix: wither no longer misses anyone sharing a tile with a target
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
