### PR TITLE
Aasimar no longer have Sama'glos as a native language

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -75,8 +75,7 @@
 		/datum/body_marking/tonage,
 	)
 	languages = list(
-		/datum/language/common,
-		/datum/language/celestial
+		/datum/language/common
 	)
 
 	custom_selection = list(


### PR DESCRIPTION
## About The Pull Request

Removes the inherent knowledge of Sama'glos from Aasimar

## Testing Evidence

It compiles and it's a one-line removal, didn't actually boot up test server

## Why It's Good For The Game

This is presumably a holdover from when /datum/language/celestial was actually used for Celestial, there's no real reason why all aasimar would know the language of Naledi

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
change: Aasimar no longer get Sama'glos as an automatic free language
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
