### PR TITLE
Reduce enchanting scroll size + t5 binding shackles cost.

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
+++ b/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
@@ -135,7 +135,7 @@
 	name = "binding shackles (T5)"
 	result = /obj/item/rope/chain/bindingshackles/t5
 	reqs = list(/obj/item/rope/chain/bindingshackles/t4 = 1,
-				/obj/item/magic/melded/t5 = 1)
+				/obj/item/magic/voidstone = 1)
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/arcana/forge

--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -10,6 +10,8 @@ T1 Enchantments below here*/
 	icon_state = "enchantment"
 	var/component
 	possible_item_intents = list(/datum/intent/use)
+	grid_width = 64
+	grid_height = 32
 
 /obj/item/enchantmentscroll/attack_obj(obj/item/O, mob/living/user)
 	if(O.unenchantable)


### PR DESCRIPTION
## About The Pull Request
Port of https://github.com/Rotwood-Vale/Ratwood-2.0/pull/635

> changes scroll size for storage from 3x3 to 2x1
changes cost for T5 binding shackles from a T5 meld to a simple voidstone

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
> Enchanting scrolls are unreasonably large size wise for little reason.
The cost to make T5 binding shackles is prohibitively high. To Bind a void dragon, you currently need to kill each T4 mob 3 times.
This change makes it so you only need to kill T4 mobs twice, by reducing the need of material for a T4 meld ontop of the voidstone.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Enchanting Scroll is now 2x1
add: T5 Binding Shackles now costs a voidstone instead of a T5 Meld
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
