### PR TITLE
River Tweaks

### DIFF
--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -537,8 +537,7 @@
 
 /turf/open/water/river/Entered(atom/movable/AM, atom/oldLoc)
 	. = ..()
-	if(isliving(AM))
-		START_PROCESSING(SSrivers, src)
+	START_PROCESSING(SSrivers, src)
 
 /turf/open/water/river/get_heuristic_slowdown(mob/traverser, travel_dir)
 	var/const/UPSTREAM_PENALTY = 4
@@ -554,16 +553,30 @@
 		. += DOWNSTREAM_BONUS // faster!
 	else if(travel_dir == GLOB.reverse_dir[dir]) // upriver
 		. += UPSTREAM_PENALTY // slower
-	else 
+	else
 		. += SIDESTREAM_PENALTY // sidestream walking isn't free, bro
 
 /turf/open/water/river/proc/process_river()
+	var/found_movable = FALSE
 	for(var/atom/movable/A in contents)
+		found_movable = TRUE
 		for(var/obj/structure/S in src)
 			if(S.obj_flags & BLOCK_Z_OUT_DOWN)
 				return
 		if((A.loc == src))
 			A.ConveyorMove(dir)
+
+	if(found_movable)
+		STOP_PROCESSING(SSrivers, src)
+		return
+
+/turf/open/water/river/CanPass(atom/movable/mover, turf/target)
+	if(isliving(mover))
+		var/mob/mover_mob = mover
+		// prevent NPCs from constantly trying to go against the flow
+		if(!mover_mob.mind && get_dir(src, mover) == dir)
+			return FALSE
+	return ..()
 
 /turf/open/water/ocean
 	name = "salt water"


### PR DESCRIPTION
## About The Pull Request

- Throwing anything into a river will now cause it to process and shift downstream.
- Rivers now stop processing when there's nothing in them.
- NPCs no longer try to swim upstream.

## Testing Evidence

yea

## Why It's Good For The Game

having a buttload of uselessly processing rivers isnt great. being able to throw stuff into rivers is cool. NPCs no longer dancing at river deltas is nice

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Throwing anything into a river will now cause it to process and shift downstream.
fix: Rivers now stop processing when there's nothing in them.
fix: NPCs no longer try to swim upstream.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
