### PR TITLE
..And Watch Me Nay-Nay - Slightly reorganizes whip.dm, reduces MINSTR_REQ for special whips, and adds explanatory descriptions.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -49,11 +49,11 @@
 	icon_state = "inlash"
 	item_d_type = "slash"
 
-//Exclusive variant to whips with alloyed tips and high Strength requirements. Nearly one-to-one with conventional lashes, with the added capability to dismember.
+//Exclusive variant to whips with alloyed tips and high Strength requirements. On par with a traditional lash, but can dismember from afar.
 /datum/intent/whip/lash/master
 	name = "lash with dismembering force"
-	desc = "Lash the whip against a target from afar, leveraging your strength - and the whip's tip - to rip them apart. </br>Uniquely deals lashing wounds, which inflicts tremendous blood loss and pain onto the target. </br>Critical hits can uniquely dismember limbs and cause disembowelements. </br>Lesser critical hits leave permenant scars, unremovable under most circumstances."
-	blade_class = BCLASS_LASHINGPLUS //Performs very similarly to regular lashes, but with the added bonus of being able to dismember limbs.
+	desc = "Lash the whip against a target from afar, leveraging your strength to lash their limbs apart. </br>Critical hits can uniquely dismember limbs and cause disembowelements."
+	blade_class = BCLASS_CUT
 	attack_verb = list("deftly lashes", "sharply cracks")
 
 //Crack = cut damage, can dismember, so lower range.
@@ -137,7 +137,7 @@
 	icon_state = "bronzewhip"
 	force = 21
 	minstr = 11
-	possible_item_intents = list(/datum/intent/whip/lash/holy, /datum/intent/whip/crack, /datum/intent/whip/punish)
+	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish)
 	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/rogueweapon/whip/antique/psywhip
@@ -146,7 +146,7 @@
 	icon_state = "psywhip"
 	is_silver = TRUE
 	force = 25
-	possible_item_intents = list(/datum/intent/whip/lash/holy, /datum/intent/whip/crack, /datum/intent/whip/punish)
+	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish)
 	minstr = 11
 	wdefense = 0
 	anvilrepair = /datum/skill/craft/weaponsmithing


### PR DESCRIPTION
## About The Pull Request

* Bronze whips and silver whips now have a minimum strength requirement of XI, down from XII and XIII _(respectively.)_
* Whip.dm is slightly tidied up. Intents and unique whips are seperated in their own little categories.
* Renames _'holy lash'_ to the more agnostic _'lash with dismembering force'_, as it's used for non-holy weapons as well.
* Whipping intents now come with specific descriptions, describing their shticks.

## Testing Evidence

Same as before. This version just lacks the weird 'fourth' intent shtick, with the only serious balance change being the reduction of certain strength requirements.

## Why It's Good For The Game

* As it turns out, minimum strength requirements are a little iffy. This reduces it so that more people - besides those who are far too cheeked up _(and thusly, more likely to take a different weapon all-together)_ - can experiment with said-weapon.
* More coherency is good. A cleaner .dm is a cleaner mind, too.
* Being able to determine how certain intents work is good, especially for those who aren't familiar with such weapons.

## Changelog

:cl:
balance: Silver and bronze whips now have a flat minimum strength requirement of 11, instead of 12 and 13.
add: Whipping intents now explain their unique gimmicks and damage types, upon examination.
code: Cleaned up whip.dm just a little bit, and further organized it.
code: Renamed 'holy lash' to 'lash with dismembering force'. Same as before, otherwise.
/:cl:

