### PR TITLE
removes Repair Kit from Valuable Jewelry Spawner

### DIFF
--- a/code/game/objects/effects/spawners/clutter_spawner.dm
+++ b/code/game/objects/effects/spawners/clutter_spawner.dm
@@ -153,5 +153,4 @@
 		/obj/item/clothing/ring/statrontz = 2,
 		/obj/item/clothing/neck/roguetown/psicross/malum/secret = 1,
 		/obj/item/clothing/neck/roguetown/psicross/weeping = 1,
-		/obj/item/repair_kit/metal = 1,
 	) //'Stat_' and 'Psicross_' rings at '2' or below provide statbuffs, and should be kept rare. Move to a seperate drop table if they become too common. Likeliest find is from high-end dungeons and mimics.


### PR DESCRIPTION
## About The Pull Request

i dont know what culture you're from where a repair kit is considered jewelry

## Testing Evidence

compiles and starts

## Why It's Good For The Game

i think if my weeping cross roll got eaten by a collection of scrap metal i would become actively homicidal. also its just not what that spawner is for

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: removes repair kit from valuable jewelry spawner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
