### PR TITLE
Fixes Carrot Steaks not having a Fare Type (Again)

### DIFF
--- a/modular/Neu_Food/code/cooked/cooked_meat_meal.dm
+++ b/modular/Neu_Food/code/cooked/cooked_meat_meal.dm
@@ -57,6 +57,7 @@
 	tastes = list("steak" = 1, "carrot" = 1)
 	list_reagents = list(/datum/reagent/consumable/nutriment = MEAL_MEAGRE)
 	foodtype = MEAT
+	faretype = FARE_FINE
 	warming = 5 MINUTES
 	rotprocess = SHELFLIFE_DECENT
 	eat_effect = /datum/status_effect/buff/mealbuff
@@ -87,6 +88,7 @@
 	icon_state = "steakmeal"
 	foodtype = VEGETABLES | MEAT
 	warming = 3 MINUTES
+	faretype = FARE_LAVISH
 	rotprocess = SHELFLIFE_DECENT
 	eat_effect = /datum/status_effect/buff/greatmealbuff
 


### PR DESCRIPTION
## About The Pull Request

It's #4784 but again since porting Ratwood's food re-added the oversight

## Testing Evidence

Same as before

## Why It's Good For The Game

Same as before
## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Carrot steaks and Carrot Onion Steaks no longer make you throw up (again)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
