### PR TITLE
Fixes malum preferring female guildsmiths.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/burghers/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/guildsman.dm
@@ -88,6 +88,7 @@
 			/obj/item/rogueweapon/hammer/iron = 1,
 			/obj/item/rogueweapon/tongs = 1,
 			/obj/item/recipe_book/blacksmithing = 1,
+			/obj/item/blueprint/mace_mushroom = 1,
 			)
 		belt = /obj/item/storage/belt/rogue/leather
 		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor


### PR DESCRIPTION
This wasn't being given to male guildies see CL.

:cl:
fix: fixed male guild blacksmiths not receiving the lithmyc mace blueprint.
/:cl:
