### PR TITLE
Lowers the Naledi Vizier's Arcyne trait to T2, removes Hierophant old age mods from Vizier and Pontifex

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -93,6 +93,7 @@
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar_pontifex
 	subclass_languages = list(/datum/language/celestial, /datum/language/thievescant)
 	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_CIVILIZEDBARBARIAN, TRAIT_ARCYNE_T1)
+	age_mod = null
 	subclass_stats = list(
 		STATKEY_STR = 3,
 		STATKEY_SPD = 2,
@@ -177,6 +178,7 @@
 		STATKEY_WIL = 2,
 	)
 	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2, TRAIT_ALCHEMY_EXPERT) //Override parent with T2 arcyne so they don't get Arcyne Affinity and purchase mindlink or whatnot
+	age_mod = null
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

Overwrites the traits for the Naledi Vizier with a list that includes T2 arcyne rather than letting it inherit T3 from Hierophant. Also fixes the old age mod from Hierophant being inherited by Vizier and Pontifex

## Testing Evidence

<img width="583" height="344" alt="image" src="https://github.com/user-attachments/assets/b0c1d7ec-8faa-4c95-aa2c-fc40d7fe274e" />

## Why It's Good For The Game

Vizier gets T4 devotion and a couple T2 arcyne spells, plus their weird stuff. They don't get any spell points naturally, but currently if they take Arcyne Affinity they can pick up mindlink, which is bad. This limits them to only T2 spells with their three points from Arcyne Affinity.

Prior to Free's rework, the old age modifiers only applied to Hierophant because it was in a proc that got overwritten by the child advclasses, but with the rework it became an inherited variable. This gave Pontifex and Vizier the ability to have Master arcyne skill and 6 extra points, which was almost certainly not intended.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: change the Naledi Vizier's arcyne trait to T2 rather than T3 so they can't get T3 spells with affinity
fix: Naledi Vizier and Pontifex no longer inherit the old age modifier from Hierophant giving them expert Arcyne and 6 extra points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
