### PR TITLE
Full-Auto (IV) / Reverence In Rarity - The Weeping Psicross now provides a Gold+ bonus to Psydonic miracles.

### DIFF
--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -70,6 +70,8 @@
 						psicross_bonus = 0.4	
 					if(/obj/item/clothing/neck/roguetown/psicross/g) // PURITY AFLOAT.
 						psicross_bonus = 0.5
+					if(/obj/item/clothing/neck/roguetown/psicross/weeping)
+						psicross_bonus = 0.7
 					if(/obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy)
 						zcross_trigger = TRUE	
 
@@ -435,6 +437,8 @@
 					psicross_bonus = -6
 				if(/obj/item/clothing/neck/roguetown/psicross/g) // PURITY AFLOAT.
 					psicross_bonus = -7
+				if(/obj/item/clothing/neck/roguetown/psicross/weeping)
+					psicross_bonus = -9
 				if(/obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy)
 					zcross_trigger = TRUE		
 	if(brute > 100) //A supplemental healing bonus, scaling off of how much damage's currently inflicted onto you.
@@ -541,6 +545,8 @@
 					psicross_bonus = -7
 				if(/obj/item/clothing/neck/roguetown/psicross/g) // PURITY AFLOAT.
 					psicross_bonus = -9
+				if(/obj/item/clothing/neck/roguetown/psicross/weeping)
+					psicross_bonus = -11
 				if(/obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy)
 					zcross_trigger = TRUE		
 	if(brute > 100)
@@ -647,6 +653,8 @@
 					psicross_bonus = -7
 				if(/obj/item/clothing/neck/roguetown/psicross/g) // PURITY AFLOAT.
 					psicross_bonus = -9
+				if(/obj/item/clothing/neck/roguetown/psicross/weeping)
+					psicross_bonus = -11
 				if(/obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy)
 					zcross_trigger = TRUE		
 	if(brute > 100)


### PR DESCRIPTION
## About The Pull Request

* The Weeping Psicross now properly interacts with Psydonic miracles, increasing their effectiveness a little more than the Golden Psycross.

## Testing Evidence

* One-liners. Or, well, technically a four-liner.

## Why It's Good For The Game

* Partially intended, but overlooked. The Weeping Psicross is extraordinarily rare and imparts the _"DNR"_ trait upon wearing. Making it amplify the effects of one's miracles a little more than the second-rarest psycross makes sense, I'd reckon.

## Changelog

:cl:
add: The Weeping Psicross now interacts with most Psydonic miracles, offering the highest amplification of their effects out of any other psycross.
/:cl:

