### PR TITLE
fixes more complicated race bonuses not saving correctly

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -144,13 +144,21 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		return
 	if (!player.prefs.race_bonus || player.prefs.race_bonus == "None")
 		return
+	if(!length(character.dna.species.custom_selection))
+		return
 	var/bonus = player.prefs.race_bonus
-	if(islist(bonus))
-		var/list/bonuslist = bonus
+	if(!(bonus in character.dna.species.custom_selection))
+		return
+	var/full_bonus 
+	full_bonus = character.dna.species.custom_selection[bonus]
+	if(!full_bonus)
+		return
+	if(islist(full_bonus))
+		var/list/bonuslist = full_bonus
 		for(var/B in bonuslist)
 			process_race_bonus_option(character, B, bonuslist)
 	else
-		process_race_bonus_option(character, bonus)
+		process_race_bonus_option(character, full_bonus)
 
 /proc/process_race_bonus_option(mob/living/carbon/human/character, bonus, list/parentlist)
 	if(ispath(bonus))	//The bonus is a real path

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -464,7 +464,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 				var/race_bonus_display
 				if(race_bonus)
 					for(var/bonus in pref_species.custom_selection)
-						if(pref_species.custom_selection[bonus] == race_bonus)
+						if(bonus == race_bonus)
 							race_bonus_display = bonus
 							break
 				dat += "<b>Race Bonus:</b> <a href='?_src_=prefs;preference=race_bonus_select;task=input'>[race_bonus_display ? "[race_bonus_display]" : "None"]</a><BR>"
@@ -2425,7 +2425,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					if(length(pref_species.custom_selection))
 						var/choice = tgui_input_list(user, "What has fate blessed your race with?", "BONUS", pref_species.custom_selection)
 						if(choice)
-							race_bonus = pref_species.custom_selection[choice]
+							race_bonus = choice
 
 				if("body_size")
 					var/new_body_size = tgui_input_number(user, "Choose your desired sprite size:\n([BODY_SIZE_MIN*100]%-[BODY_SIZE_MAX*100]%), Warning: May make your character look distorted", "Character Preference", features["body_size"]*100)


### PR DESCRIPTION
## About The Pull Request
This PR will reset everyone's race bonus, unfortunately.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed race bonuses comprised of more than one trait or stat not saving correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
