### PR TITLE
Saddleborn no longer gives you heart attacks forever

### DIFF
--- a/virtues/saddleborn.dm
+++ b/virtues/saddleborn.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_INIT(virtue_mount_choices_anthrax, (list(
 
 /datum/stressevent/precious_mob_died
 	timer = 10 MINUTES
-	stressadd = 5
+	stressadd = 8
 	desc = span_red("There will never be another creature like them. They are lost, and so am I.")
 
 /datum/component/precious_creature


### PR DESCRIPTION
## About The Pull Request

Saddleborn's malus of +10 stress forever has been reduced to +8 stress for 10 minutes.

## Why It's Good For The Game

Saddleborn, in its current state, basically bricks your character after your horse dies. Horses are incredibly fragile, and once the horse is gone, the virtue is nearly completely useless. Having a dead virtue slot is enough of a malus for losing your horse without being permanently in heart-attack-stress range. Especially since this virtue is being given to certain roles to _replace_ their riding skills, it probably shouldn't be so detrimental and risky to actually use your horse.

## Changelog

:cl:
balance: saddleborn no longer annihilates your mood
/:cl: