### PR TITLE
Fix foldable cauldron capacity to 90, output strong potions directly.

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipe_base.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipe_base.dm
@@ -25,7 +25,7 @@
 
 	html += "Requires [SSskills.level_names_plain[skill_required]] level of skills<br>"
 	
-	html += "Boil 30+ ounces of water in a Cauldron.<br>"
+	html += "Boil 90+ drams of water in a Cauldron.<br>"
 
 	html += "Add at least two ingredients with the smell of [smells_like]<br>"
 

--- a/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
@@ -18,7 +18,7 @@
 	name = "Poison (Doom)"
 	smells_like = "doom"
 	skill_required = SKILL_LEVEL_EXPERT // Strong poison should be more difficult to make
-	output_reagents = list(/datum/reagent/berrypoison = 90,/datum/reagent/additive = 90)
+	output_reagents = list(/datum/reagent/strongpoison = 90)
 
 /datum/alch_cauldron_recipe/stam_poison
 	name = "Stamina Poison"
@@ -30,7 +30,7 @@
 	name = "Stamina Poison (Strong)"
 	smells_like = "stagnant air"
 	skill_required = SKILL_LEVEL_EXPERT // Strong poison should be more difficult to make
-	output_reagents = list(/datum/reagent/stampoison = 90,/datum/reagent/additive = 90)
+	output_reagents = list(/datum/reagent/strongstampoison = 90)
 
 //Healing potions
 /datum/alch_cauldron_recipe/health_potion
@@ -42,7 +42,7 @@
 	name = "Elixir of Health (Strong)"
 	smells_like = "berry pie"
 	skill_required = SKILL_LEVEL_JOURNEYMAN // If it has "Strong", lock it roundstart for Apothecary or above
-	output_reagents = list(/datum/reagent/medicine/healthpot = 90,/datum/reagent/additive = 90)
+	output_reagents = list(/datum/reagent/medicine/stronghealth = 90)
 
 /datum/alch_cauldron_recipe/mana_potion
 	name = "Elixir of Mana"
@@ -53,7 +53,7 @@
 	name = "Elixir of Mana (Strong)"
 	smells_like = "fear"
 	skill_required = SKILL_LEVEL_JOURNEYMAN
-	output_reagents = list(/datum/reagent/medicine/manapot = 90,/datum/reagent/additive = 90)
+	output_reagents = list(/datum/reagent/medicine/strongmana = 90)
 
 /datum/alch_cauldron_recipe/stamina_potion
 	name = "Elixir of Stamina"
@@ -64,7 +64,7 @@
 	name = "Elixir of Stamina (Strong)"
 	smells_like = "clean winds"
 	skill_required = SKILL_LEVEL_JOURNEYMAN
-	output_reagents = list(/datum/reagent/medicine/stampot = 90,/datum/reagent/additive = 90)
+	output_reagents = list(/datum/reagent/medicine/strongstam = 90)
 
 //S.P.E.C.I.A.L. potions - Expert or above (roundstart Witch etc.)
 /datum/alch_cauldron_recipe/str_potion

--- a/code/modules/roguetown/roguecrafting/alchemy/cauldron.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/cauldron.dm
@@ -213,5 +213,5 @@
 /obj/machinery/light/rogue/cauldron/folding/Initialize()
 	. = ..()
 	burn_out()
-	create_reagents(60, DRAINABLE | AMOUNT_VISIBLE | REFILLABLE) //small
+	create_reagents(90, DRAINABLE | AMOUNT_VISIBLE | REFILLABLE)
 	update_icon()

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -1,8 +1,3 @@
-// Catalyst. This reagent combined with normal potion reagent makes the strong potion reagent. Reactions defined by the end of this doccument
-/datum/reagent/additive
-	name = "additive"
-	reagent_state = LIQUID
-
 //Potions
 /datum/reagent/medicine/healthpot
 	name = "Health Potion"
@@ -408,42 +403,6 @@ If you want to expand on poisons theres tons of fun effects TG chemistry has tha
 /datum/reagent/toxin/killersice/on_mob_life(mob/living/carbon/M)
 	M.adjustToxLoss(10, 0)
 	return ..()
-
-//Potion reactions
-/datum/chemical_reaction/alch/stronghealth
-	name = "Strong Health Potion"
-	id = /datum/reagent/medicine/stronghealth
-	results = list(/datum/reagent/medicine/stronghealth = 1)
-	required_reagents = list(/datum/reagent/medicine/healthpot = 1, /datum/reagent/additive = 1)
-	mix_message = "The cauldron glows for a moment."
-
-/datum/chemical_reaction/alch/strongmana
-	name = "Strong Mana Potion"
-	id = /datum/reagent/medicine/strongmana
-	results = list(/datum/reagent/medicine/strongmana = 1)
-	required_reagents = list(/datum/reagent/medicine/manapot = 1, /datum/reagent/additive = 1)
-	mix_message = "The cauldron glows for a moment."
-
-/datum/chemical_reaction/alch/strongstam
-	name = "Strong Stamina Potion"
-	id = /datum/reagent/medicine/strongstam
-	results = list(/datum/reagent/medicine/strongstam = 1)
-	required_reagents = list(/datum/reagent/medicine/stampot = 1, /datum/reagent/additive = 1)
-	mix_message = "The cauldron glows for a moment."
-
-/datum/chemical_reaction/alch/strongpoison
-	name = "Strong Health Poison"
-	id = /datum/reagent/strongpoison
-	results = list(/datum/reagent/strongpoison = 1)
-	required_reagents = list(/datum/reagent/berrypoison = 1, /datum/reagent/additive = 1)
-	mix_message = "The cauldron glows for a moment."
-
-/datum/chemical_reaction/alch/strongstampoison
-	name = "Strong Stamina Leech Potion"
-	id = /datum/reagent/strongstampoison
-	results = list(/datum/reagent/strongstampoison = 1)
-	required_reagents = list(/datum/reagent/stampoison = 1, /datum/reagent/additive = 1)
-	mix_message = "The cauldron glows for a moment."
 
 /datum/chemical_reaction/alch/vitae_essence
 	name = "Vitae Decoction"


### PR DESCRIPTION
## About The Pull Request
- Foldable Cauldron capacity increased to 90 so it can actually brew
- Now all strong potions recipes output the potion directly instead of outputting it and an additive to mixes it. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yes

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fixes bug
Makes the alchemical recipe in the book less janky

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Foldable Cauldron holds 90 units
add: Strong potions recipe now directly outputs the result and can be brewed in a foldable cauldron and also looks less weird on the recipe books
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
