### PR TITLE
Tempo requires Unrevivable

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -40,6 +40,8 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 	apply_prefs_race_bonus(character, player)
 	if(player.prefs.dnr_pref)
 		apply_dnr_trait(character, player)
+		if(!character.mind.has_antag_datum(/datum/antagonist/vampire) && !character.mind.has_antag_datum(/datum/antagonist/skeleton) && character.mind.assigned_role != "Adventurer")
+			apply_tempo_trait(character, player)
 	if(player.prefs.qsr_pref)
 		apply_qsr_trait(character, player)
 	if(player.prefs.loadout && character.get_triumphs() >= player.prefs.loadout.triumph_cost)
@@ -127,6 +129,9 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 
 /proc/apply_dnr_trait(mob/living/carbon/human/character, client/player)
 	ADD_TRAIT(player.mob, TRAIT_DNR, TRAIT_GENERIC)
+
+/proc/apply_tempo_trait(mob/living/carbon/human/character, client/player)
+	ADD_TRAIT(player.mob, TRAIT_TEMPO, TRAIT_GENERIC)
 
 /proc/apply_qsr_trait(mob/living/carbon/human/character, client/player)
 	ADD_TRAIT(player.mob, TRAIT_QUICKSILVERRESISTANT, TRAIT_GENERIC)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2313,6 +2313,10 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 				if("dnr")
 					dnr_pref = !dnr_pref
+					if(dnr_pref)
+						to_chat(usr, span_notice("Your character's death will be permanent for the round. If not undead or an Adventurer, your character is Tempo Capable."))
+					else
+						to_chat(usr, span_notice("Your character can be revived."))
 				if("qsr")
 					qsr_pref = !qsr_pref
 				if("virtue")


### PR DESCRIPTION
## About The Pull Request

<img width="652" height="353" alt="image" src="https://github.com/user-attachments/assets/957747d9-fc83-4cd0-8d89-b0a7281a1f5d" />


TRAIT_TEMPO is applied to anyone (except adventurers, ~~knight captain, inquisitor, court mage, heirs,~~ and undead antags) who takes Unrevivable. Make your final stand.

## Testing Evidence

Revivable:
<img width="470" height="413" alt="image" src="https://github.com/user-attachments/assets/834947be-3526-4320-9316-9e50d128a645" />

Unrevivable:
<img width="463" height="516" alt="image" src="https://github.com/user-attachments/assets/45be3b71-5f87-4ff5-83b3-d5a8bb7c8b32" />



## Why It's Good For The Game

<img width="369" height="192" alt="image" src="https://github.com/user-attachments/assets/305568fd-bad8-4ea1-81c4-578a554a3d92" />

"Sovl"

I don't know.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Tempo is now actually available to anyone (except advs and some special roles) but requires you to be Unrevivable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
