### PR TITLE
Giving mage armor some love

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -479,7 +479,7 @@
 /datum/status_effect/buff/magearmor/on_apply()
 	. = ..()
 	playsound(owner, 'sound/magic/magearmordown.ogg', 75, FALSE)
-	duration = (7-owner.get_skill_level(/datum/skill/magic/arcane)) MINUTES
+	duration = (60-owner.get_skill_level(/datum/skill/magic/arcane)*5) SECONDS
 
 /datum/status_effect/buff/magearmor/on_remove()
 	. = ..()

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -479,7 +479,7 @@
 /datum/status_effect/buff/magearmor/on_apply()
 	. = ..()
 	playsound(owner, 'sound/magic/magearmordown.ogg', 75, FALSE)
-	duration = (60-owner.get_skill_level(/datum/skill/magic/arcane)*5) SECONDS
+	duration = 70 SECONDS // flat number, on the shorter side since it only protect again melee attacks that targets unmarmored parts
 
 /datum/status_effect/buff/magearmor/on_remove()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Giving mage armor some much needed love, i would have wish to change it from absorbing a single hit that doesn't pierces your armor to give fateweaver spell or a special equipement slot with a unique item that absorbe a few hits, but alas this far exceed my skills, so i'm giving mage armor cooldown a much needed coat of paint

## Testing Evidence

<img width="1920" height="1080" alt="magearmorchange1" src="https://github.com/user-attachments/assets/76ecc1e2-da7b-41a5-8a35-c0d934242a85" />
<img width="1920" height="1080" alt="magearmorchange2" src="https://github.com/user-attachments/assets/5f3a6a75-a142-45ed-8409-3aa525b35b46" />


## Why It's Good For The Game

absorbing a single hit(that doesn't pierce your armor) every 7 minutes - 1 minute per arcyne skill is good and all but isn't much compared to other defensive traits like dodge expert or better tier of armor.
Protecting again a single hit that doesn't pierce your armor every 50 seconds at worse and 30 seconds at best for light armor users wont save them from a brutal assault but will still protect them again two or three attacks, the issue is amplified by their use of light armor that can easily get pierced and this allow mage armor to be ignored in many scenarios.
This rise it to an acceptable defensive trait, clearly not on par with other defensive trait but make it a bit more relevant!

## Changelog
Change mage armor recovery cooldown from 420-60xArcyne skill level Seconds to 60-5xArcyne skill level Seconds, the average mage class will recover their barrier between 50 and 40 seconds, while the higher tiers like the Court Mago will recover their barrier every 30 seconds(same time than recover 1 layer of crit resistance)

:cl:
change: reduce mage armor recovery cd to a comfortable 60 seconds reduced by 5 seconds for each arcyne skill level
/:cl:

