### PR TITLE
Zigboxes (and bandolier)

### DIFF
--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -281,3 +281,28 @@
 /datum/component/storage/concrete/roguetown/dice_pouch/New(datum/P, ...)
 	. = ..()
 	can_hold = typecacheof(list(/obj/item/dice))
+
+/datum/component/storage/concrete/roguetown/zig_box
+	screen_max_rows = 3
+	screen_max_columns = 2
+	max_w_class = WEIGHT_CLASS_SMALL
+	not_while_equipped = FALSE
+
+/datum/component/storage/concrete/roguetown/zig_box/New(datum/P, ...)
+	. = ..()
+	set_holdable(list(
+		/obj/item/clothing/mask/cigarette/rollie,
+		/obj/item/flint,
+		))
+
+/datum/component/storage/concrete/roguetown/zig_bandolier
+	screen_max_rows = 8
+	screen_max_columns = 3
+	max_w_class = WEIGHT_CLASS_SMALL
+
+/datum/component/storage/concrete/roguetown/zig_bandolier/New(datum/P, ...)
+	. = ..()
+	set_holdable(list(
+		/obj/item/clothing/mask/cigarette/rollie,
+		/obj/item/flint,
+		))

--- a/code/game/objects/items/quiver.dm
+++ b/code/game/objects/items/quiver.dm
@@ -99,7 +99,7 @@
 	. = ..()
 	if(arrows.len)
 		. += span_notice("[arrows.len] inside.")
-	. += span_notice("Click on the ground to pick up ammos on the floor.")
+	. += span_notice("Click on the ground to pick up ammo.")
 
 /obj/item/quiver/update_icon()
 	if(arrows.len)
@@ -346,64 +346,5 @@
 	. = ..()
 	for(var/i in 1 to max_storage)
 		var/obj/item/ammo_casing/caseless/rogue/sling_bullet/paalloy/A = new()
-		arrows += A
-	update_icon()
-
-/obj/item/quiver/zigs
-	name = "zig box"
-	desc = "A box for all your smoking needs."
-	icon = 'icons/roguetown/clothing/storage.dmi'
-	icon_state = "smokebox"
-	item_state = "smokebox"
-	slot_flags = ITEM_SLOT_HIP
-	max_storage = 10
-	w_class = WEIGHT_CLASS_NORMAL
-	grid_height = 64
-	grid_width = 32
-
-/obj/item/quiver/zigs/attackby(obj/A, loc, params)
-	if(A.type in subtypesof(/obj/item/clothing/mask/cigarette/rollie))
-		if(arrows.len < max_storage)
-			if(ismob(loc))
-				var/mob/M = loc
-				M.doUnEquip(A, TRUE, src, TRUE, silent = TRUE)
-			else
-				A.forceMove(src)
-			arrows += A
-			update_icon()
-		else
-
-	..()
-
-/obj/item/quiver/zigs/attack_right(mob/user)
-	if(arrows.len)
-		var/obj/O = arrows[arrows.len]
-		arrows -= O
-		O.forceMove(user.loc)
-		user.put_in_hands(O)
-		update_icon()
-		return TRUE
-
-/obj/item/quiver/zigs/update_icon()
-	return
-
-/obj/item/quiver/zigs/nicotine/Initialize()
-	. = ..()
-	for(var/i in 1 to max_storage)
-		var/obj/item/clothing/mask/cigarette/rollie/nicotine/A = new()
-		arrows += A
-	update_icon()
-
-/obj/item/quiver/zigs/trippy/Initialize()
-	. = ..()
-	for(var/i in 1 to max_storage)
-		var/obj/item/clothing/mask/cigarette/rollie/trippy/A = new()
-		arrows += A
-	update_icon()
-
-/obj/item/quiver/zigs/cannabis/Initialize()
-	. = ..()
-	for(var/i in 1 to max_storage)
-		var/obj/item/clothing/mask/cigarette/rollie/cannabis/A = new()
 		arrows += A
 	update_icon()

--- a/code/modules/cargo/packsrogue/bathmatron/drugs.dm
+++ b/code/modules/cargo/packsrogue/bathmatron/drugs.dm
@@ -67,17 +67,22 @@
 /datum/supply_pack/rogue/drugs/zigbox
 	name = "Zigbox (Empty)"
 	cost = 5
-	contains = list(/obj/item/quiver/zigs)
+	contains = list(/obj/item/storage/belt/rogue/pouch/zigarrete)
 
 /datum/supply_pack/rogue/drugs/zigbox_pipezig
 	name = "Zigbox (Pipeweed)"
 	cost = 25
-	contains = list(/obj/item/quiver/zigs/nicotine)
+	contains = list(/obj/item/storage/belt/rogue/pouch/zigarrete/nicotine)
 
 /datum/supply_pack/rogue/drugs/zigbox_swampzig
 	name = "Zigbox (Swampweed)"
 	cost = 55
-	contains = list(/obj/item/quiver/zigs/cannabis)
+	contains = list(/obj/item/storage/belt/rogue/pouch/zigarrete/cannabis)
+
+/datum/supply_pack/rogue/drugs/zigdolier
+	name = "Zigdolier (Empty)"
+	cost = 35
+	contains = list(/obj/item/storage/belt/rogue/leather/zig_bandolier)
 
 /datum/supply_pack/rogue/drugs/fermented_crab
 	name = "Fermented Crab"

--- a/code/modules/clothing/rogueclothes/storage/pouch.dm
+++ b/code/modules/clothing/rogueclothes/storage/pouch.dm
@@ -197,3 +197,34 @@
 
 /obj/item/storage/belt/rogue/pouch/food/PopulateContents()
 	new /obj/item/reagent_containers/food/snacks/rogue/crackerscooked(src)
+
+/obj/item/storage/belt/rogue/pouch/zigarrete
+	name = "zig box"
+	desc = "Used to hold someone's zigs and flints."
+	icon_state = "smokebox"
+	item_state = "smokebox"
+	component_type = /datum/component/storage/concrete/roguetown/zig_box
+
+/obj/item/storage/belt/rogue/pouch/zigarrete/nicotine/PopulateContents()
+	new /obj/item/clothing/mask/cigarette/rollie/nicotine(src)
+	new /obj/item/clothing/mask/cigarette/rollie/nicotine(src)
+	new /obj/item/clothing/mask/cigarette/rollie/nicotine(src)
+	new /obj/item/clothing/mask/cigarette/rollie/nicotine(src)
+	new /obj/item/clothing/mask/cigarette/rollie/nicotine(src)
+	new /obj/item/clothing/mask/cigarette/rollie/nicotine(src)
+
+/obj/item/storage/belt/rogue/pouch/zigarrete/trippy/PopulateContents()
+	new /obj/item/clothing/mask/cigarette/rollie/trippy(src)
+	new /obj/item/clothing/mask/cigarette/rollie/trippy(src)
+	new /obj/item/clothing/mask/cigarette/rollie/trippy(src)
+	new /obj/item/clothing/mask/cigarette/rollie/trippy(src)
+	new /obj/item/clothing/mask/cigarette/rollie/trippy(src)
+	new /obj/item/clothing/mask/cigarette/rollie/trippy(src)
+
+/obj/item/storage/belt/rogue/pouch/zigarrete/cannabis/PopulateContents()
+	new /obj/item/clothing/mask/cigarette/rollie/cannabis(src)
+	new /obj/item/clothing/mask/cigarette/rollie/cannabis(src)
+	new /obj/item/clothing/mask/cigarette/rollie/cannabis(src)
+	new /obj/item/clothing/mask/cigarette/rollie/cannabis(src)
+	new /obj/item/clothing/mask/cigarette/rollie/cannabis(src)
+	new /obj/item/clothing/mask/cigarette/rollie/cannabis(src)

--- a/code/modules/clothing/rogueclothes/storage/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage/storage.dm
@@ -496,3 +496,29 @@
 	anvilrepair = /datum/skill/craft/blacksmithing
 	smeltresult = /obj/item/ingot/bronze
 	component_type = /datum/component/storage/concrete/grid/orestore/bronze
+
+/obj/item/storage/belt/rogue/leather/zig_bandolier
+	name = "zig bandolier"
+	desc = "For when your addiction gets a hold on you."
+	icon_state = "twstrap0"
+	item_state = "twstrap"
+	icon = 'icons/obj/items/twstrap.dmi'
+	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
+	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_ARMOR
+	resistance_flags = FIRE_PROOF
+	equip_delay_self = 5 SECONDS
+	unequip_delay_self = 5 SECONDS
+	max_integrity = 0
+	sellprice = 15
+	inhand_x_dimension = 64
+	inhand_y_dimension = 64
+	pixel_y = -16
+	pixel_x = -16
+	bigboy = TRUE
+	equip_sound = 'sound/blank.ogg'
+	bloody_icon_state = "bodyblood"
+	alternate_worn_layer = UNDER_CLOAK_LAYER
+	strip_delay = 20
+	component_type = /datum/component/storage/concrete/roguetown/zig_bandolier

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -260,7 +260,7 @@
 	held_items[/obj/item/lipstick/purple] = list("PRICE" = rand(33,50),"NAME" = "purple lipstick")
 	held_items[/obj/item/lipstick/black] = list("PRICE" = rand(33,50),"NAME" = "black lipstick")
 	//azure peak addition - zigbox
-	held_items[/obj/item/quiver/zigs] = list("PRICE" = rand(5,10), "NAME" = "zigbox, empty")
+	held_items[/obj/item/storage/belt/rogue/pouch/zigarrete] = list("PRICE" = rand(5,10), "NAME" = "zigbox, empty")
 	held_items[/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab] = list("PRICE" = rand(50,70), "NAME" = "fermented crab")
 	// azure peak addition end
 


### PR DESCRIPTION
## About The Pull Request

Makes zigboxes be subtype of pouches instead of quivers which were just plain non functional at times.
It only has capacity of 6 with flints being able to be carried in them.
Zig bandolier as a speciality option with capacity of 24.

## Testing Evidence

<img width="417" height="229" alt="image" src="https://github.com/user-attachments/assets/865b27c1-c109-4a75-b1a0-599beec31653" />


## Why It's Good For The Game

Buggy code nobody bothered to fix - at least like this it's properly functional.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Zig bandolier
refactor: Zig boxes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
