### PR TITLE
[Deprived] Minor trait additions

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -572,10 +572,10 @@
 
 /datum/advclass/sfighter/deprived
 	name = "Deprived"
-	tutorial = "You are a vagrant. Your skin itches at the thought of wearing proper armor. Not after everything was taken from you. Armed with a piece of wood, it's only through your body that you endure."
+	tutorial = "You are a vagrant. Your skin itches at the thought of wearing proper armor. Not after everything was taken from you. Armed with a piece of wood, it's only through your body that you endure. At least you aren't bothered by the lack of comfort like most others."
 	outfit = /datum/outfit/job/roguetown/adventurer/deprived
 	cmode_music = 'sound/music/cmode/antag/combat_darkstar.ogg'
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE, TRAIT_NOPAINSTUN, TRAIT_SHIRTLESS)
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE, TRAIT_NOPAINSTUN, TRAIT_SHIRTLESS, TRAIT_WILD_EATER, TRAIT_OUTDOORSMAN, TRAIT_HOMESTEAD_EXPERT)
 	subclass_stats = list(
 		STATKEY_STR = 3,
 		STATKEY_CON = 2,
@@ -592,7 +592,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN
 	)
-	extra_context = "Challenge class. You don't get natural armor nor possessions save for a club and a wooden shield."
+	extra_context = "Challenge class. You don't get natural armor nor possessions save for a club and a wooden shield. You are ascetic in nature, requiring little for comfort."
 
 /datum/outfit/job/roguetown/adventurer/deprived/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()


### PR DESCRIPTION
## About The Pull Request
Rare self indulgent PR.
Gives deprived expert homesteader, outdoorsman, and beastly eater.

## Testing Evidence
It compiles, sire.

## Why It's Good For The Game
Don't feel like a class that's used to running around in their loincloth without a care for the world, would care much about a roof or a little bit of elbow grease in their meat.

Homesteader so you can hire the guy to be dumb muscle better, fetching you rocks or logs.

## Changelog
:cl:
balance: Deprived have some extra traits.
/:cl:

