### PR TITLE
Makes selecting a loadout item give you its description

### DIFF
--- a/code/datums/loadout.dm
+++ b/code/datums/loadout.dm
@@ -12,8 +12,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	if(isnull(donoritem))
 		if(ckeywhitelist)
 			donoritem = TRUE
+	var/obj/targetitem = path
+	desc = targetitem.desc
 	if (triumph_cost)
-		desc += "<b>Costs [triumph_cost] TRIUMPHS.</b>"
+		desc += "<br><b>Costs [triumph_cost] TRIUMPHS.</b>"
 
 /datum/loadout_item/proc/donator_ckey_check(key)
 	if(ckeywhitelist && ckeywhitelist.Find(key))


### PR DESCRIPTION
## About The Pull Request

When you select a loadout item it prints the description of the item in the chat.

## Testing Evidence

<img width="567" height="204" alt="image" src="https://github.com/user-attachments/assets/8a8b5765-5144-4cec-be08-ea07f720c1cc" />

## Why It's Good For The Game

Lets you know what things are.

## Changelog
:cl: Randall
add: Selecting something in the loadout now prints the description along with the name.
/:cl: