### PR TITLE
Supercharges golgotha nuke

### DIFF
--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -357,7 +357,7 @@ Inquisitorial armory down here
 	. = ..()	//We smashed a guy with it turned on. Bad idea!
 	if(ismob(A) && on && (user.used_intent.type == /datum/intent/mace/smash/flail/golgotha) && user.cmode)
 		user.visible_message(span_warningbig("[user] smashes the exposed [src], shattering the shard of SYON!"))
-		explosion(get_turf(A),devastation_range = 2, heavy_impact_range = 3, light_impact_range = 4, flame_range = 2, flash_range = 4, smoke = FALSE)
+		explosion(get_turf(A),devastation_range = 3, heavy_impact_range = 5, light_impact_range = 6, flame_range = 3, flash_range = 6, smoke = FALSE)
 		fuel = 0
 		turn_off()
 		icon_state = "psycenser-broken"
@@ -366,6 +366,8 @@ Inquisitorial armory down here
 		for(var/mob/living/carbon/human/H in view(get_turf(src)))
 			if(H.patron?.type == /datum/patron/old_god)	//Psydonites get VERY depressed seeing an artifact get turned into an ulapool caber.
 				H.add_stress(/datum/stressevent/syoncalamity)
+		for(var/mob/living/carbon/human/H in range(1, get_turf(src)))
+			H.gib()
 	if(isitem(A) && on && user.used_intent.type == /datum/intent/bless)
 		var/datum/component/silverbless/CP = A.GetComponent(/datum/component/silverbless)
 		if(CP)

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -73,6 +73,7 @@
 	damfactor = 0.9
 
 /datum/intent/mace/smash/flail/golgotha
+	chargetime = 3 SECONDS
 	hitsound = list('sound/items/beartrap2.ogg')
 
 /datum/intent/mace/smash/flailrange


### PR DESCRIPTION
## About The Pull Request

Golgotha nuke now has a bigger radius (only 1-up from the current), and gibs the user + those surrounding them.

## Testing Evidence

Yes.

## Why It's Good For The Game

Uncommon nuke should be a nuke.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Golgotha nuke is now bigger + gibs surrounding mobs.
balance: Golgotha smash takes 3s to wind up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
