### PR TITLE
Fix dupe of vials with bottles and helmets 64XY

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -145,6 +145,8 @@
 			for(var/obj/item/thing as anything in our_component.item_to_grid_coordinates)
 				var/mutable_appearance/thing_appearance = thing.build_worn_icon(default_layer, default_icon_file, isinhands, femaleuniform, override_state, female, customi, sleeveindex, boobed_overlay, clip_mask)
 				thing_appearance.appearance_flags = RESET_COLOR
+				thing_appearance.pixel_x = -standing.pixel_x
+				thing_appearance.pixel_y = -standing.pixel_y
 				standing.add_overlay(thing_appearance)
 	return standing
 

--- a/code/modules/roguetown/roguemachine/potionseller.dm
+++ b/code/modules/roguetown/roguemachine/potionseller.dm
@@ -174,9 +174,15 @@
 	// Create the vial
 	var/obj/item/reagent_containers/glass/bottle/B = null
 	if(dispensing_bottle_type == POTION_BOTTLE)
+		if(bottles_held <= 0)
+			say("I AM ALL OUT OF BOTTLES")
+			return
 		B = new /obj/item/reagent_containers/glass/bottle(src.loc)
 		bottles_held--
 	else
+		if(vials_held <= 0)
+			say("I AM ALL OUT OF VIALS")
+			return
 		B = new /obj/item/reagent_containers/glass/bottle/alchemical(src.loc)
 		vials_held--
 
@@ -282,6 +288,9 @@
 		if(!usr.canUseTopic(src, BE_CLOSE))
 			return
 		if(ishuman(usr))
+			if(vials_held <= 0)
+				to_chat(usr, span_warning("No vials left to remove."))
+				return
 			var/obj/item/reagent_containers/glass/bottle/alchemical/B = new /obj/item/reagent_containers/glass/bottle/alchemical(src.loc)
 			usr.put_in_hands(B)
 			vials_held--
@@ -290,6 +299,9 @@
 		if(!usr.canUseTopic(src, BE_CLOSE))
 			return
 		if(ishuman(usr))
+			if(bottles_held <= 0)
+				to_chat(usr, span_warning("No bottles left to remove."))
+				return
 			var/obj/item/reagent_containers/glass/bottle/B = new /obj/item/reagent_containers/glass/bottle(src.loc)
 			usr.put_in_hands(B)
 			bottles_held--


### PR DESCRIPTION
## About The Pull Request

Fixing a dupe of bottles through a vending machine. There is also a fix for displaying jewelry on helmets that have a coordinate offset.

## Testing Evidence

It's work

## Why It's Good For The Game

Fixs is good.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixing a dupe of bottles through a vending machine
fix: Fixed display of jewelry on helmets with offset coordinates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
