### PR TITLE
Fixes* heavy padded coif

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -62,7 +62,8 @@
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	blocksound = SOFTHIT
-	body_parts_covered = NECK|HAIR|EARS|HEAD|MOUTH
+	body_parts_covered = NECK|MOUTH|NOSE|HAIR|EARS|HEAD
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //padded gambeson durability
 	armor = ARMOR_PADDED_GOOD //full padded gambeson basically
 	prevent_crits = PREVENT_CRITS_MOST
 	adjustable = CAN_CADJUST


### PR DESCRIPTION

## About The Pull Request

Gives the heavy padded coif the same durability as the padded gambeson (300) and makes it protect the nose which it for some reason did not.

## Testing Evidence

It's a one line change.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Assumedly this is supposed to be a padded gambeson for your head, but has worse durability than the more protective steel neck/head underarmors and does not cover the nose like the full chain coif does. It's a strict downgrade because the 200 durability doesn't actually make it better than chain coifs vs blunt and only really helps against archers (and they can still just shoot your eyes instead).

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: They heavy padded coif now actually has padded gambeson durability and protects the nose.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
