### PR TITLE
Mage Armor PR #3: The Compromise Version

### DIFF
--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -241,9 +241,10 @@
 		if(user.m_intent == MOVE_INTENT_RUN)
 			to_chat(user, span_warning("I can't focus on this while running."))
 			return
-		if(user.magearmor == FALSE && HAS_TRAIT(user, TRAIT_MAGEARMOR))	//The magearmor is ACTIVE, so we can't Guard. (Yes, it's active while FALSE / 0.)
-			to_chat(user, span_warning("I'm already focusing on my mage armor!"))
-			return
+		if(user.magearmor == 0 && HAS_TRAIT(user, TRAIT_MAGEARMOR))	//The magearmor is ACTIVE, so we break magearmor to guard.
+			user.magearmor = 1
+			user.apply_status_effect(/datum/status_effect/buff/magearmor)
+			to_chat(user, span_warning("I drop my Mage Armor to protect myself!"))
 		user.apply_status_effect(/datum/status_effect/buff/clash)
 
 /datum/rmb_intent/guard


### PR DESCRIPTION
## About The Pull Request
Alright gamers, I've solved the issue. I have SAVED Azure Peak in a way that may appeal to the MAGE HATER FREE!!!!

Real talk, this PR looks to solve the issue of Mage Armor being more of a hinderance than a boon, but instead of giving them STACKING DEFENSES, I've come up with an ALTERNATIVE. As it currently stands if you pop your mage armor you are able to use defensive moves, so why not just make activating the defensive move DROP mage armor if it's up? A compromise that ensures that mages don't get DOUBLE DEFENCE while also being about to engage in some more interesting and skill-based combat.

Some things to note to the naysayers, with some testing, let it be known:
Even if you are Guarding, you don't get a free cast. Because how spell charging works the hit is ALWAYS GARENTEED, and will bypass the guard. No Guarding to charge meteor swarm and basically getting a free cast, you will still get hit.

Another fun fact, I think that explains why Mage Armor FEELS broken, Mage Armor isn't proc'd if you are in the process of charging a spell. The Mage armor itself isn't broken, it's just intentional "If you are casting something with a charge, you better ensure you aren't in range of a Melee or you are still a guaranteed hit"

Anyways, long spiel done. Mage Armor now automatically dissipates if you attempt to use a RMB defense and have Mage Armor up. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Booted it up on my machine and it works.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Allows mages to participate in more skill-based combat.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Mages are now able to use RMB Defense intents, however if mage armor is up it will be dropped and put on it's cooldown as if you were struck with it up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
