### PR TITLE
Full-Auto (II) / Relighting The Rondels - Fixes an errant icon discrepency with the Rondel Dagger, adds a new icon to the 'Quick Thrust' intent.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -30,6 +30,11 @@
 	penfactor = 20
 	clickcd = 11
 
+// For thrusting-focused daggers. Thinner blade, less slashing damage.
+/datum/intent/dagger/cut/light
+	name = "light cut"
+	damfactor = 0.8
+
 /datum/intent/dagger/thrust
 	name = "thrust"
 	icon_state = "instab"
@@ -552,7 +557,7 @@
 	desc = "This is the traditional sidearm of a knight: a lightweight dagger of solid steel, well-balanced for delivering rapid thrusts that can shuck grapplers like oysters."
 	icon_state = "rondel"
 	sheathe_icon = "dagger_trainer"
-	possible_item_intents = list(/datum/intent/dagger/thrust/quick, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch, /datum/intent/dagger/cut)
+	possible_item_intents = list(/datum/intent/dagger/thrust/quick, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/cut/light, /datum/intent/dagger/sucker_punch)
 	wdefense = 4 //Slightly more defense than a regular dagger. Intended to function as a tool for countering grapplers or finishing off armored opponents with broken pieces.
 	smeltresult = /obj/item/ingot/steel
 
@@ -619,7 +624,7 @@
 	name = "sharpened stake"
 	desc = "A branch that has been broken off of an azurielve tree, sharpened to a fine point. It can lay some unholy creechers to rest, but only by piercing their hearts."
 	icon_state = "stake"
-	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch, /datum/intent/dagger/thrust/quick)
+	possible_item_intents = list(/datum/intent/dagger/thrust/pick, /datum/intent/dagger/thrust/quick, /datum/intent/dagger/cut/light, /datum/intent/dagger/sucker_punch)
 	force = 12
 	throwforce = 12
 	wdefense = 0
@@ -636,7 +641,7 @@
 	name = "silver-tipped stake"
 	desc = "A branch that has been broken off of a boswellia tree, sharpened to a fine point and tipped with blessed silver. It can lay most unholy creechers to rest, but only by piercing their hearts."
 	icon_state = "stake_silver"
-	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch, /datum/intent/dagger/thrust/quick)
+	possible_item_intents = list(/datum/intent/dagger/thrust/pick, /datum/intent/dagger/thrust/quick, /datum/intent/dagger/cut/light, /datum/intent/dagger/sucker_punch)
 	force = 20
 	throwforce = 20
 	wdefense = 0


### PR DESCRIPTION
## About The Pull Request

* Rondel Daggers are no longer inexplicably invisible. They will now properly show up, in-game.
* The 'Quick Thrust' intent now uses the 'Thresh' icon to better convey its nature as a pseudo-counter to grapplers.
* Adds the 'Light Cut' intent for Rondel Daggers and Stakes. Same as regular cuts, but with a x0.8 damage penalty.

## Testing Evidence

<img width="963" height="158" alt="8ee779984c97ed6f661b5d80830e59df (1)" src="https://github.com/user-attachments/assets/d339bdc7-f115-4608-a749-97b734c54bd2" />


## Why It's Good For The Game

* Weapons being inexplicably invisible is not intended. My bad.
* A different icon from 'stab' - with more grungy wording - makes it easier to articulate that it is different than a regular stab.
* Rondel Daggers and Stakes are purpose-made for thrusting, so they should naturally be less ideal for cutting.

## Changelog

:cl:
add: The 'Quick Thrust' intent now uses the 'Thresh' icon to better differentiate it from regular stabs.
balance: Rondel Daggers and Stakes now have the 'Light Cut' intent - with a x0.8 damage penalty.
fix: Rondel Daggers are no longer invisible.
/:cl:


