### PR TITLE
Lycker Rebalance

### DIFF
--- a/code/__DEFINES/vampires.dm
+++ b/code/__DEFINES/vampires.dm
@@ -19,15 +19,15 @@
 
 #define GENERATION_MODIFIER 1
 
-#define COVENS_PER_CLAN 3
-#define COVENS_PER_WRETCH_CLAN 2
+#define COVENS_PER_CLAN 4
+#define COVENS_PER_WRETCH_CLAN 3
 
 #define VAMP_CONVERT_TIMEOUT 4 MINUTES
 #define VAMP_CONVERT_POST_STUN    1 MINUTES
 #define VAMP_CONVERT_BLOOD_GAIN   500
 
 /// Mandatory mofe_after() before a vampire can batform. (SHAPESHIFT_MOVEAFTER - vampire.generation) SECONDS
-#define SHAPESHIFT_MOVEAFTER 5
+#define SHAPESHIFT_MOVEAFTER 15
 
 /// Vitae drained from mobs **with client** is multiplied by this define
 #define CLIENT_VITAE_MULTIPLIER 3

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -34,6 +34,7 @@
 	sight = (SEE_TURFS|SEE_MOBS|SEE_OBJS|SEE_SELF)
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+	speed = -1 // good scouting animals
 
 	var/fly_time = 5 //5 ticks because vampire bats are agile
 
@@ -49,7 +50,7 @@
 /mob/living/simple_animal/hostile/retaliate/bat/Initialize()
 	. = ..()
 	verbs += list(/mob/living/simple_animal/hostile/retaliate/bat/proc/fly_up,
-	/mob/living/simple_animal/hostile/retaliate/bat/proc/fly_down) 
+	/mob/living/simple_animal/hostile/retaliate/bat/proc/fly_down)
 
 /mob/living/simple_animal/hostile/retaliate/bat/proc/fly_up()
 	set category = "Winged Form"

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -31,10 +31,6 @@
 	)
 /obj/effect/proc_holder/spell/targeted/shapeshift/cast(list/targets,mob/user = usr)
 	. = ..()
-	var/datum/antagonist/vampire/VD = usr?.mind?.has_antag_datum(/datum/antagonist/vampire)
-	if(VD && SEND_SIGNAL(user, COMSIG_DISGUISE_STATUS))
-		to_chat(usr, span_warning("My curse is hidden."))
-		return
 	if(usr.restrained(ignore_grab = FALSE))
 		to_chat(usr, span_warn("I am restrained, I can't shapeshift!"))
 		return
@@ -64,7 +60,7 @@
 					Restore(M)
 			Shapeshift(M)
 			return TRUE
-	return 
+	return
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/proc/Shapeshift(mob/living/caster)
 	var/obj/shapeshift_holder/H = locate() in caster

--- a/code/modules/vampire_neu/covens/coven_powers/bloodheal.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/bloodheal.dm
@@ -82,6 +82,7 @@
 	desc = "Regenerate wounds with visible speed, this violates the masquerade!"
 
 	level = 3
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 2
 	vitae_cost = 16
 	duration_length = 1.5 SECONDS
@@ -93,6 +94,7 @@
 	desc = "Rapidly regenerate even serious injuries. This violates the masquerade!"
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	vitae_cost = 20
 	duration_length = 1 SECONDS
@@ -104,6 +106,7 @@
 	desc = "Regenerate injuries and restore damaged organs. This violates the masquerade!"
 
 	level = 5
+	minimal_generation = GENERATION_METHUSELAH
 	research_cost = 4
 	vitae_cost = 30
 	duration_length = 0.8 SECONDS

--- a/code/modules/vampire_neu/covens/coven_powers/celerity.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/celerity.dm
@@ -66,6 +66,7 @@
 	desc = "Move faster. React in less time. Your body is under perfect control."
 
 	level = 3
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 2
 	vitae_cost = 60
 	check_flags = COVEN_CHECK_LYING | COVEN_CHECK_IMMOBILE
@@ -80,6 +81,7 @@
 	desc = "Breach the limits of what is humanly possible. Move like a lightning bolt."
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	vitae_cost = 65
 	check_flags = COVEN_CHECK_LYING | COVEN_CHECK_IMMOBILE
@@ -94,6 +96,7 @@
 	desc = "You are like light. Blaze your way through the world."
 
 	level = 5
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 4
 	vitae_cost = 70
 	check_flags = COVEN_CHECK_LYING | COVEN_CHECK_IMMOBILE

--- a/code/modules/vampire_neu/covens/coven_powers/demonic.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/demonic.dm
@@ -70,6 +70,7 @@
 	desc = "Turn your hands into deadly claws."
 
 	level = 3
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 2
 	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE
 	vitae_cost = 250
@@ -104,6 +105,7 @@
 	desc = "Set your foes on fire with a fireball."
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_LYING
 
@@ -126,6 +128,7 @@
 	name = "Wall of Fire"
 	desc = "Firebolt? Fireball? No. Wall of Fire!"
 	level = 5
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 4
 	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE
 	range = 10
@@ -133,7 +136,6 @@
 	cooldown_length = 120 SECONDS
 	violates_masquerade = TRUE
 	research_cost = 4
-	minimal_generation = GENERATION_ANCILLAE
 	var/initialized_curses = FALSE
 	var/list/curse_names = list()
 	var/list/curses = list()

--- a/code/modules/vampire_neu/covens/coven_powers/fae_trickery.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/fae_trickery.dm
@@ -25,7 +25,7 @@
 /datum/coven_power/fae_trickery/darkling_trickery/activate(mob/living/target)
 	. = ..()
 	target.visible_message(span_suicide("[target] is disarmed!"),
-					span_boldwarning("I'm disarmed!"))	
+					span_boldwarning("I'm disarmed!"))
 	playsound(get_turf(target), 'sound/magic/mockery.ogg', 40, FALSE)
 	var/turnangle = (prob(50) ? 270 : 90)
 	var/turndir = turn(target.dir, turnangle)
@@ -295,7 +295,7 @@
 		if(AM != owner)
 			AM.adjustBruteLoss(35)
 			AM.Knockdown(5)
-			AM.visible_message(span_suicide("[AM] is disarmed!"), 
+			AM.visible_message(span_suicide("[AM] is disarmed!"),
 							span_boldwarning("I'm disarmed!"))
 			playsound(get_turf(AM), 'sound/magic/mockery.ogg', 40, FALSE)
 			var/target_turf = get_ranged_target_turf(get_turf(AM), pick(GLOB.cardinals), rand(2, 5))
@@ -308,6 +308,7 @@
 	desc = "Plants a symbol under you. Brutal traps throw victims violently, spin makes them dizzy, drop knocks them on the ground and throws their weapon away."
 
 	level = 3
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 2
 	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE
 	vitae_cost = 80
@@ -340,6 +341,7 @@
 	desc = "Pose a confounding riddle to your victim, forcing them to answer it before they can do anything else."
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	vitae_cost = 250
 	minimal_generation = GENERATION_ANCILLAE
@@ -479,9 +481,9 @@
 	desc = "Unleash a barrage of strikes upon thine foes."
 
 	level = 5
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 4
 	vitae_cost = 250
-	minimal_generation = GENERATION_ANCILLAE
 	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_SPEAK
 	range = 7
 

--- a/code/modules/vampire_neu/covens/coven_powers/obfuscate.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/obfuscate.dm
@@ -126,6 +126,7 @@
 	desc = "Disappear from plain view instantly, and wipe your presence from recent memory."
 
 	level = 3
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 2
 	vitae_cost = 100
 	check_flags = COVEN_CHECK_CAPABLE
@@ -169,6 +170,7 @@
 	desc = "Hide yourself and others in a small area. All nearby allies become invisible."
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	check_flags = COVEN_CHECK_CAPABLE
 	vitae_cost = 150

--- a/code/modules/vampire_neu/covens/coven_powers/potence.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/potence.dm
@@ -92,6 +92,7 @@
 	desc = "Become an unyielding machine for as long as your Vitae lasts."
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	vitae_cost = 65
 	check_flags = COVEN_CHECK_CAPABLE
@@ -116,6 +117,7 @@
 	desc = "The people could worship you as a god if you showed them this."
 
 	level = 5
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 4
 	vitae_cost = 70
 	check_flags = COVEN_CHECK_CAPABLE

--- a/code/modules/vampire_neu/covens/coven_powers/presence.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/presence.dm
@@ -151,6 +151,7 @@
 	desc = "Make those kneel before you."
 
 	level = 3
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 2
 	vitae_cost = 200
 	check_flags = COVEN_CHECK_CAPABLE|COVEN_CHECK_SPEAK
@@ -185,6 +186,7 @@
 	desc = "Keep your friends close, but your enemies closer. Teleport a target to you."
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	vitae_cost = 200
 	check_flags = COVEN_CHECK_CAPABLE|COVEN_CHECK_SPEAK
@@ -239,6 +241,7 @@
 	desc = "Become so grand that others find it nearly impossible to disobey or harm you."
 
 	level = 5
+	minimal_generation = GENERATION_METHUSELAH
 	research_cost = 4
 	check_flags = COVEN_CHECK_CAPABLE|COVEN_CHECK_SPEAK
 	vitae_cost = 35

--- a/code/modules/vampire_neu/covens/coven_powers/quietus.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/quietus.dm
@@ -180,6 +180,7 @@
 	desc = "Transmute your vitae into a toxin that destroys all flesh it touches. Must be used on a SHARP weapon."
 
 	level = 3
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 2
 	check_flags = COVEN_CHECK_CAPABLE | COVEN_CHECK_CONSCIOUS | COVEN_CHECK_IMMOBILE | COVEN_CHECK_LYING
 	vitae_cost = 150
@@ -212,6 +213,7 @@
 	desc = "Spit a glob of caustic blood at your enemies."
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	check_flags = COVEN_CHECK_CAPABLE | COVEN_CHECK_CONSCIOUS | COVEN_CHECK_IMMOBILE | COVEN_CHECK_LYING
 	violates_masquerade = TRUE
@@ -234,8 +236,8 @@
 	desc = "Curse the last person you attacked to drown in their own blood."
 
 	level = 5
-	research_cost = 4
 	minimal_generation = GENERATION_ANCILLAE
+	research_cost = 4
 	check_flags = COVEN_CHECK_CAPABLE | COVEN_CHECK_CONSCIOUS | COVEN_CHECK_IMMOBILE | COVEN_CHECK_LYING
 	cooldown_length = 30 SECONDS
 

--- a/code/modules/vampire_neu/covens/coven_powers/siren.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/siren.dm
@@ -108,6 +108,7 @@
 	desc = "Sing a siren song, calling all nearby to you."
 
 	level = 3
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 2
 	vitae_cost = 200
 	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_SPEAK
@@ -143,6 +144,7 @@
 	desc = "Sing an unearthly song to stun those around you."
 
 	level = 4
+	minimal_generation = GENERATION_ANCILLAE
 	research_cost = 3
 	vitae_cost = 250
 	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_SPEAK
@@ -178,8 +180,8 @@
 	desc = "Scream at an unnatural pitch, shattering the bodies of your enemies."
 
 	level = 5
-	research_cost = 4
 	minimal_generation = GENERATION_ANCILLAE
+	research_cost = 4
 	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_SPEAK
 	duration_length = 3 SECONDS
 	cooldown_length = 30 SECONDS

--- a/code/modules/vampire_neu/covens/coven_unlock_menu.dm
+++ b/code/modules/vampire_neu/covens/coven_unlock_menu.dm
@@ -257,7 +257,7 @@
 		else if(parent_coven.level >= node.required_level)
 			// Check prerequisites
 			if(node.minimal_generation > user.get_vampire_generation())
-				to_chat(user, span_warning("[node.name] can be unlocked only by vampires of [GLOB.vamp_generation_to_text[node.minimal_generation]]. You are [GLOB.vamp_generation_to_text[user.get_vampire_generation()]]")) 
+				to_chat(user, span_warning("[node.name] can be unlocked only by vampires of [GLOB.vamp_generation_to_text[node.minimal_generation]]. You are [GLOB.vamp_generation_to_text[user.get_vampire_generation()]]"))
 				return
 			var/prereqs_met = TRUE
 			var/missing_prereqs = list()


### PR DESCRIPTION
## About The Pull Request

- Lyckers' powers have been limited a fair bit. They can no longer get the tier 3 or higher powers from most covens.
- Lyckers now gain access to 3 covens instead of 2.
- Vampires can now use batform while disguised, but it takes longer (5 seconds -> 15 seconds).
- Batform can now fly much faster.

## Testing Evidence

yea

## Why It's Good For The Game

lyckers are annoying

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Lyckers' powers have been limited a fair bit. They can no longer get the tier 3 or higher powers from most covens.
balance: Lyckers now gain access to 3 covens instead of 2.
balance: Vampires can now use batform while disguised, but it takes longer (5 seconds -> 15 seconds).
balance: Batform can now fly much faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
