### PR TITLE
Allows members of Heartfelt to arrive to Azure Peak without requiring a Lord

### DIFF
--- a/code/datums/migrants/migrant_waves/heartfelt wave.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt wave.dm
@@ -123,8 +123,48 @@
 /datum/migrant_wave/heartfelt_down_ten
 	name = "The Court of Heartfelt"
 	shared_wave_type = /datum/migrant_wave/heartfelt
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_eleven
 	can_roll = FALSE
 	roles = list(
 		/datum/migrant_role/heartfelt/lord = 1,
+	)
+	greet_text = "Fleeing disaster, you have came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. It was all for naught - in the end, only you are left, bereft of your family and men. How the mighty have fallen..."
+
+/datum/migrant_wave/heartfelt_down_eleven
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_twelve
+	can_roll = FALSE
+	roles = list(
+		/datum/migrant_role/heartfelt/hand = 1,
+	)
+	greet_text = "Fleeing disaster, you have came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. It was all for naught - in the end, only you are left, bereft of your family and men. How the mighty have fallen..."
+
+/datum/migrant_wave/heartfelt_down_twelve
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_thirteen
+	can_roll = FALSE
+	roles = list(
+		/datum/migrant_role/heartfelt/knight = 1,
+	)
+	greet_text = "Fleeing disaster, you have came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. It was all for naught - in the end, only you are left, bereft of your family and men. How the mighty have fallen..."
+
+/datum/migrant_wave/heartfelt_down_thirteen
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	downgrade_wave = /datum/migrant_wave/heartfelt_down_fourteen
+	can_roll = FALSE
+	roles = list(
+		/datum/migrant_role/heartfelt/retinue = 2,
+	)
+	greet_text = "Fleeing disaster, you have came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. It was all for naught - in the end, only you are left, bereft of your family and men. How the mighty have fallen..."
+
+/datum/migrant_wave/heartfelt_down_fourteen
+	name = "The Court of Heartfelt"
+	shared_wave_type = /datum/migrant_wave/heartfelt
+	can_roll = FALSE
+	roles = list(
+		/datum/migrant_role/heartfelt/retinue = 1,
 	)
 	greet_text = "Fleeing disaster, you have came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. It was all for naught - in the end, only you are left, bereft of your family and men. How the mighty have fallen..."


### PR DESCRIPTION
## About The Pull Request

Self-Descriptive title. Allows the Heartfelt Hand, Knight and Retinue to show up to Azure Peak without requiring the presence of a Lord.

## Testing Evidence

<img width="694" height="555" alt="Capture d’écran (3581)" src="https://github.com/user-attachments/assets/a888811d-c7d6-47c2-822b-adc502badba7" />
<img width="598" height="511" alt="Capture d’écran (3582)" src="https://github.com/user-attachments/assets/6d55540a-5bb7-47ee-bf8e-366ef80d0006" />

## Why It's Good For The Game

Allows people to actually play their Heartfelt characters as any of the roles without requiring a Lord, which is not always possible currently.

## Changelog

:cl:
balance: The Hand, Knight and Retinue of Heartfelt can now visit Azure Peak without having to bring their Lord alongside them.
/:cl: