### PR TITLE
Maintaining Previous PRs #5 - Fixes corks not being accounted for.

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -56,6 +56,10 @@
 		return FALSE
 	var/mob/living/carbon/C = eater
 
+	if(!spillable)
+		to_chat(user, span_warning("How am I to drink from this while it's still corked?"))
+		return FALSE
+
 	var/obj/item/bodypart/head/dullahan/eaterrelay
 	if(ishuman(src))
 		var/mob/living/carbon/human = src
@@ -81,7 +85,7 @@
 	if(covered)
 		if(!silent)
 			var/who = (isnull(user) || eater == user) ? "my" : "[eater.p_their()]"
-			to_chat(user, span_warning("I have to remove [who] [covered] first!"))
+			to_chat(user, span_warning("I have to remove [who] [covered], first!"))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

A rehost of the former pull request, [located here](https://github.com/Azure-Peak/Azure-Peak/pull/5870).
This prevents people from drinking through corks, and offers a new warning message when attempting to do so.
To note, this doesn't include the former pull request's tweakage of overdose values - the current balance's good, I'd say.

## Testing Evidence

* In the linked pull request. Same code, just slimmed down.

## Why It's Good For The Game

* Fixes a long-standing bug.
* Slightly less feasible to quickly pop-and-chug potions in combat, without first uncorking them first.

## Changelog

:cl:
fix: Corks now prevent you from drinking out of a given container, if not properly removed beforehand via RMB.
/:cl:
