### PR TITLE
[witch] cleans up witch shapeshift

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -130,6 +130,16 @@
 	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
 
+/obj/effect/proc_holder/spell/targeted/shapeshift/witch
+	die_with_shapeshifted_form = FALSE
+	gesture_required = TRUE
+	chargetime = 5 SECONDS
+	recharge_time = 50
+	cooldown_min = 50
+	convert_damage = FALSE
+	do_gib = FALSE
+	knockout_on_death = 10 SECONDS
+
 /obj/effect/proc_holder/spell/targeted/shapeshift/witch/cast(list/targets, mob/user = usr)
 	user.visible_message(span_warning("[user] begins to twist and contort!"), span_notice("I begin to transform..."))
 	return ..()
@@ -165,31 +175,53 @@
 	name = "Cat Form"
 	desc = ""
 	overlay_state = "cat_transform"
-	gesture_required = TRUE
-	chargetime = 5 SECONDS
-	recharge_time = 50
-	cooldown_min = 50
-	die_with_shapeshifted_form = FALSE
 	shapeshift_type = /mob/living/simple_animal/pet/cat/witch_shifted
-	convert_damage = FALSE
-	do_gib = FALSE
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/witch/cat/black
 	shapeshift_type = /mob/living/simple_animal/pet/cat/rogue/black/witch_shifted
-	do_gib = FALSE
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/witch/lesser_wolf
 	name = "Lesser Volf Form"
 	desc = ""
 	overlay_state = "volf_transform"
-	gesture_required = TRUE
-	chargetime = 5 SECONDS
-	recharge_time = 50
-	cooldown_min = 50
-	die_with_shapeshifted_form = FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/rogue/wolf/witch_shifted
-	convert_damage = FALSE
-	do_gib = FALSE
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/witch/bat
+	name = "Bat Form"
+	desc = ""
+	overlay_state = "bat_transform"
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
+	knockout_on_death = 30 SECONDS
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/witch/crow
+	name = "Zad Form"
+	overlay_state = "zad"
+	desc = ""
+	knockout_on_death = 15 SECONDS
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow
+	sound = 'sound/vo/mobs/bird/birdfly.ogg'
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/witch/lesser_vernard
+	name = "Lesser Vernard Form"
+	desc = ""
+	overlay_state = "vernard_transform"
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/rogue/fox/witch_shifted
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/witch/rous
+	name = "Small Rous Form"
+	desc = ""
+	overlay_state = "rous_transform"
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/smallrat/witch_shifted
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/witch/cabbit
+	name = "Cabbit Form"
+	desc = ""
+	overlay_state = "cabbit_transform"
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab/cabbit/witch_shifted
+
+/datum/intent/simple/claw/witch_cat
+	name = "scratch"
+	attack_verb = list("scratches", "claws")
 
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/witch_shifted
 	name = "lesser volf"
@@ -223,54 +255,6 @@
 	base_intents = list(/datum/intent/simple/claw/witch_cat)
 	melee_damage_lower = 2
 	melee_damage_upper = 5
-
-/datum/intent/simple/claw/witch_cat
-	name = "scratch"
-	attack_verb = list("scratches", "claws")
-
-/obj/effect/proc_holder/spell/targeted/shapeshift/witch/bat
-	name = "Bat Form"
-	desc = ""
-	overlay_state = "bat_transform"
-	recharge_time = 50
-	cooldown_min = 50
-	die_with_shapeshifted_form =  FALSE
-	do_gib = FALSE
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
-	knockout_on_death = 30 SECONDS
-
-/obj/effect/proc_holder/spell/targeted/shapeshift/witch/crow
-	name = "Zad Form"
-	overlay_state = "zad"
-	desc = ""
-	gesture_required = TRUE
-	chargetime = 5 SECONDS
-	recharge_time = 50
-	cooldown_min = 50
-	die_with_shapeshifted_form =  FALSE
-	do_gib = FALSE
-	knockout_on_death = 15 SECONDS
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow
-	sound = 'sound/vo/mobs/bird/birdfly.ogg'
-
-/obj/effect/proc_holder/spell/targeted/shapeshift/witch/lesser_vernard
-	name = "Lesser Vernard Form"
-	desc = ""
-	overlay_state = "vernard_transform"
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/rogue/fox/witch_shifted
-
-/obj/effect/proc_holder/spell/targeted/shapeshift/witch/rous
-	name = "Small Rous Form"
-	desc = ""
-	overlay_state = "rous_transform"
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/smallrat/witch_shifted
-
-/obj/effect/proc_holder/spell/targeted/shapeshift/witch/cabbit
-	name = "Cabbit Form"
-	desc = ""
-	overlay_state = "cabbit_transform"
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab/cabbit/witch_shifted
-
 
 /mob/living/simple_animal/hostile/retaliate/rogue/fox/witch_shifted
 	name = "lesser vernard"

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -11,8 +11,8 @@
 	action_icon_state = "shapeshift"
 
 	var/revert_on_death = TRUE
-	var/die_with_shapeshifted_form = TRUE
-	var/knockout_on_death = 0 // we will apply this value (as deciseconds) to our host mob as a knockout effect when punted out of the form
+	var/die_with_shapeshifted_form = FALSE
+	var/knockout_on_death = 50 // we will apply this value (as deciseconds) to our host mob as a knockout effect when punted out of the form
 	var/convert_damage = TRUE //If you want to convert the caster's health to the shift, and vice versa.
 	var/convert_damage_type = BRUTE //Since simplemobs don't have advanced damagetypes, what to convert damage back into.
 	var/do_gib = TRUE


### PR DESCRIPTION
## About The Pull Request
Standardizes and cleans up witch shapeshift.
The parent is now actually used instead of being implicitly defined.

ALL FORMS:
- Now don't instantly kill the witch on death.
- Hard knockouts the witch for 10 seconds.

Forms that had custom values like the 30 second hardstun for bat form death are unaffected.

Generously bankrolled by a bnuuy

## Testing Evidence
<img width="514" height="199" alt="image" src="https://github.com/user-attachments/assets/da57a456-712f-4db6-8f75-15ddeff13f7e" />

## Why It's Good For The Game

This was already the case for about half the forms. Given none of them are particularly tanky or transfer wounds with no real capacity to fight back, this seems sensible to continue as a trend.

## Changelog

:cl:
balance: cleaned up witch shapeshift. No death on revert, 10 second knockout on forms by default. Custom rules unaffected.
/:cl:
