### PR TITLE
Crown summoning fix

### DIFF
--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -87,7 +87,6 @@ GLOBAL_VAR_INIT(last_crown_announcement_time, -1000)
 				say("The crown is within the vault.")
 				playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
 				return
-			I.anti_stall()
 			I = summon_crown()
 			return
 
@@ -312,10 +311,11 @@ GLOBAL_VAR_INIT(last_crown_announcement_time, -1000)
 /obj/structure/roguemachine/titan/proc/summon_crown()
 	var/obj/item/clothing/head/roguetown/crown/serpcrown/I = SSroguemachine.crown
 
-	if(!I)
-		SSroguemachine.crown = I = new /obj/item/clothing/head/roguetown/crown/serpcrown(src.loc)
-	else
-		I.forceMove(src.loc)
+	if(I)
+		I.anti_stall()
+	
+	I = new /obj/item/clothing/head/roguetown/crown/serpcrown(src.loc)
+	SSroguemachine.crown = I
 
 	say("The crown is summoned!")
 	playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)


### PR DESCRIPTION
## About The Pull Request

Patch fix for #4965 where the crown would not be correctly summoned (and attempting to summon it would fail silently) if the crown did not exist to begin with (i.e. no Duke ever joined, or crown is destroyed). Didn't catch this in testing (only tested with Dukes proper), sorry!

Crown summoning logic was also cleaned up slightly behind the scenes; the actual summoning proc has been centralized (check `Files Changed` for details).

## Testing Evidence

<img width="722" height="601" alt="image" src="https://github.com/user-attachments/assets/b024ee0b-aa9b-47a7-8bd7-2287e6eefdc9" />

## Why It's Good For The Game

Becoming regent is a pretty frickin' big deal.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed crown not being summonable if the crown was absent, i.e. no Duke, or crown is physically destroyed.
code: Cleaned up the summon crown logic behind the scenes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
