### PR TITLE
Return of Bog Guard

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
@@ -1,0 +1,60 @@
+/datum/advclass/levy
+	name = "Levy"
+	tutorial = "When the bailiff came to your household it was the worst dae of your lyfe, dragging you away into service to the Crown with nothing more but a trusty spear. Safeguard your home from the terrors beyond the walls and those lurking in the bog."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/adventurer/levy
+	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)
+	cmode_music = 'sound/music/cmode/towner/combat_towner2.ogg'
+	category_tags = list(CTAG_TOWNER)
+	maximum_possible_slots = 3 //So you don't get a swarm of ppl
+	subclass_stats = list(
+		STATKEY_CON = 2,
+		STATKEY_STR = 2,
+		STATKEY_WIL = 2,
+		STATKEY_INT = -1,
+		STATKEY_SPD = -1
+	)
+	subclass_skills = list(
+		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/axes = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/carpentry = SKILL_LEVEL_NOVICE,
+		/datum/skill/labor/lumberjacking = SKILL_LEVEL_NOVICE,
+		/datum/skill/labor/farming = SKILL_LEVEL_NOVICE,
+	)
+
+/datum/outfit/job/roguetown/adventurer/levy/pre_equip(mob/living/carbon/human/H)
+	..()
+	head = /obj/item/clothing/head/roguetown/helmet/kettle/iron
+	neck = /obj/item/clothing/neck/roguetown/coif
+	mask = /obj/item/clothing/head/roguetown/armingcap
+	cloak = /obj/item/clothing/cloak/tabard/stabard/bog
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/rogueweapon/stoneaxe/woodcut
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	backr = /obj/item/storage/backpack/rogue/satchel
+	r_hand = /obj/item/rogueweapon/spear
+	backl = /obj/item/rogueweapon/scabbard/gwstrap
+	backpack_contents = list(
+		/obj/item/flashlight/flare/torch/metal = 1,
+		/obj/item/recipe_book/survival = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/rogueweapon/scabbard/sheath = 1,
+		/obj/item/rogueweapon/huntingknife = 1,
+		)
+	if(H.mind)
+		SStreasury.give_money_account(ECONOMIC_DESTITUTE, H, "Savings.")

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1729,6 +1729,7 @@
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\pilgrim\fisher.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\pilgrim\homesteader.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\pilgrim\hunter.dm"
+#include "code\modules\jobs\job_types\roguetown\adventurer\types\pilgrim\levy.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\pilgrim\miner.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\pilgrim\minstrel.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\pilgrim\peasant.dm"


### PR DESCRIPTION
## About The Pull Request

Bog Guardsman is back as Levy towner (3 slot limit) subclass

## Testing Evidence

<img width="203" height="415" alt="image" src="https://github.com/user-attachments/assets/920892ee-e039-4b78-8fbe-c3917adb2f88" />
<img width="640" height="264" alt="image" src="https://github.com/user-attachments/assets/c10a04bb-0474-4511-86a8-e64e7fe35f94" />


## Why It's Good For The Game

Ppl wanted it for a while now suppose new year new towner class.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Towner Bog Guard
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
