### PR TITLE
Runtimes fix 2

### DIFF
--- a/code/controllers/subsystem/rivers.dm
+++ b/code/controllers/subsystem/rivers.dm
@@ -22,11 +22,13 @@ SUBSYSTEM_DEF(rivers)
 		if(!istype(thing, /turf/open/water/river))
 			processing -= thing
 			continue
-		if(!QDELETED(thing))
-			thing.process_river()
+		var/turf/open/water/river/river = thing
+		if(!QDELETED(river))
+			river.process_river()
 		else
-			processing -= thing
-		if (MC_TICK_CHECK)
+			processing -= river
+
+		if(MC_TICK_CHECK)
 			return
 
 /datum/controller/subsystem/rivers/Recover()


### PR DESCRIPTION
## About The Pull Request

Fix rivers runtime.

The reason was that the river blocks weren't actually being loaded into the river controller. This was either debris from a restart, or a bridge had been added to the river block.

## Testing Evidence

Must working...

## Why It's Good For The Game

Fixing runtime
