### PR TITLE
Quadruples stairway durability

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -15,7 +15,7 @@
 	nomouseover = TRUE
 	plane = FLOOR_PLANE
 	pass_flags = LETPASSTHROW
-	max_integrity = 900 // We want these quite durable so they aren't accidentally broken during fights.
+	max_integrity = 1200 // We want these quite durable so they aren't accidentally broken during fights.
 
 /obj/structure/stairs/Initialize(mapload)
 	. = ..()
@@ -62,7 +62,7 @@
 	name = "stone stairs"
 	icon = 'icons/obj/stairs.dmi'
 	icon_state = "stonestairs"
-	max_integrity = 1800
+	max_integrity = 2400
 
 //	climb_offset = 10
 	//RTD animate climbing offset so this can be here


### PR DESCRIPTION
## About The Pull Request

As title. Both varieties of stairway now have quadruple the integrity.

## Testing Evidence

It compiles!

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

This is following up on a recent round in which the southern stairwell into the hamlet was completely broken by players accidentally attacking it during a large group fight, turning a straight road into an abrupt cliff. This preserves the potential of destroying stairwells as a defensive measure while hopefully preventing it from happening by accident.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: All stairwells now possess quadruple the integrity as before, hopefully preventing them from being broken accidentally in group fights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
