### PR TITLE
Xylixian Amulet Buff

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -508,6 +508,44 @@
 	name = "amulet of Xylix"
 	desc = "In lyfe a smile is sharper than any blade."
 	icon_state = "xylix"
+	toggle_icon_state = FALSE
+
+/obj/item/clothing/neck/roguetown/psicross/xylix/examine(mob/user)
+	. = ..()
+
+	if(!ishuman(user))
+		return
+
+	var/mob/living/carbon/human/human = user
+	if(human.patron == GLOB.patronlist[/datum/patron/divine/xylix])
+		. += span_notice("This is an amulet of Xylix! I can alter the shape this one takes... (Shift-Right Click)")
+
+/obj/item/clothing/neck/roguetown/psicross/xylix/ShiftRightClick(mob/user, params)
+	if(!ishuman(user))
+		return
+
+	var/mob/living/carbon/human/human = user
+	if(human.patron != GLOB.patronlist[/datum/patron/divine/xylix])
+		return
+
+	var/list/psycross_types = typesof(/obj/item/clothing/neck/roguetown/psicross)
+	var/list/choices = list()
+	for(var/type in psycross_types)
+		var/obj/item/clothing/neck/roguetown/psicross/cross = type
+		choices[initial(cross.name)] = type
+
+	var/selected_cross = tgui_input_list(user, "Choose the Psycross you would like to disguise this one as.", "Psycross Selection", choices)
+	if(!selected_cross)
+		return
+
+	var/obj/item/clothing/neck/roguetown/psicross/cross_type = choices[selected_cross]
+
+	name = initial(cross_type.name)
+	desc = initial(cross_type.desc)
+	icon_state = initial(cross_type.icon_state)
+	item_state = initial(cross_type.item_state)
+
+	human.regenerate_clothes()
 
 /obj/item/clothing/neck/roguetown/psicross/wood
 	name = "wooden psycross"


### PR DESCRIPTION
## About The Pull Request

- Xylixians can now disguise their amulet as any other psycross amulet by shift-right-clicking it.

## Testing Evidence

trust me

## Why It's Good For The Game

ya

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Xylixians can now disguise their amulet as any other psycross amulet by shift-right-clicking it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
