### PR TITLE
swaps the shortsword/rapier for inqconf, psyaltrist

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -43,7 +43,7 @@
 /datum/outfit/job/roguetown/confessor/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
 	if(H.mind)
-		var/weapons = list("Blessed Psydonic Dagger", "Psydonic Handmace", "Psydonic Shortsword")
+		var/weapons = list("Blessed Psydonic Dagger", "Psydonic Handmace", "Psydonic Rapier")
 		var/weapon_choice = input(H,"Choose your WEAPON.", "TAKE UP PSYDON'S ARMS.") as anything in weapons
 		switch(weapon_choice)
 			if("Blessed Psydonic Dagger")
@@ -53,8 +53,8 @@
 			if("Psydonic Handmace")
 				l_hand = /obj/item/rogueweapon/mace/cudgel/psy
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)	
-			if("Psydonic Shortsword")
-				l_hand = /obj/item/rogueweapon/sword/short/psy
+			if("Psydonic Rapier")
+				l_hand = /obj/item/rogueweapon/sword/rapier/psy
 				r_hand = /obj/item/rogueweapon/scabbard/sword
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 		var/armors = list("Confessor - Slurbow, Leather Maillecoat", "Arbalist - Crossbow, Psydonic Chestplate")

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
@@ -77,14 +77,14 @@
 			if("Flute")
 				backr = /obj/item/rogue/instrument/flute
 
-	var/weapons = list("Psydonic Whip", "Psydonic Rapier")
+	var/weapons = list("Psydonic Whip", "Psydonic Shortsword")
 	var/weapon_choice = tgui_input_list(H,"Choose your WEAPON.", "TAKE UP PSYDON'S ARMS.", weapons)
 	switch(weapon_choice)
 		if("Psydonic Whip")
 			H.put_in_hands(new /obj/item/rogueweapon/whip/psywhip_lesser(H))
 			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
-		if("Psydonic Rapier")
-			H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy(H))
+		if("Psydonic Shortsword")
+			H.put_in_hands(new /obj/item/rogueweapon/sword/short/psy(H))
 			H.put_in_hands(new /obj/item/rogueweapon/scabbard/sword(H))
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 


### PR DESCRIPTION
## About The Pull Request

1. Psyaltrist gets the shortsword now. Confessor gets the rapier.

## Testing Evidence

no but it should work

## Why It's Good For The Game

The psyrapier is arguably better than the shortsword. Better that the actual combat class gets it than the bard class.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Psyaltrist gets the Shortsword instead of the Rapier, now.
balance: Confessor gets the Rapier instead of the Shortsword, now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
