### PR TITLE
Staked To Change - Adds a proper inhand to the Stake, alongside slightly tweaking its description.

### DIFF
--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -365,7 +365,7 @@
 /obj/item/grown/log/tree/stake
 	name = "stake"
 	icon_state = "stake"
-	desc = "A sharpened piece of wood, fantastic for piercing"
+	desc = "A sharpened piece of wood, fantastic for both pinning tarps and impaling nitecreechers."
 	grid_width = 32
 	grid_height = 64
 	force = 10
@@ -382,6 +382,15 @@
 	gripped_intents = null
 	slot_flags = ITEM_SLOT_MOUTH|ITEM_SLOT_HIP
 	lumber_amount = 0
+
+/obj/item/grown/log/tree/stake/getonmobprop(tag)
+	. = ..()
+	if(tag)
+		switch(tag)
+			if("gen")
+				return list("shrink" = 0.4,"sx" = -10,"sy" = 0,"nx" = 11,"ny" = 0,"wx" = -4,"wy" = 0,"ex" = 2,"ey" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
+			if("onbelt")
+				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/grown/log/tree/stake/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

* Ports the Blessed Silver Stake's inhands to the regular Stake as well. This'll make the regular Stake no longer appear invisible when held.
* Slightly tweaks the Stake's description for more brevity.

## Testing Evidence

* One-to-one port of a small codeblock, double-checked to ensure it properly works.

## Why It's Good For The Game

* Stakes, like their blessed counterparts, can double as improvised weapons. Being able to see someone holding it is good - both for the sake of balance, and for general presentation.
* The missing period made me a little 𝒻𝓇𝑒𝑒𝓀𝓎.

## Changelog

:cl:
add: Stakes now have a visible inhand sprite, like their Blessed Silver variants.
/:cl:
