### PR TITLE
A Very Careful Arrow Rebalance

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -406,7 +406,7 @@
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/bronze
 	icon_state = "bronzearrow_proj"
 	damage = 40
-	armor_penetration = 0 // Pierces 80 (padded gambesons) at 20PER, 17PER with a longbow.
+	armor_penetration = 0 // Cannot pierce 80 (padded gambesons) with a recurve, does so at 17PER with a longbow.
 	embedchance = 70
 	npc_simple_damage_mult = 3 //More damage over simplemobs!
 	speed = 0.15 // Faster!


### PR DESCRIPTION
## About The Pull Request

Rebalances the damage and armour penetration values of the most common arrows around the framework of padded gambesons; **the ethos of this PR is that it should be difficult to penetrate a padded gambeson, or anything with a higher pierce armour value, with anything that isn't a bodkin arrow.** As such, this buffs bodkin AP by 10 to allow it to do so even with quite low perception, and lowers the damage and AP of broadheads by 5 to prevent it from doing so as easily.

This PR values AP significantly lower than it values damage, and implements documentation to reflect that. Accordingly, it also modifies the values of a few other arrows to make sense with the new framework.

## Testing Evidence

I haven't tested every single arrow, but what I did test all lined up with the math.

<img width="441" height="264" alt="image" src="https://github.com/user-attachments/assets/695724c8-a9e6-4769-b52e-93b1cd1069a0" />
<img width="121" height="56" alt="image" src="https://github.com/user-attachments/assets/5d3f9876-0e94-4b23-8932-442bac9cf3ba" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Damage for projectiles is subject to a hell of a lot of multiplication, and damage factors into penetration. The result of this has been that broadheads have both been slightly overperforming, and also totally eclipsing the niche of bodkins, as their very high damage lets them penetrate all the armour they could ever need to on a build with decent perception.

Broadheads are meant to be the high-damage option which falters against armour, and bodkins are meant to be the low-damage option which consistently penetrates armour. This aims to make that dynamic clearer - broadheads shouldn't be essentially all-penning on your standard bow build, bodkins shouldn't totally be eclipsed by broadheads, and you should be able to fight archers wearing very high pierce defense armour and be relatively confident it'll protect you, at least on your centre mass, unless they have the special armour-piercing arrows.

Another implication of this is that, if you do want to consistently penetrate 80+ armour with your usual archer build, longbows now hit some important breakpoints with broadheads that you previously didn't need a longbow for. I don't feel bad about throwing longbows a bone - they're by no means non-viable right now, but most-everyone agrees they're worse than recurves.

**This is by no means a magic bullet for bow balance!** I main an archer and generally believe they're in an okay place, this is intended as a very incremental change, not something that'll overhaul the way bows feel to play with.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Implemented a very careful rebalance for the damage of most arrows in the game. Broadheads are now slightly weaker, and penetrate armour slightly less effectively - bodkins have retained their low damage, but are capable of piercing armour more easily than before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
