### PR TITLE
remove ricochet from arcyne bolt + give it to stygian

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
@@ -45,11 +45,6 @@
 	npc_simple_damage_mult = 1.5 // Makes it more effective against NPCs.
 	hitsound = 'sound/combat/hits/blunt/shovel_hit2.ogg'
 	speed = 1
-	ricochets_max = 4
-	ricochet_chance = 90
-	ricochet_auto_aim_angle = 40
-	ricochet_auto_aim_range = 5
-	ricochet_incidence_leeway = 50
 	var/apply_mark = TRUE
 
 /obj/projectile/energy/arcynebolt/arc

--- a/code/modules/spells/spell_types/wizard/projectiles_single/tarichae_shrap.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/tarichae_shrap.dm
@@ -38,6 +38,11 @@
 	armor_penetration = 20
 	npc_simple_damage_mult = 1.5
 	speed = 2
+	ricochets_max = 4
+	ricochet_chance = 50
+	ricochet_auto_aim_angle = 40
+	ricochet_auto_aim_range = 5
+	ricochet_incidence_leeway = 50
 	hitsound = 'sound/foley/glass_step.ogg'
 
 /obj/projectile/energy/shrapnelbloom/on_hit(target) //no antimagic; knockback for full stacks


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.

## Testing Evidence

No but it should work. Should be tested in round, too.

## Why It's Good For The Game

Arcyne bolt is the utility 1-shot precise attack. Giving it ricochet does mean it loses that utility and becomes a hazard.

Instead the 3-shot shotgun spell gets it. More chaotic, more friendly fire, less expectations for actually being precise.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Stygian Efflorescene gets ricochet.
balance: Arcyne Bolt loses ricochet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
