### PR TITLE
Allows the Silky Dress to be worn in the Cloak slot

### DIFF
--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -254,7 +254,7 @@
 	name = "silky dress"
 	desc = "Despite not actually being made of silk, the legendary expertise needed to sew this puts the quality on par."
 	body_parts_covered = CHEST|GROIN|ARMS|VITALS
-	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR
+	slot_flags = ITEM_SLOT_SHIRT|ITEM_SLOT_ARMOR|ITEM_SLOT_CLOAK
 	icon_state = "silkydress"
 	item_state = "silkydress"
 	sleevetype = null


### PR DESCRIPTION
## About The Pull Request

Title. Allows the Silky Dress to be worn in the Cloak slot by adding the `ITEM_SLOT_CLOAK` flag to it

## Testing Evidence

_none lmao_
It is effectively a single line of code changed

## Why It's Good For The Game

More Drip, Less Drowning.

## Changelog

:cl:
qol: The Silky Dress can now be worn in the Cloak slot
/:cl:
