### PR TITLE
Make NPC damage multiplier only apply to simple mobs, again

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -238,8 +238,8 @@
 
 	var/mob/living/L = target
 
-	if(!L.mind)
-		damage *= npc_simple_damage_mult // bonus damage against NPCs.
+	if (!L.mind && istype(L, /mob/living/simple_animal))
+		damage *= npc_simple_damage_mult // bonus damage against simple.
 	if(blocked != 100) // not completely blocked
 		if(damage && L.blood_volume && damage_type == BRUTE)
 			var/splatter_dir = dir


### PR DESCRIPTION
## About The Pull Request
https://github.com/Azure-Peak/Azure-Peak/pull/5298 Caused a regression where my work from https://github.com/Azure-Peak/Azure-Peak/pull/3705 were overridden. 

Archers & Mages had too easy of a time with 1.5 - 2.5x damage multiplier vs complex mobs, but those modifiers are fine vs simple mobs. 3705 made it so that it only applied to simple, 5298 overrode this, leading to mage (And by extension, archers / slingers) have an overly easy time vs npcs. 

This fix that.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="844" height="533" alt="dreamseeker_o3JJjvh4Ie" src="https://github.com/user-attachments/assets/abb5f150-b02d-45e1-bf3b-9fa4cb54a8ad" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Game shouldn't be trivialized

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: NPC damage multiplier on projectiles no longer apply to complex mob. Again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
