### PR TITLE
dark souls mentorhelp

### DIFF
--- a/code/modules/admin/verbs/schizohelp.dm
+++ b/code/modules/admin/verbs/schizohelp.dm
@@ -85,6 +85,7 @@ GLOBAL_LIST_EMPTY_TYPED(schizohelps, /datum/schizohelp)
 		"Escalate appropriately and try",
 		"Don't give up!",
 		"Take inventory of your role",
+		"Try"
 	)
 	var/list/directives = list(
 		"looking for a hidden location,",
@@ -106,7 +107,9 @@ GLOBAL_LIST_EMPTY_TYPED(schizohelps, /datum/schizohelp)
 		"looking in the Discord",
 		"check the Holiest of Wikis,",
 		"Unfortunately not.",
-		"Thankfully no."
+		"Thankfully no.",
+		"bite",
+		"the squire"
 	)
 	var/list/closers = list(
 		"(No closing)",
@@ -114,6 +117,7 @@ GLOBAL_LIST_EMPTY_TYPED(schizohelps, /datum/schizohelp)
 		"and have fun!",
 		"and look carefully...",
 		"and use thyne Noccian wits.",
+		"and do as Baotha would",
 		"Use thyne Zizoan determination.",
 		"and use it upon the terrain.",
 		"do as Graggar would do.",
@@ -123,7 +127,8 @@ GLOBAL_LIST_EMPTY_TYPED(schizohelps, /datum/schizohelp)
 		"Skelelon!",
 		"PROGRESS AFLOAT, NYEHEHE.",
 		"but be careful!",
-		"and then think carefully."
+		"and then think carefully.",
+		"but, hole!"
 	)
 	var/opener = input("Compose your response: choose an opening.", "Mentorhelp Response") in openers
 	if(!opener)


### PR DESCRIPTION
## About The Pull Request

Adds dark souls mentorhelp. I made this in literally 15 minutes and it is not tested for any edge cases. This is a bad feature.

## Testing Evidence

<img width="234" height="16" alt="image" src="https://github.com/user-attachments/assets/872fa749-b3b8-4f2e-82b5-34a9bf3dd2e1" />
<img width="334" height="277" alt="image" src="https://github.com/user-attachments/assets/962d49bd-5cde-4f4c-8052-5f1266601799" />
<img width="308" height="266" alt="image" src="https://github.com/user-attachments/assets/3f5fb38a-88b1-49ef-9734-30014751c918" />
<img width="319" height="267" alt="image" src="https://github.com/user-attachments/assets/6ab0948b-1f81-4754-b99a-55f95b6a6d89" />

<img width="334" height="54" alt="image" src="https://github.com/user-attachments/assets/60fab8f2-81c3-4bd4-8b00-4d172b1fd07b" />



## Why It's Good For The Game

It really isn't, but it's a funny bit, and I think it'd be funny to use for at least one round.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: The flow of time is convoluted in Lorderon. Dark Spirit xXMeOwFlOwErXx has invaded Mentorhelp!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
