### PR TITLE
Psyaltrist Music Box Interaction

### DIFF
--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -292,10 +292,8 @@
 			owner.add_stress(/datum/stressevent/soulchurnerhorror)
 		for (var/mob/living/carbon/human/H in hearers(7, owner))
 			if (!H.client)
-				to_chat(H, "No client")
 				continue
 			if(HAS_TRAIT(H, TRAIT_INQUISITION))
-				to_chat(H, "Testing, works")
 				H.apply_status_effect(/datum/status_effect/buff/churnerprotection)
 
 /*

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
@@ -2,7 +2,7 @@
 	name = "Psyaltrist"
 	tutorial = "You spent some time with cathedral choirs and psyaltrists. Now you spend your days applying the musical arts to the practical on behalf of His most Holy of Inquisitions."
 	outfit = /datum/outfit/job/roguetown/psyaltrist
-	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_EMPATH, TRAIT_INSPIRING_MUSICIAN)
+	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_EMPATH)
 	category_tags = list(CTAG_ORTHODOXIST)
 	subclass_languages = list(/datum/language/otavan)
 	subclass_stats = list(


### PR DESCRIPTION
## About The Pull Request

- Psyaltrists can now 'Harmonize' the soul churner music box, causing it to give a reduced buff at the benefit of not mood nuking everyone.
- Makes a underused relic usable in most situations now, albeit at reduced capacity. Now only grants Inquisition members antimagic, rather than disabling *all* magic nearby. This means that necromancers/other mages can still use their AoEs/non-target spells around this usage of the box.
- Psyaltrists can still choose to use the prior version of the box in Hyperwar mode, with mood nuke and all.

## Testing Evidence
<img width="264" height="116" alt="test1" src="https://github.com/user-attachments/assets/bad0a20d-030f-4b5b-9303-fbe6949a5f3c" />


https://github.com/user-attachments/assets/0f051e04-bffb-4050-b6cf-38bea70ced08


## Why It's Good For The Game

Makes a previously very rarely used relic more usable. A 16 marque device 'ought to have a bit more usability. Also a moderate buff in utility to Psyaltrist, one of the weaker orthodoxists right now. The lesser version should be more fair towards necromancers/etc, by not *completely* turning them off, unlike the full version.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added Psyaltrist soulchurner interaction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
