### PR TITLE
Adds wood elf ears to half-elves

### DIFF
--- a/code/modules/client/customizer/customizers/organ/ears.dm
+++ b/code/modules/client/customizer/customizers/organ/ears.dm
@@ -8,6 +8,7 @@
 	organ_slot = ORGAN_SLOT_EARS
 	abstract_type = /datum/customizer_choice/organ/ears
 
+// ---- Vulpkanin
 /datum/customizer/organ/ears/vulpkanin
 	customizer_choices = list(/datum/customizer_choice/organ/ears/vulpkanin)
 
@@ -26,6 +27,7 @@
 		/datum/sprite_accessory/ears/wolf
 		)
 
+// ---- Lupian
 /datum/customizer/organ/ears/lupian
 	customizer_choices = list(/datum/customizer_choice/organ/ears/lupian)
 
@@ -42,6 +44,7 @@
 		/datum/sprite_accessory/ears/lab
 	)
 
+// ---- Tajaran
 /datum/customizer/organ/ears/tajaran
 	customizer_choices = list(/datum/customizer_choice/organ/ears/tajaran)
 
@@ -55,6 +58,7 @@
 		/datum/sprite_accessory/ears/lynx,
 		)
 
+// ---- Axian
 /datum/customizer/organ/ears/axian
 	customizer_choices = list(/datum/customizer_choice/organ/ears/axian)
 
@@ -66,6 +70,7 @@
 		/datum/sprite_accessory/ears/sergal,
 		)
 
+// ---- Cat(?) no other mentions in the codebase
 /datum/customizer/organ/ears/cat
 	customizer_choices = list(/datum/customizer_choice/organ/ears/cat)
 
@@ -74,6 +79,7 @@
 	organ_type = /obj/item/organ/ears/cat
 	sprite_accessories = list(/datum/sprite_accessory/ears/cat)
 
+// --- Elf
 /datum/customizer_choice/organ/ears/elf
 	name = "Elf Ears"
 	organ_type = /obj/item/organ/ears
@@ -85,6 +91,7 @@
 	customizer_choices = list(/datum/customizer_choice/organ/ears/elf)
 	allows_disabling = TRUE
 
+// ---- Goblin
 /datum/customizer_choice/organ/ears/goblin
 	name = "Goblin Ears"
 	organ_type = /obj/item/organ/ears
@@ -98,6 +105,7 @@
 	customizer_choices = list(/datum/customizer_choice/organ/ears/goblin)
 	allows_disabling = FALSE
 
+// ---- Half-Orc
 /datum/customizer_choice/organ/ears/halforc
 	name = "Half-Orc Ears"
 	organ_type = /obj/item/organ/ears
@@ -113,6 +121,7 @@
 	customizer_choices = list(/datum/customizer_choice/organ/ears/halforc)
 	allows_disabling = FALSE
 
+// ---- Demihuman
 /datum/customizer/organ/ears/demihuman
 	customizer_choices = list(/datum/customizer_choice/organ/ears/demihuman)
 	allows_disabling = TRUE
@@ -172,6 +181,7 @@
 		/datum/sprite_accessory/ears/zorzor
 		)
 
+// ---- Anthro
 /datum/customizer/organ/ears/anthro
 	customizer_choices = list(/datum/customizer_choice/organ/ears/anthro)
 	allows_disabling = TRUE
@@ -239,6 +249,7 @@
 		/datum/sprite_accessory/ears/zorzor
 		)
 
+// ---- Lizard
 /datum/customizer/organ/ears/lizard
 	name = "Hood"
 	customizer_choices = list(/datum/customizer_choice/organ/ears/lizard)
@@ -254,6 +265,7 @@
 		/datum/sprite_accessory/ears/cobrahoodears,
 		)
 
+// ---- Tiefling
 /datum/customizer/organ/ears/tiefling
 	customizer_choices = list(/datum/customizer_choice/organ/ears/tiefling)
 	allows_disabling = FALSE
@@ -266,6 +278,7 @@
 		/datum/sprite_accessory/ears/elfw,
 		)
 
+// ---- Dullahan
 /datum/customizer/organ/ears/dullahan
 	customizer_choices = list(/datum/customizer_choice/organ/ears/dullahan)
 	allows_disabling = TRUE

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halfelf.dm
@@ -62,6 +62,7 @@
 		)
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/organ/ears/elf,
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,


### PR DESCRIPTION
## About The Pull Request

Adds wood elf ears as a customization option to half-elves, on par with rest of the races that can have elf ears. Since a similar topic was addressed in this #4273, I assume this was overlooked

This PR also adds some comments to `ears.dm` for easy navigating

## Testing Evidence

<img width="848" height="588" alt="Screenshot_44" src="https://github.com/user-attachments/assets/373b69b1-e9cc-40db-a3c6-dbb44ca91631" />

## Why It's Good For The Game

Consistency among species customization

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fixed half-elves not being able to pick wood elf ears.
/:cl:

