### PR TITLE
updates deserter + jaks levy

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/levy.dm
@@ -9,11 +9,10 @@
 	category_tags = list(CTAG_TOWNER)
 	maximum_possible_slots = 3 //So you don't get a swarm of ppl
 	subclass_stats = list(
-		STATKEY_CON = 2,
-		STATKEY_STR = 2,
-		STATKEY_WIL = 2,
-		STATKEY_INT = -1,
-		STATKEY_SPD = -1
+		STATKEY_CON = 1,
+		STATKEY_STR = 1,
+		STATKEY_WIL = 1,
+		STATKEY_INT = -1
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
@@ -28,7 +27,7 @@
 		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
-		/datum/skill/craft/carpentry = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/carpentry = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/labor/lumberjacking = SKILL_LEVEL_NOVICE,
 		/datum/skill/labor/farming = SKILL_LEVEL_NOVICE,
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -13,7 +13,9 @@
 	subclass_stats = list(
 		STATKEY_WIL = 3,
 		STATKEY_CON = 2,
-		STATKEY_STR = 2
+		STATKEY_STR = 2,
+		STATKEY_PER = 2,
+		STATKEY_FOR = 1
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
@@ -61,6 +63,7 @@
 			"Samshir",
 			"Ssangsudo",
 			"Shashka + Shield",
+			"Steel Poleaxe"
 		)
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
@@ -96,6 +99,10 @@
 				r_hand = /obj/item/rogueweapon/sword/sabre/steppesman
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				backr = /obj/item/rogueweapon/shield/iron/steppesman
+			if("Steel Poleaxe")
+				r_hand = /obj/item/rogueweapon/greataxe/steel/knight
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
+
 		var/helmets = list(
 			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
@@ -113,6 +120,8 @@
 			"Kulah Khud"	= /obj/item/clothing/head/roguetown/helmet/sallet/raneshen,
 			"Kabuto"	= /obj/item/clothing/head/roguetown/helmet/heavy/kabuto, //No mask, fuck you
 			"Shishak"	= /obj/item/clothing/head/roguetown/helmet/sallet/shishak,
+			"Visored Barbute" = /obj/item/clothing/head/roguetown/helmet/heavy/barbute/visor,
+			"Great Barbute" = /obj/item/clothing/head/roguetown/helmet/heavy/barbute/great,
 			"None"
 		)
 		var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets


### PR DESCRIPTION
## About The Pull Request

1. Deserter Knight gets:
- +1 FOR / +2 PER to bring it up to the 11 statline that garrison knights are
- A Poleaxe option and the new Barbute helm options.
This brings them in line with garrison knights. Which they are a limited slot counterpart to.

2. Levymen changes to:
- +1 CON, +1 STR, +1 WIL, -1 INT // They get Jman Carpentry, now
from
- +2 CON, +2 STR, -1 SPD, -1 INT

a bit ridiculous to give the towner combat class a good CON/STR statline. even the author of the class agreed. 

## Testing Evidence

just a jak

## Why It's Good For The Game

argued above

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: updates deserter to 11-pt statline, with barbute and poleaxe option.
balance: downgrades levyman statline
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
