### PR TITLE
Adds a Great Furnace to The Wretch Forge

### DIFF
--- a/_maps/map_files/otherz/wretch_coast.dmm
+++ b/_maps/map_files/otherz/wretch_coast.dmm
@@ -696,7 +696,7 @@
 	icon_state = "cobbleedge-e"
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/woods/wretch_lair)
+/area/rogue/under/cave/inhumen)
 "dF" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -1194,7 +1194,7 @@
 "ge" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/woods/wretch_lair)
+/area/rogue/under/cave/inhumen)
 "gg" = (
 /obj/structure/table/wood/poor,
 /obj/item/reagent_containers/powder/salt,
@@ -6101,7 +6101,7 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/woods/wretch_lair)
+/area/rogue/under/cave/inhumen)
 "Gx" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grass,
@@ -9432,9 +9432,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/cave/inhumen)
 "Zh" = (
-/obj/machinery/light/rogue/smelter,
+/obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/twig,
-/area/rogue/outdoors/woods/wretch_lair)
+/area/rogue/under/cave/inhumen)
 "Zl" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cave/inhumen)
@@ -32796,7 +32796,7 @@ Xm
 zU
 ga
 qW
-Zn
+qW
 Zh
 UM
 CN
@@ -32926,7 +32926,7 @@ Xm
 zU
 ga
 qW
-Zn
+qW
 HO
 UM
 gr
@@ -33056,7 +33056,7 @@ HO
 UM
 UK
 dD
-Zn
+qW
 lT
 Ev
 Ev
@@ -33185,7 +33185,7 @@ Ry
 zU
 xm
 iY
-xt
+iY
 Gv
 HO
 Ev
@@ -49957,8 +49957,8 @@ ap
 Zn
 Zn
 Zn
-ap
-ap
+Zn
+Zn
 jS
 ap
 ap
@@ -50087,7 +50087,7 @@ ap
 Zn
 Zn
 Zn
-ap
+Zn
 Zn
 jS
 ap
@@ -50216,8 +50216,8 @@ ap
 Zn
 jS
 Zn
-ap
-ap
+Zn
+Zn
 Zn
 ap
 ap
@@ -50346,8 +50346,8 @@ ap
 Zn
 jS
 Zn
-ap
-ap
+Zn
+Zn
 Zn
 ap
 ap
@@ -50477,7 +50477,7 @@ Zn
 jS
 Zn
 Zn
-ap
+Zn
 Zn
 ap
 ap


### PR DESCRIPTION
## About The Pull Request

Adds a Great Furnace to the wretches forge.
Fixed the wretches forge areas.

## Testing Evidence

It was not.

## Why It's Good For The Game

I've played a bundle of rounds as Wretch Munitioneer and I'm going to be honest?
Half my round is spent grinding towards making a Great Furnace anyways. On the OFF CHANCE you manage to find steel gear around or someone's nice enough to bring it to you (to make stuff for them), you get one bar per item melted.

Not everyone wants to grind to make steel as what is already a pretty grindy sub-class.
(I also fixed up the forges roof and made the thing one area otherwise you get spammed about entering new areas in the forge.)

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Great Furnace for Wretch Forge
fix: Fixed Wretch Forge Areas
map: Great Furnace for Wretch Forge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
