### PR TITLE
Adds a Finisher for Frost Bolt

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/frost_bolt.dm
@@ -44,6 +44,7 @@
 	range = 10
 	speed = 1
 	nodamage = FALSE
+	var/freeze_duration = 5 SECONDS
 	var/aoe_range = 0
 
 /obj/projectile/magic/frostbolt/on_hit(target)
@@ -57,6 +58,14 @@
 			return BULLET_ACT_BLOCK
 		if(isliving(target))
 			var/mob/living/L = target
+			var/datum/status_effect/debuff/arcanemark/mark = L.has_status_effect(/datum/status_effect/debuff/arcanemark)
+
+			if(mark && mark.stacks == mark.max_stacks)
+				L.Immobilize(freeze_duration)
+				L.OffBalance(freeze_duration)
+				L.visible_message("<span class='warning'>[L]'s movements are halted by arcyne frost!</span>")
+				consume_arcane_mark_stacks(M)
+
 			if(L.has_status_effect(/datum/status_effect/buff/frostbite))
 				return
 			else


### PR DESCRIPTION
## About The Pull Request

Adds a finisher for Frost Bolt consisting of a 5 second Immobilize() and OffBalance() just like Ensnare.

## Testing Evidence

Spawned in complex mobs like skeletons and confirmed the immobilization, working just like Ensnare's.

## Why It's Good For The Game

Having more finishers I think is a good idea, trying to avoid a simple damage boost for my first finisher.

## Changelog

:cl: Randall
add: Adds a Finisher effect for Frost Bolt for hitting someone that's arcyne marked, triggering an Ensnare-like effect.
/:cl:
