### PR TITLE
Direbear wildshape buff

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/wildshape/direbear.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/direbear.dm
@@ -20,6 +20,7 @@
 		STAWIL = 13
 		STAPER = 8
 		STASPD = 6
+		STAINT = 8
 
 		AddSpell(new /obj/effect/proc_holder/spell/self/bearclaws)
 		real_name = "direbear"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
-This pr are buffed direbear form of druid
## Testing Evidence
-not need
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
-Ye, i know, what direbear was too power on scarlet, but how they debuffed him - its very bad. Form need to be different. Spider have good per, good spd and dodge expert (80-90 to dodge). Than Bear must have resists for pain and must be predisposed to fight face-to-face. I debuffed PER for this. And ye - 6 spd..
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: rebalanced direbear form
+Crit resist
+No pain stun
Defense of claws now 6 (was 2)
Penetration is 40 (was 10)
Force 25 (was 20)
CON now 14 (was 12)
WIL now 13 (was 12)
PER now 8 (was 10)
INT now 8 (was 10)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
