### PR TITLE
Adds Voice Pack Selection

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -147,8 +147,27 @@ GLOBAL_LIST_INIT(pronouns_list, list(HE_HIM, SHE_HER, THEY_THEM, THEY_THEM_F, IT
 // Voice types (LETHALSTONE)
 
 #define VOICE_TYPE_MASC	"Masculine"
-#define VOICE_TYPE_MASC_FOP "Masculine (Foppish)"
 #define VOICE_TYPE_FEM	"Feminine"
 #define VOICE_TYPE_ANDR	"Androgynous"
 
-GLOBAL_LIST_INIT(voice_types_list, list(VOICE_TYPE_MASC, VOICE_TYPE_MASC_FOP, VOICE_TYPE_FEM, VOICE_TYPE_ANDR))
+GLOBAL_LIST_INIT(voice_types_list, list(VOICE_TYPE_MASC, VOICE_TYPE_FEM, VOICE_TYPE_ANDR))
+
+#define VOICE_PACK_DEFAULT	"Default"
+#define VOICE_PACK_MASC	"Masculine"
+#define VOICE_PACK_MASC_ELF "Elvish (Masc)"
+#define VOICE_PACK_MASC_DWARF "Dwarvish (Masc)"
+#define VOICE_PACK_FOP	"Foppish (Masc)"
+#define VOICE_PACK_KNIGHT "Knightly (Masc)"
+#define VOICE_PACK_WARRIOR "Warrior (Masc)"
+#define VOICE_PACK_FEM	"Feminine"
+#define VOICE_PACK_FEM_ELF	"Elvish (Fem)"
+#define VOICE_PACK_FEM_DWARF "Dwarvish (Fem)"
+
+GLOBAL_LIST_INIT(voice_packs_list, list(
+	VOICE_PACK_DEFAULT = null,
+	VOICE_PACK_MASC = /datum/voicepack/male,
+	VOICE_PACK_FOP = /datum/voicepack/male/foppish,
+	VOICE_PACK_KNIGHT = /datum/voicepack/male/knight,
+	VOICE_PACK_WARRIOR = /datum/voicepack/male/warrior,
+	VOICE_PACK_FEM = /datum/voicepack/female,
+))

--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -67,12 +67,10 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 	return TRUE
 
 /proc/apply_voicepacks(mob/living/carbon/human/character, client/player)
-	if(player.prefs.voice_type_override)
-		switch(player.prefs.voice_type)
-			if(VOICE_TYPE_MASC_FOP)	//The other voice packs wouldn't have much to override, but could be included here.
-				character.dna.species.soundpack_m = new /datum/voicepack/male/foppish()
-	else
-		return	//Though optimally we'd just have a pref for voice packs.
+	if(player.prefs.voice_pack != "Default")
+		var/datum/voicepack/VP = GLOB.voice_packs_list[player.prefs.voice_pack]
+		character.dna.species.soundpack_m = new VP()
+		character.dna.species.soundpack_f = new VP()
 
 
 /proc/apply_prefs_virtue(mob/living/carbon/human/character, client/player)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -192,7 +192,7 @@
 			 // LETHALSTONE ADDITION BEGIN: use preference-set voice types where possible
 			if(H.voice_type)
 				switch (H.voice_type)
-					if (VOICE_TYPE_MASC, VOICE_TYPE_MASC_FOP)
+					if (VOICE_TYPE_MASC)
 						possible_sounds = H.dna.species.soundpack_m.get_sound(key, modifier)
 					else
 						if (H.dna.species.soundpack_f)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -70,8 +70,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/real_name						//our character's name
 	var/gender = MALE					//gender of character (well duh) (LETHALSTONE EDIT: this no longer references anything but whether the masculine or feminine model is used)
 	var/pronouns = HE_HIM				// LETHALSTONE EDIT: character's pronouns (well duh)
+	var/voice_pack = "Default"
 	var/voice_type = VOICE_TYPE_MASC	// LETHALSTONE EDIT: the type of soundpack the mob should use
-	var/voice_type_override = FALSE
 	var/datum/statpack/statpack	= new /datum/statpack/wildcard/fated // LETHALSTONE EDIT: the statpack we're giving our char instead of racial bonuses
 	var/datum/virtue/virtue = new /datum/virtue/none // LETHALSTONE EDIT: the virtue we get for not picking a statpack
 	var/datum/virtue/virtuetwo = new /datum/virtue/none
@@ -415,6 +415,12 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			// LETHALSTONE EDIT BEGIN: add pronoun prefs
 			dat += "<b>Pronouns:</b> <a href='?_src_=prefs;preference=pronouns;task=input'>[pronouns]</a><BR>"
 			// LETHALSTONE EDIT END
+			if(!voice_pack)
+				voice_pack = "Default"
+			// LETHALSTONE EDIT BEGIN: add voice type prefs
+			dat += "<b>Voice Identity</b>: <a href='?_src_=prefs;preference=voicetype;task=input'>[voice_type]</a><BR>"
+			// LETHALSTONE EDIT END
+			dat += "<b>Voice Pack</b>: <a href='?_src_=prefs;preference=voicepack;task=input'>[voice_pack]</a><BR>"
 
 			dat += "<BR>"
 			dat += "<b>Race:</b> <a href='?_src_=prefs;preference=species;task=input'>[pref_species.name]</a>[spec_check(user) ? "" : " (!)"]<BR>"
@@ -452,10 +458,6 @@ GLOBAL_LIST_EMPTY(chosen_names)
 				var/name = ispath(T) ? T::name : "None"
 				dat += "<b>Taur Body Type:</b> <a href='?_src_=prefs;preference=taur_type;task=input'>[name]</a><BR>"
 				dat += "<b>Taur Color:</b><span style='border: 1px solid #161616; background-color: #[taur_color];'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=taur_color;task=input'>Change</a><BR>"
-
-			// LETHALSTONE EDIT BEGIN: add voice type prefs
-			dat += "<b>Voice Type</b>: <a href='?_src_=prefs;preference=voicetype;task=input'>[voice_type]</a> <b>Override:</b><a href='?_src_=prefs;preference=voicetype_override;task=input'>[voice_type_override ? "Yes" : "No"]</a><BR>"
-			// LETHALSTONE EDIT END
 
 			dat += "<b>Age:</b> <a href='?_src_=prefs;preference=age;task=input'>[age]</a><BR>"
 
@@ -1719,9 +1721,14 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						voice_type = voicetype_input
 						to_chat(user, "<font color='red'>Your character will now vocalize with a [lowertext(voice_type)] affect.</font>")
 
-				if ("voicetype_override")
-					voice_type_override = !voice_type_override
-					to_chat(user, span_notice("Your character's voice type will [voice_type_override ? "" : "NOT"] override any unique class / race voice packs."))
+				if ("voicepack")
+					var/voicepack_input = tgui_input_list(user, "Choose your character's emote voice pack", "VOICE PACK", GLOB.voice_packs_list)
+					if(voicepack_input)
+						voice_pack = voicepack_input
+						if(voicepack_input != "Default")
+							to_chat(user, span_red("<font color='red'>Your character will now audibly emote with a [lowertext(voicepack_input)] affect.") + span_notice("<br>This will override your Voice Identity and Class-specific voice packs.</font>"))
+						else
+							to_chat(user, "<font color='red'>Your character will now audibly emote in accordance to their Voice Identity and any Racial / Class-specific voice packs.</font>")
 
 				if("taur_type")
 					var/list/species_taur_list = pref_species.get_taur_list()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -448,7 +448,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_ethcolor"]	>> features["ethcolor"]
 	S["pronouns"]			>> pronouns
 	S["voice_type"]			>> voice_type
-	S["voice_type_override"]>> voice_type_override
+	S["voice_pack"]			>> voice_pack
 	S["nickname"]			>> nickname
 	S["highlight_color"]	>> highlight_color
 	S["taur_type"]			>> taur_type
@@ -591,7 +591,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	S["pronouns"] >> pronouns
 	S["voice_type"] >> voice_type
-	S["voice_type_override"] >> voice_type_override
+	S["voice_pack"] >> voice_pack
 	S["body_size"] >> features["body_size"]
 	if (!features["body_size"])
 		features["body_size"] = BODY_SIZE_NORMAL
@@ -769,7 +769,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["song_title"] , song_title)
 	WRITE_FILE(S["char_accent"] , char_accent)
 	WRITE_FILE(S["voice_type"] , voice_type)
-	WRITE_FILE(S["voice_type_override"] , voice_type_override)
+	WRITE_FILE(S["voice_pack"] , voice_pack)
 	WRITE_FILE(S["pronouns"] , pronouns)
 	WRITE_FILE(S["statpack"] , statpack.type)
 	WRITE_FILE(S["virtue"] , virtue.type)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -63,7 +63,7 @@
 		switch(voice_type)
 			if(VOICE_TYPE_FEM)
 				voice_gender = "Woman"
-			if(VOICE_TYPE_MASC, VOICE_TYPE_MASC_FOP)
+			if(VOICE_TYPE_MASC)
 				voice_gender = "Man"
 			if(VOICE_TYPE_ANDR)
 				voice_gender = "Person"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -943,6 +943,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 ////////
 
 /datum/species/proc/handle_digestion(mob/living/carbon/human/H)
+	if(HAS_TRAIT(H, TRAIT_NOHUNGER))
+		return //hunger is for BABIES
 
 	//The fucking TRAIT_FAT mutation is the dumbest shit ever. It makes the code so difficult to work with
 //	if(HAS_TRAIT_FROM(H, TRAIT_FAT, OBESITY))//I share my pain, past coder.
@@ -1032,10 +1034,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 //					H.add_movespeed_modifier(MOVESPEED_ID_HUNGRY, override = TRUE, multiplicative_slowdown = (1.5 * (1 - E.get_charge(H) / 100)))
 //			else
 //				H.remove_movespeed_modifier(MOVESPEED_ID_HUNGRY)
-	if(HAS_TRAIT(H, TRAIT_NOHUNGER)) //hunger is for BABIES
-		H.nutrition = NUTRITION_LEVEL_DEATHLESS
-		H.hydration = HYDRATION_LEVEL_DEATHLESS
-
 
 	switch(H.nutrition)
 //		if(NUTRITION_LEVEL_FAT to INFINITY) //currently disabled/999999 define
@@ -1657,7 +1655,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		var/obj/item/bodypart/affecting = target.get_bodypart(check_zone(selzone))
 		if(!affecting)
 			affecting = target.get_bodypart(BODY_ZONE_CHEST)
-		var/armor_block = target.run_armor_check(selzone, "blunt", blade_dulling = BCLASS_BLUNT, armor_penetration = BLUNT_DEFAULT_PENFACTOR)
+		var/armor_block = target.run_armor_check(selzone, "blunt", blade_dulling = BCLASS_BLUNT)
 		var/damage = user.get_punch_dmg()
 		if(!target.apply_damage(damage, user.dna.species.attack_type, affecting, armor_block))
 			target.next_attack_msg += VISMSG_ARMOR_BLOCKED


### PR DESCRIPTION
## About The Pull Request
This adds a new option to char setup, and changes an old one. It's a bit confusing so bear with me.
<img width="198" height="81" alt="RNobNuYCVk" src="https://github.com/user-attachments/assets/2929fcce-2308-4463-8da0-bca45b267a4e" />

- Voice Packs!
<img width="325" height="339" alt="ToeQJPfV16" src="https://github.com/user-attachments/assets/4fb9ff9a-3965-47ec-971b-1a0f188dd573" />

It lets you select what sort of voice pack (for audible emotes) you'd like to use. Currently it does include the two class-specific ones (Knightly & Warrior), but doesn't include racial ones.

- Voice Identity is the "Voice Type" setting from before. It hasn't been changed at all.

What it DOES: It changes how your character is perceived when speaking "Unknown **Man** / Woman / Person"
AND it controls the primary voice pack your character uses IF the Voice Pack is set to "Default"
Setting it to anything but "Default" will automatically override it regardless of Voice Identity. So you can be an "Unknown Man" despite using feminine vocal emotes because you picked the Feminine Voice Pack. Got that? Good it'll be on the test.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The way the backend of voice packs worked made me realise this approach was the healthiest way of fixing the bug that prevented Foppish from working unless the override was selected. Now any option besides "Default" carries an implicit override to racials / class-specific voice packs. A bit neater, and simpler for everyone else to add to.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Voice Pack selection to char setup.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
