### PR TITLE
Lowers default migrant weight to 20

### DIFF
--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -15,7 +15,7 @@
 	/// If defined, this is the maximum amount of times this wave can spawn
 	var/max_spawns = null
 	/// The relative probability this wave will be picked, from all available waves
-	var/weight = 100
+	var/weight = 20
 	/// Name of the latejoin spawn landmark for the wave to decide where to spawn
 	var/spawn_landmark = "Pilgrim"
 	/// Text to greet all players in the wave with


### PR DESCRIPTION
## About The Pull Request

Lowers default migrant weight to 20.

Which means pilgrim/adventurer migrants are now a base weight of 20. Instead of 100. For context (Most other migrants are 50)

## Testing Evidence

### FROM: 
<img width="1602" height="912" alt="image" src="https://github.com/user-attachments/assets/118197da-42f0-4901-9942-4e5e3fc7d0ee" />
### TO:
<img width="1678" height="998" alt="image" src="https://github.com/user-attachments/assets/a67caca3-8db3-41ee-ab0b-4841127676c8" />

## Why It's Good For The Game

Lowers default Migrant from double of most other parties. Adventurer is literally just a spare 4 extra adventurers. Pilgrim is pilgrim. 

They shouldn't be double of the other more unique parties.

## Changelog
:cl:
balance: rebalanced something
/:cl: