### PR TITLE
dungeon spell scrolls are readable, noc scrolls require arcyne

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -10,6 +10,7 @@
 	var/oneuse = TRUE //default this is true, but admins can var this to 0 if we wanna all have a pass around of the rod form book
 	var/used = FALSE //only really matters if oneuse but it might be nice to know if someone's used it for admin investigations perhaps
 	var/dreamcost
+	var/arcyne_required = FALSE
 
 /obj/item/book/granter/proc/turn_page(mob/user)
 	playsound(user, pick('sound/blank.ogg'), 30, TRUE)
@@ -97,14 +98,15 @@
 	onlearned(user)
 
 /obj/item/book/granter/spell/attack_self(mob/living/user)
-	if(
-		!HAS_TRAIT(user, TRAIT_ARCYNE_T1) \
-		&& !HAS_TRAIT(user, TRAIT_ARCYNE_T2) \
-		&& !HAS_TRAIT(user, TRAIT_ARCYNE_T3) \
-		&& !HAS_TRAIT(user, TRAIT_ARCYNE_T4)
-	)
-		to_chat(user, span_danger("I don't know how to parse [src]. It hurts my head."))
-		return FALSE
+	if(arcyne_required)
+		if(
+			!HAS_TRAIT(user, TRAIT_ARCYNE_T1) \
+			&& !HAS_TRAIT(user, TRAIT_ARCYNE_T2) \
+			&& !HAS_TRAIT(user, TRAIT_ARCYNE_T3) \
+			&& !HAS_TRAIT(user, TRAIT_ARCYNE_T4)
+		)
+			to_chat(user, span_danger("I don't know how to parse [src]. It hurts my head."))
+			return FALSE
 	..()
 
 /obj/item/book/granter/spell/random

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -11,7 +11,8 @@
 	var/used = FALSE //only really matters if oneuse but it might be nice to know if someone's used it for admin investigations perhaps
 	var/dreamcost
 	var/arcyne_required = FALSE
-
+	resistance_flags = FIRE_PROOF
+	
 /obj/item/book/granter/proc/turn_page(mob/user)
 	playsound(user, pick('sound/blank.ogg'), 30, TRUE)
 	if(do_after(user,50, user))

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -735,7 +735,9 @@ Somewhat fitting, considering the broadness of their domains. I also just think 
 			recharge_time = 15 MINUTES // kept in so the intent is understood.
 		if(item.dreamcost >= 9)
 			recharge_time = 30 MINUTES
-		var/obj/item/I = new item (get_turf(user))
+		var/obj/item/book/granter/I = new item (get_turf(user))
+		I.arcyne_required = TRUE // only spellcasters can read these
+		I.desc += span_info("\nThis scroll was made by a Crescent and cannot be read without arcyne training.")
 		user.put_in_hands(I)
 		alreadychoosing = FALSE
 		return TRUE

--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -231,7 +231,7 @@
 
 /obj/effect/proc_holder/spell/invoked/projectile/sickness
 	name = "Ray of Sickness"
-	desc = ""
+	desc = "Fires a bolt of evyle magicks that poison your enemy."
 	clothes_req = FALSE
 	range = 15
 	projectile_type = /obj/projectile/magic/sickness


### PR DESCRIPTION
## About The Pull Request
- added a var to scrolls, arcyne_required
- if check for magic trait now only fires if true
- default false
- noc spell scrolls set it to true, meaning noc spell scrolls can only be read by ppl w/ arcyne traits of some sort
- also theyre fireproof by ansari request
### unatomized lazy commit: ray of sickness
- fixed ray of sickness descriptor while im at it cause i dont want 2 open another pr for it
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="509" height="197" alt="image" src="https://github.com/user-attachments/assets/4b5548df-de75-492d-b78b-19cd10ddc41f" />

https://github.com/user-attachments/assets/e28d0114-ec34-461f-84ef-88e65cb01d45


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- my other idea was to give default spell scrolls like 100 - 150 mammon value so you can sell them if u get them in a udngeon and arent a caster
- but this is cooler. i think. i would like 2 be able 2 use the loot i get... opleas... pleas... Can I win... Pleas..
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:NOCTURNE
balance: spell scrolls can again be read by anyone if found in a dungeon
balance: spell scrolls acquired by kytherian grimoire require an arcyne tier to read
add: ray of sickness has a description now
balance: spell scrolls are now fireproof
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
