### PR TITLE
Miners get +2 WIL instead of +2 CON

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -10,9 +10,9 @@
 	traits_applied = list(TRAIT_DARKVISION, TRAIT_SMITHING_EXPERT) // Smithing Expert, because from what I observe of miner players they tend to do smithing far more than farming etc.
 	subclass_stats = list(
 		STATKEY_STR = 2,
-		STATKEY_CON = 2,
+		STATKEY_CON = 1,
 		STATKEY_LCK = 2,
-		STATKEY_WIL = 1
+		STATKEY_WIL = 2
 	)
 	subclass_skills = list(
 		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,


### PR DESCRIPTION
## About The Pull Request

This is an insignificant QOL PR to make playing Miner slightly more enjoyable.

## Testing Evidence

Trust me.

## Why It's Good For The Game

WIL handles stamina, mining is very stamina intensive - hence why they get high athletics, though a one-point bonus is kind of odd.

I was initially considering getting rid of the CON altogether for a 3 WIL bonus since I didn't see a reason for it to stay, but I opted to just swap the values around. Let me know if I should've gone through with it. 
## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Miners now get +2 WIL instead of +2 CON. Their +1 is swapped.
/:cl: