### PR TITLE
Adds Examine Icons

### DIFF
--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -238,3 +238,72 @@
 	else
 		ADD_TRAIT(src, TRAIT_COMBAT_AWARE, TRAIT_VIRTUE)
 	to_chat(src, "I will see [HAS_TRAIT(src, TRAIT_COMBAT_AWARE) ? "more" : "less"] combat information now.")
+
+/mob/living/carbon/human/proc/generate_examine_tooltip(mob/living/examiner)
+	var/tooltip
+	if(HAS_TRAIT(examiner, TRAIT_ASTRATAN_AFFINITY) && get_dist(examiner, src) <= 2)
+		var/astratan_symbol
+		if(!HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS))	//Guarded virtue protects from this
+			if(issunelf(src) || patron?.type == /datum/patron/divine/astrata)
+				astratan_symbol = icon2html('icons/misc/language.dmi', world, "celestial")
+				. += SPAN_TOOLTIP("One of Astrata's [issunelf(src) ? "chosen" : "followers"]", astratan_symbol)
+	if(HAS_TRAIT(src, TRAIT_BEAUTIFUL) || (issunelf(src) && issunelf(examiner)))
+		var/heart
+		switch (pronouns)
+			if (HE_HIM)
+				tooltip = "[p_they(TRUE)] [p_are()] handsome!"
+				heart = "💙"
+			if (SHE_HER)
+				tooltip = "[p_they(TRUE)] [p_are()] beautiful!"
+				heart = "❤️"
+			if (THEY_THEM, IT_ITS)
+				tooltip = "[p_they(TRUE)] [p_are()] good-looking!"
+				heart = "💜"
+		. += SPAN_TOOLTIP(tooltip, "[heart] ")
+
+	if(HAS_TRAIT(src, TRAIT_NOBLE) || HAS_TRAIT(src, TRAIT_DEFILED_NOBLE))
+		if(HAS_TRAIT(examiner, TRAIT_NOBLE) || HAS_TRAIT(examiner, TRAIT_DEFILED_NOBLE))
+			tooltip = "A fellow noble."
+		else
+			tooltip = "A noble!"
+		. += SPAN_TOOLTIP(tooltip, "👑 " )
+
+	if(HAS_TRAIT(src, TRAIT_FREEMAN))
+		if(HAS_TRAIT(examiner, TRAIT_FREEMAN))
+			tooltip = "Fellow Free Man!"
+			. += SPAN_TOOLTIP(tooltip, "⚖️" )
+
+	if(HAS_TRAIT(examiner, TRAIT_INQUISITION))
+		if(HAS_TRAIT(src, TRAIT_INQUISITION) && HAS_TRAIT(examiner, TRAIT_INQUISITION))
+			tooltip = "A fellow adherent to the Holy Otavan Inquisition's missives."
+		if(HAS_TRAIT(src, TRAIT_PURITAN) && HAS_TRAIT(examiner, TRAIT_INQUISITION))
+			tooltip = "My superior, sent by the Holy Otavan Inquisition to lead our sect."
+		if(HAS_TRAIT(src, TRAIT_INQUISITION) && HAS_TRAIT(examiner, TRAIT_PURITAN))
+			tooltip = "A subordinate to my authority, as willed by the Holy Otavan Inquisition."
+		if(HAS_TRAIT(src, TRAIT_PURITAN) && HAS_TRAIT(examiner, TRAIT_PURITAN))
+			tooltip = "Myself. I lead this sect of the Holy Otavan Inquisition."
+		var/psy_symbol = icon2html('icons/misc/language.dmi', world, "psydon")
+		. += SPAN_TOOLTIP(tooltip, psy_symbol)
+
+	if(HAS_TRAIT(examiner, TRAIT_CLERGY))
+		if(HAS_TRAIT(src, TRAIT_CLERGY) && HAS_TRAIT(examiner, TRAIT_CLERGY))
+			tooltip = "A fellow member of the Azurian Church of the Ten."
+		if(HAS_TRAIT(src, TRAIT_CHOSEN) && HAS_TRAIT(examiner, TRAIT_CLERGY))
+			tooltip = "The Bishop, the leader of my Church and Chosen of the Ten."
+		if(HAS_TRAIT(src, TRAIT_CLERGY) && HAS_TRAIT(examiner, TRAIT_CHOSEN))
+			tooltip = "A member of the clergy under my leadership, as willed by the Ten."
+		if(HAS_TRAIT(src, TRAIT_CHOSEN) && HAS_TRAIT(examiner, TRAIT_CHOSEN))
+			tooltip = "Myself. I am the Bishop of Azuria, voice of the Ten in these lands."
+		var/astrata_symbol = icon2html('icons/misc/language.dmi', world, "celestial")
+		. += SPAN_TOOLTIP(tooltip, astrata_symbol)
+
+	if(HAS_TRAIT(src, TRAIT_WITCH))
+		if(HAS_TRAIT(examiner, TRAIT_NOBLE) || HAS_TRAIT(examiner, TRAIT_INQUISITION) || HAS_TRAIT(examiner, TRAIT_WITCH))
+			tooltip = "A witch! Their presence brings an unsettling aura."
+		else if(HAS_TRAIT(examiner, TRAIT_FREEMAN) || HAS_TRAIT(examiner, TRAIT_CABAL) || HAS_TRAIT(examiner, TRAIT_HORDE) || HAS_TRAIT(examiner, TRAIT_DEPRAVED))
+			tooltip = "A practitioner of the old ways."
+		else
+			tooltip = "Something about them seems... different."
+		. += SPAN_TOOLTIP(tooltip, "🧹" )
+	return .
+

--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -271,7 +271,7 @@
 	if(HAS_TRAIT(src, TRAIT_FREEMAN))
 		if(HAS_TRAIT(examiner, TRAIT_FREEMAN))
 			tooltip = "Fellow Free Man!"
-			. += SPAN_TOOLTIP(tooltip, "⚖️" )
+			. += SPAN_TOOLTIP(tooltip, "⚖️ " )
 
 	if(HAS_TRAIT(examiner, TRAIT_INQUISITION))
 		if(HAS_TRAIT(src, TRAIT_INQUISITION) && HAS_TRAIT(examiner, TRAIT_INQUISITION))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -131,36 +131,15 @@
 				origin = span_bold("nowhere..")
 			else
 				origin = dna.species.origin
-		var/astratan_symbol
-		var/astratan_tooltip
-		if(HAS_TRAIT(user, TRAIT_ASTRATAN_AFFINITY) && get_dist(user, src) <= 2)
-			if(!HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS))	//Guarded virtue protects from this
-				if(issunelf(src) || patron?.type == /datum/patron/divine/astrata)
-					astratan_symbol = icon2html('icons/misc/language.dmi', world, "celestial")
-					astratan_tooltip = SPAN_TOOLTIP("One of Astrata's [issunelf(src) ? "chosen" : "followers"]", astratan_symbol)
-		. += span_info("[pronoun] [wording] [origin]. [astratan_tooltip]")	//"He hails from [X / Nowhere]" || "His [word] originates from [X]" || "His [word] is implacable..."
+		. += span_info("[pronoun] [wording] [origin]. ") + generate_examine_tooltip(user)	//"He hails from [X / Nowhere]" || "His [word] originates from [X]" || "His [word] is implacable..."
 
-		if(HAS_TRAIT(src, TRAIT_WITCH))
-			if(HAS_TRAIT(user, TRAIT_NOBLE) || HAS_TRAIT(user, TRAIT_INQUISITION) || HAS_TRAIT(user, TRAIT_WITCH))
-				. += span_warning("A witch! Their presence brings an unsettling aura.")
-			else if(HAS_TRAIT(user, TRAIT_FREEMAN) || HAS_TRAIT(user, TRAIT_CABAL) || HAS_TRAIT(user, TRAIT_HORDE) || HAS_TRAIT(user, TRAIT_DEPRAVED))
-				. += span_notice("A practitioner of the old ways.")
-			else
-				. += span_notice("Something about them seems... different.")
-
+		if((HAS_TRAIT(user, TRAIT_BLACKOAK) && !(src.dna.species.name == "Elf" || src.dna.species.name == "Dark Elf" || src.dna.species.name == "Half-Elf")))
+			. += span_phobia("An invader...")
+			
 		if(SSticker.rulermob == src)
 			. += span_notice("<b>The ruler of this land.</b>")
 		else if(GLOB.lord_titles[name])
 			. += span_notice("[m3] been granted the title of \"[GLOB.lord_titles[name]]\".")
-
-		if(HAS_TRAIT(src, TRAIT_NOBLE) || HAS_TRAIT(src, TRAIT_DEFILED_NOBLE))
-			if(HAS_TRAIT(user, TRAIT_NOBLE) || HAS_TRAIT(user, TRAIT_DEFILED_NOBLE))
-				. += span_notice("A fellow noble.")
-			else
-				. += span_notice("A noble!")
-
-		if((HAS_TRAIT(user, TRAIT_BLACKOAK) && !(src.dna.species.name == "Elf" || src.dna.species.name == "Dark Elf" || src.dna.species.name == "Half-Elf")))
-			. += span_phobia("An invader...")
 
 		//For tennite schism god-event
 		if(length(GLOB.tennite_schisms))
@@ -172,11 +151,6 @@
 				var/datum/patron/their_god = (mob_side == "astrata") ? S.astrata_god.resolve() : S.challenger_god.resolve()
 				if(their_god)
 					. += (user_side == mob_side) ? span_notice("Fellow [their_god.name] supporter!") : span_userdanger("Vile [their_god.name] supporter!")
-
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			if(H.marriedto == name)
-				. += span_love("It's my spouse.")
 
 		if(name in GLOB.excommunicated_players)
 			. += span_userdanger("HERETIC! SHAME!")
@@ -261,27 +235,9 @@
 		var/villain_text = get_villain_text(user)
 		if(villain_text)
 			. += villain_text
-		var/heretic_text = get_heretic_text(user)
-		if(heretic_text)
-			. += span_notice(heretic_text)
-		var/inquisition_text = get_inquisition_text(user)
-		if(inquisition_text)
-			. +=span_notice(inquisition_text)
-		var/clergy_text = get_clergy_text(user)
-		if(clergy_text)
-			. +=span_notice(clergy_text)
 
 		if (HAS_TRAIT(src, TRAIT_LEPROSY))
 			. += span_necrosis("A LEPER...")
-
-		if (HAS_TRAIT(src, TRAIT_BEAUTIFUL) || (issunelf(src) && issunelf(user)))
-			switch (pronouns)
-				if (HE_HIM)
-					. += span_beautiful_masc("[m1] handsome!")
-				if (SHE_HER)
-					. += span_beautiful_fem("[m1] beautiful!")
-				if (THEY_THEM, IT_ITS)
-					. += span_beautiful_nb("[m1] good-looking!")
 
 		if (HAS_TRAIT(src, TRAIT_UNSEEMLY))
 			switch (pronouns)


### PR DESCRIPTION
## About The Pull Request
Takes a few of our fluffier examine texts and converts them to icons with tooltips.
<img width="347" height="64" alt="dreamseeker_yLRk848Lf4" src="https://github.com/user-attachments/assets/45889ccf-9d3d-472c-9294-2dbcefcca120" />

They save on a lot of space, though I'm really lacking in custom icons for the current ones and to do anymore, as emojis can only go so far without looking goofy (which they already do -- broom for witch is like lol).
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
These are currently ALL of the ones I've done so far.
![dreamseeker_OfAdBE36rP](https://github.com/user-attachments/assets/0e5c9bcc-b277-4810-9aca-895b24fe06cf)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I've been pretty open about hating how bloated our examine blocks are, any line saved without outright removing the text is good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Moved some of the examine text to icons with tooltips instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
