### PR TITLE
Cure rot vials no longer just kill you

### DIFF
--- a/code/modules/reagents/reagent_containers/rotcure.dm
+++ b/code/modules/reagents/reagent_containers/rotcure.dm
@@ -1,13 +1,13 @@
 //Rot-cure for revival sickness healing and rot-penalty reversal.
 /obj/item/reagent_containers/glass/bottle/alchemical/rogue/rotcure
-	list_reagents = list(/datum/reagent/rotcure = 18)	//Should be enough for 2 usages.
+	list_reagents = list(/datum/reagent/rotcure = 20)	//Should be enough for 2 usages.
 
 /datum/reagent/rotcure
 	name = "Rot-Cure"
 	description = "A putrid substance that appears to be in perpetual motion. It smells and looks of living-sludge."
 	color = "#034212"
 	taste_description = "living sludge"
-	overdose_threshold = 10	//Stops people from downing too much of it.
+	overdose_threshold = 21	//Stops people from downing too much of it.
 	metabolization_rate = 0.1
 
 /datum/reagent/rotcure/overdose_process(mob/living/M)


### PR DESCRIPTION
## About The Pull Request

It came in a vial that sips for 10, the overdose threshold was AT 10. Since Overdose thresholds are >= and not > that just killed anyone who used it.

Adds a more reasonable overdose threshold that allows someone to drink a single sip without permanently RR'ing themselves. It actually lets you drink two sips now. (Which most players who try to use it do, since they assume they're supposed to drink the whole thing) Which seems reasonable given that you're already being punished for doing that by wasting your rotcure vial. 

This also increases the amount in the vial from 18 to 20. Since based on the comments it seemed intended that you could use it twice-.. but the effect only activates if you have > 8 in your system, and not >= to 8. So the second sip wouldn't have worked anyway.
## Testing Evidence

It's a numbers change

## Why It's Good For The Game

It probably shouldn't be so easy to accidentally proc the most punishing overdose in the game. It does brain damage which we have no in-game way to heal or even show that is happening to the player until they just suddenly fall over. Also-.. the only way to even drink it without overdosing yourself in the first place was to transfer the vial to a bottle and then.. drink 5, wait for it to process a little and drink another 5 so you dont hit 10. It was jank and operating on such incredibly tight values. It's normal now.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Rotcure potions don't kill you now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
