### PR TITLE
Men

### DIFF
--- a/virtues/size.dm
+++ b/virtues/size.dm
@@ -1,6 +1,6 @@
 /datum/virtue/size/giant
 	name = "Giant"
-	desc = "I've always been larger, stronger and hardier than the average person. I tend to lumber around a lot, and my immense size can break down frail, wooden doors. +1 CON."
+	desc = "I've always been larger, stronger and hardier than the average person. I tend to lumber around a lot, and my immense size can break down frail, wooden doors."
 	added_traits = list(TRAIT_BIGGUY)
 	custom_text = "Increases your sprite size."
 
@@ -8,4 +8,3 @@
 	recipient.transform = recipient.transform.Scale(1.25, 1.25)
 	recipient.transform = recipient.transform.Translate(0, (0.25 * 16))
 	recipient.update_transform()
-	recipient.change_stat(STATKEY_CON, 1)


### PR DESCRIPTION
## About The Pull Request

(it's supposed to be "Giant Virtue Buffs" and now i can't edit it. curse you, freud!)

Ports https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1186 over from SR. Taking Giant grants 1 CON, bashing doors down deals less (200 -> 20, 80 -> 8) damage.

## Testing Evidence

it just works

## Why It's Good For The Game

The previous damage values left bashing doors down an elaborate way of unaliving yourself, and the sprite increase made you all the easier to click (ranged pokes, RMB intents and spells don't have tile-based autoaim like 1-tile melee does) with little in the way of actual value for the virtue slot.

Should hopefully encourage people to make FromSoftware boss-coded characters to cuddle me. Not like "minor utility + 1 statpoint" is anything new, what with the Intellectual meta.

## Changelog

:cl:
balance: Giant Virtue charging doors deals less damage.
/:cl: