### PR TITLE
Triples Triumph Value for Migrants

### DIFF
--- a/code/datums/migrants/migrant_pref.dm
+++ b/code/datums/migrants/migrant_pref.dm
@@ -150,7 +150,7 @@
 		else
 			roll_percentage = "0%"
 
-		sidebar_dat += "<div style='margin-bottom: 12px; padding: 8px; border: 1px solid #444; border-radius: 4px;' title='Roll Chance: [roll_percentage] (Base: [wave.weight], Triumph: +[wave.triumph_total * 4])'>"
+		sidebar_dat += "<div style='margin-bottom: 12px; padding: 8px; border: 1px solid #444; border-radius: 4px;' title='Roll Chance: [roll_percentage] (Base: [wave.weight], Triumph: +[wave.triumph_total * 6])'>"
 		sidebar_dat += "<div style='color: [wave_color]; font-weight: bold; margin-bottom: 4px;'>[wave_name]</div>"
 		sidebar_dat += "<div style='background-color: #333; height: 12px; border-radius: 6px; margin-bottom: 4px;'>"
 		sidebar_dat += "<div style='background-color: [threshold_reached ? "gold" : (is_maxed_out ? "#666666" : "cyan")]; height: 100%; width: [progress_percent]%; border-radius: 6px;'></div>"


### PR DESCRIPTION
## About The Pull Request

As said on tin. Doubles the value of paying triumphs to triple. Helps with not having to spend an absurd amount of triumphs to roll something.

## Testing Evidence

<img width="495" height="198" alt="image" src="https://github.com/user-attachments/assets/a1f3746e-8761-47bf-b32a-e54a25ab63fb" />

I know it says +4 But I just switched it to 6.  It still works and compiles

## Why It's Good For The Game

Shouldn't punish people from playing characters or wanting to do something with friends by having them wait for literal hours for hoping to roll that 10% chance

## Changelog

ONE SINGULAR LINE CHANGE

:cl:
qol: Changes value of 1 Triumph from 2 to 6
/:cl:
