### PR TITLE
Arcyne Conduit expires on death.

### DIFF
--- a/code/modules/spells/components/arcyne_conduit.dm
+++ b/code/modules/spells/components/arcyne_conduit.dm
@@ -14,6 +14,7 @@
 		outline_color = outline_color_override
 	if(owner)
 		owner_ref = WEAKREF(owner)
+		RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(on_owner_death))
 	var/obj/item/I = parent
 	I.add_filter(CONDUIT_FILTER, 2, list("type" = "outline", "color" = outline_color, "alpha" = 200, "size" = 1))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(on_attack_success))
@@ -24,6 +25,18 @@
 	if(istype(I))
 		I.remove_filter(CONDUIT_FILTER)
 	UnregisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_PARENT_EXAMINE))
+	var/mob/living/owner = owner_ref?.resolve()
+	if(owner)
+		UnregisterSignal(owner, COMSIG_LIVING_DEATH)
+
+/datum/component/arcyne_conduit/proc/on_owner_death()
+	SIGNAL_HANDLER
+	var/mob/living/owner = owner_ref?.resolve()
+	if(owner)
+		var/datum/status_effect/buff/arcyne_momentum/M = owner.has_status_effect(/datum/status_effect/buff/arcyne_momentum)
+		if(M)
+			M.bound_weapon = null
+	qdel(src)
 
 /datum/component/arcyne_conduit/proc/on_attack_success(obj/item/source, mob/living/target, mob/living/user)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
Arcyne Conduit expires on death.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Arcyne Conduit expires on death.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Arcyne Conduit expires on death.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Arcyne Conduit expires on death. Should fix an edge case with Spellblade mechanics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
