### PR TITLE
Fix TGUI Examine Panel Performance by like 3 orders of magnitude

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -202,12 +202,16 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/loadout_3_hex
 
 	var/flavortext
+	var/flavortext_cached
 
 	var/ooc_notes
+	var/ooc_notes_cached
 
 	var/nsfwflavortext
+	var/nsfwflavortext_cached
 
 	var/erpprefs
+	var/erpprefs_cached
 
 	var/list/img_gallery = list()
 
@@ -1956,6 +1960,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						ShowChoices(user)
 						return
 					flavortext = new_flavortext
+					flavortext_cached = parsemarkdown_basic(html_encode(flavortext), hyperlink = TRUE)
 					to_chat(user, "<span class='notice'>Successfully updated flavortext</span>")
 					log_game("[user] has set their flavortext'.")
 				if("ooc_notes")
@@ -1968,6 +1973,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						ShowChoices(user)
 						return
 					ooc_notes = new_ooc_notes
+					ooc_notes_cached = parsemarkdown_basic(html_encode(ooc_notes), hyperlink = TRUE)
 					to_chat(user, "<span class='notice'>Successfully updated OOC notes.</span>")
 					log_game("[user] has set their OOC notes'.")
 
@@ -2018,6 +2024,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						ShowChoices(user)
 						return
 					nsfwflavortext = new_nsfwflavortext
+					nsfwflavortext_cached = parsemarkdown_basic(html_encode(nsfwflavortext), hyperlink = TRUE)
 					to_chat(user, "<span class='notice'>Successfully updated NSFW flavortext</span>")
 					log_game("[user] has set their NSFW flavortext'.")
 				if("erpprefs")
@@ -2033,6 +2040,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 						ShowChoices(user)
 						return
 					erpprefs = new_erpprefs
+					erpprefs_cached = parsemarkdown_basic(html_encode(erpprefs), hyperlink = TRUE)
 					to_chat(user, "<span class='notice'>Successfully updated ERP Preferences.</span>")
 					log_game("[user] has set their ERP preferences'.")
 
@@ -2917,12 +2925,15 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 	character.statpack = statpack
 
 	character.flavortext = flavortext
-
 	character.ooc_notes = ooc_notes
-
 	character.nsfwflavortext = nsfwflavortext
-
 	character.erpprefs = erpprefs
+	
+	// Copy the cached version
+	character.flavortext_cached = flavortext_cached
+	character.ooc_notes_cached = ooc_notes_cached
+	character.nsfwflavortext_cached = nsfwflavortext_cached
+	character.erpprefs_cached = erpprefs_cached
 
 	character.img_gallery = img_gallery
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -599,15 +599,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(needs_update >= 0)
 		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)
 
-	// Regenerate cache for flavor texts etc. 
-	if(!flavortext_cached && flavortext)
-		flavortext_cached = parsemarkdown_basic(html_encode(flavortext), hyperlink = TRUE)
-	if(!ooc_notes_cached && ooc_notes)
-		ooc_notes_cached = parsemarkdown_basic(html_encode(ooc_notes), hyperlink = TRUE)
-	if(!nsfwflavortext_cached && nsfwflavortext)
-		nsfwflavortext_cached = parsemarkdown_basic(html_encode(nsfwflavortext), hyperlink = TRUE)
-	if(!erpprefs_cached && erpprefs)
-		erpprefs_cached = parsemarkdown_basic(html_encode(erpprefs), hyperlink = TRUE)
+	// Regenerate cache for flavor texts etc. Must be UNCONDITIONAL because prefs is on client.
+	// We use empty string if they are empty, so the previous slot's data don't get kept in the cache.
+	flavortext_cached = flavortext ? parsemarkdown_basic(html_encode(flavortext), hyperlink = TRUE) : ""
+	ooc_notes_cached = ooc_notes ? parsemarkdown_basic(html_encode(ooc_notes), hyperlink = TRUE) : ""
+	nsfwflavortext_cached = nsfwflavortext ? parsemarkdown_basic(html_encode(nsfwflavortext), hyperlink = TRUE) : ""
+	erpprefs_cached = erpprefs ? parsemarkdown_basic(html_encode(erpprefs), hyperlink = TRUE) : ""
 
 	//Sanitize
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -599,6 +599,16 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(needs_update >= 0)
 		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)
 
+	// Regenerate cache for flavor texts etc. 
+	if(!flavortext_cached && flavortext)
+		flavortext_cached = parsemarkdown_basic(html_encode(flavortext), hyperlink = TRUE)
+	if(!ooc_notes_cached && ooc_notes)
+		ooc_notes_cached = parsemarkdown_basic(html_encode(ooc_notes), hyperlink = TRUE)
+	if(!nsfwflavortext_cached && nsfwflavortext)
+		nsfwflavortext_cached = parsemarkdown_basic(html_encode(nsfwflavortext), hyperlink = TRUE)
+	if(!erpprefs_cached && erpprefs)
+		erpprefs_cached = parsemarkdown_basic(html_encode(erpprefs), hyperlink = TRUE)
+
 	//Sanitize
 
 	real_name = reject_bad_name(real_name)

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -34,7 +34,7 @@
 		ui = new(user, src, "ExaminePanel")
 		ui.open()
 
-/datum/examine_panel/familiar/ui_data(mob/user) //altered and condensed version used for familiars. sorry
+/datum/examine_panel/familiar/ui_static_data(mob/user) //altered and condensed version used for familiars. sorry
 
 	var/flavor_text
 	var/flavor_text_nsfw //probably breaks if i remove it entirely, just leaving it null
@@ -76,17 +76,21 @@
 		"flavor_text_nsfw" = flavor_text_nsfw,
 		"ooc_notes_nsfw" = ooc_notes_nsfw,
 		"img_gallery" = img_gallery,
-		"is_playing" = is_playing,
 		"has_song" = has_song,
 		"is_vet" = is_vet,
 		"is_naked" = is_naked,
 	)
+
 	return data
 
+/datum/examine_panel/familiar/ui_data(mob/user)
+	var/list/data = list( 
+		"is_playing" = is_playing,
+	)
+	return data
 
-
-/datum/examine_panel/ui_data(mob/user)
-
+// Where MOST of the examine panel data lives because it don't update mid game
+/datum/examine_panel/ui_static_data(mob/user)
 	var/flavor_text
 	var/flavor_text_nsfw
 	var/obscured
@@ -160,10 +164,15 @@
 		"flavor_text_nsfw" = flavor_text_nsfw,
 		"ooc_notes_nsfw" = ooc_notes_nsfw,
 		"img_gallery" = img_gallery,
-		"is_playing" = is_playing,
 		"has_song" = has_song,
 		"is_vet" = is_vet,
 		"is_naked" = is_naked,
+	)
+	return data
+
+/datum/examine_panel/ui_data(mob/user)
+	var/list/data = list(
+		"is_playing" = is_playing,
 	)
 	return data
 

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -52,8 +52,8 @@
 	var/datum/preferences/prefs = holder.client?.prefs
 	var/datum/familiar_prefs/fam_pref = prefs?.familiar_prefs
 
-	flavor_text = fam_pref.familiar_flavortext
-	ooc_notes = fam_pref.familiar_ooc_notes
+	flavor_text = fam_pref.familiar_flavortext_display
+	ooc_notes = fam_pref.familiar_ooc_notes_display
 	headshot = fam_pref.familiar_headshot_link
 	char_name = fam_pref.familiar_name
 	song_url = prefs.ooc_extra
@@ -63,15 +63,6 @@
 
 	if(song_url)
 		has_song = TRUE
-
-	ooc_notes = html_encode(ooc_notes)
-	ooc_notes = parsemarkdown_basic(ooc_notes, hyperlink=TRUE)
-	ooc_notes_nsfw = html_encode(ooc_notes_nsfw)
-	ooc_notes_nsfw = parsemarkdown_basic(ooc_notes_nsfw, hyperlink=TRUE)
-	flavor_text = html_encode(flavor_text)
-	flavor_text = parsemarkdown_basic(flavor_text, hyperlink=TRUE)
-	flavor_text_nsfw = html_encode(flavor_text_nsfw)
-	flavor_text_nsfw = parsemarkdown_basic(flavor_text_nsfw, hyperlink=TRUE)
 
 	var/list/data = list(
 		// Identity
@@ -91,6 +82,8 @@
 		"is_naked" = is_naked,
 	)
 	return data
+
+
 
 /datum/examine_panel/ui_data(mob/user)
 
@@ -114,10 +107,10 @@
 		if(!(holder.wear_armor && holder.wear_armor.flags_inv) && !(holder.wear_shirt && holder.wear_shirt.flags_inv))
 			is_naked = TRUE
 		obscured = ((!isobserver(user)) && !holder_human.client?.prefs?.masked_examine) && ((holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE)))
-		flavor_text = obscured ? "Obscured" : holder.flavortext
-		flavor_text_nsfw = obscured ? "Obscured" : holder.nsfwflavortext
-		ooc_notes += holder.ooc_notes
-		ooc_notes_nsfw += holder.erpprefs
+		flavor_text = obscured ? "Obscured" : holder.flavortext_cached
+		flavor_text_nsfw = obscured ? "Obscured" : holder.nsfwflavortext_cached
+		ooc_notes += holder.ooc_notes_cached
+		ooc_notes_nsfw += holder.erpprefs_cached
 		char_name = holder.name
 		song_url = holder.ooc_extra
 		is_vet = holder.check_agevet()
@@ -135,10 +128,10 @@
 	else if(pref)
 		is_naked = TRUE
 		obscured = FALSE
-		flavor_text = pref.flavortext
-		flavor_text_nsfw = pref.nsfwflavortext
-		ooc_notes = pref.ooc_notes
-		ooc_notes_nsfw = pref.erpprefs
+		flavor_text = pref.flavortext_cached
+		flavor_text_nsfw = pref.nsfwflavortext_cached
+		ooc_notes = pref.ooc_notes_cached
+		ooc_notes_nsfw = pref.erpprefs_cached
 		if(vampireplayer && (!SEND_SIGNAL(pref, COMSIG_DISGUISE_STATUS))&& !isnull(pref.vampire_headshot_link)) //vampire with their disguise down and a valid headshot
 			headshot = pref.vampire_headshot_link
 		else if (lichplayer && !isnull(pref.lich_headshot_link))//Lich with a valid headshot
@@ -154,15 +147,6 @@
 
 	if(song_url)
 		has_song = TRUE
-
-	ooc_notes = html_encode(ooc_notes)
-	ooc_notes = parsemarkdown_basic(ooc_notes, hyperlink=TRUE)
-	ooc_notes_nsfw = html_encode(ooc_notes_nsfw)
-	ooc_notes_nsfw = parsemarkdown_basic(ooc_notes_nsfw, hyperlink=TRUE)
-	flavor_text = html_encode(flavor_text)
-	flavor_text = parsemarkdown_basic(flavor_text, hyperlink=TRUE)
-	flavor_text_nsfw = html_encode(flavor_text_nsfw)
-	flavor_text_nsfw = parsemarkdown_basic(flavor_text_nsfw, hyperlink=TRUE)
 
 	var/list/data = list(
 		// Identity

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -123,6 +123,12 @@
 	var/nsfwflavortext = null
 	var/erpprefs = null
 
+	// Cached version
+	var/flavortext_cached = ""
+	var/nsfwflavortext_cached = ""
+	var/ooc_notes_cached = ""
+	var/erpprefs_cached = ""
+
 	var/list/img_gallery = list()
 	
 


### PR DESCRIPTION
## About The Pull Request
- Parsing markdown and regex is expensive. It linearly grow with the length of the text.
- The TGUI Examine Panel code - to be specific, the DM side of it, would parse and encode Flavortext, OOC Notes, NSFW Flavortext and NSFW OOC Notes everytime ui_data() was called. ui_data() is called every 2 seconds, and is meant for rapidly changing data in the UI. The flavortexts are not it.
- This was causing low amount of performance issues Free and I noticed occasionally, but we thought it was just someone doing the bee movie script in character setup (It was not)
- With Scarlettide this issue has been brought to the forefront and is accounting at times for 30 - 40% of total CPU use and 80% of overtime based on how many big chungus examine text exists

This PR fixes the issue by:
- Implementing a caching system for the flavortexts, like Free actually did before TGUI examine panel was used
- Moving all data but whether a song is playing to ui_static_data(), so data are passed ONCE on initilaization instead of every 2 seconds 

tl;dr I fixed tgui examine panel issue by caching the flavortext and sending it on load instead of parsing it every 2 seconds.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I didn't test the static_data() part besides knowing it is good practice. I did however, test the caching part with some AI assisted testcode:
<img width="780" height="602" alt="TabTip_34XPkU4nPa" src="https://github.com/user-attachments/assets/5162912c-85ff-4ff8-b30a-50a696f722f1" />
<img width="796" height="607" alt="TabTip_6wogaodKEz" src="https://github.com/user-attachments/assets/53673ff0-5d5f-41ba-b12d-5b644be0d456" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Lag tends to be pretty bad especially when it is preventable and due to silly stuffs like this

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Examine panel lagging the shit out of the server should be fixed. Report any oddity with your FT / OOC notes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
