### PR TITLE
Vampire Thrall Count Fix

### DIFF
--- a/code/modules/vampire_neu/bloodsuck.dm
+++ b/code/modules/vampire_neu/bloodsuck.dm
@@ -111,17 +111,20 @@
 
 	if(!victim.clan && victim.mind && ishuman(victim) && VDrinker.generation > GENERATION_THINBLOOD && victim.blood_volume <= BLOOD_VOLUME_BAD)
 		var/datum/antagonist/vampire/vdrinker = mind?.has_antag_datum(/datum/antagonist/vampire)
-		if(vdrinker.thrall_count < vdrinker.max_thralls || !vdrinker.max_thralls)
-			if(alert(src, "Would you like to sire a new spawn?", "THE CURSE OF KAIN", "MAKE IT SO", "I RESCIND") != "MAKE IT SO")
-				to_chat(src, span_warning("I decide [victim] is unworthy."))
-			else
-				visible_message(span_danger("[src] begins channeling their energies to [victim]!"))
-				if(!do_mob(src, victim, 7 SECONDS, double_progress = TRUE, can_move = FALSE))
-					to_chat(src, span_warning("I was interrupted during my siring!"))
-					return
-				INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob/living/carbon/human, vampire_conversion_prompt), src)
+		if((vdrinker.max_thralls <= 0) || (isnull(vdrinker.max_thralls))) //thin bloods or low level vampires can't make thralls, incase they get past the last check by leveling up off others
+			to_chat(src, span_warning("I cannot sire thralls, my blood is too weak!"))
 		else
-			to_chat(src, span_warning("I cannot sire anymore thralls.."))
+			if(vdrinker.thrall_count >= vdrinker.max_thralls) //you've hit your max
+				to_chat(src, span_warning("I cannot sire anymore thralls.."))
+			else
+				if(alert(src, "Would you like to sire a new spawn?", "THE CURSE OF KAIN", "MAKE IT SO", "I RESCIND") != "MAKE IT SO")
+					to_chat(src, span_warning("I decide [victim] is unworthy."))
+				else
+					visible_message(span_danger("[src] begins channeling their energies to [victim]!"))
+					if(!do_mob(src, victim, 7 SECONDS, double_progress = TRUE, can_move = FALSE))
+						to_chat(src, span_warning("I was interrupted during my siring!"))
+						return
+					INVOKE_ASYNC(victim, TYPE_PROC_REF(/mob/living/carbon/human, vampire_conversion_prompt), src)
 
 /mob/living/carbon/human/proc/vampire_conversion_prompt(mob/living/carbon/sire)
 	if(!mind)

--- a/code/modules/vampire_neu/vampire.dm
+++ b/code/modules/vampire_neu/vampire.dm
@@ -84,14 +84,19 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 		switch(generation)
 			if(GENERATION_METHUSELAH)
 				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 6, TRUE)
+				max_thralls = 69
 			if(GENERATION_ANCILLAE)
 				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 5, TRUE)
+				max_thralls = 3
 			if(GENERATION_NEONATE)
 				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 4, TRUE) // Licker Wretch
+				max_thralls = 1
 			if(GENERATION_THINBLOOD)
 				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 3, TRUE) // You are not even an antagonist
+				max_thralls = 0
 			else
 				vampdude?.adjust_skillrank_up_to(/datum/skill/magic/blood, 2, TRUE) // Default weight if generation not set
+				max_thralls = 0
 
 		if(HAS_TRAIT(vampdude, TRAIT_DNR)) //if you have DNR, we add dustable
 			ADD_TRAIT(vampdude, TRAIT_DUSTABLE, TRAIT_GENERIC)

--- a/code/modules/vampire_neu/vampirelord.dm
+++ b/code/modules/vampire_neu/vampirelord.dm
@@ -15,7 +15,7 @@
 	)
 	show_in_roundend = TRUE
 	var/ascended = FALSE
-	max_thralls = 0
+	max_thralls = 69
 
 /datum/antagonist/vampire/lord/get_antag_cap_weight()
 	return 3


### PR DESCRIPTION
## About The Pull Request

adds a number of  vampire thralls based on your generation when you start out.
- Vampire lords  get 69 (good luck hitting that number)
- Vampire Antags (from the random round start) get 3
- Licker Vampires get 1
- Thin bloods get none

The number will not increase if you increase your generation. This means if a licker turns you and you somehow gain a generation to a neonate (licker), you still won't be able to thrall someone that round, going from a vampire antag (ancillae) to a full vampire lord (methuselah), you won't be able to convert a horde. 

Part of this is for balance and another part is simplicity. I'd like to see how this balances out before tinkering with more

## Testing Evidence
an Vampire Antag (Ancillae) turning 3 people
<img width="352" height="249" alt="image" src="https://github.com/user-attachments/assets/9ba3061e-639f-4fef-bcce-e3382c399b5e" />

but unable to turn a 4th
<img width="238" height="139" alt="image" src="https://github.com/user-attachments/assets/9c952ef5-be91-4c7d-bf97-3ea3e58f9198" />

A neonate (one of the thralls turned above) made a thrall, but after trying to make a 2nd, failed
<img width="206" height="181" alt="image" src="https://github.com/user-attachments/assets/67c7a9a3-f657-4c79-9a6c-4297c14fa34d" />

A vampire licker (neonate) made a thrall but failed to make a second
<img width="284" height="143" alt="image" src="https://github.com/user-attachments/assets/32403f8d-d5c4-4f02-ad5d-f4e979d394c6" />



## Why It's Good For The Game

This fixes the vampire thrall issue where a higher-level vampire can only turn one thrall at a time. This should also make it a little easier to understand in the code where to tweak these numbers for future developers

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
:cl:
fix: fixes higher level vampires not able to turn multiple thralls, as intended
code: makes it easier to see where max thralls are defined
/:cl:

