### PR TITLE
Fixes a bug and adds a bed to test map

### DIFF
--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -235,6 +235,10 @@
 /obj/item/reagent_containers/powder/ozium,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors)
+"jC" = (
+/obj/structure/bed/rogue,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/outdoors)
 "jI" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
@@ -3073,7 +3077,7 @@ yK
 yK
 rT
 rT
-rT
+jC
 rT
 rT
 rT

--- a/code/datums/sexcon2/actions/sex/other/vagina.dm
+++ b/code/datums/sexcon2/actions/sex/other/vagina.dm
@@ -57,7 +57,7 @@
 	sex_session.perform_sex_action(target, 2, 4, FALSE)
 
 /datum/sex_action/sex/other/vagina/handle_climax_message(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	target.visible_message(span_love("[target] cums into [user]'s cunt!"))
+	target.visible_message(span_love("[user] cums into [target]'s cunt!"))
 	target.virginity = FALSE
 	user.virginity = FALSE
 	user.try_impregnate(target)


### PR DESCRIPTION
## About The Pull Request

Riding someone else had the climax nouns reversed. I still don't know why it happened, and if it worked prior to my changes why, but it now should work as intended. Also adds a bed to the roguetest map just above the dungeon entrances so I don't have to keep spawning one in every time I test this stuff

## Testing Evidence
Don't worry, I removed the code that yells FLIPPED at admins, that was me trying to troubleshoot
<img width="221" height="65" alt="image" src="https://github.com/user-attachments/assets/a833fcec-baf1-47e2-9b50-a99c6a2169a1" />

## Why It's Good For The Game

Bug good, fix bad. Also reduce my time to actually test any given iteration

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: The riding verb should now show who's filling whom correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
