### PR TITLE
Gives Munitioneer a Riddle of Steel.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/munitioneer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/munitioneer.dm
@@ -61,6 +61,7 @@
 		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,
 		/obj/item/rogueweapon/huntingknife/combat = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
+		/obj/item/riddleofsteel = 1
 		)
 
 /datum/outfit/job/roguetown/wretch/munitioneer/choose_loadout(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

See title.

## Testing Evidence

<img width="1625" height="1110" alt="dreamseeker_C7lweTrP2I" src="https://github.com/user-attachments/assets/3882419d-95c7-4f2c-b260-bf65e69a29e9" />

## Why It's Good For The Game

Munitioneer, currently, has a grinding cycle to prep to equip other wretches that extends far beyond the point other wretches are either dead or no longer going to wretchcoast. Giving them a riddle of steel allows them to half that grind, meaning now they can begin providing services about an hour in, rather than about 2 hours in. They still have to mine up ore, which is an extensive process by itself with how much ore spawns have been cranked down.

## Changelog

:cl:
balance: Munitioneer now gets a Riddle of Steel in their backpack.
/:cl:

