### PR TITLE
Metal Construct crests layer over hair

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -62,8 +62,6 @@
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
 		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/crest,
-		/datum/customizer/bodypart_feature/hair/head/humanoid,
-		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,
 		/datum/customizer/bodypart_feature/face_detail,
 		/datum/customizer/bodypart_feature/underwear,


### PR DESCRIPTION
## About The Pull Request
Quite simply this allows constructs to select hair in character creation, both atop their silly heads and on their face if you want. Crests should layer over their hair as well in case you still want one.

## Testing Evidence
<img width="152" height="156" alt="image" src="https://github.com/user-attachments/assets/8c4552aa-e5e9-4d2e-956f-5da8b04fec91" /><br>
<img width="282" height="281" alt="image" src="https://github.com/user-attachments/assets/021a1209-44ec-402d-8fe3-2d40ae433fb0" />

## Why It's Good For The Game
From what I can see around the Discord, people were finding scissors and giving themselves hair as constructs anyways. I haven't confirmed whether or not that still works, but at this point I feel there's enough sentiment in the community to see The Metal People have hair.

Is their hair actual protein filament growing from follicles? Fiberglass? Some random reeds and vines they found and glued to themselves? Who knows, the player should decide for themselves these sorts of things I think.

## Changelog
:cl:
fix: Construct crests layer over hair
/:cl: