### PR TITLE
Renames & Sorts Smithing Items

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -146,7 +146,7 @@
 	created_item = /obj/item/clothing/gloves/roguetown/plate/aalloy
 
 /datum/anvil_recipe/armor/aalloy/chainkilt
-	name = "Chainkilt, Decrepit"
+	name = "Kilt, Chain, Decrepit"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/kilt/aalloy
 
@@ -226,7 +226,7 @@
 	created_item = /obj/item/clothing/gloves/roguetown/plate/paalloy
 
 /datum/anvil_recipe/armor/paalloy/chainkilt
-	name = "Chainkilt, Ancient"
+	name = "Kilt, Chain, Ancient"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/kilt/paalloy
 
@@ -348,7 +348,7 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/iron
 
 /datum/anvil_recipe/armor/iron/studded
-	name = "Studded Leather Armor (+ Leather Armor)"
+	name = "Breastplate, Studded Leather (+ Leather Armor)"
 	req_bar = /obj/item/ingot/iron
 	req_blade = /obj/item/blade/iron_plate
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/leather)
@@ -430,7 +430,7 @@
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/iron
 
 /datum/anvil_recipe/armor/iron/chainleg/kilt
-	name = "Chain Kilt, Iron"
+	name = "Kilt, Chain, Iron"
 	req_bar = /obj/item/ingot/iron
 	req_blade = /obj/item/blade/iron_plate
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/iron/kilt
@@ -817,7 +817,7 @@
 	created_item = /obj/item/clothing/under/roguetown/platelegs
 
 /datum/anvil_recipe/armor/steel/chainlegs/kilt
-	name = "Chain Kilt, Steel"
+	name = "Kilt, Chain, Steel"
 	req_bar = /obj/item/ingot/steel
 	req_blade = /obj/item/blade/steel_plate
 	created_item = /obj/item/clothing/under/roguetown/chainlegs/kilt
@@ -995,13 +995,13 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate
 
 /datum/anvil_recipe/armor/blessedsilver/psyfullplate
-	name = "Full-Plate, Psydonic (+Psydonic Half-Plate, +1 Blessed Silver, +2 Cured Leather)"
+	name = "Full-Plate, Psydonic, Half-Plate Base (+Psydonic Half-Plate, +1 Blessed Silver, +2 Cured Leather)"
 	req_bar = /obj/item/ingot/silverblessed
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate, /obj/item/ingot/silverblessed, /obj/item/natural/hide/cured, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/fluted/ornate
 
 /datum/anvil_recipe/armor/blessedsilver/psyfullplatealt
-	name = "Full-Plate, Psydonic, Hauberked (+Psydonic Hauberk, +2 Blessed Silver, +2 Cured Leather)"
+	name = "Full-Plate, Psydonic, Hauberk Base (+Psydonic Hauberk, +2 Blessed Silver, +2 Cured Leather)"
 	req_bar = /obj/item/ingot/silverblessed
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/ornate, /obj/item/ingot/silverblessed, /obj/item/ingot/silverblessed, /obj/item/natural/hide/cured, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/fluted/ornate


### PR DESCRIPTION
## About The Pull Request

Sorts out the armoursmithing file properly and renames items to follow a certain pattern with examples of:

Helmet, Savoyard, Barred, Steel
Gauntlets, Chain, Ancient
"Chausses, Plated, Steel (+1 Steel)"

## Testing Evidence

<img width="601" height="696" alt="image" src="https://github.com/user-attachments/assets/ecbf4fdd-f29a-4222-b103-25363597b272" />


## Why It's Good For The Game

Hopefully it makes smithing somehow less of a pain - because it surely makes it easier to look through the code.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Armor smithing category
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
