### PR TITLE
Mana fountain crystallized mana appears below user.

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
+++ b/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
@@ -163,11 +163,10 @@
 
 	var/skill_level = user.get_skill_level(attached_spell.associated_skill)
 	gatherspeed = initial(gatherspeed) - (skill_level * 3) // 3 cleanspeed per skill level, from 35 down to a maximum of 17 (pretty quick)
-	var/turf/Turf = get_turf(target)
 	if (istype(target, /obj/structure/well/fountain/mana))
 		if (do_after(user, src.gatherspeed, target = target))
 			to_chat(user, span_notice("I mold the liquid mana in \the [target.name] with my arcane power, crystalizing it!"))
-			new /obj/item/magic/manacrystal(Turf)
+			new /obj/item/magic/manacrystal(user.loc)
 	if (istype(target, /turf/open/lava))
 		if (do_after(user, src.gatherspeed, target = target))
 			to_chat(user, span_notice("I mold a handful of oozing lava  with my arcane power, rapidly hardening it!"))


### PR DESCRIPTION
## About The Pull Request
Mana fountain crystallized mana appears below user.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_9QXlAN7QwQ](https://github.com/user-attachments/assets/e183d12f-d718-490c-9db9-51b3623f1e44)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
People get confused when the mana appears below the mana fountain and have to alt click to access it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Crystallized Mana gathered by Presdtidigitation from a Mana Fountain now appears below the user instead of underneath the fountain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
