### PR TITLE
Miacraft Aliases

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -592,6 +592,7 @@
 	data["ref"] = "[REF(R)]"
 	data["path"] = R.type
 	data["sellprice"] = R.sellprice
+	data["aliases"] = R.aliases
 	var/req_text = ""
 	var/tool_text = ""
 	var/catalyst_text = ""
@@ -621,6 +622,14 @@
 
 	data["craftingdifficulty"] = skill_to_string(R.craftdiff)
 
+	if(islist(R.result))
+		for(var/a in R.result)
+			var/atom/A = a 
+			if(!(findtext(data["aliases"],A.name)))
+				data["aliases"] += A.name + " "
+	else
+		var/atom/A = R.result
+		data["aliases"] += A.name
 
 	return data
 

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -37,6 +37,8 @@
 	var/ignoredensity = FALSE //used on objects that we want to build into walls or atop other structures
  	// If TRUE, this recipe will be skipped by the nodupe tests
 	var/bypass_dupe_test = FALSE
+	//Hardcoded aliases, fill this in for things that have things like slang names. Real item alias names will be appended automatically during build_recipe_data
+	var/aliases = ""
 /*
 /datum/crafting_recipe/example
 	name = ""

--- a/tgui/packages/tgui/interfaces/MiaCraft.js
+++ b/tgui/packages/tgui/interfaces/MiaCraft.js
@@ -17,7 +17,7 @@ const CraftingCategory = ({ crafties, key3, onlyCraftable, craftability, key, ac
       craftability.some(object => object[0] === item2.name && object[1] === 1))
       .sort(([, aVal], [, bVal]) => String(aVal.name).localeCompare(String(bVal.name)))
       .filter(([id, item]) => 
-      { return item.name.toLowerCase().includes(searchText); });
+      { return (item.name.toLowerCase().includes(searchText)) || (item.aliases.toLowerCase().includes(searchText)); });
     }, [crafties, onlyCraftable, craftability, searchText]);
     return (visibleElements.length > 0 ? 
         <Collapsible title={key3}>
@@ -43,6 +43,9 @@ const CraftingCategory = ({ crafties, key3, onlyCraftable, craftability, key, ac
         <Stack.Item basis="80%">
           <Collapsible title={recipe.name} style={{ backgroundColor: craftability.some(object => object[0] === recipe.name && object[1] === 1) ? "" : "grey" }}>
             <LabeledList >
+              <LabeledList.Item label="Also known as" style={{ 'margin-left': '20px' }}>
+                {recipe.aliases}
+              </LabeledList.Item>
               <LabeledList.Item label="Ingredients" style={{ 'margin-left': '20px' }}>
                 {recipe.req_text}
               </LabeledList.Item>


### PR DESCRIPTION
## About The Pull Request

Adds aliases support to Miacraft.

Adds an alias variable to crafting recipes, which will be automatically appended by the result item(s)'s actual name(s)!
If you are adding aliases at the definition of a recipe, add a trailing whitespace.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="406" height="662" alt="image" src="https://github.com/user-attachments/assets/9548dcd2-5d7f-4d70-998d-cac2946ce51f" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

So people can search for things by their actual name, among other things.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Miacraft now supports aliases
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
