### PR TITLE
assorted confessorjak

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -49,25 +49,25 @@
 	lifetime--
 	if(lifetime < 1)
 		kill_smoke()
-		return 0
+		return FALSE
 	for(var/mob/living/L in range(0,src))
 		smoke_mob(L)
-	return 1
+	return TRUE
 
 /obj/effect/particle_effect/smoke/proc/smoke_mob(mob/living/carbon/C)
 	if(!istype(C))
-		return 0
+		return FALSE
 	if(lifetime<1)
-		return 0
+		return FALSE
 	if(C.smoke_delay)
-		return 0
+		return FALSE
 	if(istype(C.wear_mask, /obj/item/clothing/mask/rogue/facemask/steel/confessor))
-		return 0
+		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NOBREATH) || HAS_TRAIT(C, TRAIT_NOMETABOLISM))
-		return 0
+		return FALSE
 	C.smoke_delay++
 	addtimer(CALLBACK(src, PROC_REF(remove_smoke_delay), C), 10)
-	return 1
+	return TRUE
 
 /obj/effect/particle_effect/smoke/proc/remove_smoke_delay(mob/living/carbon/C)
 	if(C)
@@ -132,7 +132,7 @@
 		M.drop_all_held_items()
 		M.adjustOxyLoss(1)
 		M.emote("cough")
-		return 1
+		return TRUE
 
 
 /datum/effect_system/smoke_spread/bad
@@ -149,10 +149,10 @@
 /obj/effect/particle_effect/smoke/poison_gas/smoke_mob(mob/living/carbon/M)
 	if(..())
 		if(HAS_TRAIT(M, TRAIT_HOLDBREATH))
-			return 0
+			return FALSE
 		M.adjustToxLoss(20, 0)
 		M.emote("cough")
-		return 1
+		return TRUE
 
 /datum/effect_system/smoke_spread/poison_gas
 	effect_type = /obj/effect/particle_effect/smoke/poison_gas
@@ -169,13 +169,13 @@
 /obj/effect/particle_effect/smoke/healing_gas/smoke_mob(mob/living/carbon/M)
 	if(..())
 		if(HAS_TRAIT(M, TRAIT_HOLDBREATH))
-			return 0
+			return FALSE
 		M.adjustBruteLoss(-5, 0)
 		M.adjustFireLoss(-2, 0)
 		M.adjustOxyLoss(-1, 0)
 		M.adjustToxLoss(-1, 0)
 		M.emote("cough")
-		return 1
+		return TRUE
 
 /datum/effect_system/smoke_spread/healing_gas
 	effect_type = /obj/effect/particle_effect/smoke/healing_gas
@@ -195,7 +195,7 @@
 		M.adjust_fire_stacks(3)
 		M.ignite_mob()
 		M.emote("scream")
-		return 1
+		return TRUE
 
 /datum/effect_system/smoke_spread/fire_gas
 	effect_type = /obj/effect/particle_effect/smoke/fire_gas
@@ -211,11 +211,11 @@
 /obj/effect/particle_effect/smoke/blind_gas/smoke_mob(mob/living/carbon/M)
 	if(..())
 		if(HAS_TRAIT(M, TRAIT_HOLDBREATH))
-			return 0
+			return FALSE
 		M.adjust_blurriness(3)
 		M.adjust_blindness(3)
 		M.emote("cry")
-		return 1
+		return TRUE
 
 /datum/effect_system/smoke_spread/blind_gas
 	effect_type = /obj/effect/particle_effect/smoke/blind_gas
@@ -232,9 +232,9 @@
 /obj/effect/particle_effect/smoke/mute_gas/smoke_mob(mob/living/carbon/M)
 	if(..())
 		if(HAS_TRAIT(M, TRAIT_HOLDBREATH))
-			return 0
+			return FALSE
 		M.silent = max(M.silent, 8)
-		return 1
+		return TRUE
 
 /datum/effect_system/smoke_spread/mute_gas
 	effect_type = /obj/effect/particle_effect/smoke/mute_gas
@@ -250,10 +250,10 @@
 /obj/effect/particle_effect/smoke/sleeping/smoke_mob(mob/living/carbon/M)
 	if(..())
 		if(HAS_TRAIT(M, TRAIT_HOLDBREATH))
-			return 0
+			return FALSE
 		M.Sleeping(200)
 		M.emote("cough")
-		return 1
+		return TRUE
 
 /datum/effect_system/smoke_spread/sleeping
 	effect_type = /obj/effect/particle_effect/smoke/sleeping
@@ -278,17 +278,17 @@
 			reagents.reaction(AM, TOUCH, fraction)
 
 		reagents.reaction(T, TOUCH, fraction)
-		return 1
+		return TRUE
 
 /obj/effect/particle_effect/smoke/chem/smoke_mob(mob/living/carbon/M)
 	if(lifetime<1)
-		return 0
+		return FALSE
 	if(!istype(M))
-		return 0
+		return FALSE
 	var/fraction = 1/initial(lifetime)
 	reagents.copy_to(M, fraction*reagents.total_volume)
 	reagents.reaction(M, INGEST, fraction)
-	return 1
+	return TRUE
 
 
 

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -527,6 +527,7 @@
 	name = "psydonic chestplate"
 	desc = "An expertly smithed form-fitting steel cuirass that is much lighter and agile, but breaks with much more ease. It's thinner, but backed with silk and leather."
 	smelt_bar_num = 1
+	max_integrity = ARMOR_INT_CHEST_LIGHT_BASE
 	smeltresult = /obj/item/ingot/silverblessed
 	icon_state = "ornatechestplate"
 	item_state = "ornatechestplate"

--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -320,7 +320,7 @@
 	body_parts_covered = NECK | HEAD | HAIR
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-	prevent_crits = PREVENT_CRITS_NONE
+	prevent_crits = PREVENT_CRITS_MOST
 	armor = ARMOR_SPELLSINGER
 	dynamic_hair_suffix = ""
 	edelay_type = 1

--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -222,7 +222,7 @@
 	armor = ARMOR_LEATHER_GOOD
 	max_integrity = ARMOR_INT_HELMET_LEATHER
 	body_parts_covered = HEAD|HAIR|EARS
-	prevent_crits = PREVENT_CRITS_NONE
+	prevent_crits = PREVENT_CRITS_MOST
 	sewrepair = TRUE
 	//dropshrink = 0.75
 	dynamic_hair_suffix = null

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -31,6 +31,7 @@
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT
 	)
 	subclass_stashed_items = list(
 		"Tome of Psydon" = /obj/item/book/rogue/bibble/psy
@@ -43,18 +44,18 @@
 /datum/outfit/job/roguetown/confessor/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
 	if(H.mind)
-		var/weapons = list("Blessed Psydonic Dagger", "Psydonic Handmace", "Psydonic Rapier")
+		var/weapons = list("Psydonic Handmace", "Psydonic Rapier", "Psydonic Shortsword")
 		var/weapon_choice = input(H,"Choose your WEAPON.", "TAKE UP PSYDON'S ARMS.") as anything in weapons
 		switch(weapon_choice)
-			if("Blessed Psydonic Dagger")
-				l_hand = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger
-				r_hand = /obj/item/rogueweapon/scabbard/sheath
-				H.adjust_skillrank_up_to(/datum/skill/combat/knives, 4, TRUE)
 			if("Psydonic Handmace")
 				l_hand = /obj/item/rogueweapon/mace/cudgel/psy
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)	
 			if("Psydonic Rapier")
 				l_hand = /obj/item/rogueweapon/sword/rapier/psy
+				r_hand = /obj/item/rogueweapon/scabbard/sword
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+			if("Psydonic Shortsword")
+				l_hand = /obj/item/rogueweapon/sword/short/psy
 				r_hand = /obj/item/rogueweapon/scabbard/sword
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 		var/armors = list("Confessor - Slurbow, Leather Maillecoat", "Arbalist - Crossbow, Psydonic Chestplate")
@@ -90,6 +91,7 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/otavan
 	belt = /obj/item/storage/belt/rogue/leather/knifebelt/black/psydon
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
+	beltl = /obj/item/rogueweapon/scabbard/sheath
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
 	mask = /obj/item/clothing/mask/rogue/facemask/steel/confessor
@@ -101,5 +103,6 @@
 		/obj/item/clothing/head/inqarticles/blackbag = 1,
 		/obj/item/inqarticles/garrote = 1,
 		/obj/item/grapplinghook = 1,
-		/obj/item/paper/inqslip/arrival/ortho = 1
+		/obj/item/paper/inqslip/arrival/ortho = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/silver/psydagger = 1
 		)


### PR DESCRIPTION
## About The Pull Request

1. Confessor hood/headband get critres (similar to literally every piece of clothing/gear in the literal game bar a few edgecases)
2. Confessors get their blessed dagger on any loadout, now.
3. Psydonite fencer cuirass has 20 more integrity (on par with the base light armour integrity).
4. Confessors get to pick a shortsword as well (alongside the other choices).

## Testing Evidence

Sure but needs ingame testing.

## Why It's Good For The Game

Confessor being balanced around a game that isn't already power-creeped to hell is a bit problematic in this environment. Templars (Orthodoxist equivalent) are a 4-slot, all plate/miracle thing. Even within the Inquisition, Confessors are the only ones *without* miracles.

They can have this little up.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Confessors get blessed dagger guaranteed.
balance: Confessor hood/headband gives critres like every other clothing item.
balance: Psydonite Fencer Cuirass has +20 integrity.
balance: Add PsyShortsword to loadout choice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
