### PR TITLE
Full-Auto / Broadening The Broadsword - Further refines the Broadsword's nature as a sidegrade to the Longsword and Axe, tweaks the Judgement/Valorian-type wielded inhands, and ups the Executioner Sword's chopping.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -147,7 +147,11 @@
 	name = "heavy thrust" //Ditto.
 	penfactor = 30
 	damfactor = 1.15
-	swingdelay = 4 //Halved swigndelay compared to chopping.
+	swingdelay = 4 //Halved swingdelay compared to chopping.
+
+/datum/intent/sword/thrust/long/broadsword/lesser
+	penfactor = 15
+	damfactor = 1.15
 
 /datum/intent/sword/thrust/long/broadsword/heavy
 	name = "impale" //Stabbing variant of the Chop intent. Higher damage, but slower and evadable. Exclusive to two-handed broadswords.
@@ -164,6 +168,7 @@
 	name = "cleave"
 	chargedrain = 1
 	chargetime = 5
+	damfactor = 1.2
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
 	desc = "A powerful, charged-up swing that deals increased damage and can throw a standing opponent back and slow them down, based on your strength. Ineffective below 10 strength. Slowdown & Knockback scales to your Strength up to 13 (1 - 3 tiles). Cannot be used consecutively more than every 5 seconds on the same target. Prone targets halve the knockback distance. Not fully charging the attack limits knockback to 1 tile."
 	var/maxrange = 3
@@ -866,13 +871,14 @@
 //Slightly more expensive than a longsword by 1 iron, so gets to be slightly better.
 /obj/item/rogueweapon/sword/long/exe
 	name = "executioners sword"
-	desc = "A longsword with extra heft to its blade, reinforced."
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/peel)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/exe, /datum/intent/rend, /datum/intent/axe/chop)
+	desc = "A heavy broadsword with a terrifyingly sharp edge, purpose-made to part heads from shoulders. Owing to its nature as a weapon of justice, it lacks the piercing tips that befit most battle-ready broadswords. If you're strong enough to wield such a weapon, however, then that probably won't stop you from finding a way."
+	possible_item_intents = list(/datum/intent/sword/chop/broadsword, /datum/intent/sword/cut, /datum/intent/sword/thrust/long/broadsword/lesser, /datum/intent/sword/strike)
+	gripped_intents = list(/datum/intent/rend, /datum/intent/sword/chop/broadsword, /datum/intent/sword/cut, /datum/intent/sword/thrust/exe)
 	icon_state = "exe"
 	minstr = 12
-	slot_flags = ITEM_SLOT_BACK //Too big for hip
+	slot_flags = ITEM_SLOT_BACK
 	smeltresult = /obj/item/ingot/iron
+	max_blade_int = 330 
 	smelt_bar_num = 2 // 1 bar loss
 	vorpal = TRUE // snicker snack this shit cuts heads off effortlessly (DO NOT PUT THIS ON ANYTHING ELSE UNLESS IT'S SUPER FUCKING RARE!!!)
 
@@ -886,8 +892,8 @@
 	desc = "An incredibly unusual executioner's sword clad in gold and brass. Two separate blades protude outwards and join near its intricately decorated crossguard. This weapon calls for order."
 	icon_state = "astratasword"
 	max_integrity = 200
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/peel, /datum/intent/axe/chop)
+	possible_item_intents = list(/datum/intent/sword/chop/broadsword, /datum/intent/sword/cut, /datum/intent/sword/thrust/long/broadsword/lesser, /datum/intent/sword/strike)
+	gripped_intents = list(/datum/intent/rend, /datum/intent/sword/chop/broadsword, /datum/intent/sword/cut, /datum/intent/sword/thrust/exe)
 	vorpal = TRUE // snicker snack this shit cuts heads off effortlessly (DO NOT PUT THIS ON ANYTHING ELSE UNLESS IT'S SUPER FUCKING RARE!!!)
 
 /obj/item/rogueweapon/sword/long/exe/getonmobprop(tag)
@@ -922,13 +928,13 @@
 	desc = "A raw heap of iron, hewn into an intimidatingly massive cleaver. Most could never aspire to effectively swing such a laborsome blade about; those few that have the strength, however, can force even the strongest opponents to stagger back."
 	icon = 'icons/roguetown/weapons/swords64.dmi'
 	icon_state = "dragonslayer"
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/axe/chop)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/exe, /datum/intent/rend, /datum/intent/sword/chop/cleave)
+	possible_item_intents = list(/datum/intent/sword/chop/broadsword, /datum/intent/sword/cut, /datum/intent/sword/thrust/long/broadsword/lesser, /datum/intent/sword/strike)
+	gripped_intents = list(/datum/intent/sword/chop/cleave, /datum/intent/rend, /datum/intent/sword/cut, /datum/intent/sword/thrust/exe)
 	wbalance = WBALANCE_HEAVY //Stronger but sturdier executioner's sword, exchanging its peelage for an armor-piercing variant of Ansari's knockback variable.
 	alt_intents = null 
 	minstr = 13 //Should be uncraftable, but obtainable through other variants. Challenge classes, dungeon rewards?
 	wdefense = 9
-	max_blade_int = 333
+	max_blade_int = 400
 
 /obj/item/rogueweapon/sword/long/exe/berserk/dragonslayer
 	name = "\"Daemonslayer\""


### PR DESCRIPTION
## About The Pull Request

Adds three new intents for the Broadsword - 'heavy thrust', 'heavy swing', and 'impale'.
* 'Heavy thrust' is a one-handed variant of the Longsword's stab with a 1.15x damage modifier, but a swing delay of 4.
* 'Heavy swing' is the same as the Longsword's chop, with a 1.15x damage modifier and swing delay of 8.
* 'Impale' is exclusive to two-handing the broadsword, with a 1.3x damage modifier and swing delay of 8.

Unlike the Longsword, the Broadsword has no instant attacks _(besides the option for pommel strikes)_. This means that your thrusts and swings _can_ be evaded by people who're quicker-footed than you: but if you can match their footwork and stay in range, you can lay some serious hate down on them.

I think this'll work nicely as a sidegrade.
_(I also tweaked the onmob value of Judgement-based swords to be slightly larger-scaled when two-handed, and - for to ensure minimal parity issues - added the 'UNENCHANT' vars to golden weapons. You'll see another PR for that, very soon.)_

* Likewise, the Executioner Swords now inherit variants of the Broadsword's intents. Their chops and cleaves hit harder - and for the Berserker's Sword, a proper damage modifier has now been added to its edge.

## Testing Evidence

<img width="218" height="156" alt="31db3f30dad3073feb54acd8b60bee1b" src="https://github.com/user-attachments/assets/383ba95f-b451-4401-8343-c031a1eb9da3" />
<img width="1881" height="647" alt="a1513ed75e364da3a719b36817365b15 (1)" src="https://github.com/user-attachments/assets/b235e1fc-bd0f-4dcc-9c85-b7c7d931db32" />


## Why It's Good For The Game

* As it turns out, the Broadsword being a near-complete 1:1 with the Longsword's a bit boring. This adds some more covetable spice to the weapon's subclass without making it a straight upgrade - more risk, more reward.
* Larger-than-life weapons looking smaller when wielded's a bit silly.

## Changelog

:cl:
balance: Broadswords are now more clearly defined as sidegrades to the Longsword and Axe. Chopping, thrusting, and impaling deals more damage, but comes with uncontestable swing delays: make sure your footwork's up-to-par, or else you won't be hitting anything.
balance: Executioner Swords now inherit variants of the Broadsword's chopping and thrusting intents, at the cost of peeling. This extends to the Solar Judge, Berserker Sword, and a certain secret item.
fix: The Steel Broadsword now properly uses the Steel Broadsword icon.
fix: Judgement- and Valorian-type swords now properly scale when wielded with both hands.
/:cl:

