### PR TITLE
Trap and Vamp tweaks

### DIFF
--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -460,6 +460,8 @@
 			negate_slowdown = TRUE
 			break
 
+	if((isliving(user))&&(user?.movement_type == FLYING))
+		negate_slowdown = TRUE
 	if(HAS_TRAIT(user, TRAIT_LONGSTRIDER))
 		negate_slowdown = TRUE
 

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -64,7 +64,7 @@
 		/datum/skill/craft/tanning = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/ceramics = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/traps = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/traps = SKILL_LEVEL_EXPERT, //setting to higher level to counter an antag trap maker
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 	)
 

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
@@ -133,7 +133,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/smelting = SKILL_LEVEL_EXPERT,
-		/datum/skill/craft/traps = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/traps = SKILL_LEVEL_EXPERT, //setting to higher level to counter an antag trap maker
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/ceramics = SKILL_LEVEL_JOURNEYMAN,	//Just for basic pottery/glass stuff.
 	)

--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -175,7 +175,7 @@
 /datum/crafting_recipe/roguetown/engineering/twentybolts
 	name = "Crossbow Bolts 20x"
 	category = "Ammo"
-	reqs = list(/obj/item/natural/wood/plank = 3, /obj/item/ingot/iron)
+	reqs = list(/obj/item/natural/wood/plank = 3, /obj/item/ingot/iron = 1)
 	result = list(/obj/item/ammo_casing/caseless/rogue/bolt,
 						/obj/item/ammo_casing/caseless/rogue/bolt,
 						/obj/item/ammo_casing/caseless/rogue/bolt,
@@ -430,7 +430,6 @@
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
 
-
 /datum/crafting_recipe/roguetown/engineering/satchelbomb
 	name = "blastsand satchel"
 	category = "Explosives"
@@ -440,11 +439,13 @@
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
 
-
+//increasing the number to reflect the effort it takes to get fyritius and firedust
 /datum/crafting_recipe/roguetown/engineering/impactexplosive
 	name = "explosive grenade"
 	category = "Explosives"
-	result = /obj/item/impact_grenade/explosion
+	result = list(/obj/item/impact_grenade/explosion,
+				  /obj/item/impact_grenade/explosion,
+				  /obj/item/impact_grenade/explosion)
 	reqs = list(/obj/item/natural/clay = 1, /obj/item/paper = 1, /obj/item/alch/coaldust = 1, /obj/item/alch/firedust = 1, /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 1)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
@@ -517,4 +518,44 @@
 	craftdiff = 4
 
 // ------------ Craftable Traps ----------
-//trying out adding in traps, we'll start with 3 of them. 
+//setting these up as a more "arcane" alternative to trap making done with engineering. 
+
+/datum/crafting_recipe/roguetown/engineering/rocktrap
+	name = "rock trap (engineered)"
+	category = "Traps"
+	result = /obj/structure/trap/rock_fall
+	reqs =  list(/obj/item/roguegear = 1, /obj/item/natural/clay = 2, /obj/item/roguegem/amethyst = 1, /obj/item/alch/irondust =1, /obj/item/natural/rock = 1)
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/engineering/sawbladetrap
+	name = "saw blades trap (engineered)"
+	category = "Traps"
+	result = /obj/structure/trap/saw_blades
+	reqs =  list(/obj/item/roguegear = 2, /obj/item/natural/clay = 2, /obj/item/roguegem/amethyst = 1, /obj/item/alch/irondust =1, /obj/item/natural/whetstone = 1)
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/engineering/flametrap
+	name = "flame trap (engineered)"
+	category = "Traps"
+	result = /obj/structure/trap/flame
+	reqs =  list(/obj/item/roguegear = 1, /obj/item/natural/clay = 2, /obj/item/roguegem/amethyst = 1, /obj/item/alch/irondust =1, /obj/item/alch/firedust =1)
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/engineering/shocktrap
+	name = "shock trap (engineered)"
+	category = "Traps"
+	result = /obj/structure/trap/shock
+	reqs =  list(/obj/item/roguegear = 1, /obj/item/natural/clay = 2, /obj/item/roguegem/amethyst = 1, /obj/item/alch/irondust =1, /obj/item/alch/magicdust =1)
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 6
+
+/datum/crafting_recipe/roguetown/engineering/bombtrap
+	name = "bomb trap (engineered)"
+	category = "Traps"
+	result = /obj/structure/trap/bomb
+	reqs =  list(/obj/item/roguegear = 1, /obj/item/natural/clay = 2, /obj/item/roguegem/amethyst = 1, /obj/item/alch/irondust =1, /obj/item/impact_grenade/explosion = 1)
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 6

--- a/code/modules/spells/roguetown/vampire.dm
+++ b/code/modules/spells/roguetown/vampire.dm
@@ -61,7 +61,7 @@
 	do_gib = FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab/cabbit
 
-/obj/effect/proc_holder/spell/targeted/vampire_float
+/obj/effect/proc_holder/spell/invoked/vampire_float
 	name = "Float"
 	desc = "Float off the air without a sound"
 	recharge_time = 5 SECONDS
@@ -80,22 +80,12 @@
 	glow_color = GLOW_COLOR_VAMPIRIC
 	glow_intensity = GLOW_INTENSITY_MEDIUM
 
-/obj/effect/proc_holder/spell/targeted/vampire_float/cast(list/targets, mob/living/user)
+/obj/effect/proc_holder/spell/invoked/vampire_float/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))
 		var/mob/living/carbon/human/vampire_caster = targets[1]
 		if(!user)
 			return
-/*
-		if(!HAS_TRAIT(BSDrinker,TRAIT_VAMPIRISM))
-			to_chat(BSDrinker, span_warning("I'm not a vampire, what am I doing?"))
-			return
-		if(BSDrinker.has_status_effect(/datum/status_effect/debuff/veil_up))
-			to_chat(BSDrinker, span_warning("My curse is hidden."))
-			return
-		if(BSDrinker.vitae < vitaedrain)
-			to_chat(BSDrinker, span_warning("Not enough vitae."))
-			return
-*/
+
 		if(vampire_caster.has_status_effect(/datum/status_effect/buff/vampire_float))
 			to_chat(vampire_caster, span_warning("Already active."))
 			return
@@ -116,7 +106,7 @@
 
 /datum/status_effect/buff/vampire_float/on_remove()
 	. = ..()
-	to_chat(owner, span_warning("My fortitude leaves me"))
+	to_chat(owner, span_warning("I'm no longer floating"))
 	owner.remove_filter(VAMPIRIC_FILTER)
 
 #undef VAMPIRIC_FILTER

--- a/code/modules/vampire_neu/vampire.dm
+++ b/code/modules/vampire_neu/vampire.dm
@@ -80,6 +80,21 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 		vampdude.hud_used?.initialize_bloodpool()
 		vampdude.hud_used?.bloodpool.set_fill_color("#510000")
 
+		switch(generation) 
+			if(GENERATION_METHUSELAH)
+				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 6, TRUE)
+			if(GENERATION_ANCILLAE)
+				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 5, TRUE)
+			if(GENERATION_NEONATE)
+				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 4, TRUE) // Licker Wretch
+			if(GENERATION_THINBLOOD)
+				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 3, TRUE) // You are not even an antagonist
+			else
+				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 2, TRUE) // Default weight if generation not set
+
+		if(HAS_TRAIT(vampdude, TRAIT_DNR)) //if you have DNR, we add dustable
+			ADD_TRAIT(vampdude, TRAIT_DUSTABLE, TRAIT_GENERIC)
+
 		if(!forced)
 			// Show clan selection interface
 			if(!clan_selected)
@@ -166,6 +181,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 		var/mob/living/carbon/human/vampdude = owner.current
 		// Remove the clan when losing antagonist status
 		vampdude.set_clan(null)
+		if(HAS_TRAIT(vampdude, TRAIT_DUSTABLE)) //if you have DNR, we add dustable
+			REMOVE_TRAIT(vampdude, TRAIT_DUSTABLE, TRAIT_GENERIC)
 	owner.current?.hud_used?.shutdown_bloodpool()
 	if(!silent && owner.current)
 		to_chat(owner.current, span_danger("I am no longer a [job_rank]!"))


### PR DESCRIPTION
## About The Pull Request
just a few trap and vampire adjustments
- things that fly no longer break twigs or rustle grass
- upped the trap skill on artificers and guild masters to counter antag trap makers
- added engineering trap making again, both trap making and engineered trap recipes are in
- fixed the crossbow bolt recipe
- upped the explosive grenade recipe to 3 to reflect how difficult fyritius and firedust is to get
- added blood sorcery levels depending on your vampire generation
- adjusted the vampire float spell, which can be admin granted.
- added dustable to any DNR vampire on gain. previously it was wretch and vampire lord only.

## Testing Evidence
showing 3 grenades made with the recipe
<img width="255" height="198" alt="image" src="https://github.com/user-attachments/assets/a85699bb-6e33-4535-a44b-bde969fbe0c3" />

showing the 20 bolts with nothing left behind
<img width="130" height="180" alt="image" src="https://github.com/user-attachments/assets/d0e601e1-474a-4f4a-9d91-c2723a0fb36a" />

5 traps made with engineering skill, the trap making versions are still there
<img width="322" height="445" alt="image" src="https://github.com/user-attachments/assets/b2710adb-9d0e-41b0-98af-e698cd78b044" />
<img width="403" height="623" alt="image" src="https://github.com/user-attachments/assets/a8a8a8c4-8e0d-459d-92e7-72496181eea6" />

a vampire antag (not a lord) with master blood sorcery
<img width="219" height="399" alt="image" src="https://github.com/user-attachments/assets/0ececa5b-e091-4ac5-aff5-2161ace92292" />

a vampire wretch with expert blood sorcery
<img width="207" height="194" alt="image" src="https://github.com/user-attachments/assets/d716b01e-1266-4dc1-8d00-606d26eac2be" />

a vampire thinblood (turned) with journeyman blood sorcery
<img width="247" height="243" alt="image" src="https://github.com/user-attachments/assets/25cf72ce-c286-48cf-a98c-ddc1787ee409" />

dustable trait given to a person just turned into a vampire that was DNR
<img width="514" height="413" alt="image" src="https://github.com/user-attachments/assets/81d2ff0d-5c9c-4f9e-abd9-b7a0e45c75b7" />

flying in batform not rustling grass
https://github.com/user-attachments/assets/6605f95f-9a57-4491-96a8-5e639341998f

## Why It's Good For The Game

Just  minor adjustments to the code and fixing bugs

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

🆑 
qol: things that fly no longer break twigs or rustle grass
balance: upped the trap skill on artificers and guild masters to counter antag trap makers
qol: added engineering trap making again, both trap making and engineered trap recipes are in
fix: fixed the crossbow bolt recipe
balance: upped the explosive grenade recipe to 3 to reflect how difficult fyritius and firedust is to get
qol: added blood sorcery levels depending on your vampire generation
admin: adjusted the vampire float spell, which can be admin granted.
qol: added dustable to any DNR vampire on gain. previously it was wretch and vampire lord only.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
