### PR TITLE
[miracles] - fixes eoran tree pruning

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -457,6 +457,7 @@
 	var/happiness = 0
 	var/water_happiness = 0
 	var/fertilizer_happiness = 0
+	var/prune_happiness = 0
 	var/prune_count = 0
 	var/list/tree_offerings = list()
 	var/happiness_tier = 1
@@ -511,6 +512,7 @@
 		var/skill = get_farming_skill(user)
 		var/prune_time = get_skill_delay(skill, fastest = 0.5, slowest = 3)
 		var/branches_pruned = 1
+		var/remaining_cap = 20 - prune_happiness
 
 		to_chat(user, span_notice("You begin pruning the tree..."))
 
@@ -520,7 +522,9 @@
 				branches_pruned++
 			else
 				prune_count++
-			happiness = min(happiness + (branches_pruned * 5), 100)
+			var/actual_gain = min(branches_pruned * 5, remaining_cap)
+			prune_happiness += actual_gain
+			happiness = min(happiness + actual_gain, 100)
 			update_happiness_tier()
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
@@ -675,6 +679,7 @@
 	water_happiness = 0
 	fertilizer_happiness = 0
 	prune_count = 0
+	prune_happiness = 0
 	update_happiness_tier()
 	update_icon()
 


### PR DESCRIPTION
## About The Pull Request
Shrimple, eoran tree pruning wasn't giving the appropriate amount of hapiness for pruning tree leaves when your skill was higher than apprentice

## Testing Evidence
checked vv, two prunes, 20 happi, me happi

## Why It's Good For The Game
how about we go to inn room IV

## Changelog

:cl:
fix: eora tree pruning now correctly updates happiness at all skill levels
/:cl:
