### PR TITLE
makes T2 raise formation into singular deadite raising

### DIFF
--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -94,11 +94,14 @@
 	miracle = TRUE
 	devotion_cost = 75
 	cabal_affine = TRUE
-	to_spawn = 2
+	to_spawn = 1
 
 // T2: carbon spawn
 
 /obj/effect/proc_holder/spell/invoked/raise_undead_guard/miracle
+	name = "Raise Deadite"
+	desc = "Raises a singular, weak deadite."
+	chargetime = 3 SECONDS
 	miracle = TRUE
 	devotion_cost = 75
 


### PR DESCRIPTION
## About The Pull Request

Replacement for #4921 
This should be proper merged.

## Testing Evidence

Yes.

## Why It's Good For The Game

Lets clerics/zeretics spawn skeletons without it being too spammy. This is still a temporary solution but better than keeping this in limbo forever.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Re-adds T2 zizite skeleton summoning but 1 skeleton.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
