### PR TITLE
Rip And Tear - Adds new intent to the Handclaws, 'CLAW'. Rapid-swinging, integrity-shredding, non-penetrating.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -935,7 +935,7 @@
 
 /datum/intent/claw/shred
 	name = "shred"
-	desc = "An incredibly quick swipe that deals additional integrity damage, but can't pierce armor on its own."
+	desc = "A quick swipe that deals additional integrity damage, but can't pierce armor on its own."
 	icon_state = "inclaw"
 	attack_verb = list("shreds", "claws")
 	animname = "chop"
@@ -946,7 +946,7 @@
 	penfactor = 0 //No penetration, but..
 	intent_intdamage_factor = 1.3 //..higher integrity damage. 
 	damfactor = 1
-	clickcd = 4 //Half the attack-speed of a dagger. Intended to break through armor and shred the delicious meat underneath, as a finisher and weakpoint-seizer.
+	clickcd = 8
 	hitsound = list('sound/combat/hits/bladed/genslash (1).ogg', 'sound/combat/hits/bladed/genslash (2).ogg', 'sound/combat/hits/bladed/genslash (3).ogg')
 	miss_sound = "bluntwooshlarge"
 	miss_text = "shreds the air!"


### PR DESCRIPTION
## About The Pull Request

* Adds a fourth intent to all Handclaws, creatively named _'CLAW.'_ Credit to Begotten III for the inspiration behind its gimmick.
* The _'CLAW'_ intent has no damage modifier _or_ armor penetration, alongside costing +50% stamina on a missed attack.
* In exchange, the _'CLAW'_ intent has a dagger's clickdelay and deals +30% integrity damage.

## Testing Evidence

* Displays the new intent, the in-game description, and its effects on a couple NPCs.
* Quick editor's note - changed the modifier from +33% to +30%, so that it fits better with other integrity-damaging scales.
<img width="486" height="247" alt="27b8d9b46d3ada8f70cf2435748e60b7" src="https://github.com/user-attachments/assets/dbee2a65-bc6f-4f01-8693-aa2bf34c5617" />
<img width="160" height="143" alt="4e98454cc999b259120756d0b8ea1b3c" src="https://github.com/user-attachments/assets/3bb7f4f5-fb34-4873-9bd1-08a657693109" />
<img width="281" height="292" alt="7e342ea297dbde1df2c82202e70452d8" src="https://github.com/user-attachments/assets/4b58a294-6efb-438e-91e9-d4a0c38c64a7" />


## Why It's Good For The Game

* It perfectly encapsulates a berserker's shtick into a single intent: an _overwhelming_ barrage of attacks that can weather down defenses and shred apart unprotected flesh. Even so, mindlessly clicking away is punished through a fairly harsh _"on-miss"_ stamina cost - getting carried away with someone who can move during combat will leave you exhausted and open for a riposte.

* It feels very nice in PVE, and offers a delightful - if quite pricey - sidegrade to the Katars and Knuckledusters.

* It'll hopefully add some flair to the claws in PVP, as well, _without_ being completely broken. Best to testmerge first, just in case.

## Changelog

:cl:
balance: Handclaws now receive the 'CLAW' intent. Unleash a rapid-fire barrage of swipes that can shred integrity and flesh, at the cost of having no damage modifier or armor penetration. Swing a little too recklessly, and you'll find yourself out of breath quicker than you can imagine.
/:cl:


