### PR TITLE
Removes offensive advantage from dual wielder

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -364,7 +364,7 @@
 					var/forceoffhand = L.dualwieldpitystacks >= L.dualwieldpitythreshhold
 					if(forceoffhand)
 						L.dualwieldpitystacks = 0
-						if(L.stamina_add(2))
+						if(L.stamina_add(3))
 							L.last_used_double_attack = world.time + 2.5 SECONDS
 							to_chat(L, span_warning("An opening! I strike with my off-hand."))
 							offh.melee_attack_chain(src, A, params)

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -193,12 +193,14 @@
 				attacker_dualw = TRUE
 		//----------Dual Wielding check end---------
 
+		var/attacker_feedback 
+
 		if(src.client?.prefs.showrolls)
 			var/text = "Roll to dodge... [prob2defend]%"
 			if((defender_dualw || attacker_dualw))
 				if(defender_dualw && attacker_dualw)
 					text += " Our dual wielding cancels out!"
-				else//If we're defending as a dual wielder, we roll disadv. But if we're both dual wielding it cancels out.
+				else//If we're defending against or as a dual wielder, we roll disadv. But if we're both dual wielding it cancels out.
 					text += " Twice! Disadvantage! ([(prob2defend / 100) * (prob2defend / 100) * 100]%)"
 			to_chat(src, span_info("[text]"))
 

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -175,7 +175,6 @@
 		//------------Dual Wielding Checks------------
 		var/attacker_dualw
 		var/defender_dualw
-		var/extraattroll
 		var/extradefroll
 		var/mainhand = L.get_active_held_item()
 		var/offhand	= L.get_inactive_held_item()
@@ -191,20 +190,15 @@
 		var/obj/item/offh = U.get_inactive_held_item()
 		if(mainh && offh && HAS_TRAIT(U, TRAIT_DUALWIELDER))
 			if(istype(mainh, offh))
-				extraattroll = prob(prob2defend)
 				attacker_dualw = TRUE
 		//----------Dual Wielding check end---------
-
-		var/attacker_feedback 
-		if(user.client?.prefs.showrolls && (attacker_dualw || defender_dualw))
-			attacker_feedback = "Attacking with advantage. ([100 - ((prob2defend / 100) * (prob2defend / 100) * 100)]%)"
 
 		if(src.client?.prefs.showrolls)
 			var/text = "Roll to dodge... [prob2defend]%"
 			if((defender_dualw || attacker_dualw))
 				if(defender_dualw && attacker_dualw)
 					text += " Our dual wielding cancels out!"
-				else//If we're defending against or as a dual wielder, we roll disadv. But if we're both dual wielding it cancels out.
+				else//If we're defending as a dual wielder, we roll disadv. But if we're both dual wielding it cancels out.
 					text += " Twice! Disadvantage! ([(prob2defend / 100) * (prob2defend / 100) * 100]%)"
 			to_chat(src, span_info("[text]"))
 
@@ -215,7 +209,7 @@
 			if(prob(prob2defend))
 				dodge_status = TRUE
 		else if(attacker_dualw)
-			if(prob(prob2defend) && extraattroll)
+			if(prob(prob2defend))
 				dodge_status = TRUE
 		else if(defender_dualw)
 			if(prob(prob2defend) && extradefroll)


### PR DESCRIPTION
## About The Pull Request
It was removed vs parry but not vs dodge, increased stamina cost slightly (a dual wield attack is now worth roughly 2.6 attacks rather than ~2.4 stamina wise). A dual wield user will still need to roll disadvantage on defense, regardless if it's parry or dodge.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Stacking attacks is fine enough on its own there is no need to still keep the advantage vs a specific niche of opponents, whether it was an oversight or not the point of the trait is the double attack now not the advantage.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Removed dual wielder still giving an offensive advantage in certain scenarios.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
