### PR TITLE
Lets Corsets be repaired

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/misc.dm
+++ b/code/modules/clothing/rogueclothes/armor/misc.dm
@@ -7,6 +7,7 @@
 	armor_class = ARMOR_CLASS_LIGHT
 	body_parts_covered = CHEST
 	salvage_result = /obj/item/natural/hide/cured
+	sewrepair = TRUE
 	salvage_amount = 1
 	
 /obj/item/clothing/suit/roguetown/armor/longcoat


### PR DESCRIPTION
## About The Pull Request

Sets the sewrepair variable on the corset to TRUE so it can be repaired like other cloth or leather items.

## Testing Evidence

<img width="424" height="123" alt="image" src="https://github.com/user-attachments/assets/5eaae98f-16b6-494b-8dc5-379f77b156b4" />

## Why It's Good For The Game

I don't see why a leather corset should be unrepairable but if there's an underlying reason do let me know.

## Changelog

:cl: Randall
add: Corsets can now be repaired with a needle.
/:cl: