### PR TITLE
Unapologetic Xylixian Devotee Buff

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -119,7 +119,8 @@
 #define TRAIT_CRACKHEAD "Blessing of Baotha" //will never overdose
 #define TRAIT_CHOSEN "Astrata's Chosen"
 #define TRAIT_ABYSSOR_SWIM "Blessing of Abyssor" //less base fatigue drain when swimming
-#define TRAIT_XYLIX "Blessing of Xylix" //secret thieves cant language
+#define TRAIT_XYLIX "Blessing of Xylix" // secret thieves cant language
+#define TRAIT_XYLIX_DEVOTEE "Xylixian Fateweaver" // fate-weaving and luck-based bonuses
 #define TRAIT_FORGEBLESSED "Blessing of Malum" //Reduces the fatigue cost of smithing a bit.
 #define TRAIT_APRICITY	"Apricity" //Decreased stamina regen time during "day" and less so during night
 #define TRAIT_SHARPER_BLADES "Sharper Blades" //Weapons lose less blade integrity
@@ -366,6 +367,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_DEATHSIGHT = span_info("I can feel when someone nearby draws the Undermaiden's attention."),
 	TRAIT_FORGEBLESSED = span_info("Countless long nights spent forging metal have honed my endurance, allowing me to work an anvil far longer than most without tiring."),
 	TRAIT_XYLIX = span_info("I know how to speak in code that only fellow tricksters can understand."),
+	TRAIT_XYLIX_DEVOTEE = span_info("Xylix smiles upon me. When there's a juncture in fate, I will be pulled toward the better outcome."),
 	TRAIT_APRICITY = span_info("Astrata's light blesses and rejuvenates me, allowing me to regain my stamina quicker."),
 	TRAIT_SHARPER_BLADES = span_info("My blades go dull slower, ensuring they stay sharp longer."),
 	TRAIT_BATTLEMASTER = span_info("I can use special attacks of any weapon without needing to be trained in it."),

--- a/code/datums/gods/patrons/divine/xylix.dm
+++ b/code/datums/gods/patrons/divine/xylix.dm
@@ -13,6 +13,7 @@
 					/obj/effect/proc_holder/spell/invoked/mastersillusion		= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/resurrect/xylix		= CLERIC_T4,
 	)
+	traits_tier = list(TRAIT_XYLIX_DEVOTEE = CLERIC_T0) //Requires a minimal holy skill or the 'Devotee' virtue to unlock. Rerolls luck events
 	confess_lines = list(
 		"ASTRATA IS MY LIGHT!",
 		"NOC IS NIGHT!",

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -334,7 +334,7 @@
 /datum/stressevent/uncanny
 	stressadd = 2
 	desc = span_red("Their face is.. wrong!")
-	timer = 3 MINUTES	
+	timer = 3 MINUTES
 
 /datum/stressevent/syoncalamity
 	stressadd = 15
@@ -441,3 +441,9 @@
 	timer = 1 MINUTES
 	stressadd = 4
 	desc = span_red("I was shushed by the archivist!")
+
+// this generally only happens if you're below 10 FOR, this is a little nudge to work on your luck stat
+/datum/stressevent/xylixian_pity
+	timer = 5 MINUTES
+	stressadd = 1
+	desc = span_red("Xylix took pity upon me and saved me from the consequences of bad luck. I must do better!")

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -371,3 +371,7 @@
 	desc = span_green("Astrata and her gaze may burn you now, but you distantly remember when it was pleasant to your skin.")
 	timer = 20 SECONDS
 
+/datum/stressevent/xylixian_fate
+	timer = 10 MINUTES
+	stressadd = -2
+	desc = span_green("Xylix spun the thread of fate in my favour! Truly, I am blessed!")

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -1,4 +1,4 @@
-	
+
 
 /mob/living
 	/// Strength.
@@ -279,7 +279,7 @@
 
 /// Calculates a luck value in the range [1, 400] (calculated as STALUC^2), then maps the result linearly to the given range
 /// min must be >= 0, max must be <= 100, and min must be <= max
-/// For giving 
+/// For giving
 /mob/living/proc/get_scaled_sq_luck(min, max)
 	if (min < 0)
 		min = 0
@@ -304,13 +304,37 @@
 	if(ignore_effects)
 		var/truefor = get_true_stat(STATKEY_LCK)
 		if(truefor < 10)
-			return prob((10 - truefor) * multi)
+			var/failed = prob((10 - truefor) * multi)
+			// if we failed, but we're a xylixian devotee, we get another shot
+			if(failed && HAS_TRAIT(src, TRAIT_XYLIX_DEVOTEE))
+				failed = prob((10 - truefor) * multi)
+				// if xylix twisted fate into our favour, get a little jingle from them
+				if(!failed)
+					play_overhead_indicator('icons/mob/overhead_effects.dmi', "sign_Xylix", 15, MUTATIONS_LAYER, private = TRAIT_XYLIX_DEVOTEE, soundin = 'sound/items/gem.ogg', y_offset = 32)
+					add_stress(/datum/stressevent/xylixian_pity)
+			return failed
 	else if(STALUC < 10)
-		return prob((10 - STALUC) * multi)
+		var/failed = prob((10 - STALUC) * multi)
+		// if we failed, but we're a xylixian devotee, we get another shot
+		if(failed && HAS_TRAIT(src, TRAIT_XYLIX_DEVOTEE))
+			failed = prob((10 - STALUC) * multi)
+			// if xylix twisted fate into our favour, get a little jingle from them
+			if(!failed)
+				play_overhead_indicator('icons/mob/overhead_effects.dmi', "sign_Xylix", 15, MUTATIONS_LAYER, private = TRAIT_XYLIX_DEVOTEE, soundin = 'sound/items/gem.ogg', y_offset = 32)
+				add_stress(/datum/stressevent/xylixian_pity)
+		return failed
 
 /mob/living/proc/goodluck(multi = 3)
 	if(STALUC > 10)
-		return prob((STALUC - 10) * multi)
+		var/succeeded = prob((STALUC - 10) * multi)
+		// if we didn't succeed, but we're a xylixian devotee, we get another shot
+		if(!succeeded && HAS_TRAIT(src, TRAIT_XYLIX_DEVOTEE))
+			succeeded = prob((STALUC - 10) * multi)
+			// if xylix twisted fate into our favour, get a little jingle from them
+			if(succeeded)
+				play_overhead_indicator('icons/mob/overhead_effects.dmi', "sign_Xylix", 15, MUTATIONS_LAYER, private = TRAIT_XYLIX_DEVOTEE, soundin = 'sound/items/gem.ogg', y_offset = 32)
+				add_stress(/datum/stressevent/xylixian_fate)
+		return succeeded
 
 /mob/living/proc/get_stat_level(stat_keys)
 	switch(stat_keys)


### PR DESCRIPTION
## About The Pull Request

- Xylixian Devotees (anyone that has access to T0 miracles) now have a passive that lets them re-roll good and bad luck events.

## Testing Evidence

I recorded a skirmish with 6 bogguards to show what it looks like when the good luck reroll triggers (it's rather boring but it showcases that it isnt extremely overbearing):

https://46au7jnxhd.ufs.sh/f/Er5uGBcI2Kg17k3Kw1FhZ4exqOm5nK7UBythad0LEzsJSluf

^ virus btw


## Why It's Good For The Game

it's neat

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Xylixian Devotees (anyone that has access to T0 miracles) now have a passive that lets them re-roll good and bad luck events.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
