### PR TITLE
One For My Honey - Adds alternative Carpenter-specific recipes to create the Silver/Psydonic Quarterstaves.

### DIFF
--- a/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
@@ -393,6 +393,28 @@
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 4
 
+/datum/crafting_recipe/roguetown/survival/quarterstaff_psydonic
+	name = "psydonic silver-reinforced quarterstaff"
+	category = "Tools"
+	result = list(/obj/item/rogueweapon/woodstaff/quarterstaff/psy)
+	reqs = list(
+		/obj/item/rogueweapon/woodstaff/quarterstaff = 1,
+		/obj/item/ingot/silverblessed = 1,
+		)
+	skillcraft = /datum/skill/craft/carpentry
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/survival/quarterstaff_psydonic/bullion
+	name = "psydonic silver-reinforced quarterstaff"
+	category = "Tools"
+	result = list(/obj/item/rogueweapon/woodstaff/quarterstaff/psy)
+	reqs = list(
+		/obj/item/rogueweapon/woodstaff/quarterstaff = 1,
+		/obj/item/ingot/silverblessed/bullion = 1,
+		)
+	skillcraft = /datum/skill/craft/carpentry
+	craftdiff = 5
+
 /datum/crafting_recipe/roguetown/survival/woodsword
 	name = "wooden sword (x2)"
 	category = "Tools"


### PR DESCRIPTION
## About The Pull Request

Hello!
Yurek, bless his heart, notified me about this minor incongruence.
Silver Quarterstaves can now be made through a Carpentry-specific recipe, just like its lesser-tiered equivalents. The listed difficulty is a level higher than the Steel Quarterstaff, which means you'll need to be an Expert in order to properly make it.

(EDIT)
* Added Carpentry-specific recipes for the Psydonic Quarterstaff, too. You can either fashion it with regular blessed silver or with the marquette's bullion: be warned, however, as you'll need to be a Master if you want to fashion it.

## Testing Evidence

Good to go! Just a brief four-liner.

## Why It's Good For The Game

All quarterstaves can now be fashioned through Carpentry, as it was _(most likely)_ intended, instead of arbitrarily requiring the Weaponsmithing skill to fashion its highest-tiered equivalence. Oversight on my end, my bad.

## Changelog

:cl:
add: Like their predecessors, the Silver (and Psydonic) Quarterstaves now have Carpentry-specific recipes.
/:cl:
