### PR TITLE
The Unstoppable Juggerjak (Tankier Berserkers and a new subclass)

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -188,6 +188,12 @@
 	desc = "I've endured enough. The onslaught has lost its meaning."
 	armor = ARMOR_LEATHER
 
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/stalker
+	name = "stalker's skin"
+	desc = "One notch, for each successful hunt. One incense burn, for each failed. Every wound is a reminder that you are but mortal."
+	max_integrity = 350
+	armor = ARMOR_LEATHER
+
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/bailiff
 	name = "executioneer's skin"
 	desc = "Bearing scars of countless whips leaves a gnarly visage. Now it's your time to inflict the same fate upon others."

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -73,14 +73,14 @@
 			if("Discipline - Stalker")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/scabbard/sword
-				r_hand = /obj/item/rogueweapon/sword/falx/stalker //functionally identical, but has the swift tag on it so you can use your speed to shred people. you're a lighter, faster berserker.
-				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker
+				r_hand = /obj/item/rogueweapon/sword/falx/stalker //functionally identical, but has the swift tag on it so you can use your speed to shred people. you're a lighter, faster berserker. rambo vs. conan
+				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/stalker // -50 integrity
 				H.change_stat(STATKEY_STR, -1) 
 				H.change_stat(STATKEY_SPD, 1)
 				H.change_stat(STATKEY_CON, -1)
 				H.change_stat(STATKEY_WIL, 1) //goes from 3/-1/-1/2/1/1 to 2/-1/-1/1/2/2. 
 			if("Katar")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE) //these are strictly all worse than discipline - unarmed but i'm worried i'll get shot if i touch them
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE) //these are strictly all worse than unarmed but i'm worried i'll get shot if i touch them
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/katar
 			if("Knuckledusters")
@@ -96,11 +96,13 @@
 				beltr = /obj/item/rogueweapon/stoneaxe/battle
 				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
+				REMOVE_TRAIT(H, TRAIT_BLOOD_RESISTANCE, TRAIT_GENERIC) 
 			if("Grand Mace")
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/mace/goden/steel
 				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 				ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
+				REMOVE_TRAIT(H, TRAIT_BLOOD_RESISTANCE, TRAIT_GENERIC)
 
 		var/helmets = list("Berserker's Volfskulle Bascinet","Steel Kettle + Wildguard")
 		var/helmet_choice = input(H, "Choose your HELMET.", "STEEL YOURSELF.") as anything in helmets

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -20,7 +20,7 @@
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
@@ -54,12 +54,13 @@
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	if(H.mind)
-		var/weapons = list("Discipline - Unarmed","Discipline - Bodybuilder","Katar","Knuckledusters","Punch Dagger","Battle Axe","Grand Mace","Falx")
+		var/weapons = list("Discipline - Unarmed","Discipline - Bodybuilder","Discipline - Stalker","Katar","Knuckledusters","Punch Dagger","Battle Axe","Grand Mace",)
 		var/weapon_choice = input(H, "Choose your WEAPON.", "SPILL THEIR ENTRAILS.") as anything in weapons
 		H.set_blindness(0)
 		switch(weapon_choice)
 			if("Discipline - Unarmed")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker
 			if("Discipline - Bodybuilder")
@@ -67,26 +68,40 @@
 				r_hand = /obj/item/rogueweapon/greatsword/paalloy
 				armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather/good
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				H.change_stat(STATKEY_INT, -3) /// Same reasoning as advent barbarian. I think it makes the subclass shit, but it is what it is.
+			if("Discipline - Stalker")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/falx/stalker //functionally identical, but has the swift tag on it so you can use your speed to shred people. you're a lighter, faster berserker.
+				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker
+				H.change_stat(STATKEY_STR, -1) 
+				H.change_stat(STATKEY_SPD, 1)
+				H.change_stat(STATKEY_CON, -1)
+				H.change_stat(STATKEY_WIL, 1) //goes from 3/-1/-1/2/1/1 to 2/-1/-1/1/2/2. 
 			if("Katar")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE) //these are strictly all worse than discipline - unarmed but i'm worried i'll get shot if i touch them
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/katar
 			if("Knuckledusters")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/knuckles
 			if("Punch Dagger")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/katar/punchdagger
 			if("Battle Axe")
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/stoneaxe/battle
+				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
+				ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
 			if("Grand Mace")
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/mace/goden/steel
-			if("Falx")
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-				beltr = /obj/item/rogueweapon/scabbard/sword
-				r_hand = /obj/item/rogueweapon/sword/falx
+				ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
+				ADD_TRAIT(H, TRAIT_CRITICAL_RESISTANCE, TRAIT_GENERIC)
+
 		var/helmets = list("Berserker's Volfskulle Bascinet","Steel Kettle + Wildguard")
 		var/helmet_choice = input(H, "Choose your HELMET.", "STEEL YOURSELF.") as anything in helmets
 		switch(helmet_choice)


### PR DESCRIPTION
## About The Pull Request

Non-unarmed Wretch berserkers got their crit resist back at the cost of some wrestling strength. Also, new berserker subclass, the stalker - they're a bit faster, and replace the falx option that was already there.

## Why It's Good For The Game

The goal of #5026 was to make wrestling and unarmed builds less good because they weren't fun to fight. Regardless of whether or not you agree with this course of action, it rendered most non-unarmed barbarians unviable by taking away their key defensive ability and not giving them the new regenerating barbarian skin in return, like they did with unarmed. 

**TL;DR, Axe-or-mace wielding berserkers got their critical resilience back, but don't have enough wrestling skill to swift pick you anymore. Unarmed berserkers are unchanged from the previous PR. New subclass that's a lighter, angrier berserker.** 

## Changelog

:cl:
add: new berserker subclass
balance: non-grappling berserkers get their critres back
/:cl: