### PR TITLE
Aasimar, Tieflings and Lux

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -220,6 +220,9 @@
 	effectedstats = list(STATKEY_STR = -1, STATKEY_WIL = -1, STATKEY_CON = -1, STATKEY_SPD = -1, STATKEY_LCK = -1)
 	duration = 5 MINUTES
 
+/datum/status_effect/debuff/devitalised/greater
+	duration = 30 MINUTES
+
 /atom/movable/screen/alert/status_effect/debuff/devitalised
 	name = "Devitalised"
 	desc = "Something has been taken from me, and it will take time to recover."

--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -28,6 +28,9 @@
 	if(target.stat == DEAD)
 		to_chat(user, "They're dead!")
 		return FALSE
+	if(istiefling(target))
+		to_chat(user, span_warning("Their Lux is infernal. It will not do."))
+		return FALSE
 
 /datum/surgery_step/extract_lux/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	display_results(user, target, span_notice("I begin to scrape lux from [target]'s heart..."),
@@ -40,16 +43,23 @@
 		target.emote("painscream")
 	if(target.has_status_effect(/datum/status_effect/debuff/devitalised))
 		display_results(user, target, span_notice("You cannot draw lux from [target]; they have none left to give."),
-		"[user] extracts lux from [target]'s innards.",
-		"[user] extracts lux from [target]'s innards.")
+		"[user] fails to extract lux from [target]'s innards.",
+		"[user] fails to extract lux from [target]'s innards.")
 		return FALSE
 	else
 		display_results(user, target, span_notice("You extract a single dose of lux from [target]'s heart."),
 			"[user] extracts lux from [target]'s innards.",
 			"[user] extracts lux from [target]'s innards.")
-		new /obj/item/reagent_containers/lux_impure(target.loc)
+		
+		var/apply_greater
+		if(isaasimar(target))
+			new /obj/item/reagent_containers/lux(target.loc)
+			apply_greater = TRUE
+		else
+			new /obj/item/reagent_containers/lux_impure(target.loc)
+		
 		SEND_SIGNAL(user, COMSIG_LUX_EXTRACTED, target)
 		//record_featured_stat(FEATURED_STATS_CRIMINALS, user)	- This.. isn't normally criminal.
 		record_round_statistic(STATS_LUX_HARVESTED)
-		target.apply_status_effect(/datum/status_effect/debuff/devitalised)
+		target.apply_status_effect((apply_greater ? /datum/status_effect/debuff/devitalised/greater : /datum/status_effect/debuff/devitalised))
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
- Tieflings cannot have their Lux extracted.
- Aasimars now give pure lux when lux extracted.
- However, their "devitalised" period is 2x as long, lasting a whole dae.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's been suggested / requested for fluff-ish purposes for a while. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Aasimar lux is now purified, but their 'devitalised' period lasts longer.
balance: Tieflings cannot have their Lux extracted. It is infernal and incompatible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
