### PR TITLE
Gives the Wardens' seax REND

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -27,7 +27,7 @@
 /datum/intent/dagger/cut/heavy
 	name = "heavy cut"
 	damfactor = 1.2
-	penfactor = 20
+	penfactor = 25
 	clickcd = 11
 
 // For thrusting-focused daggers. Thinner blade, less slashing damage.
@@ -51,6 +51,9 @@
 /datum/intent/dagger/thrust/weak
 	name = "lopsided thrust"
 	damfactor = 0.8
+	penfactor = 45 // Slightly more pen, to compensate in penetration for the lower damage.
+	// You're still doing less damage than with a stabbier dagger, but your AP isn't penalised.
+	clickcd = 10
 
 /datum/intent/dagger/thrust/pick
 	name = "icepick stab"


### PR DESCRIPTION
## About The Pull Request

Gives the Wardens' seax weapon the rend intent in place of its existing chop + shuffles the cut intent to the first slot, as it's the primary focus of the weapon.

## Testing Evidence

<img width="212" height="188" alt="image" src="https://github.com/user-attachments/assets/a06b1089-f7c7-4cf2-a778-96719b85f726" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

The Wardens' seax has been in a funny place since it was added. The chop doesn't really do much that isn't also done by its cut, and it lacks pick - there isn't much reason to take it over the steel dagger outside of fluff.

This replaces its chop intent with rend - it's quite poor at getting through armour, but once it is it can do a lot of damage, in contrast to the other higher AP weapons available to wardens. I've given it a short run in PvE and it feels quite fun to play with, and its entirely lacking AP should prevent it from being too powerful otherwise.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: The Wardens' seax now has a small demolition modifier, and its CHOP intent has been replaced with REND.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
