### PR TITLE
Gives Footman Squires apprentice shield skill

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -119,6 +119,7 @@
 	subclass_skills = list(
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,


### PR DESCRIPTION
## About The Pull Request
Title. Just gives the footman squires apprentice shield skill.
## Testing Evidence
sire its a one line change and it compiles 
## Why It's Good For The Game
Errant squire adv class gets it, and giving them apprentice right off the bat means you don't need to spend a few minutes hitting a  dummy at the start of a round to dare to use a shield. Effectively just QOL tbh, given its just a small (and annoying) timesink otherwise.

## Changelog

:cl:
qol: Footman squires now start with apprentice shield skill. In-line with Errant Squire, and no more bonking a dummy for a few minutes.
/:cl:
