### PR TITLE
Ups WW claw AP + potentially lets there be 2 roundstart WW

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -177,7 +177,7 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "chop"
 	hitsound = "genslash"
-	penfactor = 50
+	penfactor = 60
 	candodge = TRUE
 	canparry = TRUE
 	miss_text = "slashes the air!"
@@ -191,7 +191,7 @@
 	icon_state = "insmash"
 	maxrange = 5
 	chargetime = 1
-	penfactor = 50
+	penfactor = 60
 
 
 /obj/item/rogueweapon/werewolf_claw

--- a/code/modules/events/antagonist/solo/werewolf.dm
+++ b/code/modules/events/antagonist/solo/werewolf.dm
@@ -9,9 +9,9 @@
 	antag_flag = ROLE_WEREWOLF
 	shared_occurence_type = SHARED_HIGH_THREAT
 
-	denominator = 80
+	denominator = 50
 
-	base_antags = 1
+	base_antags = 2
 	maximum_antags = 2
 	min_players = 25
 	weight = 7


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. WW AP is up to 60 again.
And this one might be a bit detrimental to spawning WW (can revert if it breaks things unintentionally) - but the game will try to put in 2 roundstart WWs.

## Testing Evidence

Couldn't test the spawning.

## Why It's Good For The Game

Making WWs more of a factor.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: WW Claws are now 60 AP.
balance: The game will try to put in 2 roundstart WWs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
