### PR TITLE
[Bugfixes and QoL] - Fixes herb seeds not being crafting compliant

### DIFF
--- a/code/modules/farming/helpers.dm
+++ b/code/modules/farming/helpers.dm
@@ -14,6 +14,17 @@
 /proc/get_farming_do_time(mob/user, time)
 	return time / get_farming_effort_multiplier(user, 3)
 
+/proc/get_herb_effort_multiplier(mob/user, factor = 2)
+	var/farming_lvl = user.get_skill_level(/datum/skill/labor/farming)
+	var/medicine_lvl = user.get_skill_level(/datum/skill/misc/medicine)
+	var/effective_lvl = max(farming_lvl, medicine_lvl)
+
+	return (10 + (effective_lvl * factor)) * 0.1
+
+/proc/get_herb_do_time(mob/user, time)
+	var/multiplier = get_herb_effort_multiplier(user, 3)
+	return time / multiplier
+
 /proc/apply_farming_fatigue(mob/user, fatigue_amount)
 	var/multiplier = get_farming_effort_multiplier(user)
 	user.stamina_add(fatigue_amount / multiplier)

--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -113,7 +113,7 @@
 	name = "sui dust"
 	category = "Table"
 	result = list(/obj/item/alch/transisdust)
-	reqs = list(/obj/item/herbseed/taraxacum = 1, /obj/item/herbseed/euphrasia = 1, /obj/item/herbseed/hypericum = 1, /obj/item/herbseed/salvia = 1)
+	reqs = list(/obj/item/herbseed/taraxacum = 1, /obj/item/herbseed/hypericum = 1, /obj/item/herbseed/salvia = 1)
 	craftdiff = 3
 
 //Hard to craft but feasable, will give ONE vial but that has 10 units so, enough to cure 2 people if they ration it.

--- a/code/modules/roguetown/roguejobs/alchemist/herb_seeds.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/herb_seeds.dm
@@ -8,6 +8,10 @@
 	var/makes_herb = null
 	var/seed_identity = "unknown"
 
+/obj/item/herbseed/Initialize(mapload)
+	name = "herb seeds"
+	. = ..()
+
 /obj/item/herbseed/examine(mob/user)
 	. = ..()
 	var/show_real_identity = FALSE
@@ -30,7 +34,7 @@
 		return
 	else if(istype(T, /turf/open/floor/rogue/dirt))
 		to_chat(user, span_notice("I begin making a mound for the seeds..."))
-		if(do_after(user, get_farming_do_time(user, 5 SECONDS), target = src))
+		if(do_after(user, get_herb_do_time(user, 5 SECONDS), target = src))
 			apply_farming_fatigue(user, 30)
 			soil = get_soil_on_turf(T)
 			if(!soil)
@@ -60,65 +64,81 @@
 	return
 
 /obj/item/herbseed/atropa
-	makes_herb = /obj/structure/flora/roguegrass/herb/atropa
+	name = "atropa seeds"
 	seed_identity = "atropa seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/atropa
 
 /obj/item/herbseed/matricaria
-	makes_herb = /obj/structure/flora/roguegrass/herb/matricaria
+	name = "matricaria seeds"
 	seed_identity = "matricaria seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/matricaria
 
 /obj/item/herbseed/symphitum
-	makes_herb = /obj/structure/flora/roguegrass/herb/symphitum
+	name = "symphitum seeds"
 	seed_identity = "symphitum seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/symphitum
 
 /obj/item/herbseed/taraxacum
-	makes_herb = /obj/structure/flora/roguegrass/herb/taraxacum
+	name = "taraxacum seeds"
 	seed_identity = "taraxacum seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/taraxacum
 
 /obj/item/herbseed/euphrasia
-	makes_herb = /obj/structure/flora/roguegrass/herb/euphrasia
+	name = "euphrasia seeds"
 	seed_identity = "euphrasia seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/euphrasia
 
 /obj/item/herbseed/paris
-	makes_herb = /obj/structure/flora/roguegrass/herb/paris
+	name = "paris seeds"
 	seed_identity = "paris seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/paris
 
 /obj/item/herbseed/calendula
-	makes_herb = /obj/structure/flora/roguegrass/herb/calendula
+	name = "calendula seeds"
 	seed_identity = "calendula seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/calendula
 
 /obj/item/herbseed/mentha
-	makes_herb = /obj/structure/flora/roguegrass/herb/mentha
+	name = "mentha seeds"
 	seed_identity = "mentha seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/mentha
 
 /obj/item/herbseed/urtica
-	makes_herb = /obj/structure/flora/roguegrass/herb/urtica
+	name = "urtica seeds"
 	seed_identity = "urtica seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/urtica
 
 /obj/item/herbseed/salvia
-	makes_herb = /obj/structure/flora/roguegrass/herb/salvia
+	name = "salvia seeds"
 	seed_identity = "salvia seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/salvia
 
 /obj/item/herbseed/hypericum
-	makes_herb = /obj/structure/flora/roguegrass/herb/hypericum
+	name = "hypericum seeds"
 	seed_identity = "hypericum seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/hypericum
 
 /obj/item/herbseed/benedictus
-	makes_herb = /obj/structure/flora/roguegrass/herb/benedictus
+	name = "benedictus seeds"
 	seed_identity = "benedictus seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/benedictus
 
 /obj/item/herbseed/valeriana
-	makes_herb = /obj/structure/flora/roguegrass/herb/valeriana
+	name = "valeriana seeds"
 	seed_identity = "valeriana seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/valeriana
 
 /obj/item/herbseed/artemisia
-	makes_herb = /obj/structure/flora/roguegrass/herb/artemisia
+	name = "artemisia seeds"
 	seed_identity = "artemisia seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/artemisia
 
 /obj/item/herbseed/rosa
-	makes_herb = /obj/structure/flora/roguegrass/herb/rosa
+	name = "rosa seeds"
 	seed_identity = "rosa seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/rosa
 
 /obj/item/herbseed/manabloom
-	makes_herb = /obj/structure/flora/roguegrass/herb/manabloom
+	name = "manabloom seeds"
 	seed_identity = "manabloom seeds"
+	makes_herb = /obj/structure/flora/roguegrass/herb/manabloom


### PR DESCRIPTION
## About The Pull Request
Turns out obfuscating basic variables on initial set instead of post init is a bad idea. This fixes that bad idea.

- Cuts out one seed from sui dust crafting recipe. 4 is a bit much for something that has mostly just RP value. And a niche use for eoran trees.
- Digging furrows with herb seeds now takes the highest between medicine and farming skill, cutting out a lot of the tedium of being a keeper or apothecary growing herbs. Mages can uh, I unno.

## Testing Evidence
<img width="1900" height="1073" alt="image" src="https://github.com/user-attachments/assets/610f6861-a822-4cd5-81d4-09b27298bbda" />

## Why It's Good For The Game

Sure this technically makes herb seeds really quick farming tools for trained physicians but we'll just say being a doctor with a degree really brings out the inner bunny-burrow digging prowess. It's a lot of work but furrows should be made into their own types for herbs down the line instead of making normal farming furrows.

Herb seeds were showing up as 'herb seeds' in the crafting menu as it takes values from the type.

Let people be trans.

## Changelog

:cl:
fix: Herb seed names are no longer obfuscated in the crafting menu.
qol: Digging furrows with herb seeds now takes medicine skill if it is higher than farming skill.
balance: Sui dust is cheaper.
/:cl:
