### PR TITLE
disallow people without arcyne training from learning scroll magic

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -96,6 +96,17 @@
 	user.log_message("learned the spell [spellname] ([S])", LOG_ATTACK, color="orange")
 	onlearned(user)
 
+/obj/item/book/granter/spell/attack_self(mob/living/user)
+	if(
+		!HAS_TRAIT(user, TRAIT_ARCYNE_T1) \
+		&& !HAS_TRAIT(user, TRAIT_ARCYNE_T2) \
+		&& !HAS_TRAIT(user, TRAIT_ARCYNE_T3) \
+		&& !HAS_TRAIT(user, TRAIT_ARCYNE_T4)
+	)
+		to_chat(user, span_danger("I don't know how to parse [src]. It hurts my head."))
+		return FALSE
+	..()
+
 /obj/item/book/granter/spell/random
 	icon_state = "random_book"
 


### PR DESCRIPTION
## About The Pull Request

as it says on the tin

## Testing Evidence

tested

## Why It's Good For The Game

with the T3 miracle Noccites get, literally any person being able to learn magic for free can get problematic.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Let magic scrolls require Arcyne Training.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
