### PR TITLE
Hinterblade oversight fix

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1018,6 +1018,10 @@
 	icon_state = "shashka"
 	sheathe_icon = "shashka"
 
+/obj/item/rogueweapon/sword/sabre/steppesman/Initialize()
+	. = ..()
+	AddComponent(/datum/component/skill_blessed, TRAIT_SABRIST, /datum/skill/combat/swords, SKILL_LEVEL_MASTER, TRUE)
+
 //Unique church sword - slightly better than regular sabre due to falx chop.
 /obj/item/rogueweapon/sword/sabre/nockhopesh
 	name = "moonlight khopesh"


### PR DESCRIPTION
## About The Pull Request

Realized Halford missed a few intents that were meant to have their chargetime removed because it's buggy and unintuitive, so I fixed it. Also gave Hinterblade the shortsword stab cuz I forgot lol

## Testing Evidence

Trvst. 

## Why It's Good For The Game

This effectively ruins shortswords now. 

## Changelog

:cl:

fix: militia sword intents, hinterblade thrust fixed to what it was meant to have

/:cl:

