### PR TITLE
Removes the cooldown delay on drawing bows

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/bows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/bows.dm
@@ -11,10 +11,6 @@
 		return FALSE
 	if(istype(clicked_object, /obj/item/quiver) && istype(mastermob?.get_active_held_item(), /obj/item/gun/ballistic))
 		return FALSE
-	if(mastermob.client.last_cooldown_warn + 10 > world.time)
-		to_chat(mastermob, span_warning("I'm not ready to do that yet!"))
-		mastermob.client.last_cooldown_warn = world.time
-		return FALSE
 
 	return TRUE
 
@@ -52,10 +48,6 @@
 		to_chat(mastermob, span_warning("I need a free hand to draw [masteritem]!"))
 		return FALSE
 	if(istype(clicked_object, /obj/item/quiver) && istype(mastermob?.get_active_held_item(), /obj/item/gun/ballistic))
-		return FALSE
-	if(mastermob.client.last_cooldown_warn + 10 > world.time)
-		to_chat(mastermob, span_warning("I'm not ready to do that yet!"))
-		mastermob.client.last_cooldown_warn = world.time
 		return FALSE
 
 	return TRUE

--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -59,10 +59,6 @@
 	basetime = 20
 
 /datum/intent/shoot/crossbow/can_charge(atom/clicked_object)
-	if(mastermob.client.last_cooldown_warn + 10 > world.time)
-		to_chat(mastermob, span_warning("I'm not ready to do that yet!"))
-		mastermob.client.last_cooldown_warn = world.time
-		return FALSE
 	if(mastermob && masteritem)
 		var/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/c_bow = masteritem
 		if(mastermob.get_num_arms(FALSE) < 2 && !c_bow.onehanded || mastermob.get_inactive_held_item() && !c_bow.onehanded)
@@ -102,10 +98,6 @@
 	chargedrain = 0
 
 /datum/intent/arc/crossbow/can_charge(atom/clicked_object)
-	if(mastermob.client.last_cooldown_warn + 10 > world.time)
-		to_chat(mastermob, span_warning("I'm not ready to do that yet!"))
-		mastermob.client.last_cooldown_warn = world.time
-		return FALSE
 	if(mastermob && masteritem)
 		var/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/c_bow = masteritem
 		if(mastermob.get_num_arms(FALSE) < 2 && !c_bow.onehanded || mastermob.get_inactive_held_item() && !c_bow.onehanded)

--- a/code/game/objects/items/rogueweapons/ranged/slings.dm
+++ b/code/game/objects/items/rogueweapons/ranged/slings.dm
@@ -8,10 +8,6 @@
 /datum/intent/swing/sling/can_charge(atom/clicked_object)
 	if(istype(clicked_object, /obj/item/quiver) && istype(mastermob?.get_active_held_item(), /obj/item/gun/ballistic))
 		return FALSE
-	if(mastermob.client.last_cooldown_warn + 10 > world.time)
-		to_chat(mastermob, span_warning("I'm not ready to do that yet!"))
-		mastermob.client.last_cooldown_warn = world.time
-		return FALSE
 
 	return TRUE
 
@@ -41,10 +37,6 @@
 
 /datum/intent/arc/sling/can_charge(atom/clicked_object)
 	if(istype(clicked_object, /obj/item/quiver) && istype(mastermob?.get_active_held_item(), /obj/item/gun/ballistic))
-		return FALSE
-	if(mastermob.client.last_cooldown_warn + 10 > world.time)
-		to_chat(mastermob, span_warning("I'm not ready to do that yet!"))
-		mastermob.client.last_cooldown_warn = world.time
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

As title, in addition to some general organising of ranged weapon intent code to make sense to my eyes. Lots of guard clauses.

The cooldown delay as it exists currently prevents a character from beginning to charge a bow for around a second after nocking it from the quiver. If you try to charge it within this period, it'll misfire the bow even if it's been charging for what would've been long enough. This was introduced recently in https://github.com/Azure-Peak/Azure-Peak/pull/5298.

This PR allows bows to be charged regardless of the delay, so you can draw them immediately after nocking again.

## Testing Evidence

Tested everything I could think to test, may still be best as a TM.

<img width="514" height="352" alt="image" src="https://github.com/user-attachments/assets/a9338213-b961-4325-9ee6-8f43af3bde42" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I've waited for a good few days to make this change so I'm confident it isn't kneejerk. The cooldown regularly surprises players who find themselves unable to draw their bow in stressful situations, and it's a particularly heavy hit to longbows which already have a very long drawtime. Having to arbitrarily wait a second before performing your next action without an indicator or sound cue is quite a lot to worry about in the middle of combat and I think ranged gameplay is more enjoyable without it.

This should make bows a little more pleasant to use, and should make longbows more viable compared to now. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Removed the delay on drawing a bow after nocking it. You can now begin to draw a bow or sling immediately after nocking it.
fix: Slings no longer begin to swing when left-clicked on a quiver to load a bullet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
