### PR TITLE
Enhance memory wipe message for obfuscate power

### DIFF
--- a/code/modules/vampire_neu/covens/coven_powers/obfuscate.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/obfuscate.dm
@@ -143,7 +143,7 @@
 	for(var/mob/living/carbon/human/viewer in oviewers(7, owner))
 		if(viewer.client && viewer.stat < UNCONSCIOUS)
 			to_chat(viewer, span_hypnophrase("<span style='font-size: 200%; text-shadow: 0 0 8px #ffffff;'>Wait... wasn't someone just here? No, must be my imagination...</span>"))
-			to_chat(viewer, span_hypnophrase("<span style='font-size: 80%; text-shadow: 0 0 6px #ffffff;'>You forget that you saw this person.</span>"))
+			to_chat(viewer, span_hypnophrase("<span style='font-size: 80%; text-shadow: 0 0 6px #ffffff;'>You forget that you saw [owner].</span>"))
 			// Could add more memory effects here like removing recent chat logs mentioning the user
 
 /datum/coven_power/obfuscate/vanish_from_the_minds_eye/deactivate()


### PR DESCRIPTION
## About The Pull Request

Improved the visual presentation of the memory wipe effect by adding styled chat messages, making it clearer to players that they have forgotten seeing the vampire.

## Testing Evidence

<img width="1604" height="1038" alt="image" src="https://github.com/user-attachments/assets/855f3635-453e-4476-98f0-924c8c2c4ae9" />
<img width="664" height="424" alt="image" src="https://github.com/user-attachments/assets/d17bfe55-7675-4ef7-86f6-53f6d6c5587e" />


## Why It's Good For The Game

Players receive unmistakable feedback about the memory wipe, reducing confusion and reinforcing the power’s effect.

## Changelog
:cl:
qol: clarified and highlighted the Obfuscate memory-wipe feedback so players better understand they forgot seeing the vampire
code: adjusted chat message formatting for the Obfuscate memory wipe
/:cl: