### PR TITLE
(Don't) Say Your Prayers - Changes invocation type of all PRAYER-type miracles to "emote", instead of "shout".

### DIFF
--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -399,7 +399,7 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = null
-	invocations = list(span_blue("whispers a hushed promise to steady themselves.."))
+	invocations = list(span_blue("faithfully whispers a hushed promise to steady themselves.."))
 	invocation_type = "emote"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = FALSE
@@ -505,7 +505,7 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = null
-	invocations = list(span_blue("whispers a hushed prayer to steady themselves.."))
+	invocations = list(span_blue("passionately whispers a hushed prayer to steady themselves.."))
 	invocation_type = "emote"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = FALSE
@@ -610,7 +610,7 @@
 	range = 2
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
-	invocations = list(span_blue("whispers a hushed psalm to steady themselves.."))
+	invocations = list(span_blue("reverently whispers a hushed psalm to steady themselves.."))
 	invocation_type = "emote"
 	sound = null
 	associated_skill = /datum/skill/magic/holy


### PR DESCRIPTION
## About The Pull Request

* As the name suggests, this changes the invocation method on all internal Psydonic miracles - RESPITE, PRAYER, and PERSIST - to use _"emote"_ instead of _"shout"_. A nice azure-colored action now prints in the chat, whenever one of these miracles are fully casted.
* This solves a _(fairly pertinent)_ issue that was previously unforeseen, where Psydonic devotees with the _"muted"_ vice were completely unable to invoke most of their chosen miracles.

## Testing Evidence

* Slightly outdated, but shows the process functioning as intended - both with selectable spells on a muted Psydonite, and with the emotes printing as intended. Further tweaked the emote's specifics, after this.
<img width="421" height="378" alt="TESPRTET" src="https://github.com/user-attachments/assets/80757e7f-ffaa-4d91-8491-42cfc03e5c13" />

## Why It's Good For The Game

* Offers a slightly less clunky alternative to how the invocations on certain Psydonic miracles originally worked.
* Fixes a bug that temporarily prevented mute Psydonic devotees from using their _(previously available)_ miracles.
* Uses a little more of Wewhowait's lovely "emote" var. Thank you, by the way.

## Changelog

:cl:
add: Casting the 'PRAYER', 'RESPITE', and 'PERSIST' miracles now prints an emote instead of forcing the caster to whisper.
fix: Fixed a bug where mute Psydonites - either through vice or injury - were unable to use any of their miracles.
/:cl:

