### PR TITLE
Anti combat chugging measure - Red now drains Blue

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -6,7 +6,7 @@
 //Potions
 /datum/reagent/medicine/healthpot
 	name = "Health Potion"
-	description = "Gradually regenerates all types of damage."
+	description = "Gradually regenerates all types of damage. Also exhausts the target as they regenerate."
 	reagent_state = LIQUID
 	color = "#ff0000"
 	taste_description = "lifeblood"
@@ -14,6 +14,10 @@
 	overdose_threshold = 0
 	metabolization_rate = REAGENTS_METABOLISM
 	alpha = 173
+
+
+/datum/reagent/medicine/healthpot/on_mob_metabolize(mob/living/M)
+	to_chat(M, span_userdanger("You feel your vigor draining as your wounds begin to knit together..."))
 
 /datum/reagent/medicine/healthpot/on_mob_life(mob/living/carbon/M)
 	if(volume >= 60)
@@ -30,15 +34,19 @@
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5  * REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustCloneLoss(-1.75  * REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustOrganLoss(ORGAN_SLOT_EYES, -1 * REAGENTS_EFFECT_MULTIPLIER)
+		M.energy_add(-30) // Exhaust you while it is in your system, at similar rate to the green potion of the same caliber, as balance vs combat chugging (Or forcing you to halve your mix and use twice as much)
 	..()
 
 /datum/reagent/medicine/stronghealth
 	name = "Strong Health Potion"
-	description = "Quickly regenerates all types of damage."
+	description = "Quickly regenerates all types of damage. Also exhausts the target greatly as they regenerate."
 	color = "#820000be"
 	taste_description = "rich lifeblood"
 	scent_description = "metal"
 	metabolization_rate = REAGENTS_METABOLISM * 3
+
+/datum/reagent/medicine/stronghealth/on_mob_metabolize(mob/living/M)
+	to_chat(M, span_userdanger("You feel your vigor plummeting as your wounds rapidly knit together..."))
 
 /datum/reagent/medicine/stronghealth/on_mob_life(mob/living/carbon/M)
 	if(volume >= 60)
@@ -55,6 +63,7 @@
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5  * REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustCloneLoss(-7  * REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustOrganLoss(ORGAN_SLOT_EYES, -2.5 * REAGENTS_EFFECT_MULTIPLIER)
+		M.energy_add(-120) // Exhaust you while it is in your system, at similar rate to the green potion of the same caliber, as balance vs combat chugging (Or forcing you to halve your mix and use twice as much)
 	..()
 	. = 1
 

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -6,7 +6,7 @@
 //Potions
 /datum/reagent/medicine/healthpot
 	name = "Health Potion"
-	description = "Gradually regenerates all types of damage. Also exhausts the target as they regenerate."
+	description = "Gradually regenerates all types of damage."
 	reagent_state = LIQUID
 	color = "#ff0000"
 	taste_description = "lifeblood"
@@ -14,10 +14,6 @@
 	overdose_threshold = 0
 	metabolization_rate = REAGENTS_METABOLISM
 	alpha = 173
-
-
-/datum/reagent/medicine/healthpot/on_mob_metabolize(mob/living/M)
-	to_chat(M, span_userdanger("You feel your vigor draining as your wounds begin to knit together..."))
 
 /datum/reagent/medicine/healthpot/on_mob_life(mob/living/carbon/M)
 	if(volume >= 60)
@@ -34,7 +30,6 @@
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5  * REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustCloneLoss(-1.75  * REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustOrganLoss(ORGAN_SLOT_EYES, -1 * REAGENTS_EFFECT_MULTIPLIER)
-		M.energy_add(-30) // Exhaust you while it is in your system, at similar rate to the green potion of the same caliber, as balance vs combat chugging (Or forcing you to halve your mix and use twice as much)
 	..()
 
 /datum/reagent/medicine/stronghealth
@@ -63,7 +58,7 @@
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5  * REAGENTS_EFFECT_MULTIPLIER)
 		M.adjustCloneLoss(-7  * REAGENTS_EFFECT_MULTIPLIER, 0)
 		M.adjustOrganLoss(ORGAN_SLOT_EYES, -2.5 * REAGENTS_EFFECT_MULTIPLIER)
-		M.energy_add(-120) // Exhaust you while it is in your system, at similar rate to the green potion of the same caliber, as balance vs combat chugging (Or forcing you to halve your mix and use twice as much)
+		M.energy_add(-60) // Exhaust you while it is in your system, at similar rate to the green potion of the same caliber, as balance vs combat chugging (Or forcing you to halve your mix and use twice as much)
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request
Came up with this idea (Credit to someone else for suggesting I drain blue instead of stats) to clamp down on combat chugging of red potions, which seems to be ultra meta atm and let you last way longer than you should.

Now, when you chug Strong Red, you drain your blue bar (not green) energy bar, diminishing your long term ability to fight. To mitigate it, don't use it mid combat or mix the potion with an equivalent strength blue potion at a 75/25 ratio. 

When it metabolizes the first time it also show a message telling you what it is doing.

Originally I tried draining Green but I felt it was far too harsh with it actually stunlocking you which open it up to other abuses.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="2223" height="962" alt="dreamseeker_P1Wv032v3q" src="https://github.com/user-attachments/assets/809cfd71-8ddd-4719-9d6c-046d6dc30f1d" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Step by step, I knock down the cancerous part of AP combat where you can stack up a billion thing and prestim your way to victory

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Strong Red Potions now drain your blue at half a rate to Mana Potions of the same strength. Mix it up or don't use it mid combat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
