### PR TITLE
Fixes CM marked as nobility role

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -6,7 +6,7 @@
 	total_positions = 1
 	spawn_positions = 1
 
-	allowed_races = RACES_NO_CONSTRUCT		//Nobility, no construct
+	allowed_races = ACCEPTED_RACES
 	allowed_sexes = list(MALE, FEMALE)
 	spells = list(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 	display_order = JDO_MAGICIAN


### PR DESCRIPTION
## About The Pull Request

Court Magician isn't actually a nobility role and was accidentally marked as such (as far as I can tell, at least) and was thusly NO_CONSTRUCT. This PR makes it ACCEPTED_RACES. Dullahans still can't be CM which seems intentional.

## Testing Evidence

Singular line change anyway but:
<img width="429" height="65" alt="cmtest" src="https://github.com/user-attachments/assets/100694ba-99de-4648-8c0c-1ca08f11597f" />
<img width="500" height="72" alt="cmtest2" src="https://github.com/user-attachments/assets/acab319d-b066-47f3-b64d-262ff37925c1" />

## Why It's Good For The Game

This was a bug. Also, constructs can be mages and are inherently magical, arguably. Makes sense that some might become Court Magicians. They can already be clerks, seneschals, archivists, head physicians, sergeants, and magician's associates just to name a few. If they can be that last one, logic follows that it's possible for them to get better at magic.

## Changelog

:cl:
fix: Constructs can now be CM
/:cl:

