### PR TITLE
Gives Absolver a conversion spell

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
@@ -128,7 +128,7 @@
 		return FALSE
 	
 	if(target.cmode)
-		revert_cast
+		revert_cast()
 		return FALSE
 
 	if(istype(target.patron, /datum/patron/old_god))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -430,7 +430,7 @@
 		return FALSE
 	
 	if(target.cmode)
-		revert_cast
+		revert_cast()
 		return FALSE
 
 	//This SHOULD stop most heretics from being convertible and self-curing should they somehow get cursed in the future.

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -682,7 +682,7 @@ code\modules\admin\verbs\divinewrath.dm has a variant with all the gods so keep 
 		return FALSE
 
 	if(target.cmode)
-		revert_cast
+		revert_cast()
 		return FALSE
 
 	if(!HAS_TRAIT(target, TRAIT_HERESIARCH))


### PR DESCRIPTION
## About The Pull Request

Gives the Absolver a conversion spell to bring worshippers of the Ten and Four to the Orthodoxy. It is based off the priest spell with the following changes:

1. It just checks for if the target follows a god other than Psydon, rather than requiring them to have TRAIT_HERESIARCH (which honestly I don't like anyways but fixing it is out of the scope of this specific PR)
2. It just removes the target's previous devotion and does NOT give them any replacement Psydonite miracles (because they're not real miracles and the skills that helped you channel the power of a living god won't help you channel your own lux)
3. It doesn't inflict the revial debuff on both parties, as a balancing measure to the above

## Testing Evidence

<img width="447" height="46" alt="image" src="https://github.com/user-attachments/assets/f7d4a462-0b83-4a40-87f9-d9e7d586d437" />

I then direct controlled the converted person who was previously an Acolyte, checked that their spells were properly cleared out and their patron was set right

## Why It's Good For The Game

Currently if the Inquisition gets a heretic who wants to repent, they have to either simply RP it while they're still mechanically a follower of their old god (which has various mechanical implications for things like Unholy Blast) or they have to send them to the Tennite church for the Bishop to convert, which makes almost no sense. This gives them the opportunity to convert the people of Azuria (whether Tennite or Ascendant) to the church of Psydon, with the cost that the target loses all miracles they may have had.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Spell for Absolvers that converts people to Psydonism
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
