### PR TITLE
Estoc minor tweak

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -1284,13 +1284,13 @@
 	force = 12
 	force_wielded = 25
 	possible_item_intents = list(
-		/datum/intent/sword/chop,
+		/datum/intent/sword/cut,
 		/datum/intent/sword/strike,
 	)
 	gripped_intents = list(
 		/datum/intent/sword/thrust/estoc,
 		/datum/intent/sword/lunge,
-		/datum/intent/sword/chop,
+		/datum/intent/sword/cut,
 		/datum/intent/sword/strike,
 	)
 	bigboy = TRUE


### PR DESCRIPTION
## About The Pull Request

Swaps estoc's chop intent with cut.

## Testing Evidence

<img width="130" height="145" alt="image" src="https://github.com/user-attachments/assets/43795d78-fd3f-42c2-8e7d-5d20e63ac504" />
<img width="141" height="147" alt="image" src="https://github.com/user-attachments/assets/2f0a8edf-6afb-4c0b-8bcd-d4191670034d" />


## Why It's Good For The Game

stab >> chop
chop = cringe
cut = good
cut > chop

Stab functionally performs better than chop so it has no use. Replacing chop with cut so estoc is slightly less niche in its use.
## Changelog

:cl:
balance: Estoc now cuts instead of chops.
/:cl: