### PR TITLE
wealth churn fix + buff(???)

### DIFF
--- a/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -303,22 +303,41 @@
 			explosion(get_turf(target), light_impact_range = 1, flame_range = 1, smoke = FALSE)
 			return
 		if(totalvalue >=1001) //THE POWER OF MY STAND: 'EXPLODE AND DIE INSTANTLY'
-			target.visible_message(span_danger("[target]'s skin begins to SLOUGH AND BURN HORRIFICALLY, glowing like molten metal!"), span_userdanger("MY BODY BURNS- AGONY!! MY HEART THRASHES IN MY CHEST..."))
-			user.say("Power corrupts! YOUR FINAL TRANSACTION!!")
-			target.Stun(60)
+			target.visible_message(span_danger("[target]'s skin begins to SLOUGH AND BURN HORRIFICALLY, glowing like molten metal!"), span_userdanger("MY LIMBS BURN IN AGONY..."))
+			user.say("Wealth beyond measure- YOUR FINAL TRANSACTION!!")
+			target.Stun(80)
 			target.emote("agony")
-			target.adjustFireLoss(140)
+			target.adjustFireLoss(50)
 			target.adjust_fire_stacks(9, /datum/status_effect/fire_handler/fire_stacks/divine)
 			target.ignite_mob()
 			playsound(user, 'sound/magic/churn.ogg', 100, TRUE)
 			explosion(get_turf(target), light_impact_range = 1, flame_range = 1, smoke = FALSE)
-			sleep(40)
-			target.visible_message(span_danger("[target] EXPLODES into coin and gem!"), span_userdanger("WEALTH. POWER. INTERCONNECTION. THE FINAL SIGHT UPON MYNE EYE IS A DRAGON'S MAW TEARING ME IN TWAIN. MY ENTRAILS ARE OF GOLD AND SILVER- AND I AM NEVERMORE."))
-			new /obj/item/roguecoin/silver/pile
-			new /obj/item/roguecoin/gold/pile
-			new /obj/item/roguegem/random
-			new /obj/item/roguegem/random
-			target.gib()
+			sleep(80)
+
+			target.visible_message(span_danger("[target]'s limbs REND into coin and gem!"), span_userdanger("WEALTH. POWER. THE FINAL SIGHT UPON MYNE EYE IS A DRAGON'S MAW TEARING ME IN TWAIN. MY ENTRAILS ARE OF GOLD AND SILVER."))
+			playsound(user, 'sound/magic/churn.ogg', 100, TRUE)
+			playsound(user, 'sound/magic/whiteflame.ogg', 100, TRUE)
+			explosion(get_turf(target), light_impact_range = 1, flame_range = 1, smoke = FALSE)
+			new /obj/item/roguecoin/silver/pile(target.loc)
+			new /obj/item/roguecoin/gold/pile(target.loc)
+			new /obj/item/roguegem/random(target.loc)
+			new /obj/item/roguegem/random(target.loc)
+
+			var/list/possible_limbs = list()
+			for(var/zone in list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
+				var/obj/item/bodypart/limb = target.get_bodypart(zone)
+				if(limb)
+					possible_limbs += limb
+				var/limbs_to_gib = min(rand(1, 4), possible_limbs.len)
+				for(var/i in 1 to limbs_to_gib)
+					var/obj/item/bodypart/selected_limb = pick(possible_limbs)
+					possible_limbs -= selected_limb
+					if(selected_limb?.drop_limb())
+						var/turf/limb_turf = get_turf(selected_limb) || get_turf(target) || target.drop_location()
+						if(limb_turf)
+							new /obj/effect/decal/cleanable/blood/gibs/limb(limb_turf)
+
+			target.death()
 			return
 
 


### PR DESCRIPTION
## About The Pull Request

churn wealth above 500 now properly scales dmg with cherry on top (previously it relied on explosion logic that has not worked for a long itme, see discord bug report)

also makes it so that if u have 1k+ u die and ur limbs fly off. i don't expect anyone to die to this honestly

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

things not working is bad

people exploding is funny

## Changelog

:cl:
fix: churn wealth dmg properly applied at max level, now kills and delimbs over 1k moni

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
