### PR TITLE
Fixes shield cache modification.

### DIFF
--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -119,7 +119,7 @@
 		return
 
 	var/icon/J = new('icons/roguetown/weapons/shield_heraldry.dmi')
-	var/list/istates = get_icon_states_cached(J)
+	var/list/istates = J.IconStates()
 	if(!istates || !length(istates))
 		return
 	for(var/icon_s in istates)


### PR DESCRIPTION
## About The Pull Request
Optimization PR https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/5517 cached shield states and then modified the icon cache directly. 

This means all shield but the first shield on the server would not be able to select heraldry. I saw Vanderlin have a better and presumably working cache system. I am reverting the changes to fix it and then pulling that over when I have time

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="207" height="227" alt="dreamseeker_10G3F0fqFR" src="https://github.com/user-attachments/assets/0ed888c6-6839-430e-b6f3-278478bf484e" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Shields heraldry work again

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Shield heraldry should work again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
