### PR TITLE
add woodcutter's apprentice

### DIFF
--- a/virtues/crafter.dm
+++ b/virtues/crafter.dm
@@ -79,5 +79,18 @@
 	desc = "The dark shafts, the damp smells of ichor and the laboring hours are no stranger to me. I keep my pickaxe and lamptern close, and have been taught how to mine well."
 	added_stashed_items = list(
 		"Steel Pickaxe" = /obj/item/rogueweapon/pick/steel,
-		"Lamptern" = /obj/item/flashlight/flare/torch/lantern)
-	added_skills = list(list(/datum/skill/labor/mining, 3, 6))
+		"Lamptern" = /obj/item/flashlight/flare/torch/lantern
+	)
+	added_skills = list(
+		list(/datum/skill/labor/mining, 3, SKILL_LEVEL_LEGENDARY)
+	)
+
+/datum/virtue/utility/woodcutting
+	name = "Woodcutter's Apprentice"
+	desc = "I know which way the tree falls, when you sever it from its roots. Hence, I keep my axe close."
+	added_stashed_items = list(
+		"Steel Axe" = /obj/item/rogueweapon/stoneaxe/woodcut/steel/woodcutter
+	)
+	added_skills = list(
+		list(/datum/skill/labor/lumberjacking, 3, SKILL_LEVEL_LEGENDARY)
+		)


### PR DESCRIPTION
## About The Pull Request

what it says on the tin. +3 skill in lumberjacking and a woodcutter's axe.

## Testing Evidence

yes

## Why It's Good For The Game

lumberjack crafter virtue

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: woodcutter's apprentice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
