### PR TITLE
fix arcyne strike

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_strike.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_strike.dm
@@ -91,3 +91,7 @@
 			playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
 			qdel(src)
 			return BULLET_ACT_BLOCK
+		if(istype(M, /mob/living/carbon) && (src.apply_mark == TRUE))
+			apply_arcane_mark(M)
+	else
+		return


### PR DESCRIPTION
## About The Pull Request

Arcyne Strike now Finally inflict arcyne mark as it was supposed to do

## Testing Evidence

cut a few goblins on local, they started glowing after 3 smites

## Why It's Good For The Game
fixing my mistakes


## Changelog

:cl:
fix: fixed arcyne strike(smite) not inflicting arcane marks
/:cl:
