### PR TITLE
bandaid drow armor looting fix

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -49,6 +49,7 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 	ADD_TRAIT(src, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_DUALWIELDER, TRAIT_GENERIC)
 	equipOutfit(new /datum/outfit/job/roguetown/human/species/elf/dark/drowraider)
+	make_armor_unlootable()
 	if(prob(40))
 		gender = MALE
 	else
@@ -103,6 +104,14 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 
 	update_hair()
 	update_body()
+
+/mob/living/carbon/human/species/elf/dark/drowraider/proc/make_armor_unlootable()
+	var/static/list/armor_slots = list(SLOT_ARMOR, SLOT_PANTS, SLOT_GLOVES, SLOT_SHOES, SLOT_WRISTS, SLOT_NECK, SLOT_WEAR_MASK)
+
+	for(var/slot in armor_slots)
+		var/obj/item/armor_piece = get_item_by_slot(slot)
+		if(armor_piece)
+			ADD_TRAIT(armor_piece, TRAIT_NODROP, "drow_npc_armor")
 
 /mob/living/carbon/human/species/elf/dark/drowraider/npc_idle()
 	if(m_intent == MOVE_INTENT_SNEAK)


### PR DESCRIPTION
## About The Pull Request

Stops you from looting armor from drow. We've been talking about a solution to this for a bit and I realized, like, we already have one? I think this might just be fine. We do this for heretic NPCs, why not Drow?

## Testing Evidence

<img width="445" height="493" alt="image" src="https://github.com/user-attachments/assets/a093e06c-2f92-4f02-a6fa-71ee91a5ffdc" />
works fine

## Why It's Good For The Game

there are currently an insane amt of people beelining for the underdark to kill and loot drow for high-tier armor. There are currently this many dead fully looted or partially looted drow within 5 seconds of looking in a mid-sized round.

<img width="886" height="618" alt="image" src="https://github.com/user-attachments/assets/205c627e-4c8f-4151-8e86-6f60ff7172a1" />
<img width="376" height="273" alt="image" src="https://github.com/user-attachments/assets/79142841-7e0f-4b66-9835-5615eced693a" />

A few more just got looted offscreen in the time it took me to make this PR, actually.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Can no longer loot drow raiders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
