### PR TITLE
Scale adventurer + wretch slots BEFORE assigning jobs at ready up.

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -258,8 +258,7 @@ SUBSYSTEM_DEF(migrants)
 
 	SSticker.minds += character.mind
 	GLOB.joined_player_list += character.ckey
-	update_wretch_slots()
-	update_adventurer_slots()
+	update_scaling_slots()
 	if(character.client)
 		character.client.update_ooc_verb_visibility()
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -336,6 +336,15 @@ SUBSYSTEM_DEF(ticker)
 
 	CHECK_TICK
 
+	// Pre-scale wretch and adventurer slots before job assignment using readied player count.
+	// Add ~10% buffer to account for immediate latejoins.
+	var/readied_count = 0
+	for(var/mob/dead/new_player/player in GLOB.new_player_list)
+		if(player.ready == PLAYER_READY_TO_PLAY)
+			readied_count++
+	var/estimated_pop = round(readied_count * 1.1)
+	update_scaling_slots(estimated_pop)
+
 	can_continue = can_continue && SSjob.DivideOccupations(list()) 				//Distribute jobs
 
 	CHECK_TICK
@@ -480,8 +489,7 @@ SUBSYSTEM_DEF(ticker)
 			continue
 		if(player.ready == PLAYER_READY_TO_PLAY)
 			GLOB.joined_player_list += player.ckey
-			update_wretch_slots()
-			update_adventurer_slots()
+			update_scaling_slots()
 			player.create_character(FALSE)
 		else
 			player.new_player_panel()

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -130,9 +130,10 @@
 	to_chat(H, span_danger("You are playing an Antagonist role. By choosing to spawn as a Wretch, you are expected to actively create conflict with other players. Failing to play this role with the appropriate gravitas may result in punishment for Low Roleplay standards."))
 
 /// Returns an assoc list with all intermediate wretch scaling values for admin display.
-/proc/calculate_wretch_scaling()
+/// If override_player_count is provided (e.g. from readied player count at roundstart), use that instead of the live joined list.
+/proc/calculate_wretch_scaling(override_player_count)
 	var/list/result = list()
-	var/player_count = length(GLOB.joined_player_list)
+	var/player_count = override_player_count || length(GLOB.joined_player_list)
 	result["player_count"] = player_count
 
 	// Tier 1: Population scaling, +1 per 10 players above 40, max 10
@@ -169,11 +170,11 @@
 
 	return result
 
-/proc/update_wretch_slots()
+/proc/update_wretch_slots(override_player_count)
 	var/datum/job/wretch_job = SSjob.GetJob("Wretch")
 	if(!wretch_job)
 		return
-	var/list/scaling = calculate_wretch_scaling()
+	var/list/scaling = calculate_wretch_scaling(override_player_count)
 	var/slots = scaling["final_slots"]
 	// Never reduce below current occupancy
 	wretch_job.total_positions = max(wretch_job.current_positions, slots)
@@ -192,12 +193,13 @@
 	if(!wretch_job)
 		return
 	wretch_job.current_positions = max(0, wretch_job.current_positions - 1)
-	update_wretch_slots()
+	update_scaling_slots()
 
 /// Returns an assoc list with intermediate adventurer scaling values for admin display.
-/proc/calculate_adventurer_scaling()
+/// If override_player_count is provided (e.g. from readied player count at roundstart), use that instead of the live joined list.
+/proc/calculate_adventurer_scaling(override_player_count)
 	var/list/result = list()
-	var/player_count = length(GLOB.joined_player_list)
+	var/player_count = override_player_count || length(GLOB.joined_player_list)
 	result["player_count"] = player_count
 
 	var/slots = 20
@@ -208,12 +210,17 @@
 
 	return result
 
-/proc/update_adventurer_slots()
+/proc/update_adventurer_slots(override_player_count)
 	var/datum/job/adventurer_job = SSjob.GetJob("Adventurer")
 	if(!adventurer_job)
 		return
-	var/list/scaling = calculate_adventurer_scaling()
+	var/list/scaling = calculate_adventurer_scaling(override_player_count)
 	var/slots = scaling["final_slots"]
 	// Never reduce below current value, so admin-opened slots aren't overwritten.
 	adventurer_job.total_positions = max(adventurer_job.total_positions, slots)
 	adventurer_job.spawn_positions = max(adventurer_job.spawn_positions, slots)
+
+/// Convenience proc to update both wretch and adventurer scaling in one call.
+/proc/update_scaling_slots(override_player_count)
+	update_wretch_slots(override_player_count)
+	update_adventurer_slots(override_player_count)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -509,8 +509,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			give_madness(humanc, GLOB.curse_of_madness_triggered)
 */
 	GLOB.joined_player_list += character.ckey
-	update_wretch_slots()
-	update_adventurer_slots()
+	update_scaling_slots()
 /*
 	if(CONFIG_GET(flag/allow_latejoin_antagonists) && humanc)	//Borgs aren't allowed to be antags. Will need to be tweaked if we get true latejoin ais.
 		if(SSshuttle.emergency)


### PR DESCRIPTION
## About The Pull Request
- Now, before jobs are assigned to everyone, adventurer and wretch slots are scaled beforehand so that people don't need to wait for the next latejoin before it scales
- It treats the readied up pop as the total amount of pop in game as the amount of pop that has joined the game, and add a +10% buffer to account for our playerbase being bottoms. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
None

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Avoid having to wait for a latejoin before the first scaling

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adventurer / Wretch slots now scales before positions are assigned at roundstart, based on amount of readied up players + 10%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
