### PR TITLE
Full-Auto (V) / Atom-Sized Authenticity - Dolabras (or Bronze Axepick-Tools) are now historically accurate, and can now till soil.

### DIFF
--- a/code/modules/roguetown/roguejobs/miner/tools.dm
+++ b/code/modules/roguetown/roguejobs/miner/tools.dm
@@ -46,7 +46,7 @@
 	force = 20
 	force_wielded = 25
 	icon_state = "bronzepick"
-	possible_item_intents = list(/datum/intent/pick/bad, /datum/intent/axe/cut, /datum/intent/mace/strike)
+	possible_item_intents = list(/datum/intent/pick/bad, /datum/intent/axe/cut, /datum/intent/mace/strike, /datum/intent/till)
 	gripped_intents = list(/datum/intent/pick, /datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/mace/strike)
 	max_integrity = 500
 	max_blade_int = 225


### PR DESCRIPTION
## About The Pull Request

* Owing to their actual use in recorded history, the dolabra - or bronze axepick - can now _till_ soil _(like a hoe)_ when wielded in one hand. I do not expect much use out of this, but I still like keeping things accurate.

## Testing Evidence

* Just a one-liner.

## Why It's Good For The Game

* Historical authenticity? Maybe. Adds another little quirk to the bronze-tiered tools, which I do like.

## Changelog

:cl:
add: Dolabras can now properly till soil when held in one hand. Historical reenactors, rejoice!
/:cl: