### PR TITLE
[Leechticks] Makes leech bait easier to use

### DIFF
--- a/code/game/objects/items/rogueitems/bait.dm
+++ b/code/game/objects/items/rogueitems/bait.dm
@@ -17,6 +17,7 @@
 	var/attraction_chance = 100
 	var/deployed = 0
 	var/deploy_speed = 2 SECONDS
+	var/refund_bag = TRUE
 	resistance_flags = FLAMMABLE
 	grid_height = 32
 	grid_width = 32
@@ -92,10 +93,11 @@
 									if(prob(75))
 										M = GLOB.animal_to_undead[M]
 							new M(T)
-							if(prob(66))
-								new /obj/item/storage/roguebag/crafted(T)
-							else
-								new /obj/item/natural/cloth(T)
+							if(refund_bag)
+								if(prob(66))
+									new /obj/item/storage/roguebag/crafted(T)
+								else
+									new /obj/item/natural/cloth(T)
 							qdel(src)
 					else
 						qdel(src)
@@ -136,6 +138,7 @@
 	name = "bag of leechbait"
 	desc = "Bait that might attract a little pestran friend."
 	icon_state = "baitb"
+	refund_bag = FALSE
 	attracted_types = list(/obj/item/leechtick = 43,
 							/mob/living/simple_animal/hostile/retaliate/rogue/direbear = 5,
 							/mob/living/simple_animal/hostile/retaliate/rogue/troll/bog = 2)

--- a/code/modules/roguetown/roguecrafting/fleshcrafting.dm
+++ b/code/modules/roguetown/roguecrafting/fleshcrafting.dm
@@ -100,7 +100,7 @@
 	tech_unlocked = FALSE
 
 /datum/crafting_recipe/roguetown/fleshcrafting/leechbait
-	name = "leechbait"
+	name = "leechbait (from bag)"
 	craftdiff = 1
 	result = list(
 		/obj/item/bait/leech,
@@ -108,7 +108,22 @@
 		/obj/item/bait/leech,
 		)
 	reqs = list(
-		/obj/item/storage/roguebag = 3,
+		/obj/item/storage/roguebag = 1,
+		/obj/item/reagent_containers/lux_impure = 1,
+		)
+	subtype_reqs = TRUE
+	structurecraft = null
+
+/datum/crafting_recipe/roguetown/fleshcrafting/leechbaitcloth
+	name = "leechbait (from cloth)"
+	craftdiff = 1
+	result = list(
+		/obj/item/bait/leech,
+		/obj/item/bait/leech,
+		/obj/item/bait/leech,
+		)
+	reqs = list(
+		/obj/item/natural/cloth = 2,
 		/obj/item/reagent_containers/lux_impure = 1,
 		)
 	subtype_reqs = TRUE


### PR DESCRIPTION
## About The Pull Request
- Leech bait no longer refunds bags or cloth when consumed by a creature.
- Leech bait is now crafted with either 1 bag, or 2 cloth, making it significantly cheaper to obtain, and easier as it means you can rip your sleeves off and lure in leechticks

## Testing Evidence
Tested both crafting & attracting

## Why It's Good For The Game
Making three bags is some of effort. You need a needle and fibres from grass at a minimum. Then you still have to attract the leech and fill them up. This change slightly streamlines the process so getting ticks is faster.

## Changelog

:cl:
balance: Leechtick bait recipes rebalanced.
/:cl:

