### PR TITLE
[Bugfix] Fixed type check for iron scrap

### DIFF
--- a/code/game/objects/items/rogueitems/repair_kits.dm
+++ b/code/game/objects/items/rogueitems/repair_kits.dm
@@ -136,8 +136,8 @@
 	if(!isitem(O))
 		return
 	var/obj/item/I = O
-	if(I.anvilrepair || I == /obj/item/scrap)
-		if(I.smeltresult == /obj/item/ingot/iron || I == /obj/item/scrap) //all iron stuff and iron scrap
+	if(I.anvilrepair || I.type == /obj/item/scrap)
+		if(I.smeltresult == /obj/item/ingot/iron || I.type == /obj/item/scrap) //all iron stuff and iron scrap
 			if(!do_after(user, 2 SECONDS, target = I))
 				return
 			user.visible_message(span_notice("[user] salvages [I] into usable materials."))


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. 
Checks inside of `/obj/item/armorkit_empty/attackby()` were using the item's name instead of its type when checking for iron scrap.

## Testing Evidence

Two-line change. Compiled and tested locally.

## Why It's Good For The Game

Bugs are bad. It was always intended for iron scrap to be able to fill an empty armor kit - now it actually can.

## Changelog

:cl:
fix: iron scrap can be used to fill empty metal repair kit
/:cl:

