### PR TITLE
 Rock piles density changed to FALSE

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -350,6 +350,7 @@
 /obj/structure/flora/rock/pile
 	icon_state = "lavarocks"
 	desc = ""
+	density = FALSE
 
 //Jungle grass
 


### PR DESCRIPTION
## About The Pull Request

title

## Testing Evidence

I changed one line

## Why It's Good For The Game

You should be able to walk over these rock piles.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Rock pile density is now false.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
