### PR TITLE
Resolves a bug causing empty quivers to appear full

### DIFF
--- a/code/game/objects/items/quiver.dm
+++ b/code/game/objects/items/quiver.dm
@@ -81,6 +81,7 @@
 						var/mob/M = loc
 						if(HAS_TRAIT(M, TRAIT_COMBAT_AWARE))
 							M.balloon_alert(M, "[length(arrows)] left...")
+					update_icon()
 					break
 		return
 	..()


### PR DESCRIPTION
## About The Pull Request

As title. There was a missing update_icon() for the logic enabling pulling arrows directly from the quiver, so if you emptied it that way it'd never appear empty.

## Testing Evidence

Behold, an empty quiver!

<img width="324" height="475" alt="image" src="https://github.com/user-attachments/assets/eba3b13c-b1bc-42bc-bbe4-6e6a4879fae2" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

No more guessing if your quiver is empty.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Arrow quivers no longer appear full if emptied by clicking them directly with a bow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
