### PR TITLE
Adds Spear Hunter towners to hunter-keyed towner houses

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -1011,7 +1011,7 @@
 	lockid = "towner_fisher"
 
 /obj/structure/mineral_door/wood/towner/hunter
-	resident_advclass = list(/datum/advclass/hunter)
+	resident_advclass = list(/datum/advclass/hunter,/datum/advclass/hunter/spear)
 	lockid = "towner_hunter"
 
 /obj/structure/mineral_door/wood/towner/witch


### PR DESCRIPTION
## About The Pull Request

Towner houses keyed to Hunter are only keyed to Bow-Hunter and don't let Spear Hunters in, this PR lets Spear Hunters also claim those houses

## Testing Evidence

<img width="235" height="208" alt="image" src="https://github.com/user-attachments/assets/c2c7ca28-82f1-44aa-a5e6-1db4e88b7be4" />

## Why It's Good For The Game

They're both Hunters and should get the same houses probably

## Changelog

:cl: Randall
add: Lets Spear-Hunters claim Hunter houses just like Bow-Hunters
/:cl: