### PR TITLE
Fishing up mobs spawns them at the target tile

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -648,12 +648,11 @@
 							to_chat(user, "<span class='notice'>You see something!</span>")
 							playsound(src.loc, 'sound/items/fishing_plouf.ogg', 100, TRUE)
 							if(!do_after(user,ow, target = target))
-								if(ismob(A)) // TODO: Baits with mobs on their fishloot lists OR water tiles with their own fish loot pools
+								if(A in subtypesof(/mob/living))
 									var/mob/M = A
-									if(M.type in subtypesof(/mob/living/simple_animal/hostile))
-										new M(target)
-									else
-										new M(user.loc)
+									new M(target)
+									if (!(M.type == /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab))
+										user.playsound_local(src, pick('sound/misc/jumpscare (1).ogg','sound/misc/jumpscare (2).ogg','sound/misc/jumpscare (3).ogg','sound/misc/jumpscare (4).ogg'), 100)
 									user.mind.add_sleep_experience(/datum/skill/labor/fishing, fisherman.STAINT*2) // High risk high reward
 								else
 									new A(user.loc)

--- a/code/modules/roguetown/roguejobs/fisher/rod.dm
+++ b/code/modules/roguetown/roguejobs/fisher/rod.dm
@@ -131,12 +131,11 @@
 								target.balloon_alert_to_viewers("Tug!")
 								playsound(src.loc, 'sound/items/fishing_plouf.ogg', 100, TRUE)
 								if(!do_after(user,ow, target = target, same_direction = TRUE))
-									if(ismob(A)) // TODO: Baits with mobs on their fishloot lists OR water tiles with their own fish loot pools
+									if(A in subtypesof(/mob/living))
 										var/mob/M = A
-										if(M.type in subtypesof(/mob/living/simple_animal/hostile))
-											new M(target)
-										else
-											new M(user.loc)
+										new M(target)
+										if (!(M.type == /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab))
+											user.playsound_local(src, pick('sound/misc/jumpscare (1).ogg','sound/misc/jumpscare (2).ogg','sound/misc/jumpscare (3).ogg','sound/misc/jumpscare (4).ogg'), 100)
 										user.mind.add_sleep_experience(/datum/skill/labor/fishing, fisherman.STAINT*2) // High risk high reward
 									else
 										new A(user.loc)


### PR DESCRIPTION
## About The Pull Request

Fishing up mobs using fishing rod or fishing spear no longer spawns them underneath the player; instead, they spawn on the tile that was targeted. Additionally, if the mob is hostile (i.e. anything except a crab), an ambush sound is played to notify the player.

## Testing Evidence

Compiled, fished up some deepones, goblins, and crabs without them violating my personal space in milliseconds, spooked myself with the ambush sound.

## Why It's Good For The Game

Requested by people on Discord. Makes fishing more user-friendly, as hostile mobs appearing directly on top of the player meant they had almost no chance to react.

## Changelog

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Fished up mobs no longer spawn directly on top of the player.
/:cl:

