### PR TITLE
Buff Ritual Stacking Tweak

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1614,16 +1614,26 @@
 	effectedstats = list("strength" = 3)
 	duration = 20 MINUTES
 
+/datum/status_effect/buff/magic/strength/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/strength_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/strength_lesser)
+	return ..()
+
 /atom/movable/screen/alert/status_effect/buff/magic/strength
 	name = "arcane reinforced strength"
 	desc = "I am magically strengthened."
 	icon_state = "buff"
 
-/datum/status_effect/buff/magic/strength/lesser
+/datum/status_effect/buff/magic/strength_lesser
 	id = "lesser strength"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/strength/lesser
 	effectedstats = list("strength" = 1)
 	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/strength_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/strength))
+		return FALSE
+	return ..()
 
 /atom/movable/screen/alert/status_effect/buff/magic/strength/lesser
 	name = "lesser arcane strength"
@@ -1637,16 +1647,26 @@
 	effectedstats = list("speed" = 3)
 	duration = 20 MINUTES
 
+/datum/status_effect/buff/magic/speed/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/speed_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/speed_lesser)
+	return ..()
+
 /atom/movable/screen/alert/status_effect/buff/magic/speed
 	name = "arcane swiftness"
 	desc = "I am magically swift."
 	icon_state = "buff"
 
-/datum/status_effect/buff/magic/speed/lesser
+/datum/status_effect/buff/magic/speed_lesser
 	id = "lesser speed"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/speed/lesser
 	effectedstats = list("speed" = 1)
 	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/speed_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/speed))
+		return FALSE
+	return ..()
 
 /atom/movable/screen/alert/status_effect/buff/magic/speed/lesser
 	name = "arcane swiftness"
@@ -1659,16 +1679,26 @@
 	effectedstats = list("willpower" = 3)
 	duration = 20 MINUTES
 
+/datum/status_effect/buff/magic/willpower/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/willpower_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/willpower_lesser)
+	return ..()
+
 /atom/movable/screen/alert/status_effect/buff/magic/willpower
 	name = "arcane willpower"
 	desc = "I am magically resilient."
 	icon_state = "buff"
 
-/datum/status_effect/buff/magic/willpower/lesser
+/datum/status_effect/buff/magic/willpower_lesser
 	id = "lesser willpower"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/willpower/lesser
 	effectedstats = list("willpower" = 1)
 	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/willpower_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/willpower))
+		return FALSE
+	return ..()
 
 /atom/movable/screen/alert/status_effect/buff/magic/willpower/lesser
 	name = "lesser arcane willpower"
@@ -1681,16 +1711,26 @@
 	effectedstats = list("constitution" = 3)
 	duration = 20 MINUTES
 
+/datum/status_effect/buff/magic/constitution/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/constitution_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/constitution_lesser)
+	return ..()
+
 /atom/movable/screen/alert/status_effect/buff/magic/constitution
 	name = "arcane constitution"
 	desc = "I feel reinforced by magick."
 	icon_state = "buff"
 
-/datum/status_effect/buff/magic/constitution/lesser
+/datum/status_effect/buff/magic/constitution_lesser
 	id = "lesser constitution"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/constitution/lesser
 	effectedstats = list("constitution" = 1)
 	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/constitution_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/constitution))
+		return FALSE
+	return ..()
 
 /atom/movable/screen/alert/status_effect/buff/magic/constitution/lesser
 	name = "lesser arcane constitution"
@@ -1703,16 +1743,26 @@
 	effectedstats = list("perception" = 3)
 	duration = 20 MINUTES
 
+/datum/status_effect/buff/magic/perception/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/perception_lesser))
+		owner.remove_status_effect(/datum/status_effect/buff/magic/perception_lesser)
+	return ..()
+
 /atom/movable/screen/alert/status_effect/buff/magic/perception
 	name = "arcane perception"
 	desc = "I can see everything."
 	icon_state = "buff"
 
-/datum/status_effect/buff/magic/perception/lesser
+/datum/status_effect/buff/magic/perception_lesser
 	id = "lesser perception"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/magic/perception/lesser
 	effectedstats = list("perception" = 1)
 	duration = 20 MINUTES
+
+/datum/status_effect/buff/magic/perception_lesser/on_apply()
+	if(owner.has_status_effect(/datum/status_effect/buff/magic/perception))
+		return FALSE
+	return ..()
 
 /atom/movable/screen/alert/status_effect/buff/magic/perception/lesser
 	name = "lesser arcane perception"

--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -387,7 +387,7 @@ GLOBAL_LIST(teleport_runes)
 			if(istype(effect, /datum/status_effect/buff/magic))
 				empower_count++
 
-		if(empower_count > 1)
+		if(empower_count >= 3)
 			to_chat(living_invoker, span_warning("I'm already imbued by too many arcyne energies, this ritual does nothing for me!"))
 			invoker_list.Remove(living_invoker)
 

--- a/code/modules/roguetown/roguejobs/mages/rituals/buffs.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/buffs.dm
@@ -24,7 +24,7 @@
 
 /datum/runeritual/buff/lesserstrength
 	name = "lesser arcane augmentation of strength"
-	buff = /datum/status_effect/buff/magic/strength/lesser
+	buff = /datum/status_effect/buff/magic/strength_lesser
 	blacklisted = FALSE
 	required_atoms = list(/obj/item/magic/elemental/mote = 2,/obj/item/magic/manacrystal = 1)
 
@@ -37,7 +37,7 @@
 
 /datum/runeritual/buff/lesserconstitution
 	name = "lesser fortify constitution"
-	buff = /datum/status_effect/buff/magic/constitution/lesser
+	buff = /datum/status_effect/buff/magic/constitution_lesser
 	blacklisted = FALSE
 	required_atoms = list(/obj/item/magic/manacrystal = 1, /obj/item/magic/obsidian = 2)
 
@@ -50,7 +50,7 @@
 
 /datum/runeritual/buff/lesserspeed
 	name = "lesser haste"
-	buff = /datum/status_effect/buff/magic/speed/lesser
+	buff = /datum/status_effect/buff/magic/speed_lesser
 	blacklisted = FALSE
 	required_atoms = list(/obj/item/magic/artifact = 1, /obj/item/magic/leyline = 1)
 
@@ -63,7 +63,7 @@
 
 /datum/runeritual/buff/lesserperception
 	name = "lesser arcane eyes"
-	buff = /datum/status_effect/buff/magic/perception/lesser
+	buff = /datum/status_effect/buff/magic/perception_lesser
 	blacklisted = FALSE
 	required_atoms = list(/obj/item/reagent_containers/food/snacks/grown/manabloom = 1, /obj/item/magic/infernal/ash = 2)
 
@@ -76,7 +76,7 @@
 
 /datum/runeritual/buff/lesserwillpower
 	name = "lesser vitalized willpower"
-	buff = /datum/status_effect/buff/magic/willpower/lesser
+	buff = /datum/status_effect/buff/magic/willpower_lesser
 	blacklisted = FALSE
 	required_atoms = list(/obj/item/magic/obsidian = 2, /obj/item/magic/fairydust = 2)
 


### PR DESCRIPTION
## About The Pull Request

- The Empowerment Array ritual's lesser and greater buffs no longer stack. If you have a greater one, the lesser will do nothing. If you have a lesser, the greater will replace it.
- You can now have three of these buffs active at a time, instead of two.

## Testing Evidence

a

## Why It's Good For The Game

stacking allowed you to reach +4 in one stat. in exchange for removing the stacking, let them have one more slot

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: The Empowerment Array ritual's lesser and greater buffs no longer stack. If you have a greater one, the lesser will do nothing. If you have a lesser, the greater will replace it.
balance: You can now have three of these buffs active at a time, instead of two.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
