### PR TITLE
Maintaining Previous PRs #1 - Fixes errant path in Otavan Silver Stakes.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -763,7 +763,7 @@
 	name = "silver-tipped otavan stake"
 	desc = "A branch that has been broken off of an Otavan boswellia tree, sharpened to a fine point and tipped with blessed silver. It can lay most unholy creechers to rest, but only by piercing their hearts."
 
-/obj/item/rogueweapon/huntingknife/idagger/silver/stakepsy/ComponentInitialize()
+/obj/item/rogueweapon/huntingknife/idagger/silver/stake/psy/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
 		pre_blessed = BLESSING_NONE,\


### PR DESCRIPTION
## About The Pull Request

* Fixes a filepath under the Otavan Silver Stake, allowing it to properly vend as its Psydonic-blessable variant for the Marquette.

## Testing Evidence

One line.

## Why It's Good For The Game

* Ensures the original feature works as intended.

## Changelog

:cl:
fix: Otavan SIlver Stakes should properly be blessable by Psydonic Absolvers, now, instead of the Bishop.
/:cl: