### PR TITLE
Duke De-Blacksteeling

### DIFF
--- a/code/game/objects/structures/crates_lockers/roguetown.dm
+++ b/code/game/objects/structures/crates_lockers/roguetown.dm
@@ -210,13 +210,13 @@
 		return
 
 	new /obj/item/rogueweapon/sword/long/judgement(get_turf(src))
-	new /obj/item/clothing/wrists/roguetown/bracers(get_turf(src))
+	new /obj/item/clothing/head/roguetown/helmet/heavy/frogmouth(get_turf(src))
 	new /obj/item/clothing/neck/roguetown/gorget/steel(get_turf(src))
+	new /obj/item/clothing/suit/roguetown/armor/plate/full(get_turf(src))
+	new /obj/item/clothing/wrists/roguetown/bracers(get_turf(src))
+	new /obj/item/clothing/gloves/roguetown/plate(get_turf(src))
 	new /obj/item/storage/belt/rogue/leather/steel/tasset(get_turf(src))
-	new /obj/item/clothing/gloves/roguetown/blacksteel/modern/plategloves(get_turf(src))
-	new /obj/item/clothing/head/roguetown/helmet/blacksteel/modern/armet(get_turf(src))
-	new /obj/item/clothing/shoes/roguetown/boots/blacksteel/modern/plateboots(get_turf(src))
-	new /obj/item/clothing/suit/roguetown/armor/plate/full/blacksteel/modern(get_turf(src))
-	new /obj/item/clothing/under/roguetown/platelegs/blacksteel/modern(get_turf(src))
+	new /obj/item/clothing/under/roguetown/platelegs(get_turf(src))
+	new /obj/item/clothing/shoes/roguetown/boots/armor(get_turf(src))
 	has_spawned_gear = TRUE
 	close()


### PR DESCRIPTION
## About The Pull Request

Removes blacksteel armour from duke instead giving him back steel (infact way more than he USED to have before all this)

## Testing Evidence

Byeah

## Why It's Good For The Game

It's used exclusively to frag or to give to knights to frag, the ORIGINAL reason this was added in first place was to frag, you know on the role which has about 20 other slots to do it for it, it does NOT need it.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Duke starting armour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
