### PR TITLE
Makes maneaters deadlier

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -106,7 +106,7 @@
 			begin_eat(victim)
 		victim.flash_fullscreen("redflash3")
 		playsound(loc, list('sound/vo/mobs/plant/attack (1).ogg','sound/vo/mobs/plant/attack (2).ogg','sound/vo/mobs/plant/attack (3).ogg','sound/vo/mobs/plant/attack (4).ogg'), 100, FALSE, -1)
-		if(limb.get_damage() > 110)
+		if(limb.get_damage() > 50)
 			if(limb.dismember(damage = 20))
 				seednutrition += 25
 				if(!victim.mind)
@@ -115,7 +115,7 @@
 					return
 				maneater_spit_out(victim)
 		else
-			victim.apply_damage(60, BRUTE, zone, victim.run_armor_check(zone, BCLASS_CUT, damage = 60))
+			victim.apply_damage(60, BRUTE, zone, victim.run_armor_check(zone, BCLASS_CUT, damage = 500))
 
 	if(victim.stat == DEAD || victim.stat == UNCONSCIOUS)
 		if(!victim.mind)


### PR DESCRIPTION
## About The Pull Request
The previous PR was way too soft and didn't account for several things:
- the integrity of most to all limb armor is 200+, making 60 hits take many chews
- the maneater picking a RANDOM limb to chew on every time
- a given average user not experiencing that many bites when caught by a maneater before they break free

This PR makes it so the maneater is guaranteed to break any armor piece it chews on instantly and it will devour a limb on the 2nd hit on the same limb. It's still pretty OK to get caught in one but your mileage may wary depending on stats.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="547" height="486" alt="image" src="https://github.com/user-attachments/assets/5ad46812-26b4-4a3a-84c5-4096f2f4701a" />
this is how many chews it took to even lose a limb btw, but I spawned in as a knight so had multiple layers of armor on every limb, with old code this would've taken forever
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
We have ways to detect (looking around), avoid (sneaking) and straight up seeing (the sprite) maneaters, they really don't need to be a negligible danger as well
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Maneaters were made to be nastier to get caught in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
