### PR TITLE
Boned Down - Skeletons now have their Siegebows restricted to a slot-limited subclass, touched up the description of other skeletal roles.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -289,6 +289,8 @@ LICH SKELETONS
 /////////////////////////////
 // SPECIAL / LIMITED SLOTS //
 /////////////////////////////
+// Use this section to drop slot-limited subclasses.
+// Below is an example. You can adjust how many instances of a subclass can exist on any given round by changing the number that's attached to the 'maximum_possible_slots' variable.
 
 // Limited slot. Exclusive access to the Siegebow and slightly better melee skills, but worse speed.
 /datum/advclass/greater_skeleton/lich/rareballistiares


### PR DESCRIPTION
## About The Pull Request

* Added extra flair to most Lich-Soldier class descriptions.
* Added the 'Siege-Ballistearie', the new home for Siegebows. Only a maximum of three can be sired at any given time. They have slightly improved strength, perception, and willpower - but reduced speed and less versatile skills. They're a _master_ with the crossbow, but can choose to take an _expert_-tier sidearm in the form of a gladius or dagger.
* Skeletal sappers now get an ancient hatchet instead of a basic axe.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Player-requested alteration that still allows for Liches to siegebreak fortifications, but without the potential issues that'd come from having a potentially uncapped amount of Siegebows to work with.
* Allows sappers to better handle their specialization as laborers.
* Adds a framework that'd allow for further slot-limited skeletal classes to be added, if desired - ancient knights, champions, mages, what-have-you. Go wild!

## Changelog

:cl:
del: Skeletal bowmen no longer have access to the Siegebow.
add: Instead, the Siegebow can now be obtained through the 'Siege-Ballistiare' subclass, which is slot-limited to three per round.
balance: Siege-Ballistiares are better with crossbows, have slightly better physical stats, and can choose to be an Expert with either a dagger or gladius. In exchange, however, they lose out on the ability to work with regular bows and have poor speed.
balance: Skeletal sappers now receive a proper ancient hatchet, instead of a regular axe.
/:cl:

