### PR TITLE
Metal Constructs can have hair, and more skin tones

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -59,6 +59,8 @@
 		)
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,
+		/datum/customizer/bodypart_feature/hair/head/humanoid,
+		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/crest,
 		/datum/customizer/bodypart_feature/accessory,
 		/datum/customizer/bodypart_feature/face_detail,
@@ -99,6 +101,9 @@
 		"IRON" = "525352",
 		"STEEL" = "babbb9",
 		"BRONZE" = "e2a670",
+		"GOLD" = "bf9b30",
+		"WOOD" = "8B4513",
+		"PORCELAIN" = "FFF5EE",
 	)
 
 /datum/species/construct/metal/get_hairc_list()


### PR DESCRIPTION
## About The Pull Request

Adds the ability to have hair as a Metal Construct, as well as three additional 'material' (skin tone) options: Gold, Wood, and Porcelain.

## Testing Evidence

<img width="325" height="337" alt="KyvsYEQ1gg" src="https://github.com/user-attachments/assets/ed06817d-dfae-44b0-b25b-eb439443991b" /><br>
<img width="172" height="192" alt="mhWYhTOaxs" src="https://github.com/user-attachments/assets/920da0f3-894b-471f-b7b1-987bdad701cf" />
<img width="172" height="192" alt="gTJkvhgoMP" src="https://github.com/user-attachments/assets/a4401ff2-46f3-466a-8149-56be0e84eebf" />
<img width="172" height="192" alt="Y0owOrXXvI" src="https://github.com/user-attachments/assets/46b0db66-e250-4598-8128-da3205fc9663" />

## Why It's Good For The Game

More customization options for Metal Constructs makes them a more attractive option to play. There's no real reason why they shouldn't be allowed to have hair or more skin tones.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Hair for the Metal Construct species
add: Three additional skin tones for Metal Construct: Gold, Wood, Porcelain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
