### PR TITLE
[inhumen] - Fixes the new zizo crosses being no valid target for inhumen prayers.

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1227,14 +1227,14 @@
 	icon_state = "invertedcross"
 	divine = FALSE
 
-/obj/structure/fluff/psycross/zizo
+/obj/structure/fluff/psycross/zizocross/stone
 	name = "stone inverted cross"
 	desc = "An unholy symbol, the knowledge that something so sturdy was able to be put up in reverence of the dark star, completely unattended... is a difficult anchovy to swallow for many."
 	icon_state = "cross_zizo"
 	divine = FALSE
 	max_integrity = 200
 
-/obj/structure/fluff/psycross/zizo/golden
+/obj/structure/fluff/psycross/zizocross/golden
 	name = "golden inverted cross"
 	desc = "An unholy symbol meticilously plated with leaf gold. It stands in defiance to order. The dead will rise."
 	icon_state = "cross_zizo_u"

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -113,7 +113,7 @@
 /datum/crafting_recipe/roguetown/structure/zizo_cross_stone
 	name = "stone profane cross"
 	category = "Misc"
-	result = /obj/structure/fluff/psycross/zizo
+	result = /obj/structure/fluff/psycross/zizocross/stone
 	reqs =	list(/obj/item/natural/stone = 3)
 	verbage_simple = "construct"
 	verbage = "constructs"
@@ -121,7 +121,7 @@
 /datum/crafting_recipe/roguetown/structure/zizo_cross_gold
 	name = "gilded profane cross"
 	category = "Misc"
-	result = /obj/structure/fluff/psycross/zizo/golden
+	result = /obj/structure/fluff/psycross/zizocross/golden
 	reqs =	list(/obj/item/natural/stone = 3, /obj/item/rogueore/gold = 1)
 	verbage_simple = "construct"
 	verbage = "constructs"


### PR DESCRIPTION
## About The Pull Request
e



## Testing Evidence
<img width="1309" height="750" alt="image" src="https://github.com/user-attachments/assets/5f5e8235-b12d-49f5-b1f8-83eea5101536" />

## Why It's Good For The Game
a

## Changelog

:cl:
fix: zizo's fancier crosses are no longer prayer unworthy
/:cl:
