### PR TITLE
Scabbard Tweak

### DIFF
--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -40,6 +40,10 @@
 	var/sheathe_time = 0.1 SECONDS
 	var/sheathe_sound = 'sound/foley/equip/scabbard_holster.ogg'
 
+/obj/item/rogueweapon/scabbard/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("Left click to sheath a weapon, or to draw a sheathed weapon. Will only draw if held in hand, belt, or back.")
+	. += span_info("Right click to draw a sheathed weapon.")
 
 /obj/item/rogueweapon/scabbard/attack_obj(obj/O, mob/living/user)
 	return FALSE
@@ -139,11 +143,18 @@
 
 
 /obj/item/rogueweapon/scabbard/attack_hand(mob/user)
+	var/is_in_slot = TRUE
+	if(ishuman(user))
+		var/mob/living/carbon/human/human = user
+		is_in_slot = (src in (list(human.backl, human.backr, human.beltl, human.beltr) + human.get_inactive_held_item()))
+	if(sheathed && is_in_slot)
+		return puke_sword(user)
+	return ..()
+
+/obj/item/rogueweapon/scabbard/attack_right(mob/user)
 	if(sheathed)
 		return puke_sword(user)
-
-	..()
-
+	return ..()
 
 /obj/item/rogueweapon/scabbard/attackby(obj/item/I, mob/user, params)
 	if(!sheathed)
@@ -772,7 +783,7 @@
 /obj/item/rogueweapon/scabbard/sword/kazengun/noparry
 	name = "ceremonial kazengun scabbard"
 	desc = "A simple wooden scabbard, trimmed with bronze. Unlike its steel cousins, this one cannot parry."
-	
+
 	valid_blade = /obj/item/rogueweapon/sword/long/kriegmesser/ssangsudo
 	can_parry = FALSE
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -429,8 +429,12 @@
 	var/obj/item/stored = equipped_back.contents[equipped_back.contents.len]
 	if(!stored || stored.on_found(src))
 		return
+	if(istype(stored, /obj/item/rogueweapon/scabbard))
+		var/obj/item/rogueweapon/scabbard/scab = stored
+		if(scab.sheathed)
+			stored.attack_right(src)
+			return
 	stored.attack_hand(src) // take out thing from backpack
-	return
 
 /mob/living/carbon/human/proc/smart_equipbelt() // put held thing in belt or take most recent item out of belt
 	if(incapacitated())
@@ -465,8 +469,12 @@
 	var/obj/item/stored = equipped_belt.contents[equipped_belt.contents.len]
 	if(!stored || stored.on_found(src))
 		return
+	if(istype(stored, /obj/item/rogueweapon/scabbard))
+		var/obj/item/rogueweapon/scabbard/scab = stored
+		if(scab.sheathed)
+			stored.attack_right(src)
+			return
 	stored.attack_hand(src) // take out thing from belt
-	return
 
 /mob/living/carbon/human/proc/equip_scabbard(var/obj/item/thing, var/obj/item/equipped, slot_id)
 	var/obj/item/use_thing = null
@@ -490,7 +498,7 @@
 	if(!thing)
 		if(!scab.sheathed)
 			return FALSE
-		return scab.attack_hand(src)
+		return scab.attack_right(src)
 	if(!istype(thing, scab.valid_blade))
 		return FALSE
 	return scab.attackby(thing, src)


### PR DESCRIPTION
## About The Pull Request

- Left clicking a scabbard on the ground or in storage will now pick the entire thing up.
- Right clicking a scabbard will now always draw from it, as it works now.

## Testing Evidence

i prommy (tested the hotkeys too)

## Why It's Good For The Game

is good

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Left clicking a scabbard on the ground or in storage will now pick the entire thing up.
qol: Right clicking a scabbard will now always draw from it, as it works now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
