### PR TITLE
Projectiles now pass through stumps

### DIFF
--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -196,6 +196,7 @@
 	desc = "Someone cut this tree down."
 	icon_state = "t1stump"
 	opacity = 0
+	pass_flags = LETPASSTHROW
 	max_integrity = 100
 	climbable = TRUE
 	climb_time = 0
@@ -585,7 +586,7 @@
 
 /obj/structure/flora/roguegrass/pyroclasticflowers/update_icon()
 	icon_state = "pyroflower[rand(1,3)]"
-	
+
 /obj/structure/flora/roguegrass/pyroclasticflowers/Initialize()
 	. = ..()
 	if(prob(88))


### PR DESCRIPTION
## About The Pull Request

Makes stumps no longer block projectiles. Also includes those ancient fallen logs.

## Testing Evidence

DON'T WORRY ABOUT IT.

## Why It's Good For The Game

It is REALLY FUCKING ANNOYING that projectiles of any kind are basically useless the moment any tree stumps or fallen ancient logs show up. This makes projectiles now able to pass over those things, making projectile-based attacks less painful to use.

Seriously, they're like knee-height tops. Why do they stop projectiles?

I'll probably remove stopping projectiles from bushes next but that's out of scope for now.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Tree stumps and fallen ancient logs no longer block projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
