### PR TITLE
Final Touches (X) / Tinnage - Slightly increases the probability of gaining tin, adds tin to the base rock wall's dropchance.

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -224,7 +224,7 @@
 		/turf/closed/mineral/rogue/salt = 5,
 		/turf/closed/mineral/rogue/iron = 15,
 		/turf/closed/mineral/rogue/copper = 10,
-		/turf/closed/mineral/rogue/tin = 8,
+		/turf/closed/mineral/rogue/tin = 7,
 		/turf/closed/mineral/rogue/coal = 25)
 	mineralChance = 23
 
@@ -240,7 +240,7 @@
 		/turf/closed/mineral/rogue/elementalmote = 15,
 		/turf/closed/mineral/rogue/cinnabar = 15,
 		/turf/closed/mineral/rogue/copper = 15,
-		/turf/closed/mineral/rogue/tin = 12,
+		/turf/closed/mineral/rogue/tin = 10,
 		/turf/closed/mineral/rogue/coal = 14,
 		/turf/closed/mineral/rogue/gem = 1)
 
@@ -255,7 +255,7 @@
 		/turf/closed/mineral/rogue/silver = 5,
 		/turf/closed/mineral/rogue/iron = 33,
 		/turf/closed/mineral/rogue/copper = 20,
-		/turf/closed/mineral/rogue/tin = 15,
+		/turf/closed/mineral/rogue/tin = 14,
 		/turf/closed/mineral/rogue/coal = 19,
 		/turf/closed/mineral/rogue/gem = 3)
 


### PR DESCRIPTION
## About The Pull Request

* Regular rockwalls can now drop tin upon mining. They have a probability value of 7 - for reference, salt is 5 and copper is 10.
* High-tier rockwalls had their tin drop chances slightly increased by a value of 2, from 12 to 14.
* The probability value to gain tin from all three rockwall tiers is now 7, 10, and 14.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Tin was originally nuked early on in Azure - for good reason, as its actual use was functionally minimal.
* Now, bronze _(who's alloy desperately covets tin)_ is much more useful - and more importantly, unimportable.
* This ensures people can reasonably acquire a fair amount of tin for bronze or other things, without drowning in the ore.

## Changelog

:cl:
balance: Regular rock walls (which form a majority of the mines) now have a minor chance to drop tin. Likewise, higher-quality rock walls have a slightly increased chance to drop tin.
/:cl: