### PR TITLE
Ported CheckToolReach implementation from Vanderling.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -505,35 +505,30 @@ GLOBAL_LIST_EMPTY(reach_dummy_pool)
 	if(!here || !there)
 		return FALSE
 
+	var/turf/start = get_turf(here)
+	if(!start)
+		return FALSE
+
 	switch(reach)
 		if(0)
 			return FALSE
 		if(1)
-			return FALSE // here.Adjacent(there)
-
+			return FALSE
 		if(2 to INFINITY)
-			var/turf/start = get_turf(here)
-			if(!start)
-				return FALSE
-
-			var/obj/dummy = new(start)
+			var/obj/effect/dummy = new(start)
 			dummy.pass_flags |= PASSTABLE
 			dummy.movement_type = FLYING
 			dummy.invisibility = INVISIBILITY_ABSTRACT
-
 			for(var/i in 1 to reach)
 				if(dummy.CanReach(there))
 					qdel(dummy)
 					return TRUE
-
 				var/turf/T = get_step(dummy, get_dir(dummy, there))
 				if(!T || !dummy.Move(T))
 					qdel(dummy)
 					return FALSE
-
 			qdel(dummy)
 			return FALSE
-
 
 
 // Default behavior: ignore double clicks (the second click that makes the doubleclick call already calls for a normal click)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -503,33 +503,38 @@ GLOBAL_LIST_EMPTY(reach_dummy_pool)
 
 /proc/CheckToolReach(atom/movable/here, atom/movable/there, reach)
 	if(!here || !there)
-		return
+		return FALSE
+
 	switch(reach)
 		if(0)
 			return FALSE
 		if(1)
-			return FALSE //here.Adjacent(there)
+			return FALSE // here.Adjacent(there)
+
 		if(2 to INFINITY)
-			var/obj/dummy
-			if(GLOB.reach_dummy_pool.len)
-				dummy = GLOB.reach_dummy_pool[GLOB.reach_dummy_pool.len]
-				GLOB.reach_dummy_pool.len--
-			else
-				dummy = new /obj()
-				dummy.pass_flags |= PASSTABLE
-				dummy.invisibility = INVISIBILITY_ABSTRACT
+			var/turf/start = get_turf(here)
+			if(!start)
+				return FALSE
+
+			var/obj/dummy = new(start)
+			dummy.pass_flags |= PASSTABLE
 			dummy.movement_type = FLYING
-			dummy.forceMove(get_turf(here))
-			for(var/i in 1 to reach) //Limit it to that many tries
-				var/turf/T = get_step(dummy, get_dir(dummy, there))
+			dummy.invisibility = INVISIBILITY_ABSTRACT
+
+			for(var/i in 1 to reach)
 				if(dummy.CanReach(there))
-					GLOB.reach_dummy_pool += dummy
+					qdel(dummy)
 					return TRUE
-				if(!dummy.Move(T)) //we're blocked!
-					GLOB.reach_dummy_pool += dummy
-					return
-			GLOB.reach_dummy_pool += dummy
+
+				var/turf/T = get_step(dummy, get_dir(dummy, there))
+				if(!T || !dummy.Move(T))
+					qdel(dummy)
+					return FALSE
+
+			qdel(dummy)
 			return FALSE
+
+
 
 // Default behavior: ignore double clicks (the second click that makes the doubleclick call already calls for a normal click)
 /mob/proc/DblClickOn(atom/A, params)


### PR DESCRIPTION
## About The Pull Request

Next chapter of forcemove() fix
https://github.com/Azure-Peak/Azure-Peak/pull/5485

## Testing Evidence
There were no anomalies on the our production related to this issue  for about 12 hours.
## Why It's Good For The Game

Why this is good:
- Eliminates forceMove calls on objects with loc = null
- Removes an entire class of runtime errors ("No valid destination passed into forceMove")
- Avoids unsafe reuse of pooled dummy objects with undefined state
- Reduces side effects by not touching forceMove at all
- Logic is simpler, deterministic, and matches a proven upstream implementation

## Changelog

:cl:
qol: made something easier to use
fix: fixed a few things
code: changed some code
refactor: refactored some code
/:cl:
