### PR TITLE
Naledi Complex (bugfix and a small few things)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -25,6 +25,7 @@
 #define TRAIT_ARMOUR_DISLIKED "Misfitting Armour"
 #define TRAIT_FENCERDEXTERITY "Fencer's Dexterity"
 #define TRAIT_SKILLBLESSED "Skill Blessed"
+#define TRAIT_NALEDI "Naledi Complex"
 #define TRAIT_LONGSWORDSMAN "Master Longswordsman"
 #define TRAIT_SABRIST "Renowned Sabrist"
 #define TRAIT_MEDIUMARMOR "Maille Training"
@@ -315,6 +316,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_ARMOUR_LIKED = span_greentext("I'm wearing something more suited to my style."),
 	TRAIT_ARMOUR_DISLIKED = span_warning("I'm wearing something that burdens me."),
 	TRAIT_FENCERDEXTERITY = span_info("I've trained my entire lyfe around the art of unarmoured fencing, affording myself unmatched speed when wearing very light armour. I'm very choosy otherwise."),
+	TRAIT_NALEDI = span_info("I hail from the lands of Naledi. My blood and knowledge storied in yils of texts and techniques. My birthright is my pride."),
 	TRAIT_SKILLBLESSED = span_greentext("I've reunited with an old friend of mine. All is well."),
 	TRAIT_LONGSWORDSMAN = span_info("I am the sword, deadly against all weapons. When using any type of longsword, I fight at the level of a Master, and I can better defend against my opponents."),
 	TRAIT_SABRIST = span_info("I am the Aavnic sabre, shining arc of the Steppes. When using a shashka, I fight at the level of a Master, while swinging and thrusting faster with it."),

--- a/code/datums/components/armour_filtering.dm
+++ b/code/datums/components/armour_filtering.dm
@@ -3,13 +3,15 @@
 	var/required_trait
 	var/additive
 	var/positive
+	var/filter_id
 
-/datum/component/armour_filtering/Initialize(skill_trait, positive_bonus, bonus_additive = FALSE)
+/datum/component/armour_filtering/Initialize(skill_trait, id, bonus_additive = FALSE)
 	. = ..()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 	required_trait = skill_trait
 	additive = bonus_additive
+	filter_id = id
 
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
@@ -107,7 +109,7 @@
 				to_chat(user, span_info("..yet another piece of my armour is on my mind."))
 				return
 			ADD_TRAIT(user, TRAIT_ARMOUR_LIKED, TRAIT_GENERIC)
-		trait_boon_equip(user)
+		trait_boon_equip(user, filter_id)
 		return
 
 	if(!positive)
@@ -118,7 +120,7 @@
 		to_chat(user, span_info("I miss [parent] already. ([required_trait])"))
 		if(HAS_TRAIT(user, TRAIT_ARMOUR_LIKED))
 			REMOVE_TRAIT(user, TRAIT_ARMOUR_LIKED, TRAIT_GENERIC)
-	trait_boon_drop(user)
+	trait_boon_drop(user, filter_id)
 	return
 
 
@@ -127,7 +129,7 @@ TRAIT UNIQUE PROCS
 */
 
 
-/datum/component/armour_filtering/proc/trait_boon_equip(mob/living/carbon/human/user)
+/datum/component/armour_filtering/proc/trait_boon_equip(mob/living/carbon/human/user, id)
 	if(HAS_TRAIT(user, TRAIT_FENCERDEXTERITY))
 		if(!positive)
 			user.dropItemToGround(parent, TRUE, TRUE)
@@ -135,18 +137,38 @@ TRAIT UNIQUE PROCS
 				return
 			REMOVE_TRAIT(user, TRAIT_ARMOUR_DISLIKED, TRAIT_GENERIC)
 		return
-	
-	if(HAS_TRAIT(user, TRAIT_PSYDONIAN_GRIT))
+
+	if(HAS_TRAIT(user, TRAIT_PSYDONIAN_GRIT) && id == "ornate_plate")
 		if(positive)
 			user.apply_status_effect(/datum/status_effect/buff/psydonic_endurance)
 		return
+
+	if(HAS_TRAIT(user, TRAIT_NALEDI) && id == "naledi_mask")
+		if(positive)
+			user.remove_status_effect(/datum/status_effect/debuff/lost_naledi_mask)
+			user.remove_stress(/datum/stressevent/naledimasklost)
+		return
+
 	return
 
-/datum/component/armour_filtering/proc/trait_boon_drop(mob/living/carbon/human/user)
-	if(HAS_TRAIT(user, TRAIT_PSYDONIAN_GRIT))
+/datum/component/armour_filtering/proc/trait_boon_drop(mob/living/carbon/human/user, id)
+	if(HAS_TRAIT(user, TRAIT_PSYDONIAN_GRIT) && id == "ornate_plate")
 		if(positive)
 			if(!user.has_status_effect(/datum/status_effect/buff/psydonic_endurance))
 				return
 			user.remove_status_effect(/datum/status_effect/buff/psydonic_endurance)
 		return
+
+	if(HAS_TRAIT(user, TRAIT_NALEDI) && id == "naledi_mask")
+		if(positive)
+			if(istiefling(user))
+				return
+			if(user.has_status_effect(/datum/status_effect/debuff/lost_naledi_mask))
+				return
+			if(user.has_stress_event(/datum/stressevent/naledimasklost))
+				return
+			user.apply_status_effect(/datum/status_effect/debuff/lost_naledi_mask)
+			user.add_stress(/datum/stressevent/naledimasklost)
+		return
+
 	return

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -209,7 +209,7 @@
 	max_integrity = ARMOR_INT_CHEST_PLATE_PSYDON
 
 /obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate/ComponentInitialize()
-	AddComponent(/datum/component/armour_filtering/positive, TRAIT_PSYDONIAN_GRIT)
+	AddComponent(/datum/component/armour_filtering/positive, TRAIT_PSYDONIAN_GRIT, "ornate_plate")
 
 // HEAVY
 /obj/item/clothing/suit/roguetown/armor/plate/full
@@ -292,7 +292,7 @@
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/fluted/ornate/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/armour_filtering/positive, TRAIT_PSYDONIAN_GRIT)
+	AddComponent(/datum/component/armour_filtering/positive, TRAIT_PSYDONIAN_GRIT, "ornate_plate")
 
 /obj/item/clothing/suit/roguetown/armor/plate/fluted/shadowplate
 	name = "scourge breastplate"

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -565,22 +565,8 @@
 	flags_inv = HIDEFACE|HIDESNOUT
 	sellprice = 0
 
-/obj/item/clothing/mask/rogue/lordmask/naledi/equipped(mob/user, slot)
-	. = ..()
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.merctype == 14)	//Naledi
-			H.remove_status_effect(/datum/status_effect/debuff/lost_naledi_mask)
-			H.remove_stress(/datum/stressevent/naledimasklost)
-
-/obj/item/clothing/mask/rogue/lordmask/naledi/dropped(mob/user)
-	. = ..()
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.merctype == 14)	//Naledi
-			if(!istiefling(user)) //Funny exception
-				H.apply_status_effect(/datum/status_effect/debuff/lost_naledi_mask)
-				H.add_stress(/datum/stressevent/naledimasklost)
+/obj/item/clothing/mask/rogue/lordmask/naledi/ComponentInitialize()
+	AddComponent(/datum/component/armour_filtering/positive, TRAIT_NALEDI, "naledi_mask")
 
 /obj/item/clothing/mask/rogue/lordmask/naledi/sojourner
 	name = "sojourner's mask"

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/disciple.dm
@@ -87,6 +87,7 @@
 				l_hand = /obj/item/spellbook_unfinished/pre_arcyne
 				ADD_TRAIT(H, TRAIT_ARCYNE_T2, TRAIT_GENERIC) //Sojourners are magyck-inclined lightweights, relying on evasive maneuvers and unorthodox techniques - compared to the Disciple, who simply Kills People With Rocks.
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+				ADD_TRAIT(H, TRAIT_NALEDI, TRAIT_GENERIC)
 				REMOVE_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
 				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 3, TRUE)
 				H.grant_language(/datum/language/celestial) //They're from Naledi, they should speak Sama'glos

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -8,7 +8,7 @@
 	class_select_category = CLASS_CAT_NALEDI
 	category_tags = list(CTAG_MERCENARY)
 	cmode_music = 'sound/music/warscholar.ogg'
-	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT, TRAIT_NALEDI)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_WIL = 2,
@@ -92,7 +92,7 @@
 	tutorial = "You are a Naledi Pontifex, a warrior trained into a hybridized style of movement-controlling magic and hand-to-hand combat. Though your abilities in magical fields are lacking, you are far more dangerous than other magi in a straight fight. You manifest your calm, practiced skill into a killing intent that takes the shape of an arcyne blade."
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar_pontifex
 	subclass_languages = list(/datum/language/celestial, /datum/language/thievescant)
-	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_CIVILIZEDBARBARIAN, TRAIT_ARCYNE_T1)
+	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_CIVILIZEDBARBARIAN, TRAIT_ARCYNE_T1, TRAIT_NALEDI)
 	subclass_stats = list(
 		STATKEY_STR = 3,
 		STATKEY_SPD = 2,
@@ -171,6 +171,7 @@
 	name = "Naledi Vizier"
 	tutorial = "You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though psydonians have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough."
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar_vizier
+	traits_applied = list(TRAIT_NALEDI)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_SPD = 2,
@@ -218,7 +219,7 @@
 	r_hand = /obj/item/rogueweapon/woodstaff/naledi
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/magered
 
-	mask = /obj/item/clothing/mask/rogue/lordmask/tarnished
+	mask = /obj/item/clothing/mask/rogue/lordmask/naledi
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	pants = /obj/item/clothing/under/roguetown/trou/leather


### PR DESCRIPTION
## About The Pull Request

1. Fixes the bug of Warscholars/Viziers picking up extra masks and being stuck with the stress event.
2. Viziers get the full gold mask.
3. Sojourners need to wear their masks now.

NUFC:

1. Some additional `armour_filtering` fixes. Letting devs add `ids` to their filtering components for specific procced effects.
2. Shifted the naledi mask loss event to `armour_filtering`
4. Added `TRAIT_NALEDI` for use.

## Testing Evidence

Yes.

## Why It's Good For The Game

fugbix. also sojourners need to wear their masks now.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: armour_filtering `id` additions.
fix: naledi and mask stress event fixes.
balance: sojourners need to wear their masks now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
