### PR TITLE
Let devotees cook with orison

### DIFF
--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -349,5 +349,17 @@
 		the_cloth.wet = holy_skill * 5
 		user.visible_message(span_info("[user] closes [user.p_their()] eyes in prayer, beads of moisture coalescing in [user.p_their()] hands to moisten [the_cloth]."), span_notice("I utter forth a plea to [user.patron.name] for succour, and will moisture into [the_cloth]. I should be able to clean with it properly now."))
 		return water_moisten
+	else if (istype(thing, /obj/item/reagent_containers/powder/flour))
+		// these three should probably be abstracted but the type pathing here is a nightmare and it's only three cases for now so it's probably fine
+		var/obj/item/reagent_containers/powder/flour/the_flour = thing
+		the_flour.wet(src, user)
+		return
+	else if (istype(thing, /obj/item/reagent_containers/food/snacks/grown/rice))
+		var/obj/item/reagent_containers/food/snacks/grown/rice/the_rice = thing
+		the_rice.wet(src, user)
+		return
+	else if (istype(thing, /obj/item/reagent_containers/powder/mineral))
+		var/obj/item/reagent_containers/powder/mineral/the_mineral = thing
+		the_mineral.wet(src, user)
 	else
 		to_chat(user, span_info("I'll need to find a container that can hold water."))

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -154,16 +154,22 @@
     . += span_info("Left-clicking yourself while targeting the nose will automatically snort the powder in your hand.")
     . += span_info("Most powders can imbue a wide variety of effects, when inhaled.")
 
+// save me lazy evaluation
 /obj/item/reagent_containers/powder/flour/attackby(obj/item/I, mob/living/user, params)
+	return wet(I,user) || ..()
+
+/obj/item/reagent_containers/powder/flour/proc/wet(obj/item/I, mob/living/user)
 	var/found_table = locate(/obj/structure/table) in (loc)
 	var/obj/item/reagent_containers/R = I
+	// if false, this is a special case like orison
+	var/is_container = istype(R)
 	update_cooktime(user)
-	if(!istype(R) || (water_added))
-		return ..()
+	if(water_added)
+		return FALSE
 	if(isturf(loc)&& (!found_table))
 		to_chat(user, span_notice("Need a table..."))
-		return ..()
-	if(!R.reagents.has_reagent(/datum/reagent/water, 10))
+		return FALSE
+	if(is_container && (!R.reagents.has_reagent(/datum/reagent/water, 10)))
 		to_chat(user, span_notice("Needs more water to work it."))
 		return TRUE
 	to_chat(user, span_notice("Adding water, now its time to knead it..."))
@@ -172,7 +178,8 @@
 		add_sleep_experience(user, /datum/skill/craft/cooking, user.STAINT)
 		name = "wet flour"
 		desc = "Destined for greatness, at your hands."
-		R.reagents.remove_reagent(/datum/reagent/water, 10)
+		if(is_container)
+			R.reagents.remove_reagent(/datum/reagent/water, 10)
 		water_added = TRUE
 		color = "#d9d0cb"
 	return TRUE
@@ -210,15 +217,19 @@
 	var/water_added
 
 /obj/item/reagent_containers/food/snacks/grown/rice/attackby(obj/item/I, mob/living/user, params)
+	return wet(I, user) || ..()
+
+/obj/item/reagent_containers/food/snacks/grown/rice/proc/wet(obj/item/I, mob/living/user)
 	var/found_table = locate(/obj/structure/table) in (loc)
 	var/obj/item/reagent_containers/R = I
+	var/is_container = istype(R)
 	update_cooktime(user)
-	if(!istype(R) || (water_added))
-		return ..()
+	if(water_added)
+		return FALSE
 	if(isturf(loc)&& (!found_table))
 		to_chat(user, "<span class='notice'>Need a table...</span>")
-		return ..()
-	if(!R.reagents.has_reagent(/datum/reagent/water, 10))
+		return FALSE
+	if(is_container && (!R.reagents.has_reagent(/datum/reagent/water, 10)))
 		to_chat(user, "<span class='notice'>Needs more water to work it.</span>")
 		return TRUE
 	to_chat(user, "<span class='notice'>Adding water, now its time to hand wash it...</span>")
@@ -226,7 +237,8 @@
 	if(do_after(user,2 SECONDS, target = src))
 		user.adjust_experience(/datum/skill/craft/cooking, user.STAINT * 0.8)
 		name = "wet rice"
-		R.reagents.remove_reagent(/datum/reagent/water, 10)
+		if(is_container)
+			R.reagents.remove_reagent(/datum/reagent/water, 10)
 		water_added = TRUE
 		color = "#d9d0cb"
 	return TRUE
@@ -279,15 +291,19 @@
 	qdel(src)
 
 /obj/item/reagent_containers/powder/mineral/attackby(obj/item/I, mob/user, params)
+	return wet(I, user) || ..()
+
+/obj/item/reagent_containers/powder/mineral/proc/wet(obj/item/I, mob/user)
 	var/found_table = locate(/obj/structure/table) in (loc)
 	var/obj/item/reagent_containers/R = I
+	var/is_container = istype(R)
 	update_cooktime(user)
-	if(!istype(R) || (water_added))
-		return ..()
+	if(water_added)
+		return FALSE
 	if(isturf(loc)&& (!found_table))
 		to_chat(user, span_notice("Need a table..."))
-		return ..()
-	if(!R.reagents.has_reagent(/datum/reagent/water, 10))
+		return FALSE
+	if(is_container && (!R.reagents.has_reagent(/datum/reagent/water, 10)))
 		to_chat(user, span_notice("Needs more water to work it."))
 		return TRUE
 	to_chat(user, span_notice("Adding water, now its time to sift it..."))
@@ -295,7 +311,8 @@
 	if(do_after(user, short_cooktime, target = src))
 		name = "prepared minerals"
 		desc = "Still quite coarse, needs some sifting."
-		R.reagents.remove_reagent(/datum/reagent/water, 10)
+		if(is_container)
+			R.reagents.remove_reagent(/datum/reagent/water, 10)
 		water_added = TRUE
 		color = "#666262"
 	return TRUE

--- a/modular/Neu_Food/code/NeuFood.dm
+++ b/modular/Neu_Food/code/NeuFood.dm
@@ -172,7 +172,7 @@
 	if(is_container && (!R.reagents.has_reagent(/datum/reagent/water, 10)))
 		to_chat(user, span_notice("Needs more water to work it."))
 		return TRUE
-	to_chat(user, span_notice("Adding water, now its time to knead it..."))
+	to_chat(user, span_notice("Adding water, now it's time to knead it..."))
 	playsound(get_turf(user), 'modular/Neu_Food/sound/splishy.ogg', 100, TRUE, -1)
 	if(do_after(user, short_cooktime, target = src))
 		add_sleep_experience(user, /datum/skill/craft/cooking, user.STAINT)
@@ -232,7 +232,7 @@
 	if(is_container && (!R.reagents.has_reagent(/datum/reagent/water, 10)))
 		to_chat(user, "<span class='notice'>Needs more water to work it.</span>")
 		return TRUE
-	to_chat(user, "<span class='notice'>Adding water, now its time to hand wash it...</span>")
+	to_chat(user, "<span class='notice'>Adding water, now it's time to hand wash it...</span>")
 	playsound(get_turf(user), 'modular/Neu_Food/sound/splishy.ogg', 100, TRUE, -1)
 	if(do_after(user,2 SECONDS, target = src))
 		user.adjust_experience(/datum/skill/craft/cooking, user.STAINT * 0.8)
@@ -306,7 +306,7 @@
 	if(is_container && (!R.reagents.has_reagent(/datum/reagent/water, 10)))
 		to_chat(user, span_notice("Needs more water to work it."))
 		return TRUE
-	to_chat(user, span_notice("Adding water, now its time to sift it..."))
+	to_chat(user, span_notice("Adding water, now it's time to sift it..."))
 	playsound(get_turf(user), 'modular/Neu_Food/sound/splishy.ogg', 100, TRUE, -1)
 	if(do_after(user, short_cooktime, target = src))
 		name = "prepared minerals"


### PR DESCRIPTION
## Testing Evidence
<img width="1919" height="1051" alt="image" src="https://github.com/user-attachments/assets/6f4f3e15-5324-4e97-ad67-c7c4f0479724" />

## Why It's Good For The Game
Orison can conjure water, servants with devotee virtue would like to wet flour/wash rice with said water, they can't because it's technically a different fluid type. Instead of adding checks for the various conjured water fluid types, this pr just lets you use orison's fill intent to wet flour/rice/mineral dust directly, like how you can wet cloths to clean with it. Eoramaid sweep. This is a completely inconsequential buff mechanically (nobody is stopping mid-dungeon to make bread, then realizing they don't have the water to...) but a very soulful bit of flair. 

## Changelog

:cl:
qol: You can now use orison's conjure water to perform some cooking tasks, like wetting flour or washing rice.
/:cl:
