### PR TITLE
grave lootjak

### DIFF
--- a/code/game/objects/structures/crates_lockers/roguetown.dm
+++ b/code/game/objects/structures/crates_lockers/roguetown.dm
@@ -323,9 +323,9 @@
 	new /obj/item/skull(src)
 	new /obj/item/natural/bundle/bone/full(src)
 	var/list/loot = list(
-		/obj/item/clothing/ring/blacksteel = 30, //Valuables
-		/obj/item/clothing/ring/diamond = 20,
-		/obj/item/clothing/ring/silver = 10,
+		/obj/item/clothing/ring/blacksteel = 20, //Valuables
+		/obj/item/clothing/ring/diamond = 10,
+		/obj/item/clothing/ring/silver = 20,
 		/obj/item/clothing/neck/roguetown/ornateamulet = 15,
 		/obj/item/clothing/neck/roguetown/psicross/bpearl = 10,
 		/obj/item/roguecoin/gold/pile = 5, //Valuables (materials)
@@ -336,9 +336,9 @@
 		/obj/item/roguestatue/gold = 10,
 		/obj/item/roguestatue/silver = 10,
 		/obj/item/roguestatue/blacksteel = 5,
-		/obj/item/storage/belt/rogue/pouch/zigarrete/nicotine = 15, //Misc stuff
-		/obj/item/reagent_containers/food/snacks/canned = 15,
-		/obj/item/reagent_containers/food/snacks/butter = 15,
+		/obj/item/storage/belt/rogue/pouch/zigarrete/nicotine = 10, //Misc stuff
+		/obj/item/reagent_containers/food/snacks/canned = 20,
+		/obj/item/reagent_containers/food/snacks/butter = 5,
 		/obj/item/reagent_containers/food/snacks/rogue/raisinbread = 5,
 		/obj/item/paper/inqslip/confession = 5,
 		/obj/item/clothing/neck/roguetown/luckcharm/mercmedal/underdweller = 1,


### PR DESCRIPTION
## About The Pull Request

Adjusts the loot tables on graves to be a little less buttery.

## Testing Evidence

i opened one casket for testing. it still had butter in it

## Why It's Good For The Game

I love this mechanic. I do a comical amount of it. At the mercy of weighted random chance, it can get frustrating seeing the same items over and over again; likewise, it can get stupid if all you ever get is valuable stuff. This adds some dilution to the pool of rare items and adds some items that provide little financial value, but offer a reason to hang on to them.

Ideally, it'll also have fewer zigboxes. I never have to go to the bathhouse anymore.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: rebalanced grave loot tables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
