### PR TITLE
Ace hastily makes a hotfix to ammo.dm before a downstream maintainer notices and has him beheaded

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -407,7 +407,7 @@
 	flag = "piercing"
 	armor_penetration = BULLET_PENETRATION
 	speed = 0.1
-	npc_simple_damage_mult = 2.5 // I know this isn't used in Azure Peak but trust me some downstream guys are going to thank me for this because everything that uses it shoots so fucking slow that even volves are hard to kill.
+	npc_simple_damage_mult = 2 // I know this isn't used in Azure Peak but trust me some downstream guys are going to thank me for this because everything that uses it shoots so fucking slow that even volves are hard to kill.
 
 /obj/item/ammo_casing/caseless/rogue/bullet
 	name = "lead sphere"


### PR DESCRIPTION
## About The Pull Request

https://github.com/Azure-Peak/Azure-Peak/pull/5076 oops that was the old value, not what it was supposed to be

2.5x damage for an arquebus bullet is what I was messing with in testing but if that sneaks downstream someone is gonna yell at me.

2x is enough.

## Testing Evidence

Don't worry about it.

## Why It's Good For The Game

This honestly only affects downstreams

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Changes iron bullets for firearms to actually use the 2x multiplier on simple mobs that it was supposed to have from the start. 2.5x was in error from old code I forgot to change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
