### PR TITLE
Etruscan Mercenaries Touch-Up

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/etrusca.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/etrusca.dm
@@ -57,9 +57,9 @@
 		switch(weapon_choice)
 			if("Intrepid Leader - Dual Longswords") //It's badass fuck you
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-				r_hand = /obj/item/rogueweapon/sword/long/dec
+				r_hand = /obj/item/rogueweapon/sword/long/etruscan
 				beltl = /obj/item/rogueweapon/scabbard/sword
-				l_hand = /obj/item/rogueweapon/sword/long/dec
+				l_hand = /obj/item/rogueweapon/sword/long/etruscan
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				ADD_TRAIT(H, TRAIT_DUALWIELDER, TRAIT_GENERIC)
 				H.change_stat(STATKEY_SPD, -2)

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
@@ -65,7 +65,7 @@
 					/obj/item/rogueweapon/scabbard/sheath = 1
 					)
 	var/datum/inspiration/I = new /datum/inspiration(H)
-	I.grant_inspiration(H, bard_tier = BARD_T1)
+	I.grant_inspiration(H, bard_tier = BARD_T2)
 	if(H.mind)
 		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute", "Psyaltery")
 		var/weapon_choice = input(H, "Choose your instrument.", "TAKE UP ARMS") as anything in weapons


### PR DESCRIPTION
## About The Pull Request

- Changes Vaquero's bard tier to T2
- Replaces the Condottiero Ringleader's two decorated longswords with Etruscan longswords
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

It compiles
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Granting Vaquero a higher tier (similar to some other hybrid bard classes) will allow them to perform better in team compositions without breaking overall balance.

It's very odd that the Condotierro Ringleader has two decorated longswords, each worth 140. This is probably a mistake, so it's better to give them two Etruscan longswords, identical to the original ones.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Replaces Condottiero Ringleader's two decorated longswords with Etruscan longswords
balance: Changes Vaquero's bard tier to T2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
