### PR TITLE
Thespian Player-Requested Adjustments - Adds Apprentice-level skills to the chosen sidearm, rewords the Thespian Duelist's option to be less confusing, and adds Novice-level Medicine skills to the baseline.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -949,7 +949,7 @@
 	possible_item_intents = list(/datum/intent/shield/block, /datum/intent/mace/smash/shield/metal/great, /datum/intent/effect/daze) // No SHIELD_BASH. Able to inflict Daze due to its weight.
 	force = 28
 	coverage = 75 
-	wdefense = 12
+	wdefense = 10
 	minstr = 12 //Requires a natural +STR modifier or statpack to double as a melee weapon, for its given class. Note that it has a heavier charge time and active stamina drain, too, as.. well, it's quite heavy.
 
 /obj/item/rogueweapon/shield/bronze/great/get_mechanics_examine(mob/user)


### PR DESCRIPTION
## About The Pull Request

Player-requested points:
* Reworded the Thespian Duelist's blurb to make it more understandable that they receive the Duelist's statblock, as people were previously thinking it gave them a flat malus of VII CON _(Instead of the more managable IX CON.)_.
* Choosing a melee sidearm now provides Apprentice-level skills in said-weapon.
* Thepsians now start with Novice-tier medicine, but can achieve Apprentice-tier if they take the Bottle of Garum.
* Gave the Hoplon Greatshield's +1 WDEF.

## Testing Evidence

* One-liners.

## Why It's Good For The Game

* Ensures no one's confused or potentially misled when picking from any of the Disciplines.
* Minor quality-of-life, allows for a slightly more diverse build - about on par with the Barbarian or Battlemaster's secondary combat skills.
* Player-requested. Encouraged, as bronze armor has the lowest attack-intercept threshold of most armor in the game: they're expected to bleed a bit more than usual, so giving them a little headstart in suturing wounds is good. Makes the bottle a little more appealing as an option, too.
* As it turns out, the shield's change didn't feel as good as intended. Fixing that.

## Changelog

:cl:
fix: Reworded the Thespian-Errant's 'Duelist' blurb to clarify that picking it resets your statblock to Duelist-levels, rather than starting you off with VII CON / XIII SPD.
balance: Picking a sidearm (either in the form of a sword, axe, or bottle) as a Thespian-Errant now provides a fitting Apprentice-level skill (in swords, axes, or medicine.)
balance: Thespian-Errants now start with Novice-level medicine skills, as they're likely going to bleed a bit more than their compatriots.
balance: Hoplon Greatshields have had their +3 DEF restored.
/:cl: