### PR TITLE
Minor Warden mapping changes

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -9917,6 +9917,10 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
+"cvS" = (
+/obj/machinery/light/rogue/candle/off/r,
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/shelter/woods)
 "cvU" = (
 /obj/structure/table/wood/long_table,
 /obj/item/candle/yellow/lit,
@@ -289933,7 +289937,7 @@ dpy
 dpy
 nTq
 gap
-bWg
+cvS
 hnC
 lGG
 jaH


### PR DESCRIPTION
## About The Pull Request

Makes a few very small mapping changes relating to the wardens' barracks and outpost. 

- The bridge is now a single turf to the south to give the north more space.
- The area with grinding wheels now also has tables. Craft a hammer and it makes a functional repair station.
- Both the barracks and outpost watchtower now have vomitoriums, matching the garrison kitchen, and the watchtower has a single knob of butter.
- The barracks now has a meister, matching the garrison.
- Moved the candles on the ground floor of the watchtower away from the cart, to avoid an interaction in which the candles get initialised as being inside the cart until ejected.

## Testing Evidence

Successful compilation!

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

This resolves a gaggle of little awkward interactions that had been nagging at me, plus one minor bug. Vomitoriums should avoid the ever-awkward interaction of having to run all the way back to town for a single ingredient.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Implemented a few minor mapping changes to the outpost and wardens' barracks; notably, both now have a vomitorium in their kitchens!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
