### PR TITLE
Fixes quiver-bow nocking

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -146,7 +146,7 @@
 		mob.used_intent = mob.o_intent
 		if(mob.used_intent.get_chargetime() && !object.blockscharging && !mob.in_throw_mode)
 			mob.face_atom(object, location, control, params)
-			updateprogbar()
+			updateprogbar(object)
 		else
 			mouse_pointer_icon = 'icons/effects/mousemice/human_attack.dmi'
 	else
@@ -169,7 +169,7 @@
 		mouse_pointer_icon = 'icons/effects/mousemice/human_looking.dmi'
 	else
 		if(mob.mmb_intent.get_chargetime() && !object.blockscharging)
-			updateprogbar()
+			updateprogbar(object)
 		else
 			mouse_pointer_icon = mob.mmb_intent.pointer
 
@@ -187,7 +187,7 @@
 	mob.atkswinging = "left"
 	mob.used_intent = mob.a_intent
 	if(mob.used_intent.get_chargetime() && !object.blockscharging && !mob.in_throw_mode)
-		updateprogbar()
+		updateprogbar(object)
 	else
 		mouse_pointer_icon = 'icons/effects/mousemice/human_attack.dmi'
 

--- a/code/game/objects/items/rogueweapons/mmb/spell.dm
+++ b/code/game/objects/items/rogueweapons/mmb/spell.dm
@@ -6,7 +6,7 @@
 	warnie = "aimwarn"
 	warnoffset = 0
 
-/datum/intent/spell/can_charge()
+/datum/intent/spell/can_charge(atom/clicked_object)
 	if(mastermob?.next_move > world.time)
 		if(mastermob.client.last_cooldown_warn + 10 < world.time)
 			to_chat(mastermob, span_warning("I'm not ready to do that yet!"))


### PR DESCRIPTION
## About The Pull Request

Reimplements the parts of https://github.com/Azure-Peak/Azure-Peak/pull/4807 which were not incorporated into https://github.com/Azure-Peak/Azure-Peak/pull/5298. Clicking a quiver with a bow doesn't draw it, again.

## Testing Evidence

<img width="410" height="35" alt="image" src="https://github.com/user-attachments/assets/936eab3a-2888-4b6a-a325-b9f909249cac" />

## Why It's Good For The Game

See the previous PR, this is just getting the same system functional which was only partially implemented in the optimisation pass.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Resolves a bug around quivers; clicking a quiver to nock an arrow on a bow no longer also begins to draw the bow.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
