### PR TITLE
forceMove update

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -516,6 +516,9 @@
 	A.Bumped(src)
 
 /atom/movable/proc/forceMove(atom/destination)
+	if(!destination || QDELETED(src))
+		CRASH("[src] No valid destination passed into forceMove")
+
 	var/mob/living/carbon/human/H = null
 	if(ishuman(src.loc))
 		H = src.loc


### PR DESCRIPTION
## About The Pull Request

This enforces forceMove() invariants and eliminates all invalid-destination runtimes by turning them into explicit crashes instead of undefined behavior.
Next chapter of https://github.com/Azure-Peak/Azure-Peak/pull/5456

## Testing Evidence
- Created a filtering function - got the expected result, proving that the filtering is exists
- The test conclusively demonstrates that the early forceMove guard intercepts invalid calls deterministically and provides actionable diagnostics, whereas the unguarded implementation results in late, low-signal runtimes

## Why It's Good For The Game

Fixing runtimes

## Changelog
:cl:
fix: fixed a few things
code: changed some code
/:cl: