### PR TITLE
Frost Bolt / Snap Freeze can no longer chain stunlock (probably)

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/frost_bolt.dm
@@ -29,11 +29,6 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-/obj/effect/proc_holder/spell/self/frostbolt/cast(mob/user = usr)
-	var/mob/living/target = user
-	target.visible_message(span_warning("[target] hurls a frosty beam!"), span_notice("You hurl a frosty beam!"))
-	. = ..()
-
 /obj/projectile/magic/frostbolt
 	name = "Frost Dart"
 	icon_state = "ice_2"

--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -45,6 +45,9 @@
 /datum/status_effect/buff/frostbite/tick()
 	var/mob/living/target = owner
 	target.stamina_add(5)
+	// When stamcrit, removes it to prevent it from chaining too hard
+	if(target.stamina >= target.max_stamina)
+		target.remove_status_effect(/datum/status_effect/buff/frostbite)
 
 /datum/status_effect/buff/frostbite/on_remove()
 	var/mob/living/target = owner


### PR DESCRIPTION
## About The Pull Request
- When the user catch Frostbite and is stamcritted, Frostbite removes itself. 
- This should probably make the spell a bit less obnoxious to deal with once stamcritted by not stamcritting you constantly off cooldown

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_DV7ZWwyLpq](https://github.com/user-attachments/assets/3fa15de7-51b9-4da9-a1d9-feb1bb6f5331)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Do you like chain hardstun?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Frostbite effect from Frost Bolt should remove itself after exhausting you instead of chaining you into a stunlock. (They can still follow up with another frost bolt)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
