### PR TITLE
Net Drop Fix

### DIFF
--- a/code/game/objects/items/rogueitems/ropechainbola/net.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola/net.dm
@@ -29,6 +29,7 @@
 			M.update_inv_legcuffed()
 			if(M.has_status_effect(/datum/status_effect/debuff/netted))
 				M.remove_status_effect(/datum/status_effect/debuff/netted)
+		forceMove(M.loc)
 
 /obj/item/net/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
 	if(!..())
@@ -58,4 +59,4 @@
 // Failsafe in case the item somehow ends up being destroyed
 /obj/item/net/Destroy()
 	remove_effect()
-	return ..()	
+	return ..()


### PR DESCRIPTION
## About The Pull Request

- Nets now drop to the floor after their timer runs out.

## Testing Evidence

yea

## Why It's Good For The Game

it vanishes into the aether otherwise

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Nets now drop to the floor after their timer runs out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
