### PR TITLE
makes nudity mandatory again

### DIFF
--- a/code/modules/client/customizer/customizers/bodypart_feature/misc.dm
+++ b/code/modules/client/customizer/customizers/bodypart_feature/misc.dm
@@ -61,7 +61,7 @@
 	name = "Underwear"
 	customizer_choices = list(/datum/customizer_choice/bodypart_feature/underwear)
 	allows_disabling = TRUE
-	default_disabled = FALSE
+	default_disabled = TRUE
 
 /datum/customizer_choice/bodypart_feature/underwear
 	name = "Underwear"


### PR DESCRIPTION
## About The Pull Request

athletic leotard is no longer forced as a default to solve a problem that doesn't exist

## Testing Evidence

this is a revert to previously working code

## Why It's Good For The Game

the athletic leotard looks a lot like a normal torso, because it's supposed to, but also tends to select the same base color as the actual torso by default, causing unnecessary confusion and reports of nonexistent bugs.

## Changelog

:cl:
fix: fresh character slots default to no underwear selection
:cl: