### PR TITLE
Maintaining Previous PRs #6 - Properly cohesivizes(?) all alloyed-tipped whip recipes.

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -346,9 +346,9 @@
 	created_item = /obj/item/rogueweapon/mace/warhammer/bronze
 
 /datum/anvil_recipe/weapons/bronze/whip
-	name = "Whip, Bronze-Tipped (+3 Cured Leather)"
+	name = "Whip, Bronze-Tipped (+1 Leather Whip)"
 	req_bar = /obj/item/ingot/bronze
-	additional_items = list(/obj/item/natural/hide/cured, /obj/item/natural/hide/cured, /obj/item/natural/hide/cured)
+	additional_items = list(/obj/item/rogueweapon/whip)
 	created_item = /obj/item/rogueweapon/whip/bronze
 
 /datum/anvil_recipe/weapons/bronze/broadsword
@@ -1475,10 +1475,10 @@
 	i_type = "Weapons"
 
 /datum/anvil_recipe/weapons/psy/whip
-	name = "Psydonic Whip (+3 Cured Leather)"
+	name = "Psydonic Whip (+1 Leather Whip)"
 	req_bar = /obj/item/ingot/silverblessed
 	created_item = /obj/item/rogueweapon/whip/psywhip_lesser
-	additional_items = list(/obj/item/natural/hide/cured, /obj/item/natural/hide/cured, /obj/item/natural/hide/cured)
+	additional_items = list(/obj/item/rogueweapon/whip)
 	i_type = "Weapons"
 
 /// BLESSED SILVER, BULLION VARIANTS - FALLBACK


### PR DESCRIPTION
## About The Pull Request

* Bronze and Psydonic Whips now require a Leather Whip to craft, instead of three cured leather straps - like the Silver Whip.

## Testing Evidence

* One-liner. My bad for accidentally causing a server-wide famine with the corking PR, as well.

## Why It's Good For The Game

* Makes crafting recipe logic a little more cohesive.
* Player-requested by Lamas.

## Changelog

:cl:
add: Alloy-tipped whips now require a leather whip to craft, instead of just cured leather.
/:cl:
