### PR TITLE
Outlaws may assent but not invoke Martial Supercession.

### DIFF
--- a/code/datums/usurpation_rite/martial_supercession.dm
+++ b/code/datums/usurpation_rite/martial_supercession.dm
@@ -5,7 +5,7 @@
 
  Design intent: A military junta in all but name to makes a disloyal garrison a threat. The retinue (Marshal, Knight, Squire) and garrison (Sergeant, Man at Arms) can invoke this to seize the throne by rallying anyone with Expert weapon skill — guards, veterans, mercenaries, adventurers. Requires 7 assents due to the relative abundance of combat-skilled characters, making it a broad coalition play.
 
- Outlaws and the undead are explicitly excluded from this path - there's alternative paths for true antagonists.
+ The undead are explicitly excluded from this path - there's alternative paths for true antagonists.
  */
 /datum/usurpation_rite/martial_supercession
 	name = "Rite of Martial Supercession"
@@ -14,7 +14,7 @@
 <p><b>Who may invoke:</b> Members of the retinue (Marshal, Knight, Squire) or non-warden garrison (Sergeant, Man at Arms).</p>\
 <p><b>How it works:</b> Warriors with Expert-level weapon skill or higher must gather near the throne and speak the words 'I assent' to support your claim. Any weapon skill counts.</p>\
 <p><b>Completion condition:</b> <b>6</b> warriors must speak their assent. Once the threshold is reached, the realm is alerted and a contestation period begins — survive it and stay conscious while remaining near the throne, and it is yours.</p>\
-<p><b>Restrictions:</b> Outlaws and the undead may not invoke or assent to this rite.</p>\
+<p><b>Restrictions:</b> The undead may not invoke or assent to this rite. Outlaws may not invoke, but may assent.</p>\
 <p><b>Realm type if successful:</b> Sovereign Order, ruled by a Grand Master.</p>"}
 	new_ruler_title = "Grand Master"
 	new_ruler_title_f = "Grand Master"
@@ -47,7 +47,7 @@
 /datum/usurpation_rite/martial_supercession/on_gathering_timeout()
 	fail("The warriors of the realm did not grant sufficient assent.")
 
-/// Override: warriors assent, not nobles. Check Expert+ combat skill instead of TRAIT_NOBLE.
+/// Override: warriors assent, not nobles. Check Expert+ combat skill instead of TRAIT_NOBLE. Outlaws may assent.
 /datum/usurpation_rite/martial_supercession/try_assent(mob/living/carbon/human/warrior)
 	if(stage != RITE_STAGE_GATHERING)
 		return FALSE
@@ -60,9 +60,6 @@
 		return FALSE
 	if(!has_expert_combat_skill(warrior))
 		to_chat(warrior, span_warning("Only those who have proven themselves as expert warriors may speak assent to this rite."))
-		return FALSE
-	if(HAS_TRAIT(warrior, TRAIT_OUTLAW))
-		to_chat(warrior, span_warning("Outlaws stand outside the law. There is no justice for the lawless."))
 		return FALSE
 	if(HAS_TRAIT(warrior, TRAIT_ROTMAN) || (warrior.mob_biotypes & MOB_UNDEAD))
 		to_chat(warrior, span_warning("The dead cannot serve justice."))


### PR DESCRIPTION
## About The Pull Request
Suggested by Ezo and I think it makes sense

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
None actually

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Gathering exiled warrior to support you taking the throne. But the outlaw themselves cannot take it - far too out of the law for that.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Martial Supercession now allows for an Outlaw to give assent - but not invoke it themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
