### PR TITLE
Blunt damage tweak

### DIFF
--- a/code/__DEFINES/armor_defines.dm
+++ b/code/__DEFINES/armor_defines.dm
@@ -101,7 +101,7 @@
 #define ARMOR_PADDED_GOOD list("blunt" = 90, "slash" = 50, "stab" = 50, "piercing" = 80, "fire" = 0, "acid" = 0)
 
 // Leather should always be 10 less than their padded counterparts for piercing but is good vs arrows still.
-#define ARMOR_LEATHER list("blunt" = 60, "slash" = 50, "stab" = 40, "piercing" = 30, "fire" = 0, "acid" = 0)
+#define ARMOR_LEATHER list("blunt" = 40, "slash" = 50, "stab" = 40, "piercing" = 30, "fire" = 0, "acid" = 0)
 #define ARMOR_SPELLSINGER list("blunt" = 70, "slash" = 70, "stab" = 50, "piercing" = 40, "fire" = 0, "acid" = 0)
 #define ARMOR_LEATHER_GOOD list("blunt" = 90, "slash" = 70, "stab" = 50, "piercing" = 50, "fire" = 0, "acid" = 0)
 #define ARMOR_LEATHER_STUDDED list("blunt" = 80, "slash" = 80, "stab" = 60, "piercing" = 40, "fire" = 0, "acid" = 0) // Pseudo metallic armor therefore worse vs blunt and piercing

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -304,9 +304,9 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define BULLET_ACT_MISS				"MISS"
 
 //Weapon values
-#define BLUNT_DEFAULT_PENFACTOR		-100
-#define NONBLUNT_BLUNT_DAMFACTOR 0.6 // Damage factor when a non blunt weapon is used with blunt intent. Meant to make it worse than a real one.
-#define BLUNT_DEFAULT_INT_DAMAGEFACTOR 1.6 // Universal blunt intent integrity damage factor. Replaces Roguepen
+#define BLUNT_DEFAULT_PENFACTOR		20
+#define NONBLUNT_BLUNT_DAMFACTOR 0.4 // Damage factor when a non blunt weapon is used with blunt intent. Meant to make it worse than a real one.
+#define BLUNT_DEFAULT_INT_DAMAGEFACTOR 1.2 // Universal blunt intent integrity damage factor. Replaces Roguepen
 
 // Integrity & Sharpness Value
 #define INTEG_PARRY_DECAY			1	//Default integrity decay on parry.

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -85,7 +85,7 @@
 
 // A weaker strike for swords with high damage so that it don't end up becoming better than mace
 /datum/intent/sword/strike/bad
-	damfactor = 0.7 
+	damfactor = 0.2 
 
 /datum/intent/sword/peel
 	name = "armor peel"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -75,7 +75,8 @@
 			var/layers_deep = 1
 			var/played_sound = FALSE
 			for(var/obj/item/clothing/C in layers)
-				var/actualdmg = intdamage
+				var/reduction = min(protection, 80)
+				var/actualdmg = intdamage * (1 - reduction / 100) // so armor with good blunt defence stays longer
 				actualdmg /= layers_deep
 				C.take_damage(actualdmg, damage_flag = d_type, sound_effect = FALSE, armor_penetration = 100)
 				if(C.blocksound && !played_sound)


### PR DESCRIPTION
## About The Pull Request

Returns AP to blunt so now it deals damage through low resistant armour (mostly metal one)
The more blunt resists armor has - the less int damage it takes from blunt.
Low-tier leather armour slightly less resistant to blunt.
Blunt deals less damage to integrity overall.
All non-mace blunt intents deal drastically less damage.

## Testing Evidence

14 STR char
https://youtu.be/QlLC6YeVXWE

## Why It's Good For The Game
Blunt damage is shit. It meant to deal with heavily armoured dudes by dealing damage through armour, not by destroying armour itself. Now maces and stuff are really anti-armour and now you really need to wear smth leather/padded underneath if you don't wan't to get rekt by some strong man.
Other tweaks are meant to balance non-mace intents so they won't be as strong as mace itself.
Still scales with STR and force. The more you have, the more resistant armors you'll be able to penetrate. And vice versa
## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Armour degrade less from blunt damage the more blunt res it has.
balance: Blunt damage now penetrates armour.
balance: Low-tier leather armour slightly less resistant to blunt.
balance: Blunt now deals less damage to integrity.
/:cl:
