### PR TITLE
change butler to footman, chief butler to butler and more

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/trader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/trader.dm
@@ -31,6 +31,6 @@
 		/datum/advclass/trader/harlequin,
 		/datum/advclass/trader/cuisiner,
 		/datum/advclass/trader/peddler,
-		/datum/advclass/trader/maid,
+		/datum/advclass/trader/servant,
 		/datum/advclass/trader/doomsayer
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/trader/maid.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/trader/maid.dm
@@ -1,7 +1,7 @@
-/datum/advclass/trader/maid
-	name = "Wandering Maid"
+/datum/advclass/trader/servant
+	name = "Wandering Servant"
 	tutorial = "A surviving servant of a destroyed dynasty, an exile, or a spy, one way or another, your skills will help you serve. The rest is to find your master."
-	outfit = /datum/outfit/job/roguetown/adventurer/maid
+	outfit = /datum/outfit/job/roguetown/adventurer/servant
 	allowed_sexes = list(MALE, FEMALE)
 	category_tags = list(CTAG_TRADER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	class_select_category = CLASS_CAT_TRADER
@@ -25,19 +25,32 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE
 	)
 
-/datum/outfit/job/roguetown/adventurer/maid/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/adventurer/servant/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("A surviving servant of a destroyed dynasty, an exile, or a spy, one way or another, your skills will help you serve. The rest is to find your master."))
-	
-	head = /obj/item/clothing/head/roguetown/maidhead
-	armor = /obj/item/clothing/suit/roguetown/shirt/dress/maid
-	cloak = /obj/item/clothing/cloak/apron/waist/maid
-	belt = /obj/item/storage/belt/rogue/leather/sash/maid
-	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+
+	var/choice_list = list("Butler", "Maid")
+	var/choice = input(H, "What are you?", "Occupation") as anything in choice_list
+
+	switch(choice)
+		if("Maid")
+			head = /obj/item/clothing/head/roguetown/maidhead
+			armor = /obj/item/clothing/suit/roguetown/shirt/dress/maid
+			cloak = /obj/item/clothing/cloak/apron/waist/maid
+			belt = /obj/item/storage/belt/rogue/leather/sash/maid
+			shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+		if("Butler")
+			pants = /obj/item/clothing/under/roguetown/tights/black
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+			shoes = /obj/item/clothing/shoes/roguetown/shortboots
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
+			belt = /obj/item/storage/belt/rogue/leather
+
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
-		/obj/item/recipe_book/survival = 1)
+		/obj/item/recipe_book/survival = 1
+		)

--- a/code/modules/jobs/job_types/roguetown/courtier/seneschal.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/seneschal.dm
@@ -113,8 +113,8 @@
 		SStreasury.give_money_account(ECONOMIC_UPPER_MIDDLE_CLASS, H, "Savings.")
 
 /datum/advclass/seneschal/chiefbutler
-	name = "Chief Butler"
-	tutorial = "You are the ruling class of butler and your ability to clear your throat and murmur 'I say' is without peer. Your duties and talents as seneschal remain the same, though."
+	name = "Butler"
+	tutorial = "You are the ruling class of manservants, the butler, and your ability to clear your throat and murmur 'I say' is without peer. Your duties and talents as seneschal remain the same, though."
 	outfit = /datum/outfit/job/roguetown/seneschal/chiefbutler
 	subclass_stats = list(
 		STATKEY_INT = 2,

--- a/code/modules/jobs/job_types/roguetown/peasants/servant.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/servant.dm
@@ -10,7 +10,7 @@
 	allowed_races = ACCEPTED_RACES
 	allowed_ages = ALL_AGES_LIST
 
-	tutorial = "Granted a life of comfortable servitude in the Duke's manor, you follow the Seneschal's commands and spend your day performing necessary but menial tasks. This role offers an aesthetic choice between labor-servant, maid, and butler."
+	tutorial = "Granted a life of comfortable servitude in the Duke's manor, you follow the Seneschal's commands and spend your day performing necessary but menial tasks. This role offers an aesthetic choice between labor-servant, maid, and footman."
 
 	outfit = /datum/outfit/job/roguetown/servant
 	advclass_cat_rolls = list(CTAG_SERVANT = 20)
@@ -25,7 +25,7 @@
 	job_subclasses = list(
 		/datum/advclass/servant/servant,
 		/datum/advclass/servant/maid,
-		/datum/advclass/servant/butler
+		/datum/advclass/servant/manservant
 	)
 
 /datum/advclass/servant
@@ -107,8 +107,8 @@
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_WORKING_CLASS, H, "Savings.")
 
-/datum/advclass/servant/butler
-	name = "Butler"
+/datum/advclass/servant/manservant
+	name = "Manservant"
 	tutorial = "An impeccable appearance is your core being. You still dig through the mud, though, you just do the laundry more."
 	outfit = /datum/outfit/job/roguetown/servant/butler
 	category_tags = list(CTAG_SERVANT)


### PR DESCRIPTION
## About The Pull Request

1. Butler is now Footman (accurate).
2. Chief Butler is now Butler (accurate, because butlers used to be the head `servant`)
3. Wandering Maid is now Wandering Servant with Butler/Maid sub-choices.

## Testing Evidence

Sure.

## Why It's Good For The Game

Accuracy and equality. I like to do men in suits as much as I like to do men in maid dresses.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Butler -> Footman.
code: Chief Butler -> Butler.
code: Wandering Maid -> Wandering Servant (with Maid/Butler choices).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
