### PR TITLE
Focus Target order without the crit weakness

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -56,6 +56,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	var/takeaimtext = "Take aim!!"
 	var/holdtext = "Hold!!"
 	var/onfeettext = "On your feet!!"
+	var/focustargettext = "Focus target!!"
 	var/retreattext = "Fall back!!"
 	var/bolstertext = "Hold the line!!"
 	var/brotherhoodtext = "Stand proud, for the Brotherhood!!"

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -101,6 +101,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/takeaim)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/onfeet)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/hold)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/focustarget)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/guard) // We'll just use Watchmen as sorta conscripts yeag?
 	H.verbs |= list(/mob/living/carbon/human/proc/request_outlaw, /mob/proc/haltyell, /mob/living/carbon/human/mind/proc/setorders)
 	backpack_contents = list(
@@ -369,6 +370,51 @@
 	. = ..()
 	to_chat(owner, span_blue("My officer orders me to hold!"))
 
+#define TARGET_FILTER "target_marked"
+
+/obj/effect/proc_holder/spell/invoked/order/focustarget
+	name = "Focus target!"
+	desc = "Tells your underlings to target an enemy, demoralizing them. Gives the targeted enemy -2 Fortune."
+	overlay_state = "focustarget"
+
+
+/obj/effect/proc_holder/spell/invoked/order/focustarget/cast(list/targets, mob/living/user)
+	. = ..()
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		var/msg = user.mind.focustargettext
+		if(!msg)
+			to_chat(user, span_alert("I must say something to give an order!"))
+			return
+		if(target == user)
+			to_chat(user, span_alert("I cannot order myself to be killed!"))
+			return
+		user.say("[msg]")
+		target.apply_status_effect(/datum/status_effect/debuff/order/focustarget)
+		return TRUE
+	revert_cast()
+	return FALSE
+
+/datum/status_effect/debuff/order/focustarget
+	id = "focustarget"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/order/focustarget
+	effectedstats = list(STATKEY_LCK = -2)
+	duration = 1 MINUTES
+	var/outline_colour = "#69050a"
+
+/atom/movable/screen/alert/status_effect/debuff/order/focustarget
+	name = "Targeted"
+	desc = "A officer has marked me for death!"
+	icon_state = "targetted"
+
+
+/obj/effect/proc_holder/spell/invoked/order/focustarget
+	name = "Focus target!"
+	overlay_state = "focustarget"
+
+
+#undef TARGET_FILTER
+
 
 /mob/living/carbon/human/mind/proc/setorders()
 	set name = "Rehearse Orders"
@@ -387,5 +433,9 @@
 		return
 	mind.onfeettext = input("Send a message.", "On your feet!") as text|null
 	if(!mind.onfeettext)
+		to_chat(src, "I must rehearse something for this order...")
+		return
+	mind.focustargettext = input("Send a message.", "Focus Target!") as text|null
+	if(!mind.focustargettext)
 		to_chat(src, "I must rehearse something for this order...")
 		return

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -113,6 +113,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/takeaim)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/onfeet)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/hold)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/focustarget)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	H.verbs |= list(
 		/mob/living/carbon/human/proc/request_outlaw,


### PR DESCRIPTION


## About The Pull Request

re-adds `Focus Target!` to Sergeant-at-Arms and Knight Captain. The spell only reduces the victim's FOR stat.

## Testing Evidence

<img width="150" height="109" alt="image" src="https://github.com/user-attachments/assets/95fecb91-5da6-4780-8cd7-6eb6a0721d0d" />

<img width="359" height="228" alt="image" src="https://github.com/user-attachments/assets/762ece1c-4b83-42c8-82cb-599b1009b013" />

<img width="417" height="140" alt="image" src="https://github.com/user-attachments/assets/98ecec12-6fea-4aa9-922e-9eff211d0728" />

## Why It's Good For The Game

Spoke to @Ryan180602 about it, who initially removed the spell. Critical Weakness was the problem with Focus Target. The -2 FOR debuff is alright. Only lasts a minute and the cooldown of the order is twice as long.

It's funny to yell "I need you dead" at people. @Lamasmaster 

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Focus Target is back. It only applies -2 FOR on the victim.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
