### PR TITLE
Final Touch (XI) / The Heart And Soul Of Any Good Story - Adds Unarmed skills, alongside proper inhands, to Chairs and Stools.

### DIFF
--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -179,6 +179,8 @@
 	obj_flags = CAN_BE_HIT
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = "woodimpact"
+	associated_skill = /datum/skill/combat/unarmed
+	swingsound = BLUNTWOOSH_LARGE
 
 /obj/item/chair/rogue/getonmobprop(tag)
 	. = ..()
@@ -279,6 +281,8 @@
 	blade_dulling = DULLING_BASHCHOP
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = "woodimpact"
+	associated_skill = /datum/skill/combat/unarmed
+	swingsound = BLUNTWOOSH_LARGE
 
 /obj/item/chair/stool/bar/rogue
 	name = "stool"
@@ -298,6 +302,8 @@
 	obj_flags = CAN_BE_HIT
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = "woodimpact"
+	associated_skill = /datum/skill/combat/unarmed
+	swingsound = BLUNTWOOSH_LARGE
 
 /obj/item/chair/stool/bar/rogue/getonmobprop(tag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
My original plan was to make this quite a large and expansive request, before I realized how finnicky inhandcode can be with regular items; doubly-so, since it can't actually display dyes or overlays _(for potions, foods, garbs, etcetera)_.
So! Instead, I'll keep it quite modest.

* Stools, chairs, and bedrolls now have proper inhands.
* Stools and chairs use skills - Unarmed.

And now, I am free to finally play the game.. after three-or-so months of developmental fugue-stating. Yippie!

## Testing Evidence

The shots!
https://github.com/user-attachments/assets/d0a66eac-d7d5-4362-b000-19bf15a2d36d

https://github.com/user-attachments/assets/f76294ed-a7b4-4bc9-a263-40a52f89f662

https://github.com/user-attachments/assets/67aa50a0-0fcb-4999-84de-d9d637e51759

## Why It's Good For The Game

This was the last big thing on my list that I wanted to fix.
It looks nicer. Also, barfights can scale a little more with these improvised weapons in the hands of a trained brawler.

## Changelog

:cl:
add: At last, Stools and Chairs (and Bedrolls) now use the Unarmed skills, and have proper inhands. Rejoice, and brawl on!
/:cl:
