### PR TITLE
Fixes Disgraced Knight Fortune Statkey

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -15,7 +15,7 @@
 		STATKEY_CON = 2,
 		STATKEY_STR = 2,
 		STATKEY_PER = 2,
-		STATKEY_FOR = 1
+		STATKEY_LCK = 1
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,


### PR DESCRIPTION
## About The Pull Request

#6146 gave disgraced knight 1 Fortune
STATKEY_FOR does not exist however
its STATKEY_LCK

## Testing Evidence
nothing is consistent
anyway its 1 line
<img width="462" height="194" alt="Screenshot 2026-03-05 161158" src="https://github.com/user-attachments/assets/1d6e7b8d-d90b-4b34-b7a0-f56fd8513f2d" />

## Why It's Good For The Game

fix? fix.

## Changelog

:cl:
fix: fixed disgraced knight fortune statkey
/:cl:
