### PR TITLE
Class Refactor: Old Modifiers

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -63,6 +63,9 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		REMOVE_TRAIT(H, TRAIT_EASYDISMEMBER, null) // Doesn't care for source, they ARE getting canceled
 		REMOVE_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, null)
 		to_chat(H, span_warning("My limbs are too frail and my body too tough... the contradiction leaves me unable to resist critical wounds."))
+
+	if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician" && H.mind.assigned_role != "Inquisitor"))
+		ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	return TRUE
 
 /proc/apply_prefs_virtue(mob/living/carbon/human/character, client/player)

--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -64,8 +64,6 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		REMOVE_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, null)
 		to_chat(H, span_warning("My limbs are too frail and my body too tough... the contradiction leaves me unable to resist critical wounds."))
 
-	if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician" && H.mind.assigned_role != "Inquisitor"))
-		ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	return TRUE
 
 /proc/apply_prefs_virtue(mob/living/carbon/human/character, client/player)

--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -63,7 +63,6 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		REMOVE_TRAIT(H, TRAIT_EASYDISMEMBER, null) // Doesn't care for source, they ARE getting canceled
 		REMOVE_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, null)
 		to_chat(H, span_warning("My limbs are too frail and my body too tough... the contradiction leaves me unable to resist critical wounds."))
-
 	return TRUE
 
 /proc/apply_prefs_virtue(mob/living/carbon/human/character, client/player)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -566,7 +566,11 @@
 				dat += "</td></tr></table>"//Skill table end
 				if(adv_ref.extra_context)
 					dat += "<font color ='#a06c1e'>[adv_ref.extra_context]"
-					dat += "</font>"
+					dat += "<br></font>"
+				
+				if(istype(adv_ref.age_mod))
+					dat += adv_ref.age_mod.get_preview_string()
+
 				dat += "</details>"
 		dat += "<hr>"
 		if(length(job_stats))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -53,6 +53,14 @@
 	/// Set to FALSE to skip apply_character_post_equipment() which applies virtue, flaw, loadout
 	var/applies_post_equipment = TRUE
 
+	var/datum/class_age_mod/age_mod = null
+
+/datum/advclass/New()
+	if(ispath(age_mod) && !istype(age_mod))
+		var/datum/class_age_mod/newmod = new age_mod()
+		age_mod = newmod
+	. = ..()
+
 /datum/advclass/proc/equipme(mob/living/carbon/human/H, dummy = FALSE)
 	// input sleeps....
 	set waitfor = FALSE
@@ -98,6 +106,10 @@
 	if(length(subclass_skills))
 		for(var/skill in subclass_skills)
 			H.adjust_skillrank_up_to(skill, subclass_skills[skill], TRUE)
+
+	if(age_mod)
+		if(istype(age_mod))
+			age_mod.apply_age_mod(H)
 
 	if(length(subclass_stashed_items))
 		if(!H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_classagemods.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_classagemods.dm
@@ -1,0 +1,391 @@
+/datum/class_age_mod
+	var/target_age = null
+	var/list/stat_mods = list()
+	var/list/skill_mods = list()
+	var/sp_mod = 0
+
+/datum/class_age_mod/proc/apply_age_mod(mob/living/carbon/human/H)
+	if(H.age == target_age)
+		if(length(stat_mods))
+			for(var/stat in stat_mods)
+				H.change_stat(stat_mods[stat])
+		if(length(skill_mods))
+			for(var/S in skill_mods)
+				var/datum/skill/skill = S
+				H.adjust_skillrank_up_to(skill, skill_mods[S], TRUE)
+		if(sp_mod)
+			H.mind?.adjust_spellpoints(sp_mod)
+
+/datum/class_age_mod/proc/get_preview_string()
+	if(!target_age)
+		return null
+	var/str = ""
+	str += "<font color ='#7a4d0a'>If the Character is <font color ='#b3d6df'>[target_age]</font>, they will get these additional bonuses:</font>"
+	if(length(stat_mods))
+		for(var/stat in stat_mods)
+			str += "<br>[capitalize(stat)]: <b>[stat_mods[stat] < 0 ? "<font color = '#cf2a2a'>" : "<font color = '#91cf68'>"]\Roman[stat_mods[stat]]</font></b>"
+		str += "<font color ='#7a4d0a'><br>-----</font>"
+	if(length(skill_mods))
+		for(var/S in skill_mods)
+			var/datum/skill/skill = S
+			str += "<br><font color ='#ad9152'>[initial(skill.name)] — [SSskills.level_names[skill_mods[S]]]</font>"
+		str += "<br><font color ='#7a4d0a'>-----</font>"
+	if(sp_mod)
+		str += "<br><font color = '#4b4f7c'>Additional Spellpoints: <b>[sp_mod]</b></font>"
+
+	return str
+
+/*
+********* MODS BEGIN HERE **********
+*/
+
+//--- BANDITS ---
+
+/datum/class_age_mod/bandit/rogue_mage
+	target_age = AGE_OLD
+	stat_mods = list(
+		STATKEY_INT = 1,
+		STATKEY_PER = 1
+	)
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER
+	)
+	sp_mod = 6
+
+/datum/class_age_mod/bandit/sawbones
+	target_age = AGE_OLD
+	stat_mods = list(
+		STATKEY_SPD = -1,
+		STATKEY_INT = 1,
+		STATKEY_PER = 1,
+	)
+
+//--- WRETCHES ---
+
+/datum/class_age_mod/wretch/hedge_mage
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER
+	)
+	sp_mod = 6 
+
+// --- VETERAN ---
+/datum/class_age_mod/veteran
+	target_age = AGE_OLD	//Saving ourselves the redundancy
+
+/datum/class_age_mod/veteran/battlemaster
+	skill_mods = list(
+		/datum/skill/combat/swords = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/maces = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_MASTER,
+	)
+	stat_mods = list(
+		STATKEY_WIL = 1
+	)
+
+/datum/class_age_mod/veteran/footman
+	skill_mods = list(
+		/datum/skill/combat/shields = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/polearms = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/swords = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/maces = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/axes = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_MASTER
+	)
+
+/datum/class_age_mod/veteran/cavalryman
+	// You get a lot of weapon skills, but none are legendary. Jack of all trades, master of none. 
+	// This is probably worse than just having legendary in one, as people rarely swap weapons mid-combat.
+	skill_mods = list(
+		/datum/skill/combat/swords = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/bows = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/crossbows = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/maces = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/axes = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/polearms = SKILL_LEVEL_MASTER,
+	)
+
+/datum/class_age_mod/veteran/mercenary
+	skill_mods = list(
+		/datum/skill/combat/axes = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN
+	)
+
+/datum/class_age_mod/veteran/scout
+	skill_mods = list(
+		/datum/skill/combat/bows = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/axes = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/misc/tracking = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/swords = SKILL_LEVEL_MASTER,
+	)
+
+/datum/class_age_mod/veteran/spy
+	// Having Master Knives is extremely negligible for a singular role that isn't even meant to be combative.
+	skill_mods = list(
+		/datum/skill/misc/sneaking = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/knives = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/bows = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/climbing = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/stealing = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT
+	)
+	stat_mods = list(
+		STATKEY_SPD = 1	// You get -2 speed from being old. You are still in the negative stat wise from picking old.
+	)
+//--- THE REST ---
+
+/datum/class_age_mod/grand_duke
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/combat/swords = SKILL_LEVEL_MASTER
+	)
+
+/datum/class_age_mod/hand_blademaster
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/combat/swords = SKILL_LEVEL_MASTER
+	)
+	stat_mods = list(
+		STATKEY_LCK = 2
+	)
+
+/datum/class_age_mod/hand_advisor
+	target_age = AGE_OLD
+	stat_mods = list(
+		STATKEY_PER = 1,
+		STATKEY_INT = 1,
+		STATKEY_STR = -1,
+		STATKEY_SPD = -1,
+	)
+	sp_mod = 3
+
+/datum/class_age_mod/hand_spymaster
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/misc/sneaking = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/misc/stealing = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/misc/lockpicking = SKILL_LEVEL_LEGENDARY
+	)
+
+/datum/class_age_mod/war_scholar
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER
+	)
+	stat_mods = list(
+		STATKEY_PER = 1,
+		STATKEY_INT = 1,
+		STATKEY_SPD = -1
+	)
+	sp_mod = 6
+
+/datum/class_age_mod/apprentice_associate
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT
+	)
+	stat_mods = list(
+		STATKEY_INT = 1,
+		STATKEY_SPD = -1
+	)
+	sp_mod = 6
+
+/datum/class_age_mod/apprentice_apprentice
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN
+	)
+	stat_mods = list(
+		STATKEY_INT = 1,
+		STATKEY_SPD = -1
+	)
+	sp_mod = 3
+
+/datum/class_age_mod/apprentice_alchemist
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/alchemy = SKILL_LEVEL_MASTER
+	)
+	stat_mods = list(
+		STATKEY_INT = 1,
+		STATKEY_PER = -1
+	)
+
+/datum/class_age_mod/grenzel_mage
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_MASTER
+	)
+	stat_mods = list(
+		STATKEY_PER = 2,
+		STATKEY_INT = 2,
+		STATKEY_SPD = -1,
+		STATKEY_STR = -1,
+		STATKEY_CON = -2
+	)
+	sp_mod = 3
+
+/datum/class_age_mod/adv_mage
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT
+	)
+	sp_mod = 6
+
+/datum/class_age_mod/exorcist
+	target_age = AGE_OLD
+	stat_mods = list(
+		STATKEY_INT = 1,
+		STATKEY_CON = -2,
+	)
+	skill_mods = list(
+		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/maces = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/staves = SKILL_LEVEL_EXPERT
+	)
+
+/datum/class_age_mod/barber_surgeon
+	target_age = AGE_OLD
+	stat_mods = list(
+		STATKEY_INT = 1,
+		STATKEY_PER = 1,
+		STATKEY_SPD = -1
+	)
+
+/datum/class_age_mod/fisher
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/labor/fishing = SKILL_LEVEL_MASTER
+	)
+
+/datum/class_age_mod/witch
+	target_age = AGE_OLD
+	stat_mods = list(
+		STATKEY_LCK = 1,
+		STATKEY_INT= 1,
+		STATKEY_SPD = -1
+	)
+
+/datum/class_age_mod/druid
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/holy = SKILL_LEVEL_MASTER,
+		/datum/skill/magic/druidic = SKILL_LEVEL_MASTER
+	)
+
+/datum/class_age_mod/acolyte
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/holy = SKILL_LEVEL_MASTER,
+	)
+
+/datum/class_age_mod/priest
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/holy = SKILL_LEVEL_LEGENDARY,
+	)
+
+/datum/class_age_mod/seneschal
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/cooking = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
+		/datum/skill/labor/farming = SKILL_LEVEL_JOURNEYMAN,
+	)
+
+/datum/class_age_mod/servant
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/cooking = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/labor/farming = SKILL_LEVEL_JOURNEYMAN,
+	)
+
+/datum/class_age_mod/cook
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/cooking = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
+		/datum/skill/labor/farming = SKILL_LEVEL_JOURNEYMAN,
+	)
+
+/datum/class_age_mod/tapster
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/cooking = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
+	)
+
+/datum/class_age_mod/soilson
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/labor/farming = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/labor/butchering = SKILL_LEVEL_LEGENDARY
+	)
+
+/datum/class_age_mod/cuisiner
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/cooking = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
+	)
+
+/datum/class_age_mod/archivist
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN
+	)
+	stat_mods = list(
+		STATKEY_INT = 1,
+		STATKEY_SPD = -1
+	)
+	sp_mod = 3
+
+/datum/class_age_mod/innkeeper
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/cooking = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/misc/music = SKILL_LEVEL_EXPERT
+	)
+
+/datum/class_age_mod/guildmaster
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/blacksmithing = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/craft/armorsmithing = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/craft/smelting = SKILL_LEVEL_MASTER,
+		/datum/skill/craft/sewing = SKILL_LEVEL_JOURNEYMAN, // Worse than the real tailor, so can't steal their job right away
+		/datum/skill/craft/tanning = SKILL_LEVEL_JOURNEYMAN
+	)
+
+/datum/class_age_mod/court_magician
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/magic/arcane = SKILL_LEVEL_LEGENDARY
+	)
+	stat_mods = list(
+		STATKEY_PER = 1,
+		STATKEY_INT = 1,
+		STATKEY_SPD = -1
+	)
+	sp_mod = 6
+
+/datum/class_age_mod/court_physician
+	target_age = AGE_OLD
+	skill_mods = list(
+		/datum/skill/craft/alchemy = SKILL_LEVEL_LEGENDARY
+	)
+	stat_mods = list(
+		STATKEY_PER = 1,
+		STATKEY_INT = 1,
+		STATKEY_SPD = -1
+	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
@@ -16,6 +16,7 @@
 		STATKEY_SPD = 1,
 		STATKEY_CON = 1,
 	)
+	age_mod = /datum/class_age_mod/bandit/rogue_mage
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
@@ -66,10 +67,6 @@
 	if(H.age == AGE_OLD)
 		head = /obj/item/clothing/head/roguetown/wizhat/gen
 		armor = /obj/item/clothing/suit/roguetown/shirt/robe
-		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_MASTER, TRUE)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_PER, 1)
-		H.mind?.adjust_spellpoints(6)
 
 	if(!istype(H.patron, /datum/patron/inhumen/matthios))
 		var/inputty = input(H, "Would you like to change your patron to Matthios?", "The Transactor calls", "No") as anything in list("Yes", "No")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -12,6 +12,7 @@
 		STATKEY_SPD = 3,
 		STATKEY_LCK = 3
 	)
+	age_mod = /datum/class_age_mod/bandit/sawbones
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
@@ -49,10 +50,6 @@
 					/obj/item/flashlight/flare/torch = 1,
 					/obj/item/bedroll = 1,
 					)
-	if(H.age == AGE_OLD)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_PER, 1)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -12,6 +12,7 @@
 		STATKEY_PER = 2,
 		STATKEY_SPD = 1,
 	)
+	age_mod = /datum/class_age_mod/adv_mage
 	subclass_spellpoints = 14
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
@@ -67,9 +68,6 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/recipe_book/magic = 1,
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_EXPERT, TRUE)
-		H.mind?.adjust_spellpoints(6)
 	H.cmode_music = 'sound/music/cmode/adventurer/combat_outlander4.ogg'
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -407,6 +407,9 @@
 		STATKEY_PER = 2,
 		STATKEY_WIL = 1,
 	) //Follows the Adventurer's seven-point statblock rule. Adds an eighth point to an unoccupied statkey, when a discipline is selected.
+
+	age_mod = /datum/class_age_mod/exorcist
+
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
@@ -565,14 +568,6 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/rogueweapon/huntingknife = 1, //Ensures that Exorcists who take the Shovel can still butcher wildlife. Minor oversight on my part.
 		)
-	if(H.age == AGE_OLD)
-		H.change_stat(STATKEY_INT, 1)
-		H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE) 	
-		H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/staves, 1, TRUE)
 	//Old people get the option to become glass cannons. Expert Knives + Expert in their chosen weapon, but a permenant -I STR, -I PER, -2 SPD and -2 CON debuff.
 
 /datum/advclass/sfighter/deprived

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/barbersurgeon.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/barbersurgeon.dm
@@ -12,6 +12,9 @@
 		STATKEY_LCK = 1,
 		STATKEY_PER = 1
 	)
+
+	age_mod = /datum/class_age_mod/barber_surgeon
+
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
@@ -51,10 +54,6 @@
 						/obj/item/folding_alchcauldron_stored = 1,
 						/obj/item/recipe_book/alchemy = 1
 						)
-	if(H.age == AGE_OLD)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_PER, 1)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/fisher.dm
@@ -12,7 +12,9 @@
 		STATKEY_LCK = 2,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/fisher
 	subclass_skills = list(
+		/datum/skill/labor/fishing = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/swords = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/axes = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_NOVICE,
@@ -38,10 +40,6 @@
 
 /datum/outfit/job/roguetown/adventurer/fisher/pre_equip(mob/living/carbon/human/H)
 	..()
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/labor/fishing, SKILL_LEVEL_MASTER, TRUE)
-	else
-		H.adjust_skillrank_up_to(/datum/skill/labor/fishing, SKILL_LEVEL_EXPERT, TRUE)
 	if(H.pronouns == HE_HIM || H.pronouns == THEY_THEM || H.pronouns == IT_ITS)
 		pants = /obj/item/clothing/under/roguetown/tights/random
 		shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/random

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -11,6 +11,7 @@
 		STATKEY_SPD = 2,
 		STATKEY_LCK = 1
 	)
+	age_mod = /datum/class_age_mod/witch
 	subclass_spellpoints = 6
 	subclass_skills = list(
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
@@ -54,10 +55,6 @@
 		armor = /obj/item/clothing/suit/roguetown/armor/corset
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut
 		pants = /obj/item/clothing/under/roguetown/skirt/red
-	if(H.age == AGE_OLD)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_LCK, 1)
 
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/hedgemage.dm
@@ -16,6 +16,7 @@
 		STATKEY_SPD = 1
 	)
 	subclass_spellpoints = 27 // Unlike Rogue Mage, who gets 6 but DExpert, this one don't have DExpert but have more spell points than anyone but the CM. 
+	age_mod = /datum/class_age_mod/wretch/hedge_mage
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
@@ -57,8 +58,5 @@
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 	)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_MASTER, TRUE)
-		H.mind?.adjust_spellpoints(6)
 	if(H.mind)
 		wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -14,6 +14,7 @@
 		STATKEY_WIL = 1,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/wretch/hedge_mage
 	subclass_spellpoints = 12
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
@@ -52,9 +53,6 @@
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_MASTER, TRUE)
-		H.mind?.adjust_spellpoints(6)
 	if(H.mind)
 		H.mind?.current.faction += "[H.name]_faction"
 		H.set_patron(/datum/patron/inhumen/zizo)

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -43,6 +43,7 @@
 		STATKEY_SPD = 1,
 		STATKEY_PER = -1
 	)
+	age_mod = /datum/class_age_mod/druid
 	subclass_skills = list(
 		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/tanning = SKILL_LEVEL_NOVICE,
@@ -86,9 +87,6 @@
 	wrists = /obj/item/clothing/neck/roguetown/psicross/dendor
 	shirt = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
 	backpack_contents = list(/obj/item/ritechalk, /obj/item/storage/keyring/churchie)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/holy, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/magic/druidic, 5, TRUE)
 	H.ambushable = FALSE
 	H.AddComponent(/datum/component/wise_tree_alert)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -37,6 +37,7 @@
 		STATKEY_WIL = 2,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/acolyte
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
@@ -166,8 +167,6 @@
 
 /datum/outfit/job/roguetown/monk/basic/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 	// -- Start of section for god specific bonuses --
 	if(H.patron?.type == /datum/patron/divine/undivided)
 		H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -101,8 +101,6 @@ GLOBAL_LIST_EMPTY(heretical_players)
 		/obj/item/clothing/neck/roguetown/psicross/undivided = 1
 	)
 	H.AddComponent(/datum/component/wise_tree_alert)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/holy, 6, TRUE)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron) // This creates the cleric holder used for devotion spells
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.
 

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -55,14 +55,6 @@
 /datum/outfit/job/roguetown/seneschal
 	has_loadout = TRUE
 
-//This applies to all Seneschal subclasses
-/datum/outfit/job/roguetown/seneschal/choose_loadout(mob/living/carbon/human/H)
-	. = ..()
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-
 /datum/outfit/job/roguetown/seneschal/seneschal/pre_equip(mob/living/carbon/human/H)
 	..()
 	pants = /obj/item/clothing/under/roguetown/tights

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -37,6 +37,7 @@
 		STATKEY_LCK = 1, // Usual leadership carrot.
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/seneschal
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
@@ -61,11 +62,6 @@
 		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 
 /datum/outfit/job/roguetown/seneschal/seneschal/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -47,6 +47,7 @@
 		STATKEY_STR = -1,
 		STATKEY_CON = -1,
 	)
+	age_mod = /datum/class_age_mod/court_magician
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
@@ -73,11 +74,6 @@
 /datum/outfit/job/roguetown/magician/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
 	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 6, TRUE)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_PER, 1)
-		H.mind?.adjust_spellpoints(6)
 		if(ishumannorthern(H))
 			belt = /obj/item/storage/belt/rogue/leather/plaquegold
 			cloak = null

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -44,6 +44,7 @@
 		STATKEY_STR = -1,
 		STATKEY_CON = -1,
 	)
+	age_mod = /datum/class_age_mod/court_physician
 	subclass_skills = list(
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN, //same tier as other yeomen
@@ -91,10 +92,5 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 	if(H.age == AGE_MIDDLEAGED)
 		H.adjust_skillrank_up_to(/datum/skill/craft/sewing, 4, TRUE)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 6, TRUE) //small carrot to play old
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_PER, 1)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Savings.")

--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -90,7 +90,5 @@
 	)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank_up_to(/datum/skill/craft/sewing, 4, TRUE)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Savings.")

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -62,6 +62,7 @@
 		STATKEY_CON = 1,
 		STATKEY_PER = 1
 	)
+	age_mod = /datum/class_age_mod/veteran/battlemaster
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_MASTER,
 		/datum/skill/combat/maces = SKILL_LEVEL_MASTER,
@@ -107,11 +108,6 @@
 
 /datum/outfit/job/roguetown/vet/battlemaster/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/combat/swords, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/maces, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
-		H.change_stat(STATKEY_WIL, 1)
 
 	H.adjust_blindness(-3)
 	if(H.mind)
@@ -179,6 +175,7 @@
 		STATKEY_PER = 1,
 		STATKEY_WIL = 1
 	)
+	age_mod = /datum/class_age_mod/veteran/footman
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/maces = SKILL_LEVEL_EXPERT,
@@ -223,13 +220,6 @@
 		/obj/item/rope/chain = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/combat/shields, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/maces, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 	H.verbs |= /mob/proc/haltyell
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Retirement.")
@@ -290,6 +280,7 @@
 		STATKEY_INT = 1,
 		STATKEY_SPD = -1
 	)
+	age_mod = /datum/class_age_mod/veteran/cavalryman
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
@@ -330,14 +321,6 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/storage/keyring/guardcastle = 1
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/combat/bows, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/maces, 5, TRUE) // You get a lot of weapon skills, but none are legendary. Jack of all trades, master of none. This is probably worse than just having legendary in one, as people rarely swap weapons mid-combat.
-		H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 5, TRUE)
 	H.verbs |= /mob/proc/haltyell
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Retirement.")
@@ -418,6 +401,7 @@
 		STATKEY_INT = 1,
 		STATKEY_SPD = -1
 	)
+	age_mod = /datum/class_age_mod/veteran/mercenary
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/maces = SKILL_LEVEL_EXPERT,
@@ -466,10 +450,6 @@
 
 /datum/outfit/job/roguetown/vet/merc/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE) // two handed weapons require a LOT of stamina.
-
 	H.adjust_blindness(-3)
 	if(H.mind)
 		var/weapons = list("Zweihander","Halberd")
@@ -538,6 +518,7 @@
 		STATKEY_SPD = 1,// You get -2 speed from being old.
 		STATKEY_STR = -1
 	)
+	age_mod = /datum/class_age_mod/veteran/scout
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
@@ -581,11 +562,6 @@
 		/obj/item/storage/keyring/guardcastle = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/combat/bows, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/axes, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/misc/tracking, 6, TRUE)
 	H.verbs |= /mob/proc/haltyell
 	H.cmode_music = 'sound/music/cmode/antag/combat_deadlyshadows.ogg' // so apparently this works for veteran, but not for advents. i dont know why.
 	if(H.mind)
@@ -647,6 +623,7 @@
 		STATKEY_SPD = 1,
 		STATKEY_STR = -2
 	)
+	age_mod = /datum/class_age_mod/veteran/spy
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
@@ -693,15 +670,6 @@
 		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1,
 		/obj/item/lockpickring/mundane,
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/combat/knives, 5, TRUE) ///Having Master Knives is extremely negligible for a singular role that isn't even meant to be combative.
-		H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/bows, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/misc/climbing, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/misc/stealing, 5, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 6, TRUE)
-		H.change_stat(STATKEY_SPD, 1) // You get -2 speed from being old. You are still in the negative stat wise from picking old.
 	H.verbs |= /mob/proc/haltyell
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Retirement.")

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -211,6 +211,8 @@
 		STATKEY_PER = 3,
 		STATKEY_SPD = 1
 	)
+	extra_context = "This class gains T3 spells at Old age."
+	age_mod = /datum/class_age_mod/grenzel_mage
 	subclass_skills = list(
 		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
@@ -264,13 +266,6 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/counterspell)
 		H.mind?.adjust_spellpoints(3)
 	if(H.age == AGE_OLD) // FEAR the old man in a profession where men die young, or something corny like that.
-		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 5, TRUE)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_STR, -1)
-		H.change_stat(STATKEY_CON, -2)
-		H.change_stat(STATKEY_PER, 2)
-		H.change_stat(STATKEY_INT, 2)
-		H.mind?.adjust_spellpoints(3)
 		ADD_TRAIT(H, TRAIT_ARCYNE_T3, TRAIT_GENERIC)
 	else
 		ADD_TRAIT(H, TRAIT_ARCYNE_T2, TRAIT_GENERIC) // Only T2 arcyne (Unless they're old) so if they get spell points from something they can only pick from the curated spellblade list

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -16,6 +16,7 @@
 		STATKEY_PER = 1,
 		STATKEY_CON = -1
 	)
+	age_mod = /datum/class_age_mod/war_scholar
 	subclass_spellpoints = 15
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
@@ -54,12 +55,6 @@
 		"BLACK" = "#242526"
 	))
 	to_chat(H, span_warning("You are a Naledi Hierophant, a magician who studied under cloistered sages, well-versed in all manners of arcyne. You prioritize enhancing your teammates and distracting foes while staying in the backline."))
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 5, TRUE)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_PER, 1)
-		H.mind?.adjust_spellpoints(6)
 	if(H.mind)
 		detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 		detailcolor = naledicolors[detailcolor]

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -59,6 +59,7 @@
 		STATKEY_STR = 2,
 		STATKEY_LCK = 1,
 	)
+	age_mod = /datum/class_age_mod/hand_blademaster
 	subclass_skills = list(
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
@@ -90,9 +91,6 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/storage/keyring/hand = 1,
 	)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
-		H.change_stat(STATKEY_LCK, 2)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Savings.")
 
@@ -113,6 +111,7 @@
 		STATKEY_INT = 2,
 		STATKEY_STR = -1,
 	)
+	age_mod = /datum/class_age_mod/hand_spymaster
 	subclass_skills = list(
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/bows = SKILL_LEVEL_EXPERT,
@@ -150,10 +149,6 @@
 		backr = /obj/item/storage/backpack/rogue/satchel/black
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/hand
 		pants = /obj/item/clothing/under/roguetown/tights/black
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/misc/stealing, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/misc/lockpicking, 6, TRUE)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Savings.")
 
@@ -171,6 +166,7 @@
 		STATKEY_WIL = 2,
 		STATKEY_LCK = 2,
 	)
+	age_mod = /datum/class_age_mod/hand_advisor
 	subclass_spellpoints = 15
 	subclass_skills = list(
 		/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
@@ -208,12 +204,6 @@
 		/obj/item/lockpickring/mundane = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1,//starts with a vial of poison, like all wizened evil advisors do!
 	)
-	if(H.age == AGE_OLD)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_STR, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.change_stat(STATKEY_PER, 1)
-		H.mind?.adjust_spellpoints(3)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_RICH, H, "Savings.")
 

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -123,6 +123,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		STATKEY_SPD = 1,
 		STATKEY_STR = 1,
 	)
+	age_mod = /datum/class_age_mod/grand_duke
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
@@ -141,8 +142,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
 
 /**
 	Merchant Lord subclass. Consider this an evolution from Sheltered Aristocrat.

--- a/code/modules/jobs/job_types/roguetown/peasants/cook.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/cook.dm
@@ -36,6 +36,7 @@
 		STATKEY_STR = 1,
 		STATKEY_INT = 1
 	)
+	age_mod = /datum/class_age_mod/cook
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
@@ -76,9 +77,5 @@
 	. = ..()
 	if(H.age == AGE_MIDDLEAGED)
 		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/peasants/cook.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/cook.dm
@@ -72,10 +72,3 @@
 	)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
-
-/datum/outfit/job/roguetown/cook/choose_loadout(mob/living/carbon/human/H)
-	. = ..()
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
@@ -77,9 +77,3 @@
 	)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
-
-/datum/outfit/job/roguetown/knavewench/choose_loadout(mob/living/carbon/human/H)
-	. = ..()
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
@@ -38,6 +38,7 @@
 		STATKEY_INT = 1,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/tapster
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
@@ -80,8 +81,5 @@
 /datum/outfit/job/roguetown/knavewench/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
 	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-	if(H.age == AGE_OLD)
 		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -41,6 +41,7 @@
 		STATKEY_CON = 1,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/soilson
 	subclass_skills = list(
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
@@ -76,10 +77,6 @@
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/flint = 1,
 		)
-	if(H.age == AGE_OLD)//So ppl have reason to pick this I guess?
-		H.adjust_skillrank_up_to(/datum/skill/labor/farming, 6, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/labor/butchering, 6, TRUE)
-
 	if(should_wear_femme_clothes(H))
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 		shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/random

--- a/code/modules/jobs/job_types/roguetown/roguetown.dm
+++ b/code/modules/jobs/job_types/roguetown/roguetown.dm
@@ -94,7 +94,7 @@
 		if(H.mind.assigned_role == "Wretch" && !H.mind.has_antag_datum(/datum/antagonist/wretch))
 			H.mind.add_antag_datum(/datum/antagonist/wretch)
 
-		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer"))
+		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer"))
 			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	for(var/list_key in SStriumphs.post_equip_calls)
 		var/datum/triumph_buy/thing = SStriumphs.post_equip_calls[list_key]

--- a/code/modules/jobs/job_types/roguetown/roguetown.dm
+++ b/code/modules/jobs/job_types/roguetown/roguetown.dm
@@ -94,7 +94,7 @@
 		if(H.mind.assigned_role == "Wretch" && !H.mind.has_antag_datum(/datum/antagonist/wretch))
 			H.mind.add_antag_datum(/datum/antagonist/wretch)
 
-		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer"))
+		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && !H.mind.has_antag_datum(/datum/antagonist/werewolf) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician"))
 			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	for(var/list_key in SStriumphs.post_equip_calls)
 		var/datum/triumph_buy/thing = SStriumphs.post_equip_calls[list_key]

--- a/code/modules/jobs/job_types/roguetown/roguetown.dm
+++ b/code/modules/jobs/job_types/roguetown/roguetown.dm
@@ -94,8 +94,6 @@
 		if(H.mind.assigned_role == "Wretch" && !H.mind.has_antag_datum(/datum/antagonist/wretch))
 			H.mind.add_antag_datum(/datum/antagonist/wretch)
 
-		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician" && H.mind.assigned_role != "Inquisitor"))
-			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	for(var/list_key in SStriumphs.post_equip_calls)
 		var/datum/triumph_buy/thing = SStriumphs.post_equip_calls[list_key]
 		thing.on_activate(H)

--- a/code/modules/jobs/job_types/roguetown/roguetown.dm
+++ b/code/modules/jobs/job_types/roguetown/roguetown.dm
@@ -94,7 +94,7 @@
 		if(H.mind.assigned_role == "Wretch" && !H.mind.has_antag_datum(/datum/antagonist/wretch))
 			H.mind.add_antag_datum(/datum/antagonist/wretch)
 
-		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && !H.mind.has_antag_datum(/datum/antagonist/werewolf) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician"))
+		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician"))
 			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	for(var/list_key in SStriumphs.post_equip_calls)
 		var/datum/triumph_buy/thing = SStriumphs.post_equip_calls[list_key]

--- a/code/modules/jobs/job_types/roguetown/roguetown.dm
+++ b/code/modules/jobs/job_types/roguetown/roguetown.dm
@@ -94,7 +94,7 @@
 		if(H.mind.assigned_role == "Wretch" && !H.mind.has_antag_datum(/datum/antagonist/wretch))
 			H.mind.add_antag_datum(/datum/antagonist/wretch)
 
-		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician"))
+		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && !H.mind.has_antag_datum(/datum/antagonist/skeleton) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer" && H.mind.assigned_role != "Prince" && H.mind.assigned_role != "Court Magician" && H.mind.assigned_role != "Inquisitor"))
 			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	for(var/list_key in SStriumphs.post_equip_calls)
 		var/datum/triumph_buy/thing = SStriumphs.post_equip_calls[list_key]

--- a/code/modules/jobs/job_types/roguetown/roguetown.dm
+++ b/code/modules/jobs/job_types/roguetown/roguetown.dm
@@ -93,6 +93,9 @@
 		// Ensure Wretches are granted their antagonist datum at post-equip
 		if(H.mind.assigned_role == "Wretch" && !H.mind.has_antag_datum(/datum/antagonist/wretch))
 			H.mind.add_antag_datum(/datum/antagonist/wretch)
+
+		if(!H.mind.has_antag_datum(/datum/antagonist/vampire) && (H.mind.assigned_role != "Knight Captain" && H.mind.assigned_role != "Court Agent" && H.mind.assigned_role != "Adventurer"))
+			ADD_TRAIT(H, TRAIT_TEMPO, SPECIES_TRAIT)
 	for(var/list_key in SStriumphs.post_equip_calls)
 		var/datum/triumph_buy/thing = SStriumphs.post_equip_calls[list_key]
 		thing.on_activate(H)

--- a/code/modules/jobs/job_types/roguetown/trader/cuisiner.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/cuisiner.dm
@@ -12,6 +12,7 @@
 		STATKEY_CON = 1,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/cuisiner
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
@@ -29,12 +30,6 @@
 	..()
 	to_chat(H, span_warning("Whether a disciple of a culinary school, a storied royal chef, or a mercenary cook for hire, your trade is plied at the counter, \
 	the cutting board, and the hearth."))
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank_up_to(/datum/skill/craft/cooking, SKILL_LEVEL_MASTER, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/craft/cooking, SKILL_LEVEL_LEGENDARY, TRUE)
-		H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
 	head = /obj/item/clothing/head/roguetown/chef
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	neck = /obj/item/storage/belt/rogue/pouch/coins/poor

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -62,6 +62,7 @@
 		STATKEY_CON = -1,
 		STATKEY_STR = -1
 	)
+	age_mod = /datum/class_age_mod/archivist
 	subclass_spellpoints = 12
 	subclass_skills = list(
 		/datum/skill/misc/reading = SKILL_LEVEL_LEGENDARY,
@@ -109,8 +110,5 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/takeapprentice)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/learn)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/silence/archivist_silence)
-	if(H.age == AGE_OLD)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_UPPER_CLASS, H, "Savings.")

--- a/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
@@ -38,6 +38,7 @@
 		STATKEY_INT = 1,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/innkeeper
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
@@ -60,9 +61,6 @@
 	H.adjust_blindness(-3)
 	if(H.age == AGE_MIDDLEAGED)
 		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/music, 1, TRUE)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/music, 1, TRUE)
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots

--- a/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
@@ -59,9 +59,6 @@
 /datum/outfit/job/roguetown/barkeep/basic/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_blindness(-3)
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/music, 1, TRUE)
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	backr = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/jobs/job_types/roguetown/yeomen/crier.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/crier.dm
@@ -52,6 +52,7 @@
 		STATKEY_INT = 3,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/archivist
 	subclass_skills = list(
 		/datum/skill/misc/reading = SKILL_LEVEL_LEGENDARY,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
@@ -85,9 +86,6 @@
 	)
 	if (H && H.mind)
 		H.mind.adjust_spellpoints(6)
-	if(H.age == AGE_OLD)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_UPPER_CLASS, H, "Savings.")
 

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -45,6 +45,7 @@
 		STATKEY_WIL = 2,
 		STATKEY_INT = 1
 	)
+	age_mod = /datum/class_age_mod/guildmaster
 	subclass_skills = list(
 		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
@@ -101,13 +102,6 @@
 
 /datum/outfit/job/roguetown/guildmaster/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/blacksmithing, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/smelting, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/sewing, 1, TRUE) // Worse than the real tailor, so can't steal their job right away
-		H.adjust_skillrank(/datum/skill/craft/tanning, 1, TRUE)
 
 /mob/living/carbon/human/proc/guild_announcement()
 	set name = "Announcement"

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
@@ -43,6 +43,7 @@
 		STATKEY_CON = 2,
 		STATKEY_INT = 1
 	)
+	age_mod = /datum/class_age_mod/guildmaster
 	subclass_skills = list(
 		/datum/skill/combat/axes = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
@@ -63,11 +64,6 @@
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith
 	if(prob(50))
 		head = /obj/item/clothing/head/roguetown/hatblu
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/blacksmithing, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/armorsmithing, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/weaponsmithing, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/craft/smelting, 1, TRUE)
 	if(should_wear_femme_clothes(H))
 		pants = /obj/item/clothing/under/roguetown/trou
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -51,6 +51,7 @@
 		STATKEY_PER = 2,
 		STATKEY_SPD = 1
 	)
+	age_mod = /datum/class_age_mod/apprentice_associate
 	subclass_spellpoints = 21
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
@@ -79,11 +80,6 @@
 		/obj/item/recipe_book/magic = 1,
 		/obj/item/chalk = 1,
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.mind?.adjust_spellpoints(6)
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'
@@ -102,6 +98,7 @@
 		STATKEY_PER = 3,
 		STATKEY_WIL = 1
 	)
+	age_mod = /datum/class_age_mod/apprentice_alchemist
 	subclass_spellpoints = 18
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
@@ -131,10 +128,6 @@
 		/obj/item/chalk = 1,
 		/obj/item/spellbook_unfinished/pre_arcyne = 1
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE)
-		H.change_stat(STATKEY_PER, -1)
-		H.change_stat(STATKEY_INT, 1)
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'
@@ -153,6 +146,7 @@
 		STATKEY_SPD = 1,
 		STATKEY_LCK = 1 // this is just a carrot for the folk who are mad enough to take this role...
 	)
+	age_mod = /datum/class_age_mod/apprentice_apprentice
 	subclass_spellpoints = 18
 	subclass_skills = list(
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
@@ -171,12 +165,6 @@
 		/obj/item/spellbook_unfinished/pre_arcyne = 1,
 		/obj/item/chalk = 1,
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.mind?.adjust_spellpoints(3)
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -67,10 +67,6 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	armor = /obj/item/clothing/suit/roguetown/armor/workervest
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_WORKING_CLASS, H, "Savings.")
 
@@ -108,10 +104,6 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltr = /obj/item/storage/keyring/servant
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_WORKING_CLASS, H, "Savings.")
 
@@ -149,9 +141,5 @@
 	beltr = /obj/item/storage/keyring/servant
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
-	if(H.age == AGE_MIDDLEAGED)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_WORKING_CLASS, H, "Savings.")

--- a/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/servant.dm
@@ -30,6 +30,7 @@
 
 /datum/advclass/servant
 	traits_applied = list(TRAIT_CICERONE, TRAIT_ROYALSERVANT)
+	age_mod = /datum/class_age_mod/servant
 
 /datum/advclass/servant/servant
 	name = "Servant"
@@ -70,11 +71,6 @@
 		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_WORKING_CLASS, H, "Savings.")
 
@@ -116,11 +112,6 @@
 		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_WORKING_CLASS, H, "Savings.")
 
@@ -162,10 +153,5 @@
 		H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/cooking, 2, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/knives, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_WORKING_CLASS, H, "Savings.")

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1702,6 +1702,7 @@
 #include "code\modules\jobs\job_types\roguetown\adventurer\villager.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\wretch.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\_advclass.dm"
+#include "code\modules\jobs\job_types\roguetown\adventurer\types\_classagemods.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\antag\brigand.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\antag\demolisher.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\antag\hedgeknight.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a new datum called `/datum/class_age_modifier` and basically offloaded all of our unique class-specific age modifiers to there and added that datum as part of the advclasses.

Currently it contains:
- Bonus stats
- Bonus skills
- Bonus spellpoints

As those were the most common. There was one (1) case of an additional trait being added to Old people, but I didn't think it was worth implementing just for that one class.

Pros:
It can show up in the class preview, now, and pre_equip() of outfits is -almost- entirely clean of anything that isn't just the outfit.
<img width="391" height="206" alt="PqCwStqW82" src="https://github.com/user-attachments/assets/bc4630e8-f903-4dca-8a14-fcd29b7e5b33" />

<img width="391" height="224" alt="4yPPPPziAY" src="https://github.com/user-attachments/assets/eece4f90-8ff6-4ecc-b19c-4efbebcdd8f1" />

Cons:
Some very specific functionality has been lost. Mostly Exorcist only gaining Expert in their chosen weapon if they're Old. They sorta get it in every weapon now, so I slapped an extra -2 CON on them to compensate. That's the only balance change in this PR. All else is meant to work same as before.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Cleaned up class datums. Players can actually see what being Old gives them.

The code also supports these modifiers being applied for -any age-. As an example, this could be applied to a Court Magician:
<img width="373" height="204" alt="image" src="https://github.com/user-attachments/assets/5d883308-a904-4bb1-bf96-41a581b58789" />

Assuming they could join as an Adult. This functionality might come in handy later.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Class Old modifiers are now viewable in the class preview menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
