### PR TITLE
[Draft] Necromantic Coven

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -55,6 +55,7 @@
 #define ROLE_LICH_SKELETON		"Lich Skeleton"
 #define ROLE_CHOSEN				"Chosen"
 #define ROLE_VAMPIRE_SUMMON		"Vampire Summon"
+#define ROLE_VAMPIRE_UNDEAD		"Vampire Undead"
 
 GLOBAL_LIST_INIT(special_roles_rogue, list(
 	ROLE_MANIAC = /datum/antagonist/maniac,

--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -26,6 +26,7 @@
 #define POLL_IGNORE_DEATHKNIGHT_TARGET      "deathknight_target"
 #define POLL_IGNORE_DEATHKNIGHT             "deathknight"
 #define POLL_IGNORE_VL_SERVANT              "vl_servant"
+#define POLL_IGNORE_VAMPIRE_UNDEAD          "vampire_undead"
 
 GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_SENTIENCE_POTION = "Sentience potion",

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -256,7 +256,7 @@
 		var/list/long_job_lists = list("Peasants" = GLOB.peasant_positions,
 									"Burghers" = GLOB.burgher_positions,
 									"Sidefolk" = GLOB.sidefolk_positions,
-									"Ghost and Other Roles" = list(ROLE_NECRO_SKELETON, ROLE_LICH_SKELETON, ROLE_UNBOUND_DEATHKNIGHT, ROLE_DARK_ITINERANT),
+									"Ghost and Other Roles" = list(ROLE_NECRO_SKELETON, ROLE_LICH_SKELETON, ROLE_UNBOUND_DEATHKNIGHT, ROLE_DARK_ITINERANT, ROLE_VAMPIRE_UNDEAD),
 									"Antagonist Positions" = list(ROLE_ASCENDANT, ROLE_ASPIRANT, ROLE_BANDIT, ROLE_NBEAST, ROLE_WEREWOLF, ROLE_LICH, ROLE_PREBEL),
 									"Lesser Antagonst Positions" = list(ROLE_WRETCH, ROLE_DREAMWALKER, ROLE_GNOLL, ROLE_VAMPIRE))
 									//ADD BACK DARK ELF AND MANIAC TO THE LIST IF THEY ARE EVER REENABLED

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/licker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/licker.dm
@@ -32,13 +32,13 @@
 		to_chat(H, span_danger("You are playing an Antagonist role. By choosing to spawn as a Wretch, you are expected to actively create conflict with other players. Failing to play this role with the appropriate gravitas may result in punishment for Low Roleplay standards.")) //giving this notice, since its part of the bounty system
 		//leaving the below in if people want to give lickers outlaw/bounty status again, this will keep it off the trader roles but combat roles will have to choose a bounty
 		/*var/list/traderjobs = list("Aristocrat",
-									"Scholar", 
-								   "Peddler", 
-								   "Jeweler", 
-								   "Harlequin", 
-								   "Doomsayer", 
-								   "Cuisiner", 
-								   "Brewer") 
+									"Scholar",
+								   "Peddler",
+								   "Jeweler",
+								   "Harlequin",
+								   "Doomsayer",
+								   "Cuisiner",
+								   "Brewer")
 		if(H.advjob in traderjobs)
 			REMOVE_TRAIT(H, TRAIT_OUTLAW, JOB_TRAIT) //removing since these are non-combat roles and they need to be able to use the stocks and miesters to blend in
 			to_chat(H, span_danger("You are playing an Antagonist role. By choosing to spawn as a Wretch, you are expected to actively create conflict with other players. Failing to play this role with the appropriate gravitas may result in punishment for Low Roleplay standards.")) //giving this notice, since its part of the bounty system

--- a/code/modules/vampire_neu/covens/_base_coven.dm
+++ b/code/modules/vampire_neu/covens/_base_coven.dm
@@ -13,6 +13,8 @@
 	/* LEVELING SYSTEM */
 	///What rank, or how many dots the caster has in this Coven.
 	var/level = 1
+	///What level this coven starts with
+	var/starting_level = 1
 	///Maximum level this coven can reach
 	var/max_level = 5
 	///Current experience points in this coven
@@ -36,6 +38,8 @@
 	///If this Coven has been assigned before and post_gain effects have already been applied.
 	var/post_gain_applied
 
+	/// whether this coven has an action
+	var/has_action = TRUE
 	///our coven action
 	var/datum/action/coven/coven_action
 

--- a/code/modules/vampire_neu/covens/coven_powers/necromantic.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/necromantic.dm
@@ -1,0 +1,246 @@
+/datum/coven/necromantic
+	name = "Necromantic"
+	desc = "Speak with the dead, summon undead spirits, and manipulate life force itself."
+	icon_state = "daimonion"
+	clan_restricted = FALSE
+	power_type = /datum/coven_power/necromantic
+	has_action = FALSE
+	starting_level = 4
+	max_level = 4
+
+/datum/coven_power/necromantic
+	name = "Necromantic power name"
+	desc = "Necromantic power description"
+
+// Speak with Dead
+/datum/coven_power/necromantic/speak_with_dead
+	name = "Speak with the Dead"
+	desc = "Allows you to communicate with the spirits of the dead."
+
+	level = 1
+	research_cost = 0
+	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_LYING
+
+/datum/coven_power/necromantic/speak_with_dead/post_gain()
+	. = ..()
+	owner.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/speak_with_dead)
+
+/obj/effect/proc_holder/spell/invoked/speak_with_dead
+	name = "Speak with the Dead"
+	range = 1
+	associated_skill = /datum/skill/magic/blood
+	devotion_cost = 0
+	chargedrain = 1
+	chargetime = 15
+	releasedrain = 80
+	recharge_time = 2 MINUTES
+	miracle = FALSE
+	sound = 'sound/magic/necra_sight.ogg'
+
+/obj/effect/proc_holder/spell/invoked/speak_with_dead/cast(list/targets, mob/living/user)
+	if(ismob(targets[1]))
+		var/mob/target = targets[1]
+		if(target.stat != DEAD)
+			to_chat(user, span_warning("Your target is not dead."))
+			revert_cast()
+			return FALSE
+
+		var/input_message = tgui_input_text(user, "What do you wish to ask of the dead?", "Speak with the Dead")
+		if(!input_message)
+			revert_cast()
+			return FALSE
+
+		var/mob/player_mob = target
+		if(!target.client)
+			// last ditch effort, try to find their ghost mob
+			var/mob/ghost_mob = target.get_ghost(TRUE, TRUE)
+			if(ghost_mob.client)
+				player_mob = ghost_mob
+
+		if(!player_mob.client)
+			to_chat(user, span_warning("Necra's grasp on this one is too strong, not even your blood magic can reach them."))
+			revert_cast()
+			return FALSE
+
+		var/dead_message = tgui_input_text(player_mob, "The vampyre [user.real_name] asks of you: [input_message]. You are not compelled in any way. What is your response?", "Speak with the Dead", timeout = 2 MINUTES)
+		if(!dead_message)
+			to_chat(user, span_notice("The dead remain silent."))
+			revert_cast()
+			return FALSE
+
+		var/audible_message = "The raspy voice of [target] echoes, \"<i>[capitalize(dead_message)]</i>\"."
+		user.audible_message(audible_message, runechat_message = dead_message, custom_spans = list("mindlink", "italic"))
+		return TRUE
+
+	revert_cast()
+	return FALSE
+
+// Raise Spirits
+/datum/coven_power/necromantic/raise_spirits
+	name = "Raise Spirits"
+	desc = "Summon the spirits of the dead to serve you."
+
+	level = 2
+	research_cost = 1
+	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_LYING
+
+/datum/coven_power/necromantic/raise_spirits/post_gain()
+	. = ..()
+	owner.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_spirits)
+
+/obj/effect/proc_holder/spell/invoked/raise_spirits
+	name = "Raise Spirits"
+	desc = "Summon the spirits of the dead to serve you."
+	range = 7
+	sound = list('sound/magic/magnet.ogg')
+	releasedrain = 40
+	chargetime = 30
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	charging_slowdown = 1
+	chargedloop = /datum/looping_sound/invokeascendant
+	gesture_required = TRUE
+	associated_skill = /datum/skill/magic/blood
+	recharge_time = 90 SECONDS
+	hide_charge_effect = TRUE
+	miracle = FALSE
+	devotion_cost = 50
+	overlay_icon = 'icons/mob/actions/necramiracles.dmi'
+	overlay_state = "vengeful_spirit"
+	action_icon_state = "vengeful_spirit"
+	action_icon = 'icons/mob/actions/necramiracles.dmi'
+	invocations = list("Awaken, my spirits!")
+	invocation_type = "shout"
+
+/obj/effect/proc_holder/spell/invoked/raise_spirits/cast(list/targets, mob/living/user)
+	. = ..()
+
+	if(!isliving(targets[1]))
+		to_chat(user, span_warning("You must target a living creature to direct your spirits towards."))
+		revert_cast()
+		return FALSE
+
+	var/mob/living/target = targets[1]
+	var/list/haunts = list()
+	if(user.dir == SOUTH || user.dir == NORTH)
+		haunts += new /mob/living/simple_animal/hostile/rogue/haunt/omen(get_turf(user), user)
+		if(prob(50))
+			haunts += new /mob/living/simple_animal/hostile/rogue/haunt/omen(get_step(user, EAST), user)
+		else
+			haunts += new /mob/living/simple_animal/hostile/rogue/haunt/omen(get_step(user, WEST), user)
+	else
+		haunts += new /mob/living/simple_animal/hostile/rogue/haunt/omen(get_turf(user), user)
+		if(prob(50))
+			haunts += new /mob/living/simple_animal/hostile/rogue/haunt/omen(get_step(user, NORTH), user)
+		else
+			haunts += new /mob/living/simple_animal/hostile/rogue/haunt/omen(get_step(user, SOUTH), user)
+	for(var/mob/living/simple_animal/hostile/rogue/haunt/omen/swarm in haunts)
+		swarm.ai_controller.set_blackboard_key(BB_BASIC_MOB_CURRENT_TARGET, target)
+	return TRUE
+
+// Raise Unholy Undead
+/datum/coven_power/necromantic/raise_unholy_undead
+	name = "Raise Unholy Undead"
+	desc = "Raise an unholy, undead, thinking creature to serve you."
+
+	level = 3
+	research_cost = 2
+	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_LYING
+
+/datum/coven_power/necromantic/raise_unholy_undead/post_gain()
+	. = ..()
+	owner.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_unholy_undead)
+
+/obj/effect/proc_holder/spell/invoked/raise_unholy_undead
+	name = "Raise Unholy Undead"
+	desc = "Raise a single revenant that serves you. They are imbued with a fragment of a soul and is more intelligent than usual, simple-minded lesser undead."
+	clothes_req = FALSE
+	range = 7
+	overlay_state = "animate"
+	sound = list('sound/magic/magnet.ogg')
+	releasedrain = 40
+	chargetime = 60
+	warnie = "spellwarning"
+	no_early_release = TRUE
+	charging_slowdown = 1
+	chargedloop = /datum/looping_sound/invokeascendant
+	gesture_required = TRUE // Summon spell
+	associated_skill = /datum/skill/magic/blood
+	recharge_time = 60 SECONDS
+
+/obj/effect/proc_holder/spell/invoked/raise_unholy_undead/cast(list/targets, mob/living/user)
+	..()
+
+	var/turf/T = get_turf(targets[1])
+	if(!isopenturf(T))
+		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))
+		revert_cast()
+		return FALSE
+
+	var/list/candidates = pollGhostCandidates("Do you want to play as a Vampyre's chosen undead?", ROLE_VAMPIRE_UNDEAD, null, null, 10 SECONDS, POLL_IGNORE_VAMPIRE_UNDEAD)
+	if(!LAZYLEN(candidates))
+		to_chat(user, span_warning("The depths are hollow."))
+		return TRUE
+
+	var/mob/C = pick(candidates)
+	if(!C || !istype(C, /mob/dead))
+		revert_cast()
+		return FALSE
+
+	if (istype(C, /mob/dead/new_player))
+		var/mob/dead/new_player/N = C
+		N.close_spawn_windows()
+
+	var/mob/living/carbon/human/species/dullahan/target = new /mob/living/carbon/human/species/dullahan(T)
+	target.key = C.key
+	SSjob.EquipRank(target, "Fortified Skeleton", TRUE)
+	target.copy_known_languages_from(user, TRUE)
+	target.visible_message(span_warning("[target]'s eyes light up with an eerie glow!"))
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, choose_name_popup), "UNHOLY UNDEAD"), 3 SECONDS)
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, choose_pronouns_and_body)), 7 SECONDS)
+	return TRUE
+
+// Harvest Lux
+/datum/coven_power/necromantic/harvest_lux
+	name = "Harvest Lux"
+	desc = "Reach out and siphon the lux from any non-undead surrounding you."
+
+	level = 4
+	research_cost = 3
+	check_flags = COVEN_CHECK_CONSCIOUS | COVEN_CHECK_CAPABLE | COVEN_CHECK_IMMOBILE | COVEN_CHECK_LYING
+
+/datum/coven_power/necromantic/harvest_lux/post_gain()
+	. = ..()
+	owner.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/harvest_lux)
+
+/obj/effect/proc_holder/spell/aoe_turf/harvest_lux
+	name = "Harvest Lux"
+	desc = "Reach out and siphon the lux from any non-undead surrounding you."
+	base_icon_state = ""
+	action_icon_state = "knock"
+	overlay_state = "knock"
+	school = "transmutation"
+	recharge_time = 100
+	clothes_req = FALSE
+	invocations = list("Gaan'Lah'Haas!")
+	invocation_type = "shout"
+	range = 3
+	cooldown_min = 300 //20 deciseconds reduction per rank
+
+/obj/effect/proc_holder/spell/aoe_turf/harvest_lux/cast(list/targets,mob/living/user = usr)
+	var/targets_hit = 0
+	for(var/turf/T in targets)
+		for(var/mob/living/carbon/human/human in T.contents)
+			if(("undead" in human.faction) || human.has_status_effect(/datum/status_effect/debuff/devitalised) || human.has_status_effect(/datum/status_effect/debuff/devitalised/lesser))
+				continue
+			human.apply_status_effect(/datum/status_effect/debuff/devitalised/lesser)
+			to_chat(human, span_artery("Your breath catches in your throat. Cold, unseen fingers burrow into your chest, clawing at your very life force!"))
+			targets_hit++
+	if(targets_hit == 0)
+		to_chat(user, span_warning("You don't manage to extract lux from anyone..."))
+		return TRUE
+	var/vitae_regained = targets_hit * 50
+	to_chat(user, span_notice("You siphon lux from [targets_hit] targets around you, regenerating [vitae_regained] vitae."))
+	user.apply_status_effect(/datum/status_effect/buff/vitae)
+	user.adjust_bloodpool(vitae_regained)
+	return TRUE

--- a/code/modules/vampire_neu/living_modifications.dm
+++ b/code/modules/vampire_neu/living_modifications.dm
@@ -141,7 +141,7 @@
  */
 /mob/living/carbon/human/proc/give_coven(datum/coven/coven)
 	if(ispath(coven))
-		var/datum/coven/new_coven = new coven(1)
+		var/datum/coven/new_coven = new coven(coven.starting_level)
 		coven = new_coven
 
 	// Store the coven on the mob
@@ -154,7 +154,7 @@
 	// Store by name for easy access
 	covens[coven.name] = coven
 
-	if(coven.level > 0)
+	if(coven.has_action && coven.level > 0)
 		var/datum/action/coven/action = new(src, coven)
 		action.Grant(src)
 

--- a/code/modules/vampire_neu/vampire.dm
+++ b/code/modules/vampire_neu/vampire.dm
@@ -118,6 +118,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	. = ..()
 	equip()
 
+	owner.current.faction |= "undead"
+
 	if(HAS_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE))
 		REMOVE_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE, null)
 

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2817,6 +2817,7 @@
 #include "code\modules\vampire_neu\covens\coven_powers\demonic.dm"
 #include "code\modules\vampire_neu\covens\coven_powers\eoran.dm"
 #include "code\modules\vampire_neu\covens\coven_powers\fae_trickery.dm"
+#include "code\modules\vampire_neu\covens\coven_powers\necromantic.dm"
 #include "code\modules\vampire_neu\covens\coven_powers\obfuscate.dm"
 #include "code\modules\vampire_neu\covens\coven_powers\potence.dm"
 #include "code\modules\vampire_neu\covens\coven_powers\presence.dm"


### PR DESCRIPTION
## About The Pull Request

- Lyckers now gain access to the undead faction, meaning common undead will not attack them, even if they don't take the Necromantic Coven.
- Added the Necromantic Coven, which starts out fully upgraded with no need to farm XP. (Buying abilities still costs RP.)
- The Necromantic Coven gets the following abilities: Speak with the Dead (lets them ask a dead player anything), Raise Spirits (summons 2 NPC buffed haunts to attack their target), Raise Unholy Undead (Like lich's fortified skeleton, except it's a revenant), Harvest Lux (AoE spell that inflicts a lesser version of devitalized on every non-dead around, while also regaining vitae based on the amount of people hit)

To-do:
- [ ] Fix coven unlocking all abilities without needing to spend RP
- [ ] Get spell icon for 'Speak with the Dead'
- [ ] Fix summoned revenant being turned into a boneman anyway
- [ ] Limit summoned revenant to 2 max
- [ ] Fix Harvest Lux not appearing as an ability

## Testing Evidence

Clips to come.

## Why It's Good For The Game

I really like necromancer gameplay, and PvE with a side of summoning basic PvP goons seems to be a well-liked feature. This tries to not step on the necromancer's toes too much by not letting them summon a horde of PvE skeletons, instead, they spawn vengeful spirits instead.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Lyckers now gain access to the undead faction, meaning common undead will not attack them, even if they don't take the Necromantic Coven.
add: Added the Necromantic Coven, which starts out fully upgraded with no need to farm XP. (Buying abilities still costs RP.)
add: The Necromantic Coven gets the following abilities: Speak with the Dead (lets them ask a dead player anything), Raise Spirits (summons 2 NPC buffed haunts to attack their target), Raise Unholy Undead (Like lich's fortified skeleton, except it's a revenant), Harvest Lux (AoE spell that inflicts a lesser version of devitalized on every non-dead around, while also regaining vitae based on the amount of people hit)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
