### PR TITLE
Allows Fated Statpack to pick Two Virtues

### DIFF
--- a/_statpacks.dm
+++ b/_statpacks.dm
@@ -7,6 +7,7 @@ GLOBAL_LIST_EMPTY(statpacks)
 	var/desc
 	/// An associative list of only the stats we're altering. The value can also be a list to signify a range of values - maximum length of 2 for these.
 	var/stat_array = list()
+	var/virtuous = FALSE
 
 /datum/statpack/proc/apply_to_human(mob/living/carbon/human/recipient)
 	if (recipient && recipient.mind)

--- a/code/game/objects/structures/fartravel.dm
+++ b/code/game/objects/structures/fartravel.dm
@@ -34,6 +34,7 @@
 		in_use = FALSE
 		return
 	in_use = FALSE
+	var/fated_leave = FALSE
 	update_icon()
 	var/dat = "[ADMIN_LOOKUPFLW(user)] has despawned [departing_mob == user ? "themselves" : departing_mob], job [departing_mob.job], at [AREACOORD(src)]. Contents despawned along:"
 	if(departing_mob.mind)
@@ -43,6 +44,9 @@
 			var/target_job = SSrole_class_handler.get_advclass_by_name(user.advjob)
 			if(target_job)
 				SSrole_class_handler.adjust_class_amount(target_job, -1)
+		if(departing_mob.statpack)
+			if(istype(departing_mob.statpack, /datum/statpack/wildcard/fated))
+				fated_leave = TRUE
 	if(!length(departing_mob.contents))
 		dat += " none."
 	else
@@ -60,6 +64,8 @@
 			if(removing_bounty.target == departing_mob.real_name)
 				GLOB.head_bounties -= removing_bounty
 	GLOB.chosen_names -= departing_mob.real_name
+	if(fated_leave)
+		dat += "<br><font color = '#bb2424'>Departing with Fated</font>"
 	LAZYREMOVE(GLOB.actors_list, departing_mob.mobid)
 	LAZYREMOVE(GLOB.roleplay_ads, departing_mob.mobid)
 	message_admins(dat)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -464,7 +464,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 				if(virtuetwo.type in pref_species.restricted_virtues)
 					virtuetwo = GLOB.virtues[/datum/virtue/none]
 			dat += "<b>Virtue:</b> <a href='?_src_=prefs;preference=virtue;task=input'>[virtue]</a><BR>"
-			if(statpack.name == "Virtuous")
+			if(statpack.virtuous)
 				dat += "<b>Second Virtue:</b> <a href='?_src_=prefs;preference=virtuetwo;task=input'>[virtuetwo]</a><BR>"
 			else
 				virtuetwo = GLOB.virtues[/datum/virtue/none]

--- a/statpacks/wildcard.dm
+++ b/statpacks/wildcard.dm
@@ -7,8 +7,9 @@
 
 /datum/statpack/wildcard/fated
 	name = "Fated"
-	desc = "The first or the last - let destiny's fickle loom decree what your fate shall be."
+	desc = "The first or the last - let destiny's fickle loom decree what your fate shall be. Allows for a second virtue."
 	stat_array = list(STAT_STRENGTH = list(-2, 2), STAT_PERCEPTION = list(-2, 2), STAT_INTELLIGENCE = list(-2, 2), STAT_CONSTITUTION = list(-2, 2), STAT_WILLPOWER = list(-2, 2), STAT_SPEED = list(-2, 2), STAT_FORTUNE = list(-2, 2))
+	virtuous = TRUE
 
 /datum/statpack/wildcard/frail
 	name = "Frail"
@@ -22,4 +23,5 @@
 /datum/statpack/wildcard/virtuous
 	name = "Virtuous"
 	desc = "The breadth of my being is one of many, distinguished talents. \n (Allows access to 'virtues', special traits/quirks that replace the bonus normally given by a statpack.)"
+	virtuous = TRUE
 


### PR DESCRIPTION
## About The Pull Request
This PR allows for any statpack to have the "Virtuous" property by moving it from a name check to just a variable on the statpack datum itself.

Also adds an additional red message for admins if someone with the Fated statpack far travels to help catch rerollers.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="179" height="152" alt="QAkGnasVID" src="https://github.com/user-attachments/assets/34170e1f-d11d-4536-b180-5e55f8aa5c59" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Considering how miss or miss or hit the statpack is (the rolls are not in the roller's favor), it seemed fun to throw it an extra bone.

Let's go gambling.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Fated statpack now allows for a selection of a second Virtue.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
