### PR TITLE
lirvan merc fixes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/lirvan.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/lirvan.dm
@@ -52,7 +52,7 @@
 	cloak = /obj/item/clothing/cloak/ordinatorcape/lirvas
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/lirvas
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold
-	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
+	beltr = /obj/item/rogueweapon/sword/sabre
 	beltl = /obj/item/rogueweapon/scabbard/sword/noble
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel/gold
 	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/lirvas
@@ -60,8 +60,8 @@
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backl = /obj/item/rogueweapon/woodstaff/quarterstaff/gold
-	r_hand = /obj/item/rogueweapon/sword/sabre
+	l_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/gold
+	r_hand = /obj/item/storage/belt/rogue/pouch/coins/mid
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary = 1,
 		/obj/item/flashlight/flare/torch = 1,


### PR DESCRIPTION
## About The Pull Request

Realized that you can just...wear the quarterstaff on your back. Gets rid of the greatweapon strap and replaces it with a sword. Oops...

## Testing Evidence

Behold, An Scabbard .

<img width="174" height="127" alt="image" src="https://github.com/user-attachments/assets/964cad9d-f686-40ed-a1c2-67a63daf5bb0" />

## Why It's Good For The Game

Bugfix? Unintentionalfix. Didn't need this item, so...

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Lirvan Tithebound now spawns with 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
