### PR TITLE
Slingjak

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -929,7 +929,7 @@
 	ricochet_auto_aim_range = 5
 	ricochet_incidence_leeway = 40
 	ricochet_decay_chance = 1
-	ricochet_decay_damage = 2 /// stronger with every bounce, fuck it
+	ricochet_decay_damage = 1.5 /// stronger with every bounce, fuck it
 
 /obj/projectile/bullet/reusable/sling_bullet/on_hit(atom/target)
 	. = ..()
@@ -956,26 +956,26 @@
 /obj/projectile/bullet/reusable/sling_bullet/bronze
 	name = "bronze sling bullet"
 	damage = 35
-	armor_penetration = 20 //Slightly more damage, but with -33% AP.
+	armor_penetration = 15 //Slightly more damage, but with -33% AP.
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/bronze
 	speed = 0.15 // Faster!
 
 /obj/projectile/bullet/reusable/sling_bullet/iron
 	name = "iron sling bullet"
 	damage = 30
-	armor_penetration = 30
+	armor_penetration = 25
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/iron
 
 /obj/projectile/bullet/reusable/sling_bullet/steel
 	name = "steel sling bullet"
 	damage = 40 //Best-of-the-best. Harder to mass-produce, however.
-	armor_penetration = 40
+	armor_penetration = 35
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/steel
 
 /obj/projectile/bullet/reusable/sling_bullet/paalloy
 	name = "ancient sling bullet"
 	damage = 35 // Best of both worlds 'cuz why not
-	armor_penetration = 30
+	armor_penetration = 25
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/sling_bullet/paalloy
 	ricochets_max = 6
 

--- a/code/game/objects/items/rogueweapons/ranged/slings.dm
+++ b/code/game/objects/items/rogueweapons/ranged/slings.dm
@@ -2,7 +2,7 @@
 
 /datum/intent/swing/sling
 	chargetime = 1 //used for edge cases only, /datum/intent/shoot/sling/get_chargetime handles the actual number
-	chargedrain = 2
+	chargedrain = 1.5
 	charging_slowdown = 3
 
 /datum/intent/swing/sling/can_charge(atom/clicked_object)


### PR DESCRIPTION
## About The Pull Request

Numberjakking the sling because honestly it's not funny to onetap yourself through 3 layers of padding because you dared stand AGAINST a wall or someone fell to the ground.

Slings no longer deal double but only bit more damage when bouncing off that way it's still useful to do but not as damaging. All the bullets got little nerf to AP so they don't go through padding entirely. Reduced the stamina cost by a bit.

## Testing Evidence

Naw

## Why It's Good For The Game

🛌 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Slings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
