### PR TITLE
Kills another Hoardmaster exploit

### DIFF
--- a/code/modules/cargo/packsrogue/Mage.dm
+++ b/code/modules/cargo/packsrogue/Mage.dm
@@ -142,11 +142,6 @@
 // MAGIC //
 ///////////
 
-/datum/supply_pack/rogue/Mage/unfinbook
-	name = "Unfinished Spellbook"
-	cost = 10
-	contains = list(/obj/item/spellbook_unfinished)
-
 /datum/supply_pack/rogue/Mage/nomag
 	name = "Ring of Nullmagic"
 	cost = 200
@@ -171,10 +166,10 @@
 // UTILITY //
 /////////////
 
-/datum/supply_pack/rogue/Mage/scrolls
-	name = "Scrolls"
-	cost = 2
-	contains = list(/obj/item/paper/scroll)
+/datum/supply_pack/rogue/Mage/book
+	name = "Spellbook"
+	cost = 80
+	contains = list(/obj/item/book/spellbook)
 
 /datum/supply_pack/rogue/bandit/Mage/cinnabar
 	name = "Cinnabar Ore"
@@ -186,31 +181,31 @@
 /////////////////
 
 /datum/supply_pack/rogue/Mage/toper
-	name = "Toper"
+	name = "Toper Stave"
 	cost = 55
-	contains = list(/obj/item/roguegem/yellow)
+	contains = list(/obj/item/rogueweapon/woodstaff/toper)
 
 /datum/supply_pack/rogue/Mage/gemerald
-	name = "Gemerald"
+	name = "Gemerald Stave"
 	cost = 70
-	contains = list(/obj/item/roguegem/green)
+	contains = list(/obj/item/rogueweapon/woodstaff/emerald)
 
 /datum/supply_pack/rogue/Mage/saffira
-	name = "Saffira"
+	name = "Saffira Stave"
 	cost = 90
-	contains = list(/obj/item/roguegem/violet)
+	contains = list(/obj/item/rogueweapon/woodstaff/sapphire)
 
 /datum/supply_pack/rogue/Mage/Blortz
-	name = "Blortz"
+	name = "Blortz Stave"
 	cost = 120
-	contains = list(/obj/item/roguegem/blue)
+	contains = list(/obj/item/rogueweapon/woodstaff/quartz)
 
 /datum/supply_pack/rogue/Mage/Rontz
-	name = "Rontz"
+	name = "Rontz Stave"
 	cost = 150
-	contains = list(/obj/item/roguegem/ruby)
+	contains = list(/obj/item/rogueweapon/woodstaff/ruby)
 
 /datum/supply_pack/rogue/Mage/Dorpel
-	name = "Dorpel"
+	name = "Dorpel Stave"
 	cost = 180
-	contains = list(/obj/item/roguegem/diamond)
+	contains = list(/obj/item/rogueweapon/woodstaff/diamond)


### PR DESCRIPTION
## About The Pull Request
- Rogue mages can now purchase gem-staves and spellbooks directly, rather than being able to buy gems themselves.
- You know what you did.

## Testing Evidence

Do you believe in life after love?

## Why It's Good For The Game

Gems have been a nightmare for me to deal with for all eternity with Hoardmaster. Now to cut out the gemmy man

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Rogue mages now can only buy spellbooks or gem-staves, not gems. Kills a related exploit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
