### PR TITLE
Fixes Vizier spell point gain, makes them T2 arcyne

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -189,6 +189,7 @@
 		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,


### PR DESCRIPTION
## About The Pull Request

Fixes old Viziers not being able to get any spell points and not having mage armor or Alchemy Expert. Limits Viziers to T2 spells, but gives them Apprentice Arcyne so they have it for their few starting spells as well as any they might pick

## Testing Evidence
(Arcyne skill is Master because the character being tested is old. I did test adult age and just had Apprentice)
<img width="586" height="473" alt="image" src="https://github.com/user-attachments/assets/99b2386c-2af1-4d19-a1ac-38df92678915" />

## Why It's Good For The Game

Ryan's PR accidentally made it so old Viziers couldn't get spell points at all due to an odd interaction of things. This fixes it. There's two changes from the previous status quo: Viziers only get T2 arcyne, and they start with Apprentice Arcyne skill (same as Pontifex). The first is so that there's no possibility of an old Vizier having T4 devotion and Fireball, the second is because they've got some arcyne spells at the beginning, they should know how to use them to some degree

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Naledi Vizier got some traits back that they're supposed to have. They can now learn spells if they're old again
change: Naledi Vizier dropped to T2 arcyne and given Apprentice arcyne skill
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
