### PR TITLE
[IM SORRY FREE] jaks the dunjon type doors back down to 2 diff, adds a warning

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -857,7 +857,7 @@
 	rattlesound = 'sound/foley/doors/lockrattlemetal.ogg'
 	attacked_sound = list("sound/combat/hits/onmetal/metalimpact (1).ogg", "sound/combat/hits/onmetal/metalimpact (2).ogg")
 	lock_strength = 200
-	lockdifficulty = 3
+	lockdifficulty = 2
 	repair_cost_second = /obj/item/ingot/iron
 	repair_skill = /datum/skill/craft/carpentry
 


### PR DESCRIPTION
## About The Pull Request
hi!!!! i got a bug report that lockpicking was broken. looked into it. its not, but a recent pr set the difficulty to 3. without testing, this probably Sounded fine. turns out even at master/legendary i was consistently breaking every lockpick i put into the door, not even including how Long it took.

TL;DR, DO NOT SET LOCK DIFF TO 3. 

it might honestly need to go even lower, afaik there's nothing stopping a door diff from being 1.5 or 1.75 or some shit. 2 is what im compromising on as these *are* manor doors and such, but they're also REALLY common and its kinda insane that a master/legendary picklocker can BREAK all their picks ON ONE DOOR. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- i picked locks for an actual 20 minutes irl. fuck my life.
- each door still ate a good bit of my pick. left me w/ about 30% w/ master. i really probably shouldve made these 1.5 and 1.75 but fuck it we'll see if this is better
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- lockpicking skill should have a use bc it currently Does Not against anything beyond the most basic bitch ass wood doors
- this just makes doors useless, now
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:ADONAI
balance: dunjon-type doors should no longer break all your picks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
