### PR TITLE
[Miracles] - Eoran bud jangle (nerfs & minor rework)

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -16,20 +16,31 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 1
 	throw_range = 3
+	equip_delay_other = 10 SECONDS
+	// Pretty fragile
+	max_integrity = 150
 
 /obj/item/clothing/head/peaceflower/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
 	if(slot == SLOT_HEAD || slot == SLOT_WEAR_MASK)
 		ADD_TRAIT(user, TRAIT_PACIFISM, "peaceflower_[REF(src)]")
+		if(user.patron.type != /datum/patron/divine/eora)
+			user.AddComponent(/datum/component/peaceflower_tracker, src)
 
 /obj/item/clothing/head/peaceflower/dropped(mob/living/carbon/human/user)
 	..()
 	REMOVE_TRAIT(user, TRAIT_PACIFISM, "peaceflower_[REF(src)]")
+	var/datum/component/peaceflower_tracker/T = user.GetComponent(/datum/component/peaceflower_tracker)
+	if(T)
+		qdel(T)
 
 /obj/item/clothing/head/peaceflower/proc/peace_check(mob/living/user)
 	// return true if we should be unequippable, return false if not
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
+		// Eorans can just take these off. It's their god!
+		if(C.patron.type == /datum/patron/divine/eora && do_after(user, 4 SECONDS, src))
+			return FALSE
 		if(src == C.head || src == C.wear_mask)
 			to_chat(user, "<span class='warning'>I feel at peace. <b style='color:pink'>Why would I want anything else?</b></span>")
 			return TRUE
@@ -47,12 +58,12 @@
 	name = "Eoran Bloom"
 	desc = "Tries to grow an Eoran bud on the target tile or on the targets head, forcing their thoughts away from violence until removed."
 	clothes_req = FALSE
-	range = 7
+	range = 3
 	overlay_state = "love"
 	sound = list('sound/magic/magnet.ogg')
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	releasedrain = 40
-	chargetime = 60
+	chargetime = 1 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	charging_slowdown = 1
@@ -65,11 +76,19 @@
 	if(istype(target, /mob/living/carbon/human)) //Putting flower on head check
 		var/mob/living/carbon/human/C = target
 		if(!C.get_item_by_slot(SLOT_HEAD))
+			if(!do_after_mob(user, target, 10 SECONDS))
+				to_chat(user, span_warning("Both of you have to stand still for this to work!"))
+				revert_cast()
+				return FALSE
 			var/obj/item/clothing/head/peaceflower/F = new(get_turf(C))
 			C.equip_to_slot_if_possible(F, SLOT_HEAD, TRUE, TRUE)
 			to_chat(C, "<span class='info'>A flower of Eora blooms on my head. <b style='color:pink'> I feel at peace. </b></span>")
 			return TRUE
 		else if(!C.get_item_by_slot(SLOT_WEAR_MASK))
+			if(!do_after_mob(user, target, 10 SECONDS))
+				to_chat(user, span_warning("Both of you have to stand still for this to work!"))
+				revert_cast()
+				return FALSE
 			var/obj/item/clothing/head/peaceflower/F = new(get_turf(C))
 			C.equip_to_slot_if_possible(F, SLOT_WEAR_MASK, TRUE, TRUE)
 			to_chat(C, "<span class='info'>A flower of Eora blooms on my head. <b style='color:pink'> I feel at peace. </b></span>")

--- a/code/modules/spells/roguetown/acolyte/eora/eora_components.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_components.dm
@@ -1,0 +1,36 @@
+/datum/component/peaceflower_tracker
+	var/obj/item/clothing/head/peaceflower/flower
+
+/datum/component/peaceflower_tracker/Initialize(obj/item/clothing/head/peaceflower/flower_source)
+	if(!isliving(parent) || !istype(flower_source))
+		return COMPONENT_INCOMPATIBLE
+
+	flower = flower_source
+	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_wearer_damaged))
+	RegisterSignal(flower, COMSIG_PARENT_QDELETING, PROC_REF(on_flower_deleted))
+
+/datum/component/peaceflower_tracker/proc/on_wearer_damaged(datum/source, damage, damagetype, def_zone)
+	SIGNAL_HANDLER
+	if(!flower || damage <= 0)
+		return
+
+	flower.take_damage(damage, damagetype, "none", 0)
+	if(flower.obj_broken)
+		qdel(flower)
+		return
+
+	if(ishuman(parent))
+		var/mob/living/carbon/human/H = parent
+		if(prob(50))
+			to_chat(H, span_warning("The violence of the world withers the [flower.name]!"))
+
+/datum/component/peaceflower_tracker/proc/on_flower_deleted(datum/source)
+	SIGNAL_HANDLER
+	qdel(src)
+
+/datum/component/peaceflower_tracker/Destroy()
+	// Nulling it here to avoid hard deletes.
+	var/mob/living/carbon/C = parent
+	REMOVE_TRAIT(C, TRAIT_PACIFISM, "peaceflower_[REF(flower)]")
+	flower = null
+	return ..()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2630,6 +2630,7 @@
 #include "code\modules\spells\roguetown\acolyte\resurrect.dm"
 #include "code\modules\spells\roguetown\acolyte\xylix.dm"
 #include "code\modules\spells\roguetown\acolyte\eora\eora_arils.dm"
+#include "code\modules\spells\roguetown\acolyte\eora\eora_components.dm"
 #include "code\modules\spells\roguetown\acolyte\eora\eora_reagents.dm"
 #include "code\modules\spells\roguetown\acolyte\eora\eora_status_effects.dm"
 #include "code\modules\spells\roguetown\acolyte\necra\necra_cross.dm"


### PR DESCRIPTION
## About The Pull Request
- Eoran buds now take damage if the user isn't eoran, and takes damage. If an object breaks this way, it is deleted.
- Eorans can freely take off buds from themselves with a 4 second delay.
- Applying a bud to someone takes 10 seconds now, through the equip menu. No super sneaky rapid budding of people talking anymore.
- Applying a bud via the miracle takes 10 seconds now, requiring neither the user nor the receiver to take any actions.

## Testing Evidence
<img width="1306" height="828" alt="image" src="https://github.com/user-attachments/assets/77310286-5381-409b-b3f0-31467fc344c2" />

## Why It's Good For The Game
Eorans want buds to be able to heal better, but it shouldn't make an eoran templar an automatic valid, free frag for doing so. They're still a frag, but slightly less so.
Eoran bud has always been a miracle prone to bad faith use. The long chargetime doesn't stop it from just being used as a quick way to get someone that isn't wearing a mask or headpiece out of combat. Worse, sometimes people strip a helmet mid combat, and then slap a bud on them. Consequently the Eorans just go to... beat up the person that's pacified and skullcrack them. No, just no. I doubt this miracle was ever intended to be used mid combat, and now it is properly difficult to use mid combat.

Buds breaking when non eorans wearing them take damage is similarly, a measure to prevent abuse. You got a knocked out heretic in your clinic? you bud them? Cool. Now someone finds the need to beat them up? Well that bud is going to take every hit in damage in addition, and then vanish when it breaks. This makes it much harder to bad faith people wearing buds.

You could already self-remove buds through fire by jumping atop a brazier. Yes, this technically makes self removing buds easier when RP dictates the user would never want it removed themselves whilst they are wearing it. No, I'm not going to code an overbearing restriction to stop people from doing this. Just ahelp it if you see it, it's not like people couldn't before.

I don't trust anyone rebalancing these without making them completely useless as a RP tool.

## Changelog

:cl:
balance: Eoran buds are far harder to apply, and break eventually if non eoran users are attacked wearing them.
/:cl:
