### PR TITLE
[Fishing] - Adds resilience to cerulean arils.

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora/eora_arils.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_arils.dm
@@ -157,6 +157,7 @@
 	icon_state = "cerulean"
 	effect_desc = "Excellent fishing bait that attracts treasure."
 	baitpenalty = 5
+	baitresilience = 4
 	isbait = TRUE
 	fishingMods=list(
 		"commonFishingMod" = 0.2,


### PR DESCRIPTION
## About The Pull Request
Rarer/better bait gets resilience, this is the same for leeches, leechticks, etc

## Testing Evidence
nubmer changer merliropd

## Why It's Good For The Game
Rarer/better bait gets resilience, this is the same for leeches, leechticks, etc

## Changelog

:cl:
balance: Cerulean arils have bait resilience now
/:cl:

