### PR TITLE
Azure Assault 3: Context-Sensitive Callout on Pointing (Ctrl Shift Click)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -156,9 +156,9 @@
 //		changeNext_move(CLICK_CD_MELEE)
 //		ShiftMiddleClickOn(A)
 //		return
-//	if(modifiers["shift"] && modifiers["ctrl"])
-//		CtrlShiftClickOn(A)
-//		return
+	if(modifiers["shift"] && modifiers["ctrl"])
+		CtrlShiftClickOn(A)
+		return
 	if(modifiers["shift"] && modifiers["right"])
 		ShiftRightClickOn(A, params)
 		return
@@ -696,10 +696,10 @@ GLOBAL_LIST_EMPTY(reach_dummy_pool)
 
 /*
 	Control+Shift click
-	Unused except for AI
+	Callout point - points at the target and shouts a contact report.
 */
 /mob/proc/CtrlShiftClickOn(atom/A)
-	A.CtrlShiftClick(src)
+	callout_point(A)
 	return
 
 


### PR DESCRIPTION
## About The Pull Request
This PR solves communication issues in the chaos of PVP / PVE by implementing a video game inspired callout system. 

In case this get somehow TMed. This is binded to CTRL SHIFT CLICK and won't override normal click.

Now, every 10 seconds, whenever you point at something, your character will automatically and forcefully call out the mob / item they are pointing at in question!: 
- Your character will call out "[Thing!] [Distance] yards! [Cardinal Direction]" - For example: "Notice Board! 2 yards! Southwest!"
- If they're masked, their descriptor is used. For example - Soggy Plump Figure. Otherwise, their job is used if visible (interesting effect on mobs since they actually have a job title)
- If it is a turf, then you will add a command of "Over there!"
- If it is a mob, then context sensitive commands will be attached: "Get them!" if your hand is empty,"Cut them down!" if you are holding a rogueweapon, and "Shoot them!" if you are holding a ranged weapon. Now what if you just wanted to roleplay with them and chat? Well, too bad, I can't read your mind. 
- If you are holding a rogueweapon and pointing at an object, you will say "Break it!"
- If you point at raw silver, gold or gems you will say "We're rich!"  
- There's a 10 seconds cooldown between each pointing, in case this somehow get TMed or something. I might reopen this for April Fools as one of my joke package. 
- **ONLY APPLIES IN CMODE AND WITH A MIND ON THE MOB**: THIS IS MEANT TO BE A JOKE. Half of you think I am serious. HEEEELP

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="836" height="545" alt="dreamseeker_PpDyFS1Dkk" src="https://github.com/user-attachments/assets/21863157-5594-4507-b3b9-de86b4407c19" />
<img width="524" height="124" alt="dreamseeker_a4YXp7wZLS" src="https://github.com/user-attachments/assets/8ed59e6d-8e30-4ed6-a652-6abb25b0d432" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
please don't

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Context sensitive callout has been implemented whenever you point at as mob or object! Communicate and frag at the speed of thoughts! (Ctrl Shift Click)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
