### PR TITLE
Removes kneestinger ambushes

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -45,7 +45,6 @@
 		if(L.electrocute_act(electrodam, src))
 			L.mob_timers["kneestinger"] = world.time
 			src.take_damage(30)
-			L.consider_ambush(always = TRUE)
 			if(L.throwing)
 				L.throwing.finalize(FALSE)
 			if(mover.loc != loc && L.stat == CONSCIOUS)
@@ -81,7 +80,6 @@
 		victim.mob_timers["kneestinger"] = world.time
 		victim.emote("painscream")
 		victim.update_sneak_invis(TRUE)
-		victim.consider_ambush(always = TRUE)
 		if(victim.throwing)
 			victim.throwing.finalize(FALSE)
 		return TRUE
@@ -104,7 +102,6 @@
 			var/mob/living/L = user
 			if(L.electrocute_act(30, src)) // The kneestingers will let you pass if you worship dendor, but they won't take your stupid ass hitting them.
 				L.emote("painscream")
-				L.consider_ambush(always = TRUE)
 				if(L.throwing)
 					L.throwing.finalize(FALSE)
 				return FALSE


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin. Essentially restoring the changes of https://github.com/Azure-Peak/Azure-Peak/pull/3834, which seems to have been accidentally reverted by https://github.com/Azure-Peak/Azure-Peak/pull/5000.

## Testing Evidence

It compiles!

## Why It's Good For The Game

One should revert accidental reverts. Kneestinger ambushes are also excessively punishing.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Kneestingers no longer prompt ambushes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
