### PR TITLE
Removes the ambush from trying to cut kneestingers with the wrong tool

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -104,7 +104,7 @@
 			var/mob/living/L = user
 			if(L.electrocute_act(30, src)) // The kneestingers will let you pass if you worship dendor, but they won't take your stupid ass hitting them.
 				L.emote("painscream")
-				L.consider_ambush(always = TRUE)
+				//L.consider_ambush(always = TRUE) // Excessively punishing for what is usually a mistake.
 				if(L.throwing)
 					L.throwing.finalize(FALSE)
 				return FALSE
@@ -135,7 +135,7 @@
 	qdel(src)
 
 /obj/structure/glowshroom/dendorite
-	var/timeleft = null //5 MINUTES //balancing factor no longer relevant, uncommoent if gay. 
+	var/timeleft = null //5 MINUTES //balancing factor no longer relevant, uncommoent if gay.
 
 /obj/structure/glowshroom/dendorite/Initialize()
 	. = ..()

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -104,7 +104,6 @@
 			var/mob/living/L = user
 			if(L.electrocute_act(30, src)) // The kneestingers will let you pass if you worship dendor, but they won't take your stupid ass hitting them.
 				L.emote("painscream")
-				//L.consider_ambush(always = TRUE) // Excessively punishing for what is usually a mistake.
 				if(L.throwing)
 					L.throwing.finalize(FALSE)
 				return FALSE


### PR DESCRIPTION
## About The Pull Request

Removes the ambush from trying to cut kneestingers with the wrong tool.

## Testing Evidence

I comment out one line of code, I think you can trust me.

## Why It's Good For The Game

Players who don't know better, or make a misclick, already get punished by a pretty painful zap. To then follow up by jumping them _while they are stunned_ with multiple enemies from skeletons to bogmen will usually result in a death that feels horribly unfair.

This PR lessens the severity of the mistake so the player can learn, "Oh, this tool conducts electricity, I can't cut this."

As an aside, I feel like "conductive" is not applied consistently or intuitively across weapons. I'll look at that some other day.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Removed ambush punishment when attacking kneestingers with the wrong tool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
