### PR TITLE
Runtimes fix 4

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -895,9 +895,20 @@ GLOBAL_LIST_EMPTY(map_model_default)
 	// Note, this would actually drop area vvs in the tile, but like, why tho
 	if(!crds)
 		return
+
+	if(!islist(model) || model.len < 2)
+		return
+	if(!islist(model[1]) || ispath(model[1]))
+		model[1] = list()
+	if(!islist(model[2]) || ispath(model[2]))
+		model[2] = list()
+
 	var/index
 	var/list/members = model[1]
 	var/list/members_attributes = model[2]
+
+	if(!members.len)
+		return
 
 	// We use static lists here because it's cheaper then passing them around
 	var/static/list/default_list = GLOB.map_model_default
@@ -912,8 +923,9 @@ GLOBAL_LIST_EMPTY(map_model_default)
 	//first instance the /area and remove it from the members list
 	index = members.len
 	if(members[index] != /area/template_noop)
-		if(members_attributes[index] != default_list)
+		if(members_attributes.len >= index && members_attributes[index] != default_list)
 			world.preloader_setup(members_attributes[index], members[index])//preloader for assigning  set variables on atom creation
+
 		var/area/area_instance = loaded_areas[members[index]]
 		if(!area_instance)
 			var/area_type = members[index]
@@ -939,12 +951,16 @@ GLOBAL_LIST_EMPTY(map_model_default)
 
 	// Index right before /area is /turf
 	index--
+
+	if(index < 1 || index > members.len)
+		return
+
 	var/atom/instance
 	//then instance the /turf
 	//NOTE: this used to place any turfs before the last "underneath" it using .appearance and underlays
 	//We don't actually use this, and all it did was cost cpu, so we don't do this anymore
 	if(members[index] != /turf/template_noop)
-		if(members_attributes[index] != default_list)
+		if(members_attributes.len >= index && members_attributes[index] != default_list)
 			world.preloader_setup(members_attributes[index], members[index])
 
 		// Note: we make the assertion that the last path WILL be a turf. if it isn't, this will fail.
@@ -957,11 +973,12 @@ GLOBAL_LIST_EMPTY(map_model_default)
 
 		if(GLOB.use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 			world.preloader_load(instance)
+
 	MAPLOADING_CHECK_TICK
 
 	//finally instance all remainings objects/mobs
 	for(var/atom_index in 1 to index-1)
-		if(members_attributes[atom_index] != default_list)
+		if(members_attributes.len >= atom_index && members_attributes[atom_index] != default_list)
 			world.preloader_setup(members_attributes[atom_index], members[atom_index])
 
 		// We make the assertion that only /atom s will be in this portion of the code. if that isn't true, this will fail
@@ -969,6 +986,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 
 		if(GLOB.use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 			world.preloader_load(instance)
+
 		MAPLOADING_CHECK_TICK
 
 ////////////////

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -896,18 +896,26 @@ GLOBAL_LIST_EMPTY(map_model_default)
 	if(!crds)
 		return
 
+	// [GUARD] model sanity
 	if(!islist(model) || model.len < 2)
+		world.log << "build_coordinate: invalid model at [crds] ([model])"
 		return
+
 	if(!islist(model[1]) || ispath(model[1]))
-		model[1] = list()
+		world.log << "build_coordinate: invalid members list at [crds] ([model[1]] / [typeof(model[1])])"
+		return
+
 	if(!islist(model[2]) || ispath(model[2]))
-		model[2] = list()
+		world.log << "build_coordinate: invalid members_attributes list at [crds] ([model[2]] / [typeof(model[2])])"
+		return
 
 	var/index
 	var/list/members = model[1]
 	var/list/members_attributes = model[2]
 
+	// [GUARD] empty model
 	if(!members.len)
+		world.log << "build_coordinate: empty members list at [crds]"
 		return
 
 	// We use static lists here because it's cheaper then passing them around
@@ -952,7 +960,9 @@ GLOBAL_LIST_EMPTY(map_model_default)
 	// Index right before /area is /turf
 	index--
 
+	// [GUARD] invalid turf index
 	if(index < 1 || index > members.len)
+		world.log << "build_coordinate: invalid turf index [index] at [crds] (members.len=[members.len])"
 		return
 
 	var/atom/instance

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -902,11 +902,11 @@ GLOBAL_LIST_EMPTY(map_model_default)
 		return
 
 	if(!islist(model[1]) || ispath(model[1]))
-		world.log << "build_coordinate: invalid members list at [crds] ([model[1]] / [typeof(model[1])])"
+		world.log << "build_coordinate: invalid members list at [crds] ([model[1]])"
 		return
 
 	if(!islist(model[2]) || ispath(model[2]))
-		world.log << "build_coordinate: invalid members_attributes list at [crds] ([model[2]] / [typeof(model[2])])"
+		world.log << "build_coordinate: invalid members list at [crds] ([model[2]])"
 		return
 
 	var/index


### PR DESCRIPTION
## About The Pull Request

Added defensive guards to build_coordinate() to prevent map loading runtimes
Validates model structure and list indices before use
Adds debug-only logging for invalid map data
Preserves existing logic and comments, no behavior changes on valid maps

## Testing Evidence

Similar runtimes have disappeared:
`proc name: build coordinate (/datum/parsed_map/proc/build_coordinate)
  source file: code/modules/mapping/reader.dm,935
  usr: null
  src: /datum/parsed_map (/datum/parsed_map)
  call stack:
/datum/parsed_map (/datum/parsed_map): build coordinate(/list (/list), the thick dungeon shroud (15,90,7) (/turf/closed/dungeon_void), 1, 1, 0)
/datum/parsed_map (/datum/parsed_map):  tgm load(5, 74, 6, 1, 1, -1e+31, 1e+31, -1e+31, 1e+31, -1e+31, 1e+31, 1, 0)
/datum/parsed_map (/datum/parsed_map):  load impl(5, 74, 6, 1, 1, -1e+31, 1e+31, -1e+31, 1e+31, -1e+31, 1e+31, 1, 0)
/datum/parsed_map (/datum/parsed_map): load(5, 74, 6, 1, 1, -1e+31, 1e+31, -1e+31, 1e+31, -1e+31, 1e+31, 1, 0)
Room Tile (/datum/map_template/dungeon/room/drugden): load(the rock (5,74,6) (/turf/closed/mineral/rogue/bedrock), 0)
Matthios Creation (/datum/controller/subsystem/dungeon_generator): try pickedtype first(/datum/map_template/dungeon/ro... (/datum/map_template/dungeon/room), 4, the dirt (24,84,6) (/turf/open/floor/rogue/dirt), Dungeon Direction Helper (/obj/effect/dungeon_directional_helper/west))
Matthios Creation (/datum/controller/subsystem/dungeon_generator): find soulmate(4, the dirt (24,84,6) (/turf/open/floor/rogue/dirt), Dungeon Direction Helper (/obj/effect/dungeon_directional_helper/west))
Matthios Creation (/datum/controller/subsystem/dungeon_generator): Initialize(434999)
Master (/datum/controller/master): Initialize(10, 0, 1)
`
Please, dont trust me.
Many errors can only be fixed in active production.
I'm really scared to touch such systems, but what can I do?

## Why It's Good For The Game

Fix runtime

## Changelog
:cl:
fix: Eliminated map loading crashes caused by invalid model list structure
code: Hardened build_coordinate against malformed data while preserving existing behavior
/:cl:
