### PR TITLE
Gives Abyssorites mood buffs in rain

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -372,7 +372,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_SQUIRE_REPAIR = span_info("Trained at my Master's side, I can restore any kind of gears with time and polish them until they gleam like new."),
 	TRAIT_WATERBREATHING = span_info("I do not drown in bodies of water."),
 	TRAIT_NUDE_SLEEPER = span_warning("I can't fall asleep unless I'm nude and in bed."),
-	TRAIT_ABYSSOR_SWIM = span_info("I get far less tired when swimming than my peers."),
+	TRAIT_ABYSSOR_SWIM = span_info("I get far less tired when swimming than my peers. I also find mirth in rain and in the midst of storms."),
 	TRAIT_LONGSTRIDER = span_info("Each of my steps finds it's footing no matter how treacherous the terrain is."),
 	TRAIT_TRAINED_SMITH = span_info("I've spent long training, and with some more, I will be able to smith legendary items."),
 	TRAIT_CAUTIOUS_FISHER = span_info("I know my way around the dangers of fishing, and know how to avoid unwanted attention from the depths."),

--- a/code/datums/particle_weathers/datum_types/rain.dm
+++ b/code/datums/particle_weathers/datum_types/rain.dm
@@ -37,6 +37,10 @@
 		L.add_stress(/datum/stressevent/parasol_rain)
 		return
 
+	// Abyssorites like to be in the rain! They still get wet without a parasol, though.
+	if(HAS_TRAIT(L, TRAIT_ABYSSOR_SWIM))
+		L.add_stress(/datum/stressevent/abyssor_rain)
+
 	L.adjust_bodytemperature(-rand(1,3))
 	L.adjust_fire_stacks(-100)
 	L.SoakMob(FULL_BODY)
@@ -61,6 +65,10 @@
 
 //Makes you a bit chilly
 /datum/particle_weather/rain_storm/weather_act(mob/living/L)
+	// Abyssorites like storms even more than they like rain!
+	if(HAS_TRAIT(L, TRAIT_ABYSSOR_SWIM))
+		L.add_stress(/datum/stressevent/abyssor_storm)
+
 	L.adjust_bodytemperature(-rand(3,5))
 	L.adjust_fire_stacks(-100)
 	L.SoakMob(FULL_BODY)

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -391,6 +391,19 @@
 	stressadd = -3
 	desc = list(span_boldred("I SOAKED IN THE BLOOD OF THE THOUSANDS DEAD! GRAGGAR GRAGGAR GRAGGAR!"))
 
+// Intended to proc upon exposure to gentle rain.
+/datum/stressevent/abyssor_rain
+	timer = 1 MINUTES
+	stressadd = -2
+	desc = list(span_blue("This downpour cleanses the earth and brings into pleasing clarity \
+	my recollections of the divine dream. If only I could remember more..."))
+
+// Intended to proc upon exposure to a storm.
+/datum/stressevent/abyssor_storm
+	timer = 1 MINUTES
+	stressadd = -4
+	desc = list(span_blue("WHAT A MAJESTIC TEMPEST! BELOVED ABYSSOR, SEND STRONGER WINDS!"))
+
 /datum/stressevent/keep_standard
 	stressadd = -4
 	desc = span_aiprivradio("The standard speaks of certainty.")


### PR DESCRIPTION
## About The Pull Request

As title! -2 stress in gentle rain, -4 stress in a storm. Inspired by https://github.com/Azure-Peak/Azure-Peak/pull/5204.

## Testing Evidence

<img width="476" height="193" alt="image" src="https://github.com/user-attachments/assets/fb70ba6f-9f75-4615-a402-b4c734ce7957" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

> In the eyes of an Abyssorite, water is quite divine. Beaches should remain clean and free of sin, bathing is virtuous, and the cleansing is often performed in a bath or by virtue of leeches. Standing in the rain does not seem to bother the devout despite the cold. 

A fluffy implementation of some of our [wiki lore](https://azurepeak.miraheze.org/wiki/Abyssor).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Followers of Abyssor now gain a mood buff in rain, and a stronger mood buff in storms!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
