### PR TITLE
Fix: "Spawn Reagent Container" functionality in GM tab

### DIFF
--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -97,6 +97,8 @@
 				<script>
 				window.onload=function(){
 
+					var byondUrl = "byond://?src=[REF(usr.client.holder)]";
+
 					var reagents = [reagentsforbeakers()];
 
 					var containers = [beakersforbeakers()];
@@ -131,17 +133,14 @@
 							var ret = {};
 							grenadeData\[$(this).attr('name')\] = $(this).val();
 						});
-					  $.ajax({
-					      url: '',
-					      data: {
-									"_src_": "holder",
-									"admin_token": "[RawHrefToken()]",
-									"beakerpanel": "spawngrenade",
-									"containers": JSON.stringify(containers),
-									"grenadetype": grenadeType,
-									"grenadedata": JSON.stringify(grenadeData)
-								}
-					    });
+					  sendByond({
+							"_src_": "holder",
+							"admin_token": "[RawHrefToken()]",
+							"beakerpanel": "spawngrenade",
+							"containers": JSON.stringify(containers),
+							"grenadetype": grenadeType,
+							"grenadedata": JSON.stringify(grenadeData)
+					  });
 					});
 
 					$('.spawn-container').click(function() {
@@ -150,16 +149,13 @@
 					  var reagents = $(container).find("li.reagent").map(function() {
 					  	return { "reagent": $(this).data("type"), "volume": $(this).find('input').val()};
 					    }).get();
-					  $.ajax({
-					  	url: '',
-					    data: {
-								"_src_": "holder",
-								"admin_token": "[RawHrefToken()]",
-								"beakerpanel": "spawncontainer",
-								"container": JSON.stringify({"container": type, "reagents": reagents }),
+					  sendByond({
+							"_src_": "holder",
+							"admin_token": "[RawHrefToken()]",
+							"beakerpanel": "spawncontainer",
+							"container": JSON.stringify({"container": type, "reagents": reagents })
 
-							}
-						});
+					  });
 					});
 
 					$('.add-reagent').click(function() {
@@ -197,6 +193,12 @@
 						$('.grenade-data').hide();
 					  $('.grenade-data.'+$(this).val()).show();
 					})
+
+					function sendByond(params)
+					{
+						var query = $.param(params).replace(/&/g, ";");
+						window.location.href = byondUrl + ";" + query;
+					}
 
 					function addReagent(ul, reagentType, reagentName, amount)
 					{


### PR DESCRIPTION
## About The Pull Request
Fixed the "Spawn Reagent Container" functionality within the -Game Master- tab.
Improved UI/UX: Admins can now correctly select a container and specify which reagents should be added to it upon spawning.
Logic Correction: Ensured the reagents are properly injected into the spawned entity during the creation process.
## Testing Evidence
Opened the -Game Master- tab in-game.
Selected "Spawn Reagent Container".
Picked a "Beaker" and added reagents to the list.
Result: The beaker spawned successfully with the specified reagents inside.
## Why It's Good For The Game
Admin Quality of Life: Previously, the tool was broken or unreliable. This fix allows GMs to create custom chemical setups instantly for events or testing without manual injection.

Consistency: Restores intended functionality to the admin toolkit, making it consistent with other spawning tools.

Changelog
:cl: admin: Fixed "Spawn Reagent Container" in the Game Master tab, allowing correct reagent selection.
qol: Improved the reagent container spawning interface for admins. :cl: