### PR TITLE
[TM ONLY] kills timer based soundloop update

### DIFF
--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -1,27 +1,62 @@
 
 SUBSYSTEM_DEF(soundloopers)
-	name = "soundloopers"
+	name = "Soundloopers"
 	wait = 1
 	flags = SS_NO_INIT
 	priority = FIRE_PRIORITY_DEFAULT
 	var/list/processing = list()
 	var/list/currentrun = list()
-	var/client_ticker = 0
+	/// clients needing sound update on movement/sleep/death
+	var/list/dirty_clients = list()
+	/// dirty clients copied to this during `fire()` for clearing, after marking
+	var/list/currentdirtyrun = list()
+	/// for MC tracking
+	/*
+	L: active processing loop count.
+	P: persistent loop count.
+	D: pending/current dirty queue sizes.
+	MQ: total dirty-mark requests in the current minute.
+	UQ: unique clients enqueued in the current minute.
+	NC: nearby-client candidates scanned by source invalidation.
+	LD: loop-dirty calls in the current minute.
+	UP: actual update_sounds() runs in the current minute.	
+	SK: queued updates skipped because the client/mob no longer needed work.
+	*/
+	var/profile_window_started = 0
+	var/profile_mark_requests = 0
+	var/profile_unique_dirty_clients = 0
+	var/profile_nearby_candidates = 0
+	var/profile_loop_dirty_calls = 0
+	var/profile_updates_run = 0
+	var/profile_updates_skipped = 0
+
+/datum/controller/subsystem/soundloopers/proc/reset_profile_window()
+	profile_window_started = world.time
+	profile_mark_requests = 0
+	profile_unique_dirty_clients = 0
+	profile_nearby_candidates = 0
+	profile_loop_dirty_calls = 0
+	profile_updates_run = 0
+	profile_updates_skipped = 0
+
+/datum/controller/subsystem/soundloopers/stat_entry()
+	if(!profile_window_started || world.time >= profile_window_started + 1 MINUTES)
+		reset_profile_window()
+	..("L:[processing.len] P:[GLOB.persistent_sound_loops.len] D:[dirty_clients.len]/[currentdirtyrun.len] MQ:[profile_mark_requests] UQ:[profile_unique_dirty_clients] NC:[profile_nearby_candidates] LD:[profile_loop_dirty_calls] UP:[profile_updates_run] SK:[profile_updates_skipped]")
 
 /datum/controller/subsystem/soundloopers/fire(resumed = 0)
+	if(!profile_window_started || world.time >= profile_window_started + 1 MINUTES)
+		reset_profile_window()
+
 	if (!resumed || !currentrun.len)
-		src.currentrun = processing.Copy()
+		currentrun = processing.Copy()
+	if (!resumed || !currentdirtyrun.len)
+		currentdirtyrun = dirty_clients.Copy()
+		dirty_clients.Cut()
 
 	//cache for sanic speed (lists are references anyways)
-	var/list/current = src.currentrun
-	var/check_clients = FALSE
-	client_ticker++
-
-	if(client_ticker>=5) //this is dumb but necessary- clients update every half tick but sounds themselves need to be updated regularly
-		client_ticker = 0
-		check_clients = TRUE
-	else
-		check_clients = FALSE
+	var/list/current = currentrun
+	var/list/current_dirty = currentdirtyrun
 
 	while (current.len)
 		var/datum/looping_sound/thing = current[current.len]
@@ -36,19 +71,128 @@ SUBSYSTEM_DEF(soundloopers)
 			if(thing.sound_loop()) //returns 1 if it fails for some reason
 				continue
 
-		if(check_clients && thing.persistent_loop)
-			for(var/client/C in GLOB.clients)
-				if(C.mob) //Not in the lobby
-					C.update_sounds()
-
 		if (MC_TICK_CHECK)
 			return
 
+	while(current_dirty.len)
+		var/client/C = current_dirty[current_dirty.len]
+		current_dirty.len--
+		if(!C?.mob)
+			profile_updates_skipped++
+			continue
+		if(!C.played_loops.len && !GLOB.persistent_sound_loops.len)
+			profile_updates_skipped++
+			continue
+		profile_updates_run++
+		C.update_sounds()
+		if (MC_TICK_CHECK)
+			return
+
+// did this after a back and forth with AI for keeping clients/mobs clean and dirty and looping them.
+
+// marks a client for sound update
+/datum/controller/subsystem/soundloopers/proc/mark_client_dirty(client/C)
+	if(!C?.mob)
+		return
+	profile_mark_requests++
+	if(!(C in dirty_clients))
+		profile_unique_dirty_clients++
+	dirty_clients |= C
+
+// marks clients nearby for sound updates, too
+/datum/controller/subsystem/soundloopers/proc/mark_nearby_clients_dirty(atom/source)
+	var/turf/source_turf = get_turf(source)
+	if(!source_turf)
+		return
+
+	var/min_z = max(1, source_turf.z - 2)
+	var/max_z = min(world.maxz, source_turf.z + 2)
+	for(var/z_level in min_z to max_z)
+		for(var/mob/M as anything in SSmobs.clients_by_zlevel[z_level])
+			if(M?.client)
+				profile_nearby_candidates++
+				mark_client_dirty(M.client)
+
+// marks a soundloop as outdated if it moves/changes
+/datum/controller/subsystem/soundloopers/proc/mark_loop_dirty(datum/looping_sound/loop)
+	if(!loop?.persistent_loop)
+		return
+	profile_loop_dirty_calls++
+
+	var/atom/loop_parent = loop.parent?.resolve()
+	if(loop_parent)
+		mark_nearby_clients_dirty(loop_parent)
+
+	for(var/datum/weakref/listener_ref in loop.thingshearing)
+		var/mob/M = listener_ref.resolve()
+		if(M?.client)
+			mark_client_dirty(M.client)
+
+/client
+	var/datum/weakref/soundloop_tracked_mob
+	var/soundloop_waiting_for_revive = FALSE
+
+// handle mobs when sleeping or dead or revived (don't want soundloops processing during down stages)
+/client/proc/clear_soundloop_tracking(wait_for_revive = FALSE)
+	var/mob/tracked_mob = soundloop_tracked_mob?.resolve()
+	if(tracked_mob)
+		UnregisterSignal(tracked_mob, COMSIG_MOVABLE_MOVED)
+		if(isliving(tracked_mob))
+			UnregisterSignal(tracked_mob, list(COMSIG_LIVING_STATUS_SLEEP, COMSIG_LIVING_DEATH))
+			if(!wait_for_revive)
+				UnregisterSignal(tracked_mob, COMSIG_LIVING_REVIVE)
+	soundloop_waiting_for_revive = wait_for_revive
+	if(!wait_for_revive)
+		soundloop_tracked_mob = null
+
+// re-init loops to client/mob after stat changes
+/client/proc/refresh_soundloop_tracking()
+	clear_soundloop_tracking()
+	if(!mob)
+		return
+
+	RegisterSignal(mob, COMSIG_MOVABLE_MOVED, PROC_REF(handle_soundloop_mob_moved))
+	if(isliving(mob))
+		RegisterSignal(mob, COMSIG_LIVING_STATUS_SLEEP, PROC_REF(handle_soundloop_sleep_changed))
+		RegisterSignal(mob, COMSIG_LIVING_DEATH, PROC_REF(handle_soundloop_mob_death))
+		RegisterSignal(mob, COMSIG_LIVING_REVIVE, PROC_REF(handle_soundloop_mob_revive))
+	soundloop_tracked_mob = WEAKREF(mob)
+	soundloop_waiting_for_revive = FALSE
+	SSsoundloopers.mark_client_dirty(src)
+
+/client/proc/handle_soundloop_mob_moved(datum/source, atom/old_loc, dir, forced)
+	SIGNAL_HANDLER
+	SSsoundloopers.mark_client_dirty(src)
+
+/client/proc/handle_soundloop_sleep_changed(datum/source, amount, updating = TRUE, ignore_canstun = FALSE)
+	SIGNAL_HANDLER
+	SSsoundloopers.mark_client_dirty(src)
+
+/client/proc/handle_soundloop_mob_death(datum/source, gibbed)
+	SIGNAL_HANDLER
+	if(source == mob)
+		clear_soundloop_tracking(TRUE)
+
+/client/proc/handle_soundloop_mob_revive(datum/source, full_heal, admin_revive)
+	SIGNAL_HANDLER
+	if(source == mob && soundloop_waiting_for_revive)
+		refresh_soundloop_tracking()
+
+// micro-opt of caching refs
 /client/proc/update_sounds()
+	if(!mob)
+		return
+
+	var/list/client_played_loops = played_loops
+	var/turf/mob_turf = get_turf(mob)
+	if(!mob_turf)
+		return
+
+	var/datum/weakref/mob_ref = WEAKREF(mob)
 
 	//First we need to periodically scan if we moved into range of an already-playing sound
 	for(var/datum/looping_sound/PS in GLOB.persistent_sound_loops)
-		if(PS in played_loops) //Make sure it's not already on the list
+		if(PS in client_played_loops) //Make sure it's not already on the list
 			continue
 
 		var/atom/PS_parent = PS.parent.resolve()
@@ -56,11 +200,10 @@ SUBSYSTEM_DEF(soundloopers)
 			continue
 
 		var/turf/parent_turf = get_turf(PS_parent)
-		var/turf/mob_turf = get_turf(mob)
-		if(get_dist(get_turf(mob),parent_turf) > world.view + PS.extra_range) //Too far away. get_dist shouldn't be too awful for repeated calcs
+		if(get_dist(mob_turf, parent_turf) > world.view + PS.extra_range) //Too far away. get_dist shouldn't be too awful for repeated calcs
 			continue
 
-		if(mob_turf.z - parent_turf.z > 2 || mob_turf.z - parent_turf.z < 2) //for some reason get_dist not checking this properly
+		if(mob_turf.z - parent_turf.z > 2 || mob_turf.z - parent_turf.z < -2) //for some reason get_dist not checking this properly
 			continue
 
 		//otherwise add it to the client loops and off we go from there
@@ -73,9 +216,9 @@ SUBSYSTEM_DEF(soundloopers)
 		mob.playsound_local(parent_turf, PS.cursound, PS.volume, PS.vary, PS.frequency, PS.falloff, PS.channel, FALSE, our_sound, repeat = PS)
 
 	//Now we check how far away etc we are
-	for(var/datum/looping_sound/loop in played_loops)
+	for(var/datum/looping_sound/loop in client_played_loops)
 		if (!loop)
-			played_loops -= loop
+			client_played_loops -= loop
 			continue
 		
 		var/atom/loop_parent = loop.parent?.resolve()
@@ -87,18 +230,19 @@ SUBSYSTEM_DEF(soundloopers)
 
 		var/max_distance = world.view + loop.extra_range
 		var/turf/source_turf = get_turf(loop_parent)
-		var/distance_between = get_dist(mob, loop_parent)
 
 		if(isturf(loop_parent))
 			source_turf = loop_parent
 		if(!source_turf) //somehow
 			continue
 
-		var/list/found_loop = played_loops[loop]
+		var/distance_between = get_dist(mob_turf, source_turf)
+
+		var/list/found_loop = client_played_loops[loop]
 		var/sound/found_sound = found_loop["SOUND"]
 
 		if(!found_loop || !istype(found_sound)) //somethin fucky goin on. lets ignore it
-			played_loops -= loop
+			client_played_loops -= loop
 			continue
 
 		if(distance_between > max_distance || mob.IsSleeping()) // || !mob in hearers(max_distance,source_turf))
@@ -108,8 +252,8 @@ SUBSYSTEM_DEF(soundloopers)
 				found_loop["VOL"] = 0
 				mob.mute_sound(found_sound)
 			else
-				played_loops -= loop
-				loop.thingshearing -= WEAKREF(mob)
+				client_played_loops -= loop
+				loop.thingshearing -= mob_ref
 				mob.stop_sound_channel(found_sound.channel)
 
 		else if(distance_between <= max_distance)
@@ -129,8 +273,8 @@ SUBSYSTEM_DEF(soundloopers)
 					found_loop["VOL"] = 0
 					mob.mute_sound(found_sound)
 				else
-					played_loops -= loop
-					loop.thingshearing -= WEAKREF(mob)
+					client_played_loops -= loop
+					loop.thingshearing -= mob_ref
 					mob.stop_sound_channel(found_sound.channel)
 				continue
 
@@ -144,13 +288,12 @@ SUBSYSTEM_DEF(soundloopers)
 			new_volume = new_volume * (prefs.mastervol * 0.01) //Modify it at the end by the player's volume setting
 
 			if(old_volume != new_volume)
-				var/turf/T = get_turf(mob)
-				var/dx = source_turf.x - T.x
+				var/dx = source_turf.x - mob_turf.x
 				if(dx <= 1 && dx >= -1)
 					found_sound.x = 0
 				else
 					found_sound.x = dx
-				var/dz = source_turf.y - T.y
+				var/dz = source_turf.y - mob_turf.y
 				if(dz <= 1 && dz >= -1)
 					found_sound.z = 0
 				else
@@ -162,5 +305,5 @@ SUBSYSTEM_DEF(soundloopers)
 					found_loop["MUTESTATUS"] = FALSE
 					mob.unmute_sound(found_sound)
 				found_loop["VOL"] = new_volume
-				mob.update_sound_volume(played_loops[loop]["SOUND"], new_volume)
+				mob.update_sound_volume(found_sound, new_volume)
 

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -37,6 +37,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 */
 /datum/looping_sound
 	var/datum/weakref/parent // weakref to the atom we belong to
+	var/datum/weakref/movement_proxy
 	var/mid_sounds
 	var/mid_length = 1
 	var/start_sound
@@ -52,22 +53,22 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	var/falloff
 	var/frequency
 	var/stopped = TRUE
-	var/persistent_loop = FALSE //we stay in the client's played_loops so we keep updating volume even when out of range
+	/// If the soundloop stays in the client's played_loops so that volume is updated even when out of range.
+	var/persistent_loop = FALSE
 	var/cursound
-	var/list/thingshearing = list() // this is a list of WEAKREFS to the mobs that can currently hear us
+	// List of WEAKREFs listening in
+	var/list/thingshearing = list()
 	var/ignore_walls = TRUE
-	var/timerid
 	/// Has the looping started yet?
 	var/loop_started = FALSE
-	///our sound channel
+	/// Our sound channel
 	var/channel
 	var/datum/sound_group/sound_group
-	var/starttime // A world.time snapshot of when the loop was started.
+	// A world.time snapshot of when the loop was started.
+	var/starttime
+
 
 /datum/looping_sound/New(_parent, start_immediately=FALSE, _direct=FALSE, _channel = 0)
-/*	if(!mid_sounds)
-		WARNING("A looping sound datum was created without sounds to play.")//Obsolete now, instruments don't start with sounds
-		return*/
 	if(islist(_parent))
 		WARNING("A looping sound datum was created using a list, this is no longer allowed please change to a parent")
 		return
@@ -99,6 +100,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	if(start_immediately)
 		start()
 
+
 /datum/looping_sound/Destroy()
 	stop()
 	// really seriously make sure we have like none of these references hanging...
@@ -111,17 +113,18 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 		SSsounds.free_datum_channels(src)
 		channel = null
 	parent = null
+	movement_proxy = null
 	thingshearing = null
 	return ..()
+
 
 /datum/looping_sound/proc/start(atom/on_behalf_of)
 	stopped = FALSE
 	if(on_behalf_of)
 		set_parent(on_behalf_of)
 	loop_started = TRUE
-//	if(timerid)
-//		return
 	on_start()
+
 
 /datum/looping_sound/proc/stop(null_parent)
 	stopped = TRUE
@@ -129,15 +132,11 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 		set_parent(null)
 	on_stop()
 	loop_started = FALSE
-//		if(!timerid)
-//			return
-//		deltimer(timerid)
-//		timerid = null
+
 
 /datum/looping_sound/proc/sound_loop()
-//	START_PROCESSING(SSsoundloopers, src)
 	if(!cursound)
-		cursound = get_sound(starttime)
+		cursound = get_sound()
 
 	if(max_loops && cur_num_loops >= max_loops)
 		cur_num_loops = 0
@@ -150,8 +149,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 		return 1
 	if(!chance || prob(chance))
 		play(cursound)
-//	if(!timerid)
-//		timerid = addtimer(CALLBACK(src, PROC_REF(sound_loop), world.time), mid_length, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP)
+
 
 /datum/looping_sound/proc/play(soundfile)
 	var/sound/S = soundfile
@@ -196,6 +194,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 			else
 				on_hear_sound(M)
 
+
 /datum/looping_sound/proc/on_hear_sound(mob/M)
 	if(!persistent_loop || !M?.client)
 		return
@@ -211,41 +210,31 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	if(SD)
 		M.unmute_sound(SD)
 
-/datum/looping_sound/proc/get_sound(starttime, _mid_sounds)
+
+/datum/looping_sound/proc/get_sound(_mid_sounds)
 	. = _mid_sounds || mid_sounds
 	while(!isfile(.) && !isnull(.))
 		. = pickweight(.)
+
 
 /datum/looping_sound/proc/on_start()
 	var/start_wait = 0
 	if(start_sound) //does ANYTHING even use start_sound
 		play(start_sound)
 		start_wait = start_length
-	if(persistent_loop)
-		attach_loop_to_all_clients()
+	if(persistent_loop && !cursound)
+		cursound = get_sound(world.time, mid_sounds)
 	addtimer(CALLBACK(src, PROC_REF(begin_loop)), start_wait, TIMER_CLIENT_TIME)
 	if(persistent_loop && !(src in GLOB.persistent_sound_loops))
 		GLOB.persistent_sound_loops += src
 
-/datum/looping_sound/proc/attach_loop_to_all_clients()
-	if(!persistent_loop)
-		return
-
-	var/soundfile = get_sound(world.time, mid_sounds)
-	if(!soundfile)
-		return
-
-	cursound = soundfile
-	for(var/client/C in GLOB.clients)
-		var/mob/M = C.mob
-		if(!M)
-			continue
-
-		M.playsound_local(null, soundfile, 0, vary, frequency, falloff, channel, FALSE, null, src) 
 
 /datum/looping_sound/proc/begin_loop()
 	sound_loop()
+	if(persistent_loop)
+		SSsoundloopers.mark_loop_dirty(src)
 	START_PROCESSING(SSsoundloopers, src)
+
 
 /datum/looping_sound/proc/on_stop()
 //	play(end_sound)
@@ -270,18 +259,51 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 		if(P && P.client)
 			P.stop_sound_channel(channel) //This is mostly used for weather
 
+
+// handling movement of sound source
+/datum/looping_sound/proc/handle_move(atom/new_parent)
+	var/atom/movable/old_proxy = movement_proxy?.resolve()
+	if(old_proxy)
+		UnregisterSignal(old_proxy, COMSIG_MOVABLE_MOVED)
+	movement_proxy = null
+
+	if(!persistent_loop || !ismovableatom(new_parent))
+		return
+
+	var/atom/movable/proxy = get_atom_on_turf(new_parent)
+	if(!ismovableatom(proxy))
+		return
+
+	if(proxy == new_parent)
+		return
+
+	movement_proxy = WEAKREF(proxy)
+	RegisterSignal(proxy, COMSIG_MOVABLE_MOVED, PROC_REF(handle_parent_move))
+
+
 /datum/looping_sound/proc/set_parent(new_parent)
 	var/atom/real_parent = parent.resolve()
 
 	if(real_parent)
-		UnregisterSignal(real_parent, COMSIG_PARENT_QDELETING)
+		UnregisterSignal(real_parent, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
+	handle_move()
 	if(new_parent)
 		if(istype(new_parent, /datum/weakref)) // probably shouldn't happen but it does, so?
 			var/datum/weakref/passed_weakref = new_parent
 			new_parent = passed_weakref.resolve()
 		parent = WEAKREF(new_parent)
 		RegisterSignal(new_parent, COMSIG_PARENT_QDELETING, PROC_REF(handle_parent_del))
+		if(persistent_loop)
+			RegisterSignal(new_parent, COMSIG_MOVABLE_MOVED, PROC_REF(handle_parent_move))
+		handle_move(new_parent)
+
 
 /datum/looping_sound/proc/handle_parent_del(datum/source)
 	SIGNAL_HANDLER
 	set_parent(null)
+
+
+/datum/looping_sound/proc/handle_parent_move(datum/source, atom/old_loc, dir, forced)
+	SIGNAL_HANDLER
+	if(loop_started)
+		SSsoundloopers.mark_loop_dirty(src)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -92,6 +92,8 @@
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
 	if(isliving(src))
 		enable_client_mobs_in_contents(client)
+	if(client)
+		client.refresh_soundloop_tracking()
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
 
 /**

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,6 +1,8 @@
 /mob/Logout()
 	log_message("[key_name(src)] is no longer owning mob [src]([src.type])", LOG_OWNERSHIP)
 	SStgui.on_logout(src)
+	if(client)
+		client.clear_soundloop_tracking()
 	unset_machine()
 	clear_typing_indicator()
 	GLOB.player_list -= src


### PR DESCRIPTION
## About The Pull Request

back and forthing with AI got me this, now. 

ENTIRELY NUFC:

soundloop updates refreshing on ticks is massively unhealthy for what it effectively deals with. so the biggest change here is letting it use signals to check `outdated` clients/mobs and refreshing them as needed.
also kills soundloop updating for dead people.

## Testing Evidence

sounds do work but whether the micro-opts do anything needs to be tested.

## Why It's Good For The Game

who even gaf anymo

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: refactors soundloop updates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
