### PR TITLE
[lithmyc] - Lithmyc mace buff

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -1021,11 +1021,11 @@
 	spawn(0)
 		spawn_spore_clouds(target, user)
 
-	if(hit_count == 6)
+	if(hit_count == 4)
 		playsound(user, 'sound/magic/magnet.ogg', 75)
 		to_chat(user, span_userdanger("The mushroom mace is pulsing wildly!"))
 
-	if(hit_count >= 7)
+	if(hit_count >= 5)
 		spawn(0)
 			mushroom_boom(target, user)
 		hit_count = 0 // Reset after the big boom
@@ -1053,9 +1053,9 @@
 	explosion(T, devastation_range = 0, heavy_impact_range = 0, light_impact_range = 4, smoke = TRUE, soundin = pick('sound/misc/explode/explosion.ogg'))
 
 	for(var/mob/living/L in range(2, T))
-		var/damage = 30
+		var/damage = 25
 		if(L == user)
-			damage = 10 // User takes reduced damage
+			damage = 5 // User takes reduced damage
 		L.apply_damage(damage, TOX)
 		if(L != user && ishuman(L))
 			var/mob/living/carbon/human/H = L
@@ -1068,7 +1068,7 @@
 	duration = 16 SECONDS
 	plane = GAME_PLANE_UPPER
 	layer = ABOVE_ALL_MOB_LAYER
-	var/damage_amount = 5
+	var/damage_amount = 6
 
 /obj/effect/temp_visual/spore/Initialize(mapload)
 	. = ..()
@@ -1102,7 +1102,7 @@
 	desc = "A heavy mace forged from fungal-infused metals. Looks spiky!"
 	icon_state = "mushroom"
 	force = 18
-	force_wielded = 24
+	force_wielded = 27
 	max_integrity = 500
 	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/boom, /datum/intent/mace/strike/dislocate)
 	gripped_intents = list(/datum/intent/mace/strike, /datum/intent/mace/boom, /datum/intent/mace/strike/dislocate, /datum/intent/mace/smash)


### PR DESCRIPTION
## About The Pull Request
Slightly boosts the lithmyc mace.
- Wielded dam 24 => 27 (steel mace is 32 || 16.67% damage increase) 
- spore dam 5 => 6 (20% increase)
- explosion tox damage 30 => 25 (16.67% damage decrease)
- explosion tox self damage 10 => 5 (50% decrease)
- hits needed per explosion 7 => 5 (40%~ decrease)
- This comes down to an explosion tox DPS increase of (16.67%)
- Fire and physical damage from explosion is hard to tell, but about a (40% increase) there. Keep in mind this part of the damage is very light, like being in range of a bottlebomb but not point of impact.

## Testing Evidence
Number change milord

## Why It's Good For The Game
It's pretty rare. I can't give exact numbers, but it's somewhere between 33% - 50% of rounds that lithmyc spawns at all. Reportedly pretty weak, and given it uses 3 damage types, miracles are very effective against this weapon. 

Hence some slight buffs, mostly to the flashier part of the weapon.

## Changelog
:cl:
balance: Lithmyc maces are stronger now.
/:cl:

