### PR TITLE
Net Buff

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -167,7 +167,7 @@
 	id = "net"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/netted
 	effectedstats = list(STATKEY_SPD = -5, STATKEY_WIL = -2)
-	duration = 3 MINUTES
+//	duration = 3 MINUTES // WHY?????
 
 /datum/status_effect/debuff/netted/on_apply()
 		. = ..()

--- a/code/game/objects/items/rogueitems/ropechainbola/net.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola/net.dm
@@ -40,11 +40,10 @@
 	if(..() || !iscarbon(hit_atom))//if it gets caught or the target can't be cuffed,
 		return//abort
 	ensnare(hit_atom)
-	/*
-	// Nets always fall off after 10 seconds resist or not, so that the advantage it brings you is limited
+	// Nets always fall off after 30 seconds resist or not, so that the advantage it brings you is limited
 	// Being hit by a net and instalossing isn't fun for anyone because removing can be interrupted
-	addtimer(CALLBACK(src, PROC_REF(remove_effect)), TIMER_OVERRIDE|TIMER_UNIQUE)
-*/
+	addtimer(CALLBACK(src, PROC_REF(remove_effect)), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
+
 /obj/item/net/proc/ensnare(mob/living/carbon/C)
 	if(!C.legcuffed && C.get_num_legs(FALSE) >= 2)
 		visible_message("<span class='danger'>\The [src] ensnares [C]!</span>")


### PR DESCRIPTION
## About The Pull Request
Now, it takes 5 seconds to get out of the net, instead of 2 seconds as before. In addition, it now falls off 30 seconds after being thrown at the player.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yep, yes, yae
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Nets was useless even with server lags, really. 
If anyone thinks this is bad idea, don't forget that you can still JUMP away from the enemy and have the “Acrobat” and “Wood Walker” virtues and simply escape from the enemy through z-levels or simply through leaves. And also don't forget to switch to parrying. You can still parry and use shields. 
AND AFTER ALL JUST CATCH IT, LIKE A BOLAS IN GOOD OLD SPACE STATION TIMES. 
P.S. Fuck dodgers
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: 5 sec to get out of the net, instead of 2 as before and net falls off after 30 sec
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
