### PR TITLE
fixes lousy code practices

### DIFF
--- a/code/game/objects/inhands_rogue.dm
+++ b/code/game/objects/inhands_rogue.dm
@@ -1,22 +1,3 @@
-/obj/item
-	/// A lazylist to store inhands data.
-	var/list/onprop
-	var/d_type = "blunt"
-//#ifdef TESTSERVER
-	var/force_reupdate_inhand = TRUE
-	var/smelted = FALSE // Sanity for smelteries to avoid runtimes, if this is a bar smelted through ore for exp gain
-	/// Determines whether this item is silver or not.
-	var/is_silver = FALSE
-	var/last_used = 0
-	var/toggle_state = null
-	var/icon_x_offset = 0
-	var/icon_y_offset = 0
-	var/always_destroy = FALSE
-	var/is_important = FALSE // If TRUE, this item is not allowed to be minted. May be useful for other things later.
-	var/vorpal = FALSE // does this item/weapon circumvent two-stage death during dismemberment? (do not add this to anything but ultra rare shit)
-//#else
-//	var/force_reupdate_inhand = FALSE
-//#endif
 
 // Initalize addon for the var for custom inhands 32x32.
 /obj/item/Initialize()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -254,6 +254,24 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	/// Makes this item impossible to enchant, for temporary item
 	var/unenchantable = FALSE
 
+	/// A lazylist to store inhands data.
+	var/list/onprop
+	var/d_type = "blunt"
+	var/force_reupdate_inhand = TRUE
+	/// Sanity for smelteries to avoid runtimes, if this is a bar smelted through ore for exp gain
+	var/smelted = FALSE
+	/// Determines whether this item is silver or not.
+	var/is_silver = FALSE
+	var/last_used = 0
+	var/toggle_state = null
+	var/icon_x_offset = 0
+	var/icon_y_offset = 0
+	var/always_destroy = FALSE
+	/// If TRUE, this item is not allowed to be minted. May be useful for other things later.
+	var/is_important = FALSE
+	/// does this item/weapon circumvent two-stage death during dismemberment? (do not add this to anything but ultra rare shit)
+	var/vorpal = FALSE
+
 /obj/item/Initialize()
 	. = ..()
 	if(!pixel_x && !pixel_y && !bigboy)


### PR DESCRIPTION
## About The Pull Request

basically someone redefined `/obj/item` for the purposes of the autogenned inhands we have, and in doing so made their redefine the top-level call for `/obj/item` which led further people to pollute the inhands dm with new vars instead of sticking it in item.dm where they belong. this fixes that problem, ensures the original definition of `/obj/item` is top level, and fixes the random comments syntax so that they will appear in VSC when highlighting vars.

## Testing Evidence

<img width="106" height="130" alt="image" src="https://github.com/user-attachments/assets/9981e9b6-4954-448e-9657-f6c953782789" />

no player facing changes or effects to things like inhands, it's just cleanup stuff.

## Why It's Good For The Game

can we at least pretend we know what we're doing here

## Changelog

:cl:
fix: reorganized code related to /obj/item to function better in visual code editors.
:cl: