### PR TITLE
gives tracks to some more floor types

### DIFF
--- a/code/game/objects/effects/track.dm
+++ b/code/game/objects/effects/track.dm
@@ -21,6 +21,9 @@
 /turf/open/floor/rogue/snow
 	track_prob = 20
 
+/turf/open/floor/rogue/snowpatchy
+	track_prob = 10
+
 /turf/open/floor/rogue/AzureSand
 	track_prob = 20
 
@@ -30,7 +33,16 @@
 /turf/open/floor/carpet
 	track_prob = 10
 
+/turf/open/floor/rogue/twig
+	track_prob = 5
+
 /turf/open/floor/rogue/wood
+	track_prob = 5
+
+/turf/open/floor/rogue/woodturned
+	track_prob = 5
+
+/turf/open/floor/rogue/ruinedwood
 	track_prob = 5
 
 /turf/open/floor/rogue/dirt/road
@@ -45,6 +57,9 @@
 /turf/open/floor/rogue/cobble
 	track_prob = 3
 
+/turf/open/floor/rogue/cobble/mossy
+	track_prob = 10
+
 /turf/open/floor/rogue/blocks
 	track_prob = 10
 
@@ -57,13 +72,25 @@
 /turf/open/floor/rogue/hexstone
 	track_prob = 10
 
+/turf/open/floor/rogue/herringbone
+	track_prob = 10
+
 /turf/open/floor/rogue/churchmarble
 	track_prob = 5
+
+/turf/open/floor/rogue/church
+	track_prob = 5
+
+/turf/open/floor/rogue/churchrough
+	track_prob = 10
 
 /turf/open/floor/rogue/churchbrick
 	track_prob = 5
 
 /turf/open/floor/rogue/cobblerock
+	track_prob = 10
+
+/turf/open/floor/rogue/naturalstone
 	track_prob = 10
 
 //Probabilities end (albeit mud is handled seperately).


### PR DESCRIPTION
## About The Pull Request

There are a few floors like the floors of the town walls, and twig platforms, that don't have a track_prob value and it could be worth adding it to them, was trying to stick to giving them values the same as similar flooring that does have track_prob.

## Testing Evidence

Went into the game and walked around on a floor type that could not have tracks previously. Now it has tracks.

## Why It's Good For The Game

I think having more tracking possibilities is always nice, some of these floor types are decently common and used for travel.

## Changelog

:cl: Randall
add: More floors can have tracks.
/:cl: