### PR TITLE
calfix (calyx fix)

### DIFF
--- a/code/modules/roguetown/roguemachine/heartbeast/heart_slab.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_slab.dm
@@ -78,11 +78,13 @@
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen
 	calyx_spawn_chance = 15
 
-/obj/effect/landmark/chimeric_calyx_spawner/Initialize()
+/obj/effect/landmark/chimeric_calyx_spawner/Initialize(mapload)
 	. = ..()
+	if(SSticker && SSticker.setup_done)
+		return INITIALIZE_HINT_QDEL
 	if(prob(calyx_spawn_chance))
 		new /obj/structure/roguemachine/chimeric_calyx(loc)
-	qdel(src)
+	return INITIALIZE_HINT_QDEL
 
 /obj/structure/roguemachine/chimeric_calyx
 	name = "Heartbeast Calyx"


### PR DESCRIPTION
## About The Pull Request

stops calyxes from spawning after init in custom loaded maps

## Testing Evidence

spawn custom area. no more 5000 calyxes in garbage collector. garbage collector still, for some reason, very full? dunno why. question for later.

## Why It's Good For The Game

I would like to be able to run events

## Changelog

:cl:
fix: calyx fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
