### PR TITLE
Maneater rework: I'M KICKING DENDOR'S WALNUTS TILL THEY CRACK

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -198,7 +198,7 @@
 		playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
 		if(W.loc)
 			W.forceMove(src)
-		seednutrition += 10
+		seednutrition += 20
 
 		if(!oldagg)
 			START_PROCESSING(SSobj, src)


### PR DESCRIPTION
## About The Pull Request
Maneater dismember behavior has been mildly reworked and debugged.  The ability to feed maneaters meat for seeds has also been added back in. The randomness has been removed from the dismember proc, it now works on a damage threshold and relies on the limb selection for it's RNG.   It goes as follows:

- The maneater begins to chew after three seconds.  It also plays a noise when it grabs you, and the font is larger and includes a prompt to RESIST and properly get off of the plant in **BIG RED LETTERS.**

- The maneater randomly selects a limb to chew every few seconds, then deals 60 damage per bite.  First it deals damage to armor, then to limbs. This is three times more than the previous default damage to armor. 

- When a victim attempts to resist, they'll automatically attempt to resist again every .75 seconds until freed.

- When a limb reaches 110 damage or more, it will be dismembered the next time it's selected for a chew.   Note that already severely damaged limbs can be dismembered by the first chew.  Undamaged limbs will need to be selected three times.  It CAN dismember in as few as three chews, but it's very, very unlikely to do so.

- Limbs are longer are teleported away from the maneater, and use the default dismemberment code to place them in unoccupied adjacent spaces. (ALSO NO FUCKING CLUE WHY THIS WASN'T THE CASE TO BEGIN WITH BUT **WHATEVER.**)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
https://files.catbox.moe/rcdatc.mp4
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I hated the RNG insta-dismembers from the old maneaters.  If you're running into the forest severely crippled and with broken armor, this will hurt more- but... have you considered not doing that?   This is way safer for most towner roles and means that an unarmored individual will have way more time to escape a maneater, but they won't come out unscathed doing so.  An uninjured individual now has NO chance of being dismembered.  You also have no chance of losing your limb INSIDE TREES or other props.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Reworked maneater chew behavior.
fix: Maneaters no longer teleport limbs randomly without checking for objects in the space they spit it into.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
