### PR TITLE
Clock loadout stash colors fix

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -642,17 +642,8 @@
 	pixel_y = 32
 
 /obj/structure/fluff/wallclock/attack_right(mob/user)
-	if(user.mind && isliving(user))
-		if(user.mind.special_items && user.mind.special_items.len)
-			var/item = input(user, "What will I take?", "STASH") as null|anything in user.mind.special_items
-			if(item)
-				if(user.Adjacent(src))
-					if(user.mind.special_items[item])
-						var/path2item = user.mind.special_items[item]
-						user.mind.special_items -= item
-						var/obj/item/I = new path2item(user.loc)
-						user.put_in_hands(I)
-			return
+	handle_special_items_retrieval(user, src)
+	return
 
 /obj/structure/fluff/wallclock/Destroy()
 	if(soundloop)


### PR DESCRIPTION
## About The Pull Request

Loadout items taken from wall clocks now correctly apply their loadout color if specified. Previously this was bugged due to a snowflake proc on the wall clock that didn't take color into consideration; this standardizes it so wall clocks now use the same `handle_special_items_retrieval()` proc as every other loadout stash item (tower clocks, statues, etc).

## Testing Evidence

<img width="1048" height="154" alt="image" src="https://github.com/user-attachments/assets/c17b51fe-2976-4969-949c-c5645a5846d6" />

See? Red! No, wait, that's blood...

## Why It's Good For The Game

taste the rainbow

## Changelog
:cl:
fix: Taking loadout items from wall clocks now correctly applies their loadout color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
