### PR TITLE
Fixes revivals

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -157,8 +157,6 @@
 	bruteloss = CLAMP((bruteloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	. -= bruteloss
 
-	if (!.)
-		return FALSE
 
 	if(updating_health)
 		updatehealth()
@@ -178,9 +176,6 @@
 	. = oxyloss
 	oxyloss = CLAMP((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	. -= oxyloss
-
-	if (!.)
-		return FALSE
 
 	if(updating_health)
 		updatehealth()
@@ -204,9 +199,6 @@
 	. = toxloss
 	toxloss = CLAMP((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	. -= toxloss
-
-	if (!.)
-		return FALSE
 
 	if(updating_health)
 		updatehealth()
@@ -249,8 +241,6 @@
 	cloneloss = CLAMP((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	. -= cloneloss
 
-	if (!.)
-		return FALSE
 
 	if(updating_health)
 		updatehealth()


### PR DESCRIPTION
## About The Pull Request

Currently, if had died exclusively of oxyloss, or accumulated 200 oxy or more in any other scenario, revivals would have healed you your entire oxyloss deficit, but if it goes to 0, then health doesn't get updated, leaving you below threshold for revivals.
This is due to an optimization ported in #4423 .
Unfortunately, this might make the server a bit more laggy like it was previously, but I believe it is a goofy sacrifice to just not run important code and results in edge case scenarios like this, which has became a problem downstream.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
Downstream prod

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Bug = le bad or so I heard

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Makes health updated mandatory on loss adjusts, even if the final damage of a certain value is zero.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
