### PR TITLE
Stat Influences

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -364,7 +364,7 @@ Medical defines
 #define CONSTITUTION_BLEEDRATE_MOD 0.05	//How much slower we'll be bleeding for every CON point. 0.1 = 10% slower.
 #define CONSTITUTION_BLEEDRATE_CAP 20	//The CON value up to which we get a bleedrate reduction.
 
-#define WILLPOWER_STARTING_STAMINA 120	//Starting stamina (green bar) value.
+#define WILLPOWER_STARTING_STAMINA 135	//Starting stamina (green bar) value. Before major changes this would represent Expert Athletics + ~11.5 WIL 
 #define WILLPOWER_MODIFIER	5	//How much stamina (flat value) we gain (or lose) for every WIL above / below 10.
 
 #define SPEED_MOVSPD_MOD 0.075	//Multiplicative modifier for our speed, per point (for both <10 and >10 values)

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -367,6 +367,8 @@ Medical defines
 #define WILLPOWER_STARTING_STAMINA 120	//Starting stamina (green bar) value.
 #define WILLPOWER_MODIFIER	5	//How much stamina (flat value) we gain (or lose) for every WIL above / below 10.
 
+#define SPEED_MOVSPD_MOD 0.075	//Multiplicative modifier for our speed, per point (for both <10 and >10 values)
+
 /*
  Misc. Category. Spin it out if needed
 */

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -364,7 +364,7 @@ Medical defines
 #define CONSTITUTION_BLEEDRATE_MOD 0.05	//How much slower we'll be bleeding for every CON point. 0.1 = 10% slower.
 #define CONSTITUTION_BLEEDRATE_CAP 20	//The CON value up to which we get a bleedrate reduction.
 
-#define WILLPOWER_STARTING_STAMINA 100	//Starting stamina (green bar) value.
+#define WILLPOWER_STARTING_STAMINA 120	//Starting stamina (green bar) value.
 #define WILLPOWER_MODIFIER	5	//How much stamina (flat value) we gain (or lose) for every WIL above / below 10.
 
 /*

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -361,8 +361,11 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 Medical defines
 */
 #define ARTERY_LIMB_BLEEDRATE 20	//This is used as a reference point for dynamic wounds, so it's better off as a define.
-#define CONSTITUTION_BLEEDRATE_MOD 0.1	//How much slower we'll be bleeding for every CON point. 0.1 = 10% slower.
-#define CONSTITUTION_BLEEDRATE_CAP 15	//The CON value up to which we get a bleedrate reduction.
+#define CONSTITUTION_BLEEDRATE_MOD 0.05	//How much slower we'll be bleeding for every CON point. 0.1 = 10% slower.
+#define CONSTITUTION_BLEEDRATE_CAP 20	//The CON value up to which we get a bleedrate reduction.
+
+#define WILLPOWER_STARTING_STAMINA 100	//Starting stamina (green bar) value.
+#define WILLPOWER_MODIFIER	5	//How much stamina (flat value) we gain (or lose) for every WIL above / below 10.
 
 /*
  Misc. Category. Spin it out if needed

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -24,7 +24,7 @@
 	update_health_hud()
 
 /mob/living/proc/calculate_stamina()
-	max_stamina = WILLPOWER_STARTING_STAMINA + (STAWIL - 10) * WILLPOWER_MODIFIER
+	max_stamina = WILLPOWER_STARTING_STAMINA + ((STAWIL - 10) * WILLPOWER_MODIFIER)
 
 /mob/living/proc/update_energy()
 	calculate_energy()

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -24,7 +24,7 @@
 	update_health_hud()
 
 /mob/living/proc/calculate_stamina()
-	max_stamina = max_energy / 10
+	max_stamina = WILLPOWER_STARTING_STAMINA + (STAWIL - 10) * WILLPOWER_MODIFIER
 
 /mob/living/proc/update_energy()
 	calculate_energy()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2224,8 +2224,8 @@
 			_y = min(0,_y)
 	else if(STAPER > 11)
 		var/offset = STAPER - 10
-		if(offset > 5)	//Caps the bonus at 15 PER, which is a whole extra screen in an orthogonal direction. Anymore will get disorienting.
-			offset = 5
+		if(offset >= 5)	//Caps the bonus at 15 PER, which is a whole extra screen in an orthogonal direction. Anymore will get disorienting.
+			offset = 4
 		if(STAPER >= 12)
 			message = span_info("[src] easily peers afar.")
 		if(_x > 0)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -69,9 +69,9 @@
 				mod = 6
 
 	var/spdchange = (10-STASPD)*0.1
-	spdchange = clamp(spdchange, -0.5, 1)  //if this is not clamped, maniacs will run at unfathomable speed
+	spdchange = clamp(spdchange, -0.4, 1)  //if this is not clamped, maniacs will run at unfathomable speed
 	mod = mod+spdchange
-	//maximum speed is achieved at 15spd, everything else results in insanity
+	//maximum speed is achieved at 14 SPD, everything else results in insanity
 	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -68,10 +68,9 @@
 			else
 				mod = 6
 
-	var/spdchange = (10-STASPD)*0.1
-	spdchange = clamp(spdchange, -0.4, 1)  //if this is not clamped, maniacs will run at unfathomable speed
+	var/spdchange = (10-STASPD)*SPEED_MOVSPD_MOD
+	//spdchange = clamp(spdchange, -0.5, 1)  //Previous clamp when MOVSPD_MOD was at 0.1
 	mod = mod+spdchange
-	//maximum speed is achieved at 14 SPD, everything else results in insanity
 	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)
 
 /mob/living/proc/update_turf_movespeed(turf/open/T)


### PR DESCRIPTION
## About The Pull Request
This PR mildly tones down some stat influences.
- SPD is now uncapped, but gives slightly less speed per point. You'll generally need 16-ish to feel like you're at 14-ish. Kinda. You'll notice when playing.
- Green bar is no longer directly tied to blue bar. Green bar is now only directly influenced by WIL, at half the rate than before. Blue bar unchanged (Athletics & WIL still influence blue bar in the same way).
   - Consequently, everyone's starting stamina was raised to be about equivalent to Jman / Expert athletics, which pretty much all classes had.
- CON influence on bleedrate reduced by half (5% per point). Its cap has been raised to 20.
- PER lookahead maximum range reduced by a few tiles.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
None, they're mostly var changes, though SPD was explicitly tested.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- CON influencing bleed rate (especially at that rate) was a complete throw-at-wall compensation that came with Omniwounds, back when they were much deadlier.
Since then, omniwounds have been toned down, and feint / exposed changes made it so only one penetrative hit is gonna be going through every once in a bit in a given encounter. (skirmishes not withstanding you can't account for anything in those) making such extreme rates not be necessary at all. 

- WIL is similar, green bar in general is the more immediately important one and managing stam should be important to everyone. Your WIL will let you -regenerate- more of it (again, no changes to blue), but the actual green bar is now more normalized, though people with 13-15+ WIL will still have a notable difference.
Oh, and Athletics not influencing green is just good overall, I dunno how many people were levelling it but their skilling will be less directly influential.

- SPD follows a similar vein, it just clamps it down on a per-point basis, while allowing extremes to surpass what 15 used to be.

- PER change is more about rangers being forced to be closer if they're maxing out their effective range. It's not that much, and it was going hella far anyway.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: SPD cap on movement speed reduced to 14.
balance: CON influence on bleedrate reduced.
balance: WIL influence on green stamina bar reduced. (Blue bar unaffected.)
balance: Athletic skill influence on green bar removed. (Blue bar unaffected.)
balance: PER influence on max lookahead distance slightly reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
