### PR TITLE
let saddleborn tame your horse + dying caparison + passengers

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -21,16 +21,16 @@
 
 	var/del_on_unbuckle_all = FALSE
 
-/datum/component/riding/no_ocean/Initialize()//no copy paste
-	. = ..()
-	forbid_turf_typecache = typecacheof(/turf/open/water/ocean/deep)
-
 /datum/component/riding/Initialize()
 	if(!ismovableatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, PROC_REF(vehicle_mob_buckle))
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, PROC_REF(vehicle_mob_unbuckle))
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(vehicle_moved))
+
+/datum/component/riding/no_ocean/Initialize()//no copy paste
+	. = ..()
+	forbid_turf_typecache = typecacheof(/turf/open/water/ocean/deep)
 
 /datum/component/riding/proc/vehicle_mob_unbuckle(datum/source, mob/living/M, force = FALSE)
 	var/atom/movable/AM = parent
@@ -118,22 +118,40 @@
 							x2off = diroffsets[1]
 							if(diroffsets.len >= 2)
 								y2off = diroffsets[2]
+							if(passindex > 1)
+								if(AM.dir == EAST)
+									x2off -= 10
+								else if(AM.dir == WEST)
+									x2off += 10
+							if(passindex == 1 && length(AM.buckled_mobs) > 1)
+								if(AM.dir == EAST)
+									x2off += 2
+								else if(AM.dir == WEST)
+									x2off -= 2
 							if(diroffsets.len == 3)
 								buckled_mob.layer = diroffsets[3]
+							else
+								if(AM.dir == SOUTH)
+									// South: passenger < rider < mount
+									if(passindex == 1)
+										buckled_mob.layer = MOB_LAYER
+									else
+										buckled_mob.layer = BELOW_MOB_LAYER
+								else if(AM.dir == NORTH)
+									// North: driver > mount, passenger > driver
+									if(passindex == 1)
+										buckled_mob.layer = ABOVE_MOB_LAYER
+									else
+										buckled_mob.layer = ABOVE_ALL_MOB_LAYER
+								else
+									// East/West: driver > passenger
+									if(passindex == 1)
+										buckled_mob.layer = ABOVE_MOB_LAYER
+									else
+										buckled_mob.layer = MOB_LAYER
 							buckled_mob.set_mob_offsets("riding", _x = x2off, _y = y2off)
 							break dir_loop
 	var/list/static/default_vehicle_pixel_offsets = list(TEXT_NORTH = list(0, 0), TEXT_SOUTH = list(0, 0), TEXT_EAST = list(0, 0), TEXT_WEST = list(0, 0))
-/*	var/px = default_vehicle_pixel_offsets[AM_dir]
-	var/py = default_vehicle_pixel_offsets[AM_dir]
-	if(directional_vehicle_offsets[AM_dir])
-		if(isnull(directional_vehicle_offsets[AM_dir]))
-			px = AM.pixel_x
-			py = AM.pixel_y
-		else
-			px = directional_vehicle_offsets[AM_dir][1]
-			py = directional_vehicle_offsets[AM_dir][2]
-	AM.pixel_x = px
-	AM.pixel_y = py*/
 
 /datum/component/riding/proc/set_vehicle_dir_offsets(dir, x, y)
 	directional_vehicle_offsets["[dir]"] = list(x, y)
@@ -186,27 +204,25 @@
 		return
 	last_vehicle_move = world.time
 
-	if(keycheck(user))
-		var/turf/next = get_step(AM, direction)
-		var/turf/current = get_turf(AM)
-		if(!istype(next) || !istype(current))
-			return	//not happening.
-		if(!turf_check(next, current))
-			to_chat(user, span_warning("My [AM] can not go onto [next]!"))
-			return
-		if(!isturf(AM.loc))
-			return
-		step(AM, direction)
-
-		if((direction & (direction - 1)) && (AM.loc == next))		//moved diagonally
-			last_move_diagonal = TRUE
-		else
-			last_move_diagonal = FALSE
-
-		handle_vehicle_layer()
-		handle_vehicle_offsets()
-	else
+	if(!keycheck(user))
 		to_chat(user, span_warning("You'll need the keys in one of my hands to [drive_verb] [AM]."))
+		return TRUE
+	var/turf/next = get_step(AM, direction)
+	var/turf/current = get_turf(AM)
+	if(!istype(next) || !istype(current))
+		return
+	if(!turf_check(next, current))
+		to_chat(user, span_warning("My [AM] can not go onto [next]!"))
+		return
+	if(!isturf(AM.loc))
+		return
+	step(AM, direction)
+	if((direction & (direction - 1)) && (AM.loc == next))
+		last_move_diagonal = TRUE
+	else
+		last_move_diagonal = FALSE
+	handle_vehicle_layer()
+	handle_vehicle_offsets()
 	return TRUE
 
 /datum/component/riding/proc/Unbuckle(atom/movable/M)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -713,9 +713,18 @@
 	TT.tick()
 
 /atom/movable/proc/handle_buckled_mob_movement(newloc, direct, glide_size_override)
+	if(!has_buckled_mobs())
+		return TRUE
+	var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding)
 	for(var/m in buckled_mobs)
 		var/mob/living/buckled_mob = m
+		// multi-mount affair
 		if(!buckled_mob.Move(newloc, direct, glide_size_override))
+			if(riding_datum && buckled_mob.buckled == src)
+				buckled_mob.forceMove(newloc)
+				continue
+
+			//regular ass mount
 			forceMove(buckled_mob.loc)
 			last_move = buckled_mob.last_move
 			inertia_dir = last_move

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -12,15 +12,19 @@
 /atom/movable/attack_hand(mob/living/user)
 	. = ..()
 	if(.)
-		return
-	if(can_buckle && has_buckled_mobs())
-		if(buckled_mobs.len > 1)
-			var/unbuckled = input(user, "Who do you wish to remove?","?") as null|mob in sortNames(buckled_mobs)
-			if(user_unbuckle_mob(unbuckled,user))
-				return 1
-		else
-			if(user_unbuckle_mob(buckled_mobs[1],user))
-				return 1
+		return FALSE
+	if(!can_buckle || !has_buckled_mobs())
+		return FALSE
+	if(user.buckled == src)
+		user_unbuckle_mob(user, user)
+		return TRUE
+	if(buckled_mobs && buckled_mobs.len > 1)
+		var/unbuckled = input(user, "Who do you wish to remove?","?") as null|mob in sortNames(buckled_mobs)
+		if(unbuckled && user_unbuckle_mob(unbuckled,user))
+			return TRUE
+	else if(buckled_mobs && buckled_mobs.len)
+		if(user_unbuckle_mob(buckled_mobs[1],user))
+			return TRUE
 
 /atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -98,11 +98,12 @@
 
 	if(..()) // call parent buckle
 		var/datum/component/riding/human/riding_datum = LoadComponent(/datum/component/riding/human)
-		riding_datum.vehicle_move_delay = 2
-		if(M.mind)
-			var/riding_skill = M.get_skill_level(/datum/skill/misc/riding)
-			if(riding_skill)
-				riding_datum.vehicle_move_delay = max(1, 2 - (riding_skill * 0.2))
+		if(!buckled_mobs || buckled_mobs.Find(M) == 1)
+			riding_datum.vehicle_move_delay = 2
+			if(M.mind)
+				var/riding_skill = M.get_skill_level(/datum/skill/misc/riding)
+				if(riding_skill)
+					riding_datum.vehicle_move_delay = max(1, 2 - (riding_skill * 0.2))
 		return TRUE
 	return FALSE
 
@@ -115,7 +116,13 @@
 	if(HAS_TRAIT(src, TRAIT_MOUNTABLE))
 		var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding)
 		if(riding_datum)
-			return riding_datum.handle_ride(user, direction)
+			// one rider
+			var/mob/living/driver = null
+			if(buckled_mobs && buckled_mobs.len)
+				driver = buckled_mobs[1]
+			if(!driver || user != driver)
+				return
+			return riding_datum.handle_ride(driver, direction)
 	return ..()
 
 /mob/living/carbon/human/Knockdown(amount, updating = TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/saiga.dm
@@ -13,16 +13,16 @@
 
 /mob/living/carbon/human/species/wildshape/saiga/gain_inherent_skills()
 	. = ..()
-	if(src.mind)
-		src.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-		src.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-		src.adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
-		src.adjust_skillrank(/datum/skill/misc/athletics, 5, TRUE)
+	if(mind)
+		adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+		adjust_skillrank(/datum/skill/misc/swimming, 4, TRUE)
+		adjust_skillrank(/datum/skill/misc/athletics, 5, TRUE)
 
-		src.STASTR = 10
-		src.STACON = 13
-		src.STAWIL = 18 //Because I don't want to give it TRAIT_INFINITE_STAMINA
-		src.STASPD = 13
+		STASTR = 10
+		STACON = 13
+		STAWIL = 18 //Because I don't want to give it TRAIT_INFINITE_STAMINA
+		STASPD = 13
 
 		AddSpell(new /obj/effect/proc_holder/spell/self/saigahoofs)
 		real_name = "saiga doe" //So we don't get a random name

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -422,6 +422,13 @@
 
 	if(isliving(AM))
 		var/mob/living/target = AM
+		if(buckled)
+			var/datum/component/riding/riding_datum = buckled.GetComponent(/datum/component/riding)
+			if(riding_datum)
+				if(target.stat == CONSCIOUS && !target.incapacitated(FALSE, TRUE))
+					to_chat(src, span_warning("[target] needs to be tied up or unaware for me to drag them."))
+					stop_pulling()
+					return FALSE
 		log_combat(src, target, "grabbed", addition="passive grab")
 		if(!iscarbon(src))
 			target.LAssailant = null

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -513,8 +513,7 @@
 /mob/living/simple_animal/hostile/Move(atom/newloc, dir , step_x , step_y)
 	if(dodging && approaching_target && prob(dodge_prob) && moving_diagonally == 0 && isturf(loc) && isturf(newloc) && !incapacitated())
 		return dodge(newloc,dir)
-	else
-		return ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/proc/dodge(moving_to,move_direction)
 	//Assuming we move towards the target we want to swerve toward them to get closer

--- a/code/modules/mob/living/simple_animal/rogue/farm/fogbeast.dm
+++ b/code/modules/mob/living/simple_animal/rogue/farm/fogbeast.dm
@@ -50,6 +50,7 @@ GLOBAL_LIST_INIT(valid_fogbeast_colors, list("White" = COLOR_WHITE, "Gray" = COL
 	can_buckle = TRUE
 	buckle_lying = 0
 	can_saddle = TRUE
+	max_buckled_mobs = 2
 	aggressive = TRUE
 	remains_type = /obj/effect/decal/remains/saiga
 
@@ -107,13 +108,7 @@ GLOBAL_LIST_INIT(valid_fogbeast_colors, list("White" = COLOR_WHITE, "Gray" = COL
 /mob/living/simple_animal/hostile/retaliate/rogue/fogbeast/tamed()
 	..()
 	deaggroprob = 20
-	if(can_buckle)
-		var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
-		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 8), TEXT_SOUTH = list(0, 8), TEXT_EAST = list(-2, 8), TEXT_WEST = list(2, 8)))
-		D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
-		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
-		D.set_vehicle_dir_layer(EAST, OBJ_LAYER)
-		D.set_vehicle_dir_layer(WEST, OBJ_LAYER)
+	setup_mount_riding()
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fogbeast/death()
 	unbuckle_all_mobs()
@@ -164,10 +159,12 @@ GLOBAL_LIST_INIT(valid_fogbeast_colors, list("White" = COLOR_WHITE, "Gray" = COL
 /mob/living/simple_animal/hostile/retaliate/rogue/fogbeast/proc/check_sprint_dismount()
 	SIGNAL_HANDLER
 	for(var/mob/living/carbon/human/rider in buckled_mobs)
-		if(rider.m_intent == MOVE_INTENT_RUN)
-			var/rider_skill = rider.get_skill_level(/datum/skill/misc/riding)
-			if(rider_skill < SKILL_LEVEL_MASTER)
-				violent_dismount(rider)
+		if(rider.m_intent != MOVE_INTENT_RUN)
+			continue
+		var/rider_skill = rider.get_skill_level(/datum/skill/misc/riding)
+		if(rider_skill >= SKILL_LEVEL_MASTER)
+			continue
+		violent_dismount(rider)
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fogbeast/post_buckle_mob(mob/living/M)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
+++ b/code/modules/mob/living/simple_animal/rogue/game/saiga.dm
@@ -70,6 +70,7 @@
 	can_buckle = TRUE
 	buckle_lying = 0
 	can_saddle = TRUE
+	max_buckled_mobs = 2
 	aggressive = 1
 	remains_type = /obj/effect/decal/remains/saiga
 
@@ -194,13 +195,7 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tamed()
 	..()
 	deaggroprob = 30
-	if(can_buckle)
-		var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
-		D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 8), TEXT_SOUTH = list(0, 8), TEXT_EAST = list(-2, 8), TEXT_WEST = list(2, 8)))
-		D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
-		D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
-		D.set_vehicle_dir_layer(EAST, OBJ_LAYER)
-		D.set_vehicle_dir_layer(WEST, OBJ_LAYER)
+	setup_mount_riding()
 
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/death()
 	unbuckle_all_mobs()
@@ -213,10 +208,12 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/proc/check_sprint_dismount()
 	SIGNAL_HANDLER
 	for(var/mob/living/carbon/human/rider in buckled_mobs)
-		if(rider.m_intent == MOVE_INTENT_RUN)
-			var/rider_skill = rider.get_skill_level(/datum/skill/misc/riding)
-			if(rider_skill < SKILL_LEVEL_MASTER)
-				violent_dismount(rider)
+		if(rider.m_intent != MOVE_INTENT_RUN)
+			continue
+		var/rider_skill = rider.get_skill_level(/datum/skill/misc/riding)
+		if(rider_skill >= SKILL_LEVEL_MASTER)
+			continue
+		violent_dismount(rider)
 
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/post_buckle_mob(mob/living/M)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -195,6 +195,11 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 	var/caparison_over_barding = FALSE
 	var/barding_speed_mult = 1
 
+/mob/living/simple_animal/get_mechanics_examine(mob/user)
+	. = ..()
+	if(can_buckle && max_buckled_mobs)
+		. += span_info("This can carry up to [max_buckled_mobs] rider[max_buckled_mobs == 1 ? "" : "s"].")
+
 /mob/living/simple_animal/Initialize()
 	. = ..()
 	GLOB.simple_animals[AIStatus] += src
@@ -938,17 +943,31 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 
 //ANIMAL RIDING
 
-/mob/living/simple_animal/hostile/user_unbuckle_mob(mob/living/M, mob/user)
-	if(user != M)
-		return
+/mob/living/simple_animal/hostile/proc/get_mount_time(mob/living/M, default_fail)
 	var/time2mount = 12
 	if(M.mind)
 		var/amt = M.get_skill_level(/datum/skill/misc/riding)
 		if(amt)
 			if(amt > 3)
-				time2mount = 0
+				return 0
 		else
-			time2mount = 30
+			return default_fail
+	return time2mount
+
+/mob/living/simple_animal/hostile/proc/setup_mount_riding()
+	if(!can_buckle)
+		return
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding/no_ocean)
+	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 8), TEXT_SOUTH = list(0, 8), TEXT_EAST = list(-2, 8), TEXT_WEST = list(2, 8)))
+	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
+	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
+	D.set_vehicle_dir_layer(EAST, OBJ_LAYER)
+	D.set_vehicle_dir_layer(WEST, OBJ_LAYER)
+
+/mob/living/simple_animal/hostile/user_unbuckle_mob(mob/living/M, mob/user)
+	if(user != M)
+		return
+	var/time2mount = get_mount_time(M, 30)
 	if(ssaddle)
 		playsound(src, 'sound/foley/saddledismount.ogg', 100, TRUE)
 	if(!move_after(M,time2mount, target = src))
@@ -963,27 +982,17 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 	if(user != M)
 		return
 	var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding/no_ocean)
-	if(riding_datum)
-		var/time2mount = 12
-		riding_datum.vehicle_move_delay = move_to_delay
-		if(M.mind)
-			var/amt = M.get_skill_level(/datum/skill/misc/riding)
-			if(amt)
-				if(amt > 3)
-					time2mount = 0
-			else
-				time2mount = 50
-
-		if(!move_after(M,time2mount, target = src))
-			return
-		if(user.incapacitated())
-			return
-//		for(var/atom/movable/A in get_turf(src))
-//			if(A != src && A != M && A.density)
-//				return
-		M.forceMove(get_turf(src))
-		if(ssaddle)
-			playsound(src, 'sound/foley/saddlemount.ogg', 100, TRUE)
+	if(!riding_datum)
+		return
+	var/time2mount = get_mount_time(M, 50)
+	riding_datum.vehicle_move_delay = move_to_delay
+	if(!move_after(M,time2mount, target = src))
+		return
+	if(user.incapacitated())
+		return
+	M.forceMove(get_turf(src))
+	if(ssaddle)
+		playsound(src, 'sound/foley/saddlemount.ogg', 100, TRUE)
 	..()
 	update_icon()
 
@@ -995,46 +1004,61 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		return
 	var/oldloc = loc
 	var/datum/component/riding/riding_datum = GetComponent(/datum/component/riding/no_ocean)
-	if(tame && riding_datum)
-		if(riding_datum.handle_ride(user, direction))
-			riding_datum.vehicle_move_delay = move_to_delay
-			if(user.m_intent == MOVE_INTENT_RUN)
-				riding_datum.vehicle_move_delay -= 1
-				if(loc != oldloc)
-					var/turf/open/T = loc
-					if(!do_footstep && T.footstep)
-						do_footstep = TRUE
-						playsound(loc,pick('sound/foley/footsteps/hoof/horserun (1).ogg','sound/foley/footsteps/hoof/horserun (2).ogg','sound/foley/footsteps/hoof/horserun (3).ogg'), 100, TRUE)
-					else
-						do_footstep = FALSE
-			else
-				if(loc != oldloc)
-					var/turf/open/T = loc
-					if(!do_footstep && T.footstep)
-						do_footstep = TRUE
-						playsound(loc,pick('sound/foley/footsteps/hoof/horsewalk (1).ogg','sound/foley/footsteps/hoof/horsewalk (2).ogg','sound/foley/footsteps/hoof/horsewalk (3).ogg'), 100, TRUE)
-					else
-						do_footstep = FALSE
-			if(user.mind)
-				var/amt = user.get_skill_level(/datum/skill/misc/riding)
-				if(amt)
-					riding_datum.vehicle_move_delay -= 5 + amt/6
-				else
-					riding_datum.vehicle_move_delay -= 3
+	if(!tame || !riding_datum)
+		return
+
+	var/mob/living/driver = null
+	if(buckled_mobs && buckled_mobs.len)
+		driver = buckled_mobs[1]
+	if(!driver || user != driver)
+		return
+
+	if(riding_datum.handle_ride(driver, direction))
+		riding_datum.vehicle_move_delay = move_to_delay
+		if(driver && user == driver && driver.m_intent == MOVE_INTENT_RUN)
+			riding_datum.vehicle_move_delay -= 1
 			if(loc != oldloc)
-				var/obj/structure/mineral_door/MD = locate() in loc
-				if(MD && !MD.ridethrough)
-					if(!HAS_TRAIT(user, TRAIT_EQUESTRIAN))
-						violent_dismount(user)
+				var/turf/open/T = loc
+				if(!do_footstep && T.footstep)
+					do_footstep = TRUE
+					playsound(loc,pick('sound/foley/footsteps/hoof/horserun (1).ogg','sound/foley/footsteps/hoof/horserun (2).ogg','sound/foley/footsteps/hoof/horserun (3).ogg'), 100, TRUE)
+				else
+					do_footstep = FALSE
+		else
+			if(loc != oldloc)
+				var/turf/open/T = loc
+				if(!do_footstep && T.footstep)
+					do_footstep = TRUE
+					playsound(loc,pick('sound/foley/footsteps/hoof/horsewalk (1).ogg','sound/foley/footsteps/hoof/horsewalk (2).ogg','sound/foley/footsteps/hoof/horsewalk (3).ogg'), 100, TRUE)
+				else
+					do_footstep = FALSE
+
+		if(driver && driver.mind)
+			var/amt = driver.get_skill_level(/datum/skill/misc/riding)
+			if(amt)
+				riding_datum.vehicle_move_delay -= 5 + amt/6
+			else
+				riding_datum.vehicle_move_delay -= 3
+		if(loc != oldloc)
+			var/obj/structure/mineral_door/MD = locate() in loc
+			if(MD && !MD.ridethrough)
+				for(var/mob/living/carbon/mountee in buckled_mobs)
+					if(HAS_TRAIT(mountee, TRAIT_EQUESTRIAN))
+						continue
+					violent_dismount(mountee)
 
 /mob/living/simple_animal/proc/violent_dismount(mob/living/user)
-	if(isliving(user))
-		var/mob/living/L = user
-		unbuckle_mob(L)
-		L.Paralyze(50)
-		L.Stun(50)
-		playsound(L.loc, 'sound/foley/zfall.ogg', 100, FALSE)
-		L.visible_message(span_danger("[L] falls off [src]!"))
+	if(!isliving(user))
+		return FALSE
+
+	var/mob/living/L = user
+	unbuckle_mob(L)
+	L.Paralyze(5 SECONDS)
+	L.Stun(5 SECONDS)
+	playsound(L.loc, 'sound/foley/zfall.ogg', 100, FALSE)
+	L.visible_message(span_danger("[L] falls off [src]!"))
+
+	return TRUE
 
 /mob/living/simple_animal/buckle_mob(mob/living/buckled_mob, force = 0, check_loc = 1)
 	. = ..()

--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -24,7 +24,8 @@ var/list/used_colors
 			/obj/item/flowercrown,
 			/obj/item/legwears,
 			/obj/item/undies,
-			/obj/item/natural/cloth
+			/obj/item/natural/cloth,
+			/obj/item/caparison
 			)
 
 /obj/machinery/gear_painter/Initialize()

--- a/code/modules/virtues/saddleborn.dm
+++ b/code/modules/virtues/saddleborn.dm
@@ -110,6 +110,9 @@ GLOBAL_LIST_INIT(virtue_mount_choices_anthrax, (list(
 		the_real_honse = new our_chosen_honse(user.loc)
 	the_real_honse.AddComponent(/datum/component/precious_creature, user)
 	user.saddleborn_mount = WEAKREF(the_real_honse)
+	if(istype(the_real_honse, /mob/living/simple_animal/hostile))
+		var/mob/living/simple_animal/hostile/friendly_horse = the_real_honse
+		friendly_horse.friends += user
 
 	if (has_name == "Yes")
 		var/honse_name = input(user, "What is your steed's name?", "Saddleborn")


### PR DESCRIPTION
## About The Pull Request

what it says on the tin.
1. Spawning your mount via saddleborn tames it to you automagically.
2. Caparisons can be dyed now in bins.
3. Mounts now can have multiple passengers. currently only fogbeasts and saigas only allow the driver + 1 passenger. examine the mount to see how many it can carry.
4. Riders have lost the ability to drag people behind them. If they are unconscious, then it'll work, still.

## Testing Evidence

yes

## Why It's Good For The Game

QOL.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Calling a mount now tames it to your name.
add: Caparisons can be dyed in bins.
add: Passengers to saiga/fogbeasts.
del: Riders can no longer drag conscious, standing people around.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
