### PR TITLE
Dreamwalker summon weapon skill name fix

### DIFF
--- a/code/game/objects/items/ritualcircles.dm
+++ b/code/game/objects/items/ritualcircles.dm
@@ -460,7 +460,7 @@
 		var/current_athletics = user.get_skill_level(/datum/skill/misc/athletics)
 		if(current_skill < 4)
 			user.adjust_skillrank_up_to(skill_to_teach, 4)
-			to_chat(user, span_notice("Knowledge of [skill_to_teach] floods your mind!"))
+			to_chat(user, span_notice("Knowledge of [skill_to_teach.name] floods your mind!"))
 		if(current_athletics < 6)
 			user.adjust_skillrank_up_to(/datum/skill/misc/athletics, 6)
 			to_chat(user, span_notice("Your endurance swells!"))


### PR DESCRIPTION
## About The Pull Request

Fixes a bug where the dreamwalker rite where you make a weapon outputs this into the chatlog

<img width="389" height="79" alt="image" src="https://github.com/user-attachments/assets/2d68857d-d581-403d-8f1f-154235138acb" />

## Testing Evidence

<img width="499" height="105" alt="image" src="https://github.com/user-attachments/assets/b9586262-5bbf-45f3-a9c6-e3cebc5623ed" />


## Why It's Good For The Game

We should show skill names and not code paths

## Changelog

:cl: Randall
fix: Fixed the dreamwalker summon weapon rite showing the wrong skill name
/:cl: