### PR TITLE
Ravox's arena border control

### DIFF
--- a/code/modules/spells/pantheon/divine/necra.dm
+++ b/code/modules/spells/pantheon/divine/necra.dm
@@ -501,6 +501,12 @@
 
 /obj/effect/proc_holder/spell/invoked/raise_spirits_vengeance/cast(list/targets, mob/living/user)
 	. = ..()
+
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I reach for outer help, but something rebukes me! This challenge is only for me to overcome!"))
+		revert_cast()
+		return FALSE
+
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]
 		if(user.dir == SOUTH || user.dir == NORTH)

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -112,6 +112,11 @@
 	var/turf/T = get_turf(targets[1])
 	if(!isopenturf(T))
 		return FALSE
+	
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I tried to escape, but something rebukes me! There's no escape until the end of the challenge!"))
+		revert_cast()
+		return FALSE
 
 	if(locate(/obj/structure/deaths_door_portal) in T)
 		to_chat(user, span_warning("A gate already stands here."))

--- a/code/modules/spells/roguetown/acolyte/ravox.dm
+++ b/code/modules/spells/roguetown/acolyte/ravox.dm
@@ -561,6 +561,12 @@ GLOBAL_LIST_EMPTY(arenafolks) // we're just going to use a list and add to it. S
 
 /obj/effect/proc_holder/spell/invoked/raise_warrior_spirits/cast(list/targets, mob/living/user)
 	. = ..()
+
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I reach for outer help, but Ravox rebukes me! This opponet is only for me to overcome!"))
+		revert_cast()
+		return FALSE
+
 	if(!("[user.mind.current.real_name]_faction" in user.faction))  //FUCK VVV
 		user.faction |= "[user.mind.current.real_name]_faction"
 

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -92,6 +92,11 @@
 /obj/effect/proc_holder/spell/invoked/raise_undead_formation/cast(list/targets, mob/living/user)
 	..()
 
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I reach for outer help, but something rebukes me! This challenge is only for me to overcome!"))
+		revert_cast()
+		return FALSE
+	
 	var/turf/T = get_turf(targets[1])
 	if(!isopenturf(T))
 		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))
@@ -159,6 +164,11 @@
 /obj/effect/proc_holder/spell/invoked/raise_undead_guard/cast(list/targets, mob/living/user)
 	..()
 
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I reach for outer help, but something rebukes me! This challenge is only for me to overcome!"))
+		revert_cast()
+		return FALSE
+		
 	var/turf/T = get_turf(targets[1])
 	if(!isopenturf(T))
 		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))

--- a/code/modules/spells/spell_types/undead/summon/raise_undead.dm
+++ b/code/modules/spells/spell_types/undead/summon/raise_undead.dm
@@ -20,6 +20,11 @@
 /obj/effect/proc_holder/spell/invoked/raise_undead/cast(list/targets, mob/living/user)
 	..()
 
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I reach for outer help, but something rebukes me! This challenge is only for me to overcome!"))
+		revert_cast()
+		return FALSE
+
 	var/turf/T = get_turf(targets[1])
 	if(!isopenturf(T))
 		to_chat(user, span_warning("The targeted location is blocked. My summon fails to come forth."))

--- a/code/modules/spells/spell_types/wildshape.dm
+++ b/code/modules/spells/spell_types/wildshape.dm
@@ -28,6 +28,11 @@
 /obj/effect/proc_holder/spell/self/wildshape/cast(list/targets, mob/living/carbon/human/user = usr)
 	. = ..()
 
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I tried to transform, but something rebukes me! This challenge is for my current vessel only!"))
+		revert_cast()
+		return FALSE
+
 	if(user.has_status_effect(/datum/status_effect/debuff/submissive))
 		to_chat(user, span_warning("Your will is too broken to change form."))
 		return FALSE

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_primordial.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_primordial.dm
@@ -23,6 +23,12 @@
 	var/spellsgranted = FALSE
 /obj/effect/proc_holder/spell/invoked/conjure_primordial/cast(list/targets, mob/living/user)
 	. = ..()
+
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I reach for outer help, but something rebukes me! This challenge is only for me to overcome!"))
+		revert_cast()
+		return
+
 	if(length(conjured_mobs) >= 2)
 		to_chat(user, span_warning("You can not possibly maintain your focus on any more primordials!"))
 		revert_cast()

--- a/code/modules/spells/spell_types/wizard/conjure/find_familiar.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/find_familiar.dm
@@ -33,7 +33,12 @@
 /obj/effect/proc_holder/spell/self/findfamiliar/cast(list/targets, mob/living/carbon/user)
 	if (!user)
 		return FALSE
-
+	
+	if(istype(get_area(user), /area/rogue/indoors/ravoxarena))
+		to_chat(user, span_userdanger("I reach for outer help, but something rebukes me! This challenge is only for me to overcome!"))
+		revert_cast()
+		return FALSE
+		
 	// Prevent multiple simultaneous summon attempts
 	if (user.busy_summoning_familiar)
 		to_chat(user, span_warning("You are already attempting to summon a familiar! Please wait for your current summon to resolve."))


### PR DESCRIPTION
## About The Pull Request

While at Ravox's arena, you;re no longer able to summon dudes. Skeletons for zizoids, skulls/door for necrites, familiars or primordials for mages and warrior spirits for ravoxites.
Also dendorites are no longer able to transform while challenged 'cause if they do they'll stuck at the arena forever.

## Testing Evidence

<img width="1607" height="989" alt="image" src="https://github.com/user-attachments/assets/69a3e57b-44a7-4285-9326-cfd6b25eca9c" />
<img width="583" height="106" alt="image" src="https://github.com/user-attachments/assets/51ec8ee3-1d11-41de-987d-81eab5823e75" />



## Why It's Good For The Game
![Без имени-1](https://github.com/user-attachments/assets/df2c4e76-118a-49d1-9833-5ab5ad7c6852)

I mean, it's a duel. There's no way for your friends to participate.
Arena barely fits two people.
Also all summons stay at the arena forever.

## Changelog

:cl:
add: You're no longer able to summon creatures while at Ravox's arena.
add: Dendorites no longer able to transform while at Ravox's arena.
add: Necrites no longer able to leave through the Door while at Ravox's arena.
/:cl:
