### PR TITLE
let ravox challenge not work on people who can't fight back

### DIFF
--- a/code/modules/spells/roguetown/acolyte/ravox.dm
+++ b/code/modules/spells/roguetown/acolyte/ravox.dm
@@ -285,53 +285,65 @@ GLOBAL_LIST_EMPTY(arenafolks) // we're just going to use a list and add to it. S
 		revert_cast()
 		return FALSE
 
-	if(isliving(targets[1]))
-		var/mob/living/target = targets[1]
-		var/originalcmodeuser = user.cmode_music
-		var/originalcmodetarget = target.cmode_music
-		var/turf/storedchallengerturf = get_turf(user)
-		var/turf/storedchallengedturf = get_turf(target)
-		if(user.z != target.z)
-			revert_cast()
-			return FALSE
-		if(target == user)
-			revert_cast()
-			return FALSE
+	if(!isliving(targets[1]))
+		revert_cast()
+		return FALSE
 
-		for(var/obj/structure/fluff/ravox/challenger/aflag in thearena)
-			challengerspawnpoint = get_turf(aflag)
-		for(var/obj/structure/fluff/ravox/challenged/bflag in thearena)
-			challengedspawnpoint = get_turf(bflag)
-		
-		do_teleport(user, challengerspawnpoint)
-		do_teleport(target, challengedspawnpoint)
-		GLOB.arenafolks += user
-		GLOB.arenafolks += target
-		storedchallengerturf.visible_message((span_cult("[user] calls upon the Ravoxian rite of Trial! [target] and [user] are brought to Trial!")))
+	var/mob/living/carbon/target = targets[1]
+	var/originalcmodeuser = user.cmode_music
+	var/originalcmodetarget = target.cmode_music
+	var/turf/storedchallengerturf = get_turf(user)
+	var/turf/storedchallengedturf = get_turf(target)
 
-		new /obj/structure/fluff/ravox/challenger/recall(storedchallengerturf)
-		new /obj/structure/fluff/ravox/challenged/recall(storedchallengedturf)
+	if(user.z != target.z)
+		revert_cast()
+		return FALSE
+	if(target == user)
+		revert_cast()
+		return FALSE
+	if(
+		(target.stat > CONSCIOUS) || \
+		!(target.mobility_flags & MOBILITY_STAND) || \
+		!(target.mobility_flags & MOBILITY_MOVE) || \
+		(HAS_TRAIT(target, TRAIT_PACIFISM)) || \
+		(target.handcuffed) || \
+		(target.legcuffed)
+	)
+		to_chat(user, span_warning("[target] is in no shape to accept the duel!"))
+		revert_cast()
+		return FALSE
 
-		to_chat(user, span_userdanger("THE TRIAL IS CALLED, IMPRESS US, PROSECUTOR!!"))
-		to_chat(target, span_userdanger("A TRIAL OF RAVOX BEGINS. IMPRESS US, DEFENDANT!!"))
+	for(var/obj/structure/fluff/ravox/challenger/aflag in thearena)
+		challengerspawnpoint = get_turf(aflag)
+	for(var/obj/structure/fluff/ravox/challenged/bflag in thearena)
+		challengedspawnpoint = get_turf(bflag)
 
-		user.cmode_change('sound/music/ravoxarena.ogg')
-		target.cmode_change('sound/music/ravoxarena.ogg')
+	do_teleport(user, challengerspawnpoint)
+	do_teleport(target, challengedspawnpoint)
+	GLOB.arenafolks += user
+	GLOB.arenafolks += target
+	storedchallengerturf.visible_message((span_cult("[user] calls upon the Ravoxian rite of Trial! [target] and [user] are brought to Trial!")))
 
-		addtimer(CALLBACK(user, GLOBAL_PROC_REF(do_teleport), user, storedchallengerturf), 3 MINUTES)
-		addtimer(CALLBACK(target, GLOBAL_PROC_REF(do_teleport), target, storedchallengedturf), 3 MINUTES)
-		addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, cmode_change), originalcmodeuser), 3 MINUTES)
-		addtimer(CALLBACK(target,TYPE_PROC_REF(/mob, cmode_change), originalcmodetarget), 3 MINUTES)
-		addtimer(CALLBACK(thearena,TYPE_PROC_REF(/area/rogue/indoors/ravoxarena, cleanthearena), storedchallengedturf), 3 MINUTES) // shunt all items from the arena out onto the challenged spot.
+	new /obj/structure/fluff/ravox/challenger/recall(storedchallengerturf)
+	new /obj/structure/fluff/ravox/challenged/recall(storedchallengedturf)
 
-		if(iscarbon(target))
-			var/mob/living/carbon/human/spawnprotectiontarget = target
-			addtimer(CALLBACK(spawnprotectiontarget,TYPE_PROC_REF(/mob/living/carbon/human, do_invisibility), 10 SECONDS), 3 MINUTES)
+	to_chat(user, span_userdanger("THE TRIAL IS CALLED, IMPRESS US, PROSECUTOR!!"))
+	to_chat(target, span_userdanger("A TRIAL OF RAVOX BEGINS. IMPRESS US, DEFENDANT!!"))
 
+	user.cmode_change('sound/music/ravoxarena.ogg')
+	target.cmode_change('sound/music/ravoxarena.ogg')
 
-		return TRUE
-	revert_cast()
-	return FALSE
+	addtimer(CALLBACK(user, GLOBAL_PROC_REF(do_teleport), user, storedchallengerturf), 3 MINUTES)
+	addtimer(CALLBACK(target, GLOBAL_PROC_REF(do_teleport), target, storedchallengedturf), 3 MINUTES)
+	addtimer(CALLBACK(user, TYPE_PROC_REF(/mob, cmode_change), originalcmodeuser), 3 MINUTES)
+	addtimer(CALLBACK(target,TYPE_PROC_REF(/mob, cmode_change), originalcmodetarget), 3 MINUTES)
+	addtimer(CALLBACK(thearena,TYPE_PROC_REF(/area/rogue/indoors/ravoxarena, cleanthearena), storedchallengedturf), 3 MINUTES) // shunt all items from the arena out onto the challenged spot.
+
+	if(iscarbon(target))
+		var/mob/living/carbon/human/spawnprotectiontarget = target
+		addtimer(CALLBACK(spawnprotectiontarget,TYPE_PROC_REF(/mob/living/carbon/human, do_invisibility), 10 SECONDS), 3 MINUTES)
+
+	return TRUE
 
 
 /obj/structure/fluff/ravox


### PR DESCRIPTION
## About The Pull Request

As it says on the tin. People on the floor, in crit/uncon, bound, are pacifists can't be challenged.

## Testing Evidence

More or less.

## Why It's Good For The Game

Less cheese, more `in faith` to the intent.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Ravox duel does not work on critted/floored/chained/pacifist people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
