### PR TITLE
Removes Crit Resist From Orc Ambushes because they're immune to hammers and I like using them

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
@@ -117,8 +117,6 @@
 	H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-	ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, INNATE_TRAIT)
 
 // Heavily armored orc with complete iron protection, heavy armor, and a two hander.
 /datum/outfit/job/roguetown/orc/npc/warlord/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

Removes crit resist and no pain from NPC orcs, allowing them to be taken down with blunt weapons easier.

## Testing Evidence

<img width="620" height="62" alt="image" src="https://github.com/user-attachments/assets/c6f3b371-2ec7-4c21-8b2e-d1aa3a4f320f" />

^ this doesn't happen anymore.

## Why It's Good For The Game

Ambushes should be threatening, but orc ambushes are meant to be lower-mid level and shouldn't be exceedingly strong against builds that stack pain.

## Changelog

:cl:
del: crit resist from orc NPC's
/:cl: