### PR TITLE
Improve Phalangite & Macebearer charge, make javelin slightly better.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/spellblade_chant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/spellblade_chant.dm
@@ -301,7 +301,7 @@ a.choose-btn:hover {
 <ul>
 <li><b>Azurean Phalanx</b> — 3-tile line thrust that pushes enemies back 1 tile. Empowered: doubles damage.</li>
 <li><b>Azurean Javelin</b> — Hurl an armor-piercing phantom spear that slows. No slowdown while charging.</li>
-<li><b>Advance!</b> — Charge forward and jab 3 times ahead. Must build up 1 pace first. If blocked, keeps jabbing in place. Brief chargeup before moving.</li>
+<li><b>Advance!</b> — Leap forward up to 4 tiles, passing through enemies, then stab ahead on landing. Brief chargeup before leaping. Empowered: doubles damage.</li>
 <li><b>Gate of Reckoning</b> — Conjure a portal above a target, raining phantom spears down, then blink to their position and sweep everyone around you.</li>
 </ul>
 </div>
@@ -320,7 +320,7 @@ a.choose-btn:hover {
 <ul>
 <li><b>Shatter</b> — 3-tile line smash that devastates armor integrity and knocks targets back 1 tile. Empowered: doubles damage.</li>
 <li><b>Tremor</b> — Slam the ground, damaging and pushing back everyone adjacent 1 tile. Empowered: doubles damage.</li>
-<li><b>Charge!</b> — Charge forward 3 paces and bash, knocking targets back 1 tile. Empowered: doubles damage. Brief chargeup before moving.</li>
+<li><b>Charge!</b> — Charge forward 5 paces, ramming everyone in the path aside, then bash at the end. Knocks the final target back 1 tile. Empowered: doubles damage. Brief chargeup before moving.</li>
 <li><b>Cataclysm</b> — Conjure and hurl an arcyne hammer at a target area. Crushes a 5x5 area and leaves victims Vulnerable. Bonus damage at max momentum.</li>
 </ul>
 </div>

--- a/code/modules/spells/spell_types/classunique/spellblade/advance.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/advance.dm
@@ -1,29 +1,25 @@
-/* Advance! - Phalangite jousting charge.
-Must move at least one tile to start (no free point-blank).
-Once moving, jabs ahead 3 times. If blocked mid-charge, keeps
-jabbing in place for the remaining steps.
+/* Advance! - Phalangite leap-strike.
+Leaps up to 4 tiles in the aimed direction, passing through mobs.
+On landing, stabs 1 tile ahead in the aimed direction.
 
-Fast — 1 tick between jabs. Counterplay is sidestepping or parrying.
-Interruptible by stun/knockdown.
+The 5-tick telegraph is the counterplay window. The leap itself is fast.
 
-At 3+ momentum: consumes 3, jab damage increases from 15 to 25.
-Builds 1 momentum on hit. */
+At 3+ momentum: consumes 3, doubles strike damage.
+Does NOT build momentum on hit — use normal melee for that. */
 
 /obj/effect/proc_holder/spell/invoked/advance
 	name = "Advance!"
-	desc = "Lower the spear and charge — one pace to build speed, then three rapid jabs ahead. \
-		If blocked, keeps jabbing in place. \
-		Builds 1 momentum on hit. \
-		At 3+ momentum: consumes 3 to increase jab damage. \
+	desc = "Leap forward up to 4 tiles, passing through enemies, then stab ahead on landing. \
+		At 3+ momentum: consumes 3 to double damage. \
 		Strikes your aimed bodypart. Can be deflected by Defend stance."
 	clothes_req = FALSE
-	range = 5
+	range = 15
 	action_icon = 'icons/mob/actions/spellblade.dmi'
 	overlay_state = "advance"
 	releasedrain = 15
 	chargedrain = 0
 	chargetime = 5
-	recharge_time = 12 SECONDS
+	recharge_time = 15 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
@@ -33,9 +29,9 @@ Builds 1 momentum on hit. */
 	invocation_type = "shout"
 	gesture_required = TRUE
 	xp_gain = FALSE
-	var/charge_steps = 3
-	var/base_damage = 15
-	var/empowered_damage = 25
+	var/leap_range = 4
+	var/base_damage = 30
+	var/empowered_mult = 2
 	var/momentum_cost = 3
 	var/step_delay = 1
 
@@ -61,7 +57,7 @@ Builds 1 momentum on hit. */
 
 	var/turf/first_step = get_step(start, facing)
 	if(!first_step || first_step.density)
-		to_chat(H, span_warning("There's no room to charge!"))
+		to_chat(H, span_warning("There's no room to leap!"))
 		revert_cast()
 		return
 
@@ -72,67 +68,88 @@ Builds 1 momentum on hit. */
 		empowered = TRUE
 		to_chat(H, span_notice("[momentum_cost] momentum released — empowered advance!"))
 
-	var/damage = empowered ? empowered_damage : base_damage
+	var/damage = empowered ? (base_damage * empowered_mult) : base_damage
 
 	if(H.buckled)
 		H.buckled.unbuckle_mob(H, TRUE)
 
 	H.visible_message(
-		span_warning("[H] lowers [H.p_their()] [held_weapon.name] and charges!"),
+		span_warning("[H] lowers [H.p_their()] [held_weapon.name] and leaps forward!"),
 		span_notice("I advance!"))
 	playsound(start, pick('sound/combat/wooshes/bladed/wooshsmall (1).ogg', 'sound/combat/wooshes/bladed/wooshsmall (2).ogg'), 60, TRUE)
 
-	// First step is mandatory — prevents free point-blank abuse
-	if(!step(H, facing))
-		to_chat(H, span_warning("My charge is blocked!"))
-		return
-	new /obj/effect/temp_visual/kinetic_blast(get_turf(H))
+	// Leap phase — pass through mobs with jump arc animation
+	var/old_pass = H.pass_flags
+	H.pass_flags |= PASSMOB
+	var/prev_pixel_z = H.pixel_z
+	var/prev_transform = H.transform
 
-	var/hit_count = 0
-	var/stopped = FALSE
+	// Launch into the air — dramatic arc
+	animate(H, pixel_z = prev_pixel_z + 18, time = 1, easing = EASE_OUT)
 
-	for(var/i in 1 to charge_steps)
+	var/steps_taken = 0
+	for(var/i in 1 to leap_range)
 		if(H.stat != CONSCIOUS || H.IsParalyzed() || H.IsStun() || QDELETED(H))
 			break
+		var/turf/next = get_step(get_turf(H), facing)
+		if(!next || next.density)
+			break
 
-		// Jab the tile ahead — spear thrust forward
-		var/turf/jab_turf = get_step(get_turf(H), facing)
-		if(jab_turf)
-			for(var/mob/living/victim in jab_turf)
-				if(victim == H || victim.stat == DEAD)
-					continue
-				if(spell_guard_check(victim, FALSE, hit_count == 0 ? H : null))
-					continue
-				arcyne_strike(H, victim, held_weapon, damage, def_zone, BCLASS_STAB, spell_name = "Advance!")
-				hit_count++
+		var/blocked = FALSE
+		for(var/obj/structure/S in next.contents)
+			if(S.density && !S.climbable)
+				blocked = TRUE
+				break
+		if(blocked)
+			break
 
-		if(i < charge_steps)
+		step(H, facing)
+		steps_taken++
+
+		if(i < leap_range)
 			sleep(step_delay)
 
-		// Try to advance after jabbing (except on final step)
-		if(i < charge_steps && !stopped)
-			var/turf/next = get_step(get_turf(H), facing)
-			if(!next || next.density)
-				stopped = TRUE
-			else
-				var/struct_blocked = FALSE
-				for(var/obj/structure/S in next.contents)
-					if(S.density && !S.climbable)
-						struct_blocked = TRUE
-						break
-				if(struct_blocked)
-					stopped = TRUE
-				else if(!step(H, facing))
-					stopped = TRUE
-			if(!stopped)
-				new /obj/effect/temp_visual/kinetic_blast(get_turf(H))
+	// Slam down — fast drop with impact tilt
+	var/land_angle = pick(-20, -15, 15, 20)
+	animate(H, pixel_z = prev_pixel_z, transform = turn(prev_transform, land_angle), time = 1, easing = EASE_IN)
+	animate(transform = prev_transform, time = 2)
 
-	if(hit_count)
-		if(M)
-			M.add_stacks(1)
-		H.visible_message(span_danger("[H] skewers [hit_count > 1 ? "[hit_count] targets" : "a target"] during [H.p_their()] advance!"))
+	H.pass_flags = old_pass
+
+	if(steps_taken == 0)
+		to_chat(H, span_warning("My leap is blocked!"))
+		return
+
+	// Strike phase — stab 1 tile ahead of landing
+	var/turf/jab_turf = get_step(get_turf(H), facing)
+	if(!jab_turf)
+		H.visible_message(span_notice("[H] lands with a thrust at the air."))
+		return
+
+	var/hit_count = 0
+	for(var/mob/living/victim in jab_turf)
+		if(victim == H || victim.stat == DEAD)
+			continue
+		if(spell_guard_check(victim, FALSE, hit_count == 0 ? H : null))
+			continue
+		arcyne_strike(H, victim, held_weapon, damage, def_zone, BCLASS_STAB, spell_name = "Advance!")
+		hit_count++
+
+	if(!hit_count)
+		// Also check landing tile for targets standing on top of caster
+		var/turf/landing = get_turf(H)
+		for(var/mob/living/victim in landing)
+			if(victim == H || victim.stat == DEAD)
+				continue
+			if(spell_guard_check(victim, FALSE, hit_count == 0 ? H : null))
+				continue
+			arcyne_strike(H, victim, held_weapon, damage, def_zone, BCLASS_STAB, spell_name = "Advance!")
+			hit_count++
+
+	if(!hit_count)
+		H.visible_message(span_notice("[H] lands with a thrust at the air."))
 	else
-		H.visible_message(span_notice("[H] finishes the charge with a thrust at the air."))
+		H.visible_message(span_danger("[H] lands and drives [H.p_their()] [held_weapon.name] forward!"))
 
 	log_combat(H, null, "used Advance! ([hit_count] hits)")
 	return TRUE

--- a/code/modules/spells/spell_types/classunique/spellblade/azurean_javelin.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/azurean_javelin.dm
@@ -10,9 +10,11 @@ To make it versatile for dungeon support - if it is a stab intent,
 it is a direct throw. Cut intent turns it into an arced throw that
 flies over allies.
 
-CD: 12 seconds, you are not a true ranged class and you can literally
+CD: 10 seconds, you are not a true ranged class and you can literally
 rotate tossing your actual spear risk free unlike a real melee. Plus,
 it is an AP projectile and high impact vs other light.
+
+Chargetime reduced from 20 to 10 ticks (1 second) to feel less awkward.
 
 */
 
@@ -23,12 +25,12 @@ it is an AP projectile and high impact vs other light.
 		At 3+ momentum: consumes 3 to double damage. \
 		In Stab stance: direct throw. In Cut stance: arced throw (flies over allies)."
 	clothes_req = FALSE
-	range = 7
+	range = 15
 	projectile_type = /obj/projectile/energy/azurean_javelin
 	sound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg')
 	releasedrain = 30
 	chargedrain = 1
-	chargetime = 20
+	chargetime = 10
 	recharge_time = 10 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE

--- a/code/modules/spells/spell_types/classunique/spellblade/charge.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/charge.dm
@@ -1,28 +1,27 @@
-/* Charge! - Macebearer charge attack.
-3 rapid steps forward in the user's facing direction, ending with
-a bash on anything at the destination. Knockback on hit.
-Interruptible by stun/knockdown.
+/* Charge! - Macebearer ramming charge.
+5 rapid steps forward in the user's facing direction, shoving
+anyone in the path to the sides for zero damage.
+Only strikes at the final tile (or wherever the charge stops).
 
-More disruptive than Advance (knockback on arrival). Strikes aimed bodypart.
-
-At 3+ momentum: consumes 3 stacks, doubles damage and knockback distance.
-Builds 1 momentum on hit. */
+Knockback on final hit is 1 tile regardless of empowerment.
+At 3+ momentum: consumes 3 stacks, doubles strike damage.
+Does NOT build momentum on hit — use normal melee for that. */
 
 /obj/effect/proc_holder/spell/invoked/charge
 	name = "Charge!"
-	desc = "Infuse mana into your legs, charging forth three paces with unexpected force — \
-		bashing everything at the destination and knocking them back 1 tile. \
-		Builds 1 momentum on hit. \
+	desc = "Infuse mana into your legs, charging forth five paces — \
+		ramming everyone in your path to the sides for no damage. \
+		Bashes everything at the destination and knocks them back 1 tile. \
 		At 3+ momentum: consumes 3 to double damage. \
 		Strikes your aimed bodypart. Can be deflected by Defend stance."
 	clothes_req = FALSE
-	range = 5
+	range = 15
 	action_icon = 'icons/mob/actions/spellblade.dmi'
 	overlay_state = "advance" // Icon by Prominence. Shared with Advance since the spells are very similar.
 	releasedrain = 15
 	chargedrain = 0
 	chargetime = 5
-	recharge_time = 12 SECONDS
+	recharge_time = 15 SECONDS
 	warnie = "spellwarning"
 	no_early_release = TRUE
 	movement_interrupt = FALSE
@@ -32,11 +31,10 @@ Builds 1 momentum on hit. */
 	invocation_type = "shout"
 	gesture_required = TRUE
 	xp_gain = FALSE
-	var/charge_steps = 3
+	var/charge_steps = 5
 	var/base_damage = 45
 	var/empowered_mult = 2
 	var/base_push = 1
-	var/empowered_push = 1
 	var/momentum_cost = 3
 	var/step_delay = 2
 
@@ -73,7 +71,6 @@ Builds 1 momentum on hit. */
 		to_chat(H, span_notice("[momentum_cost] momentum released — empowered charge!"))
 
 	var/damage = empowered ? (base_damage * empowered_mult) : base_damage
-	var/push_dist = empowered ? empowered_push : base_push
 
 	if(H.buckled)
 		H.buckled.unbuckle_mob(H, TRUE)
@@ -82,6 +79,10 @@ Builds 1 momentum on hit. */
 		span_warning("[H] barrels forward!"),
 		span_notice("I charge!"))
 	playsound(start, pick('sound/combat/wooshes/bladed/wooshsmall (1).ogg', 'sound/combat/wooshes/bladed/wooshsmall (2).ogg'), 60, TRUE)
+
+	// Compute perpendicular directions for side-shoving
+	var/list/perp_dirs = get_perpendicular_dirs(facing)
+	var/shove_toggle = 0 // Alternate left/right
 
 	var/steps_taken = 0
 	for(var/i in 1 to charge_steps)
@@ -98,6 +99,17 @@ Builds 1 momentum on hit. */
 				break
 		if(blocked)
 			break
+
+		// Shove mobs on the next tile to the sides before stepping in
+		for(var/mob/living/victim in next)
+			if(victim == H || victim.stat == DEAD)
+				continue
+			var/shove_dir = perp_dirs[(shove_toggle % 2) + 1]
+			shove_toggle++
+			var/turf/shove_dest = get_step(get_turf(victim), shove_dir)
+			if(shove_dest && !shove_dest.density)
+				victim.safe_throw_at(shove_dest, 1, 1, H, force = MOVE_FORCE_STRONG)
+				victim.visible_message(span_warning("[victim] is shoved aside by [H]'s charge!"))
 
 		step(H, facing)
 		steps_taken++
@@ -127,22 +139,13 @@ Builds 1 momentum on hit. */
 		var/push_dir = get_dir(H, victim)
 		if(!push_dir)
 			push_dir = facing
-		victim.safe_throw_at(get_ranged_target_turf(victim, push_dir, push_dist), push_dist, 1, H, force = MOVE_FORCE_STRONG)
+		victim.safe_throw_at(get_ranged_target_turf(victim, push_dir, base_push), base_push, 1, H, force = MOVE_FORCE_STRONG)
 
-	// If no one was hit at destination, check the next tile ahead AND the tile
-	// that blocked the charge (e.g. someone standing on a table or log)
+	// If no one was hit at destination, check the next tile ahead
 	if(!hit_count)
-		var/list/extra_turfs = list()
 		var/turf/ahead = get_step(dest, facing)
 		if(ahead)
-			extra_turfs += ahead
-		// If the charge was stopped short, the blocking tile may have victims on it
-		if(steps_taken < charge_steps)
-			var/turf/blocked_turf = get_step(dest, facing)
-			if(blocked_turf && !(blocked_turf in extra_turfs))
-				extra_turfs += blocked_turf
-		for(var/turf/check_turf in extra_turfs)
-			for(var/mob/living/victim in check_turf)
+			for(var/mob/living/victim in ahead)
 				if(victim == H || victim.stat == DEAD)
 					continue
 				if(spell_guard_check(victim, FALSE, hit_count == 0 ? H : null))
@@ -156,15 +159,29 @@ Builds 1 momentum on hit. */
 				var/push_dir = get_dir(H, victim)
 				if(!push_dir)
 					push_dir = facing
-				victim.safe_throw_at(get_ranged_target_turf(victim, push_dir, push_dist), push_dist, 1, H, force = MOVE_FORCE_STRONG)
+				victim.safe_throw_at(get_ranged_target_turf(victim, push_dir, base_push), base_push, 1, H, force = MOVE_FORCE_STRONG)
 
 	if(!hit_count)
 		H.visible_message(span_notice("[H] finishes the charge with a swing at the air."))
 		return
 
-	if(M)
-		M.add_stacks(1)
 	playsound(dest, pick('sound/combat/ground_smash1.ogg', 'sound/combat/ground_smash2.ogg', 'sound/combat/ground_smash3.ogg'), 80, TRUE)
 
 	log_combat(H, null, "used Charge!")
 	return TRUE
+
+/obj/effect/proc_holder/spell/invoked/charge/proc/get_perpendicular_dirs(dir)
+	switch(dir)
+		if(NORTH, SOUTH)
+			return list(WEST, EAST)
+		if(EAST, WEST)
+			return list(NORTH, SOUTH)
+		if(NORTHEAST)
+			return list(NORTHWEST, SOUTHEAST)
+		if(NORTHWEST)
+			return list(NORTHEAST, SOUTHWEST)
+		if(SOUTHEAST)
+			return list(NORTHEAST, SOUTHWEST)
+		if(SOUTHWEST)
+			return list(NORTHWEST, SOUTHEAST)
+	return list(WEST, EAST)


### PR DESCRIPTION
## About The Pull Request
- Phalangite's Advance is now a 5 tiles leap (Visible) that jump you over mobs and let you stab someone
- Macebearer's Charge is now a 5 tiles charge that shoves people outta the way and bonk them.
- Reduced charge time to 1 on Azurean Javelin because it felt really awkward to charge for 2 seconds.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yae

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Stylistically both Phalangite and Macebearer felt a bit bad especially after I updated both of them's E to be something that is telegraphed when I realized a lot of their abilities weren't predictable or readable for fairness sake. 

But the two's E 's power is now underpowered relative to the charge time and predictability. So I distinguished the two once I figured out how

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Tweaked Spellblade Phalangite and Macebearer's E to become a 5 tiles leap / displacing charge respectively. Azurean Javelin now have a 1 second instead of 2 second charge time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
