### PR TITLE
[TM only] Armor Recipe Changes Port

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -477,6 +477,7 @@
 	req_blade = /obj/item/blade/iron_plate
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/cuirass/iron, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/iron
+	bypass_dupe_test = TRUE
 
 /datum/anvil_recipe/armor/iron/fullplate
 	name = "Full-Plate, Iron (+1 Half-Plate, Iron)"
@@ -484,6 +485,7 @@
 	req_blade = /obj/item/blade/iron_plate
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/iron)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/iron
+	bypass_dupe_test = TRUE
 
 /datum/anvil_recipe/armor/iron/chainglove
 	name = "Chain Gauntlets, Iron"


### PR DESCRIPTION
## About The Pull Request
Ports over: https://github.com/Rotwood-Vale/Ratwood-2.0/pull/459

Halfplate Upgrade: 1 Cuirass + Cured Leather
Note: Bronze requires fur too.

Hauberk: Chainmail.

Steel=/Fluted Steel=/Valorian Steel

Steel and Fluted Steel are separate paths.
Valorian Steel is also different path. (AKA LEGACY ARMOR)

The intention of this pull request is to change armor recipes for cuirasses, half-plate, and full plate to mirror that of the Psydonic Silver Armor recipes and to effectively create an 'upgrade' system allowing for people to have the option of augmenting, rather than replacing their armor as a given round plays out.

## Testing Evidence

WIP

## Why It's Good For The Game

Allows people to upgrade existing armor sets. Also makes it a clear upgrade path w/o having to smelt down armor again and again.

I feel like this is good because it introduced a standardized system for this armor 'family' (cuirass, half plate, and full plate) as well as encouraging people to hold onto things that could be useful later in the round rather than needing to throw it away the second they have a 'better' armor option available to them.

## Changelog
:cl:
balance: armor smithing now requires the prerequisite armor before it. 
/:cl:
