### PR TITLE
fix calcic outburst + fix lich announce + add remote bomb

### DIFF
--- a/code/modules/antagonists/roguetown/villain/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich.dm
@@ -149,6 +149,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/suicidebomb)
+		H.mind.AddSpell(new	/obj/effect/proc_holder/spell/invoked/remotebomb)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/lich_announce)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tame_undead)
@@ -307,6 +308,13 @@
 	if(!calltext)
 		return FALSE
 
-	priority_announce("[calltext]", title = "Your Lich King Commands", sound = 'sound/misc/deadbell.ogg', sender = user, receiver = /mob/living/carbon/human/species/skeleton)
+	for(var/datum/antagonist/A in GLOB.antagonists)
+		if(!A.owner)
+			continue
+		if(!istype(A, /datum/antagonist/skeleton) && !istype(A, /datum/antagonist/lich))
+			continue
+		var/datum/mind/skele = A.owner
+		to_chat(skele.current, span_boldannounce("[span_purple(user.real_name)] shrieks out their commandment: [calltext]"))
+		skele.current.playsound_local(get_turf(A.owner), 'sound/misc/deadbell.ogg', 50, FALSE)
 
 	..()

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -129,10 +129,13 @@ LICH SKELETONS
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/aalloy
-
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
+	backl = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+		/obj/item/ammo_casing/caseless/rogue/heavy_bolt = 1
+	)
 	H.adjust_blindness(-3)
-	var/weapons = list("Bow & 20 Arrows", "Heavy Longbow & 20 Arrows", "Crossbow & 16 Bolts", "Sling")
+	var/weapons = list("Bow & 20 Arrows", "Longbow & 20 Arrows", "Crossbow & 16 Bolts", "Sling")
 	var/weapon_choice = input(H, "Choose your MISSILE.", "CONDEMN THE LYVING FROM AFAR.") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
@@ -140,7 +143,7 @@ LICH SKELETONS
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			beltl = /obj/item/quiver/paalloy
 			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
-		if("Heavy Longbow & 20 Arrows")
+		if("Longbow & 20 Arrows")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 			beltl = /obj/item/quiver/paalloy
 			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
@@ -148,6 +151,8 @@ LICH SKELETONS
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 			beltl = /obj/item/quiver/bolt/paalloy
 			H.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
+			if(prob(30))
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/heavy/paalloy
 		if("Sling")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
 			beltl = /obj/item/quiver/sling/paalloy

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -104,36 +104,38 @@
 
 	var/skeleton_roll
 
-	var/list/turf/target_turfs = list(T)
-	if(usr.dir == NORTH || usr.dir == SOUTH)
-		target_turfs += get_step(T, EAST)
-		target_turfs += get_step(T, WEST)
-	else
-		target_turfs += get_step(T, NORTH)
-		target_turfs += get_step(T, SOUTH)
-
 	for(var/i = 1 to to_spawn)
 		if(i > to_spawn)
 			i = 1
 
-		var/t_turf = target_turfs[i]
+		if(i > 1)
+			if(user.dir == NORTH || user.dir == SOUTH)
+				if(prob(50))
+					T = get_step(T, EAST)
+				else
+					T = get_step(T, WEST)
+			else
+				if(prob(50))
+					T = get_step(T, NORTH)
+				else
+					T = get_step(T, SOUTH)
 
-		if(!isopenturf(t_turf))
+		if(!isopenturf(T))
 			continue
 
-		new /obj/effect/temp_visual/bluespace_fissure(t_turf)
+		new /obj/effect/temp_visual/bluespace_fissure(T)
 		skeleton_roll = rand(1,100)
 		switch(skeleton_roll)
 			if(1 to 20)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(t_turf, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T, user, cabal_affine)
 			if(21 to 40)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(t_turf, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T, user, cabal_affine)
 			if(41 to 60)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(t_turf, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T, user, cabal_affine)
 			if(61 to 80)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(t_turf, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T, user, cabal_affine)
 			if(81 to 100)
-				new /mob/living/simple_animal/hostile/rogue/skeleton(t_turf, user, cabal_affine)
+				new /mob/living/simple_animal/hostile/rogue/skeleton(T, user, cabal_affine)
 	return TRUE
 
 /obj/effect/proc_holder/spell/invoked/raise_undead_formation/necromancer

--- a/code/modules/spells/spell_types/undead/self/calcic_outburst.dm
+++ b/code/modules/spells/spell_types/undead/self/calcic_outburst.dm
@@ -10,42 +10,104 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	stat_allowed = TRUE
-	var/exp_heavy = 0
-	var/exp_light = 3
-	var/exp_flash = 3
+	var/exp_heavy = 2
+	var/exp_light = 5
+	var/exp_flash = 5
 	var/exp_fire = 0
 
 /obj/effect/proc_holder/spell/self/suicidebomb/cast(list/targets, mob/living/user = usr)
 	..()
 	if(!user)
+		revert_cast()
 		return FALSE
 	if(user.stat == DEAD)
+		revert_cast()
 		return FALSE
 	if(alert(user, "Do you wish to sacrifice this vessel in a powerful explosion?", "ELDRITCH BLAST", "Yes", "No") == "No")
+		revert_cast()
 		return FALSE
-	playsound(get_turf(user), 'sound/magic/antimagic.ogg', 100)
-	user.visible_message(
-		span_danger("[user] begins to shake violently, a blindingly bright light beginning to emanate from them!"), 
-		span_danger("Powerful energy begins to expand outwards from inside me!")
-	)
 
 	user.Immobilize(5 SECONDS)
 	user.Knockdown(5 SECONDS)
 
-	addtimer(CALLBACK(src, PROC_REF(lichdeath), user), 5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(skele_explode), user, user, exp_heavy, exp_light, exp_flash, exp_fire), 5 SECONDS)
+	return TRUE
 
-/obj/effect/proc_holder/spell/self/suicidebomb/proc/lichdeath(mob/living/user)
-	var/datum/antagonist/lich/lichman = user.mind.has_antag_datum(/datum/antagonist/lich)
-	explosion(get_turf(user), -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, soundin = 'sound/misc/explode/incendiary (1).ogg')
-	if(lichman && user.stat != DEAD && lichman.consume_phylactery(0)) // Use phylactery at 0 timer. Die if none.
+/obj/effect/proc_holder/spell/proc/skele_explode(mob/living/user, mob/living/target = user, exp_heavy, exp_light, exp_flash, exp_fire)
+	var/datum/antagonist/lich/lich_antag
+
+	if(user.mind.has_antag_datum(/datum/antagonist/lich))
+		lich_antag = user.mind.has_antag_datum(/datum/antagonist/lich)
+
+	if(user != target && !user.mind)
+		exp_light -= 2
+		exp_flash -= 2
+
+	playsound(get_turf(target), 'sound/magic/antimagic.ogg', 100)
+	target.visible_message(
+		span_danger("[target] begins to shake violently, a blindingly bright light beginning to emanate from them!")
+	)
+
+	explosion((user == target) ? get_turf(user) : get_turf(target), 1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, soundin = 'sound/misc/explode/incendiary (1).ogg')
+	if(lich_antag && user.stat != DEAD && lich_antag.consume_phylactery(0) && user == target) // Use phylactery at 0 timer. Die if none.
 		return TRUE
 
-	user.death()
+	target.gib()
 	return TRUE
 
 /obj/effect/proc_holder/spell/self/suicidebomb/lesser
 	name = "Lesser Calcic Outburst"
 	exp_heavy = 0
-	exp_light = 2
-	exp_flash = 2
+	exp_light = 3
+	exp_flash = 3
 	exp_fire = 0
+
+
+/obj/effect/proc_holder/spell/invoked/remotebomb
+	name = "Shell Outburst"
+	desc = "Cause a minion to give up their lyfe for the Exarch.."
+	overlay_state = "tragedy"
+	chargedrain = 0
+	range = 7
+	chargetime = 2 SECONDS
+	recharge_time = 15 SECONDS
+	gesture_required = TRUE
+	charging_slowdown = 1
+	sound = 'sound/magic/swap.ogg'
+	warnie = "spellwarning"
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+	stat_allowed = TRUE
+	var/exp_heavy = 1
+	var/exp_light = 3
+	var/exp_flash = 3
+	var/exp_fire = 0
+
+/obj/effect/proc_holder/spell/invoked/remotebomb/cast(list/targets, mob/living/user)
+	..()
+
+	if(!isliving(targets[1]))
+		revert_cast()
+		return FALSE
+
+	var/mob/living/target = targets[1]
+
+	if(target == user)
+		to_chat(user, span_warning("I've my own manoeuvre for this."))
+		revert_cast()
+		return FALSE
+
+	if(!istype(target, /mob/living/carbon/human/species/skeleton))
+		to_chat(user, span_warning("[target] is not a shambler. I'm powerless."))
+		revert_cast()
+		return FALSE
+
+	user.pointed(target)
+
+	if(target.mind)
+		to_chat(target, span_warning("The Exarch calls for me. This is it!"))
+
+	target.Immobilize(5 SECONDS)
+	target.Knockdown(5 SECONDS)
+
+	addtimer(CALLBACK(src, PROC_REF(skele_explode), user, target, exp_heavy, exp_light, exp_flash, exp_fire), 5 SECONDS)


### PR DESCRIPTION
## About The Pull Request

1. Calcic Outburst is now deadlier. Even more so for the Lich.
2. The Lich can now remotely explode a skeleton. NPC or otherwise. Player skeletons blow up more.
3. Lich announce works.

## Testing Evidence

More-or-less. Will need ingame testing.

## Why It's Good For The Game

Bugfixes and a funny new spell.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Calcic outburst hurts, now.
fix: Lich announce works, now.
add: Shell Outburst for the Lich, to remotely explode NPC/Player skeletons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
