### PR TITLE
Fixes pronouns on SCOMstones (and crown)

### DIFF
--- a/code/modules/clothing/rogueclothes/crown.dm
+++ b/code/modules/clothing/rogueclothes/crown.dm
@@ -45,7 +45,7 @@
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/attack_right(mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_MELEE)
-	visible_message(span_notice ("[user] presses their hands against their crown."))
+	visible_message(span_notice ("[user] presses [user.p_their()] hands against the [src]."))
 	var/input_text = input(user, "Enter your ducal message:", "Crown SCOM")
 	if(input_text)
 		var/usedcolor = user.voice_color

--- a/code/modules/roguetown/roguemachine/scomm/scomstone.dm
+++ b/code/modules/roguetown/roguemachine/scomm/scomstone.dm
@@ -34,7 +34,7 @@
 		playsound(loc, 'sound/misc/machineno.ogg', 100, FALSE, -1)
 		return
 	user.changeNext_move(CLICK_CD_INTENTCAP)
-	visible_message(span_notice ("[user] presses their ring against their mouth."))
+	visible_message(span_notice ("[user] presses [user.p_their()] [src] against [user.p_their()] mouth."))
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(!input_text)
 		return
@@ -170,7 +170,7 @@
 	if(!get_location_accessible(user, BODY_ZONE_PRECISE_MOUTH, grabs = TRUE))
 		to_chat(user, span_warning("My mouth is covered!"))
 		return
-	visible_message(span_notice ("[user] presses their [src] against their mouth."))
+	visible_message(span_notice ("[user] presses [user.p_their()] [src] against [user.p_their()] mouth."))
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(!input_text)
 		return


### PR DESCRIPTION
## About The Pull Request

Title

## Testing Evidence

<img width="584" height="87" alt="image" src="https://github.com/user-attachments/assets/35500718-098b-4b41-92d2-ed7821958856" />
<img width="540" height="41" alt="image" src="https://github.com/user-attachments/assets/fa9b9106-e97f-4810-aa5d-cdd94b26261f" />


## Why It's Good For The Game

Wasn't aware at the time on how to do it when making it, might as well fix it now.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: SCOMstones/Crown not using your pronouns for text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
