### PR TITLE
Increase pariah slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/blackoak.dm
@@ -10,7 +10,7 @@
 	)
 	outfit = /datum/outfit/job/roguetown/wretch/blackoak
 	cmode_music = 'sound/music/combat_blackoak.ogg'
-	maximum_possible_slots = 1
+	maximum_possible_slots = 2
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_AZURENATIVE, TRAIT_OUTDOORSMAN, TRAIT_RACISMISBAD, TRAIT_DODGEEXPERT, TRAIT_ARCYNE_T2)
 	//lower-than-avg stats for wretch but their traits are insanely good


### PR DESCRIPTION
## About The Pull Request

Increases wretch Black Oak slots to 2.

## Testing Evidence

No but it'll work.

## Why It's Good For The Game

Light armoured magic-polearm user wretch class being 1-slot capped is a bit silly. They aren't that strong. Bloak threats are good.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Increases Bloak Pariah slots to 2 (from 1).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
