### PR TITLE
Knucklebusting Down - Adds current silver damage logic to the Psydonic Knuckles, boosting it from 17-to-27 force.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -369,7 +369,7 @@
 	name = "psydonic knuckles"
 	desc = "A simple piece of harm molded in a holy mixture of steel and silver, finished with three stumps - Psydon's crown - to crush the heretics' garments and armor into smithereens."
 	icon_state = "psyknuckle"
-	force = 17
+	force = 27 //Smaller silver blunt weapons should have a +2-3 damage bonus, compared to their steel counterparts.
 	wdefense = 5
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed


### PR DESCRIPTION
## About The Pull Request

* Fixes the Psydonic Knuckles dealing far less damage than intended, by applying the _intended_ logic used for its balancing.
* Similar to the Silver War Axe, it had a _-8 (!!!)_ damage malus. This turns it into a +2 damage bonus, over its steel counterpart.

## Testing Evidence

♫ _I got two.. lines; one for the jakker and one for the vine.._ ♫

## Why It's Good For The Game

* Psydonic Knuckles dealing less damage than an actual rock you can find on the side of the road is not, in fact, intended.
* This allows for its wielders to properly use its integrity damage modifiers, as intended, to bust through armor.

## Changelog

:cl:
balance: Increases the damage of Psydonic Knuckles from 17 to 27, fixing a months-long oversight that left them far weaker than intended.
/:cl:
