### PR TITLE
Gives the harlot a hairpin rather than regular lockpicks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -124,7 +124,12 @@
 
 /datum/outfit/job/bathworkerghtmaiden/harlot/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/roguetown/armingcap
+	var/pinroll = rand(1, 20)
+	switch(pinroll)
+		if(1 to 19)
+			head = /obj/item/lockpick/goldpin
+		if(20)
+			head = /obj/item/lockpick/goldpin/silver
 	neck = /obj/item/clothing/neck/roguetown/collar/leather
 	beltl = /obj/item/roguekey/nightmaiden
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
@@ -132,7 +137,6 @@
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	backpack_contents = list(
 		/obj/item/soap/bath = 1,
-		/obj/item/lockpickring/mundane = 1
 	)
 	if(should_wear_femme_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy/random


### PR DESCRIPTION
## About The Pull Request

Removes the ring of lockpicks from the harlot's pack in favor of giving them a hairpin roll like the courtesan.

## Testing Evidence

<img width="576" height="276" alt="image" src="https://github.com/user-attachments/assets/012f4cb3-b8e7-4c93-a5ba-395964add1c7" />

## Why It's Good For The Game

Harlot's supposed to be good at picking locks but didn't get the one good piece of bathworker near-exclusive lockpicking gear, the one that lets you pretend it's just a normal pin (until the ubertracker says that it was in fact a hairpin used to pick the stewardry).

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
change: Harlot advclass for bathworker gets the funny lockpicking hairpin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
