### PR TITLE
Full-Auto (VII) / Not All That Glitters Is Gold - Removes the Golden Barbute crafting recipe.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -1297,18 +1297,6 @@
 	additional_items = list(/obj/item/ingot/gold, /obj/item/natural/silk, /obj/item/natural/silk, /obj/item/roguegem/diamond)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/knight/gold/king
 
-/datum/anvil_recipe/armor/gold/helmet
-	name = "Golden Barbute (+1 Gold, +2 Silk)"
-	req_bar = /obj/item/ingot/gold
-	additional_items = list(/obj/item/ingot/gold, /obj/item/natural/silk, /obj/item/natural/silk)
-	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/sheriff/gold
-
-/datum/anvil_recipe/armor/gold/helmetcrown
-	name = "Golden Barbute, Royal (+1 Gold, +2 Silk, +1 Dorpel)"
-	req_bar = /obj/item/ingot/gold
-	additional_items = list(/obj/item/ingot/gold, /obj/item/natural/silk, /obj/item/natural/silk, /obj/item/roguegem/diamond)
-	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/sheriff/gold/king
-
 /datum/anvil_recipe/armor/gold/gorget
 	name = "Golden Gorget (+1 Gold, +2 Silk)"
 	req_bar = /obj/item/ingot/gold


### PR DESCRIPTION
## About The Pull Request

* The Golden Barbute can no longer be smithed. The Golden Armet, however, takes its place.

## Testing Evidence

* One-liner. Or, rather, two-liner.

## Why It's Good For The Game

* The Golden Barbute doesn't actually match the same stylings as the _other_ Barbutes, and - more importantly - doesn't look very regal. That could also just be the Half-Sworder within me speaking.
* The Golden Knight's Armet _(and its royal variant)_ can cover for them. I'd imagine this would be a little more covetable for royalty, or a potential Duke-loadout later down the line.

## Changelog

:cl:
del: Removed the Golden Barbute's crafting recipe, though it still exists as an item. The Golden Knight's Armet fully takes its place.
/:cl:

