### PR TITLE
Change up heartfelt

### DIFF
--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -48,7 +48,7 @@
 		H.name = "[honorary] [prev_name]"
 
 /datum/migrant_role/heartfelt/retinue
-	name = "Heartfeltian Retinue"
+	name = "Heartfelt Retinue"
 	advclass_cat_rolls = list(CTAG_HFT_RETINUE = 20)
 	allowed_races = ACCEPTED_RACES
 	grant_lit_torch = FALSE

--- a/code/datums/migrants/migrant_waves/heartfelt wave.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt wave.dm
@@ -10,7 +10,7 @@
 		/datum/migrant_role/heartfelt/knight = 1,
 		/datum/migrant_role/heartfelt/retinue = 4,
 	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes!"
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs.. Stay close and watch out for each other, for all of your sakes!"
 
 /datum/migrant_wave/heartfelt_down_one
 	name = "The Court of Heartfelt"
@@ -23,7 +23,7 @@
 		/datum/migrant_role/heartfelt/knight = 1,
 		/datum/migrant_role/heartfelt/retinue = 3,
 	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs.. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
 
 /datum/migrant_wave/heartfelt_down_two
 	name = "The Court of Heartfelt"
@@ -36,7 +36,7 @@
 		/datum/migrant_role/heartfelt/knight = 1,
 		/datum/migrant_role/heartfelt/retinue = 2,
 	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs.. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
 
 
 /datum/migrant_wave/heartfelt_down_three
@@ -50,7 +50,7 @@
 		/datum/migrant_role/heartfelt/knight = 1,
 		/datum/migrant_role/heartfelt/retinue = 1,
 	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs.. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
 
 /datum/migrant_wave/heartfelt_down_four
 	name = "The Court of Heartfelt"
@@ -62,7 +62,7 @@
 		/datum/migrant_role/heartfelt/hand = 1,
 		/datum/migrant_role/heartfelt/knight = 1,
 	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs.. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
 
 /datum/migrant_wave/heartfelt_down_five
 	name = "The Court of Heartfelt"
@@ -74,7 +74,7 @@
 		/datum/migrant_role/heartfelt/hand = 1,
 		/datum/migrant_role/heartfelt/retinue = 1,
 	)
-	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
 
 /datum/migrant_wave/heartfelt_down_six
 	name = "The Court of Heartfelt"
@@ -85,7 +85,7 @@
 		/datum/migrant_role/heartfelt/lord = 1,
 		/datum/migrant_role/heartfelt/retinue = 2,
 	)
-	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
 
 /datum/migrant_wave/heartfelt_down_seven
 	name = "The Court of Heartfelt"
@@ -96,7 +96,7 @@
 		/datum/migrant_role/heartfelt/lord = 1,
 		/datum/migrant_role/heartfelt/knight = 1,
 	)
-	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Now, in the end, it is only the Lord and their trusty knight left on their lonesome..."
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs. Now, in the end, it is only the Lord and their trusty knight left on their lonesome..."
 
 /datum/migrant_wave/heartfelt_down_eight
 	name = "The Court of Heartfelt"
@@ -107,7 +107,7 @@
 		/datum/migrant_role/heartfelt/lord = 1,
 		/datum/migrant_role/heartfelt/hand = 1,
 	)
-	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Now, in the end, it is only the Lord and their trusty Hand left on their lonesome..."
+	greet_text = "Fleeing the disaster at Heartfelt, you have come together - to find aide for your house, or to infest Azure Peak with the boons of the Ecclesiarchs. Now, in the end, it is only the Lord and their trusty Hand left on their lonesome..."
 
 /datum/migrant_wave/heartfelt_down_nine
 	name = "The Court of Heartfelt"

--- a/code/game/objects/items/rogueitems/caparison.dm
+++ b/code/game/objects/items/rogueitems/caparison.dm
@@ -64,7 +64,7 @@
 	female_caparison_state = "azure_caparison-f"
 
 /obj/item/caparison/heartfelt
-	name = "heartfeltian caparison"
-	desc = "A decorative piece of cloth meant to be used as a saddle decoration. It's adorned with heartfeltian colours. This one fits on a Saiga."
+	name = "Heartfelt caparison"
+	desc = "A decorative piece of cloth meant to be used as a saddle decoration. It's adorned with the colours of Heartfelt. This one fits on a Saiga."
 	caparison_state = "heartfelt_caparison"
 	female_caparison_state = "heartfelt_caparison-f"

--- a/code/modules/clothing/rogueclothes/armor/leather.dm
+++ b/code/modules/clothing/rogueclothes/armor/leather.dm
@@ -56,7 +56,7 @@
 /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket
 	name = "artificer jacket"
 	icon_state = "artijacket"
-	desc = "A thick leather jacket adorned with fur and cog decals. The height of Heartfeltian fashion."
+	desc = "A thick leather jacket adorned with fur and cog decals. The height of Heartfelt fashion."
 
 /obj/item/clothing/suit/roguetown/armor/leather/cuirass
 	name = "leather cuirass"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfelthand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfelthand.dm
@@ -2,6 +2,7 @@
 	title = "Hand of Heartfelt"
 	tutorial = "You are the Hand of Heartfelt, burdened by the perception in protecting your Lord's domain. \
 	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of. \
 	Despite doubts from others, your loyalty remains steadfast as you journey to the Peaks, determined to fulfill your duties."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
@@ -44,8 +45,6 @@
 		STATKEY_STR = 2,
 		STATKEY_PER = 2,
 		STATKEY_INT = 2,
-		STATKEY_CON = 1,
-		STATKEY_WIL = 1,
 	)
 
 	subclass_stashed_items = list("Heartfelt Caparison" = /obj/item/caparison/heartfelt)
@@ -55,13 +54,14 @@
 
 	subclass_skills = list(
 	/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
-	/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
+	/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/craft/cooking = SKILL_LEVEL_EXPERT,
 	/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
-	/datum/skill/misc/riding = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
-	/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
+	/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
@@ -72,25 +72,22 @@
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel
 	armor = /obj/item/clothing/suit/roguetown/armor/heartfelt/hand
 	r_hand = /obj/item/rogueweapon/sword/long/dec
-	//l_hand = banner-pike for when I add it
+	l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 	beltl = /obj/item/rogueweapon/scabbard/sword/noble
+	backr = /obj/item/quiver/bolts
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
 		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
-		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 1,
-		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
 		/obj/item/natural/feather = 1,
 		/obj/item/paper/scroll = 1,
 		)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/heartfelt)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/retreat)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/bolster)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/charge)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/forheartfelt)
-		// H.mind.AddSpell(new/obj/effect/proc_holder/spell/invoked/order/heartfelt/focustarget)
 		H.verbs |= list(/mob/living/carbon/human/mind/proc/setordersheartfelt)
+
 	var/helmet = list("Etruscan Bascinet","Volf Plate Helmet","Beak Helmet","Visored Sallet",)
 	var/helmet_choice = input("Choose your Helm.", "TAKE UP HELMS") as anything in helmet
 	switch(helmet_choice)
@@ -116,12 +113,10 @@
 	Pressed once more into service by tragedy, you climb towards the Peaks."
 	outfit = /datum/outfit/job/roguetown/heartfelt/hand/steward
 	category_tags = list(CTAG_HFT_HAND)
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_SEEPRICES, TRAIT_HEARTFELT)
+	traits_applied = list(TRAIT_SEEPRICES, TRAIT_HEARTFELT)
 	subclass_stats = list(
-		STATKEY_STR = 1,
 		STATKEY_SPD = 2,
 		STATKEY_INT = 2,
-		STATKEY_CON = 1,
 		STATKEY_WIL = 2,
 	)
 
@@ -131,7 +126,7 @@
 	)
 
 	subclass_skills = list(
-	/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
+	/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
 	/datum/skill/craft/cooking = SKILL_LEVEL_EXPERT,
@@ -146,7 +141,7 @@
 
 /datum/outfit/job/roguetown/heartfelt/hand/steward/pre_equip(mob/living/carbon/human/H)
 	..()
-	armor = /obj/item/clothing/suit/roguetown/armor/brigandine
+	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	gloves = /obj/item/clothing/gloves/roguetown/leather/black
 	r_hand = /obj/item/rogueweapon/sword/sabre/dec
 	beltl = /obj/item/rogueweapon/scabbard/sword/noble
@@ -157,7 +152,7 @@
 		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 2,
-		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
 		/obj/item/natural/feather = 1,
 		/obj/item/paper/scroll = 1,
 		)
@@ -178,7 +173,7 @@
 	category_tags = list(CTAG_HFT_HAND)
 	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2, TRAIT_INTELLECTUAL, TRAIT_SEEPRICES_SHITTY, TRAIT_HEARTFELT)
 	subclass_stats = list(
-		STATKEY_INT = 4,
+		STATKEY_INT = 3,
 		STATKEY_PER = 3,
 		STATKEY_SPD = 1
 	)
@@ -191,8 +186,7 @@
 	subclass_spellpoints = 15
 
 	subclass_skills = list(
-		/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
@@ -212,14 +206,12 @@
 /datum/outfit/job/roguetown/heartfelt/hand/advisor/pre_equip(mob/living/carbon/human/H)
 	..()
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
-	r_hand = /obj/item/rogueweapon/sword/sabre/dec
-	beltl = /obj/item/rogueweapon/scabbard/sword/noble
 	mask = /obj/item/clothing/mask/rogue/spectacles/golden
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
 		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
-		/obj/item/storage/belt/rogue/pouch/coins/veryrich = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
 		/obj/item/lockpickring/mundane = 1, 
 		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1,
 		/obj/item/natural/feather = 1,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltknight.dm
@@ -61,23 +61,22 @@
 	)
 
 	subclass_stats = list(
-		STATKEY_STR = 3,
-		STATKEY_PER = 1,
-		STATKEY_INT = 2,
-		STATKEY_CON = 3,
+		STATKEY_STR = 1,
+		STATKEY_INT = 1,
+		STATKEY_CON = 2,
 		STATKEY_WIL = 2,
-		STATKEY_SPD = -1,
+		STATKEY_SPD = -2,
 	)
 
 	subclass_skills = list(
-	/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/maces = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT,
+	/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/whipsflails = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
-	/datum/skill/combat/unarmed =SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/bows = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
@@ -90,32 +89,28 @@
 /datum/outfit/job/heartfelt/knight/pre_equip(mob/living/carbon/human/H)
 	..()
 
-	gloves = /obj/item/clothing/gloves/roguetown/plate
-	pants = /obj/item/clothing/under/roguetown/platelegs
+	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
+	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 	cloak = /obj/item/clothing/cloak/tabard
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight
-	neck = /obj/item/clothing/neck/roguetown/bevor
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/full
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
+	neck = /obj/item/clothing/neck/roguetown/bevor/iron
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/iron
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
 	beltr = /obj/item/rogueweapon/scabbard/sword/noble
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	belt = /obj/item/storage/belt/rogue/leather/steel
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/knight
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
 		/obj/item/rope/chain = 1,
 		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
-		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
 		/obj/item/natural/bundle/cloth/bandage/full = 1,
 	)
-	// This code is broken but also not, I assume because it has 1 Advanced Class at the moment DO NOT UNCOMMENT. 
-	// IT WORKS :TM: still gives them a helm and grandmace, just not the choice
-	
 	H.adjust_blindness(-3)
-	var/weapons = list("Dec Sword + Shield"," Zweihander","Great Mace","Battle Axe","Greataxe","Estoc","Eagle Beak", "Partizan", "Lance + Shield")
+	var/weapons = list("Dec Sword + Shield","Zweihander","Great Mace","Battle Axe","Greataxe","Estoc","Eagle Beak", "Partizan", "Lance + Shield")
 	var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
@@ -123,40 +118,50 @@
 			l_hand = /obj/item/rogueweapon/sword/long/dec
 			backl = /obj/item/rogueweapon/shield/tower/metal
 			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 		if("Zweihander")
 			l_hand = /obj/item/rogueweapon/sword/long
 			r_hand = /obj/item/rogueweapon/greatsword/zwei
 			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 		if("Great Mace")
 			l_hand = /obj/item/rogueweapon/sword/long
 			r_hand = /obj/item/rogueweapon/mace/goden/steel
 			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
 		if("Battle Axe")
 			l_hand = /obj/item/rogueweapon/sword/long
 			r_hand = /obj/item/rogueweapon/stoneaxe/battle
 			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 		if("Greataxe")
 			l_hand = /obj/item/rogueweapon/sword/long
 			r_hand = /obj/item/rogueweapon/greataxe/steel
 			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 		if("Estoc")
 			l_hand = /obj/item/rogueweapon/sword/long
 			r_hand = /obj/item/rogueweapon/estoc
 			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 		if("Eagle Beak")
 			l_hand = /obj/item/rogueweapon/sword/long
 			r_hand = /obj/item/rogueweapon/eaglebeak
 			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
 		if("Partizan")
 			l_hand = /obj/item/rogueweapon/sword/long
 			r_hand = /obj/item/rogueweapon/spear/partizan
 			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
 		if("Lance + Shield")
 			l_hand = /obj/item/rogueweapon/spear/lance
 			backl = /obj/item/rogueweapon/shield/tower/metal
 			H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
 		else //In case they DC or don't choose close the panel, etc
 			r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
+			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)
 
 	var/helmet = list("Pigface Bascinet","Guard Helmet","Barred Helmet","Bucket Helmet","Knight's Helmet","Knight's Armet","Volf Plate Helmet" ,"Visored Sallet","Armet","Hounskull Bascinet", "Etruscan Bascinet", "Slitted Kettle")
 	var/helmet_choice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmet
@@ -185,5 +190,3 @@
 			head = /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan
 		if("Slitted Kettle") 
 			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle
-		else //In case they DC or don't choose close the panel, etc
-			head = /obj/item/clothing/head/roguetown/helmet/heavy/knight

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltlord.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltlord.dm
@@ -2,7 +2,8 @@
 /datum/job/roguetown/heartfelt/lord
 	title = "Lord of Heartfelt"
 	tutorial = "You are the Lord of Heartfelt, ruler of a prosperous borderlands now in Azuria. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = null
@@ -21,7 +22,8 @@
 /datum/advclass/heartfelt/lord/lord
 	name = "Lord of Heartfelt"
 	tutorial = "You are the Lord of Heartfelt, ruler of a prosperous borderlands now in Azuria. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	category_tags = list(CTAG_HFT_LORD)
 	maximum_possible_slots = 1
 	outfit = /datum/outfit/job/heartfelt/lord/lord
@@ -38,8 +40,6 @@
 		STATKEY_STR = 2,
 		STATKEY_INT = 2,
 		STATKEY_PER = 2,
-		STATKEY_WIL = 2,
-		STATKEY_SPD = 1,
 		STATKEY_LCK = 5,
 	)
 
@@ -56,7 +56,6 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
 	)
@@ -89,13 +88,13 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/bolster)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/charge)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/forheartfelt)
-		// H.mind.AddSpell(new/obj/effect/proc_holder/spell/invoked/order/heartfelt/focustarget)
 		H.verbs |= list(/mob/living/carbon/human/mind/proc/setordersheartfelt)
 
 /datum/advclass/heartfelt/lord/archmage
 	name = "Archmagos of Heartfelt"
 	tutorial = "You are the Archmagos of Heartfelt, ruler of a acryne-borderlands in Azuria. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	category_tags = list(CTAG_HFT_LORD)
 	maximum_possible_slots = 1
 	outfit = /datum/outfit/job/heartfelt/lord/archmage
@@ -111,8 +110,6 @@
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 2,
-		STATKEY_WIL = 1,
-		STATKEY_SPD = 1,
 		STATKEY_LCK = 5,
 	)
 
@@ -160,22 +157,22 @@
 	id = /obj/item/scomstone
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/heartfelt)
-	if(H.mind)
-		H?.mind.adjust_spellpoints(24)
+		H?.mind.adjust_spellpoints(16)
 	if(H.age == AGE_OLD)
 		H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
 		H.change_stat("speed", -1)
 		H.change_stat("intelligence", 1)
 		H.change_stat("perception", 1)
-		H?.mind.adjust_spellpoints(6)
+		H?.mind.adjust_spellpoints(4)
 
 // Funny role I thought I'd make. Reminded me of Canute and his Jarldom
 
 /datum/advclass/heartfelt/lord/chief
 	name = "Chieftain of Heartfelt"
 	tutorial = "You are the Chieftain of Heartfelt, Chieftain of a once tribal lands over Azuria. Now, you rule it under the watchful gaze of the Grand Duchy. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	category_tags = list(CTAG_HFT_LORD)
 	maximum_possible_slots = 1
 	outfit = /datum/outfit/job/heartfelt/lord/chief
@@ -192,13 +189,13 @@
 		STATKEY_STR = 3,
 		STATKEY_WIL = 3,
 		STATKEY_CON = 2,
-		STATKEY_SPD = 1,
 		STATKEY_PER = -2,
 		STATKEY_INT = -1,
 		STATKEY_LCK = 5,
 	)
 
 	subclass_skills = list(
+		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
@@ -244,7 +241,6 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/bolster)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/charge)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/heartfelt/forheartfelt)
-		// H.mind.AddSpell(new/obj/effect/proc_holder/spell/invoked/order/heartfelt/focustarget)
 		H.verbs |= list(/mob/living/carbon/human/mind/proc/setordersheartfelt)
 	var/weapons = list("Double-Headed Greataxe", "Great Mace", "Battle Axe + Shield", , "Warhammer + Shield")
 	var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
@@ -268,7 +264,7 @@
 
 /obj/effect/proc_holder/spell/self/convertrole/heartfelt
 	name = "Recruit Retinue"
-	new_role = "Heartfeltian Retinue"
+	new_role = "Heartfelt Retinue"
 	overlay_state = "recruit_brother"
 	recruitment_faction = "Heartfelt"
 	recruitment_message = "Join in the service of Heartfelt, %RECRUIT!"
@@ -301,7 +297,7 @@
 			return 0
 		else
 			return 1
-	if(!(target.job in list("Heartfeltian Retinue", "Knight of Heartfelt")))
+	if(!(target.job in list("Heartfelt Retinue", "Knight of Heartfelt")))
 		to_chat(user, span_alert("I cannot order one not in our cause!"))
 		return 0
 	return 1

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltarmorer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltarmorer.dm
@@ -1,8 +1,9 @@
 
 /datum/advclass/heartfelt/retinue/armorer
-	name = "Heartfeltian Armorer"
-	tutorial = "You are the Heartfeltian Armorer destined for greatness,\
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	name = "Heartfelt Armorer"
+	tutorial = "You are the Heartfelt Armorer destined for greatness,\
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/armorer
 	maximum_possible_slots = 1
@@ -13,12 +14,10 @@
 // Master Smith role for Heartfelt
 
 	traits_applied = list(TRAIT_TRAINED_SMITH, TRAIT_SMITHING_EXPERT, TRAIT_MEDIUMARMOR, TRAIT_HEARTFELT)
-	subclass_stats = list( // idk what to say bruh, i guess he's legendary indeed
+	subclass_stats = list(
 		STATKEY_LCK = 1,
 		STATKEY_STR = 2,
-		STATKEY_INT = 1,
 		STATKEY_WIL = 2,
-		STATKEY_CON = 2,
 	)
 
 	subclass_skills = list(
@@ -45,7 +44,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/hammer/iron
 	beltl = /obj/item/rogueweapon/tongs
-	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	neck = /obj/item/storage/belt/rogue/pouch/coins/mid
 	mouth = /obj/item/rogueweapon/huntingknife
 	gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves/blacksmith
 	mask = /obj/item/clothing/mask/rogue/facemask/steel

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltcourtier.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltcourtier.dm
@@ -1,8 +1,9 @@
 
 /datum/advclass/heartfelt/retinue/courtier
-	name = "Heartfeltian Courtier"
+	name = "Heartfelt Courtier"
 	tutorial = "You are a Courtier of Heartfelt, a respected noblewoman looking to impress your lover. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/courtier
@@ -17,7 +18,6 @@
 
 	subclass_stats = list(
 		STATKEY_INT = 3,
-		STATKEY_WIL = 3,
 		STATKEY_SPD = 2,
 		STATKEY_PER = 2,
 		STATKEY_LCK = 5,
@@ -42,7 +42,7 @@
 /datum/outfit/job/roguetown/heartfelt/retinue/courtier/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/circlet
-	neck = /obj/item/storage/belt/rogue/pouch/coins/veryrich
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	cloak = /obj/item/clothing/cloak/heartfelt
 	shirt = /obj/item/clothing/suit/roguetown/shirt/dress/silkydress/random
 	if(isdwarf(H))
@@ -54,7 +54,7 @@
 			armor = /obj/item/clothing/suit/roguetown/armor/armordress
 	belt = /obj/item/storage/belt/rogue/leather/cloth/lady
 	beltl = /obj/item/flashlight/flare/torch/lantern
-	beltr = /obj/item/rogueweapon/huntingknife/idagger/silver/elvish
+	beltr = /obj/item/rogueweapon/huntingknife/idagger/silver
 	id = /obj/item/clothing/ring/silver
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	backl = /obj/item/storage/backpack/rogue/satchel/black

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltjester.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltjester.dm
@@ -1,6 +1,6 @@
 
 /datum/advclass/heartfelt/retinue/jester
-	name = "Heartfeltian Jester"
+	name = "Heartfelt Jester"
 	tutorial = "You are the Jester of Heartfelt, a bringer of laughter in brighter days. \
 	Though grief weighs heavy beneath your painted smile, you turn your steps toward the Peak—hoping your wit, charm, and cunning may yet carve out a place for joy."
 	allowed_sexes = list(MALE, FEMALE)
@@ -20,30 +20,28 @@
 	pants = /obj/item/clothing/under/roguetown/tights
 	armor = /obj/item/clothing/suit/roguetown/shirt/jester
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/belt/rogue/pouch/coins/rich
 	head = /obj/item/clothing/head/roguetown/jester
 	neck = /obj/item/clothing/neck/roguetown/coif
-	H.adjust_skillrank(/datum/skill/combat/knives, rand(2,5), TRUE)
-	H.adjust_skillrank(/datum/skill/misc/reading, rand(1,6), TRUE) 
-	H.adjust_skillrank(/datum/skill/misc/sneaking, rand(2,6), TRUE)
-	H.adjust_skillrank(/datum/skill/misc/stealing, rand(1,6), TRUE)
-	H.adjust_skillrank(/datum/skill/misc/climbing, rand(2,6), TRUE)
-	H.adjust_skillrank(/datum/skill/misc/athletics, rand(4,6), TRUE) //a showman like no other. you need to be fit to perform.
-	H.adjust_skillrank(/datum/skill/misc/music, rand(4,6), TRUE)
-	H.adjust_skillrank(/datum/skill/combat/unarmed, rand(1,5), TRUE) // is this a good idea? Probably not, but the idea of a master fighter jester with 20 str is too good to pass on, this can only go well
-	H.adjust_skillrank(/datum/skill/combat/wrestling, rand(1,5), TRUE)
-	H.adjust_skillrank(/datum/skill/misc/lockpicking, rand(1,4), TRUE)
-	H.adjust_skillrank(/datum/skill/craft/cooking, rand(1,3), TRUE)
-	H.STASTR = rand(3, 21) //Slightly better odds for a Heartfelter AKA a migrant
-	H.STAWIL = rand(3, 21)
-	H.STACON = rand(3, 21)
-	H.STAINT = rand(3, 21)
-	H.STAPER = rand(3, 21)
-	H.STALUC = rand(3, 21)
+	H.adjust_skillrank(/datum/skill/combat/knives, rand(SKILL_LEVEL_APPRENTICE , SKILL_LEVEL_MASTER), TRUE)
+	H.adjust_skillrank(/datum/skill/misc/reading, rand(SKILL_LEVEL_NOVICE, SKILL_LEVEL_LEGENDARY), TRUE) 
+	H.adjust_skillrank(/datum/skill/misc/sneaking, rand(SKILL_LEVEL_APPRENTICE, SKILL_LEVEL_EXPERT), TRUE)
+	H.adjust_skillrank(/datum/skill/misc/stealing, rand(SKILL_LEVEL_NOVICE, SKILL_LEVEL_EXPERT), TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, rand(SKILL_LEVEL_APPRENTICE, SKILL_LEVEL_MASTER), TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, rand(SKILL_LEVEL_JOURNEYMAN, SKILL_LEVEL_MASTER), TRUE)
+	H.adjust_skillrank(/datum/skill/misc/music, rand(SKILL_LEVEL_EXPERT, SKILL_LEVEL_LEGENDARY), TRUE)
+	H.adjust_skillrank(/datum/skill/combat/unarmed, rand(SKILL_LEVEL_NONE, SKILL_LEVEL_EXPERT), TRUE)
+	H.adjust_skillrank(/datum/skill/combat/wrestling, rand(SKILL_LEVEL_NONE, SKILL_LEVEL_EXPERT), TRUE)
+	H.adjust_skillrank(/datum/skill/misc/lockpicking, rand(SKILL_LEVEL_NOVICE, SKILL_LEVEL_EXPERT), TRUE)
+	H.adjust_skillrank(/datum/skill/craft/cooking, rand(SKILL_LEVEL_APPRENTICE, SKILL_LEVEL_EXPERT), TRUE)
+	H.STASTR = rand(3, 20) //Slightly better odds for a Heartfelter AKA a migrant
+	H.STAWIL = rand(3, 20)
+	H.STACON = rand(3, 20)
+	H.STAINT = rand(3, 20)
+	H.STAPER = rand(3, 20)
+	H.STALUC = rand(3, 20)
 	H.cmode_music = 'sound/music/combat_jester.ogg'
 	if(H.mind)
 		// Mime vs Jester. 
-		// As a mute jester you cannot cast Tell Joke/Tragedy, so why even have them?
 		if(HAS_TRAIT(H, TRAIT_PERMAMUTE)) // I considered adding a check for Xylix patron but in the off chance there's a mute non-xylix jester I don't want to fuck them over.
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltmagos.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltmagos.dm
@@ -1,8 +1,9 @@
 
 /datum/advclass/heartfelt/retinue/magos
-	name = "Heartfeltian Magos"
+	name = "Heartfelt Magos"
 	tutorial = "You are the Magos of Heartfelt, renowned for your arcane knowledge. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/magos
@@ -11,24 +12,21 @@
 	category_tags = list(CTAG_HFT_RETINUE)
 	class_select_category = CLASS_CAT_HFT_COURT
 
-// HIGH COURT - /ONE SLOT/ Roles that were previously in the Court, but moved here.
-
-
-	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T4, TRAIT_INTELLECTUAL, TRAIT_SEEPRICES, TRAIT_ALCHEMY_EXPERT, TRAIT_HEARTFELT)
+	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3, TRAIT_INTELLECTUAL, TRAIT_ALCHEMY_EXPERT, TRAIT_HEARTFELT)
 	subclass_stats = list(
-		STATKEY_INT = 5,
-		STATKEY_PER = 3,
-		STATKEY_WIL = 2,
-		STATKEY_STR = -1,
-		STATKEY_CON = -1,
+		STATKEY_INT = 2,
+		STATKEY_PER = 2,
+		STATKEY_WIL = 1,
+		STATKEY_STR = -2,
+		STATKEY_CON = -2,
 	)
 
-	subclass_spellpoints = 36
+	subclass_spellpoints = 24
 
 	subclass_skills = list(
 	/datum/skill/misc/reading = SKILL_LEVEL_LEGENDARY,
 	/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
-	/datum/skill/magic/arcane = SKILL_LEVEL_MASTER,
+	/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT,
 	/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
@@ -37,14 +35,10 @@
 	/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 	/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
 	/datum/skill/misc/athletics = SKILL_LEVEL_NOVICE,
-	/datum/skill/combat/swords = SKILL_LEVEL_NOVICE,
-	/datum/skill/combat/knives = SKILL_LEVEL_NOVICE,
 	/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
 	/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
 	)
-
-
 
 /datum/outfit/job/roguetown/heartfelt/retinue/magos/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -60,14 +54,12 @@
 	r_hand = /obj/item/rogueweapon/woodstaff/ruby //Two Levels down from CW
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
-		/obj/item/reagent_containers/glass/bottle/rogue/poison,
-		/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-		/obj/item/recipe_book/alchemy,
-		/obj/item/roguegem/amethyst,
-		/obj/item/spellbook_unfinished/pre_arcyne,
-		/obj/item/rogueweapon/huntingknife/idagger/silver/arcyne,
-		/obj/item/scrying,
-		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1,
+		/obj/item/recipe_book/alchemy = 1,
+		/obj/item/roguegem/amethyst  = 1,
+		/obj/item/spellbook_unfinished/pre_arcyne = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/silver/arcyne = 1,
+		/obj/item/scrying = 1,
 		)
 	if(H.age == AGE_OLD)
 		H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
@@ -75,7 +67,7 @@
 		H.change_stat("intelligence", 1)
 		H.change_stat("perception", 1)
 	if(H.mind)
-		H?.mind.adjust_spellpoints(6)
+		H?.mind.adjust_spellpoints(4)
 	if(ishumannorthern(H))
 		belt = /obj/item/storage/belt/rogue/leather/plaquegold
 		cloak = null

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltphyscian.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltphyscian.dm
@@ -1,8 +1,9 @@
 
 /datum/advclass/heartfelt/retinue/physician
-	name = "Heartfeltian Physician"
+	name = "Heartfelt Physician"
 	tutorial = "You are the Physician of Heartfelt, celebrated for your steady hands and healing wisdom. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/physician
@@ -14,10 +15,9 @@
 	traits_applied = list(TRAIT_HEARTFELT, TRAIT_NOSTINK, TRAIT_EMPATH)
 
 	subclass_stats = list(
-		STATKEY_INT = 4,
-		STATKEY_WIL = 1,
-		STATKEY_LCK = 1,
-		STATKEY_SPD = 2,
+		STATKEY_INT = 3,
+		STATKEY_SPD = 1,
+		STATKEY_LCK = 2,
 	)
 
 	subclass_skills = list(
@@ -25,12 +25,12 @@
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_MASTER,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/medicine = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/misc/medicine = SKILL_LEVEL_MASTER,
 	)
 // HIGH COURT - /ONE SLOT/ Roles that were previously in the Court, but moved here.
 
@@ -47,9 +47,9 @@
 	backpack_contents = list(
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpotnew = 2,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 2,
-		/obj/item/natural/worms/leech/cheele = 1, //little buddy
+		/obj/item/natural/worms/leech/cheele = 1,
 		/obj/item/reagent_containers/glass/bottle/waterskin = 1,
-		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
 		/obj/item/recipe_book/alchemy = 1,
 		/obj/item/bedroll = 1,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltprior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltprior.dm
@@ -1,6 +1,6 @@
 
 /datum/advclass/heartfelt/retinue/prior
-	name = "Heartfeltian Priest"
+	name = "Heartfelt Priest"
 	tutorial = "The Priest of Heartfelt, you were destined for ascension within the Church. \
 	. Still guided by the blessings of Astrata, you journey to the Peak, determined to offer what aid and solace you can."
 	allowed_sexes = list(MALE, FEMALE)
@@ -23,8 +23,8 @@
 	)
 
 	subclass_skills = list(
-	/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
+	/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
 	/datum/skill/combat/staves = SKILL_LEVEL_EXPERT,
 	/datum/skill/misc/reading = SKILL_LEVEL_LEGENDARY,
@@ -47,7 +47,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	beltl = /obj/item/flashlight/flare/torch/lantern
-	beltr = /obj/item/storage/belt/rogue/pouch/coins/veryrich
+	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/priest
 	cloak = /obj/item/clothing/cloak/chasuble
 	backl = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltwarriors.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltwarriors.dm
@@ -1,8 +1,9 @@
 
 /datum/advclass/heartfelt/retinue/houseguard
-	name = "Heartfeltian House Guard"
+	name = "Heartfelt House Guard"
 	tutorial = "You are a House Guard for the Lord of Heartfelt, a valiant defender of the prosperous borderlands. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/houseguard
@@ -13,46 +14,44 @@
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_STEELHEARTED, TRAIT_HEARTFELT) // MAA footman W/O Guardsman Trait
 	subclass_stats = list( //
 		STATKEY_STR = 2, 
-		STATKEY_INT = 1,
-		STATKEY_CON = 3,
 		STATKEY_WIL = 2,
 		STATKEY_SPD = 1,
 	)
 
 	subclass_skills = list(
-	/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/maces = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
+	/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/combat/whipsflails = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/combat/slings = SKILL_LEVEL_NOVICE,
 	/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
-	/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
-	/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
+	/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+	/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
 	/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 	/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 	/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
-	/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
+	/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
 	)
 
 /datum/outfit/job/roguetown/heartfelt/retinue/houseguard/pre_equip(mob/living/carbon/human/H)
 	..()
 
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/black // Fur cloak, instead using the brigandine for 'identification'
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	beltl = /obj/item/rogueweapon/scabbard/sword
 	l_hand = /obj/item/rogueweapon/sword
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy		//Bit worse shirt protection than the archer
-	armor = /obj/item/clothing/suit/roguetown/armor/brigandine	//Makes up for worse shirt protection with kinda better armor protection
-	pants = /obj/item/clothing/under/roguetown/chainlegs
-	neck = /obj/item/clothing/neck/roguetown/gorget/steel
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	armor = /obj/item/clothing/suit/roguetown/armor/brigandine
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	neck = /obj/item/clothing/neck/roguetown/gorget/
 
 	H.adjust_blindness(-3)
 	var/weapons = list("Warhammer & Shield","Axe & Shield","Halberd","Greataxe")
@@ -79,7 +78,6 @@
 		/obj/item/rope/chain = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
-		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
 	)
 	H.verbs |= /mob/proc/haltyell
 
@@ -108,9 +106,10 @@
 
 // Ranged weapons
 /datum/advclass/heartfelt/retinue/housearb
-	name = "Heartfeltian Missilite"
+	name = "Heartfelt Missilite"
 	tutorial = "You are a Missilite for the Lord of Heartfelt, a ranged combatant of the prosperous borderlands. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/housearb
 	category_tags = list(CTAG_HFT_RETINUE)
@@ -119,23 +118,21 @@
 	subclass_stats = list(
 		STATKEY_SPD = 2,
 		STATKEY_PER = 2,
-		STATKEY_WIL = 2,
-		STATKEY_STR = 1,
-		STATKEY_CON = 2,				
+		STATKEY_LCK = 2	
 	)
 
 	subclass_skills = list(
-		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE, 		// Still have a cugel.
-		/datum/skill/combat/crossbows = SKILL_LEVEL_MASTER,		//Only effects draw and reload time.
-		/datum/skill/combat/bows = SKILL_LEVEL_MASTER,			//Only effects draw times.
-		/datum/skill/combat/slings = SKILL_LEVEL_MASTER,
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/knives = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/bows = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/slings = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, // A little better; run fast, weak boy.
-		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
@@ -145,17 +142,17 @@
 	..()
 
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/black // Fur cloak, instead of tabard due to using the brigandine for 'identification'
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/iron
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	beltl = /obj/item/rogueweapon/scabbard/sword
 	l_hand = /obj/item/rogueweapon/sword
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy		
-	armor = /obj/item/clothing/suit/roguetown/armor/brigandine
-	pants = /obj/item/clothing/under/roguetown/chainlegs
-	neck = /obj/item/clothing/neck/roguetown/gorget/steel
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
+	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	neck = /obj/item/clothing/neck/roguetown/gorget/
 
 	H.adjust_blindness(-3)
 	var/weapons = list("Crossbow","Bow","Sling")
@@ -214,35 +211,34 @@
 //  SQUIRE - Pseudo Cavalry/MAA/Skirmisher. Jack of All Trades. Master of None. Can't get trained due to Knight not getting good training.
 
 /datum/advclass/heartfelt/retinue/squire
-	name = "Heartfeltian Squire"
+	name = "Heartfelt Squire"
 	tutorial = "You are a Squire for the Knights of Heartfelt, a trainee of the valiant defenders of the prosperous borderlands. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/squire
-	maximum_possible_slots = 2 // Knight and Hand/Lord. 
+	maximum_possible_slots = 2
 	pickprob = 100
 	category_tags = list(CTAG_HFT_RETINUE)
 	class_select_category = CLASS_CAT_HFT_GUARD
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_SQUIRE_REPAIR, TRAIT_STEELHEARTED, TRAIT_HEARTFELT)
-	subclass_stats = list( // Made 9 points due to lack of Guardsman Trait
-		STATKEY_STR = 1, 
-		STATKEY_INT = 1,
+	subclass_stats = list(
+		STATKEY_INT = 2,
 		STATKEY_PER = 1,
 		STATKEY_CON = 2,
-		STATKEY_WIL = 2,
 		STATKEY_SPD = 2,
 	)
 	cmode_music = 'sound/music/combat_squire.ogg'
 
 	subclass_skills = list(
-		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,		
-		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,		
-		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,		//Only effects draw and reload time.
-		/datum/skill/combat/bows = SKILL_LEVEL_EXPERT,			//Only effects draw times.
+		/datum/skill/combat/swords = SKILL_LEVEL_NOVICE,		
+		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/maces = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/shields = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_NOVICE,		
+		/datum/skill/combat/crossbows = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/bows = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
@@ -269,7 +265,7 @@
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger = 1,  
 		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
-		/obj/item/rogueweapon/hammer/iron = 1, // Failed Squire Virtue Items
+		/obj/item/rogueweapon/hammer/iron = 1,
 		/obj/item/polishing_cream = 1,
 		/obj/item/armor_brush = 1,
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpotnew = 1,
@@ -283,18 +279,23 @@
 			l_hand = /obj/item/rogueweapon/sword
 			beltr = /obj/item/rogueweapon/scabbard/sword
 			backl = /obj/item/rogueweapon/shield/iron
+			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		if("Mace & Shield")
 			beltr = /obj/item/rogueweapon/mace/steel
 			backl = /obj/item/rogueweapon/shield/iron
+			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		if("Spear")
 			r_hand = /obj/item/rogueweapon/spear
 			backl = /obj/item/rogueweapon/scabbard/gwstrap
+			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		if("Crossbow")
 			beltr = /obj/item/quiver/bolts
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-		if("Bow") // They can head down to the armory to sideshift into one of the other bows.
+			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_JOURNEYMAN, TRUE)
+		if("Bow")
 			beltr = /obj/item/quiver/arrows
 			backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		else
 			beltr = /obj/item/rogueweapon/sword
 			backl = /obj/item/rogueweapon/shield/iron

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltworkers.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltworkers.dm
@@ -1,7 +1,8 @@
 /datum/advclass/heartfelt/retinue/servant
-	name = "Heartfeltian Servant"		
+	name = "Heartfelt Servant"		
 	tutorial = "You are Servant of Heartfelt, a Servant of the prosperous borderlands. \
-	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be."
+	However, with the increase in banditry, necromancy, deadite risings, and increasing sea raider raids, there are rumors abound that Heartfelt is not what it used to be. \
+	Travellers often warn of Heartfelt having fallen already, and words of secretive cultists isn't unheard of."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/servant
@@ -12,8 +13,7 @@
 	traits_applied = list(TRAIT_CICERONE, TRAIT_KEENEARS, TRAIT_SLEUTH, TRAIT_HOMESTEAD_EXPERT, TRAIT_SEWING_EXPERT, TRAIT_HEARTFELT)
 
 	subclass_stats = list(
-		STATKEY_PER = 2,
-		STATKEY_INT = 1,
+		STATKEY_INT = 2,
 		STATKEY_SPD = 2,
 	)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/retinue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/retinue.dm
@@ -1,6 +1,6 @@
 
 /datum/job/roguetown/heartfelt/retinue
-	title = "Heartfeltian Retinue"
+	title = "Heartfelt Retinue"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
 	job_traits = list(TRAIT_HEARTFELT)

--- a/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
+++ b/code/modules/spells/spell_types/skills/invoked_aoe/orders.dm
@@ -25,7 +25,7 @@
 		else if(user.job == "Wretch")
 			affectedjobs = list("Brother")
 		else if(user.job == "Migrant")
-			affectedjobs = list("Heartfeltian Retinue", "Migrant")
+			affectedjobs = list("Heartfelt Retinue", "Migrant")
 		else //failsafe in case someone somehow gets the spells without a role that uses them
 			to_chat(user, span_alert("I don't have authority to order anyone!"))
 			revert_cast()

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -445,7 +445,7 @@ Their proximity to the Terrorbog, however, means that they're also oft-beleaguer
 		<br><br>
 		A greater kingdom of mild renown, Heartfelt sits upon the Borderland - a remarkably temperate mesa that is equally distant from Azuria, Rockhill, Lyndvhar, and the Vale. Such makes it the ideal destination for the intermingling, banqueting, and negotiating of noblemen all across the inner contient.
 <br><br>
-Trouble has recently tickled its underbelly, however, with the steadying presence of misfortune and malice. Heartfeltian envoys are becoming increasingly common, and can now oft-be-seen as diplomatic guests to many of the aforementioned kingdoms.
+Trouble has recently tickled its underbelly, however, with the steadying presence of misfortune and malice. Heartfelt envoys are becoming increasingly common, and can now oft-be-seen as diplomatic guests to many of the aforementioned kingdoms. Be wary, Heartfelt is considered to be a hot-bed for Ecclesiarch occultism.
 		<br>
 	</details>
 


### PR DESCRIPTION
## About The Pull Request

Heartfelt kit+stats+skills were very overtuned for what recently got a bunch of content and was played as Keep+. This eases up on all of that. A lot of armour was swapped out to be iron/leather, skills were lessened, and so were the coins and stats given overall.

Changes `Heartfeltian` to `Heartfelt`. Doesn't make sense.

Bits of the lore were changed to put insight into the fact that Heartfelt might already be compromised and folks coming from there could be Ascendants looking for trouble.

## Testing Evidence

Balancejakking, sooo.

## Why It's Good For The Game

Upgeared freeks acting on behalf of the keep is a problem we're not going to solve with this. But curbing it and allowing for more gimmicks with less things is good and cool.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Rebalanced/Restatted/Rekitted a lot of Heartfelt roles to be lesser.
code: Made Heartfelt be a 'state in disaster' with 'potentially unfaithful actors' already in play. Use it to make ascendant retinue members or something.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
