### PR TITLE
[Bugfixes] Windowfires, floaty fires, and combative corpses.

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -78,6 +78,7 @@
 		if(ishumannorthern(src))
 			record_round_statistic(STATS_HUMEN_DEATHS)
 		if(mind)
+			cmode = FALSE
 			if(mind.assigned_role in GLOB.church_positions)
 				record_round_statistic(STATS_CLERGY_DEATHS)
 			if(mind.has_antag_datum(/datum/antagonist/vampire))

--- a/code/modules/spells/spell_types/wizard/utility/create_campfire.dm
+++ b/code/modules/spells/spell_types/wizard/utility/create_campfire.dm
@@ -31,7 +31,8 @@
 /obj/effect/proc_holder/spell/invoked/create_campfire/cast(list/targets, mob/user = usr)
 	var/turf/target = get_turf(targets[1])
 
-	if(!target || target.density)
+	if(!target || !target.Enter(user) || istransparentturf(target))
+		to_chat(user, "<span class='warning'>This turf can't be on fiyaaaah! (It's blocked sire.)</span>")
 		revert_cast()
 		return
 	new /obj/machinery/light/rogue/campfire/create_campfire(target)


### PR DESCRIPTION
## About The Pull Request
- Fixes magefire being able to be placed on turfs with obstacles such as windows or tables.
- Fixes magefire being able to be placed on air tiles. The fire may be magic, but it ain't that magic okay.
- Carbons with a mind will now turn cmode off after they die.

## Testing Evidence
<img width="280" height="150" alt="image" src="https://github.com/user-attachments/assets/16098ab0-f587-406b-b358-6642e556d93d" />

## Why It's Good For The Game
If we let the bugs fester for too long they will mutate into giant twink devouring monstrosities. That cannot be. Only I'm allowed to-

Honestly everyone should fix at least one bug every week and we can be rid of these pretty quickly.

## Changelog

:cl:
fix: Magefire can't be placed on blocked turfs or air turfs.
fix: Mind-owning carbons now turn combat mode off when they die.
/:cl:

