### PR TITLE
Revert moving spells from FastProcessing to Timer.

### DIFF
--- a/code/modules/spells/roguetown/_roguetown.dm
+++ b/code/modules/spells/roguetown/_roguetown.dm
@@ -36,8 +36,8 @@
 		active = TRUE
 		add_ranged_ability(user, null, TRUE)
 		on_activation(user)
-	
 	update_icon()
+	start_recharge()
 
 /obj/effect/proc_holder/spell/invoked/deactivate(mob/living/user) //Deactivates the currently active spell (icon click)
 	..()

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -130,15 +130,17 @@
 	/// Amount of PQ gained for reviving people
 	var/revive_pq = PQ_GAIN_REVIVE
 
-/obj/effect/proc_holder/spell/invoked/revive/calculate_recharge_time()
-	var/final_time = ..() 
-	
+/obj/effect/proc_holder/spell/invoked/revive/start_recharge()
+	var/old_recharge = recharge_time
+	// Because the cooldown for anastasis is so incredibly low, not having tech impacts them more heavily than other faiths
 	var/tech_resurrection_modifier = SSchimeric_tech.get_resurrection_multiplier()
-	
 	if(tech_resurrection_modifier > 1)
-		final_time *= (tech_resurrection_modifier * 1.25)
-	
-	return max(cooldown_min, round(final_time))
+		recharge_time = initial(recharge_time) * (tech_resurrection_modifier * 1.25)
+	else
+		recharge_time = initial(recharge_time)
+	if(charge_counter >= old_recharge && old_recharge > 0)
+		charge_counter = recharge_time
+	. = ..()
 
 /obj/effect/proc_holder/spell/invoked/revive/cast(list/targets, mob/living/user)
 	..()

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -376,14 +376,19 @@
 	to_chat(user, span_notice("You bless [target] with Eora's love!"))
 	return TRUE
 
-/obj/effect/proc_holder/spell/invoked/bless_food/calculate_recharge_time()
-	if(!ranged_ability_user)
-		return base_recharge_time
-		
-	var/holy_skill = ranged_ability_user.get_skill_level(associated_skill)
-	var/skill_reduction = (6 SECONDS) * holy_skill
-	
-	return max(cooldown_min, base_recharge_time - skill_reduction)
+/obj/effect/proc_holder/spell/invoked/bless_food/start_recharge()
+	if(ranged_ability_user)
+		var/holy_skill = ranged_ability_user.get_skill_level(associated_skill)
+		// Reduce recharge by 6 seconds per skill level
+		var/skill_reduction = (6 SECONDS) * holy_skill
+		recharge_time = base_recharge_time - skill_reduction
+		// Ensure recharge doesn't go below 0
+		if(recharge_time < 0)
+			recharge_time = 0
+	else
+		recharge_time = base_recharge_time
+
+	START_PROCESSING(SSfastprocess, src)
 
 /obj/effect/proc_holder/spell/invoked/pomegranate
 	name = "Amaranth Sanctuary"

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -198,35 +198,21 @@ Somewhat fitting, considering the broadness of their domains. I also just think 
 	associated_skill = /datum/skill/magic/holy
 
 /obj/effect/proc_holder/spell/invoked/invisibility/cast(list/targets, mob/living/user)
-	if(!isliving(targets[1]))
-		revert_cast()
-		return FALSE
-
-	var/mob/living/target = targets[1]
-	if(target.anti_magic_check(TRUE, TRUE))
-		return FALSE
-
-	target.visible_message(span_warning("[target] starts to fade into thin air!"), span_notice("You start to become invisible!"))
-	var/dur = max((5 * (user.get_skill_level(associated_skill))), 5)
-	animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
-	target.mob_timers[MT_INVISIBILITY] = world.time + dur SECONDS
-
-	addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), dur SECONDS)
-	addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), dur SECONDS)
-
-	return TRUE
-
-/obj/effect/proc_holder/spell/invoked/invisibility/calculate_recharge_time()
-    var/final_time = ..() 
-    
-    if(ranged_ability_user)
-        var/skill_level = ranged_ability_user.get_skill_level(associated_skill)
-        var/dur = max((5 * skill_level), 5) SECONDS
-        
-        if(dur >= final_time)
-            final_time = dur + 5 SECONDS
-            
-    return max(cooldown_min, final_time)
+	if(isliving(targets[1]))
+		var/mob/living/target = targets[1]
+		if(target.anti_magic_check(TRUE, TRUE))
+			return FALSE
+		target.visible_message(span_warning("[target] starts to fade into thin air!"), span_notice("You start to become invisible!"))
+		var/dur = max((5 * (user.get_skill_level(associated_skill))), 5)
+		if(dur >= recharge_time)
+			recharge_time = dur + 5 SECONDS
+		animate(target, alpha = 0, time = 1 SECONDS, easing = EASE_IN)
+		target.mob_timers[MT_INVISIBILITY] = world.time + dur SECONDS
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, update_sneak_invis), TRUE), dur SECONDS)
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/atom/movable, visible_message), span_warning("[target] fades back into view."), span_notice("You become visible again.")), dur SECONDS)
+		return TRUE
+	revert_cast()
+	return FALSE
 
 /obj/effect/proc_holder/spell/self/noc_spell_bundle
 	name = "Arcyne Affinity"

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -26,12 +26,13 @@
 	var/harms_undead = TRUE
 	priest_excluded = TRUE
 
-/obj/effect/proc_holder/spell/invoked/resurrect/calculate_recharge_time()
-	var/final_time = ..()
-	
-	final_time *= SSchimeric_tech.get_resurrection_multiplier()
-	
-	return max(cooldown_min, round(final_time))
+/obj/effect/proc_holder/spell/invoked/resurrect/start_recharge()
+	var/old_recharge = recharge_time
+	recharge_time = initial(recharge_time) * SSchimeric_tech.get_resurrection_multiplier()
+	// If the spell was fully charged, keep it fully charged after adjusting recharge_time
+	if(charge_counter >= old_recharge && old_recharge > 0)
+		charge_counter = recharge_time
+	. = ..()
 
 /obj/effect/proc_holder/spell/invoked/resurrect/proc/get_current_required_items()
 	if(SSchimeric_tech.has_revival_cost_reduction() && length(alt_required_items))


### PR DESCRIPTION
## About The Pull Request
Alternative to: https://github.com/Azure-Peak/Azure-Peak/pull/5704
While working on adding cooldown on spells I realized that moving it to a timer make it functionally impossible to implement the feature. In addition, it caused quite a bit of bugs that I had to work around in 5704. 

So this reverts it back to where it was before.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yae

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No more infinite spells and it enable me to put back in spell cooldown text. Which will be in a separate, atomized PR

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Spells has been moved back to a processor for cooldown. Spells that did not respect cooldown should be fixed now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
