### PR TITLE
Fix Vampire Lord thrall limit initialization

### DIFF
--- a/code/modules/vampire_neu/vampire.dm
+++ b/code/modules/vampire_neu/vampire.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	var/datum/clan/forcing_clan
 	var/generation
 	var/research_points = 10
-	var/max_thralls = 0
+	var/max_thralls = 1
 	var/thrall_count = 0
 
 /datum/antagonist/vampire/New(incoming_clan = /datum/clan/nosferatu, forced_clan = FALSE, generation)
@@ -74,13 +74,14 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	//move_to_spawnpoint()
 	owner.special_role = name
 	owner.current.adjust_bloodpool()
+	max_thralls = initial(max_thralls)
 	if(ishuman(owner.current))
 		var/mob/living/carbon/human/vampdude = owner.current
 		vampdude.hud_used?.shutdown_bloodpool()
 		vampdude.hud_used?.initialize_bloodpool()
 		vampdude.hud_used?.bloodpool.set_fill_color("#510000")
 
-		switch(generation) 
+		switch(generation)
 			if(GENERATION_METHUSELAH)
 				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 6, TRUE)
 			if(GENERATION_ANCILLAE)
@@ -102,15 +103,10 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 			else
 				// Apply the selected clan
 				vampdude.set_clan(default_clan)
-			max_thralls = 1
 		else
 			vampdude.set_clan_direct(forcing_clan)
 			forcing_clan = null
 
-		if(vampdude.job == "Wretch")
-			max_thralls = 1
-		if(vampdude.mind.special_role == "Vampire Lord")
-			max_thralls = 0
 
 	// The clan system now handles most of the setup, but we can still do antagonist-specific things
 	after_gain()

--- a/code/modules/vampire_neu/vampirelord.dm
+++ b/code/modules/vampire_neu/vampirelord.dm
@@ -15,6 +15,7 @@
 	)
 	show_in_roundend = TRUE
 	var/ascended = FALSE
+	max_thralls = 0
 
 /datum/antagonist/vampire/lord/get_antag_cap_weight()
 	return 3
@@ -40,7 +41,7 @@
 		H.change_stat(S, 2)
 	H.forceMove(pick(GLOB.vlord_starts))
 	ADD_TRAIT(H, TRAIT_DUSTABLE, TRAIT_GENERIC) //They are ancient and have a great risk. Maybe add a quest to reclaim their power?
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC) //Brute-forced method to ensure that Vampire Lords, no matter what, receive their most important traits. 
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC) //Brute-forced method to ensure that Vampire Lords, no matter what, receive their most important traits.
 	ADD_TRAIT(H, TRAIT_INFINITE_ENERGY, TRAIT_GENERIC) //Playing it safe, with the assumption that Vampire Lords already inherit any traits given to regular Vampires.
 	ADD_TRAIT(H, TRAIT_STRENGTH_UNCAPPED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_BITERHELM, TRAIT_GENERIC)
@@ -54,9 +55,9 @@
 
 /datum/outfit/job/vamplord/pre_equip(mob/living/carbon/human/H)
 	..()
-	H.adjust_skillrank_up_to(/datum/skill/magic/blood, 6, TRUE) 
+	H.adjust_skillrank_up_to(/datum/skill/magic/blood, 6, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE) //Reduced from Legendary-tier, as Halford's new Blood Magic system compensates a lot for this.
-	H.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE) //Equalized all combat skills to be Master-tier, otherwise, 
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE) //Equalized all combat skills to be Master-tier, otherwise,
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 5, TRUE)


### PR DESCRIPTION
Fix Vampire Lord thrall limit being overwritten during initialization by restoring subtype-defined defaults via initial(max_thralls)

## About The Pull Request

- Fixed an issue where Vampire Lord thrall limits were overwritten during initialization
- Restored role-defined defaults using `initial(max_thralls)`

## Testing Evidence

- Spawned regular vampire: thrall limit set to 1
- Spawned Vampire Lord (Methuselah): thrall limit set to 0 (unlimited)
- Vampire who adjusted to Methuselah (By admin) has 0 limit

## Why It's Good For The Game

- Allows safe extension of vampire subtypes
- Fixes incorrect Vampire Lord behavior

## Changelog

:cl:
fix: Vampire Lords no longer initialize with an incorrect thrall limit
code: Restored subtype-defined thrall limits during vampire initialization
refactor: Removed hardcoded thrall limit overrides
/:cl:
