### PR TITLE
Truthnukes Dragonscale

### DIFF
--- a/code/modules/cargo/packsrogue/Mage.dm
+++ b/code/modules/cargo/packsrogue/Mage.dm
@@ -138,19 +138,34 @@
 	cost = 100
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/silver)
 
-///////////
-// MAGIC //
-///////////
+//////////////////
+// ✨ MAGIC ✨ //
+//////////////////
 
 /datum/supply_pack/rogue/Mage/unfinbook
 	name = "Unfinished Spellbook"
 	cost = 10
 	contains = list(/obj/item/spellbook_unfinished)
 
-/datum/supply_pack/rogue/Mage/nomag
+/datum/supply_pack/rogue/Mage/ring_nomag
 	name = "Ring of Nullmagic"
 	cost = 200
 	contains = list(/obj/item/clothing/ring/active/nomag)
+
+/datum/supply_pack/rogue/Mage/ring_swiftness
+	name = "Ring of Swiftness"
+	cost = 250
+	contains = list(/obj/item/clothing/ring/statgemerald)
+
+/datum/supply_pack/rogue/Mage/ring_vitality
+	name = "Ring of Vitality"
+	cost = 250
+	contains = list(/obj/item/clothing/ring/statonyx)
+
+/datum/supply_pack/rogue/Mage/ring_wisdom
+	name = "Ring of Wisdom"
+	cost = 250
+	contains = list(/obj/item/clothing/ring/statamythortz)
 
 /datum/supply_pack/rogue/Mage/talkstone
 	name = "Talkstone"

--- a/code/modules/cargo/packsrogue/Things.dm
+++ b/code/modules/cargo/packsrogue/Things.dm
@@ -91,19 +91,14 @@
 	cost = 15
 	contains = list(/obj/item/reagent_containers/powder/spice)
 
-//////////////
+/////////////
 // UTILITY //
-//////////////
+/////////////
 
 /datum/supply_pack/rogue/Things/rubyband
 	name = "Matthian SCOMSTONE"
 	cost = 20
 	contains = list(/obj/item/mattcoin)
-
-/datum/supply_pack/rogue/Things/Dragonscale
-	name = "Dragonscale Necklace"
-	cost = 900
-	contains = list(/obj/item/clothing/neck/roguetown/blkknight)
 
 /datum/supply_pack/rogue/Things/smokebomb
 	name = "Smoke Bomb"


### PR DESCRIPTION
## About The Pull Request

Removes dragonscale from being purchasable instead gives Bandit Mage ability to buy 3 out of the 4 statrings - this way they actually have to trade in something for their stats instead of getting supreme gorget WITH bonus stats.
To those who might be well what if they get the strenght ring and make the omnipotence one - it requires legendary smithing none of them can achieve in round realistically.

## Testing Evidence

Byeah

## Why It's Good For The Game

Truecel approved.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Bandit statitem shop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
