### PR TITLE
Sets subtype_reqs to FALSE on two bandage recipes

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -378,6 +378,7 @@
 		/obj/item/alch/bonemeal = 1,
 		)
 	craftdiff = 2
+	subtype_reqs = FALSE //so you dont craft bandages from bandages
 
 /datum/crafting_recipe/roguetown/alchemy/glut
 	name = "glut (from gnoll flesh)"

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -346,6 +346,7 @@
 	result = list(/obj/item/natural/cloth/bandage)
 	reqs = list(/obj/item/natural/silk = 2,
 				/obj/item/natural/cloth = 1)
+	subtype_reqs = FALSE //so you cant continuously craft bandages from bandages
 
 /datum/crafting_recipe/roguetown/sewing/gweightedbandagesalt
 	name = "bandages into weighted bandages, gloved"


### PR DESCRIPTION
## About The Pull Request

Sets subtype_reqs to FALSE on two bandage recipes, becaause previously you could use bandages as a crafting ingredient to make bandages which would waste materials and confuse people

## Testing Evidence

Hopped into a test server and confirmed it was ignoring bandages but taking regular cloth, subtypes of other ingredients in these two recipes either don't exist so changing the var doesn't bother them.

## Why It's Good For The Game

Removes confusion

## Changelog

:cl: Randall
fix: You can no longer use bandages to craft bandages
/:cl: