### PR TITLE
adds charge immune + charge immunity to charged victims

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -21,6 +21,7 @@
 #define TRAIT_EXPLOSIVE_SUPPLY "Explosive Supply"
 #define TRAIT_BOMBER_EXPERT "Explosive Specialist"
 #define TRAIT_BREADY "Battleready"
+#define TRAIT_CHARGEIMMUNE "Charge Immune"
 #define TRAIT_ARMOUR_LIKED "Fitting Armour"
 #define TRAIT_ARMOUR_DISLIKED "Misfitting Armour"
 #define TRAIT_FENCERDEXTERITY "Fencer's Dexterity"
@@ -317,6 +318,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_DEFILED_NOBLE = span_blue("I'm of noble blood but... Something feels off!"),
 	TRAIT_EMPATH = span_info("I can notice when people are in pain."),
 	TRAIT_EXPLOSIVE_SUPPLY = span_info("I have very good friends! I get explosives on my HERMES every day."),
+	TRAIT_CHARGEIMMUNE = span_green("My stance is firm, I won't topple over when charged at."),
 	TRAIT_BREADY = span_info("Defensive stance does not passively fatigue me. I regain energy slowly over time."),
 	TRAIT_ARMOUR_LIKED = span_greentext("I'm wearing something more suited to my style."),
 	TRAIT_ARMOUR_DISLIKED = span_warning("I'm wearing something that burdens me."),

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -358,7 +358,12 @@
 	. = ..()
 	if(owner)
 		owner.stamina = max((owner.stamina - owner.max_stamina / 2), 0)
+		ADD_TRAIT(owner, TRAIT_CHARGEIMMUNE, TRAIT_STATUS_EFFECT)
 		to_chat(owner, span_notice("Tempo!!"))
+
+/datum/status_effect/buff/tempo_two/on_remove()
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_CHARGEIMMUNE, TRAIT_STATUS_EFFECT)
 
 #define TEMPO_MAX_FILTER "tempo_max_glow"
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -182,6 +182,10 @@
 				return FALSE
 			var/mob/living/L = M
 
+			if(HAS_TRAIT(L, TRAIT_CHARGEIMMUNE))
+				L.visible_message("[L] resists [src]'s charge!")
+				return FALSE
+
 			var/self_points = FLOOR((STACON + STASTR)/2, 1)
 			var/target_points = FLOOR((L.STACON + L.STASTR)/2, 1)
 
@@ -231,11 +235,15 @@
 				clash_blocked = TRUE
 			if(self_points > target_points)
 				L.Knockdown(1)
+				ADD_TRAIT(L, TRAIT_CHARGEIMMUNE, TRAIT_GENERIC)
+				addtimer(CALLBACK(L, PROC_REF(remove_charge_immunity)), 12 SECONDS)
 			if(self_points < target_points)
 				Knockdown(30)
 			if(self_points == target_points)
 				L.Knockdown(1)
 				Knockdown(30)
+				ADD_TRAIT(L, TRAIT_CHARGEIMMUNE, TRAIT_GENERIC)
+				addtimer(CALLBACK(L, PROC_REF(remove_charge_immunity)), 6 SECONDS)
 			Immobilize(5)
 			var/playsound = FALSE
 			if(L.apply_damage(15, BRUTE, "chest", L.run_armor_check("chest", "blunt", damage = 10)))
@@ -285,6 +293,16 @@
 		if(!istype(M, /obj/item/clothing))
 			if(prob(I.block_chance*2))
 				return
+
+/mob/living/proc/remove_charge_immunity()
+	if(!isliving(src))
+		return FALSE
+	if(!HAS_TRAIT(src, TRAIT_CHARGEIMMUNE))
+		return FALSE
+
+	REMOVE_TRAIT(src, TRAIT_CHARGEIMMUNE, TRAIT_GENERIC)
+	to_chat(src, span_warning("I'm no longer sturdy - charges will knock me down, once more."))
+	return TRUE
 
 //Called when we bump onto an obj
 /mob/living/proc/ObjBump(obj/O)


### PR DESCRIPTION
## About The Pull Request

1. When charged, if the victim topples over, they get 12s of Charge Immunity.
2. If both victim and charger topple over, victim gets 6s of Charge Immunity.
3. Tempo Lvl2 gives Charge Immunity.

## Testing Evidence

No, it'll need ingame testing. But should work.

## Why It's Good For The Game

Nobody likes being chain charged. 

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Being charged gives you charge immunity (6/12s).
balance: Tempo Lvl2 gives charge immunity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
