### PR TITLE
Adds muscular skin to monk and biome wanderer on request

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -47,7 +47,6 @@
 	to_chat(H, span_warning("You are a wandering acolyte, versed in both miracles and martial arts. You forego the hauberk that paladins wear in favor of humbling your foes through bloodless strikes. Your satchel hangs heavy, too, with ample provisions for the pilgrimage you're upon."))
 	head = /obj/item/clothing/head/roguetown/headband/monk
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-	armor = /obj/item/clothing/suit/roguetown/shirt/robe/monk
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	backl = /obj/item/storage/backpack/rogue/satchel
@@ -64,6 +63,13 @@
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)	//Capped to T1 miracles. Better passive regeneration.
 	if(H.mind)
+		var/armors = list("Robes","Bodybuilder")
+		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMS") as anything in armors
+		switch(armor_choice)
+			if("Robes")
+				armor = /obj/item/clothing/suit/roguetown/shirt/robe/monk
+			if("Bodybuilder") //Not adding any nerfs to getting leather armor should be fine, since it is unupgradable throughout the round. Roundstart armor in return for never getting good armor.
+				armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather
 		var/weapons = list("Discipline - Unarmed","Katar","Knuckledusters","Quarterstaff")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -230,7 +230,7 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 				beltl = /obj/item/quiver/bolts
-		var/armors = list("Light Armor","Medium Armor")
+		var/armors = list("Light Armor","Medium Armor", "Bodybuilder")
 		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMS") as anything in armors
 		switch(armor_choice)
 			if("Light Armor")
@@ -246,3 +246,9 @@
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 				H.change_stat(STATKEY_STR, 1)
 				H.set_blindness(0)
+			if("Bodybuilder") // We effectively just replace the hide armor with leather armor that's harder to repair.
+				armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+				gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+				H.change_stat(STATKEY_SPD, 1)


### PR DESCRIPTION
## About The Pull Request

Does what the title says. Gives biome wanderer and monk an option to take muscular skin.

## Testing Evidence

I spawned in as both monk and biome wanderer, and successfully got the option to take muscular skin, and it worked as expected.

## Why It's Good For The Game

For balancejaks: Biome wanderer loses a better set of roundstart armor to take this, and monks trade the opportunity to get better armor for permanently shitty roundstart armor. I don't think there are any severe balance implications for either class, and it means more buff men.

## Changelog
:cl:
add: Added an option for biome wanderers and monks to take muscular skin.
/:cl:
