### PR TITLE
Replace T2 Zizite Skeleton  Summoning for Wither

### DIFF
--- a/code/datums/gods/patrons/inhumen/zizo.dm
+++ b/code/datums/gods/patrons/inhumen/zizo.dm
@@ -9,8 +9,7 @@
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 					= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/blood_heal					= CLERIC_T1,
 					/obj/effect/proc_holder/spell/invoked/projectile/profane/miracle 	= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/raise_undead_formation/miracle= CLERIC_T2,
-					/obj/effect/proc_holder/spell/invoked/raise_undead_guard/miracle	= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/wither/miracle				= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/tame_undead/miracle			= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/rituos/miracle 				= CLERIC_T3,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -85,8 +85,8 @@
 	if (istype (H.patron, /datum/patron/inhumen/zizo))
 		if(H.mind)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
-			H.verbs |= /mob/living/carbon/human/proc/revelations
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
+			H.verbs |= /mob/living/carbon/human/proc/revelations
 			H.mind?.current.faction += "[H.name]_faction"
 		ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
 	mask = /obj/item/clothing/mask/rogue/facemask/steel

--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -88,19 +88,11 @@
 	to_chat(user, span_danger("[src] crumbles into dust..."))
 	qdel(src)
 
-// T2: just use lesser animate undead for now
+// T2: wither as a temporary replacement to free skelelons.
 
-/obj/effect/proc_holder/spell/invoked/raise_undead_formation/miracle
+/obj/effect/proc_holder/spell/invoked/wither/miracle
 	miracle = TRUE
-	devotion_cost = 75
-	cabal_affine = TRUE
-	to_spawn = 2
-
-// T2: carbon spawn
-
-/obj/effect/proc_holder/spell/invoked/raise_undead_guard/miracle
-	miracle = TRUE
-	devotion_cost = 75
+	devotion_cost = 30
 
 // T3: tames bio_type = undead mobs
 


### PR DESCRIPTION
## About The Pull Request

Affects clerics and zeretics. Not Necromancer or Liches.

## Testing Evidence

Tested.

## Why It's Good For The Game

Bandaid till I can get the summoned mob cleaner working (or atleast, get the will to get around to doing it). I added formation summoning and frankly should've packaged atleast a cap with it. 

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: T2 Zizites lose skeleton summoning.
balance: T2 Zizites get Wither.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
