### PR TITLE
tones down bandits

### DIFF
--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -118,7 +118,7 @@
 	weight = 16
 	spawn_landmark = "Bandit"
 	roles = list(
-		/datum/migrant_role/bandit = 4,
+		/datum/migrant_role/bandit = 3,
 	)
 
 /datum/migrant_wave/bandit_down_one
@@ -127,19 +127,10 @@
 	can_roll = FALSE
 	spawn_landmark = "Bandit"
 	roles = list(
-		/datum/migrant_role/bandit = 3,
-	)
-
-/datum/migrant_wave/bandit_down_two
-	name = "Bandit Raid"
-	downgrade_wave = /datum/migrant_wave/bandit_down_three
-	can_roll = FALSE
-	spawn_landmark = "Bandit"
-	roles = list(
 		/datum/migrant_role/bandit = 2,
 	)
 
-/datum/migrant_wave/bandit_down_three
+/datum/migrant_wave/bandit_down_two
 	name = "Bandit Raid"
 	can_roll = FALSE
 	spawn_landmark = "Bandit"

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -17,8 +17,8 @@
 	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
 	bandit_job.total_positions = min(bandit_job.total_positions + 5, 10)
 	bandit_job.spawn_positions = min(bandit_job.spawn_positions + 5, 10)
-	if(bandit_job.total_positions < 6) // Not at max capacity, increasing goal.
-		SSmapping.retainer.bandit_goal += 3 * rand(200, 400)
+	if(bandit_job.total_positions < 4) // Not at max capacity, increasing goal.
+		SSmapping.retainer.bandit_goal += 1 * rand(200, 400)
 		SSrole_class_handler.bandits_in_round = TRUE
 		for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
 			if(!player.client)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/Iconoclast.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/Iconoclast.dm
@@ -14,7 +14,6 @@
 	subclass_stats = list(
 		STATKEY_STR = 3,// LETS WRASSLE
 		STATKEY_WIL = 3,// This is our Go Big stat, we want lots of stamina for miracles and WRASSLIN.
-		STATKEY_LCK = 2,//We have a total of +12 in stats. 
 		STATKEY_CON = 1
 	)
 	subclass_skills = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/brigand.dm
@@ -9,10 +9,8 @@
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_STEELHEARTED)
 	subclass_stats = list(
 		STATKEY_STR = 4,//have you seen this idiot's starting gear and skill spread??
-		STATKEY_WIL = 2,
-		STATKEY_CON = 2,
-		STATKEY_SPD = 1,
-		STATKEY_LCK = 1,
+		STATKEY_WIL = 1,
+		STATKEY_CON = 1,
 		STATKEY_INT = -1
 	)
 	subclass_skills = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/demolisher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/demolisher.dm
@@ -12,11 +12,9 @@
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_STEELHEARTED, TRAIT_ALCHEMY_EXPERT, TRAIT_EXPLOSIVE_SUPPLY, TRAIT_BOMBER_EXPERT)
 	subclass_stats = list(
 		STATKEY_STR = 1,
-		STATKEY_WIL = 4, //extreme VVV
-		STATKEY_CON = 4, //hardy
+		STATKEY_WIL = 3, //extreme VVV
+		STATKEY_CON = 3, //hardy
 		STATKEY_SPD = -2, //slow
-		STATKEY_LCK = 1,
-		STATKEY_INT = 2
 	)
 	subclass_skills = list(
 		/datum/skill/combat/maces = SKILL_LEVEL_EXPERT,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
@@ -9,11 +9,9 @@
 	cmode_music = 'sound/music/cmode/antag/combat_thewall.ogg' // big chungus gets the wall too
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_HEAVYARMOR, TRAIT_NOBLE)
 	subclass_stats = list(
-		STATKEY_CON = 3, //dark souls 3 dual greatshield moment
+		STATKEY_CON = 2, //dark souls 3 dual greatshield moment
 		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
-		STATKEY_LCK = 2,
-		STATKEY_INT = 1,
 		STATKEY_SPD = 1,
 	)
 	subclass_skills = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/knave.dm
@@ -12,8 +12,6 @@
 		STATKEY_PER = 2,
 		STATKEY_LCK = 2,
 		STATKEY_STR = 1,
-		STATKEY_WIL = 1,
-		STATKEY_CON = 1
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/roguemage.dm
@@ -10,11 +10,9 @@
 	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3, TRAIT_DODGEEXPERT, TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
 		STATKEY_INT = 3,
-		STATKEY_WIL = 3,
+		STATKEY_WIL = 1,
 		STATKEY_PER = 2, // Adv mage get 2 perception so whatever. It is useful for aiming body parts but have no direct synergy with spells. 
-		STATKEY_LCK = 2,
-		STATKEY_SPD = 1,
-		STATKEY_CON = 1,
+		STATKEY_LCK = 1,
 	)
 	age_mod = /datum/class_age_mod/bandit/rogue_mage
 	subclass_skills = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sawbones.dm
@@ -10,7 +10,7 @@
 	subclass_stats = list(
 		STATKEY_INT = 4,
 		STATKEY_SPD = 3,
-		STATKEY_LCK = 3
+		STATKEY_LCK = 1
 	)
 	age_mod = /datum/class_age_mod/bandit/sawbones
 	subclass_skills = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/sellsword.dm
@@ -10,9 +10,7 @@
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
-		STATKEY_SPD = 2,
-		STATKEY_CON = 1,
-		STATKEY_LCK = 1
+		STATKEY_SPD = 1,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,


### PR DESCRIPTION
## About The Pull Request

Fixes what wasn't fixed in Lamas' PR. 
This tones down bandit stats + roleslots. Considering bandits are generally teaming up with the more than ample wretch + gnolls.

Bandits can *also* rush dungeons for loot. Which isn't something easily, code-wise, fixable. Maybe for the future, and then this can be toned back up.

Max bandit slots are 4 now, and it ticks 1 up instead of 3.

## Testing Evidence

Should be fine.

## Why It's Good For The Game

As stated above.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: 6->4 max bandit slots.
balance: Tones down bandit stats, overall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
