### PR TITLE
haha free i have found another gamebreaking bug in our codebase

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -105,7 +105,7 @@
 		if(bp && istype(bp , /obj/item/clothing))
 			var/obj/item/clothing/C = bp
 			if(zone2covered(def_zone, C.body_parts_covered_dynamic))
-				if(C.obj_integrity > 1)
+				if(C.obj_integrity > 1 && C.armor_class != ARMOR_CLASS_NONE) 
 					switch(C.prevent_crits)
 						if(PREVENT_CRITS_NONE)
 							return FALSE


### PR DESCRIPTION
## About The Pull Request
### the problem
- #4821 introduced the three states of crit susceptibility 
- set clothes default to prevents crit most
- armor w/ ARMOR_CLASS_NONE cannot be destroyed or penned, which means that the integ is always above one
- most "cosmetic" clothing items can be stabbed thru to still deal damage, but actual crits can be impossible. namely; tabards, chaperons, etc, all prevent crits like skullcracks or whatever
- this means that if a skeleton wears one of these for some reason they are functionally immortal until its removed
- this might also explain, to an extent, why blunt has felt "weak". though im still VERY much unsure how much of this applied to normal people
### fix
- the check to see whether a prevent crits even goes off now checks for if the ac = none. frankly; the "best" solution is to completely redo where we assign crit suscept w/ the default being none but im too fucking tired to do that right now and this is gen. gamebreaking
### need
- once this is merged, please re-tm #5750
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- spawned in one of my new skeleton npcs that has gear that was previously broken, preventing all headcrits. you can now kick them and then crit them evil style.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- bugfix
- someone please go through and set the crit suscepts per /armor or whatever. pelas. please. pleas.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: 0 armor clothing will now no longer prevent crits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
