### PR TITLE
Fixes female bodybuilders getting a bikini instead of boobs out abs toned

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -312,7 +312,7 @@
 	if(should_wear_masc_clothes(H))
 		H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	if(should_wear_femme_clothes(H))
-		if(weapon_choice != "Discipline - Unarmed" && weapon_choice != "Discipline - Bodybuilder")
+		if(weapon_choice != "Discipline - Unarmed" && weapon_choice != "Discipline - Bodybuilder (-III INT)")
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/bikini
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(


### PR DESCRIPTION
…oned

## About The Pull Request

The bodybuilder discipline got a rename, but the check further down did not, and so the muscle armor was getting replaced by a corslet for women.

## Testing Evidence

It compiles. If it doesn't work I will be very confused and embarrassed, given the simplicity of the fix.

## Why It's Good For The Game

don't hide those muscles behind a corslet babe

## Changelog

:cl:
fix: Bodybuilders can be women again.
/:cl:
