### PR TITLE
Whips are now Long

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/roguetown/weapons/whips32.dmi'
 	sharpness = IS_BLUNT
 	//dropshrink = 0.75
-	wlength = WLENGTH_NORMAL
+	wlength = WLENGTH_LONG
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BELT
 	associated_skill = /datum/skill/combat/whipsflails


### PR DESCRIPTION
## About The Pull Request

Rejoice! The longest ranged melee weapon in the game can now hit feet while standing.

## Testing Evidence

<img width="194" height="24" alt="image" src="https://github.com/user-attachments/assets/893ccb34-6ce7-4d82-8b2d-b6c46dbac00e" />

single word change PR :imliterallystevejobs: :learntocode: :technology:

## Why It's Good For The Game

Whips aren't really fantastic weapons - in exchange for having outstanding reach, they give up essentially everything else. This is a small buff towards them that makes a lot of sense - whips absolutely would be used to attack people's feet. Just remember that, like everywhere else, if you're going up against an armored target the whip might break before the armor does.

## Changelog

:cl:
add: whips can now hit feet
/:cl: