### PR TITLE
Separates knockdowns and disarms

### DIFF
--- a/code/datums/ai/controllers/abyssal.dm
+++ b/code/datums/ai/controllers/abyssal.dm
@@ -195,6 +195,7 @@
 		else
 			if((stander && target.stamina >= target.max_stamina) || target.IsOffBalanced()) //if you are kicked while fatigued, you are knocked down no matter what
 				target.Knockdown(target.IsOffBalanced() ? SHOVE_KNOCKDOWN_SOLID : 100)
+				target.drop_all_held_items()
 				target.visible_message(span_danger("[user.name] charges [target.name], knocking them down!"),
 				span_danger("I'm knocked down from a devestating leg swipe by the [user.name]!"), span_hear("I hear aggressive clacking followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)
 				log_combat(user, target, "kicked", "knocking them down")
@@ -214,17 +215,20 @@
 						break
 		if((!target_table && !target_collateral_mob) || directional_blocked)
 			target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
+			target.drop_all_held_items()
 			target.visible_message(span_danger("[user.name] charges [target.name], knocking them down!"),
 			span_danger("I'm knocked down from a devestating leg swipe by the [user.name]!"), span_hear("I hear aggressive clacking followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)
 			log_combat(user, target, "kicked", "knocking them down")
 		else if(target_table)
 			target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
+			target.drop_all_held_items()
 			target.visible_message(span_danger("[user.name] charges [target.name] onto \the [target_table]!"),
 			span_danger("I'm knocked down from a devestating leg swipe by the [user.name]!"), span_hear("I hear aggressive clacking followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)
 			target.throw_at(target_table, 1, 1, null, FALSE) //1 speed throws with no spin are basically just forcemoves with a hard collision check
 			log_combat(user, target, "kicked", "onto [target_table] (table)")
 		else if(target_collateral_mob)
 			target.Knockdown(SHOVE_KNOCKDOWN_HUMAN)
+			target.drop_all_held_items()
 			target_collateral_mob.Knockdown(SHOVE_KNOCKDOWN_COLLATERAL)
 			target.visible_message(span_danger("[user.name] charges [target.name] into [target_collateral_mob.name]!"),
 			span_danger("I'm knocked down from a devestating leg swipe by the [user.name]!"), span_hear("I hear aggressive clacking followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)

--- a/code/datums/magic_items/mythical_items/mythic.dm
+++ b/code/datums/magic_items/mythical_items/mythic.dm
@@ -156,6 +156,7 @@
 			if(2)
 				L.apply_damage(10, BRUTE)
 				L.Knockdown(20)
+				L.drop_all_held_items()
 				to_chat(L, span_warning("Chaotic force slams into you!"))
 			if(3)
 				L.electrocute_act(12, source, 1)

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -387,6 +387,7 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 		if(L.m_intent == MOVE_INTENT_RUN)
 			L.visible_message(span_warning("[L] trips over the boulder!"),span_warning("I trip over the boulder!"))
 			L.Knockdown(10)
+			L.drop_all_held_items()
 			L.consider_ambush(always = TRUE)
 	..()
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -639,7 +639,8 @@
 	if(!forced)
 		return
 	playsound(src, "bodyfall", 100, TRUE)
-	faller.drop_all_held_items()
+	if(!faller.mind)
+		faller.drop_all_held_items()
 
 /turf/proc/photograph(limit=20)
 	var/image/I = new()

--- a/code/modules/antagonists/roguetown/villain/dreamwalker/dreamwalker_trident.dm
+++ b/code/modules/antagonists/roguetown/villain/dreamwalker/dreamwalker_trident.dm
@@ -107,6 +107,7 @@
 	// Special knockup effect for strong throws
 	if(effect_strength >= 2 && radius <= 3)
 		L.Knockdown(1 * effect_strength)
+		L.drop_all_held_items()
 		knockup_effect(L)
 	else
 		L.set_resting(TRUE, TRUE)

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -34,6 +34,7 @@
 			to_chat(H, span_userdanger("UNIMAGINABLE PAIN!"))
 			H.Stun(30)
 			H.Knockdown(30)
+			H.drop_all_held_items()
 
 		else if (world.time >= transforming + 10 SECONDS) // Stage 1
 			H.emote("")
@@ -190,6 +191,7 @@
 	playsound(W.loc, pick('sound/combat/gib (1).ogg','sound/combat/gib (2).ogg'), 200, FALSE, 3)
 	W.spawn_gibs(FALSE)
 	W.Knockdown(30)
+	W.drop_all_held_items()
 	W.Stun(30)
 
 	qdel(src)

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_wound_infection.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_wound_infection.dm
@@ -39,4 +39,5 @@
 	to_chat(owner, span_danger("It hurts... Is this really the end for me?"))
 	owner.emote("scream") // heres your warning to others bro
 	owner.Knockdown(1)
+	owner.drop_all_held_items()
 	return wolfy

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -402,6 +402,7 @@
 		zombie.flash_fullscreen("redflash3")
 		zombie.emote("scream") // Warning for nearby players
 		zombie.Knockdown(1)
+		zombie.drop_all_held_items()
 
 ///Making sure they're not any other antag as well as adding the zombie datum to their mind
 /mob/living/carbon/human/proc/zombie_check_can_convert()

--- a/code/modules/mob/living/carbon/human/npc/deadite.dm
+++ b/code/modules/mob/living/carbon/human/npc/deadite.dm
@@ -201,5 +201,6 @@
 	to_chat(src, span_danger("It hurts... Is this really the end for me?"))
 	emote("scream") // heres your warning to others bro
 	Knockdown(1)
+	drop_all_held_items()
 	zombie_antag.wake_zombie(TRUE)
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1415,6 +1415,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 			if((!target_table && !target_collateral_mob) || directional_blocked)
 				target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
+				target.drop_all_held_items()
 				target.visible_message(
 					span_danger("[user.name] shoves [target.name], knocking them down!"),
 					span_danger("You're knocked down from a shove by [user.name]!"),
@@ -1427,6 +1428,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 			else if(target_table)
 				target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
+				target.drop_all_held_items()
 				target.visible_message(
 					span_danger("[user.name] shoves [target.name] onto \the [target_table]!"),
 					span_danger("I'm shoved onto \the [target_table] by [user.name]!"),
@@ -1440,6 +1442,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 			else if(target_collateral_mob)
 				target.Knockdown(SHOVE_KNOCKDOWN_HUMAN)
+				target.drop_all_held_items()
 				target_collateral_mob.Knockdown(SHOVE_KNOCKDOWN_COLLATERAL)
 				target.visible_message(
 					span_danger("[user.name] shoves [target.name] into [target_collateral_mob.name]!"),
@@ -1606,6 +1609,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		else
 			if(HAS_TRAIT(user, TRAIT_STRONGKICK))
 				target.Knockdown(SHOVE_KNOCKDOWN_HUMAN)
+				target.drop_all_held_items()
 				var/throwtarget = get_edge_target_turf(user, get_dir(user, get_step_away(target, user)))
 				if(target.pulling && target.grab_state < GRAB_AGGRESSIVE)
 					target.throw_at(throwtarget, 2, 2)
@@ -1621,6 +1625,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 			else if((stander && target.stamina >= target.max_stamina) || target.IsOffBalanced()) //if you are kicked while fatigued, you are knocked down no matter what
 				target.Knockdown(target.IsOffBalanced() ? SHOVE_KNOCKDOWN_SOLID : 100)
+				target.drop_all_held_items()
 				target.visible_message(span_danger("[user.name] kicks [target.name], knocking them down!"),
 				span_danger(
 					"I'm knocked down from a kick by [user.name]!"),
@@ -1646,12 +1651,14 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 							break
 			if((!target_table && !target_collateral_mob) || directional_blocked)
 				target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
+				target.drop_all_held_items()
 				target.visible_message(span_danger("[user.name] kicks [target.name], knocking them down!"),
 								span_danger("I'm knocked down from a kick by [user.name]!"), span_hear("I hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)
 				to_chat(user, span_danger("I kick [target.name], knocking them down!"))
 				log_combat(user, target, "kicked", "knocking them down")
 			else if(target_table)
 				target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
+				target.drop_all_held_items()
 				target.visible_message(span_danger("[user.name] kicked [target.name] onto \the [target_table]!"),
 								span_danger("I'm kicked onto \the [target_table] by [user.name]!"), span_hear("I hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)
 				to_chat(user, span_danger("I kick [target.name] onto \the [target_table]!"))
@@ -1659,6 +1666,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				log_combat(user, target, "kicked", "onto [target_table] (table)")
 			else if(target_collateral_mob)
 				target.Knockdown(SHOVE_KNOCKDOWN_HUMAN)
+				target.drop_all_held_items()
 				target_collateral_mob.Knockdown(SHOVE_KNOCKDOWN_COLLATERAL)
 				target.visible_message(span_danger("[user.name] kicks [target.name] into [target_collateral_mob.name]!"),
 					span_danger("I'm kicked into [target_collateral_mob.name] by [user.name]!"), span_hear("I hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, user)

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -137,6 +137,7 @@
 	if(H)
 		if(!H?.check_armor_skill() || H?.legcuffed)
 			H.Knockdown(1)
+			H.drop_all_held_items()
 			return FALSE
 		if(I) //the enemy attacked us with a weapon
 			if(!I.associated_skill) //the enemy weapon doesn't have a skill because its improvised, so penalty to attack

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -559,6 +559,7 @@ SPECIALS START HERE
 			//We offbalance them OR knock them down if they're already offbalanced
 			if(L.IsOffBalanced())
 				L.Knockdown(KD_dur)
+				L.drop_all_held_items()
 			else
 				L.OffBalance(Offb_dur)
 			apply_generic_weapon_damage(L, dam, "blunt", BODY_ZONE_CHEST, bclass = BCLASS_BLUNT, no_pen = TRUE)
@@ -622,11 +623,13 @@ SPECIALS START HERE
 			victim.Immobilize(newimmob)
 			victim.apply_status_effect(/datum/status_effect/debuff/exposed, newexposed)
 			victim.Knockdown(knockdown)
+			victim.drop_all_held_items()
 		if(5 to 9)
 			victim.Slowdown(newslow)
 			victim.Immobilize(newimmob)
 			victim.apply_status_effect(/datum/status_effect/debuff/exposed, newexposed)
 			victim.Knockdown(knockdown)
+			victim.drop_all_held_items()
 			victim.OffBalance(newoffb)
 			victim.Stun(5 SECONDS)
 	if(victim_count < 3)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -132,6 +132,7 @@
 					sleep(10)
 					Stun(110)
 					Knockdown(110)
+					drop_all_held_items()
 
 /mob/living/proc/handle_environment()
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1165,6 +1165,7 @@
 	vis_contents += flaggy
 	Stun(300)
 	Knockdown(300)
+	drop_all_held_items()
 	apply_status_effect(/datum/status_effect/debuff/breedable)
 	apply_status_effect(/datum/status_effect/debuff/submissive)
 	src.visible_message(span_notice("[src] yields!"))


### PR DESCRIPTION
## About The Pull Request
Pulled the code from knockdowns that disarmed the target and applied it in various places by hand.
I won't go through every change but here are the highlights of what had its disarms removed:
- Simple mob effects that knocked the user down will now not disarm the user (volfs mainly) -> simple mob rng, there's a lot of it and I don't think it'll affect that much.
- Charging no longer disarms the user -> this will be the replacement for the charge immunity PR that's been TMed this whole time
- Pinning knockdowns (from wrestling) no longer disarm the target
- Rituals and silver-touching from vampires or werewolves no longer disarms -> Rituals don't really matter as it's done voluntarily, and WWs have nodrop claws and it's unlikely they're touching that stuff on purpose.
- Nets no longer disarm -> they already do *a lot*. I'm not sure why they're in the state that they are atm.
- Everything else that used to disarm via knockdowns still does -- specials, abyssor dreamer stuff, kicking people into things / while they're exhausted, painstuns, etc.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Kinda hard to show
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
We did not have a way to knock someone down from effects without disarming them on top. Now knocking people down without disarming is possible, as its a distinct debuff on its own.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Changed knockdown logic to not involve a disarm. Consequently several effects no longer disarm that used to knock the target down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
