### PR TITLE
removes soap slip

### DIFF
--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -15,9 +15,6 @@
 	var/cleanspeed = 20 //as fast as 5 arcyne Prestidigitation
 	var/uses = 100
 
-/obj/item/soap/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/slippery, 80)
 
 /obj/item/soap/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

removes soap slip

## Testing Evidence

linechange

## Why It's Good For The Game

whilst this is one of my favorite features in ss13 in general, time has proven over and over that people cant be trusted to not abuse this
a 10 second stun is too viable in combat for people not to abuse at the detriment of thy neighbor

## Changelog

:cl: jacksepticeye
balance: removes soap stun
/:cl: