### PR TITLE
Spells going on CD is unconditional instead of dependent on cast succ…

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -437,18 +437,15 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 /obj/effect/proc_holder/spell/proc/start_recharge()
     var/final_time = calculate_recharge_time()
-
+    
     next_recharge_time = world.time + final_time
     addtimer(CALLBACK(src, .proc/finish_recharge), final_time)
-    if(action?.button)
-        action.button.update_maptext(final_time)
 
 /obj/effect/proc_holder/spell/proc/finish_recharge()
 	charge_counter = recharge_time
 
 	// Notify it is recharged - even if you cannot cast right now.
 	if(action?.button)
-		action.button.update_maptext(0)
 		action.button.color = rgb(255,255,255,255)
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = TRUE, mob/user = usr) //if recharge is started is important for the trigger spells
@@ -578,8 +575,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		if("holdervar")
 			adjust_var(user, holder_var_type, -holder_var_amount)
 	START_PROCESSING(SSfastprocess, src)
-	if(action?.button)
-		action.button.update_maptext(0)
+	if(action)
 		action.UpdateButtonIcon()
 	if(user.mmb_intent && user.mmb_intent.mob_light)
 		QDEL_NULL(user.mmb_intent.mob_light)


### PR DESCRIPTION
## About The Pull Request
- Fixes issues with multiple spells not having cooldown due to a missing return
- Now if it cast it is going on cooldown, period.
It was broken with 5517 https://github.com/Azure-Peak/Azure-Peak/pull/5517 as the previous processing system was a bandaid upon this issue
- Also added a cast_reverted check so that reverted cast actually don't trigger cooldown
- Also added cooldown count to spells

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yeah

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugged cooldown is bad.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Several spells like secular appraisal and meteor storm should actually go on cooldown while cast. Reports any spells that fail to cast and fails to revert.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
