### PR TITLE
Minor Martyr Update

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -293,11 +293,6 @@
 				current_holder.STAPER += stat_bonus_martyr
 				current_holder.STALUC += stat_bonus_martyr
 				H.energy_add(9999)
-			if(STATE_MARTYRULT)	//This is ONLY accessed during the last 30 seconds of the shorter variant.
-				H.energy_add(9999)
-				current_holder.visible_message(span_warning("[current_holder] rises up, empowered once more!"), span_warningbig("I rise again! I can feel my god flow through me!"))
-				flash_lightning(current_holder)
-				current_holder.revive(full_heal = TRUE, admin_revive = TRUE)
 
 //This is called regardless of the activated state (safe or not)
 /datum/component/martyrweapon/proc/deactivate()
@@ -387,19 +382,28 @@
 				adjust_stats(current_state)	//Lowers the damage of the sword due to safe activation.
 				current_holder.energy = current_holder.max_energy
 				current_holder.stamina = 0
+				I.sharpness = I.max_blade_int
 			if(STATE_MARTYR)
 				end_activation = world.time + martyr_duration
 				I.max_integrity = 2000				//If you're committing, we repair the weapon and give it a boost so it lasts the whole fight
 				I.obj_integrity = I.max_integrity
+
+				I.max_blade_int = 9999
+				I.sharpness = I.max_blade_int
 				adjust_stats(current_state)	//Gives them extra stats.
 
 				current_holder.stamina = 0
 				current_holder.energy = current_holder.max_energy
+
+				current_holder.adjust_skillrank_down_to(/datum/skill/combat/wrestling, SKILL_LEVEL_NONE, TRUE)
 			if(STATE_MARTYRULT)
 				end_activation = world.time + ultimate_duration
 				I.max_integrity = 9999				//why not, they got 2 mins anyway
 				I.obj_integrity = I.max_integrity
 
+				I.max_blade_int = 9999
+				I.sharpness = I.max_blade_int
+				
 				current_holder.adjust_skillrank(/datum/skill/misc/athletics, 6, FALSE)
 
 				current_holder.STASTR = 20
@@ -413,7 +417,7 @@
 				current_holder.energy = current_holder.max_energy
 				current_holder.stamina = 0
 
-				current_holder.adjust_skillrank(/datum/skill/combat/wrestling, 6, FALSE)
+				current_holder.adjust_skillrank_down_to(/datum/skill/combat/wrestling, SKILL_LEVEL_NONE, TRUE)
 				current_holder.adjust_skillrank(/datum/skill/combat/swords, 6, FALSE)
 				current_holder.adjust_skillrank(/datum/skill/combat/unarmed, 6, FALSE)
 


### PR DESCRIPTION
## About The Pull Request
god this code is butt and a half, anyway:

After seeing the struggle in the most recent martyr PR I updated a few things:

### PLAYER FACING / BALANCE:
- 2 minute duration's buffs are now frontloaded instead of being given at the last 30 seconds.
- 2 minute duration no longer has an aheal / revive.
- Martyr gets Tempo as a job trait inherently.

### FOR DEVS:
- Added a few extra vars to help add new martyr weapons, this component was only -barely- made to fit custom weapons and it's kind of sad other people had to deal with this.
  - List vars for items to swap out, added in in the initialization of the component
  - Vars for safe activation damage values, both wielded and unwielded
  - A bit of cleanup of needless repeated code
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Tempo's been added and other than Jester Martyr seemed the only other class fitting for it without much contest. It -could- be limited to only while the sword is active, but 2/3 times (2 / 7 minute duration modes) it won't mean much because of all the stamina, infinite sharpness, infinite integ etc they get on their main weapon. 
He kinda already gets most of all the good stuff and the rest requires attrition the role has no time for.

For the 2 min duration, it's just simpler to manage only one stat shift code-wise and from what I've read the 30 second period hasn't mattered much, and made the option less desirable than the 7 min one. I'm basing this entirely on what other people have said, though. Likewise, the revive is gone in a sort of 'exchange' for this.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Martyr now gets the Tempo trait.
balance: Martyr gets all the benefits of the 2-minute duration from the start.
balance: Martyr 2-minute duration option no longer has a heal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
