### PR TITLE
red potions now heal eye damage - blindness weirdness pt 1

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -54,7 +54,7 @@
 		M.adjustOxyLoss(-5, 0)
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5  * REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustCloneLoss(-7  * REAGENTS_EFFECT_MULTIPLIER, 0)
-		M.adjustOrganLoss(ORGAN_SLOT_EYES, -2.5 * REAGENTS_EFFECT_MULTIPLIER) //
+		M.adjustOrganLoss(ORGAN_SLOT_EYES, -2.5 * REAGENTS_EFFECT_MULTIPLIER)
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request
hey guys! thought about an old bug that occurred to me. when i inserted damaged eyes into myself, i was blinded for a bit and nothing seemed to be able to fix it. after some testing, it turns out when you aheal someone, if they have damaged eyes, the damage sticks unless you manually go into the eye organ slot & then set the damage to 22 or something then let it heal back.

this pr does NOT fix that, however, it does provide an option _to_ heal damaged eyes... if you have them, for whatever reason. while all damage heals naturally, it can take ages. therefore: red potions will now give it back. 

this should not affect anything like eyestabbing someone until they get poked out. this is intentional.

hopefully if i can figure it out blindness in the future will only inflict a severe impairment similar to tg ss13, however, they completely refactored their blindness code and so i'm going to have to be really hacky w/ it. i'd just like the blindness flaw, among other things, to be more playable. i will probably also fold in some of these changes into my new blindness spell, maybe a slight impairment.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- set my eye damage to 50. drank potion. it healed.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- honestly this is just a weird way of fixing a potential bug. "fixing" the aheal proc to properly remove your blindness would be the best way but organ failure and blindness both use bit shifting which is beyond my skull level
- if any of you want to take acrack at it, check out  eyes.dm's on_life. when you get healed and dam and damaged get set to 0 and false respectively, it does not update the overlay on the mob. not sure how to fix that w/o borking other stuff structure wise.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: potions of red now heal eye damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
