### PR TITLE
Psydonian barbarians are no longer frauds (Bugfix)

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -151,7 +151,7 @@
 			continue
 		var/bodypart_pain = ((limb.brute_dam + limb.burn_dam) / limb.max_damage) * limb.max_pain_damage
 		for(var/datum/wound/wound as anything in limb.wounds)
-			bodypart_pain += wound.woundpain
+			bodypart_pain += wound?.woundpain
 		bodypart_pain = min(bodypart_pain, limb.max_pain_damage)
 		if(HAS_TRAIT(src, TRAIT_ADRENALINE_RUSH))
 			bodypart_pain = bodypart_pain * 0.5


### PR DESCRIPTION
## About The Pull Request

Psydonian grit was doing its mini-pain stuns without checking to see if the user had the trait that prevents them entirely. This was making Barbarians who picked Psydon decidedly worse than any other barbarian, as they would still get mini-pain crits instead of none at all.

## Testing Evidence

<img width="573" height="367" alt="image" src="https://github.com/user-attachments/assets/a3f04226-75c5-4a31-934c-3a5cb1108f9d" />

Yeah I stood here for like ten minutes with every part mangled, it works now

## Why It's Good For The Game

Bugfix 
## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Psydonian Barbarians no longer get mini-pain crits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
