### PR TITLE
Midnight (Balance)snakk™ - Reduces the power of most Siegebolts to deal 90 damage (or +33% of a regular bolt), instead of 120 (or +66%).

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -179,10 +179,10 @@
 
 /obj/projectile/bullet/reusable/heavy_bolt
 	name = "heavy bolt"
-	damage = BOLT_DAMAGE
+	damage = BOLT_DAMAGE + 20 // +33% the damage.
 	damage_type = BRUTE
 	armor_penetration = BOLT_PENETRATION + 25 // +50% the penetrative power.
-	object_damage_multiplier = 18 //Determines the multiplier that's applied to the bolt's damage value, when striking a structure. By default, it can destroy any wooden defense - a door, barricade, wall - in one shot.
+	object_damage_multiplier = 14 //Determines the multiplier that's applied to the bolt's damage value, when striking a structure. By default, it can destroy any wooden defense - a door, barricade, wall - in one shot.
 	wall_impact_break_probability = 100 //Determines the chance that a bolt will destroy itself, when striking a structure. By default, it will always destroy itself after successfully impacting a wall.
 	damages_turf_walls = TRUE //Determines whether the bolt can damage turfs or not. By default, yes.
 	icon = 'icons/roguetown/weapons/ammo.dmi'
@@ -248,7 +248,7 @@
 
 /obj/projectile/bullet/reusable/heavy_bolt/aalloy
 	name = "decrepit heavy bolt"
-	damage = 60 
+	damage = BOLT_DAMAGE - 10
 	object_damage_multiplier = 20 //Ensures the bolt can still, at a minimum, destroy most wooden barricades and doors in one shot.
 	icon_state = "ancientbolt_proj"
 	poisontype = /datum/reagent/stampoison
@@ -534,7 +534,7 @@
 
 /obj/projectile/bullet/reusable/heavy_bolt/silver
 	name = "heavy silver bolt"
-	damage = 100
+	damage = BOLT_DAMAGE + 30
 	armor_penetration = 777 //Same damage, but with absolute penetration. 
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/heavy_bolt/silver
 	icon_state = "silvheavybolt_proj"


### PR DESCRIPTION
## About The Pull Request

* All Siegebolts have had their damage reduced from 120 to 70. This is, for reference, the same damage as a crossbow's bolt.
* Silver siegebolts have had their damage reduced from 120 to 100.

## Testing Evidence

Simple one-liner. Hopefully, none more _(after this)._

## Why It's Good For The Game

* I can't find a way to properly handle this piece of ammunition without either making it _too_ powerful or _too_ weak, and I'd rather not step away from something while said-something still feels unbalanced.
* The shtick of the Siegebow remains - high structural damage, heavy debuffing - without the raw damage boost that allowed it to potentially one-shot people from afar. 
* No salt, no jakkage. I ultimately want what's healthiest for the game, and I think this is the best compromise that can be done _(or more specifically, to the best of my code-limited ability.)_
* Silver bolts still remain as a proverbial silver bullet, but aren't as overwhelmingly powerful as before.

## Changelog

:cl:
balance: Siegebolts deal a little less damage, now.
/:cl:
