### PR TITLE
Ovens, smelters, etc. no longer start turned on at roundstart.

### DIFF
--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -12,6 +12,7 @@
 	var/cookonme = FALSE
 	var/crossfire = TRUE
 	var/can_damage = FALSE
+	var/roundstart_forbid = FALSE
 
 /obj/machinery/light/rogue/Initialize()
 	if(soundloop)
@@ -21,7 +22,8 @@
 	if(fueluse > 0)
 		fueluse = fueluse - (rand(fueluse*0.1,fueluse*0.3))
 	update_icon()
-	seton(TRUE)
+	if(!roundstart_forbid)
+		seton(TRUE)
 	. = ..()
 
 /obj/machinery/light/rogue/weather_trigger(W)

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -415,6 +415,7 @@
 	layer = TABLE_LAYER
 	climb_offset = 14
 	on = FALSE
+	roundstart_forbid = TRUE
 	cookonme = TRUE
 	soundloop = /datum/looping_sound/fireloop
 	var/obj/item/attachment = null

--- a/code/modules/roguetown/roguecrafting/alchemy/cauldron.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/cauldron.dm
@@ -15,7 +15,7 @@
 	var/mob/living/carbon/human/lastuser
 	fueluse = 20 MINUTES
 	crossfire = FALSE
-
+	roundstart_forbid = TRUE
 /obj/machinery/light/rogue/cauldron/update_icon()
 	..()
 	cut_overlays()

--- a/code/modules/roguetown/roguejobs/blacksmith/forge.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/forge.dm
@@ -8,6 +8,7 @@
 	density = TRUE
 	anchored = TRUE
 	on = FALSE
+	roundstart_forbid = TRUE
 	climbable = TRUE
 	climb_time = 0
 	var/heat_time = 20 SECONDS

--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -16,7 +16,8 @@
 	climbable = TRUE
 	climb_time = 0
 	climb_offset = 10
-	on = TRUE
+	on = FALSE
+	roundstart_forbid = TRUE
 
 	/// Which ores are contained within us?
 	var/list/contained_items = list()

--- a/code/modules/roguetown/roguejobs/cook/tools/oven.dm
+++ b/code/modules/roguetown/roguejobs/cook/tools/oven.dm
@@ -7,6 +7,7 @@
 	base_state = "oven"
 	density = FALSE
 	on = FALSE
+	roundstart_forbid = TRUE
 	var/list/food = list()
 	var/maxfood = 5
 	var/donefoods = FALSE


### PR DESCRIPTION
## About The Pull Request
Title says it all. They can still be turned on they just aren't by default on roundstartt
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
works 👍 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
good QOL
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: ovens/forges/hearths/smelters no longer spawn on at roundstart by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
