### PR TITLE
MORE FOREIGNERS ARE COMING! - Grenzelhoft Bludhund and Etruscan Nostromo

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -1139,7 +1139,7 @@
 				H.change_stat(STATKEY_PER, 2)
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)	//No shield skill, since you're buckler reliant.
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)	//So you don't get IMMEDIATELY folded by a basic grappler 
-				r_hand = /obj/item/rogueweapon/sword/long/etruscan	//You'd stolen this, probably. It's just a longsword reskin.
+				r_hand = /obj/item/rogueweapon/sword/long	//You'd stolen this, probably. It's just a longsword reskin.
 				beltl = /obj/item/rogueweapon/scabbard/sword
 				backr = /obj/item/rogueweapon/shield/buckler
 				backpack_contents = list(


### PR DESCRIPTION
## About The Pull Request
I was lookin' at the foreigner classes (Most notably the Freifetcher lite) and I went - hey, Ratwood did something like this. Discount mercs. Significantly weaker than actual mercs. Why not do that?

### INTRODUCING THE BLUDHUND AND THE NOSTROMO!

Two new Foreigner classes (Woe, adventureslop upon thee) that are meant to be a diet version of the mercs we all know and love.

**GRENZELHOFTIAN BLUDHUND**
*A contract gone wrong? Perhaps you were kicked out of the Guild? They may take that blacksteel, but they can't take your lessons.*

No armor nor dodge expert. All you have is your Grenzel uniform, your polearm (or zwei) of choice, and you just *hope* that your fellow once-brother-in-arms don't cross you for wearing the uniform.

"Why not go battlemaster?" - Battlemaster is arguably stronger. They can wear medium armor, they've a larger weapon variety, and the only difference would be a slightly... different statspread. You're losing on armor in favor of the roleplay potential.

**ETRUSCAN NOSTROMO**
*Sailing isn't easy, and more often than not, the Captain will always tell you that you can kindly **fuck off** if you don't like his ship. Guess what you did?*

Once more - no armor nor dodge expert! A roaming Etruscan - a duelist, perhaps? Maybe a cheat and a scoundrel? A musician, a flirt! Once a sailor, likely. **You can choose between getting a longsword + journeyman swords & wrestling, or journeyman lockpick/pickpocketing and T1 bard skills**. Are ye a lover or a fighter?
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="454" height="77" alt="image" src="https://github.com/user-attachments/assets/ba20612c-34a5-4ccc-8c21-3d032b8ea4b5" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
May as well let Adventurers be able to have some fun as their allegedly merc gents w/o losing on the drip. Are you willing to sacrifice combat skills in favor of drip and flavor? I know I am.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: **Adventurer Foreigner** receives two new subclasses: Grenzelhoftian Bludhund and Etruscan Nostromo. Themed around Grenzel merc and Vaquero/Condottieri merc respectively. **SIGNIFICANTLY WEAKER** than the actual merc counterparts. Soul.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
