### PR TITLE
Fix coat of commander coloring

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/brigandine.dm
+++ b/code/modules/clothing/rogueclothes/armor/brigandine.dm
@@ -80,9 +80,6 @@
 	desc = "A coat of plates concealed beneath a heavy leather surcoat. Only the most battle-hardened of Azuria's commanders can hope to bear its burden, both metaphorically and quite literally."
 	icon_state = "leathercoat"
 	item_state = "leathercoat"
-	sleeved_detail = TRUE
-	boobed_detail = TRUE
-	color = "#7D6653"
 
 /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	slot_flags = ITEM_SLOT_ARMOR


### PR DESCRIPTION
## About The Pull Request

Fixes Coat of Commander details not working for feminine sprites.

## Testing Evidence

Before
<img width="135" height="126" alt="image" src="https://github.com/user-attachments/assets/e399fb06-eeb2-4e23-bfca-440c1a22e6e6" />
After
<img width="98" height="116" alt="image" src="https://github.com/user-attachments/assets/6a90839b-7d7e-49d6-92d4-a75ee72aa0e8" />
<img width="147" height="196" alt="image" src="https://github.com/user-attachments/assets/aac72a27-ef05-48aa-9dbd-60ec02fa0231" />



## Why It's Good For The Game

🤷 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Coat of Commander details for feminine sprites.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
