### PR TITLE
Removes Otavan gear from the Sojourner, gives them Sama'glos

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -71,6 +71,8 @@
 			if("Otavan - Heavyweight, Blacksteel Thorns")
 				head = /obj/item/clothing/head/roguetown/roguehood/psydon
 				mask = /obj/item/clothing/head/roguetown/helmet/blacksteel/psythorns
+				backl = /obj/item/storage/backpack/rogue/satchel/otavan
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/psythorns
 				neck = /obj/item/clothing/neck/roguetown/psicross/silver
 				id = /obj/item/clothing/ring/signet/silver
@@ -78,6 +80,8 @@
 				head = /obj/item/clothing/head/roguetown/headband/naledi
 				mask = /obj/item/clothing/mask/rogue/lordmask/naledi/sojourner
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/cloth/naledi
+				backl = /obj/item/storage/backpack/rogue/satchel/black
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 				neck = /obj/item/clothing/neck/roguetown/psicross/g //Naledians covet gold far more than the Orthodoxists cover silver. Emphasizes their nature as 'visitors', more-so than anything else.
 				id = /obj/item/clothing/ring/signet
 				l_hand = /obj/item/spellbook_unfinished/pre_arcyne
@@ -85,7 +89,8 @@
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				REMOVE_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
 				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 3, TRUE)
-				H.mind.adjust_spellpoints(6) //Messed this up. Should add spellpoints for use, now.
+				H.grant_language(/datum/language/celestial) //They're from Naledi, they should speak Sama'glos
+				H.mind.adjust_spellpoints(6)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch) //Pre-set spell list. Same as before. 
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/forcewall) //Weak, destroyable forcewall.
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message)
@@ -97,12 +102,11 @@
 
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
 	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple
-	backl = /obj/item/storage/backpack/rogue/satchel/otavan
+	
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1,
 	/obj/item/paper/inqslip/arrival/ortho = 1,
 	/obj/item/roguegem/amethyst/naledi = 1) //Kept here for now, until we figure out how to make it better fit in overfilled hands.
 	belt = /obj/item/storage/belt/rogue/leather/rope/dark
-	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/mid
 	cloak = /obj/item/clothing/cloak/tabard/psydontabard/alt
 


### PR DESCRIPTION
## About The Pull Request

In the Sojourner (Naledi Disciple) loadout, replaces the Otavan Leather Satchel with a normal black leather satchel, and the Otavan leather pants with normal hardened leather pants (which the Otavan ones are a child of). Also adds Sama'glos language to the Sojourner since that's their native tongue.

## Testing Evidence

Spawned with Sojourner, new gear
<img width="1107" height="541" alt="image" src="https://github.com/user-attachments/assets/27d472b8-633a-4aeb-b156-9ecf0599fcd7" />
Spawned with Otavan, old gear
<img width="1115" height="529" alt="image" src="https://github.com/user-attachments/assets/3ecba853-1235-4c9e-a11c-a4a32f80c62f" />


## Why It's Good For The Game

Sojourners are from Naledi and should speak the language of Naledi. (Yes, it's an extra language, but I don't think that's a huge balance issue.) The rest of their outfit is also Naledi. Maybe having normal backpack and pants will stop people from calling my Sojourner Otavan.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
tweak: Sojourners now start with Sama'glos and don't have Otavan-specific clothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
