### PR TITLE
Flexing And Fixing - Templar!Monks now (mostly) spawn with their specialized gloves and robes, and the Discipline's skill bonus is changed to Master Athletics.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -207,6 +207,8 @@
 		H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/music, 1, TRUE)
+	if(H.patron?.type == /datum/patron/divine/ravox)
+		H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 5, TRUE)
 	// -- End of section for god specific bonuses --
 
 /datum/advclass/templar/crusader


### PR DESCRIPTION
## About The Pull Request

Shoutout to Sanshroom for bringing this to my attention. Thank you, young thug.
* Templar!Monks, for some odd reason, suddenly stopped spawning with their specialized gloves. My initial attempts to fix this didn't work, so I made a bandaid fix instead. The role's base loadout now spawns with the _weighted bandages_ _(which every other weapon choice previously gave)_, while selecting the Unarmed Discipline now plops a pair of _pugilist bandages_ into your hands. It's a little rough, but it works. Worst case is that they hand out the spare weighted bandages to a buddy.
* When selecting the Unarmed Discipline as a Templar!Monk, you now gain Master Athletics - a +1 bonus to the base skill.
* A minor parity check: the Templar!Monks now receive the properly-sprited robes that their Adventure!Monkly cousins got.

## Testing Evidence

Everything still spawns as normal, if you take the other options.
<img width="248" height="513" alt="ac78aa683bb50cde8eafe58e462a8d87" src="https://github.com/user-attachments/assets/17075a98-573f-4582-ad52-97ce54e73f7b" />
<img width="305" height="266" alt="b057c558b7c1e85d87e89f061436120a" src="https://github.com/user-attachments/assets/ca66800d-6a6b-43ac-8272-f71b78098d61" />


## Why It's Good For The Game

* Templar!Monks not receiving the gloves that greatly encourage their main fighting style is both unideal and unintended. I'm not actually sure _how_ this bug cropped up, but it's good to get it squashed sooner than later.
* After the Wrestling Rebalance PR, the Unarmed Discipline's original bonus _(of Master Unarmed skills)_ got bumped down a level. This effectively made it useless, as Templar!Monks already get Expert Unarmed skills from the start. This new skill option _(taken from the Disciples)_ should hopefully give an incentive to bare-knuckle it out, without bricking the balance.
* The custom-sprited robes are awesome as hell, and - I _think_ - were simply never added due to how old this subclass was when it was originally made.

## Changelog

:cl:
balance: The Unarmed Discipline for Templar!Monks now gives Master Athletics, instead of nothing at all.
add: Templar!Monks, like their adventuring counterparts, now properly spawn with patron-specific robes and tabards.
fix: Templar!Monks no longer spawn without their specialized gloves.
code: Note - this fix is mostly a bandaid, as I couldn't find any other way to restore the glove-giving component without potentially rewriting the Templar!Monk's loadout code. If you pick 'Unarmed Discipline', it'll give you the better gloves as an item.
code: For Templar!Monks, the Ravox-specific buff has been changed to use 'H.adjust_skillrank_up_to'. Everything'll still work exactly the same as before, but it'll prevent someone from potentially getting Legendary Athletics. Do we want that for later? Maybe.
/:cl:

