### PR TITLE
[TESTMERGE ONLY] - Disables 90% of gnoll instances through testmerge

### DIFF
--- a/code/__DEFINES/gnoll.dm
+++ b/code/__DEFINES/gnoll.dm
@@ -12,7 +12,8 @@ GLOBAL_VAR_INIT(gnoll_scaling_mode, 0)
 	var/datum/storyteller/ST =  SSgamemode.selected_storyteller
 	// Roll a coinflip to decide the round's behavior when default value is supplied.
 	if(ST.preferred_gnoll_mode == GNOLL_SCALING_RANDOM)
-		GLOB.gnoll_scaling_mode = pick(GNOLL_SCALING_DYNAMIC, GNOLL_SCALING_FLAT, GNOLL_SCALING_SINGLE)
+		GLOB.gnoll_scaling_mode = pick(//GNOLL_SCALING_DYNAMIC,
+										 GNOLL_SCALING_FLAT, GNOLL_SCALING_SINGLE)
 	else
 		GLOB.gnoll_scaling_mode = ST.preferred_gnoll_mode
 	return GLOB.gnoll_scaling_mode
@@ -23,17 +24,17 @@ GLOBAL_VAR_INIT(gnoll_scaling_mode, 0)
 	switch(mode)
 		if(GNOLL_SCALING_DYNAMIC)
 			// up to two gnolls guaranteed if there's hunted.
-			if(total_positions <= 1)
+			if(total_positions <= 0)
 				return 1
-			// up to three gnolls with a 50% chance per hunted if there's more hunted.
-			if(total_positions <= 2 && prob(50))
-				return 1
-			// Up to four gnolls with a 25% chance per hunted if there's more hunted.
-			if(total_positions <= 3 && prob(25))
-				return 1
+			// // up to three gnolls with a 50% chance per hunted if there's more hunted.
+			// if(total_positions <= 2 && prob(50))
+			// 	return 1
+			// // Up to four gnolls with a 25% chance per hunted if there's more hunted.
+			// if(total_positions <= 3 && prob(25))
+			// 	return 1
 
-		if(GNOLL_SCALING_FLAT)
-			if(total_positions < 2 && prob(15))
-				return 1
+		// if(GNOLL_SCALING_FLAT)
+		// 	if(total_positions < 2 && prob(15))
+		// 		return 1
 				
 	return 0

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -4,8 +4,8 @@
 	department_flag = ANTAGONIST
 	antag_job = TRUE // whoever wrote this, I'm- gghrhhah!
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = RACES_NO_CONSTRUCT
 	tutorial = "You have proven yourself worthy to Graggar, and he's granted you his blessing most divine. Now you hunt for worthy opponents, seeking out those strong enough to make you bleed."
 	outfit = null


### PR DESCRIPTION
## About The Pull Request
Limits gnolls to 1 per round, when hunted are present, and only if zizo or graggar storyteller is picked.

## Testing Evidence
compiles

## Why It's Good For The Game
Just a temporary measure for when I get around to tweaking gnolls later in the week. I'm getting exhausted with people trying to press gnolls into being a critical issue, so this just heavily reduces their pop until I get around to touching them properly.

