### PR TITLE
Aerosolization COMPROMISE - The alternative to the Aerosolization Removal PR

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_aoe/aerosolize.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/aerosolize.dm
@@ -1,9 +1,9 @@
 /obj/effect/proc_holder/spell/invoked/aerosolize
 	name = "Aerosolize" //once again renamed to fit better :)
-	desc = "Turns a container of liquid into a smoke containing the reagents of that liquid."
+	desc = "Turns a container of liquid into a smoke containing the reagents of that liquid. Be warned, you absord the liquid you aerosolize"
 	overlay_state = "aerosolize"
 	releasedrain = 50
-	chargetime = 3
+	chargetime = 15 // same as a fireball
 	recharge_time = 30 SECONDS
 	range = 6
 	warnie = "spellwarning"
@@ -26,25 +26,24 @@
 	miracle = FALSE
 
 	var/delay = 12
+	var/mutable_appearance/aero_target
 	
 /obj/effect/proc_holder/spell/invoked/aerosolize/cast(list/targets, mob/living/user)
-	var/turf/T = get_turf(targets[1]) //check for turf
+	var/turf/T = get_turf(targets[1])
 	if(T)
 		new /obj/effect/temp_visual/trap(T)
 		sleep(delay)
-		var/obj/item/held_item = user.get_active_held_item() //get held item
-		var/obj/item/reagent_containers/con = held_item //get held item
+		var/obj/item/held_item = user.get_active_held_item()
+		var/obj/item/reagent_containers/con = held_item
 		if(con)
 			if(con.spillable)
 				if(con.reagents.total_volume > 0)
 					var/datum/reagents/R = con.reagents
 					var/datum/effect_system/smoke_spread/chem/smoke = new
-
 					smoke.set_up(R, 1, T, FALSE)
 					smoke.start()
-
-					user.visible_message(span_warning("[user] sprays the contents of the [held_item], creating a cloud!"), span_warning("You spray the contents of the [held_item], creating a cloud!"))
-					con.reagents.clear_reagents() //empty the container
+					con.reagents.trans_to(user, con.reagents.total_volume) // Transfers all of the reagents into the user
+					user.visible_message(span_warning("[user] sprays the contents of the [held_item], absorbing it and creating a cloud!"), span_warning("You spray the contents of the [held_item], absorbing it and creating a cloud!"))
 					playsound(user, 'sound/magic/webspin.ogg', 100)
 				else
 					to_chat(user, "<span class='warning'>The [held_item] is empty!</span>")


### PR DESCRIPTION
## About The Pull Request
An alternative option to https://github.com/Azure-Peak/Azure-Peak/pull/5740

Essentially what this PR does is a few things.

FIRSTLY, when you aerosolize something, you absorb the reagent. Cast sewage water? You now have sewage in you. Cast killersice? You're dead. Cast soup? Yum.

There are naturally ways to get around being killed by casting poison:
A: Prep an antidote (Smart on you, that requires you to interact with alchemy and ingredient gathering to effectively use your spell in combat)
B: Pick something like rotcured (You are taking a virtue to make a specific spell viable, while also locking yourself out of miracle healing, being able to hold silver or be touched by silver (fun fact a silver dagger is needed to make large enchanting circle stuff), and easy dislimb)
C: are an undead antag (You're an antag, you SHOULD be scary)

This also encourages MORE than just combat uses for the spell, like using it for buffing allies with alchemical goods or healing them. 

It is already choreographed as well, you have a solid two seconds or so to get out of the range of the little effect. BUT, as a bonus, NOW its not an INSTANT charge for picking a location. I have increased its charge time to the same that a FIREBALL uses, so it's entirely valid to sprint up to a mage casting it and get a free hit in. (If you are casting a spell you cannot dodge or parry, it's a guaranteed hit)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
There's a gif here it'll probably take a second to appear c:

![compromise](https://github.com/user-attachments/assets/33d6f51d-a4f8-4bda-ac42-b778feec2c56)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Instead of removing a spell, makes it slightly less abuseable in combat. Gives consequences to using poisons with it to encourage using other things.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Aerosolization now causes the caster to consume the entire reagent, and had it's charge time raised to the same charge time as a fireball.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
