### PR TITLE
Envoy + Migrant updates + Triumph fix

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -473,7 +473,7 @@ SUBSYSTEM_DEF(migrants)
 	var/triumph_bonus = wave.triumph_total
 
 	// Triumph provides a linear bonus to weight (configurable multiplier)
-	var/triumph_multiplier = 2 // Each triumph point adds 2x weight
+	var/triumph_multiplier = 6 // Each triumph point adds 6x weight
 	var/final_weight = base_weight + (triumph_bonus * triumph_multiplier)
 
 	return max(final_weight, 1) // Ensure minimum weight of 1

--- a/code/datums/migrants/migrant_waves/fablefield roles.dm
+++ b/code/datums/migrants/migrant_waves/fablefield roles.dm
@@ -8,7 +8,7 @@
 /datum/outfit/job/roguetown/fablefield/goliard/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/bardhat
-	neck = /obj/item/storage/belt/rogue/pouch/coins/mid
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	pants = /obj/item/clothing/under/roguetown/tights/random
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt
@@ -54,7 +54,7 @@
 /datum/outfit/job/roguetown/fablefield/troubadour/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/bardhat
-	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+	neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 	shoes = /obj/item/clothing/shoes/roguetown/boots
 	pants = /obj/item/clothing/under/roguetown/tights/random
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt

--- a/code/datums/migrants/migrant_waves/grenzel_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/grenzel_noble_roles.dm
@@ -59,7 +59,9 @@
 		/obj/item/rogueweapon/huntingknife/idagger = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1, 
 		/obj/item/natural/feather = 1,
-		/obj/item/paper/scroll = 2
+		/obj/item/paper/scroll = 2,
+		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 2,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
 		)
 	H.cmode_music = 'sound/music/combat_grenzelhoft.ogg'
 	H.grant_language(/datum/language/grenzelhoftian)
@@ -116,9 +118,11 @@
 	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	r_hand = /obj/item/rogueweapon/greatsword/grenz
 	backpack_contents = list(
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
 		/obj/item/rogueweapon/huntingknife/idagger = 1,
-		/obj/item/rogueweapon/scabbard/sheath = 1
+		/obj/item/rogueweapon/scabbard/sheath = 1,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
+		/obj/item/natural/bundle/cloth/bandage/full = 1,
 		)
 	H.cmode_music = 'sound/music/combat_grenzelhoft.ogg'
 	H.grant_language(/datum/language/grenzelhoftian)
@@ -161,7 +165,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltl = /obj/item/flashlight/flare/torch/lantern
-	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
+	beltr = /obj/item/storage/belt/rogue/pouch/coins/veryrich
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/priest
 	cloak = /obj/item/clothing/cloak/chasuble
 	backl = /obj/item/storage/backpack/rogue/satchel

--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -18,28 +18,34 @@
 	allowed_races = RACES_NO_CONSTRUCT
 	grant_lit_torch = FALSE
 	show_wanderer_examine = FALSE
+	outfit = /datum/outfit/job/roguetown/heartfelt/cloak
+
+/datum/outfit/job/roguetown/heartfelt/cloak/pre_equip(mob/living/carbon/human/H)
+	cloak = /obj/item/clothing/cloak/tabard
+
 
 /datum/migrant_role/heartfelt/knight/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		if(istype(H.cloak, /obj/item/clothing/cloak/tabard/knight/guard))
-			var/obj/item/clothing/S = H.cloak
-			var/index = findtext(H.real_name, " ")
-			if(index)
-				index = copytext(H.real_name, 1,index)
-			if(!index)
-				index = H.real_name
-			S.name = "knight tabard ([index])"
-		var/prev_real_name = H.real_name
-		var/prev_name = H.name
-		var/honorary = "Ser"
-		if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
-			honorary = "Dame"
-		GLOB.chosen_names -= prev_real_name
+	if(!ishuman(L))
+		return
+	var/mob/living/carbon/human/H = L
+	if(istype(H.cloak, /obj/item/clothing/cloak/tabard))
+		var/obj/item/clothing/S = H.cloak
+		var/index = findtext(H.real_name, " ")
+		if(index)
+			index = copytext(H.real_name, 1,index)
+		if(!index)
+			index = H.real_name
+		S.name = "knight's tabard ([index])"
+	var/prev_real_name = H.real_name
+	var/prev_name = H.name
+	var/honorary = "Ser"
+	if(should_wear_femme_clothes(H))
+		honorary = "Dame"
+	// check if they already have it to avoid stacking titles
+	if(findtextEx(H.real_name, "[honorary] ") == 0)
 		H.real_name = "[honorary] [prev_real_name]"
 		H.name = "[honorary] [prev_name]"
-		GLOB.chosen_names += H.real_name
 
 /datum/migrant_role/heartfelt/retinue
 	name = "Heartfeltian Retinue"

--- a/code/datums/migrants/migrant_waves/ranesheni_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/ranesheni_noble_roles.dm
@@ -61,7 +61,9 @@
 		/obj/item/rogueweapon/huntingknife/idagger/navaja = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1, 
 		/obj/item/natural/feather = 1,
-		/obj/item/paper/scroll = 2
+		/obj/item/paper/scroll = 2,
+		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 2,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
 		)
 	H.cmode_music = 'sound/music/combat_desertrider.ogg'
 	H.grant_language(/datum/language/celestial)
@@ -118,7 +120,9 @@
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1, 
 		/obj/item/natural/feather = 1,
-		/obj/item/paper/scroll = 2
+		/obj/item/paper/scroll = 2,
+		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 1,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
 	)
 	H.cmode_music = 'sound/music/combat_desertrider.ogg'
 	H.grant_language(/datum/language/celestial)
@@ -177,7 +181,9 @@
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/navaja = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
+		/obj/item/natural/bundle/cloth/bandage/full = 1,
 		)
 	H.cmode_music = 'sound/music/combat_desertrider.ogg'
 	H.grant_language(/datum/language/celestial)
@@ -236,7 +242,7 @@
 		/obj/item/rogueweapon/huntingknife/idagger/navaja = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1
+		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 1,
 		)
 	H.cmode_music = 'sound/music/combat_desertrider.ogg'
 	H.grant_language(/datum/language/celestial)

--- a/code/datums/migrants/migrant_waves/ranesheni_noble_wave.dm
+++ b/code/datums/migrants/migrant_waves/ranesheni_noble_wave.dm
@@ -99,8 +99,19 @@
 	name = "Ranesheni Emir"
 	shared_wave_type = /datum/migrant_wave/ranesheni_noble
 	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/ranesheni_noble_down_nine
 	roles = list(
 		/datum/migrant_role/ranesheni/emir = 1,
 		/datum/migrant_role/ranesheni/janissary = 1,
+	)
+	greet_text = "You are far from home on missive from the Ranesheni Empire."
+
+/datum/migrant_wave/ranesheni_noble_down_nine
+	name = "Ranesheni Emir"
+	shared_wave_type = /datum/migrant_wave/ranesheni_noble
+	can_roll = FALSE
+	downgrade_wave = /datum/migrant_wave/ranesheni_noble_down_nine
+	roles = list(
+		/datum/migrant_role/ranesheni/emir = 1,
 	)
 	greet_text = "You are far from home on missive from the Ranesheni Empire."

--- a/code/modules/antagonists/roguetown/villain/dark_itinerant.dm
+++ b/code/modules/antagonists/roguetown/villain/dark_itinerant.dm
@@ -44,9 +44,10 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/rogueweapon/hammer/iron = 1, 
 		/obj/item/rogueweapon/tongs = 1, 
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1, 
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1, 
 		/obj/item/repair_kit/metal = 1,
 		/obj/item/repair_kit = 1,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
 	)
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
@@ -119,7 +120,8 @@
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel = 1, 
 		/obj/item/rogueweapon/scabbard/sheath = 1,
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
 		/obj/item/ritechalk = 1,
 	)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfelthand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfelthand.dm
@@ -68,10 +68,10 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/heartfelt/hand
 	r_hand = /obj/item/rogueweapon/sword/long/dec
 	//l_hand = banner-pike for when I add it
-	beltl = /obj/item/rogueweapon/scabbard/sword/royal
+	beltl = /obj/item/rogueweapon/scabbard/sword/noble
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
-		/obj/item/rogueweapon/scabbard/sheath/royal = 1,
+		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 1,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
@@ -137,12 +137,12 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine
 	gloves = /obj/item/clothing/gloves/roguetown/leather/black
 	r_hand = /obj/item/rogueweapon/sword/sabre/dec
-	beltl = /obj/item/rogueweapon/scabbard/sword/royal
+	beltl = /obj/item/rogueweapon/scabbard/sword/noble
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	neck = /obj/item/storage/belt/rogue/pouch/coins/veryrich
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
-		/obj/item/rogueweapon/scabbard/sheath/royal = 1,
+		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 2,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
@@ -196,11 +196,11 @@
 	..()
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 	r_hand = /obj/item/rogueweapon/sword/sabre/dec
-	beltl = /obj/item/rogueweapon/scabbard/sword/royal
+	beltl = /obj/item/rogueweapon/scabbard/sword/noble
 	mask = /obj/item/clothing/mask/rogue/spectacles/golden
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
-		/obj/item/rogueweapon/scabbard/sheath/royal = 1,
+		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 1,
 		/obj/item/lockpickring/mundane = 1, 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltknight.dm
@@ -15,25 +15,26 @@
 
 /datum/job/roguetown/heartfelt/knight/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		if(istype(H.cloak, /obj/item/clothing/cloak/tabard/knight/guard))
-			var/obj/item/clothing/S = H.cloak
-			var/index = findtext(H.real_name, " ")
-			if(index)
-				index = copytext(H.real_name, 1,index)
-			if(!index)
-				index = H.real_name
-			S.name = "knight tabard ([index])"
-		var/prev_real_name = H.real_name
-		var/prev_name = H.name
-		var/honorary = "Ser"
-		if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
-			honorary = "Dame"
-		GLOB.chosen_names -= prev_real_name
+	if(!ishuman(L))
+		return
+	var/mob/living/carbon/human/H = L
+	if(istype(H.cloak, /obj/item/clothing/cloak/tabard))
+		var/obj/item/clothing/S = H.cloak
+		var/index = findtext(H.real_name, " ")
+		if(index)
+			index = copytext(H.real_name, 1,index)
+		if(!index)
+			index = H.real_name
+		S.name = "knight's tabard ([index])"
+	var/prev_real_name = H.real_name
+	var/prev_name = H.name
+	var/honorary = "Ser"
+	if(should_wear_femme_clothes(H))
+		honorary = "Dame"
+	// check if they already have it to avoid stacking titles
+	if(findtextEx(H.real_name, "[honorary] ") == 0)
 		H.real_name = "[honorary] [prev_real_name]"
 		H.name = "[honorary] [prev_name]"
-		GLOB.chosen_names += H.real_name
 
 		for(var/X in peopleknowme)
 			for(var/datum/mind/MF in get_minds(X))
@@ -69,6 +70,7 @@
 	/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
 	/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT,
 	/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/combat/unarmed =SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/bows = SKILL_LEVEL_JOURNEYMAN,
@@ -84,7 +86,7 @@
 
 	gloves = /obj/item/clothing/gloves/roguetown/plate
 	pants = /obj/item/clothing/under/roguetown/platelegs
-	cloak = /obj/item/clothing/cloak/tabard/knight/guard
+	cloak = /obj/item/clothing/cloak/tabard
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight
 	neck = /obj/item/clothing/neck/roguetown/bevor
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
@@ -96,6 +98,7 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	belt = /obj/item/storage/belt/rogue/leather/steel
 	backr = /obj/item/storage/backpack/rogue/satchel/black
+	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
@@ -103,6 +106,7 @@
 		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
+		/obj/item/natural/bundle/cloth/bandage/full = 1,
 	)
 	// This code is broken but also not, I assume because it has 1 Advanced Class at the moment DO NOT UNCOMMENT. 
 	// IT WORKS :TM: still gives them a helm and grandmace, just not the choice

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltlord.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltlord.dm
@@ -65,14 +65,14 @@
 	cloak = /obj/item/clothing/cloak/heartfelt
 	armor = /obj/item/clothing/suit/roguetown/armor/heartfelt
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel
-	beltl =/obj/item/rogueweapon/scabbard/sword/royal
+	beltl = /obj/item/rogueweapon/scabbard/sword/noble
 	r_hand = /obj/item/rogueweapon/sword/long/marlin
 	beltr = /obj/item/rogueweapon/huntingknife
 	gloves = /obj/item/clothing/gloves/roguetown/leather/black
 	backl = /obj/item/storage/backpack/rogue/satchel // Paper and Feather
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
-		/obj/item/rogueweapon/scabbard/sheath/royal = 1,
+		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 2,
 		/obj/item/natural/feather = 1,
 		/obj/item/paper/scroll = 1,
@@ -218,7 +218,7 @@
 	backl = /obj/item/storage/backpack/rogue/satchel // Paper and Feather
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
-		/obj/item/rogueweapon/scabbard/sheath/royal = 1,
+		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 1,
 		/obj/item/natural/feather = 1,
 		/obj/item/paper/scroll = 1,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltwarriors.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltwarriors.dm
@@ -67,10 +67,13 @@
 			backl = /obj/item/rogueweapon/shield/iron
 		if("Halberd")
 			r_hand = /obj/item/rogueweapon/halberd
+			backl = /obj/item/rogueweapon/scabbard/gwstrap
 		if("Greataxe")
 			r_hand = /obj/item/rogueweapon/greataxe
+			backl = /obj/item/rogueweapon/scabbard/gwstrap
 		else
 			r_hand = /obj/item/rogueweapon/halberd
+			backl = /obj/item/rogueweapon/scabbard/gwstrap
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
 		/obj/item/rope/chain = 1,
@@ -232,6 +235,7 @@
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,		
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,		
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,		//Only effects draw and reload time.
 		/datum/skill/combat/bows = SKILL_LEVEL_EXPERT,			//Only effects draw times.
@@ -255,7 +259,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/flashlight/flare/torch/lantern
-	cloak = /obj/item/clothing/cloak/tabard/knight/guard
+	cloak = /obj/item/clothing/cloak/tabard
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
@@ -280,6 +284,7 @@
 			backl = /obj/item/rogueweapon/shield/iron
 		if("Spear")
 			r_hand = /obj/item/rogueweapon/spear
+			backl = /obj/item/rogueweapon/scabbard/gwstrap
 		if("Crossbow")
 			beltr = /obj/item/quiver/bolts
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow


### PR DESCRIPTION
## About The Pull Request

Actually makes triumphs work 6x instead of making it visually work.

ALL ENVOYS get 2 Very Rich Pouches + 2 Strong Healing Vials 
ALL GUARDS get 1 Mid Pouches + 1 Strong Healing Vials + Bandages

BUFFS Unknightly Journey to have 2 and 1 Healing Vials + Mid Pouches.

Removes royal scabbards from Heartfelt, replace with noble scabbards.

Finally fixes HF Knight Tabard
HF Knight gets GW Strap
HF Knight gets bandages.
HF Knight gets apprentice shields

HF Warriors get GW strap if right equipment. HF Squire also gets missing shield skill JOURNEYMAN

EMIR can now solo roll. Grenz Envoy is able to, why not Emir?

## Testing Evidence
<img width="411" height="213" alt="Screenshot 2026-02-01 151552" src="https://github.com/user-attachments/assets/f3b6f9e9-d78c-48f2-8a6e-57b3781ee635" />
<img width="1888" height="781" alt="Screenshot 2026-02-01 153013" src="https://github.com/user-attachments/assets/69504230-9db5-49de-8b16-0c85b4438c59" />
<img width="1157" height="313" alt="Screenshot 2026-02-01 154349" src="https://github.com/user-attachments/assets/f952c776-e40e-41a6-9501-9e72c88ec114" />
<img width="453" height="208" alt="Screenshot 2026-02-01 155036" src="https://github.com/user-attachments/assets/44ed8401-8069-40b5-bb4c-0434fd3696fb" />
<img width="1899" height="627" alt="Screenshot 2026-02-01 163136" src="https://github.com/user-attachments/assets/15a23611-2716-4f7e-9108-86e2a007b07d" />
<img width="410" height="204" alt="Screenshot 2026-02-01 151251" src="https://github.com/user-attachments/assets/30c2dee9-1909-4f70-b484-420ddd238bad" />
<img width="1121" height="640" alt="Screenshot 2026-02-01 151439" src="https://github.com/user-attachments/assets/5fe48c46-8048-42c1-a825-d5748d40848c" />


## Why It's Good For The Game

1) Fixes Oversight and Bug. I hate visual but not mechanical changes.
2) Allows for envoys to actually roleplay and have monetary sway over people like mercs to serve them and more. 3
3) Gives Guards actually a way to save their envoy from attacks or atleast some staying power and healing. Lifeguards especially, they are there to guard life.
4) Gives Guards some money for repairs, food or even a room at the inn. They are still people even if they have an envoy.
5) Same reason as No. 3.
6) Heartfeltians are a Marquis/Marchland in lore. Not royals. They deserve noble scabbards

## Changelog
:cl:
qol: Migrant QOL once more
balance: Gave Envoys a lot more money to RP instead of have to worry about actually needing to rely on Keep to not be assholes, also allows them to have RP freedom instead of needing to do contracts or random stuff.
/:cl:
