### PR TITLE
Gives the kampfmesser the Messer's special

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -469,6 +469,7 @@
 	sheathe_icon = "minimesser"
 	max_blade_int = 200
 	max_integrity = 150
+	special = /datum/special_intent/shin_swipe
 
 /obj/item/rogueweapon/huntingknife/idagger/virtue
 	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch)


### PR DESCRIPTION
## About The Pull Request

I thought it having no special was a shame, I wasn't sure what special to give it, Lamas suggested maybe the Messer's special since it's just a mini-messer and I think it could work.

## Testing Evidence

Went into a test server and confirmed you perform the shin swipe.

## Why It's Good For The Game

I think specials are good to have for a combat knife and I don't think Shin Swipe would be gamebreaking on a cutting/chopping dagger.

## Changelog

:cl: Randall
add: Added the Shin Swipe special to the Kampfmesser
/:cl: