### PR TITLE
Veteran Readability and Virtues

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/veteran.dm
@@ -82,6 +82,7 @@
 	)
 	subclass_stashed_items = list(
 		"Spare House Key" = /obj/item/roguekey/veteran,
+		"Prized Aged Cheese" = /obj/item/reagent_containers/food/snacks/rogue/cheddar/aged,
 	)
 // Normal veteran start, from the olden days.
 
@@ -197,6 +198,7 @@
 	)
 	subclass_stashed_items = list(
 		"Spare House Key" = /obj/item/roguekey/veteran,
+		"Prized Aged Cheese" = /obj/item/reagent_containers/food/snacks/rogue/cheddar/aged,
 	)
 
 // No hero, just a normal guy who happened to survive war.
@@ -309,6 +311,7 @@
 	)
 	subclass_stashed_items = list(
 		"Spare House Key" = /obj/item/roguekey/veteran,
+		"Prized Aged Cheese" = /obj/item/reagent_containers/food/snacks/rogue/cheddar/aged,
 	)
 
 // You get a SAIGA. Saigas are pretty good, you lose out on your legendary weapon skills and you suck more on foot though.
@@ -432,6 +435,7 @@
 	)
 	subclass_stashed_items = list(
 		"Spare House Key" = /obj/item/roguekey/veteran,
+		"Prized Aged Cheese" = /obj/item/reagent_containers/food/snacks/rogue/cheddar/aged,
 	)
 
 // Normal veteran start, from the olden days
@@ -564,6 +568,7 @@
 	)
 	subclass_stashed_items = list(
 		"Spare House Key" = /obj/item/roguekey/veteran,
+		"Prized Aged Cheese" = /obj/item/reagent_containers/food/snacks/rogue/cheddar/aged,
 	)
 
 // Originally was meant to be a horse archer. I decided that was a bad idea.
@@ -675,6 +680,7 @@
 	)
 	subclass_stashed_items = list(
 		"Spare House Key" = /obj/item/roguekey/veteran,
+		"Prized Aged Cheese" = /obj/item/reagent_containers/food/snacks/rogue/cheddar/aged,
 	)
 
 // The sneaker. Not really typical, but hey, wildcard. Wanna-be Spymaster. I guess that just makes them a normal spy, or, once one.


### PR DESCRIPTION
## About The Pull Request
Major Points:

All Veteran Subclasses now get Spare house Keys in their stash.

All Veteran Subclasses now get Battleready. (Essentially no stam loss while staying in combat mode) - Battle Master already had this!

To counteract this: Battlemaster will get  Battle Aware as extra.

Veteran Scout now gets the Sleuth Trait.
Veteran Spy now gets Light Step Trait.
Veteran Mercenaries now get to choose the other usual loadout stuff from Grenzelhoft. Regimen is now Master.

Veterans now have their skills listed w/o having to scroll down to the modifier.  AKA the Old Modifier.

Aged Cheese. Because I have been told to do so and I found it quite funny.

Minor Points:

Knight now gets a Noble Scabbard. They are nobility

Mercenary gets shield skill to Journeyman. Normal Grenzels get it. Mercenary also gets a Mercenary key, if its abused remove it.

## Testing Evidence

<img width="1242" height="728" alt="Screenshot 2026-03-08 182423" src="https://github.com/user-attachments/assets/0207d904-78b7-4f8e-b530-79a767907823" />

<img width="1286" height="697" alt="image" src="https://github.com/user-attachments/assets/b3f22231-2190-4590-89b1-2d1b44c86673" />

## Why It's Good For The Game

Readability. Parity. Roleplay. Cheese.

## Changelog

:cl:
qol: Veteran is now more readable for Devs and Players
balance: Gave more traits and rebalanced some of the advance classes to fit their role better
/:cl:

