### PR TITLE
Brings back hood layer adjustment

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/_head.dm
+++ b/code/modules/clothing/rogueclothes/headwear/_head.dm
@@ -10,9 +10,11 @@
 	dynamic_hair_suffix = "+generic"
 	bloody_icon_state = "helmetblood"
 	experimental_onhip = FALSE
-	var/mask_override = FALSE //override if we want to always respect our inv flags if the helm is in a mask slot
+	/// Override if we want to always respect our inv flags if the helm is in a mask slot.
+	var/mask_override = FALSE
 	experimental_inhand = FALSE
 	var/hidesnoutADJ = FALSE
+	/// Tracks if we're currently over or under the armor layer. Mainly used for the feedback message.
 	var/overarmor = TRUE
 
 /obj/item/clothing/head/roguetown/equipped(mob/user, slot)

--- a/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/adjusthoods.dm
@@ -32,7 +32,6 @@
 /obj/item/clothing/head/roguetown/roguehood/MiddleClick(mob/user)
 	if(!ishuman(user))
 		return
-	to_chat(user, span_info("I [overarmor ? "wear \the [src] under my hair" : "wear \the [src] over my hair"]."))
 	if(flags_inv & HIDEHAIR)
 		flags_inv &= ~HIDEHAIR
 	else
@@ -40,9 +39,21 @@
 	user.update_inv_wear_mask()
 	user.update_inv_head()
 
+/obj/item/clothing/head/roguetown/roguehood/AltRightClick(mob/user)
+	overarmor = !overarmor
+	to_chat(user, span_info("I wear \the [src] [overarmor ? "under" : "over"] my hair."))
+	if(overarmor)
+		alternate_worn_layer = HOOD_LAYER //Below Hair Layer
+	else
+		alternate_worn_layer = BACK_LAYER //Above Hair Layer
+	user.update_inv_wear_mask()
+	user.update_inv_head()
+
 /obj/item/clothing/head/roguetown/roguehood/get_mechanics_examine(mob/user)
-    . = ..()
-    . += span_info("Right click to adjust the hood's coverage. Most fully-drawn hoods will hide the wearer's identity.")
+	. = ..()
+	. += span_info("Right click to adjust the hood's coverage. Most fully-drawn hoods will hide the wearer's identity.")
+	. += span_info("Middle click to toggle hair.")
+	. += span_info("Alt Right click to move hood layer under or above hair.")
 
 /obj/item/clothing/head/roguetown/roguehood/red
 	color = CLOTHING_RED


### PR DESCRIPTION
## About The Pull Request

As title. You can now use Alt + Right Click to adjust hood layer once again

## Testing Evidence

It's a previously existed code!

## Why It's Good For The Game

Fashion. It was a good function to have
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added back the hood layer adjustment, it now uses Alt + Right Click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
