### PR TITLE
Cleaning A Mess - The Loadout-specific Mess Kit now produces the item, instead of nothing.

### DIFF
--- a/code/datums/loadout.dm
+++ b/code/datums/loadout.dm
@@ -861,7 +861,7 @@ GLOBAL_LIST_EMPTY(loadout_items)
 
 /datum/loadout_item/triumph_messkit
 	name = "Mess Kit (-5 TRI)"
-	path = /datum/component/storage/concrete/roguetown/messkit
+	path = /obj/item/storage/gadget/messkit
 	triumph_cost = 5
 
 /datum/loadout_item/triumph_foldtable


### PR DESCRIPTION
## About The Pull Request

* Redeeming a Mess Kit via the loadout now properly gives you the item, rather than a misattributed datum.

## Testing Evidence

One line change.

## Why It's Good For The Game

* Fixes a minor flummoxing on my end.
* Paying for a Mess Kit should give a Mess Kit, rather than nothing at all.

## Changelog

:cl:
fix: Purchasing a Mess Kit via the loadout system will now properly give you a Mess Kit, instead of nothing.
/:cl:

