### PR TITLE
1handed Weapon Polishing Force Fix

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -207,6 +207,7 @@
 			polished = 0
 			force -= 2
 			force_wielded -= 3
+			update_force_dynamic()
 			max_integrity -= polish_bonus
 			polish_bonus = 0
 			obj_integrity = min(obj_integrity, max_integrity)
@@ -226,6 +227,7 @@
 		obj_integrity += polish_bonus
 		force += 2
 		force_wielded += 3
+		update_force_dynamic()
 		AddComponent(/datum/component/metal_glint)
 		UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
 


### PR DESCRIPTION
## About The Pull Request

Polishing a one-handed weapon now updates its force like the force blade enchant does. Otherwise, polishing a weapon only applied bonus force when it got wielded and updated its damage that way.

## Testing Evidence

i forgort to take screenshots

## Why It's Good For The Game

less stuff breaky more minmaxy damage
This doesn't actually do anything to masterwork weapon/armor cosmetic "polish" that locks the item out of proper polishing - I'm not sure at all how to approach that aside from just removing it, since tacking all the bonuses on it would just clog the smithy line even harder as people ask to reforge their entire kit.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Polishing a one-handed weapon properly updates its force.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
