### PR TITLE
Crossbow now actually uses skill.

### DIFF
--- a/code/datums/skills/combat.dm
+++ b/code/datums/skills/combat.dm
@@ -82,7 +82,7 @@
 
 /datum/skill/combat/crossbows
 	name = "Crossbows"
-	desc = "Alongside perception, increases the speed you ready a crossbow and have it ready to shoot. Does not influence damage or chance to hit."
+	desc = "Alongside perception, increases the speed you ready a crossbow and have it ready to shoot as well it's draw speed. Does not influence damage or chance to hit."
 	dreams = list(
 	"...you put your foot down and pull on the string. You wind the crossbow back with all your might. It feels like the thing is mocking you, impossible to pull taut. Only when a seasoned arbalist reminds you to pull from your back, and not your knees, do you make progress...",
 	"...the crossbow is a deadly marvel of engineering, waiting for your guidance. You steady your breath, finger poised on the trigger. The world narrows as you take aim, the perfect shot soon to come..."

--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -147,11 +147,11 @@
 		if(!cocked)
 			to_chat(user, span_info("I step on the stirrup and use all my might..."))
 			if(!movingreload)
-				if(do_after(user, reloadtime - user.STASTR, target = user))
-					playsound(user, 'sound/combat/Ranged/crossbow_medium_reload-01.ogg', 100, FALSE)
-					cocked = TRUE
+				if(do_after(user, reloadtime - user.STASTR - user.get_skill_level(/datum/skill/combat/crossbows), target = user ))
+					playsound(user, 'sound/combat/Ranged/crossbow_medium_reload-01.ogg', 100, FALSE) //11 STR + MASTER Crossbow = 2.5~ second reload not including TIDI
+					cocked = TRUE //13 STR + NO Crossbow still amounts to around 3 seconds reload, so as it is each level of skill is +1 STR equivalent.
 			else
-				if(move_after(user, reloadtime - user.STASTR, target = user))
+				if(move_after(user, reloadtime - user.STASTR, target = user)) //Slurbow becomes instant loading if it uses skills at 11 STR + MASTER Crossbow
 					playsound(user, 'sound/combat/Ranged/crossbow_medium_reload-01.ogg', 100, FALSE)
 					cocked = TRUE
 		else


### PR DESCRIPTION
## About The Pull Request

Crossbow reloads now take into account your CROSSBOW skill at rate of 1 LEVEL = 1 STR for purposes of the reload. Does not apply to slurbows as it turns them into practically instant reload only stationary.

## Testing Evidence

Can't record it exactly but ran tests of :
Skirmisher 11 STR + Master skill amounting to about 2.4 seconds reload
Footman 13 STR + No skill amounting to about 3.1 seconds reload

Hard to gauge precise numbers due to all the delays with the UI sounds and all that but this I'm pretty confident as it is.
## Why It's Good For The Game

Unlike bow the only thing crossbow rewards you in having high skill in is it's instant fire potential (which already peaks at Jman with about 14 PER or expert at 12)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Crossbow reload speed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
