### PR TITLE
Adds pop scaling to Gnolls, limits to Abduct anchors

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -259,6 +259,7 @@ SUBSYSTEM_DEF(migrants)
 	SSticker.minds += character.mind
 	GLOB.joined_player_list += character.ckey
 	update_wretch_slots()
+	update_gnoll_slots()
 	if(character.client)
 		character.client.update_ooc_verb_visibility()
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -472,6 +472,7 @@ SUBSYSTEM_DEF(ticker)
 		if(player.ready == PLAYER_READY_TO_PLAY)
 			GLOB.joined_player_list += player.ckey
 			update_wretch_slots()
+			update_gnoll_slots()
 			player.create_character(FALSE)
 		else
 			player.new_player_panel()

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -405,14 +405,16 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	..()
 	if(!ishuman(user))
 		return
-	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
-	var/total_gnoll_positions = gnoll_job.total_positions
-	var/gnoll_increase = get_gnoll_slot_increase(total_gnoll_positions)
+	
+	if(length(GLOB.joined_player_list) >= 30)
+		var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
+		var/total_gnoll_positions = gnoll_job.total_positions
+		var/gnoll_increase = get_gnoll_slot_increase(total_gnoll_positions)
 
-	if(gnoll_increase >= 1)
-		to_chat(user, span_notice("I have offended graggarite agents, and they may be tracking my scent."))
-		gnoll_job.total_positions = min(total_gnoll_positions + gnoll_increase, 10)
-		gnoll_job.spawn_positions = min(total_gnoll_positions + gnoll_increase, 10)
+		if(gnoll_increase >= 1)
+			to_chat(user, span_notice("I have offended graggarite agents, and they may be tracking my scent."))
+			gnoll_job.total_positions = min(total_gnoll_positions + gnoll_increase, 10)
+			gnoll_job.spawn_positions = min(total_gnoll_positions + gnoll_increase, 10)
 
 /datum/charflaw/unintelligible
 	name = "Unintelligible"

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -407,14 +407,17 @@ GLOBAL_LIST_INIT(averse_factions, list(
 		return
 	
 	if(length(GLOB.joined_player_list) >= 30)
-		var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
-		var/total_gnoll_positions = gnoll_job.total_positions
-		var/gnoll_increase = get_gnoll_slot_increase(total_gnoll_positions)
+		addtimer(CALLBACK(src, PROC_REF(add_gnolls), user), 10 SECONDS)
 
-		if(gnoll_increase >= 1)
-			to_chat(user, span_notice("I have offended graggarite agents, and they may be tracking my scent."))
-			gnoll_job.total_positions = min(total_gnoll_positions + gnoll_increase, 10)
-			gnoll_job.spawn_positions = min(total_gnoll_positions + gnoll_increase, 10)
+/datum/charflaw/hunted/proc/add_gnolls(mob/user)
+	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
+	var/total_gnoll_positions = gnoll_job.total_positions
+	var/gnoll_increase = get_gnoll_slot_increase(total_gnoll_positions)
+
+	if(gnoll_increase >= 1)
+		to_chat(user, span_notice("I have offended graggarite agents, and they may be tracking my scent."))
+		gnoll_job.total_positions = min(total_gnoll_positions + gnoll_increase, 10)
+		gnoll_job.spawn_positions = min(total_gnoll_positions + gnoll_increase, 10)
 
 /datum/charflaw/unintelligible
 	name = "Unintelligible"

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -112,7 +112,7 @@
 	if(targets[1] == user)
 		var/check_turf = get_turf(user)
 		var/can_abduct = FALSE
-		switch(destination_turf.z)
+		switch(check_turf.z)
 			if(2,3,4)	//very shoddy way of checking if it's within the "normal" game world, there's probably a zweb check for this
 				can_abduct = TRUE
 		if(!can_abduct)

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -110,6 +110,15 @@
 
 /obj/effect/proc_holder/spell/invoked/abduct/cast(list/targets, mob/user)
 	if(targets[1] == user)
+		var/check_turf = get_turf(user)
+		var/can_abduct = FALSE
+		switch(destination_turf.z)
+			if(2,3,4)	//very shoddy way of checking if it's within the "normal" game world, there's probably a zweb check for this
+				can_abduct = TRUE
+		if(!can_abduct)
+			to_chat(user, span_warning("This is not a suitable place for such an anchor!"))
+			revert_cast()
+			return FALSE
 		destination_turf = get_turf(user)
 		to_chat(user, span_notice("You anchor your connection to graggar's plane here. Any abducted will be fetched here."))
 		// We are reverting cast because we're only setting the destination.

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -110,7 +110,7 @@
 
 /obj/effect/proc_holder/spell/invoked/abduct/cast(list/targets, mob/user)
 	if(targets[1] == user)
-		var/check_turf = get_turf(user)
+		var/turf/check_turf = get_turf(user)
 		var/can_abduct = FALSE
 		switch(check_turf.z)
 			if(2,3,4)	//very shoddy way of checking if it's within the "normal" game world, there's probably a zweb check for this

--- a/code/modules/events/antagonist/migrant_waves/gnolls.dm
+++ b/code/modules/events/antagonist/migrant_waves/gnolls.dm
@@ -21,3 +21,15 @@
 				continue
 
 			to_chat(player, span_danger("Graggar demands blood, gnolls flock to Azuria."))
+
+/proc/update_gnoll_slots()
+	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
+	if(!gnoll_job)
+		return
+
+	var/player_count = length(GLOB.joined_player_list)
+	
+	//Add 1 slot for every 10 players over 30. Less than 40 players, 5 slots. 40 or more players, 6 slots. 50 or more players, 7 slots - etc.
+	if(player_count > 40 && gnoll_job.total_positions <= 0)
+		gnoll_job.total_positions = 1
+		gnoll_job.spawn_positions = 1

--- a/code/modules/events/antagonist/migrant_waves/gnolls.dm
+++ b/code/modules/events/antagonist/migrant_waves/gnolls.dm
@@ -29,7 +29,7 @@
 
 	var/player_count = length(GLOB.joined_player_list)
 	
-	//Add 1 slot for every 10 players over 30. Less than 40 players, 5 slots. 40 or more players, 6 slots. 50 or more players, 7 slots - etc.
+	//Add 1 slot if there's more than 40 players in the game and there are no Gnolls.
 	if(player_count > 40 && gnoll_job.total_positions <= 0)
 		gnoll_job.total_positions = 1
 		gnoll_job.spawn_positions = 1

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -4,8 +4,8 @@
 	department_flag = ANTAGONIST
 	antag_job = TRUE // whoever wrote this, I'm- gghrhhah!
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = RACES_NO_CONSTRUCT
 	tutorial = "You have proven yourself worthy to Graggar, and he's granted you his blessing most divine. Now you hunt for worthy opponents, seeking out those strong enough to make you bleed."
 	outfit = null

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -147,5 +147,5 @@
 	
 	//Add 1 slot for every 10 players over 30. Less than 40 players, 5 slots. 40 or more players, 6 slots. 50 or more players, 7 slots - etc.
 	if(player_count > 40 && gnoll_job.total_positions <= 0)
-		gnoll_job.total_positions = slots
-		gnoll_job.spawn_positions = slots
+		gnoll_job.total_positions = 1
+		gnoll_job.spawn_positions = 1

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -137,3 +137,15 @@
 
 	wretch_job.total_positions = slots
 	wretch_job.spawn_positions = slots
+
+/proc/update_gnoll_slots()
+	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
+	if(!gnoll_job)
+		return
+
+	var/player_count = length(GLOB.joined_player_list)
+	
+	//Add 1 slot for every 10 players over 30. Less than 40 players, 5 slots. 40 or more players, 6 slots. 50 or more players, 7 slots - etc.
+	if(player_count > 40 && gnoll_job.total_positions <= 0)
+		gnoll_job.total_positions = slots
+		gnoll_job.spawn_positions = slots

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -137,15 +137,3 @@
 
 	wretch_job.total_positions = slots
 	wretch_job.spawn_positions = slots
-
-/proc/update_gnoll_slots()
-	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
-	if(!gnoll_job)
-		return
-
-	var/player_count = length(GLOB.joined_player_list)
-	
-	//Add 1 slot for every 10 players over 30. Less than 40 players, 5 slots. 40 or more players, 6 slots. 50 or more players, 7 slots - etc.
-	if(player_count > 40 && gnoll_job.total_positions <= 0)
-		gnoll_job.total_positions = 1
-		gnoll_job.spawn_positions = 1

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -504,6 +504,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 */
 	GLOB.joined_player_list += character.ckey
 	update_wretch_slots()
+	update_gnoll_slots()
 /*
 	if(CONFIG_GET(flag/allow_latejoin_antagonists) && humanc)	//Borgs aren't allowed to be antags. Will need to be tweaked if we get true latejoin ais.
 		if(SSshuttle.emergency)


### PR DESCRIPTION
## About The Pull Request
- Gnolls will now only get 1 slot opened if there are no other gnolls and there's at least 30-40 joined players.
- Gnolls will not get any slot increases from hunted vice if there aren't enough players (same number).
- Gnolls cannot anchor their Abduct anywhere but in the main game world z levels.

The Azurian Special of getting lowpop annoyed / ravaged by antags expected to be ganged up on. IDK why pop scaling didn't exist for the roundstart slot in the first place. 

No, I'm not happy with the vice not spawning gnolls until a certain pop level either, but gnolls have carte blanche to *not care about their target* so them being allowed at all seems to create fuss. I'd rather staff kneecapped gnoll players that were egregious like that, but that sorta loops back to a previous point that lowpop doesn't seem able-bodied to handle them, regardless if they're going after true targets or being little rascals.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I'mma be real I have no idea how I could even theoretically test these pop numbers locally we just kinda TM and pray
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
EU pop shouldn't be disregarded or told "owned", it just sorta seems like the design of gnolls isn't compatible with low numbers.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Gnoll slots are now tied to active pop.
balance: Gnolls cannot anchor their Abduction destination on z levels outside the main ones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
