### PR TITLE
Easy Keep Colours

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -83,9 +83,9 @@
 		symbol_chosen = TRUE
 	var/list/colors_to_pick = list()
 	if(GLOB.lordprimary)
-		colors_to_pick["Keep Color Primary"] = GLOB.lordprimary
+		colors_to_pick["Primary Keep Color"] = GLOB.lordprimary
 	if(GLOB.lordsecondary)
-		colors_to_pick["Keep Color Secondary"] = GLOB.lordsecondary
+		colors_to_pick["Secondary Keep Color"] = GLOB.lordsecondary
 	var/list/color_map_list = COLOR_MAP
 	colors_to_pick += color_map_list.Copy()
 	var/colorone = input(user, "Select a primary color.","Tabard Design") as null|anything in colors_to_pick

--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -65,9 +65,9 @@ var/list/used_colors
 
 	var/list/colors_to_pick = list()
 	if(GLOB.lordprimary)
-		colors_to_pick["Keep Color Primary"] = GLOB.lordprimary
+		colors_to_pick["Primary Keep Color"] = GLOB.lordprimary
 	if(GLOB.lordsecondary)
-		colors_to_pick["Keep Color Secondary"] = GLOB.lordsecondary
+		colors_to_pick["Secondary Keep Color"] = GLOB.lordsecondary
 	colors_to_pick += used_colors.Copy()
 	var/picked = input(user, "Choose your dye:", "Dyes", null) as null|anything in colors_to_pick
 	if(!picked)


### PR DESCRIPTION
## About The Pull Request

- You can now select the keep colours when using a dye station or when choosing tabard heraldry.
- Using the dye station will now automatically update the UI.

## Testing Evidence

trust

## Why It's Good For The Game

color matching is a PITA

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: You can now select the keep colours when using a dye station or when choosing tabard heraldry.
fix: Using the dye station will now automatically update the UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
