### PR TITLE
Outfit Hand Swaps

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -238,11 +238,17 @@
 			WARNING("Unable to equip accessory [accessory] in outfit [name]. No uniform present!")
 
 	if(!visualsOnly)
-		if(l_hand)
-			H.put_in_hands(new l_hand(get_turf(H)), FALSE, forced = TRUE)
-		if(r_hand)
-
-			H.put_in_hands(new r_hand(get_turf(H)), FALSE, forced = TRUE)
+		// gives a 50/50 chance for hands to be swapped
+		if(prob(50))
+			if(l_hand)
+				H.put_in_l_hand(new l_hand(get_turf(H)), TRUE)
+			if(r_hand)
+				H.put_in_r_hand(new r_hand(get_turf(H)), TRUE)
+		else
+			if(l_hand)
+				H.put_in_r_hand(new l_hand(get_turf(H)), TRUE)
+			if(r_hand)
+				H.put_in_l_hand(new r_hand(get_turf(H)), TRUE)
 
 	if(!visualsOnly) // Items in pockets or backpack don't show up on mob's icon.
 		if(l_pocket)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -187,12 +187,12 @@
 	return hand_index
 
 //Puts the item into the first available left hand if possible and calls all necessary triggers/updates. returns 1 on success.
-/mob/proc/put_in_l_hand(obj/item/I)
-	return put_in_hand(I, get_empty_held_index_for_side(LEFT_HANDS))
+/mob/proc/put_in_l_hand(obj/item/I, forced = FALSE)
+	return put_in_hand(I, get_empty_held_index_for_side(LEFT_HANDS), forced)
 
 //Puts the item into the first available right hand if possible and calls all necessary triggers/updates. returns 1 on success.
-/mob/proc/put_in_r_hand(obj/item/I)
-	return put_in_hand(I, get_empty_held_index_for_side(RIGHT_HANDS))
+/mob/proc/put_in_r_hand(obj/item/I, forced = FALSE)
+	return put_in_hand(I, get_empty_held_index_for_side(RIGHT_HANDS), forced)
 
 /mob/proc/put_in_hand_check(obj/item/I)
 	return FALSE					//nonliving mobs don't have hands


### PR DESCRIPTION
## About The Pull Request

- Outfits now have a 50/50 chance of having their hands swapped. This means ambushing mobs can now wield their weapon in their right hand too.

## Testing Evidence

ye

## Why It's Good For The Game

This prevents people from just aiming left hand and dealing with every mob easily.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Outfits now have a 50/50 chance of having their hands swapped. This means ambushing mobs can now wield their weapon in their right hand too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
