### PR TITLE
Churn Wealthy requires <2500 mammon to instakill.

### DIFF
--- a/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -291,7 +291,7 @@
 			target.Stun(40)
 			playsound(user, 'sound/magic/churn.ogg', 100, TRUE)
 			return
-		if(totalvalue <= 1000)
+		if(totalvalue <= 2500)
 			target.visible_message(span_danger("[target] is smited with holy light!"), span_userdanger("I feel the weight of my wealth rend my soul apart!"))
 			user.say("Your final transaction! The Free-God rebukes!!")
 			target.Stun(60)
@@ -302,7 +302,7 @@
 			playsound(user, 'sound/magic/churn.ogg', 100, TRUE)
 			explosion(get_turf(target), light_impact_range = 1, flame_range = 1, smoke = FALSE)
 			return
-		if(totalvalue >=1001) //THE POWER OF MY STAND: 'EXPLODE AND DIE INSTANTLY'
+		if(totalvalue >=2501) //THE POWER OF MY STAND: 'EXPLODE AND DIE INSTANTLY'
 			target.visible_message(span_danger("[target]'s skin begins to SLOUGH AND BURN HORRIFICALLY, glowing like molten metal!"), span_userdanger("MY LIMBS BURN IN AGONY..."))
 			user.say("Wealth beyond measure- YOUR FINAL TRANSACTION!!")
 			target.Stun(80)


### PR DESCRIPTION
## About The Pull Request

Churn Wealthy requires 2500 to instakill instead of 1000. This is because the Duke starts with 1000.

## Testing Evidence

No.

## Why It's Good For The Game

The Duke is unrevivable now. This is no longer very funny. It's now a funny easter egg for mammon hoarders only!

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Duke can no longer be nuked by Churn Wealthy by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
