### PR TITLE
A mid-point and adjustment for Migrants

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(migrants)
 	var/time_until_next_wave = 2 MINUTES
 	var/wave_timer = 0
 
-	var/time_between_waves = 3 MINUTES
+	var/time_between_waves = 2 MINUTES
 	var/time_between_fail_wave = 90 SECONDS
 	var/wave_wait_time = 30 SECONDS
 
@@ -473,7 +473,7 @@ SUBSYSTEM_DEF(migrants)
 	var/triumph_bonus = wave.triumph_total
 
 	// Triumph provides a linear bonus to weight (configurable multiplier)
-	var/triumph_multiplier = 6 // Each triumph point adds 6x weight
+	var/triumph_multiplier = 10 // Each triumph point adds 6x weight
 	var/final_weight = base_weight + (triumph_bonus * triumph_multiplier)
 
 	return max(final_weight, 1) // Ensure minimum weight of 1

--- a/code/datums/migrants/migrant_pref.dm
+++ b/code/datums/migrants/migrant_pref.dm
@@ -150,7 +150,7 @@
 		else
 			roll_percentage = "0%"
 
-		sidebar_dat += "<div style='margin-bottom: 12px; padding: 8px; border: 1px solid #444; border-radius: 4px;' title='Roll Chance: [roll_percentage] (Base: [wave.weight], Triumph: +[wave.triumph_total * 6])'>"
+		sidebar_dat += "<div style='margin-bottom: 12px; padding: 8px; border: 1px solid #444; border-radius: 4px;' title='Roll Chance: [roll_percentage] (Base: [wave.weight], Triumph: +[wave.triumph_total * 10])'>"
 		sidebar_dat += "<div style='color: [wave_color]; font-weight: bold; margin-bottom: 4px;'>[wave_name]</div>"
 		sidebar_dat += "<div style='background-color: #333; height: 12px; border-radius: 6px; margin-bottom: 4px;'>"
 		sidebar_dat += "<div style='background-color: [threshold_reached ? "gold" : (is_maxed_out ? "#666666" : "cyan")]; height: 100%; width: [progress_percent]%; border-radius: 6px;'></div>"

--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -46,7 +46,7 @@
 /datum/migrant_wave/pilgrim
 	name = "Pilgrimage"
 	downgrade_wave = /datum/migrant_wave/pilgrim_down_one
-	weight = 100 // It is a "default" wave 
+	weight = 50 // It is a "default" wave 
 	roles = list(
 		/datum/migrant_role/pilgrim = 4,
 	)
@@ -84,7 +84,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 4,
 	)
-	weight = 100 // Adventurers is the default spillover role and instead of just setting adventurers slots up high at roundstart we'll let people join in gradually through the round
+	weight = 50 // Adventurers is the default spillover role and instead of just setting adventurers slots up high at roundstart we'll let people join in gradually through the round
 	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Azure Peak, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/adventurer_down_one

--- a/code/datums/migrants/migrant_waves/fablefield wave.dm
+++ b/code/datums/migrants/migrant_waves/fablefield wave.dm
@@ -1,7 +1,7 @@
 /datum/migrant_wave/fablefield
 	name = "The Fablefield Troupe"
 	max_spawns = 1
-	weight = 20
+	weight = 25
 	downgrade_wave = /datum/migrant_wave/fablefield_down_one
 	roles = list(
 		/datum/migrant_role/fablefield/goliard = 1,

--- a/code/datums/migrants/migrant_waves/grenzel_noble_wave.dm
+++ b/code/datums/migrants/migrant_waves/grenzel_noble_wave.dm
@@ -2,7 +2,7 @@
 	name = "Grenzelhoftian Envoy"
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/grenzel_envoy
-	weight = 50
+	weight = 25
 	downgrade_wave = /datum/migrant_wave/grenzel_envoy_down_one
 	roles = list(
 		/datum/migrant_role/grenzel/envoy = 1,

--- a/code/datums/migrants/migrant_waves/heartfelt wave.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt wave.dm
@@ -2,7 +2,7 @@
 	name = "The Court of Heartfelt"
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/heartfelt
-	weight = 50
+	weight = 25
 	downgrade_wave = /datum/migrant_wave/heartfelt_down_one
 	roles = list(
 		/datum/migrant_role/heartfelt/lord = 1,

--- a/code/datums/migrants/migrant_waves/knightly_journey_wave.dm
+++ b/code/datums/migrants/migrant_waves/knightly_journey_wave.dm
@@ -3,7 +3,7 @@
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/knightly_journey
 	downgrade_wave = /datum/migrant_wave/knightly_journey_down_one
-	weight = 50
+	weight = 25
 	roles = list(
 		/datum/migrant_role/kj_knight = 1,
 		/datum/migrant_role/kj_squire = 1,

--- a/code/datums/migrants/migrant_waves/ranesheni_noble_wave.dm
+++ b/code/datums/migrants/migrant_waves/ranesheni_noble_wave.dm
@@ -2,7 +2,7 @@
 	name = "Ranesheni Emir"
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/ranesheni_noble
-	weight = 50
+	weight = 25
 	downgrade_wave = /datum/migrant_wave/ranesheni_noble_down_one
 	roles = list(
 		/datum/migrant_role/ranesheni/emir = 1,

--- a/code/datums/migrants/migrant_waves/runaway_prisoners.dm
+++ b/code/datums/migrants/migrant_waves/runaway_prisoners.dm
@@ -5,7 +5,7 @@
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/runaway_prisoners
 	downgrade_wave = /datum/migrant_wave/runaway_prisoners_down_one
-	weight = 50
+	weight = 25
 	roles = list(
 		/datum/migrant_role/runaway_prisoner = 4
 	)

--- a/code/modules/events/antagonist/migrant_waves/dark_itinerant_knight_wave.dm
+++ b/code/modules/events/antagonist/migrant_waves/dark_itinerant_knight_wave.dm
@@ -2,7 +2,7 @@
 	name = "The Unknightly journey"
 	wave_type = /datum/migrant_wave/evil_knight
 
-	weight = 6
+	weight = 4
 	max_occurrences = 1
 
 	earliest_start = 10 MINUTES
@@ -17,7 +17,7 @@
 	name = "The Unknightly journey"
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/evil_knight
-	weight = 8
+	weight = 4
 	roles = list(
 		/datum/migrant_role/dark_itinerant_knight = 1,
 		/datum/migrant_role/dark_itinerant_squire = 1,


### PR DESCRIPTION
## About The Pull Request

This is in response to https://github.com/Azure-Peak/Azure-Peak/pull/5674 and my own PR of https://github.com/Azure-Peak/Azure-Peak/pull/5415

Essentially this reduces the weight of all the parties by half, except for Fablefield.

Also increases the weight of triumphs to 10

## Testing Evidence

<img width="437" height="408" alt="Screenshot 2026-02-14 214931" src="https://github.com/user-attachments/assets/9598ef50-02f6-4bc7-af88-2cfbe73e65ec" />
<img width="459" height="535" alt="Screenshot 2026-02-14 215300" src="https://github.com/user-attachments/assets/9c2f1e46-af23-4d1a-849e-9e54e6550a9c" />
<img width="401" height="126" alt="Screenshot 2026-02-14 215315" src="https://github.com/user-attachments/assets/83a916db-1563-4f10-8358-5922fe4c2116" />


## Why It's Good For The Game

Quite literally just better for both adventurer parties. Allowing them to naturally spawn better. While also allowing the more specialized rolls to also be accessible and not need an absurd amount of triumphs. Also, Fablefield being 20 was odd. 