### PR TITLE
Un-Nerfs Graggar Organeating

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -170,7 +170,7 @@
 
 /obj/item/reagent_containers/food/snacks/organ/On_Consume(mob/living/eater)		//Graggarites looove eating organs, they loooove eating organs!
 	if(HAS_TRAIT(eater, TRAIT_ORGAN_EATER))
-		eat_effect = /datum/status_effect/buff/snackbuff
+		eat_effect = /datum/status_effect/buff/greatsnackbuff
 		foodtype = RAW | MEAT
 	else
 		eat_effect = initial(eat_effect)


### PR DESCRIPTION
## About The Pull Request

Organs now give great snack buff instead of good snack, providing +1 CON and +1 WIL instead of just the latter.

## Testing Evidence

i know it works, i just can't prove it

## Why It's Good For The Game

The mealbuff rework bumped organ eating down a notch - I'm not sure if it was intended. Let cannibals and gnolls enjoy the buff a bit better, for all the risks they take when it comes to eating people or carrying around lunchables.

## Changelog

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Eating organs now grants the "great" snack buff.
/:cl:

