### PR TITLE
additional martyr changes

### DIFF
--- a/code/controllers/subsystem/rogue/roguemachine.dm
+++ b/code/controllers/subsystem/rogue/roguemachine.dm
@@ -14,7 +14,7 @@ PROCESSING_SUBSYSTEM_DEF(roguemachine)
 	var/list/death_queue = list()
 	var/last_death_report
 	var/obj/item/clothing/head/roguetown/crown/serpcrown/crown
-	var/obj/item/rogueweapon/sword/long/martyr/martyrweapon
+	var/obj/item/rogueweapon/martyrweapon
 	var/obj/item/key
 
 /datum/controller/subsystem/processing/roguemachine/fire(resumed = 0)

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1371,10 +1371,10 @@
 		return
 
 	var/list/weapon_choices = list(
-		"Sword" = CALLBACK(src, PROC_REF(summon_and_equip_sword), user),
-		"Axe" = CALLBACK(src, PROC_REF(summon_and_equip_axe), user),
-		"Mace" = CALLBACK(src, PROC_REF(summon_and_equip_mace), user),
-		"Trident" = CALLBACK(src, PROC_REF(summon_and_equip_spear), user)
+		"Sword" = CALLBACK(src, PROC_REF(summon_and_equip), user, /obj/item/rogueweapon/sword/long/martyr),
+		"Axe" = CALLBACK(src, PROC_REF(summon_and_equip), user, /obj/item/rogueweapon/greataxe/steel/doublehead/martyr),
+		"Mace" = CALLBACK(src, PROC_REF(summon_and_equip), user, /obj/item/rogueweapon/mace/goden/martyr),
+		"Trident" = CALLBACK(src, PROC_REF(summon_and_equip), user, /obj/item/rogueweapon/spear/partizan/martyr)
 	)
 
 	var/result = tgui_input_list(user, "Choose a martyr weapon to summon:", "Martyr Weapon", weapon_choices)
@@ -1385,69 +1385,26 @@
 	else
 		to_chat(user, span_warning("No weapon was chosen."))
 
-/obj/structure/fluff/psycross/proc/summon_and_equip_sword(mob/user)
-	var/obj/item/rogueweapon/sword/long/martyr/I = SSroguemachine.martyrweapon
+/obj/structure/fluff/psycross/proc/summon_and_equip(mob/user, var/obj/item/rogueweapon/weapontype)
+	var/obj/item/rogueweapon/old_weapon = SSroguemachine.martyrweapon
+	var/integrity
 
-	if(I)
-		I.anti_stall()
+	if(old_weapon)
+		integrity = old_weapon.obj_integrity
+		old_weapon.visible_message(span_danger("[old_weapon] dissolves into mere dust, and flitters away - unbound."))
+		SSroguemachine.martyrweapon = null
+		qdel(old_weapon)
 
-	I = new /obj/item/rogueweapon/sword/long/martyr(src.loc)
-	SSroguemachine.martyrweapon = I
+	var/obj/item/rogueweapon/new_weapon = new weapontype(src.loc)
+	new_weapon.obj_integrity = integrity
+	SSroguemachine.martyrweapon = new_weapon
 
-	if(user.put_in_hands(I))
-		to_chat(user, span_notice("The martyr sword appears in your hand."))
+	if(user.put_in_hands(new_weapon))
+		to_chat(user, span_notice("[new_weapon] appears in your hand."))
 	else
-		to_chat(user, span_warning("Your hands are full! The sword falls to the ground."))
+		to_chat(user, span_warning("Your hands are full! [new_weapon] falls to your feet."))
 
-	return I
-
-/obj/structure/fluff/psycross/proc/summon_and_equip_axe(mob/user)
-	var/obj/item/rogueweapon/greataxe/steel/doublehead/martyr/I = SSroguemachine.martyrweapon
-
-	if(I)
-		I.anti_stall()
-
-	I = new /obj/item/rogueweapon/greataxe/steel/doublehead/martyr(src.loc)
-	SSroguemachine.martyrweapon = I
-
-	if(user.put_in_hands(I))
-		to_chat(user, span_notice("The martyr axe appears in your hand."))
-	else
-		to_chat(user, span_warning("Your hands are full! The axe falls to the ground."))
-
-	return I
-
-/obj/structure/fluff/psycross/proc/summon_and_equip_mace(mob/user)
-	var/obj/item/rogueweapon/mace/goden/martyr/I = SSroguemachine.martyrweapon
-
-	if(I)
-		I.anti_stall()
-
-	I = new /obj/item/rogueweapon/mace/goden/martyr(src.loc)
-	SSroguemachine.martyrweapon = I
-
-	if(user.put_in_hands(I))
-		to_chat(user, span_notice("The martyr mace appears in your hand."))
-	else
-		to_chat(user, span_warning("Your hands are full! The mace falls to the ground."))
-
-	return I
-
-/obj/structure/fluff/psycross/proc/summon_and_equip_spear(mob/user)
-	var/obj/item/rogueweapon/spear/partizan/martyr/I = SSroguemachine.martyrweapon
-
-	if(I)
-		I.anti_stall()
-
-	I = new /obj/item/rogueweapon/spear/partizan/martyr(src.loc)
-	SSroguemachine.martyrweapon = I
-
-	if(user.put_in_hands(I))
-		to_chat(user, span_notice("The martyr trident appears in your hand."))
-	else
-		to_chat(user, span_warning("Your hands are full! The spear falls to the ground."))
-
-	return I
+	return new_weapon
 
 /obj/structure/fluff/psycross/attack_hand(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

1. Martyr weapons when un-ulted have regular integrity.
2. When they break, they swap into a random weapon after a 5s delay.
3. Pulling in a new martyr weapon from a cross carries the old weapon's integrity.
4. Martyr armour is once again, 999 mammons.

NUFC:
general code cleanup

## Testing Evidence

Yes.

## Why It's Good For The Game

Code cleaning good. Also good that the Martyr's weapon isn't an unbreakable beast (outside of the ult). It has counters but it's also magical and doesn't actually break, it just reforms into a random other martyr weapon.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Martyr weapons have regular integrity.
balance: Once a martyr weapon breaks, it reshifts into a random martyr weapon.
balance: Pulling in a new martyr weapon from a cross carries the old integrity.
balance: Martyr armour sellprice is 999 mammons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
