### PR TITLE
Suffering In Silence - Changes the 'ENDURE' miracle to have an emote-styled invocation, and slightly touches up the rest of the 'PRAYER'-type miracles' wording.

### DIFF
--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -505,7 +505,7 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = null
-	invocations = list(span_blue("quietly recites a lesser psalm, steadying their mind."))
+	invocations = list(span_blue("quietly recites a lesser psalm, soothing their pains."))
 	invocation_type = "emote"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = FALSE
@@ -610,7 +610,7 @@
 	range = 2
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
-	invocations = list(span_blue("quietly recites a greater psalm, steadying their mind."))
+	invocations = list(span_blue("quietly recites a greater psalm, soothing their pains."))
 	invocation_type = "emote"
 	sound = null
 	associated_skill = /datum/skill/magic/holy


### PR DESCRIPTION
## About The Pull Request

* The 'ENDURE' miracle is now non-verbal, only requiring the character's ability to emote. No more shouting.
* The 'PRAYER'-series of miracles have been slightly reworded, to be more clear and less wordy.

## Testing Evidence

Note: I edited this image a little bit afterwards to show how the new wording for 'RESPITE' and 'PERSIST' would look.
<img width="461" height="456" alt="Untitled1422141241412421" src="https://github.com/user-attachments/assets/09d9f818-8277-4b7f-8490-0e56bcec0b41" />


## Why It's Good For The Game

* 'ENDURE' is often casted in situations that, in hindsight, wouldn't really command a frenzied shout: comforting a dying compatriot, trying to steady your own wounds, etcetera. The silence - I think - makes for a more impactful use, and makes Psydonians seem _just_ a little less like Warhammer LARPers in disguise. 
* While _technically_ not important, this also means the 'ENDURE' miracle should be easier to notice in a more hectic situation: the unique, azure-colored emotes are far easier to distinguish in _'the heat of the moment'_ than mere shouting. 
* I wasn't happy with my initial wording on the other miracles. This should hopefully strike a nice balance between _'subduedness'_ and _'impact'_.

* On that note - we should probably keep the Absolver-exclusive miracles audible, but it's absolutely no hill I'd die on. If someone can retain the impactful nature of ABSOLVE without dialogue, I'm all for it.

## Changelog

:cl:
add: The 'ENDURE' miracle now prints a uniquely-colored emote upon casting, instead of forcing the caster to shout.
add: Slightly tweaked the verbage on the emotes that 'PRAYER', 'RESPITE', and 'PERSIST' print upon completion.
/:cl: