### PR TITLE
Eora Worshippers can now pray at the Shrine and Eoran Trees

### DIFF
--- a/code/datums/gods/patrons/divine/eora.dm
+++ b/code/datums/gods/patrons/divine/eora.dm
@@ -23,7 +23,7 @@
 	traits_tier = list(TRAIT_EORAN_CALM = CLERIC_T0, TRAIT_EORAN_SERENE = CLERIC_T2)
 	storyteller = /datum/storyteller/eora
 
-// Near a psycross, inside the church, holding poppy flowers, or has pacifism trait
+// Near a psycross, by an eoran sacred tree, inside the church, at the eoran shrine, holding poppy flowers, or has pacifism trait
 /datum/patron/divine/eora/can_pray(mob/living/follower)
 	. = ..()
 	// Allows prayer near psycross
@@ -32,8 +32,14 @@
 			to_chat(follower, span_danger("That defiled cross interupts my prayers!"))
 			return FALSE
 		return TRUE
+	// Allows prayer near eoran sacred tree
+	for(var/obj/structure/eoran_pomegranate_tree in view(4, get_turf(follower)))
+		return TRUE
 	// Allows prayer in the church
 	if(istype(get_area(follower), /area/rogue/indoors/town/church))
+		return TRUE
+	// Allows prayer at the eoran shrine
+	if(istype(get_area(follower), /area/rogue/outdoors/rtfield/eora))
 		return TRUE
 	// Allows Eorans to pray using flowers
 	var/obj/item/held_item = follower.get_active_held_item()


### PR DESCRIPTION
## About The Pull Request

In response to: https://discord.com/channels/1264916899653746808/1478246296501358612

Allows Eoran Worshippers to worship at the Shrine and Eoran Pomegranate Trees

## Testing Evidence

<img width="1911" height="747" alt="image" src="https://github.com/user-attachments/assets/a9f2915c-5fc8-4678-b7a6-d47fc1a6dcc1" />

## Why It's Good For The Game

Allows Eoran Worshippers to worship at the Shrine and Eoran Pomegranate Trees

## Changelog
:cl:
add: Allows Eoran Worshippers to worship at the Shrine and Eoran Pomegranate Trees
/:cl:

