### PR TITLE
Curse Mine Chudde Lyfe - Minor hotfix, allows Bronze Panoply Armor to be smithed again.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -299,7 +299,7 @@
 	req_bar = /obj/item/ingot/bronze
 	req_blade = /obj/item/blade/bronze_plate
 	additional_items = list(/obj/item/ingot/bronze, /obj/item/ingot/bronze, /obj/item/ingot/bronze, /obj/item/natural/hide/cured, /obj/item/natural/fur)
-	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/bronze/alt
+	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/bronze
 	craftdiff = 3
 
 /datum/anvil_recipe/armor/bronze/gorget


### PR DESCRIPTION
## About The Pull Request

* Namesake.

## Testing Evidence

* One-liner.

## Why It's Good For The Game

* Items working as intended is good.

## Changelog

:cl:
fix: The recipe for a full set of Bronze Panoply Armor should now properly make its namesake, instead of another halved set.
/:cl:
