### PR TITLE
[Abyssor] Reduces the cost of abyssor revival

### DIFF
--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -172,7 +172,7 @@
 	the blessing on yourself to check what's needed. </br>The resurrected target will not be brought back, alone; a fierce dreamfriend will be tethered to their spirit, \
 	stalking and sapping their strength. Slaying this dreamfiend will fully restore their strength. </br>Unlike a regular Healing miracle, this can affect - and resurrect - devout Psydonians as well."
 	sound = 'sound/magic/whale.ogg'
-	//A medley of common ocean fish, totalling 10
+	//A medley of common ocean fish, totalling 6
 	required_items = list(
 		/obj/item/reagent_containers/food/snacks/fish/sole = 2,
 		/obj/item/reagent_containers/food/snacks/fish/cod = 2,


### PR DESCRIPTION
## About The Pull Request
Lowers the cost of abyssor revival significantly down to 6 fish from 10

## Testing Evidence
number change milord

## Why It's Good For The Game

Abyssal revival is meant to be one of the hardest revivals, owing to the chaotic nature of abyssor & the power level of their other spells. But the recent fishing update heavily diluted the fishing pool to the point you can no longer fish up 2 revivals worth of fish in 10 minutes with master fishing, let alone the cost of sorting the fish out.

Penalty of having to fight off a potentially powerful dreamfiend still applies.

## Changelog

:cl:
balance: Cost of abyssor revival reduced
/:cl:
