### PR TITLE
Her Love, Unbound - Eora's Tree no longer explodes ugly people (but explodes those who've been cursed by Eora instead), proximinally beautifies ugly people (at the cost of -II CON), and has a unique interaction with lepers.

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora/eora_status_effects.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_status_effects.dm
@@ -289,25 +289,25 @@
 	id = "pomegranate_beauty"
 	duration = -1
 	alert_type = /atom/movable/screen/alert/status_effect/pomegranate_aura
-	outline_colour ="#42001f"
+	var/outline_colour ="#42001f"
 	var/datum/weakref/source_ref
 	effectedstats = list(STATKEY_CON = -2, STATKEY_LCK = 2)
 
 /datum/status_effect/debuff/pomegranate_beauty/on_apply()
 	. = ..()
-	filter = owner.get_filter(POM_FILTER)
+	var/filter = owner.get_filter(POM_FILTER)
 	if (!filter)
 		owner.add_filter(POM_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 180, "size" = 1))
 	to_chat(owner, span_rose("Wisps of rose seep into my features, as the tree blesses me with beauty once more! The divine energy strains my body, yet my guise has never looked prettier!"))
-	ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
-	REMOVE_TRAIT(H, TRAIT_UNSEEMLY, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_UNSEEMLY, TRAIT_GENERIC)
 
 /datum/status_effect/debuff/pomegranate_beauty/on_remove()
 	. = ..()
 	owner.remove_filter(POM_FILTER)
 	to_chat(owner, span_warning("Wisps of rose seep from my features, as the tree's blessings - and my gifted beauty - fades away. The divine energy's burden is no more, and my body relaxes once again.."))
-	REMOVE_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_UNSEEMLY, TRAIT_GENERIC)
+	REMOVE_TRAIT(owner, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
+	ADD_TRAIT(owner, TRAIT_UNSEEMLY, TRAIT_GENERIC)
 
 /datum/status_effect/debuff/pomegranate_beauty/tick()
 	// Check if source tree still exists


### PR DESCRIPTION
## About The Pull Request

* Eora's Tree will no longer cause constant damage and disorientation to characters with the _'ugly'_ trait.
* Instead, a unique interaction is available for those who've specifically taken the _'leper'_ trait.
* Very rarely, a leper within the bounds of Eora's Tree will receive a lesser healing miracle and a unique message in the chat.
* Whenever this event triggers, a supplemental message is printed - and a somber, angelic tune - softly plays.
* The constant damage and disorientation _now_ applies when someone specifically has the _'curse of Eora'_ trait.
* Ugly people now have a very rare chance to be blessed, giving them proximal beauty at the cost of Constitution.

## Testing Evidence

_“Beauty is more than skin deep; it issues from the core of one’s being and shows one’s fair face to the world.”_

https://github.com/user-attachments/assets/30d78bda-674d-468d-ac94-86149839869e

_(Note: much quieter in practice. Volume's increase for the sake of testing.)_
<img width="503" height="162" alt="90fde99756dbb009929a099a2238a38c" src="https://github.com/user-attachments/assets/f3fbfacc-61e7-4257-9a11-4acb54789bbf" />


## Why It's Good For The Game

* As funny as _"Eora blowing non-beautiful people up"_ sounds, it directly contracts the [lore](https://azurepeak.miraheze.org/wiki/The_Gods#Eora) of Eora being the God of Love - wholly, unconditionally, and totally.
* _(Snipped this part out, as it turns out that Eorans are all supernaturally beautiful. Belay last.)_
* Adds a little extra flavor to Eora's Tree, and more strictly differentiates _"Eora hating those she's cursed with ugliness"_ from _"Eora hating anyone who happens to be ugly, no matter what."_

## Changelog

:cl:
del: Eora's Tree no longer explodes ugly people.
add: Eora's Tree now explodes people who've been cursed by Eora.
add: Eora's Tree very rarely blesses people with leprosy.
add: Eora's Tree very rarely blesses people with ugliness, temporarily gifting them beauty at the cost of Constitution.
code: Added more distinct coloration to the 'blessed-by-Eora's-Tree' messages.
/:cl:

