### PR TITLE
Judgement O' Thine Jakkage - Restores the Judgement's strength (at the cost of exceptionally low sharpness), adds supplemental descriptions to all derivatives.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -508,13 +508,13 @@
 
 /obj/item/rogueweapon/sword/long/judgement
 	name = "\"Judgement\""
-	desc = "A noble longsword, and the cherished heirloom of Azuria's royal bloodline. Its blade is made from Aavnr's finest Vyšvou steel - held from an ornate carved ivory grip from the region's \"Mamük\" megafauna, and decorated with heraldric engravings of silver. </br>'When you stand before thine lord, you cannot say, '..but I was told by others to do thus..', or that, '..virtue was not convenient at the time.' This will not suffice. Remember that.'"
+	desc = "A noble longsword, and the cherished heirloom of Azuria's royal bloodline. Its blade is made from Aavnr's finest Vyšvou steel - held from an ornate carved ivory grip from the region's \"Mamük\" megafauna, and decorated with heraldric engravings of silver. ‎</br>‎‎ </br>'When you stand before thine lord, you cannot say, '..but I was told by others to do thus..', or that, '..virtue was not convenient at the time.' This will not suffice. Remember that.'"
 	icon_state = "judgement"
 	item_state = "judgement"
 	sheathe_icon = "judgement"
 	force = 40
 	force_wielded = 50
-	max_blade_int = 100 //Roughly on par with Decrepit-tier weapons, as a heirloom that should be sparingly used.
+	max_blade_int = 77 //Roughly on par with Decrepit-tier weapons, as a heirloom that should be sparingly used.
 	max_integrity = 333
 	wbalance = WBALANCE_HEAVY
 	sellprice = 333
@@ -533,24 +533,9 @@
 			if("onbelt")
 				return list("shrink" = 0.4,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/rogueweapon/sword/long/judgement/ascendant //meant to be insanely OP; solo antag wep
-	name = "\"The Redentor\""
-	desc = "A resplendent longsword, assembled from an otherworldly alloy. Intersecting visions from beyond-and-before cross your mind, as your fingers curl along the leather; all merging into a final truth, sailing across the star-speckled phlogiston. </br>'And the preacher said: \"For the Lord is my tower, and He gives me the power to tear down the works of the enemy.\""
-	force = 66
-	force_wielded = 99
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
-	icon_state = "crucified"
-	sheathe_icon = "crucified"
-	item_state = "judgement"
-	sellprice = 999
-	static_price = TRUE
-	max_integrity = 9999
-	max_blade_int = 999
-
 /obj/item/rogueweapon/sword/long/judgement/vlord
 	name = "\"Ichor Fang\""
-	desc = "An unholy longsword, who's crystalline blade radiates with insurmountable sharpness. It has been brought forth unto this world for a singular purpose; not to bring peace, but to dominate all who'd dare to oppose the coming darkness. </br>'And I looked, and beheld a pale horse - the name that sat upon Her was Death, and Hell followed with them.'"
+	desc = "An unholy longsword, who's crystalline blade radiates with insurmountable sharpness. It has been brought forth unto this world for a singular purpose; not to bring peace, but to dominate all who'd dare to oppose the coming darkness. ‎</br>‎‎ </br>'And I looked, and beheld a pale horse - the name that sat upon Her was Death, and Hell followed with them.'"
 	force = 45
 	force_wielded = 55
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/peel)
@@ -576,6 +561,21 @@
 
 	src.visible_message(span_warning("\The [src] crumbles to dust, the ashes spiriting away."))
 	qdel(src)
+
+/obj/item/rogueweapon/sword/long/judgement/ascendant //meant to be insanely OP; solo antag wep
+	name = "\"The Redentor\""
+	desc = "A resplendent longsword, assembled from an otherworldly alloy. Intersecting visions from beyond-and-before cross your mind, as your fingers curl along the leather; all merging into a final truth, sailing across the star-speckled phlogiston. ‎</br>‎‎ </br>'And the preacher said: \"For the Lord is my tower, and He gives me the power to tear down the works of the enemy.\""
+	force = 66
+	force_wielded = 99
+	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
+	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
+	icon_state = "crucified"
+	sheathe_icon = "crucified"
+	item_state = "judgement"
+	sellprice = 999
+	static_price = TRUE
+	max_integrity = 9999
+	max_blade_int = 999
 
 /obj/item/rogueweapon/sword/long/marlin
 	name = "shalal saber"


### PR DESCRIPTION
## About The Pull Request

Here we are; a _rare_, properly controversial balancejak!
No pressure on this, by the way, since this is far from being a hill I'd die on. I _do_ want to see how people might feel about this, however.
In short:
* Restores the pre-nerfed damage values of the 'Judgement' sword. For those tuning at home, this means it now deals _40_ to _50_ damage. I've also upped the durability to 333, which is about ~33%-ish better than the longsword it's forked from.
* Dramatically reduced the sharpness of the 'Judgement' sword. For reference, it's _slightly_ less sharp than most Decrepit-tier weapons. This means that it _should_ rapidly lose its damage after a few parries, or roughly a dozen strikes. Tweak as needed.
* Touches up some of the other 'Judgement' derivatives. New descriptions for all three, more defined sharpness and sale values, and a _slight_ +5 one-handed damage buff to the 'Ichor Fang'.

## Testing Evidence
* Slightly outdated. Added a minor space between the descriptions and quotes afterwards, to improve readability.
<img width="1178" height="529" alt="6a4713c23dea9fb5f5634a34611b7729" src="https://github.com/user-attachments/assets/a37b1b08-3355-46c4-aad1-d82a2c82151f" />


## Why It's Good For The Game

The 'Judgement' sword is cool. 
Some changes have been recently made to curtail its most problematic issues: namely, it no longer spawns at all unless a Duke has joined the round _(which prevents it from being immediately rushed and stolen by villains and courtiers alike)_. 

Likewise, the extremely low sharpness - courtesy of Free's changes - _should_ nail an excellent balance: lethal enough to befit a Duke for duels and defense, but at the cost of rapidly losing its capacity for damage and dismemberment if treated like a conventional longsword. 

Loaning it to the Knight-Captain for their crusade can still be done, of course, but its performance in anything larger than a one-on-one clash will quickly diminish. Pray that they have the breathing space to constantly flick a whetstone, or a second sword to handle the lesser rabble.

Beyond that, however, this readds some much needed love to the Duke. They're the most important role in the server, and are oft-expected to _"get the ball rolling"_. If this encourages the return of more proactive Dukes who can better flex their authority, then I am all for it.

_(As for the other changes, they're mostly just little nitpicks.)_
_(Double-note: this should probably be testmerged before anything else, so that we can fine-tune how it feels. Maybe inverting the statistics to make it exceptionally sharp but fragile would feel better? Will it summon a massive horde of Dukes-turned-Rambos? Let's find out!)_

## Changelog

:cl:
balance: Restored the Judgement's pre-nerf damage and durability, but dramatically reduced their sharpness value in exchange.
balance: Slightly increased the Ichor Fang's one-handed damage, alongside increasing its sharpness.
add: New descriptions to the Judgement, Ichor Fang, and Redentor.
/:cl:
