### PR TITLE
Ropes and Helping Hands

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -222,3 +222,30 @@
 		if(EAST)
 			pixel_x = 4
 	. = ..()
+
+/obj/structure/rope_ladder
+	name = "rope"
+	desc = "A length of rope that has been lowered against a surface to allow climbing."
+	icon = 'icons/roguetown/misc/structure.dmi'
+	icon_state = "pillar"
+	anchored = TRUE
+	obj_flags = BLOCK_Z_OUT_DOWN
+	max_integrity = 50
+	blade_dulling = DULLING_BASHCHOP
+
+/obj/structure/rope_ladder/get_mechanics_examine(mob/user)
+	. = ..()
+	. += "The rope can be retrieved by dragging it onto yourself."
+
+/obj/structure/rope_ladder/MouseDrop(atom/over)
+	if(usr != over)
+		return ..()
+	var/mob/living/living_user = usr
+	if(!Adjacent(living_user))
+		return
+	living_user.visible_message(span_notice("[living_user] begins removing the rope ladder from the wall..."), span_notice("You begin removing the rope ladder from the wall..."))
+	if(do_after(living_user, 5 SECONDS, TRUE, src))
+		var/obj/item/rope/rope = new(src.loc)
+		living_user.put_in_hands(rope)
+		living_user.visible_message(span_notice("[living_user] removes the rope ladder from the wall."), span_notice("You remove the rope ladder from the wall."))
+		qdel(src)

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -153,20 +153,57 @@
 					to_chat(user, span_warning("I can't climb here."))
 					return
 			var/used_time = 0
+			var/list/helping_items = list()
 			if(L.mind)
 				var/myskill = L.get_skill_level(/datum/skill/misc/climbing)
+
+				var/has_step_ladder = FALSE
 				var/obj/structure/table/TA = locate() in L.loc
 				if(TA)
 					myskill += 1
-				else
+					helping_items += TA.name
+					has_step_ladder = TRUE
+				if(!has_step_ladder)
 					var/obj/structure/chair/CH = locate() in L.loc
 					if(CH)
 						myskill += 1
-					var/obj/structure/wallladder/WL = locate() in L.loc
-					if(WL)
-						if(get_dir(WL.loc,src) == WL.dir)
-							myskill += 8
-							climbsound = 'sound/foley/ladder.ogg'
+						helping_items += CH.name
+						has_step_ladder = TRUE
+				if(!has_step_ladder)
+					for(var/mob/living/carbon/human/human in L.loc)
+						if(human == L)
+							continue
+						if(!human.cmode && !human.get_active_held_item() && human.mob_size >= MOB_SIZE_HUMAN)
+							myskill += 1
+							helping_items += human.name
+							has_step_ladder = TRUE
+							break
+				if(!has_step_ladder)
+					for(var/mob/living/simple_animal/animal in L.loc)
+						if(animal == L)
+							continue
+						if(animal.tame && animal.mob_size >= MOB_SIZE_HUMAN)
+							myskill += 1
+							helping_items += animal.name
+							has_step_ladder = TRUE
+							break
+
+				var/has_wall_ladder = FALSE
+				for(var/obj/structure/wallladder/WL in L.loc)
+					if(get_dir(WL.loc,src) == WL.dir)
+						myskill += 8
+						climbsound = 'sound/foley/ladder.ogg'
+						helping_items += WL.name
+						has_wall_ladder = TRUE
+						break
+				if(!has_wall_ladder)
+					for(var/obj/structure/rope_ladder/rope in L.loc)
+						if(get_dir(rope.loc, src) == rope.dir)
+							myskill += 5
+							climbsound = 'sound/foley/noose_idle.ogg'
+							helping_items += rope.name
+							has_wall_ladder = TRUE
+							break
 
 				if(myskill < climbdiff)
 					to_chat(user, span_warning("I'm not capable of climbing this wall."))
@@ -174,7 +211,7 @@
 				used_time = max(70 - (myskill * 10) - (L.STASPD * 3), 30)
 			if(user.m_intent != MOVE_INTENT_SNEAK)
 				playsound(user, climbsound, 100, TRUE)
-			user.visible_message(span_warning("[user] starts to climb [src]."), span_warning("I start to climb [src]..."))
+			user.visible_message(span_warning("[user] starts to climb [src][length(helping_items) ? " with the help of \the [english_list(helping_items)]" : ""]."), span_warning("I start to climb [src][length(helping_items) ? " with the help of \the [english_list(helping_items)]" : ""]..."))
 			if(do_after(L, used_time, target = src))
 				var/pulling = user.pulling
 				var/mob/living/carbon/human/climber = user

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -277,6 +277,34 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 
 /turf/open/transparent/openspace/attackby(obj/item/C, mob/user, params)
 	..()
+	if(C.type == /obj/item/rope && isliving(user))
+		var/mob/living/living_user = user
+		living_user.visible_message(span_notice("[living_user] begins to lay down a rope for climbing..."), span_notice("I begin to lay down a rope for climbing..."))
+		if(do_after(living_user, 3 SECONDS, TRUE, target = src))
+			var/turf/target = get_step_multiz(src, DOWN)
+			if(!target)
+				to_chat(living_user, span_warning("There's nowhere to tie the rope here."))
+				return
+			var/obj/structure/rope_ladder/rope = new(target)
+			if(living_user.wallpressed)
+				rope.dir = living_user.dir
+			else
+				rope.dir = get_dir(src, living_user)
+				if(!(rope.dir in GLOB.cardinals))
+					rope.dir = living_user.dir
+			switch(rope.dir)
+				if(NORTH)
+					rope.pixel_y = 20
+				if(SOUTH)
+					rope.layer = ABOVE_MOB_LAYER
+				if(WEST)
+					rope.pixel_x = -12
+				if(EAST)
+					rope.pixel_x = 12
+			living_user.visible_message(span_notice("[living_user] secures the rope to the surface below."), span_notice("I secure the rope to the surface below."))
+			playsound(living_user, 'sound/foley/trap.ogg', 100, TRUE)
+			qdel(C)
+		return
 	if(!CanBuildHere())
 		return
 


### PR DESCRIPTION
## About The Pull Request

- You can now lower a rope to help someone below you climb. This works similarly to a rope ladder. Click on an open turf from above to lay down the rope. Drag the rope onto yourself to retrieve it. (+5 climbing skill)
- Standing atop a tamed animal now gives you the same climbing bonus as standing on a table or a chair. (+1 climbing skill)
- Having another human in your turf, with combat mode disabled, will also give you a climbing boost. (+1 climbing skill)

## Testing Evidence

<img width="493" height="452" alt="image" src="https://github.com/user-attachments/assets/86f96086-251f-4290-87c5-f2cdca6ee763" />

## Why It's Good For The Game

teamwork is dreamwork. and also makes ropes useful for something.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: You can now lower a rope to help someone below you climb. This works similarly to a rope ladder. Click on an open turf from above to lay down the rope. Drag the rope onto yourself to retrieve it. (+5 climbing skill)
add: Standing atop a tamed animal now gives you the same climbing bonus as standing on a table or a chair. (+1 climbing skill)
add: Having another human in your turf, with combat mode disabled, will also give you a climbing boost. (+1 climbing skill)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
