### PR TITLE
Reduces bardic inspiration energy drain

### DIFF
--- a/code/modules/spells/spell_types/bardic/melody-dirges.dm
+++ b/code/modules/spells/spell_types/bardic/melody-dirges.dm
@@ -40,6 +40,7 @@
 	var/ticks_to_apply = 10
 	duration = -1
 	var/obj/effect/temp_visual/songs/effect = /obj/effect/temp_visual/songs/inspiration_dirget1
+	var/energytodrain = -12.5
 
 
 /atom/movable/screen/alert/status_effect/buff/playing_dirge
@@ -56,7 +57,7 @@
 	new effect(get_turf(owner))
 	if (pulse >= ticks_to_apply)
 		pulse = 0
-		O.energy_add(-25)
+		O.energy_add(energytodrain)
 		for (var/mob/living/carbon/human/H in hearers(10, owner))
 			if(!O.in_audience(H))
 				H.apply_status_effect(debuff_to_apply)
@@ -71,6 +72,7 @@
 	var/ticks_to_apply = 10
 	duration = -1
 	var/obj/effect/temp_visual/songs/effect = /obj/effect/temp_visual/songs/inspiration_melodyt1
+	var/energytodrain = -12.5
 
 
 /atom/movable/screen/alert/status_effect/buff/playing_melody
@@ -87,7 +89,7 @@
 	pulse += 1
 	if (pulse >= ticks_to_apply)
 		pulse = 0
-		O.energy_add(-25)
+		O.energy_add(energytodrain)
 		for (var/mob/living/carbon/human/H in hearers(10, owner))
 			if(O.in_audience(H))
 				H.apply_status_effect(buff_to_apply)


### PR DESCRIPTION
## About The Pull Request

- Halves energy drain for bardic inspiration

## Testing Evidence

Numerical change

## Why It's Good For The Game

I may have been a bit heavy handed in energy drain values when originally designing bardic inspiration. Now, It won't completely nuke your blue to the point of being more of a drain than a buff. Taken from feedback after quite alot of people playing around with bardic inspiration now, blue drain was one of the primary crippling factors to it being useful.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Halves bardic inspiration energy drain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
