### PR TITLE
some bold text fixes

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -119,4 +119,4 @@
 
 GLOBAL_LIST_INIT(correct_punctuation, list("!" = TRUE, "." = TRUE, "?" = TRUE, "-" = TRUE, "~" = TRUE, \
 											"*" = TRUE, "/" = TRUE, ">" = TRUE, "'" = TRUE, "|" = TRUE, \
-											"," = TRUE, ":" = TRUE, ";" = TRUE, "\"" = TRUE))
+											"," = TRUE, ":" = TRUE, ";" = TRUE, "\"" = TRUE, "+" = TRUE))

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -130,6 +130,8 @@
 	if(copytext_char(message, 1, 2) == "+")
 		var/text = copytext(message, 2)
 		var/boldcheck = findtext_char(text, "+")	//Check for a *second* + in the text, implying the message is meant to have something formatted as bold (+text+)
+		if (boldcheck != 0)
+			return 0
 		whisper(copytext_char(message, boldcheck ? 1 : 2),sanitize = FALSE)//already sani'd
 		return 1
 


### PR DESCRIPTION
## About The Pull Request

beginning a message with bold text no longer forces it into a whisper (using just a single + will whisper like normal. use # or the whisper verb if you want to whisper boldly)

ending a text with bold text no longer forcibly appends a period resulting in weird double punctuation

## Testing Evidence

<img width="470" height="82" alt="image" src="https://github.com/user-attachments/assets/4811befd-ad88-417d-b0c3-2ac78df1471c" />

please TM this for at least a round first theres a very low but nonzero chance this might have hit something i forgot to test and with something as important as typing in our typing game i think its best to be safe

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
idk if it was up to me we'd remove the say verb entirely and turn azure into a tdm server but the girl kisser part of my brain says typing words is cool so maybe that should function correctly. i guess. rolls eyes
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: starting sentences with bold words no longer makes it a whisper
fix: ending sentences with bold words no longer adds an extra period
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
