### PR TITLE
Maintaining Previous PRs #2 - Adds fireproofedness to the Inquisitor's spiffy hat.

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -298,6 +298,7 @@
 	body_parts_covered = HEAD|HAIR|EARS
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_TWIST)
 	sewrepair = TRUE
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/head/roguetown/inqhat/gravehat
 	name = "gravetender's hat"


### PR DESCRIPTION
## About The Pull Request

* Adds the appropriate tag to the Inquisitor's unique hat, so that it isn't easily burnt and destroyed from minor fires.

## Testing Evidence

One line.

## Why It's Good For The Game

* Player-requested, overlooked for some time. Ensures the unique hat of the Inquisitor isn't easily destroyed due to minor flames, owing to the awkwardness of patting out fires on such items.

## Changelog

:cl:
balance: The Inquisitor's hat is now treated with a fireproof lining.
/:cl: