### PR TITLE
Starting fire() delay

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -1,3 +1,5 @@
+#define LIGHTING_INITIAL_FIRE_DELAY 2
+
 SUBSYSTEM_DEF(lighting)
 	name = "Lighting"
 	wait = 0
@@ -24,9 +26,13 @@ SUBSYSTEM_DEF(lighting)
 		create_all_lighting_objects()
 		initialized = TRUE
 
-	fire(FALSE, TRUE)
+	can_fire = FALSE
+	addtimer(CALLBACK(src, PROC_REF(enable_lighting)), LIGHTING_INITIAL_FIRE_DELAY)
 
 	return ..()
+
+/datum/controller/subsystem/lighting/proc/enable_lighting()
+	can_fire = TRUE
 
 /datum/controller/subsystem/lighting/fire(resumed, init_tick_checks)
 	MC_SPLIT_TICK_INIT(3)
@@ -90,3 +96,5 @@ SUBSYSTEM_DEF(lighting)
 /datum/controller/subsystem/lighting/Recover()
 	initialized = SSlighting.initialized
 	..()
+
+#undef LIGHTING_INITIAL_FIRE_DELAY


### PR DESCRIPTION
Delay fire() starting to 2 ticks for the runtime prevert

## About The Pull Request

Fix  https://github.com/Azure-Peak/Azure-Peak/pull/5463

## Testing Evidence

https://github.com/user-attachments/assets/1bab2adc-0190-47ec-af5f-1ef9efa76531

https://github.com/user-attachments/assets/3431ba14-122e-48f8-8473-a3476256509f



Result: The dun_world loaded correctly and the lights are working.

## Why It's Good For The Game

Runtune fix

## Changelog

Added a 2-tick delay before starting the fire() function.
:cl:
fix: fixed a few things
code: changed some code
/:cl:
