### PR TITLE
excidium timer cannot exceed 20 minutes

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -419,7 +419,8 @@
 			var/additional_time = bounty_amount * 0.1 // 10 mammon = 1 minute
 			additional_time = round(additional_time)
 			timer += additional_time MINUTES
-
+			timer = clamp(timer, 0 MINUTES, 20 MINUTES)
+	
 		var/timer_minutes = timer / 600
 
 		addtimer(CALLBACK(src, PROC_REF(timerup), user), timer)


### PR DESCRIPTION
## About The Pull Request
- the excidium timer now clamps to 20 minutes max
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1514" height="893" alt="image" src="https://github.com/user-attachments/assets/a636760d-197b-48c9-aa54-bb4c63e8dd80" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
so this is a ""salt pr"", technically. it didnt actually negatively affect my game. unfortunately; wretches no longer show up unless you pick the highest tier of crime, which gives you a bounty  that adds rooooughly 30 minutes onto a ten minute timer.

now; okay. i get it. if you catch a wretch, they should get punished, right? im signing up for the role. that's great. however, rounds last 3 hours. 40 minutes is almost a 1/3rd of the round that you Literally Cannot Interact w/ the Game in the Main Way Youre Supposed to interact w/ it. 

this is also not including how contemporary wretches are treated, which is (usually) as loot goblins for whoever captures them. not only are you likely to be masked, you are likely to lose your armor, your weapon, and/or be brought in for a court trial for an ungodly amount of time depending on the day.

the one time i was masked towards round-end, the garrison member who masked me looc'd me to ask wtf was with my timer amount because he Did Not Want to Mask me Until Roundend (2:20 into the game). and yeah, i was lucky enough to find some rp that didn't involve violence, but we need 2 be realistic here.

TL;DR
- if you are already getting caught, you are probably having your armor, weapons, and money stolen
- this removes your main way of interacting w/ the game
- the mask then further obliterates any hope of interaction w/ the game for UP TO ALMOST 1/3RD OF THE ROUND. 
- this is stupid. 20 minutes is still 1/6th of the round but might allow for some sort of ""comeback"" if you really put your nose to the ground. it also means if some dumbass starts conflict just before round-end and u beat them up you can still make them wait it out

<img width="1207" height="438" alt="image" src="https://github.com/user-attachments/assets/2a9ccd87-adbd-4da1-ae38-a181aa488652" />


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: excidium timers can no longer exceed 20 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
