### PR TITLE
Graverobber Powercreep

### DIFF
--- a/code/datums/gods/patrons/inhumen/matthios.dm
+++ b/code/datums/gods/patrons/inhumen/matthios.dm
@@ -16,6 +16,7 @@
 					/obj/effect/proc_holder/spell/invoked/churnwealthy					= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/resurrect/matthios			= CLERIC_T3, // Counterpart to anastasis
 	)
+	traits_tier = list(TRAIT_GRAVEROBBER = CLERIC_T0) //Requires a minimal holy skill or the 'Devotee' virtue to unlock. Allows you to rob graves without the FOR malus.
 	confess_lines = list(
 		"MATTHIOS STEALS FROM THE WORTHLESS!",
 		"MATTHIOS IS JUSTICE!",


### PR DESCRIPTION
## About The Pull Request

Devotees of Matthios now get the 'expert graverobber' trait.

## Testing Evidence

<img width="587" height="221" alt="image" src="https://github.com/user-attachments/assets/a1917588-65e1-4657-9293-86f69c7b2a7a" />

## Why It's Good For The Game

The God Who Steals Things can now steal even more things. This trait prevents a fairly significant fortune malus(-2 for ten minutes) from robbing marked graves.

Considering robbing graves increases Matthios' influence, I figure this is within his realm. In the spirit of fairness I will ideasjak some stuff for everyone else to get as well, though after a point you run out of 'little' things to give.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl: Matthios
add: Matthiosite devotees now have the 'experienced graverobber' trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
