### PR TITLE
Deaths Door bugfix

### DIFF
--- a/code/modules/deathsdoor/deathsdoor.dm
+++ b/code/modules/deathsdoor/deathsdoor.dm
@@ -207,55 +207,26 @@ GLOBAL_VAR_INIT(underworld_strands, 0)
 	if(spawn_timer)
 		deltimer(spawn_timer)
 
-	var/delay = rand(15 MINUTES, 30 MINUTES)
 	spawn_timer = addtimer(
 		CALLBACK(src, PROC_REF(try_spawn)),
-		delay,
+		40 MINUTES,
 		TIMER_STOPPABLE
 	)
+
 /obj/effect/landmark/underworldstrands/proc/try_spawn()
 	spawn_timer = null
-	if(GLOB.underworld_strands >= 4)
-		start_timer()
-		return
 	var/turf/T = get_turf(src)
 	if(!T)
 		start_timer()
 		return
 
-	// If lux already present, reset timer
-	for(var/obj/item/soulthread/deathsdoor/L in T)
-		start_timer()
-		return
-
-	// Otherwise spawn new lux
 	new /obj/item/soulthread/deathsdoor(T)
-
 	start_timer()
+
 /obj/item/soulthread/deathsdoor
 	name = "shimmering lux-thread"
 	desc = "Eerie glowing thread, cometh from the grave"
-	var/should_track = TRUE
 
-/obj/item/soulthread/deathsdoor/Initialize()
-	. = ..()
-	if(should_track)
-		GLOB.underworld_strands += 1
-
-/obj/item/soulthread/deathsdoor/Destroy()
-	if(should_track)
-		GLOB.underworld_strands -= 1
-	return ..()
-
-/obj/item/soulthread/deathsdoor/pickup(mob/user)
-	..()
-	if(should_track)
-		GLOB.underworld_strands -= 1
-
-/obj/item/soulthread/deathsdoor/dropped(mob/user)
-	..()
-	if(should_track)
-		GLOB.underworld_strands += 1
 
 /mob/living/proc/extract_from_deaths_edge()//for total exhaustion in death's precipice
 	// Already unconscious? Don't loop


### PR DESCRIPTION
## About The Pull Request

- Fixes deaths door, now lux strands simply spawn every 40 minutes

## Testing Evidence

Set timer to 1 minute, it works.

## Why It's Good For The Game

yea

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fix death's door lux strand spawning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
