### PR TITLE
Panel Sound Privacy

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -29,7 +29,12 @@
 	var/runechat_msg = null
 	// If this is true, we skip setting the base runechat message and instead use whatever our at-emote-runtime message is. Useful for things like kiss/lick which change message based on conditions.
 	var/use_params_for_runechat = FALSE
+
+	/// Whether this emote is filtered by our "hear animal noises" preference.
 	var/is_animal = FALSE
+
+	/// Whether this emote will ONLY go through a few walls on the same z-level.
+	var/is_quiet = FALSE
 
 /datum/emote/New()
 	if(!runechat_msg && !use_params_for_runechat)
@@ -116,7 +121,7 @@
 			else// if(!vision.viewing_head)
 				emotelocation = user
 
-		playsound(emotelocation, tmp_sound, snd_vol, FALSE, snd_range, soundping = soundping, animal_pref = animal)
+		playsound(emotelocation, tmp_sound, snd_vol, FALSE, snd_range, soundping = soundping, animal_pref = animal, quiet = is_quiet)
 	if(!nomsg)
 		user.log_message(msg, LOG_EMOTE)
 		var/pre_color_msg = msg

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -2,7 +2,7 @@
 	var/list/played_loops = list() //uses dlink to link to the sound
 
 
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel, pressure_affected = FALSE, ignore_walls = TRUE, soundping = FALSE, repeat, animal_pref = FALSE)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel, pressure_affected = FALSE, ignore_walls = TRUE, soundping = FALSE, repeat, animal_pref = FALSE, quiet = FALSE)
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
@@ -68,6 +68,12 @@
 			var/datum/species/dullahan/dullahan = human.dna.species
 			if(dullahan.headless)
 				turf_check = get_turf(dullahan.my_head)
+		
+		if(quiet)
+			if(turf_check.z != turf_source.z)
+				continue
+			if(get_dist(turf_check, turf_source) > 3)
+				continue
 
 		if(get_dist(turf_check, turf_source) <= maxdistance)
 			if(animal_pref)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -31,6 +31,7 @@
 	emote_type = EMOTE_AUDIBLE
 	nomsg = TRUE
 	only_forced_audio = TRUE
+	is_quiet = TRUE
 
 /datum/emote/living/carbon/human/sexmoanlight/can_run_emote(mob/living/user, status_check = TRUE , intentional)
 	. = ..()
@@ -44,6 +45,7 @@
 	emote_type = EMOTE_AUDIBLE
 	nomsg = TRUE
 	only_forced_audio = TRUE
+	is_quiet = TRUE
 
 /datum/emote/living/carbon/human/sexmoanhvy/can_run_emote(mob/living/user, status_check = TRUE , intentional)
 	. = ..()

--- a/code/modules/sexcon/components/arousal.dm
+++ b/code/modules/sexcon/components/arousal.dm
@@ -354,7 +354,7 @@
 		if(0 to 5)
 			chosen_emote = "sexmoanlight"
 		if(5 to INFINITY)
-			chosen_emote = "sexamoanhvy"
+			chosen_emote = "sexmoanhvy"
 
 	if(pain_amt >= PAIN_MILD_EFFECT)
 		if(giving)


### PR DESCRIPTION
## About The Pull Request
- Panel Sounds now have a limited range of 3 tiles
- Panel Sounds no longer travel across z-levels
- This does NOT apply to groans or painmoans.
- Fixed a bug that prevented *saucier* moans from being used when arousal is high enough.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
needs testing, hit me up
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The first two were suggested many times by several people. It's more than reasonable tbh.
As for the fourth one, I didn't spend hours listening to all those sounds to not make sure they can be heard in-game. Sorry Mascs, your moans do suck those exaggerated "HOAAAHHHH" are hilarious.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Panel noises now do not travel across z-levels and only propagate for 3 tiles from the source.
fix: Fixed the Panel not using all the sounds properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
