### PR TITLE
Limbguard Minor Tweaks

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1337,9 +1337,6 @@
 		mob_effect.alpha = 255
 		is_active = TRUE
 
-/datum/status_effect/buff/clash/limbguard/guard_swaphands()
-	return
-
 /datum/status_effect/buff/clash/limbguard/on_creation(mob/living/new_owner, ...)
 	. = ..()
 	shield_origin = owner.get_active_held_item()
@@ -1471,8 +1468,16 @@
 	owner.apply_status_effect(/datum/status_effect/debuff/specialcd, 60 SECONDS)
 	owner.apply_status_effect(/datum/status_effect/debuff/clashcd)
 
+//We don't have a cost to cancelling limbguard, so most of these are overridden.
+//No green regen at all + the initial cost is steep already.
 /datum/status_effect/buff/clash/limbguard/guard_kicked()
 	return
+
+/datum/status_effect/buff/clash/limbguard/guard_swaphands()
+	return
+
+/datum/status_effect/buff/clash/limbguard/guard_on_kick()
+	return	
 
 #define BLOODRAGE_FILTER "bloodrage"
 

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -723,9 +723,8 @@ SPECIALS START HERE
 	desc = "Raise your shield to protect a limb. You will deflect projectiles and anyone striking that limb will be severely penalized. \n\
 		You cannot regain stamina while this is active. It can be cancelled by jumping, kicking or by using MMB again with the same shield out."
 	respect_adjacency = FALSE
-	cooldown = 30 SECONDS
-	stamcost = 30
-
+	cooldown = 60 SECONDS
+	stamcost = 25
 
 //apply_cost is called before anything else, so it works here for the toggle checks, but it's kind of a bad example -- don't do this.
 /datum/special_intent/limbguard/apply_cost(mob/living/L)


### PR DESCRIPTION
## About The Pull Request
- Slightly reduced cost
- Kicking to cancel Limbguard no longer strains the user
- Minor code reorganisation
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed Limbguard Special straining the user when they try to kick with it active.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
