### PR TITLE
[Deadites] - Fixes cure rot killing alive humans that aren't deadited.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -223,6 +223,7 @@
 #define TRAIT_TOXIMMUNE	"Poison Immune"
 #define TRAIT_GRABIMMUNE "Unstoppable"
 #define TRAIT_ROTMAN "Rotman"
+#define TRAIT_DEADITE "Deadite"
 #define TRAIT_ZOMBIE_IMMUNE "Deadite Immunity" //immune to deadite infection
 #define TRAIT_NOHUNGER	"Foodless"
 #define TRAIT_DARKVISION "Darksight"
@@ -425,6 +426,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_CICERONE = span_info("I am well-versed in the differences of brews and spirits, and can tell them apart at a glance."),
 	TRAIT_BETTER_SLEEP = span_info("I recover more energy when sleeping."),
 	TRAIT_ROTMAN = span_info("I am partially undead. My heart does not beat."),
+	TRAIT_DEADITE = span_info("I am a feral deadite."),
 	TRAIT_EASYDISMEMBER = span_info("My limbs are frail and fragile. They can be dismembered with greater ease, including my neck."),
 	TRAIT_HARDDISMEMBER = span_info("My body is strong and endurant. My limbs are not easily dismembered."),
 	TRAIT_NOPAIN = span_info("I feel no pain."),

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -54,7 +54,8 @@
 		TRAIT_ZOMBIE_IMMUNE,
 		TRAIT_ROTMAN,
 		TRAIT_NORUN,
-		TRAIT_SILVER_WEAK
+		TRAIT_SILVER_WEAK,
+		TRAIT_DEADITE,
 	)
 	/// Traits applied to the owner when we are cured and turn into just "rotmen"
 	var/static/list/traits_rotman = list(

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -39,7 +39,7 @@
 		if(medskill > SKILL_LEVEL_EXPERT)
 			burndam = 0
 
-	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
+	var/was_zombie = HAS_TRAIT(target, TRAIT_DEADITE)
 	if(target.infected == FALSE)
 		if(target.stat == DEAD || was_zombie)											//Checks if the target is a dead rotted corpse.
 			target.death()	//Kills the target if they are a zombie as a fail-safe.


### PR DESCRIPTION
## About The Pull Request
- Stops cure rot from killing people who are just infected, not turned.

## Testing Evidence
<img width="552" height="159" alt="image" src="https://github.com/user-attachments/assets/d7f18e77-6792-4b4c-ac4d-53a83664edc3" />
<img width="522" height="349" alt="image" src="https://github.com/user-attachments/assets/d1a206d2-0889-40ea-9a77-ea1655cd95b1" />

## Why It's Good For The Game

Felt like a bug, probably is a bug. Cure rot will still kill deadites who are cured with the surgery, just not people who are merely infected. Since it was checking for the antag datum presence. People get the antag datum when they are infected, and lose it when cured. It cannot be used as a valid check to see whether or not someone is a fully turned deadite.

This issue didn't seem to be consistent, I'm not sure why. I've cured infected people before without killing them. I've killed infected people before whilst curing them. This should fix it though.

## Changelog

:cl:
fix: Cure rot will no longer kill people who are infected with deadite disease, only actual deadites.
/:cl:
