### PR TITLE
removes progress bars from specials, uses immobilize & clickcd instead

### DIFF
--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -544,7 +544,7 @@ SPECIALS START HERE
 	post_icon_state = "sweep_fx"
 	pre_icon_state = "trap"
 	sfx_pre_delay = 'sound/combat/flail_sweep.ogg'
-	use_doafter = TRUE
+	use_doafter = FALSE
 	respect_adjacency = FALSE
 	delay = 0.7 SECONDS
 	cooldown = 25 SECONDS
@@ -557,8 +557,10 @@ SPECIALS START HERE
 	var/dam = 20
 
 /datum/special_intent/flail_sweep/on_create()
-	. = ..()
 	victim_count = initial(victim_count)
+	if(howner)
+		howner.Immobilize(delay)
+		howner.apply_status_effect(/datum/status_effect/debuff/clickcd(delay))
 
 /datum/special_intent/flail_sweep/apply_hit(turf/T)
 	for(var/mob/living/L in get_hearers_in_view(0, T))
@@ -611,7 +613,7 @@ SPECIALS START HERE
 	tile_coordinates = AXE_SWING_GRID_DEFAULT
 	post_icon_state = "sweep_fx"
 	pre_icon_state = "trap"
-	use_doafter = TRUE
+	use_doafter = FALSE
 	respect_adjacency = FALSE
 	delay = 0.5 SECONDS
 	cooldown = 25 SECONDS
@@ -635,7 +637,9 @@ SPECIALS START HERE
 
 //We play the pre-sfx here because it otherwise it gets played per tile. Sounds funky.
 /datum/special_intent/axe_swing/on_create()
-	..()
+	if(howner)
+		howner.Immobilize(0.9 SECONDS)	//total pause for all the hits
+		howner.apply_status_effect(/datum/status_effect/debuff/clickcd(0.9 SECONDS))
 	playsound(howner, 'sound/combat/rend_start.ogg', 100, TRUE)
 
 /datum/special_intent/axe_swing/apply_hit(turf/T)

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -560,7 +560,7 @@ SPECIALS START HERE
 	victim_count = initial(victim_count)
 	if(howner)
 		howner.Immobilize(delay)
-		howner.apply_status_effect(/datum/status_effect/debuff/clickcd(delay))
+		howner.apply_status_effect(/datum/status_effect/debuff/clickcd, delay)
 
 /datum/special_intent/flail_sweep/apply_hit(turf/T)
 	for(var/mob/living/L in get_hearers_in_view(0, T))
@@ -639,7 +639,7 @@ SPECIALS START HERE
 /datum/special_intent/axe_swing/on_create()
 	if(howner)
 		howner.Immobilize(0.9 SECONDS)	//total pause for all the hits
-		howner.apply_status_effect(/datum/status_effect/debuff/clickcd(0.9 SECONDS))
+		howner.apply_status_effect(/datum/status_effect/debuff/clickcd, 0.9 SECONDS)
 	playsound(howner, 'sound/combat/rend_start.ogg', 100, TRUE)
 
 /datum/special_intent/axe_swing/apply_hit(turf/T)


### PR DESCRIPTION
## About The Pull Request
Only two had it, Flail & Axe. I moved away from the bar as I developed more Specials because it proved to be very wonky for the timing logic and for general feel.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_s0PQnpOO7g](https://github.com/user-attachments/assets/1015c8ce-04fd-4356-812f-40c1773f0dfb)
![dreamseeker_ek3OqHjrTQ](https://github.com/user-attachments/assets/776d6cf3-4ba7-4999-8842-04b261192fc4)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Pros:
- The user will know exactly what happens when you activate a Special timings-wise (more consistent)
- The user will be able to rotate if needed
- The Specials can no longer be interrupted

Cons:
- Slight loss of visual indicators (no progress bar anymore)
- The Specials can no longer be interrupted, so the user WILL be immobilized / clickCD'd for the duration of the windup.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Specials no longer use progress bars, they immobilize and apply a clickcd instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
