### PR TITLE
SCOMM Machines Show Own Message

### DIFF
--- a/code/modules/clothing/rogueclothes/crown.dm
+++ b/code/modules/clothing/rogueclothes/crown.dm
@@ -52,6 +52,7 @@
 				S.repeat_message(input_text, src, usedcolor)
 			for(var/obj/item/listenstone/S in SSroguemachine.scomm_machines)
 				S.repeat_message(input_text, src, usedcolor)
+			SSroguemachine.crown?.repeat_message(input_text, src, usedcolor)
 
 			GLOB.broadcast_list += list(list(
 			"message"   = input_text,
@@ -68,6 +69,7 @@
 			for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
 				if(S.garrisonline)
 					S.repeat_message(input_text, src, usedcolor)
+			SSroguemachine.crown?.repeat_message(input_text, src, usedcolor)
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/attack_self(mob/living/user)
 	if(.)
@@ -94,8 +96,6 @@
 	update_icon()
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/proc/repeat_message(message, atom/A, tcolor, message_language)
-	if(A == src)
-		return
 	if(!ismob(loc))
 		return
 	if(tcolor)

--- a/code/modules/roguetown/roguemachine/scomm/emerald_choker.dm
+++ b/code/modules/roguetown/roguemachine/scomm/emerald_choker.dm
@@ -52,8 +52,6 @@
 
 
 /obj/item/listenstone/proc/repeat_message(message, atom/A, tcolor, message_language)
-	if(A == src)
-		return
 	if(tcolor)
 		voicecolor_override = tcolor
 	if(speaking && message)

--- a/code/modules/roguetown/roguemachine/scomm/rontzring.dm
+++ b/code/modules/roguetown/roguemachine/scomm/rontzring.dm
@@ -72,8 +72,6 @@
 	return ..()
 
 /obj/item/mattcoin/proc/repeat_message(message, atom/A, tcolor, message_language)
-	if(A == src)
-		return
 	if(!ismob(loc))
 		return
 	if(tcolor)

--- a/code/modules/roguetown/roguemachine/scomm/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm/scomm.dm
@@ -1,5 +1,5 @@
 #define NORMAL_SCOM_TRANSMISSION_DELAY 15 SECONDS
-#define NORMAL_SCOM_PER_MESSAGE_DELAY 15 SECONDS 
+#define NORMAL_SCOM_PER_MESSAGE_DELAY 15 SECONDS
 #define CHEESE_QUIET_TIME 2 MINUTES // How long stuffing a slice of cheese in quieten the SCOM
 
 /obj/structure/roguemachine/scomm
@@ -22,7 +22,7 @@
 	var/scom_tag
 	var/obj/structure/roguemachine/scomm/calling = null
 	var/obj/structure/roguemachine/scomm/called_by = null
-	/// Last time the SCOM sent a message. Used to check delay  
+	/// Last time the SCOM sent a message. Used to check delay
 	var/last_message = 0
 	/// Whether this is a receive only SCOM, that cannot transmit any messages. Uses this for any kind of SCOM that is out of town and is not actionable
 	var/receive_only = FALSE
@@ -303,9 +303,7 @@
 	animate(pixel_x = oldx, time = 0.5)
 
 /obj/structure/roguemachine/scomm/proc/repeat_message(message, atom/A, tcolor, message_language, list/tspans, broadcaster_tag)
-	if(A == src)
-		return
-	// The SCOM just do not work silently if cheesed 
+	// The SCOM just do not work silently if cheesed
 	if(last_cheese && (last_cheese + CHEESE_QUIET_TIME >= world.time))
 		return
 	if(tcolor)
@@ -369,7 +367,7 @@
 		else
 			addtimer(CALLBACK(src, PROC_REF(repeat_message_scom), raw_message, usedcolor, message_language), NORMAL_SCOM_TRANSMISSION_DELAY)
 
-// Repeat message for normal SCOM. Meant to be used in a callback with delay 
+// Repeat message for normal SCOM. Meant to be used in a callback with delay
 /obj/structure/roguemachine/scomm/proc/repeat_message_scom(raw_message, usedcolor, message_language)
 	for(var/obj/structure/roguemachine/scomm/S in SSroguemachine.scomm_machines)
 		if(!S.calling)

--- a/code/modules/roguetown/roguemachine/scomm/scomstone.dm
+++ b/code/modules/roguetown/roguemachine/scomm/scomstone.dm
@@ -100,8 +100,6 @@
 		. += "Its designation is #[scomstone_number]."
 
 /obj/item/scomstone/proc/repeat_message(message, atom/A, tcolor, message_language)
-	if(A == src)
-		return
 	if(!ismob(loc))
 		return
 	if(tcolor)
@@ -155,7 +153,7 @@
 		return
 	if(!get_location_accessible(user, BODY_ZONE_PRECISE_MOUTH, grabs = TRUE))
 		to_chat(user, span_warning("My mouth is covered!"))
-		return 
+		return
 	visible_message(span_notice ("[user] presses their ring against their mouth."))
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(!input_text)
@@ -188,7 +186,7 @@
 		S.repeat_message(input_text, src, usedcolor)
 	SSroguemachine.crown?.repeat_message(input_text, src, usedcolor)
 	on_cooldown = TRUE
-	
+
 	//Log messages that aren't sent on the garrison line.
 	GLOB.broadcast_list += list(list(
 	"message"   = input_text,

--- a/code/modules/roguetown/roguemachine/scomm/whisperer.dm
+++ b/code/modules/roguetown/roguemachine/scomm/whisperer.dm
@@ -20,8 +20,6 @@
 	var/fakename = "secret whisperer"
 
 /obj/item/speakerinq/proc/repeat_message(message, atom/A, tcolor, message_language)
-	if(A == src)
-		return
 	if(!ismob(loc))
 		return
 	if(tcolor)
@@ -51,9 +49,9 @@
 	. = ..()
 	switch(slot)
 		if(SLOT_RING)
-			fakename = "silver signet ring"	
+			fakename = "silver signet ring"
 			name = fakename
-	return TRUE		
+	return TRUE
 
 
 /obj/item/speakerinq/dropped(mob/user, silent)


### PR DESCRIPTION
## About The Pull Request

- SCOMM Machines, such as the Crownstone or the Crown itself will now show you your own message when sent.

## Testing Evidence

<img width="452" height="155" alt="image" src="https://github.com/user-attachments/assets/3f1a6df5-dbad-4d6b-b6ee-facea1111c8c" />

<img width="452" height="89" alt="image" src="https://github.com/user-attachments/assets/8db45f29-3638-4296-9296-43c747750657" />

## Why It's Good For The Game

I find that not showing your own message was really confusing, like it was broken for some reason.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: SCOMM Machines, such as the Crownstone or the Crown itself will now show you your own message when sent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
