### PR TITLE
Fixes tempo messages

### DIFF
--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -302,10 +302,13 @@
 	manage_tempo()
 
 /mob/living/carbon/human/proc/clear_tempo_all()
-	if(length(tempo_attackers) >= TEMPO_ONE && HAS_TRAIT(src, TRAIT_TEMPO))
-		LAZYCLEARLIST(tempo_attackers)
-		to_chat(src, span_info("My muscles relax. My tempo is gone."))
-		manage_tempo()
+	if(HAS_TRAIT(src, TRAIT_TEMPO))
+		var/tempo_amt = length(tempo_attackers)
+		if(tempo_amt)
+			LAZYCLEARLIST(tempo_attackers)
+			if(tempo_amt >= TEMPO_ONE)
+				to_chat(src, span_info("My muscles relax. My tempo is gone."))
+			manage_tempo()
 
 /mob/living/proc/get_tempo_bonus(id)
 	switch(id)

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -302,7 +302,7 @@
 	manage_tempo()
 
 /mob/living/carbon/human/proc/clear_tempo_all()
-	if(length(tempo_attackers) && HAS_TRAIT(src, TRAIT_TEMPO))
+	if(length(tempo_attackers) >= TEMPO_ONE && HAS_TRAIT(src, TRAIT_TEMPO))
 		LAZYCLEARLIST(tempo_attackers)
 		to_chat(src, span_info("My muscles relax. My tempo is gone."))
 		manage_tempo()


### PR DESCRIPTION
## About The Pull Request
Tempo messages will no longer show for people who have not reached at least stage one.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed Tempo message showing for users who have not reached any stage of Tempo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
