### PR TITLE
Spellblade no longer lose momentum on off balance.

### DIFF
--- a/code/modules/spells/spell_types/classunique/spellblade/arcyne_momentum.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/arcyne_momentum.dm
@@ -30,11 +30,10 @@
 	. = ..()
 	RegisterSignal(owner, COMSIG_LIVING_STATUS_STUN, PROC_REF(on_stunned))
 	RegisterSignal(owner, COMSIG_LIVING_STATUS_KNOCKDOWN, PROC_REF(on_knockdown))
-	RegisterSignal(owner, COMSIG_LIVING_STATUS_OFFBALANCED, PROC_REF(on_offbalanced))
 	update_alert()
 
 /datum/status_effect/buff/arcyne_momentum/on_remove()
-	UnregisterSignal(owner, list(COMSIG_LIVING_STATUS_STUN, COMSIG_LIVING_STATUS_KNOCKDOWN, COMSIG_LIVING_STATUS_OFFBALANCED))
+	UnregisterSignal(owner, list(COMSIG_LIVING_STATUS_STUN, COMSIG_LIVING_STATUS_KNOCKDOWN))
 	if(is_overcharged)
 		owner.cut_overlay(electricity_overlay)
 	owner.clear_fullscreen("momentum_strain")
@@ -62,18 +61,6 @@
 	update_alert()
 	update_spell_buttons()
 	to_chat(owner, span_warning("I hit the ground — all momentum lost!"))
-
-/datum/status_effect/buff/arcyne_momentum/proc/on_offbalanced()
-	SIGNAL_HANDLER
-	if(stacks <= 0)
-		return
-	var/lost = min(stacks, 3)
-	stacks = max(stacks - lost, 0)
-	owner.balloon_alert(owner, "M: [stacks]/[max_stacks]")
-	update_visuals()
-	update_alert()
-	update_spell_buttons()
-	to_chat(owner, span_warning("Thrown off balance — momentum falters!"))
 
 /datum/status_effect/buff/arcyne_momentum/proc/add_stacks(amount)
 	var/old_stacks = stacks
@@ -146,7 +133,6 @@
 			S.action.UpdateButtonIcon(status_only = TRUE)
 
 /datum/status_effect/buff/arcyne_momentum/tick()
-	// Decay: once no hits for MOMENTUM_DECAY_DELAY, lose 1 stack every SECOND_PER_MOMENTUM
 	if(stacks > 0 && world.time - last_stack_time >= MOMENTUM_DECAY_DELAY)
 		if(world.time - last_decay_time >= SECOND_PER_MOMENTUM)
 			last_decay_time = world.time


### PR DESCRIPTION
## About The Pull Request
Spellblade no longer lose momentum on off balance.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Spellblade no longer lose momentum on off balance.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Spellblade no longer lose momentum on off balance.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Spellblade no longer lose momentum on off balance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
