### PR TITLE
Removes armour from Hijabs

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -74,7 +74,6 @@
 	alternate_worn_layer  = 8.9 //On top of helmet
 	body_parts_covered = HEAD|HAIR|EARS|NECK
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
-	armor = ARMOR_CLOTHING
 	dynamic_hair_suffix = ""
 	edelay_type = 1
 	adjustable = CAN_CADJUST


### PR DESCRIPTION
## About The Pull Request

This is literally only so you can put them in helmet storage for drip management, their armour was FAR from anything worthwhile anyways so nothing should be lost from this. 

## Testing Evidence

Nothing broke when i pressed f5

## Why It's Good For The Game

More drip options by placing hijabs in headgear storage, their default armour wasnt enough to be called armour anyways so there shouldnt be any issues with balance since who is relying on their hijab to block blows

## Changelog

:cl:
del: Armour from Hijab
/:cl:


