### PR TITLE
Makes Underdark Drows only neutral to Anthrax Mercs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/anthrax.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/anthrax.dm
@@ -66,6 +66,8 @@
 	beltr = /obj/item/rogueweapon/whip/spiderwhip	
 	beltl = /obj/item/rope/chain
 
+	H.faction += "spider_lowers"
+
 	if(H.mind)
 		var/riding = list("I'm a spider rider (your pet with you)", "I walk on my legs (+1 for athletics)")
 		var/ridingchoice = input(H, "Choose your faith", "FAITH") as anything in riding
@@ -121,6 +123,8 @@
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
 	beltl = /obj/item/rogueweapon/scabbard/sword
 	r_hand = /obj/item/rogueweapon/sword/sabre/stalker
+
+	H.faction += "spider_lowers"
 
 	if(H.mind)
 		var/weapon = list("Bow and Arrow", "Dual Sabres")

--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -98,6 +98,9 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 		real_name = pick(world.file2list("strings/rt/names/elf/elfdf.txt"))
 	else
 		real_name = pick(world.file2list("strings/rt/names/elf/elfdm.txt"))
+
+	faction += "spider_lowers"
+
 	update_hair()
 	update_body()
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -124,8 +124,6 @@
 	stress_examine = TRUE
 	stress_desc = span_red("A loathesome dark elf.")
 
-/datum/species/elf/dark/after_creation(mob/living/carbon/C)
-	C.faction += "spider_lowers"
 
 /datum/species/elf/dark/get_span_language(datum/language/message_language)
 	if(!message_language)


### PR DESCRIPTION
## About The Pull Request
This basically created a similar situation to the "let's have zizites be ignored by skeletons" issue of Drowfolk being able to treat the underdark as a free loot pinata. This keeps the fluff but makes it niche to a couple of thematically-ish fitting people rather than every drow.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
surfies get out
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Underdark Drow now hate all Drow except for Anthrax mercs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
