### PR TITLE
nerfs the lance a bit

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -210,7 +210,7 @@
 	clickcd = CLICK_CD_CHARGED
 
 /datum/intent/spear/thrust/lance
-	damfactor = 1.5 // Turns its base damage into 30 on the 2hand thrust. It keeps the spear thrust one handed.
+	damfactor = 1.25 // Turns its base damage into 30 on the 2hand thrust. It keeps the spear thrust one handed.
 
 /datum/intent/lance
 	name = "lance"
@@ -218,13 +218,18 @@
 	attack_verb = list("lances", "runs through", "skewers")
 	animname = "stab"
 	item_d_type = "stab"
-	penfactor = BLUNT_DEFAULT_PENFACTOR // Not a mistake, to prevent it from nuking through armor.
+	penfactor = BLUNT_DEFAULT_PENFACTOR
 	chargetime = 4 SECONDS
-	damfactor = 4 // 80 damage on hit. It is gonna hurt.
+	damfactor = 4
 	reach = 3 // Yep! 3 tiles
+	effective_range = 3
+	effective_range_type = EFF_RANGE_EXACT
 
 /datum/intent/lance/onehand
-	chargetime = 5 SECONDS
+	chargetime = 6 SECONDS
+	reach = 1
+	damfactor = 2
+	effective_range_type = EFF_RANGE_NONE
 
 //polearm objs ฅ^•ﻌ•^ฅ
 


### PR DESCRIPTION
## About The Pull Request

i buffed the lance n forgot taht the 1h lance intent also takes from it. oops.
1h lance intent is now:
2s longer than 2h lance. it also has an effective range of 3 tiles. maybe the damfactor halving doesnt matter still but we can always adjust that.
2x damfactor (instead of 4x)
1 reach instead of 3 reach

## Testing Evidence

ingame testing.

## Why It's Good For The Game

turbobuffed the lance oops

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: 1h lancing is now: 2x damfactor, 1 reach, 6s charge.
balance: 2h thrust is now 1.25x damfactor (down from 1.5x)
balance: 2h lance has an effective range of 3 tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
