### PR TITLE
bugfix/tweak: no more rituos speedruns/spellpoint stacking

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1843,6 +1843,7 @@
 	. = ..()
 	to_chat(owner, span_warning("I fall back to the ground."))
 	owner.movement_type = GROUND
+
 /datum/status_effect/buff/ravox_vow
 	id = "ravox_vow"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/ravox_vow
@@ -1896,7 +1897,7 @@
 	if(target.fire_stacks >= 3)
 		return
 
-	target.adjust_fire_stacks(1)
+	target.adjust_fire_stacks(1, /datum/status_effect/fire_handler/fire_stacks/divine)
 	INVOKE_ASYNC(target, TYPE_PROC_REF(/mob/living, ignite_mob))
 
 /datum/status_effect/buff/ravox_vow/on_remove()

--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -124,6 +124,12 @@
 	movement_interrupt = TRUE
 	recharge_time = 2 MINUTES
 	var/list/excluded_bodyparts = list(/obj/item/bodypart/head)
+	var/list/to_skeletonize = list(
+		/obj/item/bodypart/l_arm::name = BODY_ZONE_L_ARM, 
+		/obj/item/bodypart/r_arm::name = BODY_ZONE_R_ARM,
+		/obj/item/bodypart/l_leg::name = BODY_ZONE_L_LEG,
+		/obj/item/bodypart/r_leg::name = BODY_ZONE_R_LEG,
+		)
 	hide_charge_effect = TRUE
 
 /obj/effect/proc_holder/spell/invoked/rituos/miracle
@@ -131,59 +137,25 @@
 	devotion_cost = 120
 	associated_skill = /datum/skill/magic/holy
 
-/obj/effect/proc_holder/spell/invoked/rituos/proc/check_ritual_progress(mob/living/carbon/user)
-	var/rituos_complete = TRUE
-	for (var/obj/item/bodypart/our_limb in user.bodyparts)
-		if (our_limb.type in excluded_bodyparts)
-			continue
-		if (!our_limb.skeletonized)
-			rituos_complete = FALSE
-
-	return rituos_complete
-
-/obj/effect/proc_holder/spell/invoked/rituos/proc/get_skeletonized_bodyparts(mob/living/carbon/user)
-	var/skeletonized_parts = list()
-	for (var/obj/item/bodypart/our_limb in user.bodyparts)
-		if (our_limb.type in excluded_bodyparts)
-			continue
-		if (our_limb.skeletonized)
-			skeletonized_parts += our_limb.type
-
-	return skeletonized_parts
-
 /obj/effect/proc_holder/spell/invoked/rituos/cast(list/targets, mob/living/carbon/user)
-	//check to see if we're all skeletonized first
-	var/pre_rituos = check_ritual_progress(user)
-	if (pre_rituos)
-		to_chat(user, span_notice("I have completed Her Lesser Work. Only lichdom awaits me now, but just out of reach..."))
-		return FALSE
+	if(!LAZYLEN(to_skeletonize) && tgui_alert(user, "Restore skeleton bodyparts?", "FINISHED RITUOS", list("Nae", "Yae")) == "Yae")
+		skeletonize_bodyparts(user)
+		return TRUE
 
-	if (user.mind?.has_rituos)
+	if(user.mind?.has_rituos)
 		to_chat(user, span_warning("I have not the mental fortitude to enact the Lesser Work again. I must rest first..."))
 		return FALSE
 
-	//hoo boy. here we go.
-	var/list/possible_parts = user.bodyparts.Copy()
-	var/list/skeletonized_parts = get_skeletonized_bodyparts(user)
-
-	for(var/obj/item/bodypart/BP in possible_parts)
-		for(var/bodypart_type in excluded_bodyparts)
-			if(istype(BP, bodypart_type))
-				possible_parts -= BP
-				break
-		for(var/skeleton_part in skeletonized_parts)
-			if (istype(BP, skeleton_part))
-				possible_parts -= BP
-				break
-
-	var/obj/item/bodypart/the_part = pick(possible_parts)
-	var/obj/item/bodypart/part_to_bonify = user.get_bodypart(the_part.body_zone)
+	var/bodypart_choice = tgui_input_list(user, "Which bodypart will be sacrificed?", "SACRIFICE", to_skeletonize)
+	
+	if(!bodypart_choice)
+		return FALSE
 
 	var/list/choices = list()
 	var/list/spell_choices = GLOB.learnable_spells
 	for(var/i = 1, i <= spell_choices.len, i++)
 		var/obj/effect/proc_holder/spell/spell_item = spell_choices[i]
-		if(spell_item.spell_tier > 3) // Hardcap Rituos choice to T3 to avoid Court Mage spells access
+		if(spell_item.spell_tier > 3)
 			continue
 		choices["[spell_item.name]"] = spell_item
 
@@ -199,38 +171,58 @@
 		user.visible_message(span_warning("The pallor of the grave descends across [user]'s skin in a wave of arcyne energy..."), span_boldwarning("A deathly chill overtakes my body at my first culmination of the Lesser Work! I feel my heart slow down in my chest..."))
 		user.mob_biotypes |= MOB_UNDEAD
 		to_chat(user, span_smallred("I have forsaken the living. I am now closer to a deadite than a mortal... but I still yet draw breath and bleed."))
+	
+	var/obj/item/bodypart/part = user.get_bodypart(to_skeletonize[bodypart_choice])
 
-	part_to_bonify.skeletonize(FALSE)
-	user.update_body_parts()
-	user.visible_message(span_warning("Faint runes flare beneath [user]'s skin before [user.p_their()] flesh suddenly slides away from [user.p_their()] [part_to_bonify.name]!"), span_notice("I feel arcyne power surge throughout my frail mortal form, as the Rituos takes its terrible price from my [part_to_bonify.name]."))
+	if(part)
+		part.skeletonize(FALSE)
+		user.update_body_parts()
+		user.visible_message(span_warning("Faint runes flare beneath [user]'s skin before [user.p_their()] flesh suddenly slides away from [user.p_their()] [part.name]!"), span_notice("I feel arcyne power surge throughout my frail mortal form, as the Rituos takes its terrible price from my [part.name]."))
 
-	if (user.mind?.rituos_spell)
+	if(user.mind?.rituos_spell)
 		to_chat(user, span_warning("My knowledge of [user.mind.rituos_spell.name] flees..."))
 		user.mind.RemoveSpell(user.mind.rituos_spell)
 		user.mind.rituos_spell = null
 
 	user.mind.has_rituos = TRUE
+	to_skeletonize -= bodypart_choice
 
-	var/post_rituos = check_ritual_progress(user)
-	if (post_rituos)
-		//everything but our head is skeletonized now, so grant them journeyman rank and 3 extra spellpoints to grief people with
-		user.adjust_skillrank(/datum/skill/magic/arcane, 3, TRUE)
-		user.grant_language(/datum/language/undead)
-		user.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-		user.mind?.adjust_spellpoints(18)
-		user.visible_message(span_boldwarning("[user]'s form swells with terrible power as they cast away almost all of the remnants of their mortal flesh, arcyne runes glowing upon their exposed bones..."), span_notice("I HAVE DONE IT! I HAVE COMPLETED HER LESSER WORK! I stand at the cusp of unspeakable power, but something is yet missing..."))
-		ADD_TRAIT(user, TRAIT_NOHUNGER, "[type]")
-		ADD_TRAIT(user, TRAIT_NOBREATH, "[type]")
-		ADD_TRAIT(user, TRAIT_ARCYNE_T3, "[type]")
-		if (prob(33))
-			to_chat(user, span_small("...what have I done?"))
+	if(!LAZYLEN(to_skeletonize))
+		finalize(user)
 		return TRUE
-	else
-		to_chat(user, span_notice("The Lesser Work of Rituos floods my mind with stolen arcyne knowledge: I can now cast [item.name] until I next rest..."))
-		user.mind.rituos_spell = item
-		user.mind.AddSpell(new item)
-		return TRUE
+	
+	to_chat(user, span_notice("The Lesser Work of Rituos floods my mind with stolen arcyne knowledge: I can now cast [item.name] until I next rest..."))
+	user.mind.rituos_spell = item
+	user.mind.AddSpell(new item)
 
+	return TRUE
+
+/obj/effect/proc_holder/spell/invoked/rituos/proc/finalize(mob/living/carbon/human/user)
+	var/obj/item/bodypart/torso = user.get_bodypart(BODY_ZONE_CHEST)
+	torso?.skeletonize(FALSE)
+	user.update_body_parts()
+
+	user.adjust_skillrank(/datum/skill/magic/arcane, 3, TRUE)
+	user.grant_language(/datum/language/undead)
+	user.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+	user.mind?.adjust_spellpoints(18)
+	user.visible_message(span_boldwarning("[user]'s form swells with terrible power as they cast away almost all of the remnants of their mortal flesh, arcyne runes glowing upon their exposed bones..."), span_notice("I HAVE DONE IT! I HAVE COMPLETED HER LESSER WORK! I stand at the cusp of unspeakable power, but something is yet missing..."))
+
+	ADD_TRAIT(user, TRAIT_NOHUNGER, "[type]")
+	ADD_TRAIT(user, TRAIT_NOBREATH, "[type]")
+	ADD_TRAIT(user, TRAIT_ARCYNE_T3, "[type]")
+
+	if(prob(33))
+		to_chat(user, span_small("...what have I done?"))
+
+/obj/effect/proc_holder/spell/invoked/rituos/proc/skeletonize_bodyparts(mob/living/carbon/human/user)
+	for(var/obj/item/bodypart/part as anything in user.bodyparts)
+		if(part.type in excluded_bodyparts)
+			continue
+
+		part.skeletonize(FALSE)
+
+	user.update_body_parts()
 
 /obj/effect/proc_holder/spell/self/zizo_snuff
 	name = "Snuff Lights"


### PR DESCRIPTION
## About The Pull Request
bugfixes:
Rituos can no longer be speedrunned by becoming a nugget or sewing on skeletal limbs.
Once Rituos is complete, spell points can no longer be stacked by sewing on a normal limb and using Rituos again.
ravox's vow ignition uses divine fire stack handler to avoid setting the attacker on fire

tweaks/additions:
Now it takes only 4 days instead of 5 to complete rituos
When Rituos is finished and you somehow lost your cool limbs, its activation will prompt to reskeletonize limbs (head is obviously excluded, does not restore lost limbs)

## Testing Evidence
(chest is not on the list; it skeletonizes upon rituos completion) 
<img width="317" height="315" alt="Zrzut ekranu 2025-12-31 155033" src="https://github.com/user-attachments/assets/edd2806b-777d-45d1-a70a-40f80127269e" />

selected limb is properly skeletonized
<img width="1755" height="912" alt="Zrzut ekranu 2025-12-31 155047" src="https://github.com/user-attachments/assets/ddd5a2f8-c8da-4d91-aa4b-4bd3a4b5f43d" />

ascension works
<img width="1759" height="910" alt="Zrzut ekranu 2025-12-31 162220" src="https://github.com/user-attachments/assets/0427cd5c-df98-449e-be50-a15aec11db2b" />

## Why It's Good For The Game
bugfixes + small boons

## Changelog
:cl:
fix: fixed rituos spellpoints stacking/speedrunning
/:cl:
