### PR TITLE
Final Touches (IX) / Dripless To Drowning - Touches up the Naledian Vizier's style.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -169,7 +169,7 @@
 
 /datum/advclass/mercenary/warscholar/vizier
 	name = "Naledi Vizier"
-	tutorial = "You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though psydonians have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough."
+	tutorial = "You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though Psydonians have long struggled to channel their All-Father's divinity, a combination of the Saint's power may be similar enough."
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar_vizier
 	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2, TRAIT_ALCHEMY_EXPERT, TRAIT_NALEDI)
 	subclass_stats = list(
@@ -219,19 +219,18 @@
 	to_chat(H, span_warning("You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though psydonians have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough."))
 	r_hand = /obj/item/rogueweapon/woodstaff/naledi
 
-	head = /obj/item/clothing/head/roguetown/roguehood/shalal/black
-	mask = /obj/item/clothing/mask/rogue/lordmask/naledi
-	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/pontifex
-	shirt = /obj/item/clothing/suit/roguetown/shirt/robe/pointfex
+	head = /obj/item/clothing/head/roguetown/roguehood/hierophant
 	cloak = /obj/item/clothing/cloak/hierophant
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hierophant
+	shirt = /obj/item/clothing/suit/roguetown/shirt/robe/hierophant
 	pants = /obj/item/clothing/under/roguetown/trou/leather
-	gloves = /obj/item/clothing/gloves/roguetown/angle
-	backr = /obj/item/storage/backpack/rogue/satchel/black
+	mask = /obj/item/clothing/mask/rogue/lordmask/naledi
 	wrists = /obj/item/clothing/neck/roguetown/psicross/naledi
-	belt = /obj/item/storage/belt/rogue/leather/battleskirt/black
+	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/flashlight/flare/torch
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
+	backr = /obj/item/storage/backpack/rogue/satchel/black
 
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary = 1,


### PR DESCRIPTION
## About The Pull Request

Redacted the original post, as I was misinformed. Not that anything too damning was written, of course. Anyhow!

This..
* ..ports most of the Hierophant's drip onto the Vizier, who was previously dripless.



## Testing Evidence

No longer content with their zenny-store garbs, the Vizier has decided to finally adopt a more regal and scholarly garb.

<img width="88" height="122" alt="778a38e1fc493413225314f5c6c1de42" src="https://github.com/user-attachments/assets/43f34049-5346-4f54-88ad-3cd2538e185e" />

## Why It's Good For The Game

* A player-requested change that gifts unique _(relative to the faction, at least)_ garb.
* Viziers will no longer look like run-of-the-mill adventuring mages, despite their elevated position.

## Changelog

:cl:
add: Viziers now bare the Hierophant's garb as well, instead of the generic and adventuring-tier robes.
/:cl: