### PR TITLE
stygjakk

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/tarichae_shrap.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/tarichae_shrap.dm
@@ -3,7 +3,7 @@
 
 /obj/effect/proc_holder/spell/invoked/projectile/shrapnelbloom
 	name = "Stygian Efflorescence"
-	desc = "Burst forth a triad of sharpened onyxian shards, cut from Mount Golgotha herself. Strips away a fully-stacked Arcane Mark to briefly immobilize an enemy and off-balance them for a few seconds."
+	desc = "Burst forth a triad of sharpened onyxian shards, cut from Mount Golgotha herself. Strips away a fully-stacked Arcane Mark to off-balance an enemy for a few seconds, and Expose them for half as long."
 	range = 7 //no reason to not
 	projectile_type = /obj/projectile/energy/shrapnelbloom
 	projectiles_per_fire = 3
@@ -63,6 +63,7 @@
 	if(has_full_mark && M)
 		M.Immobilize(2) //less actual effect and more 'woah. Something Just Happened'. sets up transition to the post-hit kick-juking mindgame
 		M.OffBalance(40)
+		M.apply_status_effect(/datum/status_effect/debuff/exposed, 2 SECONDS) //rock paper scissors and shoot
 
 
 /obj/effect/proc_holder/spell/invoked/projectile/shrapnelbloom/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)


### PR DESCRIPTION
## About The Pull Request

stygian does a brief immob and off-balances you (with a brief Exposed) instead of knockdown at full stacks. brief dmg up to compensate for cooldown as well as tightening spread (honestly won't matter that much but it just kinda looks better)

## Testing Evidence

yea it works fine, can't take videos

## Why It's Good For The Game

honestly i don't think it is, i would have preferred to do this a different way, along with a whole touch-up for the mark system, but ppl rushed me

no charge bc other things have expose for a far longer time and are instant- feint and bait, for example, own da Hell out of u but don't take a cooldown

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: stygian now sets up off-balance and a brief exposed to set up a rock-paper-scissors for knockdown instead of guarenteed knockdown, so pure mages probably can't exploit it as hard. will monitor as needed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
