### PR TITLE
removes hierophant having every single buff spell

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/warscholar.dm
@@ -17,7 +17,7 @@
 		STATKEY_CON = -1
 	)
 	age_mod = /datum/class_age_mod/war_scholar
-	subclass_spellpoints = 15
+	subclass_spellpoints = 24
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
@@ -58,12 +58,6 @@
 	if(H.mind)
 		detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 		detailcolor = naledicolors[detailcolor]
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/giants_strength)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/longstrider)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/haste)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortitude)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/forcewall/greater)
 	r_hand = /obj/item/rogueweapon/woodstaff/naledi
 
 


### PR DESCRIPTION
i made it, i can take it away, and i'm taking it away

justification will be discussed elsewhere because i refuse to engage on the git itself

## About The Pull Request

replaces the 'all buff spells' with 24 spellpoints full free select
## Testing Evidence

single line change
## Why It's Good For The Game

like i'd discuss it on github

## Changelog

:cl:
del: Removed hierophant's default preselect spells.
/:cl:
