### PR TITLE
Comment out Azurcaephon (Spellblade) Associate.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
@@ -199,175 +199,177 @@
 // And unlike adventurer, the University being technically keep aligned means they can jump in and gank antags and there's less admins can do about it.
 // If the University becomes independent one day, we can restore it. Until then, it will remain commented out.
 
-// /datum/advclass/wapprentice/spellblade
-// 	name = "Azurcaephan Associate"
-// 	maximum_possible_slots = 2
-// 	tutorial = "You are an Azurcaephan Associate — a Spellblade, carrier of the five hundred yils tradition \
-// 		originating in Azurea. You are employed under the University \
-// 		as a fellow Magos. The arcyne arts are dangerous, \
-// 		and you are to protect your peers from their own recklessness. \
-// 		You are not a member of the retinue - though the Crown may pay you a salary. \
-// 		It is not your job to wield your power in the Crown's name. \
-// 		Further your mastery, your camaraderie, and the safety of your fellow mages."
-// 	outfit = /datum/outfit/job/roguetown/wapprentice/spellblade
-// 	category_tags = list(CTAG_WAPPRENTICE)
-// 	traits_applied = list(TRAIT_ARCYNE_T2)
-// 	subclass_stats = list(
-// 		STATKEY_INT = 2,
-// 		STATKEY_PER = 1,
-// 		STATKEY_CON = 1,
-// 		STATKEY_WIL = 1,
-// 	)
-// 	subclass_spell_point_pools = list("utility" = 4)
-// 	subclass_skills = list(
-// 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
-// 		/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
-// 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
-// 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
-// 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
-// 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-// 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
-// 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
-// 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-// 	)
+/*
+/datum/advclass/wapprentice/spellblade
+	name = "Azurcaephan Associate"
+	maximum_possible_slots = 2
+	tutorial = "You are an Azurcaephan Associate — a Spellblade, carrier of the five hundred yils tradition \
+		originating in Azurea. You are employed under the University \
+		as a fellow Magos. The arcyne arts are dangerous, \
+		and you are to protect your peers from their own recklessness. \
+		You are not a member of the retinue - though the Crown may pay you a salary. \
+		It is not your job to wield your power in the Crown's name. \
+		Further your mastery, your camaraderie, and the safety of your fellow mages."
+	outfit = /datum/outfit/job/roguetown/wapprentice/spellblade
+	category_tags = list(CTAG_WAPPRENTICE)
+	traits_applied = list(TRAIT_ARCYNE_T2)
+	subclass_stats = list(
+		STATKEY_INT = 2,
+		STATKEY_PER = 1,
+		STATKEY_CON = 1,
+		STATKEY_WIL = 1,
+	)
+	subclass_spell_point_pools = list("utility" = 4)
+	subclass_skills = list(
+		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+	)
 
-// /datum/outfit/job/roguetown/wapprentice/spellblade
-// 	// Type-level defaults — equipped initially before chant selection
-// 	head = /obj/item/clothing/head/roguetown/bucklehat
-// 	shoes = /obj/item/clothing/shoes/roguetown/boots
-// 	pants = /obj/item/clothing/under/roguetown/trou/leather
-// 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-// 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-// 	gloves = /obj/item/clothing/gloves/roguetown/angle
-// 	belt = /obj/item/storage/belt/rogue/leather
-// 	neck = /obj/item/clothing/neck/roguetown/chaincoif
-// 	backl = /obj/item/storage/backpack/rogue/satchel
-// 	beltl = /obj/item/storage/magebag/associate
-// 	beltr = null
-// 	backr = null
-// 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-// 	var/subclass_selected
+/datum/outfit/job/roguetown/wapprentice/spellblade
+	// Type-level defaults — equipped initially before chant selection
+	head = /obj/item/clothing/head/roguetown/bucklehat
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	gloves = /obj/item/clothing/gloves/roguetown/angle
+	belt = /obj/item/storage/belt/rogue/leather
+	neck = /obj/item/clothing/neck/roguetown/chaincoif
+	backl = /obj/item/storage/backpack/rogue/satchel
+	beltl = /obj/item/storage/magebag/associate
+	beltr = null
+	backr = null
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	var/subclass_selected
 
-// /datum/outfit/job/roguetown/wapprentice/spellblade/Topic(href, href_list)
-// 	. = ..()
-// 	if(href_list["subclass"])
-// 		subclass_selected = href_list["subclass"]
-// 	else if(href_list["close"])
-// 		if(!subclass_selected)
-// 			subclass_selected = "blade"
+/datum/outfit/job/roguetown/wapprentice/spellblade/Topic(href, href_list)
+	. = ..()
+	if(href_list["subclass"])
+		subclass_selected = href_list["subclass"]
+	else if(href_list["close"])
+		if(!subclass_selected)
+			subclass_selected = "blade"
 
-// /datum/outfit/job/roguetown/wapprentice/spellblade/pre_equip(mob/living/carbon/human/H)
-// 	head = /obj/item/clothing/head/roguetown/bucklehat
-// 	shoes = /obj/item/clothing/shoes/roguetown/boots
-// 	pants = /obj/item/clothing/under/roguetown/trou/leather
-// 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-// 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-// 	gloves = /obj/item/clothing/gloves/roguetown/angle
-// 	belt = /obj/item/storage/belt/rogue/leather
-// 	neck = /obj/item/clothing/neck/roguetown/chaincoif
-// 	backl = /obj/item/storage/backpack/rogue/satchel
-// 	beltl = /obj/item/storage/magebag/associate
-// 	beltr = null
-// 	backr = /obj/item/rogueweapon/shield/wood
-// 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-// 	backpack_contents = list(
-// 		/obj/item/recipe_book/alchemy = 1,
-// 		/obj/item/recipe_book/magic = 1,
-// 		/obj/item/storage/keyring/apprentice = 1,
-// 		/obj/item/chalk = 1,)
+/datum/outfit/job/roguetown/wapprentice/spellblade/pre_equip(mob/living/carbon/human/H)
+	head = /obj/item/clothing/head/roguetown/bucklehat
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	gloves = /obj/item/clothing/gloves/roguetown/angle
+	belt = /obj/item/storage/belt/rogue/leather
+	neck = /obj/item/clothing/neck/roguetown/chaincoif
+	backl = /obj/item/storage/backpack/rogue/satchel
+	beltl = /obj/item/storage/magebag/associate
+	beltr = null
+	backr = /obj/item/rogueweapon/shield/wood
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	backpack_contents = list(
+		/obj/item/recipe_book/alchemy = 1,
+		/obj/item/recipe_book/magic = 1,
+		/obj/item/storage/keyring/apprentice = 1,
+		/obj/item/chalk = 1,)
 
-// 	to_chat(H, span_warning("You start with Bind Weapon. Remember to Bind your weapon so you can use your abilities and build up Arcyne Momentum."))
+	to_chat(H, span_warning("You start with Bind Weapon. Remember to Bind your weapon so you can use your abilities and build up Arcyne Momentum."))
 
-// 	subclass_selected = null
-// 	var/selection_html = get_spellblade_chant_html(src, H, "conventional")
-// 	H << browse(selection_html, "window=spellblade_chant;size=1100x900")
-// 	onclose(H, "spellblade_chant", src)
+	subclass_selected = null
+	var/selection_html = get_spellblade_chant_html(src, H, "conventional")
+	H << browse(selection_html, "window=spellblade_chant;size=1100x900")
+	onclose(H, "spellblade_chant", src)
 
-// 	var/open_time = world.time
-// 	while(!subclass_selected && world.time - open_time < 5 MINUTES)
-// 		stoplag(1)
-// 	H << browse(null, "window=spellblade_chant")
+	var/open_time = world.time
+	while(!subclass_selected && world.time - open_time < 5 MINUTES)
+		stoplag(1)
+	H << browse(null, "window=spellblade_chant")
 
-// 	if(!subclass_selected)
-// 		subclass_selected = "blade"
+	if(!subclass_selected)
+		subclass_selected = "blade"
 
-// 	var/datum/status_effect/buff/arcyne_momentum/momentum = H.apply_status_effect(/datum/status_effect/buff/arcyne_momentum)
-// 	if(momentum)
-// 		momentum.chant = subclass_selected
+	var/datum/status_effect/buff/arcyne_momentum/momentum = H.apply_status_effect(/datum/status_effect/buff/arcyne_momentum)
+	if(momentum)
+		momentum.chant = subclass_selected
 
-// 	if(H.mind)
-// 		switch(subclass_selected)
-// 			if("blade")
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/caedo)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/air_strike)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/leyline_anchor)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/blade_storm)
-// 			if("phalangite")
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/azurean_phalanx)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/azurean_javelin)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/advance)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gate_of_reckoning)
-// 			if("macebearer")
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
-// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
+	if(H.mind)
+		switch(subclass_selected)
+			if("blade")
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/caedo)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/air_strike)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/leyline_anchor)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/blade_storm)
+			if("phalangite")
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/azurean_phalanx)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/azurean_javelin)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/advance)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gate_of_reckoning)
+			if("macebearer")
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
-// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)
-// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/empower_weapon)
-// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/bind_weapon)
-// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mending)
-// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
-// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/empower_weapon)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/bind_weapon)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mending)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 
-// 	switch(subclass_selected)
-// 		if("blade")
-// 			var/weapons = list("Longsword", "Rapier", "Sabre", "Arming Sword", "Shortsword", "Hwando", "Steel Dagger")
-// 			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-// 			beltr = /obj/item/rogueweapon/scabbard/sword
-// 			switch(weapon_choice)
-// 				if("Longsword")
-// 					r_hand = /obj/item/rogueweapon/sword/long
-// 				if("Rapier")
-// 					r_hand = /obj/item/rogueweapon/sword/rapier
-// 				if("Sabre")
-// 					r_hand = /obj/item/rogueweapon/sword/sabre
-// 				if("Arming Sword")
-// 					r_hand = /obj/item/rogueweapon/sword
-// 				if("Shortsword")
-// 					r_hand = /obj/item/rogueweapon/sword/short
-// 				if("Hwando")
-// 					r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
-// 					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
-// 				if("Steel Dagger")
-// 					r_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
-// 			if(weapon_choice == "Steel Dagger")
-// 				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
-// 			else
-// 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-// 		if("phalangite")
-// 			var/spear_weapons = list("Spear", "Dory", "Naginata")
-// 			var/spear_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in spear_weapons
-// 			switch(spear_choice)
-// 				if("Spear")
-// 					r_hand = /obj/item/rogueweapon/spear
-// 				if("Dory")
-// 					r_hand = /obj/item/rogueweapon/spear/spellblade
-// 				if("Naginata")
-// 					r_hand = /obj/item/rogueweapon/spear/naginata
-// 					backr = /obj/item/rogueweapon/scabbard/gwstrap
-// 					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
-// 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
-// 		if("macebearer")
-// 			var/mace_weapons = list("Mace", "Warhammer")
-// 			var/mace_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in mace_weapons
-// 			switch(mace_choice)
-// 				if("Mace")
-// 					r_hand = /obj/item/rogueweapon/mace
-// 				if("Warhammer")
-// 					r_hand = /obj/item/rogueweapon/mace/warhammer
-// 			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
+	switch(subclass_selected)
+		if("blade")
+			var/weapons = list("Longsword", "Rapier", "Sabre", "Arming Sword", "Shortsword", "Hwando", "Steel Dagger")
+			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			beltr = /obj/item/rogueweapon/scabbard/sword
+			switch(weapon_choice)
+				if("Longsword")
+					r_hand = /obj/item/rogueweapon/sword/long
+				if("Rapier")
+					r_hand = /obj/item/rogueweapon/sword/rapier
+				if("Sabre")
+					r_hand = /obj/item/rogueweapon/sword/sabre
+				if("Arming Sword")
+					r_hand = /obj/item/rogueweapon/sword
+				if("Shortsword")
+					r_hand = /obj/item/rogueweapon/sword/short
+				if("Hwando")
+					r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
+					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+				if("Steel Dagger")
+					r_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
+			if(weapon_choice == "Steel Dagger")
+				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			else
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+		if("phalangite")
+			var/spear_weapons = list("Spear", "Dory", "Naginata")
+			var/spear_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in spear_weapons
+			switch(spear_choice)
+				if("Spear")
+					r_hand = /obj/item/rogueweapon/spear
+				if("Dory")
+					r_hand = /obj/item/rogueweapon/spear/spellblade
+				if("Naginata")
+					r_hand = /obj/item/rogueweapon/spear/naginata
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
+					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+		if("macebearer")
+			var/mace_weapons = list("Mace", "Warhammer")
+			var/mace_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in mace_weapons
+			switch(mace_choice)
+				if("Mace")
+					r_hand = /obj/item/rogueweapon/mace
+				if("Warhammer")
+					r_hand = /obj/item/rogueweapon/mace/warhammer
+			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
 
-// 	H.cmode_music = 'sound/music/cmode/nobility/combat_courtmage.ogg'
-// 	if(H.mind)
-// 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
+	H.cmode_music = 'sound/music/cmode/nobility/combat_courtmage.ogg'
+	if(H.mind)
+		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
+*/

--- a/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
@@ -28,7 +28,7 @@
 		/datum/advclass/wapprentice/associate,
 		/datum/advclass/wapprentice/alchemist,
 		/datum/advclass/wapprentice/apprentice,
-		/datum/advclass/wapprentice/spellblade
+		// /datum/advclass/wapprentice/spellblade
 	)
 
 /datum/outfit/job/roguetown/wapprentice
@@ -195,175 +195,179 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
 
-/datum/advclass/wapprentice/spellblade
-	name = "Azurcaephan Associate"
-	maximum_possible_slots = 2
-	tutorial = "You are an Azurcaephan Associate — a Spellblade, carrier of the five hundred yils tradition \
-		originating in Azurea. You are employed under the University \
-		as a fellow Magos. The arcyne arts are dangerous, \
-		and you are to protect your peers from their own recklessness. \
-		You are not a member of the retinue - though the Crown may pay you a salary. \
-		It is not your job to wield your power in the Crown's name. \
-		Further your mastery, your camaraderie, and the safety of your fellow mages."
-	outfit = /datum/outfit/job/roguetown/wapprentice/spellblade
-	category_tags = list(CTAG_WAPPRENTICE)
-	traits_applied = list(TRAIT_ARCYNE_T2)
-	subclass_stats = list(
-		STATKEY_INT = 2,
-		STATKEY_PER = 1,
-		STATKEY_CON = 1,
-		STATKEY_WIL = 1,
-	)
-	subclass_spell_point_pools = list("utility" = 4)
-	subclass_skills = list(
-		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-	)
+// Here lies the grave of Azurcaephon Associate, removed because a good portion of mage players are using it as a validhunting class
+// And unlike adventurer, the University being technically keep aligned means they can jump in and gank antags and there's less admins can do about it.
+// If the University becomes independent one day, we can restore it. Until then, it will remain commented out.
 
-/datum/outfit/job/roguetown/wapprentice/spellblade
-	// Type-level defaults — equipped initially before chant selection
-	head = /obj/item/clothing/head/roguetown/bucklehat
-	shoes = /obj/item/clothing/shoes/roguetown/boots
-	pants = /obj/item/clothing/under/roguetown/trou/leather
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-	gloves = /obj/item/clothing/gloves/roguetown/angle
-	belt = /obj/item/storage/belt/rogue/leather
-	neck = /obj/item/clothing/neck/roguetown/chaincoif
-	backl = /obj/item/storage/backpack/rogue/satchel
-	beltl = /obj/item/storage/magebag/associate
-	beltr = null
-	backr = null
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	var/subclass_selected
+// /datum/advclass/wapprentice/spellblade
+// 	name = "Azurcaephan Associate"
+// 	maximum_possible_slots = 2
+// 	tutorial = "You are an Azurcaephan Associate — a Spellblade, carrier of the five hundred yils tradition \
+// 		originating in Azurea. You are employed under the University \
+// 		as a fellow Magos. The arcyne arts are dangerous, \
+// 		and you are to protect your peers from their own recklessness. \
+// 		You are not a member of the retinue - though the Crown may pay you a salary. \
+// 		It is not your job to wield your power in the Crown's name. \
+// 		Further your mastery, your camaraderie, and the safety of your fellow mages."
+// 	outfit = /datum/outfit/job/roguetown/wapprentice/spellblade
+// 	category_tags = list(CTAG_WAPPRENTICE)
+// 	traits_applied = list(TRAIT_ARCYNE_T2)
+// 	subclass_stats = list(
+// 		STATKEY_INT = 2,
+// 		STATKEY_PER = 1,
+// 		STATKEY_CON = 1,
+// 		STATKEY_WIL = 1,
+// 	)
+// 	subclass_spell_point_pools = list("utility" = 4)
+// 	subclass_skills = list(
+// 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+// 		/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
+// 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
+// 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
+// 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
+// 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+// 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
+// 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+// 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+// 	)
 
-/datum/outfit/job/roguetown/wapprentice/spellblade/Topic(href, href_list)
-	. = ..()
-	if(href_list["subclass"])
-		subclass_selected = href_list["subclass"]
-	else if(href_list["close"])
-		if(!subclass_selected)
-			subclass_selected = "blade"
+// /datum/outfit/job/roguetown/wapprentice/spellblade
+// 	// Type-level defaults — equipped initially before chant selection
+// 	head = /obj/item/clothing/head/roguetown/bucklehat
+// 	shoes = /obj/item/clothing/shoes/roguetown/boots
+// 	pants = /obj/item/clothing/under/roguetown/trou/leather
+// 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+// 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+// 	gloves = /obj/item/clothing/gloves/roguetown/angle
+// 	belt = /obj/item/storage/belt/rogue/leather
+// 	neck = /obj/item/clothing/neck/roguetown/chaincoif
+// 	backl = /obj/item/storage/backpack/rogue/satchel
+// 	beltl = /obj/item/storage/magebag/associate
+// 	beltr = null
+// 	backr = null
+// 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+// 	var/subclass_selected
 
-/datum/outfit/job/roguetown/wapprentice/spellblade/pre_equip(mob/living/carbon/human/H)
-	head = /obj/item/clothing/head/roguetown/bucklehat
-	shoes = /obj/item/clothing/shoes/roguetown/boots
-	pants = /obj/item/clothing/under/roguetown/trou/leather
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-	gloves = /obj/item/clothing/gloves/roguetown/angle
-	belt = /obj/item/storage/belt/rogue/leather
-	neck = /obj/item/clothing/neck/roguetown/chaincoif
-	backl = /obj/item/storage/backpack/rogue/satchel
-	beltl = /obj/item/storage/magebag/associate
-	beltr = null
-	backr = /obj/item/rogueweapon/shield/wood
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	backpack_contents = list(
-		/obj/item/recipe_book/alchemy = 1,
-		/obj/item/recipe_book/magic = 1,
-		/obj/item/storage/keyring/apprentice = 1,
-		/obj/item/chalk = 1,)
+// /datum/outfit/job/roguetown/wapprentice/spellblade/Topic(href, href_list)
+// 	. = ..()
+// 	if(href_list["subclass"])
+// 		subclass_selected = href_list["subclass"]
+// 	else if(href_list["close"])
+// 		if(!subclass_selected)
+// 			subclass_selected = "blade"
 
-	to_chat(H, span_warning("You start with Bind Weapon. Remember to Bind your weapon so you can use your abilities and build up Arcyne Momentum."))
+// /datum/outfit/job/roguetown/wapprentice/spellblade/pre_equip(mob/living/carbon/human/H)
+// 	head = /obj/item/clothing/head/roguetown/bucklehat
+// 	shoes = /obj/item/clothing/shoes/roguetown/boots
+// 	pants = /obj/item/clothing/under/roguetown/trou/leather
+// 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+// 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+// 	gloves = /obj/item/clothing/gloves/roguetown/angle
+// 	belt = /obj/item/storage/belt/rogue/leather
+// 	neck = /obj/item/clothing/neck/roguetown/chaincoif
+// 	backl = /obj/item/storage/backpack/rogue/satchel
+// 	beltl = /obj/item/storage/magebag/associate
+// 	beltr = null
+// 	backr = /obj/item/rogueweapon/shield/wood
+// 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+// 	backpack_contents = list(
+// 		/obj/item/recipe_book/alchemy = 1,
+// 		/obj/item/recipe_book/magic = 1,
+// 		/obj/item/storage/keyring/apprentice = 1,
+// 		/obj/item/chalk = 1,)
 
-	subclass_selected = null
-	var/selection_html = get_spellblade_chant_html(src, H, "conventional")
-	H << browse(selection_html, "window=spellblade_chant;size=1100x900")
-	onclose(H, "spellblade_chant", src)
+// 	to_chat(H, span_warning("You start with Bind Weapon. Remember to Bind your weapon so you can use your abilities and build up Arcyne Momentum."))
 
-	var/open_time = world.time
-	while(!subclass_selected && world.time - open_time < 5 MINUTES)
-		stoplag(1)
-	H << browse(null, "window=spellblade_chant")
+// 	subclass_selected = null
+// 	var/selection_html = get_spellblade_chant_html(src, H, "conventional")
+// 	H << browse(selection_html, "window=spellblade_chant;size=1100x900")
+// 	onclose(H, "spellblade_chant", src)
 
-	if(!subclass_selected)
-		subclass_selected = "blade"
+// 	var/open_time = world.time
+// 	while(!subclass_selected && world.time - open_time < 5 MINUTES)
+// 		stoplag(1)
+// 	H << browse(null, "window=spellblade_chant")
 
-	var/datum/status_effect/buff/arcyne_momentum/momentum = H.apply_status_effect(/datum/status_effect/buff/arcyne_momentum)
-	if(momentum)
-		momentum.chant = subclass_selected
+// 	if(!subclass_selected)
+// 		subclass_selected = "blade"
 
-	if(H.mind)
-		switch(subclass_selected)
-			if("blade")
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/caedo)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/air_strike)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/leyline_anchor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/blade_storm)
-			if("phalangite")
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/azurean_phalanx)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/azurean_javelin)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/advance)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gate_of_reckoning)
-			if("macebearer")
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
+// 	var/datum/status_effect/buff/arcyne_momentum/momentum = H.apply_status_effect(/datum/status_effect/buff/arcyne_momentum)
+// 	if(momentum)
+// 		momentum.chant = subclass_selected
 
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/empower_weapon)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/bind_weapon)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mending)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+// 	if(H.mind)
+// 		switch(subclass_selected)
+// 			if("blade")
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/caedo)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/air_strike)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/leyline_anchor)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/blade_storm)
+// 			if("phalangite")
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/azurean_phalanx)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/azurean_javelin)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/advance)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gate_of_reckoning)
+// 			if("macebearer")
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+// 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
-	switch(subclass_selected)
-		if("blade")
-			var/weapons = list("Longsword", "Rapier", "Sabre", "Arming Sword", "Shortsword", "Hwando", "Steel Dagger")
-			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-			beltr = /obj/item/rogueweapon/scabbard/sword
-			switch(weapon_choice)
-				if("Longsword")
-					r_hand = /obj/item/rogueweapon/sword/long
-				if("Rapier")
-					r_hand = /obj/item/rogueweapon/sword/rapier
-				if("Sabre")
-					r_hand = /obj/item/rogueweapon/sword/sabre
-				if("Arming Sword")
-					r_hand = /obj/item/rogueweapon/sword
-				if("Shortsword")
-					r_hand = /obj/item/rogueweapon/sword/short
-				if("Hwando")
-					r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
-					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
-				if("Steel Dagger")
-					r_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
-			if(weapon_choice == "Steel Dagger")
-				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
-			else
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-		if("phalangite")
-			var/spear_weapons = list("Spear", "Dory", "Naginata")
-			var/spear_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in spear_weapons
-			switch(spear_choice)
-				if("Spear")
-					r_hand = /obj/item/rogueweapon/spear
-				if("Dory")
-					r_hand = /obj/item/rogueweapon/spear/spellblade
-				if("Naginata")
-					r_hand = /obj/item/rogueweapon/spear/naginata
-					backr = /obj/item/rogueweapon/scabbard/gwstrap
-					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
-			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
-		if("macebearer")
-			var/mace_weapons = list("Mace", "Warhammer")
-			var/mace_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in mace_weapons
-			switch(mace_choice)
-				if("Mace")
-					r_hand = /obj/item/rogueweapon/mace
-				if("Warhammer")
-					r_hand = /obj/item/rogueweapon/mace/warhammer
-			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
+// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)
+// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/empower_weapon)
+// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/bind_weapon)
+// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mending)
+// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
+// 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 
-	H.cmode_music = 'sound/music/cmode/nobility/combat_courtmage.ogg'
-	if(H.mind)
-		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
+// 	switch(subclass_selected)
+// 		if("blade")
+// 			var/weapons = list("Longsword", "Rapier", "Sabre", "Arming Sword", "Shortsword", "Hwando", "Steel Dagger")
+// 			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+// 			beltr = /obj/item/rogueweapon/scabbard/sword
+// 			switch(weapon_choice)
+// 				if("Longsword")
+// 					r_hand = /obj/item/rogueweapon/sword/long
+// 				if("Rapier")
+// 					r_hand = /obj/item/rogueweapon/sword/rapier
+// 				if("Sabre")
+// 					r_hand = /obj/item/rogueweapon/sword/sabre
+// 				if("Arming Sword")
+// 					r_hand = /obj/item/rogueweapon/sword
+// 				if("Shortsword")
+// 					r_hand = /obj/item/rogueweapon/sword/short
+// 				if("Hwando")
+// 					r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
+// 					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+// 				if("Steel Dagger")
+// 					r_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
+// 			if(weapon_choice == "Steel Dagger")
+// 				H.adjust_skillrank_up_to(/datum/skill/combat/knives, SKILL_LEVEL_JOURNEYMAN, TRUE)
+// 			else
+// 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+// 		if("phalangite")
+// 			var/spear_weapons = list("Spear", "Dory", "Naginata")
+// 			var/spear_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in spear_weapons
+// 			switch(spear_choice)
+// 				if("Spear")
+// 					r_hand = /obj/item/rogueweapon/spear
+// 				if("Dory")
+// 					r_hand = /obj/item/rogueweapon/spear/spellblade
+// 				if("Naginata")
+// 					r_hand = /obj/item/rogueweapon/spear/naginata
+// 					backr = /obj/item/rogueweapon/scabbard/gwstrap
+// 					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+// 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+// 		if("macebearer")
+// 			var/mace_weapons = list("Mace", "Warhammer")
+// 			var/mace_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in mace_weapons
+// 			switch(mace_choice)
+// 				if("Mace")
+// 					r_hand = /obj/item/rogueweapon/mace
+// 				if("Warhammer")
+// 					r_hand = /obj/item/rogueweapon/mace/warhammer
+// 			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
+
+// 	H.cmode_music = 'sound/music/cmode/nobility/combat_courtmage.ogg'
+// 	if(H.mind)
+// 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")


### PR DESCRIPTION
## About The Pull Request
This PR comments out Azurcaephon (Spellblade) Associate from being a class in associate, with an eye to return once we figure out a better solution to the persistent validhunting example. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="400" height="520" alt="2FzkocxZuo" src="https://github.com/user-attachments/assets/65d34396-1486-488e-a817-58de7fc17ccd" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I have spent like 20 - 30 hours of my life on Spellblade2, in an attempt to make a "mage" (in truth, a martial in disguise) that is fun to play as and against. 

While working on it, I decided not to put it in University initially due to fear of University being a keep aligned faction and making the "ganking antags" problem worse. However, Free raised the idea off hand of putting it in University and it aligned with my ideas of allowing better character expression for my own character (As you all know, I main a mage / spellblade as my main character) and fitting it into local Azurean lore and everything. 

Unfortunately, the problem associated with people playing Court Magician and Magician's Associate to gain town privileges and then adventure, hang out with other adventurers to clear dungeons and underdark for armor or validhunt antags **became remarkably worse**, and this problem was already existent before Scarlettide or Spellblade2, it just became even more excaberated. Azurcaephon associates running out to validhunt, play Adv+ or just disappear for the entire 3 hours. All kind of shitty behaviors.

And university being keep aligned means admin don't have a free hand to slap them. I have an alternative solution I will PR shortly, much to the chagrin of some mage players, but for now, I will comment it out because I absolutely do not want to create more administrative headache or drain all the goodwill I have from one of my most inspired class design so far because I wanted to add one subclass.

Genuinely, fuck you, adv+ and validhunters.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Azurcaephon Associate has been removed due to excessive player behavior problems with validhunting and adv+. Take Traditionalist and larp in the university instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
