### PR TITLE
Functionally revert the adventurer wave adjustment.

### DIFF
--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -46,6 +46,7 @@
 /datum/migrant_wave/pilgrim
 	name = "Pilgrimage"
 	downgrade_wave = /datum/migrant_wave/pilgrim_down_one
+	weight = 100 // It is a "default" wave 
 	roles = list(
 		/datum/migrant_role/pilgrim = 4,
 	)
@@ -83,6 +84,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 4,
 	)
+	weight = 100 // Adventurers is the default spillover role and instead of just setting adventurers slots up high at roundstart we'll let people join in gradually through the round
 	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Azure Peak, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/adventurer_down_one


### PR DESCRIPTION
## About The Pull Request
On AP, when Adventurer slots fills up, the strategy is often to blow triumphs on a party or wait for an adventurer wave to roll (1 in 5) to latejoin. 

https://github.com/Azure-Peak/Azure-Peak/pull/5415 functionally killed this by lowering the pilgrimage and adventurer wave weight to lower than other special waves, which in turn benefits getting Heartfelt for free.

This changes reverts both Pilgrimage and Adventurer weight back to 100 (this time explicitly defined) because those waves rolling benefits **FAR** more people than hyperspecialized migration waves.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="650" height="500" alt="vKg3Z14q8c" src="https://github.com/user-attachments/assets/b81ada3b-a0c3-483d-a8f1-fd2afe5986f3" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This is an entirely self serving PR to revert the other self serving PR.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Adventurer & Pilgrimage wave weight reverted back to 100 with approximately 20% chance of rolling each wave.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
