### PR TITLE
Stops primordials attacking their summoners

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_primordial.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_primordial.dm
@@ -49,8 +49,8 @@
 		user.mind.AddSpell(primordial_order )
 		user.mind.AddSpell(primordialmark)
 		spellsgranted = TRUE
-	if(!("[user.name]_faction" in user.mind?.current.faction))
-		user.mind?.current.faction |= "[user.name]_faction"
+	if(!("[user.real_name]_faction" in user.mind?.current.faction))
+		user.mind?.current.faction |= "[user.real_name]_faction"
 
 	var/mob/living/simple_animal/hostile/retaliate/rogue/primordial/conjured
 	switch(sacrifice.type)


### PR DESCRIPTION
## About The Pull Request

If your face was concealed when you summoned a primordial, you didn't get the correct faction added and your primordial would attack you if set to aggressive. This fixes that issue.

## Testing Evidence

Me and my aggro buddy chilling without him attacking me
<img width="323" height="224" alt="image" src="https://github.com/user-attachments/assets/2042f270-a5f1-4e05-869d-dc8d5bed9ed5" />

## Why It's Good For The Game

Bug bad, fix good 

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Summoning a primordial while your face is concealed will no longer make your the primordial hostile to you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
