### PR TITLE
Hand Stat and Loadout adjustment

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/hand.dm
@@ -31,6 +31,7 @@
 /datum/outfit/job/roguetown/hand
 	backr = /obj/item/storage/backpack/rogue/satchel/short
 	shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/light/fencer //steel protection with awful integrity, to go under the awful integrity gambeson- light tho
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy/hand
 	belt = /obj/item/storage/belt/rogue/leather/steel
 	id = /obj/item/scomstone/garrison/hand
@@ -60,12 +61,13 @@
 	outfit = /datum/outfit/job/roguetown/hand/blademaster
 
 	category_tags = list(CTAG_HAND)
-	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_HEAVYARMOR)
+	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_MEDIUMARMOR)
 	subclass_stats = list(
 		STATKEY_PER = 3,
 		STATKEY_INT = 3,
 		STATKEY_STR = 2,
-		STATKEY_LCK = 1,
+		STATKEY_CON = 1,
+		STATKEY_LCK = 1, //less lucky than the rest... go figure
 	)
 	age_mod = /datum/class_age_mod/hand_blademaster
 	subclass_skills = list(
@@ -90,10 +92,6 @@
 	head = /obj/item/clothing/head/roguetown/chaperon/noble/hand
 	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hand
 	pants = /obj/item/clothing/under/roguetown/tights/black
-	if(should_wear_femme_clothes(H))
-		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_f
-	else if(should_wear_masc_clothes(H))
-		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_m
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/dtace = 1,
 		/obj/item/rogueweapon/scabbard/sheath/royal = 1,
@@ -118,7 +116,7 @@
 		STATKEY_SPD = 3,
 		STATKEY_PER = 2,
 		STATKEY_INT = 2,
-		STATKEY_STR = -1,
+		STATKEY_LCK = 2,
 	)
 	age_mod = /datum/class_age_mod/hand_spymaster
 	subclass_skills = list(
@@ -152,14 +150,12 @@
 		/obj/item/lockpickring/mundane = 1,
 	)
 	if(H.dna.species.type in NON_DWARVEN_RACE_TYPES)
-		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/shadowrobe
 		cloak = /obj/item/clothing/cloak/half/shadowcloak
 		gloves = /obj/item/clothing/gloves/roguetown/fingerless/shadowgloves
 		mask = /obj/item/clothing/mask/rogue/shepherd/shadowmask
 		pants = /obj/item/clothing/under/roguetown/trou/shadowpants
 	else
 		cloak = /obj/item/clothing/cloak/raincloak/mortus //cool spymaster cloak
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
 		backr = /obj/item/storage/backpack/rogue/satchel/black
 		pants = /obj/item/clothing/under/roguetown/tights/black
 	if(H.mind)
@@ -176,7 +172,8 @@
 	subclass_stats = list(
 		STATKEY_INT = 4,
 		STATKEY_PER = 3,
-		STATKEY_WIL = 2,
+		STATKEY_SPD = 1,
+		STATKEY_WIL = 1,
 		STATKEY_LCK = 2,
 	)
 	age_mod = /datum/class_age_mod/hand_advisor
@@ -184,7 +181,7 @@
 	subclass_skills = list(
 		/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN, //they get the whole cane sword, they should use the whole cane sword
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
@@ -208,10 +205,6 @@
 
 //Advisor start. Trades combat skills for more knowledge and skills - for older hands, hands that don't do combat - people who wanna play wizened old advisors.
 /datum/outfit/job/roguetown/hand/advisor/pre_equip(mob/living/carbon/human/H)
-	if(should_wear_femme_clothes(H))
-		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_f
-	else if(should_wear_masc_clothes(H))
-		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_m
 	backpack_contents = list(
 		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/storage/keyring/lord = 1,


### PR DESCRIPTION
## About The Pull Request

Oh god, Eiren made a pull request, it might blow up.
I should not be allowed to touch code.

Anyway.

Now that the new items and loadouts for hand have settled a few cracks began to show, namely the fact that the blademaster can't hold their own in melee very well and- oh god spymaster was not looking good.

This PR aims to aid in some of these issues by:
- Giving blademaster a single extra point of CON
- raising spymaster stats to the same level as other subclasses (its mostly FOR and no more negative STR)
- taking a point of WIL from advisor and giving it one SPD instead, as well as raising their sword skill to journeyman so they can use the damn cane sword better
- giving all hand loudouts the "Besilked Haubergeon" as maille tier light armour with awful intergrity to wear under their unique gambeson which only fits in the armour slot

## Testing Evidence
Tested all the loudouts on a statless aasimar after having a drink
1 extra for on spymaster cause the creechur got happy- woe

<img width="2149" height="1249" alt="Screenshot 2026-02-20 023807" src="https://github.com/user-attachments/assets/c2a903d8-7bd9-493d-a444-6a569a24e4d3" />
<img width="2513" height="1256" alt="Screenshot 2026-02-20 023711" src="https://github.com/user-attachments/assets/f2a0e00a-d1bc-4c63-88f3-ab7ab200fe17" />
<img width="2317" height="1264" alt="Screenshot 2026-02-20 023850" src="https://github.com/user-attachments/assets/d2a9714c-d767-4b39-a9a3-ffd60296c15d" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Blademaster hand suffers massively from getting literally no CON, meaning anything that does penetrate your armour will lead to rapid bleedout, even more so due to CON/WIL being a common dump of statpacks.
A single point added to their statweight still leaves them below marshal- and far below duchess in power while aiding in surviving the nasty bleeds.
As a trade off, no more full plate, wear the gambeson.

Hand has been given a shiny new gambeson which however can only be worn in the armour slot.
This left both spymaster and advisor in the awkward place where they can not wear any non-merc shirt armour.
So instead hand has been given the "Besilked Haubergeon" which is a light, and far more fragile, version of a regular haubergeon.
This should give them some decent protection while remaining in line with the fragility of those subclasses.

Advisor lacked the skills to actually use the cane sword, now they got journeyman... some people will train to expert anyways.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: added and expanded hand stat weights to be equal accross subclasses
balance: replaced the bandaid drip with fragile light maille
balance: lets the evil advisor hand use their sword
/:cl:
