### PR TITLE
skill_holder adjustment

### DIFF
--- a/code/datums/skill_holder.dm
+++ b/code/datums/skill_holder.dm
@@ -25,7 +25,7 @@
 
 /mob/proc/adjust_skillrank_down_to(skill, amt, silent = FALSE)
 	return ensure_skills().adjust_skillrank_down_to(skill, amt, silent)
-	
+
 /mob/proc/print_levels()
 	return ensure_skills().print_levels(src)
 
@@ -68,7 +68,7 @@
 
 /datum/skill_holder/proc/set_current(mob/incoming)
 	current = incoming
-	RegisterSignal(incoming, COMSIG_MIND_TRANSFER, PROC_REF(transfer_skills))
+	RegisterSignal(incoming, COMSIG_MIND_TRANSFER, PROC_REF(transfer_skills),override = TRUE)
 	incoming.skills = src
 
 /datum/skill_holder/proc/transfer_skills(mob/source, mob/destination)


### PR DESCRIPTION
## About The Pull Request

[21:52:56] Runtime in code/__HELPERS/unsorted.dm,1129: mind_transfer overridden. Use override = TRUE to suppress this warning
  proc name: stack trace (/datum/proc/stack_trace)
  usr: *no key*/(Eduard)
  usr.loc: (Outdoors Roguetown (30, 34, 2))
  src: /datum/skill_holder (/datum/skill_holder)
  call stack:
  /datum/skill_holder (/datum/skill_holder): stack trace("mind_transfer overridden. Use ...")
  /datum/skill_holder (/datum/skill_holder): RegisterSignal(the bat (/mob/living/simple_animal/hostile/retaliate/bat), "mind_transfer", "transfer_skills", 0)
  /datum/skill_holder (/datum/skill_holder): set current(the bat 

## Testing Evidence

No runtimes(WARNINGS) afther the shapeshifting
<img width="1455" height="583" alt="image" src="https://github.com/user-attachments/assets/b93195d2-3724-49a8-9887-2f0495de0129" />

## Why It's Good For The Game

Runtime logs will be more clearly

## Changelog

:cl:
qol: made something easier to use
code: changed some code
/:cl:
