### PR TITLE
Black Oak Pariahs can now actually be a treeclimbing guerilla degenerate

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/blackoak.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/blackoak.dm
@@ -12,7 +12,7 @@
 	cmode_music = 'sound/music/combat_blackoak.ogg'
 	maximum_possible_slots = 1
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_AZURENATIVE, TRAIT_OUTDOORSMAN, TRAIT_RACISMISBAD, TRAIT_DODGEEXPERT, TRAIT_ARCYNE_T2)
+	traits_applied = list(TRAIT_AZURENATIVE, TRAIT_OUTDOORSMAN, TRAIT_RACISMISBAD, TRAIT_DODGEEXPERT, TRAIT_ARCYNE_T2, TRAIT_WOODWALKER)
 	//lower-than-avg stats for wretch but their traits are insanely good
 	subclass_stats = list(
 		STATKEY_STR = 2,
@@ -29,10 +29,11 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT, //Why the fuck did the treeclimber role have worse skills than THE KNIGHTS?
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/carpentry = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/tanning = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

Gives Boak Pariah woodwalker, apprentice sewing, and expert climbing.

## Testing Evidence

Trust

## Why It's Good For The Game

Black Oak Pariah was almost a 1:1 copy and paste of the Black Oak merc, plus arcyne stuff thrown in and the medium armor thrown out skills wise. This diversifies their skillset and actually makes them a formidable one-slot-wretch. 

This effectively ruins every elf in the game now. 

## Changelog

:cl:
add: Woodwalker, sewing, climbing for black oak pariah

/:cl:

