### PR TITLE
Lighting issue fix

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -42,15 +42,13 @@ SUBSYSTEM_DEF(lighting)
 		MC_SPLIT_TICK
 
 	var/list/queue
-	var/i
 
 	queue = sources_queue
-	i = 1
-	while(i <= queue.len)
-		var/datum/light_source/L = queue[i]
+	while(queue.len)
+		var/datum/light_source/L = queue[1]
+		queue.Cut(1, 2)
 		L.update_corners()
 		L.needs_update = LIGHTING_NO_UPDATE
-		queue.Cut(i, i+1)
 		if(init_tick_checks)
 			CHECK_TICK
 		else if(MC_TICK_CHECK)
@@ -60,12 +58,11 @@ SUBSYSTEM_DEF(lighting)
 		MC_SPLIT_TICK
 
 	queue = corners_queue
-	i = 1
-	while(i <= queue.len)
-		var/datum/lighting_corner/C = queue[i]
+	while(queue.len)
+		var/datum/lighting_corner/C = queue[1]
+		queue.Cut(1, 2)
 		C.update_objects()
 		C.needs_update = FALSE
-		queue.Cut(i, i+1)
 		if(init_tick_checks)
 			CHECK_TICK
 		else if(MC_TICK_CHECK)
@@ -75,10 +72,9 @@ SUBSYSTEM_DEF(lighting)
 		MC_SPLIT_TICK
 
 	queue = objects_queue
-	i = 1
-	while(i <= queue.len)
-		var/atom/movable/lighting_object/O = queue[i]
-		queue.Cut(i, i+1)
+	while(queue.len)
+		var/atom/movable/lighting_object/O = queue[1]
+		queue.Cut(1, 2)
 		if(QDELETED(O))
 			continue
 		O.update()


### PR DESCRIPTION
## About The Pull Request

Lighting subsystem called fire(FALSE, TRUE) during Initialize() before lighting queues were populated, causing the first tick to operate on empty lists.

## Testing Evidence

Ill going to fix it on the downstream

## Why It's Good For The Game

Runtime fix

## Changelog

Deferred the initial lighting fire() call by one server tick and added a guard to skip execution when lighting queues are empty.

:cl:
fix: fixed a few things
code: changed some code
/:cl: