### PR TITLE
light steps muffles armor rustling

### DIFF
--- a/code/datums/item_equipped_movement_rustle.dm
+++ b/code/datums/item_equipped_movement_rustle.dm
@@ -24,6 +24,9 @@ with light edits to work with roguecode */
 	///when sounds start falling off for the rustle rustle.
 	var/sound_falloff_distance = 1
 
+	///whether our owner has a muffling trait.
+	var/has_light_steps = FALSE
+
 	var/static/list/valid_storage_rustlers = list(
 		/datum/component/storage/concrete/roguetown/hat
 	)
@@ -53,6 +56,7 @@ with light edits to work with roguecode */
 /datum/component/item_equipped_movement_rustle/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
 
+	has_light_steps = HAS_TRAIT(equipper, TRAIT_LIGHT_STEP)
 	RegisterSignal(equipper, COMSIG_MOVABLE_MOVED, PROC_REF(try_step), override = TRUE)
 	RegisterSignal(equipper, COMSIG_SEX_JOSTLE, PROC_REF(try_step_quick), override = TRUE)
 
@@ -60,6 +64,7 @@ with light edits to work with roguecode */
 	SIGNAL_HANDLER
 
 	move_counter = 0
+	has_light_steps = FALSE
 	UnregisterSignal(dropped, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(dropped, COMSIG_SEX_JOSTLE)
 
@@ -69,10 +74,12 @@ with light edits to work with roguecode */
 	if(!is_type_in_list(storage_datum, valid_storage_rustlers))
 		return
 
+	has_light_steps = FALSE
 	RegisterSignal(storage_master, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 	RegisterSignal(storage_master, COMSIG_ITEM_DROPPED, PROC_REF(on_unequip))
 
 	if(storage_master.loc == user)
+		has_light_steps = HAS_TRAIT(user, TRAIT_LIGHT_STEP)
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(try_step), override = TRUE)
 
 /datum/component/item_equipped_movement_rustle/proc/handle_storage_remove(datum/source, obj/storage_master, mob/user, datum/storage_datum)
@@ -81,6 +88,7 @@ with light edits to work with roguecode */
 	if(!is_type_in_list(storage_datum, valid_storage_rustlers))
 		return
 
+	has_light_steps = FALSE
 	UnregisterSignal(storage_master, COMSIG_ITEM_EQUIPPED)
 	UnregisterSignal(storage_master, COMSIG_ITEM_DROPPED)
 
@@ -106,4 +114,5 @@ with light edits to work with roguecode */
 		move_counter = 0
 
 /datum/component/item_equipped_movement_rustle/proc/play_rustle_sound(obj/item/clothing/source)//(mob/source)
-	playsound(source, rustle_sounds, volume, sound_vary, sound_extra_range, sound_falloff_exponent, falloff = sound_falloff_distance)
+	if(!has_light_steps)
+		playsound(source, rustle_sounds, volume, sound_vary, sound_extra_range, sound_falloff_exponent, falloff = sound_falloff_distance)


### PR DESCRIPTION
## About The Pull Request
Saw this randomly mentioned on discord and thought the idea was cute. Meant to be combined with the virtue rework but probably isn't a big deal on its own.

Due to how the component works the user will have to re-equip their spawn gear for it to work with this. Virtues are applied -after- armor, unfortunately.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/9643a5ea-10a1-4b23-ac47-d7c37700ab08


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's kinda just neat.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Light Steps now muffles armor sounds when walking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
