### PR TITLE
Removes court agent (the Hand can still use their spell)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/courtagent.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/courtagent.dm
@@ -3,8 +3,8 @@
 	flag = COURTAGENT
 	display_order = JDO_COURTAGENT
 	allowed_races = RACES_ALL_KINDS
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	round_contrib_points = 2
 	tutorial = "Whether acquired by merit, shrewd negotiation or fulfilled bounties, you have found yourself under the underhanded employ of the Hand. Fulfill desires and whims of the court that they would rather not be publicly known. Your position is anything but secure, and any mistake can leave you disowned and charged like the petty criminal are. Garrison and Court members know who you are."
 	min_pq = 5

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -157,7 +157,6 @@ GLOBAL_LIST_INIT(wanderer_positions, list(
 	"Mercenary",
 	"Bandit",
 	"Assassin",
-	"Court Agent",
 	"Wretch",
 ))
 

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -86,7 +86,6 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	var/list/wanderer_jobs = list(
 		"Adventurer",
 		"Wretch",
-		"Court Agent"
 	)
 
 	for (var/mob/dead/new_player/player in GLOB.player_list)


### PR DESCRIPTION
## About The Pull Request

This removes court agent as a choosable role. The Hand can still use their spell to hire.

## Testing Evidence

Tested.

## Why It's Good For The Game

Often used by adventurers to be given a reason to frag (sometimes even without escalation, which is a rules issue to be handled administratively). Frankly, with the way things are and how numerically stacked (and devoid of gameplay) keep-side can be. We need less `other parties` that can pitch the fight against antagonists.

Hiring through in-round means is cool and chill, though.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Remove Court Agent as a pickable role.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
