### PR TITLE
Fix and adjust logic

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -413,7 +413,7 @@
 				pulledby.moving_from_pull = null
 	if(. && pulling && pulling == pullee && pulling != moving_from_pull) //we were pulling a thing and didn't lose it during our move.
 		if(!pulling || QDELETED(pulling))
-    		return
+			return
 		if(pulling.anchored)
 			stop_pulling()
 		else


### PR DESCRIPTION


## About The Pull Request
Fixing runtime
[2026-01-30 17:18:57] runtime error: Cannot modify null.moving_from_pull. proc name: Move (/atom/movable/Move)
  source file: code/game/atoms_movable.dm,424
  usr: (src)
  src: Ruppert (/mob/living/carbon/human)
  src.loc: the floor (17,125,3) (/turf/open/floor/rogue/hexstone)
  call stack:
Ruppert (/mob/living/carbon/human): Move(the floor (17,125,3) (/turf/open/floor/rogue/hexstone), 8, 0) Ruppert (/mob/living/carbon/human): Move(the floor (17,1  25,3) (/turf/open/floor/rogue/hexstone), 8, null) Ruppert (/mob/living/carbon/human): Move(the floor (17,125,3) (/turf/open/floor/rogue/hexstone), 8) Ruppert (/mob/living/carbon/human): Move(the floor (17,125,3) (/turf/open/floor/rogue/hexstone), 8) PoNcHiK228 (/client): Move(the floor (17,125,3) (/turf/open/floor/rogue/hexstone), 8) Ruppert (/mob/living/carbon/human): keyLoop(PoNcHiK228 (/client)) 
Input (/datum/controller/subsystem/input): fire(0) Input (/datum/controller/subsystem/input): ignite(0) Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)

## Testing Evidence

May be work...

## Why It's Good For The Game

Runtime fix

## Changelog

:cl:
fix: fixed a few things
code: changed some code
/:cl:
