### PR TITLE
Fixes Heretic Spy Bow loadout

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -316,7 +316,7 @@
 				beltl = /obj/item/rogueweapon/scabbard/sword
 			if("Bow")
 				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				beltl = /obj/item/quiver/arrows
+				beltr = /obj/item/quiver/arrows
 				backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_EXPERT, TRUE)
 				beltl = /obj/item/rogueweapon/scabbard/sheath


### PR DESCRIPTION
## About The Pull Request

quiver and knife sheath were assigned to the same slot, resulting in the quiver getting eaten by the void
oversight most likely, single letter fix

## Testing Evidence
its a single letter, but sure
<img width="395" height="673" alt="Screenshot 2026-02-25 052858" src="https://github.com/user-attachments/assets/45157b58-49fd-4dc0-a345-0665b7239e6e" />


## Why It's Good For The Game

bow needs pointy things to shoot with

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fixed heretic spy bow loadout to include quiver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
