### PR TITLE
Gives Dendor Heretic/H-Spy Woodwalker and Outdoorsman

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -149,7 +149,9 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/roguetown/helmet/heavy/dendorhelm, SLOT_HEAD, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/clothing/cloak/tabard/crusader/dendor, SLOT_CLOAK, TRUE)
 			H.cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg'
-			H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
+			ADD_TRAIT(H, TRAIT_WOODWALKER, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)
+			H.adjust_skillrank(/datum/skill/magic/druidic, 3, TRUE) //so they can shapeshift
 			H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 		if(/datum/patron/divine/necra)
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/necra, SLOT_RING, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -359,7 +359,9 @@
 		if(/datum/patron/divine/dendor)
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/dendor, SLOT_RING, TRUE)
 			H.cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg'
-			H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
+			ADD_TRAIT(H, TRAIT_WOODWALKER, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_OUTDOORSMAN, TRAIT_GENERIC)
+			H.adjust_skillrank(/datum/skill/magic/druidic, 3, TRUE) //so they can shapeshift
 			H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 		if(/datum/patron/divine/necra)
 			H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/psicross/necra, SLOT_RING, TRUE)


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin!

## Testing Evidence
<img width="2078" height="721" alt="DendorHereticSpyTest" src="https://github.com/user-attachments/assets/add7bec0-5528-4f03-abb9-2ba99b0e7c5f" />

## Why It's Good For The Game
Druids, Black Oaks, and Wardens all get these traits. Dendor Heretic should too as a matter of symmetry.

## Changelog
:cl:
add: Gave Dendor Heretic woodwalker and outdoorsman
add: Jman druidry to match Druid
del: Removed novice farming
/:cl:
