### PR TITLE
Runtimes fix 1

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -17,7 +17,7 @@
 
 /mob/living/CanPass(atom/movable/mover, turf/target)
 	if(!mover)
-		mover = src
+		return ..()
 	if((mover.pass_flags & PASSMOB))
 		return TRUE
 	if(istype(mover, /obj/projectile))


### PR DESCRIPTION
## About The Pull Request

Fix CanPass runtime - This function was called by other functions NOT FOR MOVEMENT

## Testing Evidence

It must work...

## Why It's Good For The Game

Runtime fix

## Changelog

Added protection against entering the body of a movement when calling something not related to movement.

:cl:
fix: fixed a few things
code: changed some code
/:cl:
