### PR TITLE
Showerthought - Fixes errant intents on hunting knife.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -102,12 +102,7 @@
 
 /obj/item/rogueweapon/huntingknife
 	force = 12
-	possible_item_intents = list(
-		/datum/intent/dagger/thrust,
-		/datum/intent/dagger/cut,
-		/datum/intent/dagger/thrust/pick,
-		/datum/intent/dagger/sucker_punch,
-		)
+	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust, /datum/intent/dagger/chop)
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_MOUTH
 	name = "hunting knife"
 	desc = "A hunter's prized possession. Keep it sharp, and it might last you through the wild."


### PR DESCRIPTION
## About The Pull Request

In shower right now. Can’t give too much of an explanation. Hunting knife no longer inherits intents from iron dagger.

## Testing Evidence

One line replacement.

## Why It's Good For The Game

Fixes a faulty parity check of mine.
Allows hunting knives to properly chop again, as they should.

## Changelog

:cl:
fix: Hunting knife’s intents work as intended, once again. Chop away!
/:cl:

