### PR TITLE
Freeze and flame enchants fix

### DIFF
--- a/code/datums/magic_items/mythical_items/mythic.dm
+++ b/code/datums/magic_items/mythical_items/mythic.dm
@@ -11,6 +11,8 @@
 	var/warned
 
 /datum/magic_item/mythic/infernalflame/on_hit(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
+	if(!proximity_flag)
+		return
 	if(world.time < src.last_used + INFERNAL_FLAME_COOLDOWN)
 		return
 	if(isliving(target))
@@ -68,6 +70,8 @@
 			src.last_used = world.time
 
 /datum/magic_item/mythic/freezing/on_hit(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
+	if(!proximity_flag)
+		return
 	if(world.time < src.last_used + FREEZING_COOLDOWN)
 		return
 	if(isliving(target))

--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -428,6 +428,9 @@ T1 Enchantments below here*/
 
 /obj/item/enchantmentscroll/infernalflame/attack_obj(obj/item/O, mob/living/user)
 	.=..()
+	if(findtext(O.name, "of freezing"))
+		to_chat(user, span_notice("[O] is already enchanted with freezing and cannot be enchanted with infernal flame!"))
+		return
 	if(istype(O,/obj/item/gun/ballistic/revolver/grenadelauncher)|| istype(O,/obj/item/rogueweapon)|| istype(O,/obj/item/clothing))	//bow and crossbows included
 		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
 		var/magiceffect= new component
@@ -445,6 +448,9 @@ T1 Enchantments below here*/
 
 /obj/item/enchantmentscroll/freeze/attack_obj(obj/item/O, mob/living/user)
 	.=..()
+	if(findtext(O.name, "of infernal flame"))
+		to_chat(user, span_notice("[O] is already enchanted with infernal flame and cannot be enchanted with freezing!"))
+		return
 	if(istype(O,/obj/item/gun/ballistic/revolver/grenadelauncher)||istype(O,/obj/item/clothing)|| istype(O,/obj/item/rogueweapon))//bow and crossbows included
 		to_chat(user, span_notice("You open [src] and place [O] within. Moments later, it flashes blue with arcana, and [src] crumbles to dust."))
 		var/magiceffect= new component


### PR DESCRIPTION
## About The Pull Request

You can no longer cast fire and frost enchantments on the same item. 
Also, they now only work on impact.

Before that, it was possible to enchant an object with both of these enchantments and, from a great distance, by clicking on the character, both freeze and set on fire, which is almost impossible to resist. It clearly shouldn't be like this.

In fact, I went to fix it, because wretch beat me when I was playing as a mercenary. He humiliated me and made me cry...

## Testing Evidence

<img width="553" height="41" alt="image" src="https://github.com/user-attachments/assets/1ceb55ef-9b08-4e3e-985b-54401195f103" />

## Why It's Good For The Game

It's always cool to have less cheating in the game.

![caption (1)](https://github.com/user-attachments/assets/e97313b7-b9b5-4b4f-af31-d4ec3b8ba443)

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: infernalflame and freeze enchantments cannot be combined on the same item. They only work on impact.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
