### PR TITLE
Special Tweaks (Part II)

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/special.dm
+++ b/code/game/objects/items/rogueweapons/mmb/special.dm
@@ -32,7 +32,7 @@
 			if(user.get_skill_level(skillreq) < SKILL_LEVEL_JOURNEYMAN)
 				to_chat(user, span_info("I'm not knowledgeable enough in the arts of this weapon to use this."))
 				return
-		if(W.special.check_range(user, target) && W.special.check_reqs(user))
+		if(W.special.check_range(user, target) && W.special.check_reqs(user, W))
 			if(W.special.apply_cost(user))
 				W.special.deploy(user, W, target)
 

--- a/code/game/objects/items/rogueweapons/mmb/special.dm
+++ b/code/game/objects/items/rogueweapons/mmb/special.dm
@@ -32,7 +32,7 @@
 			if(user.get_skill_level(skillreq) < SKILL_LEVEL_JOURNEYMAN)
 				to_chat(user, span_info("I'm not knowledgeable enough in the arts of this weapon to use this."))
 				return
-		if(W.special.check_range(user, target))
+		if(W.special.check_range(user, target) && W.special.check_reqs(user))
 			if(W.special.apply_cost(user))
 				W.special.deploy(user, W, target)
 

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -46,7 +46,7 @@
 	if(HT.has_status_effect(/datum/status_effect/debuff/baited) || user.has_status_effect(/datum/status_effect/debuff/baitcd))
 		return	//We don't do anything if either of us is affected by bait statuses
 
-	if(!HT.can_see_cone(user) && HT.mind)
+	if(!HT.can_see_cone(user) && HT.mind && HT.get_tempo_bonus(TEMPO_TAG_FEINTBAIT_FOV))
 		newcd = 5 SECONDS
 		to_chat(user, span_notice("[HT.p_they()] didn't see me! Nothing happened!"))
 		HU.apply_status_effect(/datum/status_effect/debuff/baitcd, newcd)
@@ -195,16 +195,16 @@
 	skill_factor = (ourskill - theirskill)/2
 
 	var/special_msg
-	var/newcd = (BASE_RCLICK_CD - user.get_tempo_bonus(TEMPO_TAG_RCLICK_CD_BONUS)) + feintdur
+	var/newcd = (FEINT_RCLICK_CD - user.get_tempo_bonus(TEMPO_TAG_RCLICK_CD_BONUS))
 
-	if(L.has_status_effect(/datum/status_effect/debuff/exposed))
+	if(L.has_status_effect(/datum/status_effect/debuff/exposed) || L.has_status_effect(/datum/status_effect/debuff/vulnerable))
 		perc = 0
 
 	if(L.has_status_effect(/datum/status_effect/debuff/feinted))
 		perc = 0
 		special_msg = span_warning("Too soon! They were expecting it!")
 
-	if(!L.can_see_cone(user) && L.mind)
+	if(!L.can_see_cone(user) && L.mind && L.get_tempo_bonus(TEMPO_TAG_FEINTBAIT_FOV))
 		perc = 0
 		newcd = 5 SECONDS
 		special_msg = span_warning("They need to see me for me to feint them!")
@@ -223,13 +223,16 @@
 	if(L.has_status_effect(/datum/status_effect/buff/clash))
 		L.remove_status_effect(/datum/status_effect/buff/clash)
 		to_chat(user, span_notice("[L.p_their(TRUE)] Guard disrupted!"))
-	L.apply_status_effect(/datum/status_effect/debuff/exposed, feintdur)
+	
+	var/effect_to_apply = (L.mind ? /datum/status_effect/debuff/vulnerable : /datum/status_effect/debuff/exposed)
+
+	L.apply_status_effect(effect_to_apply, feintdur)
 	L.apply_status_effect(/datum/status_effect/debuff/clickcd, max(1.5 SECONDS + skill_factor, 2.5 SECONDS))
-	L.apply_status_effect(/datum/status_effect/debuff/feinted, newcd)
 	L.Immobilize(0.5 SECONDS)
 	L.stamina_add(L.stamina * 0.1)
 	L.Slowdown(2)
 
+	user.changeNext_move(CLICK_CD_FAST)	//We don't want the feint effect to be popped instantly.
 	user.apply_status_effect(/datum/status_effect/debuff/feintcd, newcd)
 	to_chat(user, span_notice("[L.p_they(TRUE)] fell for my feint attack!"))
 	to_chat(L, span_danger("I fall for [user.p_their()] feint attack!"))

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -46,7 +46,7 @@
 	if(HT.has_status_effect(/datum/status_effect/debuff/baited) || user.has_status_effect(/datum/status_effect/debuff/baitcd))
 		return	//We don't do anything if either of us is affected by bait statuses
 
-	if(!HT.can_see_cone(user) && HT.mind && HT.get_tempo_bonus(TEMPO_TAG_FEINTBAIT_FOV))
+	if(!HT.can_see_cone(user) && HT.mind)
 		newcd = 5 SECONDS
 		to_chat(user, span_notice("[HT.p_they()] didn't see me! Nothing happened!"))
 		HU.apply_status_effect(/datum/status_effect/debuff/baitcd, newcd)
@@ -145,7 +145,7 @@
 			if(user.get_skill_level(skillreq) < SKILL_LEVEL_JOURNEYMAN)
 				to_chat(user, span_info("I'm not knowledgeable enough in the arts of this weapon to use this."))
 				return
-		if(W.special.check_range(user, target))
+		if(W.special.check_range(user, target) && W.special.check_reqs(user, W))
 			if(W.special.apply_cost(user))
 				W.special.deploy(user, W, target)
 
@@ -195,16 +195,16 @@
 	skill_factor = (ourskill - theirskill)/2
 
 	var/special_msg
-	var/newcd = (FEINT_RCLICK_CD - user.get_tempo_bonus(TEMPO_TAG_RCLICK_CD_BONUS))
+	var/newcd = (BASE_RCLICK_CD - user.get_tempo_bonus(TEMPO_TAG_RCLICK_CD_BONUS)) + feintdur
 
-	if(L.has_status_effect(/datum/status_effect/debuff/exposed) || L.has_status_effect(/datum/status_effect/debuff/vulnerable))
+	if(L.has_status_effect(/datum/status_effect/debuff/exposed))
 		perc = 0
 
 	if(L.has_status_effect(/datum/status_effect/debuff/feinted))
 		perc = 0
 		special_msg = span_warning("Too soon! They were expecting it!")
 
-	if(!L.can_see_cone(user) && L.mind && L.get_tempo_bonus(TEMPO_TAG_FEINTBAIT_FOV))
+	if(!L.can_see_cone(user) && L.mind)
 		perc = 0
 		newcd = 5 SECONDS
 		special_msg = span_warning("They need to see me for me to feint them!")
@@ -223,16 +223,13 @@
 	if(L.has_status_effect(/datum/status_effect/buff/clash))
 		L.remove_status_effect(/datum/status_effect/buff/clash)
 		to_chat(user, span_notice("[L.p_their(TRUE)] Guard disrupted!"))
-	
-	var/effect_to_apply = (L.mind ? /datum/status_effect/debuff/vulnerable : /datum/status_effect/debuff/exposed)
-
-	L.apply_status_effect(effect_to_apply, feintdur)
+	L.apply_status_effect(/datum/status_effect/debuff/exposed, feintdur)
 	L.apply_status_effect(/datum/status_effect/debuff/clickcd, max(1.5 SECONDS + skill_factor, 2.5 SECONDS))
+	L.apply_status_effect(/datum/status_effect/debuff/feinted, newcd)
 	L.Immobilize(0.5 SECONDS)
 	L.stamina_add(L.stamina * 0.1)
 	L.Slowdown(2)
 
-	user.changeNext_move(CLICK_CD_FAST)	//We don't want the feint effect to be popped instantly.
 	user.apply_status_effect(/datum/status_effect/debuff/feintcd, newcd)
 	to_chat(user, span_notice("[L.p_they(TRUE)] fell for my feint attack!"))
 	to_chat(L, span_danger("I fall for [user.p_their()] feint attack!"))

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -28,9 +28,11 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 	/// The list of turfs the grid will be drawn on and 
 	var/list/affected_turfs = alist()
 
-	/// Whether to have the howner pass through a doafter for the delay rather than it being on every turf.
-	/// Default code here does not allow for dir switching during the do after.
+	/// Whether we'll use a doafter to "charge" our Special before activating it. The var is the delay in seconds.
 	var/use_doafter = FALSE
+
+	/// Whether our howner needs to be wielding the weapon. DO NOT USE THIS FOR ESOTERIC SPECIALS WITHOUT A MOB (TRAPS, ETC)
+	var/requires_wielding = FALSE
 
 	/// Whether the special uses the target atom that was clicked on. Generally best reserved to be a turf.
 	/// This WILL change how the grid is drawn, as the 'origin' will become the clicked-on turf.
@@ -65,9 +67,14 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 
 	// Hacky bool end ^^
 
-	/// The delay for either the doafter or the timers on the turfs before calling post_delay() and apply_hit()
-	/// Or in other words. The pause before the hit of the special happens.
+	/// The delay for either the doafter or the timers on the turfs before calling post_delay() and apply_hit().
+	/// Or in other words, the pause before the hit of the special happens.
+	/// This is overridden by custom_delays where applicable.
 	var/delay = 1 SECONDS
+
+	/// Custom delays applied to each timing instance. This is the delay between the ! disappearing and the hit occurring.
+	/// It's to be structured in simple 1 = X SECONDS, 2 = Y SECONDS manner, with the index representing the 'wave' the delay is for.
+	var/list/custom_delays = list()
 
 	///The amount of time the post-delay effect is meant to linger.
 	var/fade_delay = 0.5 SECONDS
@@ -127,6 +134,10 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 ///Main pipeline. Note that _delay() calls post_delay() after a timer.
 /datum/special_intent/proc/process_attack()
 	SHOULD_CALL_PARENT(TRUE)
+
+	if(!_do_after())
+		return
+	
 	_add_log()
 	_reset()
 	_clear_grid()
@@ -143,12 +154,30 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 	else
 		log_admin("[name] Special was deployed.")
 
-/// Checks if the range & z levels are valid. Best handled by external sources just like the cost.
+/datum/special_intent/proc/_do_after()
+	if(use_doafter)
+		if(do_after(howner, use_doafter, TRUE, howner, same_direction = TRUE))
+			return TRUE
+		else
+			return FALSE
+	else
+		return TRUE
+
+/// Checks if the range & z levels are valid, along with other reqs. Best handled by external sources just like the cost.
 /// Really only usable with use_clickloc, as otherwise the Special will be anchored to the source on the same plane anyway.
 /datum/special_intent/proc/check_range(atom/source, atom/target)
 	if(range)
 		if((get_dist(get_turf(source), get_turf(target)) > range) || source.z != target.z)
 			to_chat(source, span_warning("It's too far!"))
+			return FALSE
+	return TRUE
+
+/datum/special_intent/proc/check_reqs(mob/living/carbon/human/user, obj/item/I)
+	if(requires_wielding)
+		if(I.wielded)
+			return TRUE
+		else
+			to_chat(user, span_warning("I need to be wielding the weapon in both hands!"))
 			return FALSE
 	return TRUE
 
@@ -211,11 +240,13 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 /datum/special_intent/proc/_manage_grid()
 	if(!length(affected_turfs))	//Nothing to draw, but technically possible without being an error.
 		return
+	var/wave_counter = 1
 	for(var/newdelay in affected_turfs)
 		if(newdelay == 0)	//Default index without a custom delay, we process it immediately
-			_process_grid(affected_turfs[0])
+			_process_grid(affected_turfs[0], LAZYACCESS(custom_delays, wave_counter) ? custom_delays[wave_counter] : null)
 		else
-			addtimer(CALLBACK(src, PROC_REF(_process_grid), affected_turfs[newdelay], newdelay), newdelay)
+			addtimer(CALLBACK(src, PROC_REF(_process_grid), affected_turfs[newdelay], LAZYACCESS(custom_delays, wave_counter) ? custom_delays[wave_counter] : null), newdelay)
+		wave_counter++
 
 ///Called to process the grid of turfs. The main proc that draws, delays and applies the post-delay effects.
 /datum/special_intent/proc/_process_grid(list/turfs, newdelay)
@@ -225,7 +256,7 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 
 /datum/special_intent/proc/_draw(list/turfs, newdelay)
 	for(var/turf/T in turfs)
-		var/obj/effect/temp_visual/special_intent/fx = new (T, delay)
+		var/obj/effect/temp_visual/special_intent/fx = new (T, newdelay ? newdelay : delay)
 		fx.icon = _icon
 		fx.icon_state = pre_icon_state
 	
@@ -241,14 +272,7 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 ///Delay proc. Preferably it won't be hooked into.
 /datum/special_intent/proc/_delay(list/turfs, newdelay)
 	if(!cancelled)
-		if(use_doafter && !is_doing)
-			if(!succeeded)
-				if(_try_doafter())
-					post_delay(turfs)
-			else
-				post_delay(turfs)
-		else
-			addtimer(CALLBACK(src, PROC_REF(post_delay), turfs), delay)
+		addtimer(CALLBACK(src, PROC_REF(post_delay), turfs), newdelay ? newdelay : delay)
 
 /datum/special_intent/proc/_try_doafter()
 	is_doing = TRUE
@@ -403,6 +427,7 @@ SPECIALS START HERE
 	sfx_post_delay = 'sound/combat/sidesweep_hit.ogg'
 	delay = 0.6 SECONDS
 	cooldown = 17 SECONDS
+	requires_wielding = TRUE
 	stamcost = 25
 	var/eff_dur = 4 SECONDS
 	var/dam = 20
@@ -500,6 +525,7 @@ SPECIALS START HERE
 	post_icon_state = "kick_fx"
 	pre_icon_state = "trap"
 	respect_adjacency = TRUE
+	requires_wielding = TRUE
 	delay = 0.7 SECONDS
 	cooldown = 25 SECONDS
 	stamcost = 25
@@ -546,7 +572,6 @@ SPECIALS START HERE
 	post_icon_state = "sweep_fx"
 	pre_icon_state = "trap"
 	sfx_pre_delay = 'sound/combat/flail_sweep.ogg'
-	use_doafter = FALSE
 	respect_adjacency = FALSE
 	delay = 0.7 SECONDS
 	cooldown = 25 SECONDS
@@ -616,7 +641,7 @@ SPECIALS START HERE
 	tile_coordinates = AXE_SWING_GRID_DEFAULT
 	post_icon_state = "sweep_fx"
 	pre_icon_state = "trap"
-	use_doafter = FALSE
+	requires_wielding = TRUE
 	respect_adjacency = FALSE
 	delay = 0.5 SECONDS
 	cooldown = 25 SECONDS
@@ -689,8 +714,8 @@ SPECIALS START HERE
 		playsound(T, 'sound/combat/sp_whip_whiff.ogg', 100, TRUE)
 	..()
 
-#define GAREN_WAVE1 0.7 SECONDS
-#define GAREN_WAVE2 1.4 SECONDS
+#define GAREN_WAVE1 1 SECONDS
+#define GAREN_WAVE2 1.7 SECONDS
 
 /datum/special_intent/greatsword_swing
 	name = "Great Swing"
@@ -707,14 +732,16 @@ SPECIALS START HERE
 	respect_dir = TRUE
 	delay = 0.7 SECONDS
 	cooldown = 30 SECONDS
+	requires_wielding = TRUE
+	custom_delays = list(1 SECONDS)	//First wave is delayed.
 	stamcost = 25	//Stamina cost
 	var/dam = 60
 	var/slow_dur = 2
 	var/hitcount = 0
 	var/self_debuffed = FALSE
-	var/self_immob = 2.2 SECONDS
-	var/self_clickcd = 2.1 SECONDS
-	var/self_vuln = 2.3 SECONDS
+	var/self_immob = 2.5 SECONDS
+	var/self_clickcd = 3 SECONDS
+	var/self_vuln = 3 SECONDS
 
 /datum/special_intent/greatsword_swing/_reset()
 	hitcount = initial(hitcount)

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -111,7 +111,10 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 	str +="<i>[desc]</i>"
 	if(range)
 		str += "\n<i>Max Range: ["\Roman [range]"]"
-	str +="\n<i><font size = 1>This ability can be used by right clicking while in STRONG stance or by using the Special MMB.</font></i></details>"
+	if(requires_wielding)
+		str += "\n<i>Requires Wielding</i>"
+	str +="\n<i><font size = 1>This ability can be used by right clicking while in STRONG stance or by using the Special MMB.</font></i>
+	str += "</details>"
 	return str
 
 ///Called by external sources -- likely an rclick or mmb. By default the 'target' will be stored as a turf.

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -113,7 +113,7 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 		str += "\n<i>Max Range: ["\Roman [range]"]"
 	if(requires_wielding)
 		str += "\n<i>Requires Wielding</i>"
-	str +="\n<i><font size = 1>This ability can be used by right clicking while in STRONG stance or by using the Special MMB.</font></i>
+	str += "\n<i><font size = 1>This ability can be used by right clicking while in STRONG stance or by using the Special MMB.</font></i>"
 	str += "</details>"
 	return str
 


### PR DESCRIPTION
## About The Pull Request
- Added custom delay support for customising the delay between the "!" and the hit connecting, previously every "wave" of a Special had the same delay.

Great Swing (G. Sword) now has a longer delay for the -first- attack, but not any of the follow ups.
- Added support for wielding being required for a Special to be used.

Ground Smash (maces)
Distracting Swipe (L. Sword)
Hefty Swing (Axes)
Beyblade (G. Sword)

All require the weapon to be wielded in both hands to use.
- Added support for do afters preceding the actual Special, like a "wind up". No Special uses this, currently.
- Increased the self-debuff durations for the Judgement (G. Sword) Special to account for the increased first attack delay.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
This showcases the new doafter functionality as well as the new changes to the Greatsword (G. Swing) Special

https://github.com/user-attachments/assets/903d39db-ef71-487f-b702-b34d9a40dfb1

Again, to note, the actual in-game Special doesn't have the progress bar, it's just for visual purposes.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Better backend functionality for more customisation, feedback-based balancing. The wielding requirement in particular was a long-time coming. Further tweaks might be done if this isn't 'it' (like the numbers being too high, or the pattern too broad).
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Greatsword Special now has a delayed first hit.
balance: Various Specials now require wielding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
