### PR TITLE
LOWLANDS AWAY ME JOHN || TELESCOPE REDO || TEENY BUFFS -- LORE -- MORE || THIS PROBABLY NEEDS REVIEW ON THE LIFE() PART

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -222,3 +222,25 @@
 	id = "compliance"
 	alert_type = /atom/movable/screen/alert/status_effect/compliance
 	needs_processing = FALSE
+
+/datum/status_effect/zuranus // this will hook into dreamcode.
+	id = "zuranus"
+	alert_type = /atom/movable/screen/alert/status_effect/zuranus
+	duration = 25 MINUTES
+	// honestly this might be better off as something else but a status effect is temporary
+	// id prefer it to be hidden but i dont think i can hide it. lol.
+
+/atom/movable/screen/alert/status_effect/zuranus
+	name = "Something is Stirring"
+	desc = span_purple("I feel... off. There's a weird chill throughout my body. I feel an odd desire to touch gilbronze...?")
+
+/datum/status_effect/telescope_used
+	id = "telescope"
+	alert_type = /atom/movable/screen/alert/status_effect/telescope_used
+	duration = 15 MINUTES
+	// honestly this might be better off as something else but a status effect is temporary
+	// id prefer it to be hidden but i dont think i can hide it. lol.
+
+/atom/movable/screen/alert/status_effect/telescope_used
+	name = "Minds Eye Expended"
+	desc = span_purple("Gazing upon the tapestry's celestial bodies takes an odd amount of energy. I must rest before trying again.")

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -232,7 +232,7 @@
 
 /atom/movable/screen/alert/status_effect/zuranus
 	name = "Something is Stirring"
-	desc = span_purple("I feel... off. There's a weird chill throughout my body. I feel an odd desire to touch gilbronze...?")
+	desc = span_purple("I feel... off. There's a weird chill throughout my body. I feel an odd desire to put gilbranze under my tongue...?")
 
 /datum/status_effect/telescope_used
 	id = "telescope"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -2140,19 +2140,22 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/hermes_trismegistus
 	duration = 20 MINUTES
 	var/original_skill = null // we need scope for the whole thing so this gotta b here and null
+	var/gave_buff = FALSE
 
 /atom/movable/screen/alert/status_effect/buff/hermes_trismegistus
 	name = "Hermetick Blessing" // yes, hermetick. with a k. 
-	desc = "Looking at HERMES has given me a blessing of the Stars... words make more sense." // dont ask how this works its magic biyatch
+	desc = "Looking at HERMES has given me a blessing of the Stars... written words begin to make more sense." // dont ask how this works its magic biyatch
 
 /datum/status_effect/buff/hermes_trismegistus/on_apply()
 	. = ..()
 	if(owner)
 		original_skill = owner.get_skill_level(/datum/skill/misc/reading) // cache it
-		if(original_skill < 3)
+		if(original_skill < SKILL_LEVEL_JOURNEYMAN)
 			owner.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE) // +1 reading. this technically lets u read if ur illtierate, ithink. idk. its cool, ok.
+			gave_buff = TRUE
 
 /datum/status_effect/buff/hermes_trismegistus/on_remove()
 	. = ..()
-	owner.adjust_skillrank_down_to(/datum/skill/misc/reading, original_skill, TRUE)
-	to_chat(owner, span_warning("The blessing of HERMES begins to wear off. Words lose their meaning in my skull."))
+	if(gave_buff) // because we ensure that the buff was actually given out, and due to the 0-3 scale of it, we can just
+		owner.adjust_skillrank(/datum/skill/misc/reading, -1, TRUE) // -1 skill once it wears off and it (should) be fine.
+		to_chat(owner, span_warning("The blessing of HERMES begins to wear off. The written word loses it's meaning in my skull."))

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -2113,3 +2113,46 @@
 	to_chat(owner, span_warning("The droning quiets. My footsteps are noisy, again."))
 	REMOVE_TRAIT(owner, TRAIT_SILENT_FOOTSTEPS, "xylixboon")
 	REMOVE_TRAIT(owner, TRAIT_LIGHT_STEP, "xylixboon")
+
+/datum/status_effect/buff/transparent_eyeball
+	id = "transparent_eyeball"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/transparent_eyeball
+	duration = 20 MINUTES
+	// this should hook into the scrying code rather than anything here
+	// it just gives them less chance to break shit. thats it.
+
+// https://www.youtube.com/watch?v=v_UvrYT26o4
+// https://en.wikipedia.org/wiki/Transparent_eyeball
+/atom/movable/screen/alert/status_effect/buff/transparent_eyeball
+	name = "Transparent Eyeball"
+	desc = "Nepolx's red surface has blessed me... I shall find it easier to use scrying orbs." + span_gamedeadsay("\n...I AM NOTHING, I SEE ALL.")
+
+/datum/status_effect/buff/transparent_eyeball/on_apply()
+	. = ..()
+	to_chat(owner, span_gamedeadsay("I feel unbound to my mortal coil-- scrying orbs will be easier to use, for a time!"))
+
+/datum/status_effect/buff/transparent_eyeball/on_remove()
+	. = ..()
+	to_chat(owner, span_gamedeadsay("I become one with myself, again..."))
+
+/datum/status_effect/buff/hermes_trismegistus
+	id = "hermes_trismegistus"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/hermes_trismegistus
+	duration = 20 MINUTES
+	var/original_skill = null // we need scope for the whole thing so this gotta b here and null
+
+/atom/movable/screen/alert/status_effect/buff/hermes_trismegistus
+	name = "Hermetick Blessing" // yes, hermetick. with a k. 
+	desc = "Looking at HERMES has given me a blessing of the Stars... words make more sense." // dont ask how this works its magic biyatch
+
+/datum/status_effect/buff/hermes_trismegistus/on_apply()
+	. = ..()
+	if(owner)
+		original_skill = owner.get_skill_level(/datum/skill/misc/reading) // cache it
+		if(original_skill < 3)
+			owner.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE) // +1 reading. this technically lets u read if ur illtierate, ithink. idk. its cool, ok.
+
+/datum/status_effect/buff/hermes_trismegistus/on_remove()
+	. = ..()
+	owner.adjust_skillrank_down_to(/datum/skill/misc/reading, original_skill, TRUE)
+	to_chat(owner, span_warning("The blessing of HERMES begins to wear off. Words lose their meaning in my skull."))

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -470,3 +470,21 @@
 	timer = 5 MINUTES
 	stressadd = 4
 	desc = span_boldred("I feel watched... did something *hear* me?")
+
+/datum/stressevent/something_stirs/telescope
+	desc = span_boldred("That THING'S red eyes are still burning in my mind...")
+
+/datum/stressevent/see_zuranus
+	timer = 5 MINUTES
+	stressadd = 4
+	desc = span_boldred("Zuranus, that basterd body. Just looking at it makes my skin crawl...")
+
+/datum/stressevent/xylix_star
+	timer = 10 MINUTES // this will anger u for a long time
+	stressadd = 2
+	desc = span_boldred("Long ago, XYLIX put up an extra star in the sky to anger NOC... seeing it is a TERRIBLE omen.")
+
+/datum/stressevent/terrible_dreams
+	timer = 10 MINUTES
+	stressadd = 3
+	desc = span_boldred("I had terrible nightmares... there's a lingering buzzing in my mind.") + span_gamedeadsay("\nIn gi rum imus Noc te et con sumi...")

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -417,3 +417,22 @@
 	desc = span_aiprivradio("The standard calls out to me! It knows we're to see victory!")
 	timer = 3 MINUTES
 
+/datum/stressevent/kytherian_blessing
+	timer = 5 MINUTES
+	stressadd = -2
+	desc = span_rose("Kytheria is beautiful...")
+
+/datum/stressevent/see_zuranus/zizoite
+	timer = 5 MINUTES
+	stressadd = -2
+	desc = span_purple("...Zuranus is visible, surely, a sign of our continued Progress! ZIZO, ZIZO, ZIZO!")
+
+/datum/stressevent/see_zuranus/graggarite
+	timer = 5 MINUTES
+	stressadd = -2
+	desc = span_purple("JOVE! ANOTHER SYMBOL OF GRAGGAR'S DOMINANCE! HE REIGNS IN THE NOCMOS!")
+
+/datum/stressevent/xylix_star/xylixian
+	timer = 10 MINUTES // this will :) you for a while
+	stressadd = -2
+	desc = span_boldred("Long ago, XYLIX put up an extra star in the sky to anger NOC... seeing it is a FANTASTIC sign!")

--- a/code/game/objects/items/rogueitems/magic.dm
+++ b/code/game/objects/items/rogueitems/magic.dm
@@ -131,6 +131,14 @@
 			if(SKILL_LEVEL_MASTER to SKILL_LEVEL_LEGENDARY) // Magus has this
 				success_chance = 100
 
+	// fairly rarely, if you look into a telescope at night w/ an arcyne tier, you can get this buff.
+	// ensures your orb doesnt break and gives you a teensy boost. 
+	if(user.has_status_effect(/datum/status_effect/buff/transparent_eyeball))
+		break_on_fail = FALSE
+		if(success_chance < 100)
+			success_chance += 10
+			success_chance = clamp(success_chance, 0, 100) // dont go over 100 cause that might break shit
+
 	if (debugseverity)
 		success_chance = 0
 

--- a/code/game/objects/structures/roguetown/telescope.dm
+++ b/code/game/objects/structures/roguetown/telescope.dm
@@ -6,6 +6,16 @@
 	icon_state = "telescope"
 	density = TRUE
 	anchored = FALSE
+	// this is for later use in the proc, idk i feel better storing it here than in the proc
+	// before you ask this is just what noc sounds like and i found it in the files and it works ok...
+	var/static/list/star_sounds = list(
+		'sound/items/carvgood.ogg',
+		'sound/items/carvhello.ogg',
+		'sound/items/carvsorry.ogg',
+		'sound/items/carvhelp.ogg',
+		'sound/items/carvty.ogg',
+
+	)
 
 /obj/structure/telescope/get_mechanics_examine(mob/user)
 	. = ..()
@@ -14,25 +24,140 @@
 /obj/structure/telescope/attack_hand(mob/user)
 	if(!ishuman(user))
 		return
+	// TODO: STATUS EFFECT THAT CALLS EARLY RETURN IF YOU'VE USED A TELE W/I THE LAST 15. OR. ALT MESSAGE.
 
-	var/mob/living/carbon/human/H = user
-	var/random_message = pick("Noc's silvered glare soothes your mind..", "Astrata's fiery presence blinds you!", "Hermes's swifted orbit graces a shadow between Astrata and Noc..", "Kytheria's golden clouds swirl with blessed strife..", "Neoplx's saffiric glow wounds the heart with a sense of sudden somberness..", "Jove's bleeding vortex marrs its width with a crimson trail..", "Zuranus's shadowed presence looks upon you with eternal malice..", "Psydonia's worldly horizon reaches out as far as the telescope can see..", "You see a star!", "The stars smile upon you!", "Bands of starlight bedazzle the sky!")
-	to_chat(H, span_notice("[random_message]"))
+	var/mob/living/carbon/human/H = user	
 
-	if(random_message == "Astrata's fiery presence blinds you!")
-		if(do_after(H, 25, target = src))
-			var/obj/item/bodypart/affecting = H.get_bodypart("head")
-			to_chat(H, span_warning("Astrata's blinding light causes you intense pain! Ow, fuck!"))
-			if(affecting && affecting.receive_damage(0, 5))
+	if(H.has_status_effect(/datum/status_effect/telescope_used))
+		to_chat(H, span_warning("My mind and eyes are exhausted! Let me rest!"))
+		return
+	
+	var/picked_message = "You see nothing noteworthy." // debug
+	var/got_fucked = FALSE // if u got astrata'd you can try again. as a treat.
+
+	// these are so we can apply them at the end AFTER getting the message. visual clarity.
+	var/status_effect = null
+	var/stress_event = null
+	
+	to_chat(H,span_info("I begin looking through the telescope..."))
+	H.emote("hmm", intentional = TRUE)
+	if(do_after(H, 15 SECONDS, TRUE))
+		// DAY.
+		// ...who the fuck looks through a telescope during the day?
+		if(GLOB.tod == "day")
+			got_fucked = TRUE
+			picked_message = span_warning("ASTRATA'S BLINDING LIGHT causes you INTENSE PAIN! OH, FUCK!")
+			var/obj/item/bodypart/affecting = H.get_bodypart(BODY_ZONE_HEAD)
+			if(affecting && affecting.receive_damage(0,5))
+				// this also should blur the eyes but idk if adjust_blurriness is permanent or not and i dont want to risk it
 				H.update_damage_overlays()
-	if(random_message == "Noc's silvered glare soothes your mind..")
-		if(do_after(H, 2.5 SECONDS, target = src))
-			to_chat(H, span_rose("Noc's calming glow seems to help clear your thoughts.."))
-			H.apply_status_effect(/datum/status_effect/buff/nocblessing)
-	if(random_message == "Zuranus's shadowed presence looks upon you with eternal malice..")
-		if(do_after(H, 2.5 SECONDS, target = src))
-			to_chat(H, span_warning("You feel an otherworldly presence watching you.."))
-			H.apply_status_effect(/datum/status_effect/debuff/dazed)
+		
+		// DUSK. 
+		// ZURANUS only appears in the Dusk hours, while Astrata is lowering but Noc still isnt fully awakened.
+		// If ZURANUS is not visible... IDK. Stars, I guess.
+		else if(GLOB.tod == "dusk")
+			var/see_zuranus = rand(0,2)
+			if(see_zuranus == 2) // 33% chance
+				// the mundane cannot see it
+				picked_message = span_info("I feel a tad... strange. Maybe that was just a weird cloud?")
+				H.playsound_local(H, 'sound/misc/adrenaline_rush.ogg', 30, TRUE)
+				status_effect = /datum/status_effect/zuranus // special dreams... perhaps.
+				switch(H.patron?.type)
+					if(/datum/patron/divine/noc)
+						picked_message = span_userdanger("Zuranus' shadowy presence gazes at me with eternal malice...")
+						// bad stress
+						stress_event = /datum/stressevent/see_zuranus
+					if(/datum/patron/inhumen/zizo)
+						picked_message = span_rose("I see the celestial form of Our Lady... how beautiful!")
+						// good stress
+						stress_event = /datum/stressevent/see_zuranus/zizoite
+			else // no zuranus
+				picked_message = span_info("NOC is settling in, the stars are just starting to shine!")
+		
+		// DAWN. 
+		// KYTHERIA is VISIBLE... ASTRATA MIGHT ALSO BLIND YOU. MOOD BUFF OR BLINDNESS.. CHOOSE WISELY...
+		else if(GLOB.tod == "dawn")
+			var/what_do_see = rand(0,2) // 33% of each
+			switch(what_do_see)
+				if(0) // hey jimmy, get me a pizza wit nothin. nothin?
+					picked_message = span_info("NOC is performing his final rotations... Astrata is rising, a GLORIOUS MORNING...") // https://www.youtube.com/watch?v=7T_YtklLyyo
+				if(1) // good luck! kytheria!
+					picked_message = span_rose("Kytheria's golden clouds swirl with blessed strife...")
+					stress_event = /datum/stressevent/kytherian_blessing
+					H.playsound_local(H, 'sound/magic/eora_bless.ogg', 40, TRUE)
+				if(2) // bad luck-- astrata!
+					got_fucked = TRUE
+					picked_message = span_warning("ASTRATA'S BLINDING LIGHT causes you INTENSE PAIN! OH, FUCK!")
+					var/obj/item/bodypart/affecting = H.get_bodypart(BODY_ZONE_HEAD)
+					if(affecting && affecting.receive_damage(0,5))
+						// this also should blur the eyes but idk if adjust_blurriness is permanent or not and i dont want to risk it
+						H.update_damage_overlays()
+		
+		// NITE. most planets are visible. chance to see jove, hermes, noc, AND nepolx. random stars, too... or that XYLIXIAN FALSE-STAR.
+		else if(GLOB.tod == "night")
+			var/what_do_see = rand(0, 5)
+			switch(what_do_see)
+				if(0) // damn you xylix
+					picked_message = span_info("It's too cloudy out to see anything! NO!!")
+					switch(H.patron?.type)
+						if(/datum/patron/divine/noc)
+							picked_message = span_danger("Something is wrong-- I SEE A STAR WHERE IT SHOULDN'T BE IN THE HALF-SWORD CONSTELLATION!")
+							stress_event = /datum/stressevent/xylix_star
+							H.playsound_local(H, 'sound/magic/decoylaugh.ogg', 30, TRUE)
+						if(/datum/patron/divine/xylix)
+							picked_message = span_info("I see the Tricksters nocturnal machinations! Hehe!")
+							stress_event = /datum/stressevent/xylix_star/xylixian
+							H.playsound_local(H, 'sound/magic/decoylaugh.ogg', 30, TRUE)
+				if(1) // and the wonders of the stars...
+					// for some reason beyond my comprehension these HAVE to be in a /list var. so stupid.
+					var/list/wonders_of_the_stars = list(
+						span_info("You see a star!"),
+						span_info("The stars smile upon you!"),
+						span_info("Bands of starlight bedazzle the sky!"),
+						span_info("Psydonia's worldly horizon stretches out as far as the telescope can see...")
+					)
+					var/star_audio = pick(star_sounds)
+					picked_message = pick(wonders_of_the_stars)
+					H.playsound_local(H, star_audio, 40, TRUE)
+				if(2) // NOC
+					status_effect = /datum/status_effect/buff/nocblessing
+					H.playsound_local(H, 'sound/magic/message.ogg', 40, TRUE)
+					var/list/wonders_of_the_stars = list(
+						span_blue("Noc's silvered glare soothes your mind..."),
+						span_blue("You see NOC spinning in the skyline!")
+					)
+					picked_message = pick(wonders_of_the_stars)
+				if(3) // HERMES
+					H.apply_status_effect(/datum/status_effect/buff/hermes_trismegistus)
+					picked_message = span_info("Hermes' swifted orbit graces a shadow between Astrata and Noc...")
+					H.playsound_local('sound/items/write.ogg', 40, TRUE)
+				if(4) // NEPOLX OR NEOPLX or NEOPETS
+					picked_message = span_info("Nepolx's saffiric glow wounds the heart with a sense of sudden somberness...")
+					H.playsound_local(H, 'sound/magic/mindlink.ogg', 40, TRUE)
+					if(is_user_magic(H))
+						// if theyre capable of using a scrying orb, nepolx makes them less likely 2 fuck it up
+						status_effect = /datum/status_effect/buff/transparent_eyeball
+				if(5) // JOVE. graggar ate ravox's celestial body, which turned it blue and gave it red(er) eyes. 
+					picked_message = span_warning("Jove's bleeding vortex marrs its width with a crimson trail... ")
+					H.playsound_local(H, 'sound/magic/psydonbleeds.ogg', 40, TRUE) // HE IS COMING.
+					switch(H.patron?.type) // fucks w/ ravoxites and noccites.
+						if(/datum/patron/divine/noc, /datum/patron/divine/ravox)
+							stress_event = /datum/stressevent/something_stirs/telescope
+							picked_message += span_warning("Jove used to represent justice, before it turned blue.") // pim turns green
+						if(/datum/patron/inhumen/graggar)
+							stress_event = /datum/stressevent/see_zuranus/graggarite
+							picked_message += span_warning("The Goresworn often speak of Graggar's dominance over Jove! They say he ate it whole-- turned it blue!")
+		// give out our message
+		to_chat(H, picked_message)
+		// apply extra effects
+		if(stress_event)
+			H.add_stress(stress_event)
+		// apply our statuses
+		if(status_effect)
+			H.apply_status_effect(status_effect)
+		// no spamming the 'scope pal
+		if(!got_fucked)
+			H.apply_status_effect(/datum/status_effect/telescope_used)
 
 /obj/structure/globe
 	name = "globe"

--- a/code/game/objects/structures/roguetown/telescope.dm
+++ b/code/game/objects/structures/roguetown/telescope.dm
@@ -72,7 +72,9 @@
 						// good stress
 						stress_event = /datum/stressevent/see_zuranus/zizoite
 			else // no zuranus
+				var/star_audio = pick(star_sounds)
 				picked_message = span_info("NOC is settling in, the stars are just starting to shine!")
+				H.playsound_local(H, star_audio, 40, TRUE)
 		
 		// DAWN. 
 		// KYTHERIA is VISIBLE... ASTRATA MIGHT ALSO BLIND YOU. MOOD BUFF OR BLINDNESS.. CHOOSE WISELY...
@@ -80,7 +82,9 @@
 			var/what_do_see = rand(0,2) // 33% of each
 			switch(what_do_see)
 				if(0) // hey jimmy, get me a pizza wit nothin. nothin?
+					var/star_audio = pick(star_sounds)
 					picked_message = span_info("NOC is performing his final rotations... Astrata is rising, a GLORIOUS MORNING...") // https://www.youtube.com/watch?v=7T_YtklLyyo
+					H.playsound_local(H, star_audio, 40, TRUE)
 				if(1) // good luck! kytheria!
 					picked_message = span_rose("Kytheria's golden clouds swirl with blessed strife...")
 					stress_event = /datum/stressevent/kytherian_blessing

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -630,6 +630,27 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 						if(!is_asleep) //to not spam chat
 							to_chat(src, span_blue("I've fallen asleep."))
 							is_asleep = TRUE
+						// those who have gazed upon zuranus may have... odd dreams.
+						if(has_status_effect(/datum/status_effect/zuranus))
+							var/zizo_dream = has_status_effect(/datum/status_effect/zuranus) // this is stupid im sorry
+							var/list/evil_dreams = list(
+								span_cultsmall("It's as if all my other memories have been taken. It feels like hours, daes, only blood, only war. No friends. No family. Just war."),
+								span_cultsmall("Every single one of my failures becomes clear to me. I am staring into a river flowing red, and within it is the reflection of everyone I've lost."),
+								span_cultsmall("There is a dark star in the sky. The grassy field turns black. I begin coughing-- I clutch at my chest...")
+							)
+							var/terrible_dreams = TRUE
+							if(istype(src.mouth, /obj/item/roguecoin/aalloy)) // psila will Show You Things. i talked 2 ambrose about this like 2 months ago.
+								evil_dreams = list(
+									span_gamedeadsay("My deft hands rattle along a table, odd machinery laid around me. I fetch my scalpel and begin shoving a rat into a box..."),
+									span_gamedeadsay("I stand over sketches of a chair, swiftly inspeckting vial after vial of a queer green fluid. It's still not ready. Not just yet."),
+									span_gamedeadsay("I speak, but I cannot comprehend my own words. Within a near pitch-black room, a corpse animates... I smile.")
+								)
+								terrible_dreams = FALSE // this sucks so much. free forgive me. please. its for sovl.
+							var/picked_dream = pick(evil_dreams)
+							to_chat(src, picked_dream)
+							src.remove_status_effect(zizo_dream)
+							if(terrible_dreams)
+								src.add_stress(/datum/stressevent/terrible_dreams)
 						if(sleepless_flaw) // If you're sleepless, you have a higher chance of going to a nightmare. Every time you sleep, the chance gets higher for the rest of the round.
 							teleport_to_dream(src, 10000, sleepless_flaw.dream_prob, FALSE)
 							sleepless_flaw.dream_prob += 500

--- a/code/modules/spells/roguetown/helper.dm
+++ b/code/modules/spells/roguetown/helper.dm
@@ -23,3 +23,15 @@
 	if(HAS_TRAIT(target, TRAIT_WITCH))		//Not evil but you know, witch.
 		return 1
 	return 0
+
+/// dookie proc that serves as an alternative to 5 billion cluttered has_traits. if they have ANY arcyne trait, returns true.
+/proc/is_user_magic(mob/target)
+	if(HAS_TRAIT(target, TRAIT_ARCYNE_T4))
+		return TRUE
+	if(HAS_TRAIT(target, TRAIT_ARCYNE_T3))
+		return TRUE
+	if(HAS_TRAIT(target, TRAIT_ARCYNE_T2))
+		return TRUE
+	if(HAS_TRAIT(target, TRAIT_ARCYNE_T1))
+		return TRUE
+	return 0


### PR DESCRIPTION
## About The Pull Request
### LONG AGO, I HAD A DREAM WHEN I WAS TALKING TO DONGWAIVER...

## THE TELESCOPE: NEW AND IMPROVED
- the telescope has been completely re-written to have mechanics that make sense, alongside having FAR more functionality, interesting text, and teeny (NON STAT BOOSTING, IF YOU CAN BELIEVE IT) effects! text by dongwaiver, mostly.
<details><summary><H2>DAWN<H2></summary>
<p>
- the start of every day, dawn has a chance for you to see KYTHERIA, or our version of venus. doing so gives you a teeny little moodboost. you may also just see noc, or, worse, you get blinded by astrata.
</p>
</details> 

<details><summary><H2>DAE<H2></summary>
<p>
- you get blinded by astrata. thats it.
</p>
</details> 

<details><summary><H2>DUSK<H2></summary>
<p>
- between noc's rising and astrata's falling, there's a chance to glimpse ZURANUS. zuranus is only visible to followers of noc and zizo, as the planetary body often hides itself from the uninitiated. it's taunting perversion on the nite sky stresses followers of noc, but blesses those of zizo.
- even for those who cannot comprehend what they're looking at, a special effect is granted... which has interesting effects when you sleep . depending on a few conditions...
<h6> spoilers</h6>
<img width="100" height="100" alt="image" src="https://github.com/user-attachments/assets/b7d5adb6-8623-4c6a-87c8-c4589377f65c" />

- alternatively; you may see nothing
</p>
</details> 

<details><summary><H2>NITE<H2></summary>
<p>

- nite has the largest variety of options!
- you may see noc, which grants a (+1 int) ((it was like this before so i just kept it))
- you may see nepolx, which, if you can cast spells, will make your scrying orb chance just a liititle higher and prevent it from breaking!
- you may see hermes, which, if you have less than 3 reading skill, will give you a +1 for 15 minutes! illiterate barbarians can learn to read by looking at the stars, dont ask me, it's cool, okay. pls. can i have this.
- you may also see jove. jove is like jupiter, but it's blue, because graggar is said to have eaten / corrupted it. it was formerly a symbol of justice. noccites and ravoxites both get stressed from looking at it-- and a little extra DeepLore. graggarites get LESS stressed and their own DeepLore. 
</p>
</details> 

looking at any of these takes 15 seconds per attempt, and if you ARENT blinded by astrata, theres a 15 minute cooldown thru status effect code. its nearly impossible to game these-- just cool stuff if you take the time to go look thru a telescope for rp purposes.

(most) of the planets will play a little jingle and add an effect or message of some kind, but the generic stars messages do not provide anything. thats just for balance to ENSURE no one can game these. i hate GAMING!!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
- trust me i tried nearly everything

https://github.com/user-attachments/assets/549f2e49-0553-478d-8de6-85c486c78805

<details><summary>SPOILERS FOR THE DREAMING</summary>
<p>


https://github.com/user-attachments/assets/63012456-a404-4ef7-b6d7-03637fffdff8



</p>
</details> 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- idk honestly i just thought about doing a lot of the ideas in this months ago but didnt get the time and/or will and/or knowledge until now
- id like one of my last prs for the game to be something awesome and sovlful instead of stupid balance shit
- ambrose seemed 2 like it, sans seemed 2 like it, squid seemed 2 like it, i just think it'll be cool 2 add to the game
- frankly; the life() dreaming changes prolly could be done better somehow but i just dont know how. idk im scared life() is scary.
- @ me on the discord if any of this can be improved and/or start a code review. thx.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:NOCTURNE
add: telescopes have significantly more effects!
del: zerobrine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
