### PR TITLE
gives confessor shitty repairable skin armour + adds framework for that

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -278,7 +278,9 @@
 						if(!item || !SEND_SIGNAL(item, COMSIG_TRY_STORAGE_INSERT, new_item, null, TRUE, TRUE))
 							item = H.get_item_by_slot(SLOT_BELT)
 							if(!item || !SEND_SIGNAL(item, COMSIG_TRY_STORAGE_INSERT, new_item, null, TRUE, TRUE))
-								addtimer(CALLBACK(PROC_REF(move_storage), new_item, H.loc), 3 SECONDS)
+								item = H.get_item_by_slot(SLOT_CLOAK)
+								if(!item || !SEND_SIGNAL(item, COMSIG_TRY_STORAGE_INSERT, new_item, null, TRUE, TRUE))
+									addtimer(CALLBACK(PROC_REF(move_storage), new_item, H.loc), 3 SECONDS)
 
 	post_equip(H, visualsOnly)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1706,15 +1706,15 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			return .
 	if(isnull(anvilrepair) && isnull(sewrepair))
 		return .
-	else
-		var/str = "This object can be repaired using "
-		if(anvilrepair)
-			var/datum/skill/S = anvilrepair		//Should only ever be a skill or null
-			str += "<b>[initial(S.name)]</b> and a hammer."
-		if(sewrepair)
-			str += "<b>Sewing</b> and a needle."
-		str = span_info(str)
-		. += str
+
+	var/str = "This object can be repaired using "
+	if(anvilrepair)
+		var/datum/skill/S = anvilrepair		//Should only ever be a skill or null
+		str += "<b>[initial(S.name)]</b> and a hammer."
+	if(sewrepair)
+		str += "<b>Sewing</b> and a needle."
+	str = span_info(str)
+	. += str
 
 /obj/item/proc/update_force_dynamic()
 	force_dynamic = (wielded ? force_wielded : force)

--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -30,7 +30,7 @@
 	if(QDELETED(src))
 		return
 	qdel(src)
-    
+
 /obj/item/clothing/suit/roguetown/armor/manual/proc/armour_regen(var/repair_percent = 0.2 * max_integrity)
     if(obj_integrity >= max_integrity)
         to_chat(loc, span_notice(repairmsg_end))
@@ -39,15 +39,94 @@
     if(obj_broken)
         obj_fix(full_repair = FALSE)
 
+
+/*
+ * PUSHUP ARMOUR
+ */
+
 /obj/item/clothing/suit/roguetown/armor/manual/pushups
-    name = "Muscular Skin"
+    name = "muscular skin"
     desc = "The reward for all your hard work. </br>THE INFLUENCE OF THE HAM SANDWYCH RACE IS WANING. I MUST DO PUSH-UPS, TO REMIND MY MUSCLES OF THEIR OWN STRENGTH."
 
     repairmsg_end = "My muscles sheen with vitality!"
     repairmsg_continue = "My muscles are reminded of their own strength."
 
+/obj/item/clothing/suit/roguetown/armor/manual/pushups/get_mechanics_examine(mob/user)
+	. = ..()
+
+	. += span_info("Repairable via push-up emotes.")
+
 /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather
-    armor_class = ARMOR_LEATHER
+    armor = ARMOR_LEATHER
 
 /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather/good
-    armor_class = ARMOR_LEATHER_GOOD
+    armor = ARMOR_LEATHER_GOOD
+
+
+/*
+ * SEWABLE ARMOUR
+ */
+
+/obj/item/clothing/suit/roguetown/armor/manual/sewable
+	var/list/repair_items[] = list(
+		/obj/item/needle = 'sound/foley/sewflesh.ogg'
+	)
+
+/obj/item/clothing/suit/roguetown/armor/manual/sewable/get_mechanics_examine(mob/user)
+	. = ..()
+
+	for(var/repair_thing in repair_items)
+		var/obj/item/thing = new repair_thing
+		. += span_info("Repairable via [thing.name].")
+
+/obj/item/clothing/suit/roguetown/armor/manual/sewable/attackby(obj/item/I, mob/user, params)
+	if(user != loc)
+		return FALSE
+	if(!repair_check(user, I))
+		return FALSE
+
+	if(!do_after(user, 5 SECONDS, target = src))
+		return FALSE
+
+	armour_regen()
+
+	playsound(loc, repair_items[I.type], 100, TRUE)
+	return TRUE
+
+/obj/item/clothing/suit/roguetown/armor/manual/sewable/proc/repair_check(mob/user, obj/item/I)
+	if(!(I.type in repair_items))
+		return FALSE
+
+	if(istype(I, /obj/item/needle))
+		var/obj/item/needle/sew_needle = I
+		if(!sew_needle.stringamt)
+			to_chat(user, span_warning("[src] has no thread!"))
+			return FALSE
+
+	return TRUE
+
+
+/obj/item/clothing/suit/roguetown/armor/manual/sewable/confessor
+	name = "arbalist's skin"
+	desc = "Taut lyke the bow I draw."
+	armor = ARMOR_CLOTHING_GOOD
+	max_integrity = ARMOR_INT_CHEST_CIVILIAN
+	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
+	repair_items = list(
+		/obj/item/needle = 'sound/foley/sewflesh.ogg',
+		/obj/item/rogueweapon/surgery/cautery = 'sound/surgery/cautery1.ogg',
+	)
+
+/obj/item/clothing/suit/roguetown/armor/manual/sewable/repair_check(mob/user, obj/item/I)
+	. = ..()
+
+	if(!.)
+		return FALSE
+
+	if(istype(I, /obj/item/rogueweapon/surgery/cautery))
+		var/obj/item/rogueweapon/surgery/cautery/sew_cautery = I
+		if(!sew_cautery.heated)
+			to_chat(user, span_warning("[src] is not heated up!"))
+			return FALSE
+
+	return TRUE

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -58,7 +58,7 @@
 				l_hand = /obj/item/rogueweapon/sword/short/psy
 				r_hand = /obj/item/rogueweapon/scabbard/sword
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
-		var/armors = list("Confessor - Slurbow, Leather Maillecoat", "Arbalist - Crossbow, Psydonic Chestplate")
+		var/armors = list("Confessor - Slurbow, Leather Maillecoat", "Arbalist - Crossbow, Psydonic Chestplate, Pushup Armour")
 		var/armor_choice = input(H, "Choose your ARCHETYPE.", "TAKE UP PSYDON'S DUTY.") as anything in armors
 		switch(armor_choice)
 			if("Confessor - Slurbow, Leather Maillecoat")
@@ -66,9 +66,10 @@
 				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/confessor
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/inq
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
-			if("Arbalist - Crossbow, Psydonic Chestplate")
+			if("Arbalist - Crossbow, Psydonic Chestplate, Pushup Armour")
 				head = /obj/item/clothing/head/roguetown/headband/bloodied
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fencer/psydon
+				shirt = /obj/item/clothing/suit/roguetown/armor/manual/sewable/confessor
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 				REMOVE_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 5, TRUE)
@@ -91,7 +92,6 @@
 	backr = /obj/item/storage/backpack/rogue/satchel/otavan
 	belt = /obj/item/storage/belt/rogue/leather/knifebelt/black/psydon
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
-	beltl = /obj/item/rogueweapon/scabbard/sheath
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots
 	mask = /obj/item/clothing/mask/rogue/facemask/steel/confessor
@@ -104,5 +104,6 @@
 		/obj/item/inqarticles/garrote = 1,
 		/obj/item/grapplinghook = 1,
 		/obj/item/paper/inqslip/arrival/ortho = 1,
-		/obj/item/rogueweapon/huntingknife/idagger/silver/psydagger = 1
+		/obj/item/rogueweapon/huntingknife/idagger/silver/psydagger = 1,
+		/obj/item/rogueweapon/scabbard/sheath = 1
 		)


### PR DESCRIPTION
## About The Pull Request

As it says on the tin. Also fixes the leather push-up armours to be actually leather tier.

adds manually sewable armour framework. easy to add new sewable armour (and what item you want them to be repaired by + sound particular).

confessor armour can be repaired (while worn) with needle or cautery.

NUFC:
Spawn equip proc will now check for cloak storage items too.

## Testing Evidence

Yes.

## Why It's Good For The Game

Was supposed to be a part of the last one. makes them *actually viable* now. They get the same armour tier as the grenz plume hat (so even cuts can go through).

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Confessor Arbalist gets D-all tier, 100 integ manually repairable (with needle or cautery) skin armour.
fix: Pushup armour that were leather tier are actually leather tier, now.
add: Sewable armour.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
