### PR TITLE
[Miracles] Generalizes healing messages.

### DIFF
--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -202,8 +202,8 @@
 			user.playsound_local(user, 'sound/magic/PSY.ogg', 100, FALSE, -1)
 			return FALSE
 		if(user.patron?.undead_hater && (target.mob_biotypes & MOB_UNDEAD))
-			target.visible_message(span_danger("[target] is crushed by divine pressure!"), span_userdanger("I'm crushed by divine pressure!"))
-			target.adjustBruteLoss(30)			
+			// We do nothing to avoid meta checking for undead
+			target.visible_message(span_info("A wave of divine energy crashes over [target]!"), span_notice("I'm crushed by healing energies!"))
 			return TRUE
 
 		var/conditional_buff = FALSE

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -33,9 +33,10 @@
 		return FALSE
 
 	if(user.patron?.undead_hater && (target.mob_biotypes & MOB_UNDEAD))
-		target.visible_message(span_danger("[target] is burned by holy light!"), span_userdanger("I'm burned by holy light!"))
-		target.adjustFireLoss(10)
-		target.fire_act(1, 10)
+		// We simply do nothing to avoid healing being used to vamp/skelly check!
+		var/message_out_undead = span_info("Healing energies envelop [target]!")
+		var/message_self_undead = span_notice("I am bathed in healing choral hymns!")
+		target.visible_message(message_out_undead, message_self_undead)
 		return TRUE
 
 	if(target.has_status_effect(/datum/status_effect/buff/healing))
@@ -47,6 +48,7 @@
 	var/situational_bonus = 1
 	var/is_inhumen = FALSE
 
+	// Edit - This is overwritten near the end of the proc to prevent metagaming.
 	var/message_out = span_info("A choral sound comes from above and [target] is healed!")
 	var/message_self = span_notice("I am bathed in healing choral hymns!")
 		
@@ -81,6 +83,10 @@
 		return FALSE
 
 	target.apply_status_effect(/datum/status_effect/buff/healing, healing)
+
+	// Edit - Overwriting the outgoing message here to prevent metagaming faith via message.
+	// Not getting rid of the messages in the code, we might want them for something else later.
+	message_out = span_info("Healing energies envelop [target]!")
 	target.visible_message(message_out, message_self)
 
 	return TRUE

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -35,8 +35,8 @@
 		var/damtotal = brute + burn
 		var/zcross_trigger = FALSE
 		if(user.patron?.undead_hater && (target.mob_biotypes & MOB_UNDEAD)) // YOU ARE NO LONGER MORTAL. NO LONGER OF HIM. PSYDON WEEPS.
-			target.visible_message(span_danger("[target] shudders with a strange stirring feeling!"), span_userdanger("It hurts. You feel like weeping."))
-			target.adjustBruteLoss(40)			
+			// We do nothing to avoid meta checking for undead
+			target.visible_message(span_info("A strange stirring feeling pours from [target]!"), span_info("Sentimental thoughts drive away my pain..."))		
 			return TRUE
 
 		// Bonuses! Flavour! SOVL!


### PR DESCRIPTION
## About The Pull Request
Two things.

- All generic healing miracles now show a generic healing message.
- Undead aren't healed, aren't damaged, and play the usual healing message when undead-hating patrons have their healing spells cast on them.

The patron specific healing message is still shown to whomever receives the healing. You know, just to retain a modicum of risk if you're a heretic healing some templar!

## Testing Evidence
<img width="1562" height="1046" alt="image" src="https://github.com/user-attachments/assets/0e5d7ec3-5905-4f09-84dd-539ad4326aea" />

## Why It's Good For The Game

Gets rid of metagaming antags with miracles. It's not allowed as per the rules, setting people on fire is obnoxious at best as it burns cloth items, undead mobs tend to put out the fires instantly. There's offensive miracles for damage purposed anyhow.

## Changelog

:cl:
balance: Miracles use a generic message when cast now, to avoid metagaming. Undead no longer catch fire from healing miracles.
/:cl:

