### PR TITLE
Lets slurbows be onehanded + let dualwielder affect slurbows

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -17,6 +17,7 @@
 	var/chargingspeed = 40
 	var/reloadtime = 40
 	var/movingreload = FALSE
+	var/onehanded = FALSE
 	var/hasloadedsprite = FALSE
 	force = 10
 	var/cocked = FALSE
@@ -35,6 +36,10 @@
 	. += span_info("Crossbows increase in accuracy with a higher <b>PERCEPTION</b>, but deal a static amount of damage \
 	regardless of character stats.")
 	. += span_info("Crossbows cannot be nocked directly from their quiver and require time to load.")
+	if(onehanded)
+		. += span_info("This weapon can be used in one hand, at the penalty of aim time.")
+		if(HAS_TRAIT(user, TRAIT_DUALWIELDER))
+			. += span_info("You can fire two of this weapon at the same time. You shoot the second at half its accuracy factor.")
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/getonmobprop(tag)
 	. = ..()
@@ -54,10 +59,11 @@
 	basetime = 20
 
 /datum/intent/shoot/crossbow/can_charge(atom/clicked_object)
-	if(mastermob)
-		if(mastermob.get_num_arms(FALSE) < 2)
+	if(mastermob && masteritem)
+		var/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/c_bow = masteritem
+		if(mastermob.get_num_arms(FALSE) < 2 && !c_bow.onehanded)
 			return FALSE
-		if(mastermob.get_inactive_held_item())
+		if(mastermob.get_inactive_held_item() && !c_bow.onehanded)
 			return FALSE
 		if(istype(clicked_object, /obj/item/quiver) && istype(mastermob.get_active_held_item(), /obj/item/gun/ballistic))
 			return FALSE
@@ -65,12 +71,17 @@
 
 
 /datum/intent/shoot/crossbow/get_chargetime()
-	if(mastermob && chargetime)
+	if(mastermob && chargetime && masteritem)
+		var/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/c_bow = masteritem
 		var/newtime = chargetime
 		//skill block
-		newtime = newtime + basetime
-		newtime = newtime - (mastermob.get_skill_level(/datum/skill/combat/crossbows) * 4.25) // minus 4.25 per skill point
-		newtime = newtime - ((mastermob.STAPER)) // minus 1 per perception
+		newtime += basetime
+		newtime -= (mastermob.get_skill_level(/datum/skill/combat/crossbows) * 4.25) // minus 4.25 per skill point
+		newtime -= ((mastermob.STAPER)) // minus 1 per perception
+
+		if(c_bow.onehanded)
+			if(mastermob.get_num_arms(FALSE) < 2 || mastermob.get_inactive_held_item())
+				newtime *= 1.5 // more time if firing one-handed.
 		if(newtime > 1)
 			return newtime
 		else
@@ -90,24 +101,31 @@
 
 
 /datum/intent/arc/crossbow/can_charge(atom/clicked_object)
-	if(mastermob)
-		if(mastermob.get_num_arms(FALSE) < 2)
+	if(mastermob && masteritem)
+		var/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/c_bow = masteritem
+		if(mastermob.get_num_arms(FALSE) < 2 && !c_bow.onehanded)
 			return FALSE
-		if(mastermob.get_inactive_held_item())
+		if(mastermob.get_inactive_held_item() && !c_bow.onehanded)
 			return FALSE
 		if(istype(clicked_object, /obj/item/quiver) && istype(mastermob.get_active_held_item(), /obj/item/gun/ballistic))
 			return FALSE
 	return TRUE
 
 /datum/intent/arc/crossbow/get_chargetime()
-	if(mastermob && chargetime)
+	if(mastermob && chargetime && masteritem)
+		var/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/c_bow = masteritem
 		var/newtime = chargetime
 		//skill block
-		newtime = newtime + basetime
-		newtime = newtime - (mastermob.get_skill_level(/datum/skill/combat/crossbows) * 20)
+		newtime += basetime
+		newtime -= (mastermob.get_skill_level(/datum/skill/combat/crossbows) * 20)
 		//per block
-		newtime = newtime + 20
-		newtime = newtime - ((mastermob.STAPER)*1.5)
+		newtime += 20
+		newtime -= ((mastermob.STAPER)*1.5)
+
+		if(c_bow.onehanded)
+			if(mastermob.get_num_arms(FALSE) < 2 || mastermob.get_inactive_held_item())
+				newtime *= 2 // more time if firing one-handed.
+
 		if(newtime > 0)
 			return newtime
 		else
@@ -151,9 +169,9 @@
 
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	if(user.get_num_arms(FALSE) < 2)
+	if(user.get_num_arms(FALSE) < 2 && !onehanded)
 		return FALSE
-	if(user.get_inactive_held_item())
+	if(user.get_inactive_held_item() && !onehanded)
 		return FALSE
 	if(user.client)
 		if(user.client.chargedprog >= 100)
@@ -171,7 +189,25 @@
 		BB.armor_penetration *= penfactor
 		BB.damage *= damfactor
 	cocked = FALSE
+
 	..()
+
+	if(!onehanded)
+		return
+	var/obj/item/other_hand = user.get_inactive_held_item()
+	var/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/alt_cbow
+	if(other_hand.type != type)
+		return
+	alt_cbow = other_hand
+	if(!alt_cbow)
+		return
+	if(!alt_cbow.chambered)
+		return
+	if(HAS_TRAIT(user, TRAIT_DUALWIELDER) && alt_cbow.onehanded)
+		alt_cbow.accfactor /= 2
+		alt_cbow.process_fire(target, user, FALSE)
+		alt_cbow.accfactor = initial(alt_cbow.accfactor)
+		return
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/update_icon()
 	. = ..()
@@ -209,6 +245,7 @@
 	reloadtime = 20
 	hasloadedsprite = TRUE
 	movingreload = TRUE
+	onehanded = TRUE
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_HIP
 	penfactor = 0.5		//Bolts have 50 pen, this decreases to 25. Should only pen armor with less than 67 protection.
 


### PR DESCRIPTION
## About The Pull Request

1. Slurbows can be shot one-handed, with aim-time penalty (1.5x for shoot/2x for arc).
2. Dual Wielder means two slurbows can be shot at once. You shoot the second slurbow at half of its accuracy factor.

## Testing Evidence

Tested.

## Why It's Good For The Game

Aura

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Slurbows can be shot 1-handed with aim penalty.
balance: Dual Wielder now affects slurbows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
