### PR TITLE
makes the virtue rework unTMable without runtimes

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -411,12 +411,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["virtue"] >> virtue_type
 	S["virtuetwo"] >> virtuetwo_type
 	S["virtue_origin"] >> origin_type
-	if (virtue_type)
+	if(virtue_type && ispath(virtue_type))
 		virtue = new virtue_type()
 	else
 		virtue = new /datum/virtue/none
 
-	if( virtuetwo_type)
+	if(virtuetwo_type && ispath(virtuetwo_type))
 		virtuetwo = new virtuetwo_type
 	else
 		virtuetwo = new /datum/virtue/none


### PR DESCRIPTION
## About The Pull Request
Previously if the PR was TMed and then unTMed it would cause everyone's virtues to stop working. This fixes that, no user facing changes.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
