### PR TITLE
Acolytes count as two  person for antagonist scale, half for wretch s…

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -220,6 +220,7 @@
 #define BITFLAG_ROYALTY (1<<1)
 #define BITFLAG_CONSTRUCTOR (1<<2)
 #define BITFLAG_GARRISON (1<<3)
+#define BITFLAG_HALF_COMBATANT (1<<4) // For acolytes only, who are counted as half combatant for the purposes of wretch / antagonist scaling
 
 // START OF THE ECONOMY SECTION 
 #define ECONOMIC_RICH rand(120, 140)

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -11,6 +11,8 @@
 #define DESC_POPUP_HEIGHT 250
 /// A town combatant role counts as 1 + this value towards effective population
 #define TOWN_COMBATANT_ADDITIONAL_WEIGHT 2
+/// A half combatant (acolyte) counts as 1 + this value towards effective population
+#define HALF_COMBATANT_ADDITIONAL_WEIGHT 1
 
 SUBSYSTEM_DEF(gamemode)
 	name = "Gamemode"
@@ -170,7 +172,8 @@ SUBSYSTEM_DEF(gamemode)
 	var/constructor = 0
 	var/garrison = 0
 	var/holy_warrior = 0
-	/// Calculated effective pop after weighing garrison & holy warriors at 2x
+	var/half_combatant = 0
+	/// Calculated effective pop after weighing garrison & holy warriors at 3x, acolytes at 2x
 	var/effective_pop = 0 
 
 	/// Is storyteller secret or not
@@ -283,7 +286,7 @@ SUBSYSTEM_DEF(gamemode)
 
 /// Gets the number of antagonists the antagonist injection events will stop rolling after.
 /datum/controller/subsystem/gamemode/proc/get_antag_cap()
-	var/total_number = get_correct_popcount() + (garrison * TOWN_COMBATANT_ADDITIONAL_WEIGHT) + (holy_warrior * TOWN_COMBATANT_ADDITIONAL_WEIGHT)
+	var/total_number = get_correct_popcount() + (garrison * TOWN_COMBATANT_ADDITIONAL_WEIGHT) + (holy_warrior * TOWN_COMBATANT_ADDITIONAL_WEIGHT) + (half_combatant * HALF_COMBATANT_ADDITIONAL_WEIGHT)
 	effective_pop = total_number // For panel tracking
 	var/cap = FLOOR((total_number / ANTAG_CAP_DENOMINATOR), 1) + ANTAG_CAP_FLAT
 	return cap
@@ -489,6 +492,7 @@ SUBSYSTEM_DEF(gamemode)
 	constructor = 0
 	holy_warrior = 0
 	garrison = 0
+	half_combatant = 0
 	for(var/mob/player_mob as anything in GLOB.player_list)
 		if(!player_mob.client)
 			continue
@@ -506,6 +510,8 @@ SUBSYSTEM_DEF(gamemode)
 				constructor++
 			if(player_mob.mind.job_bitflag & BITFLAG_HOLY_WARRIOR)
 				holy_warrior++
+			if(player_mob.mind.job_bitflag & BITFLAG_HALF_COMBATANT)
+				half_combatant++
 			if(player_mob.mind.job_bitflag & BITFLAG_GARRISON)
 				garrison++
 	update_pop_scaling()
@@ -774,8 +780,8 @@ SUBSYSTEM_DEF(gamemode)
 	dat += "Storyteller: [current_storyteller ? "[current_storyteller.name]" : "None"] "
 	dat += " <a href='byond://?src=[REF(src)];panel=main;action=halt_storyteller' [halted_storyteller ? "class='linkOn'" : ""]>HALT Storyteller</a> <a href='byond://?src=[REF(src)];panel=main;action=open_stats'>Event Panel</a> <a href='byond://?src=[REF(src)];panel=main;action=set_storyteller'>Set Storyteller</a> <a href='byond://?src=[REF(user.client)];panel=main;viewinfluences=1'>View Influences</a> <a href='byond://?src=[REF(src)];panel=main'>Refresh</a>"
 	dat += "<BR><font color='#888888'><i>Storyteller determines points gained, event chances, and is the entity responsible for rolling events.</i></font>"
-	dat += "<BR>Active Players: [active_players]   (Royalty: [royalty], Garrison: [garrison], Town Workers: [constructor], Holy Warriors: [holy_warrior])"
-	dat += "<BR>Effective Population: [effective_pop] (Total: [active_players] + Garrison Bonus: [garrison * 2] + Holy Warrior Bonus: [holy_warrior * 2])"
+	dat += "<BR>Active Players: [active_players]   (Royalty: [royalty], Garrison: [garrison], Town Workers: [constructor], Holy Warriors: [holy_warrior], Acolytes: [half_combatant])"
+	dat += "<BR>Effective Population: [effective_pop] (Total: [active_players] + Garrison Bonus: [garrison * 2] + Holy Warrior Bonus: [holy_warrior * 2] + Acolyte Bonus: [half_combatant * 1])"
 	dat += "<BR>Antagonist Count vs Maximum: [get_antag_count()] / [get_antag_cap()]"
 
 	// Job Scaling Info
@@ -783,7 +789,7 @@ SUBSYSTEM_DEF(gamemode)
 	var/list/wretch_scaling = calculate_wretch_scaling()
 	var/datum/job/wretch_job = SSjob.GetJob("Wretch")
 	dat += "<BR>Wretch Slots: [wretch_job?.current_positions]/[wretch_job?.total_positions] — T1: [wretch_scaling["tier1_slots"]]/10, T2: +[wretch_scaling["tier2_extra"]] / 5 = [wretch_scaling["final_slots"]] final"
-	dat += "<BR>&nbsp;&nbsp;Garrison: [wretch_scaling["garrison"]], Holy Warriors: [wretch_scaling["holy_warrior"]], Combat Total: [wretch_scaling["combat_total"]] (need > 10 for T2)"
+	dat += "<BR>&nbsp;&nbsp;Garrison: [wretch_scaling["garrison"]], Holy Warriors: [wretch_scaling["holy_warrior"]], Acolytes: [wretch_scaling["acolyte"]] (half weight), Combat Total: [wretch_scaling["combat_total"]] (need > 10 for T2)"
 	if(wretch_scaling["major_antag_active"])
 		dat += "<BR>&nbsp;&nbsp;<font color='red'>MAJOR ANTAG ACTIVE (VL/LICH) — Tier 2 locked, max 10</font>"
 
@@ -1475,5 +1481,6 @@ SUBSYSTEM_DEF(gamemode)
 #undef DESC_POPUP_WIDTH
 #undef DESC_POPUP_HEIGHT
 #undef TOWN_COMBATANT_ADDITIONAL_WEIGHT
+#undef HALF_COMBATANT_ADDITIONAL_WEIGHT
 
 #undef INIT_ORDER_GAMEMODE

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -198,7 +198,7 @@
 	dat += "<b>Job Scaling:</b> "
 	dat += "Wretch [wretch_job?.current_positions]/[wretch_job?.total_positions] (T1: [wretch_scaling["tier1_slots"]]/10, T2: +[wretch_scaling["tier2_extra"]]/5) | "
 	dat += "Adventurer [adv_job?.current_positions]/[adv_job?.total_positions] (calc: [adv_scaling["final_slots"]]) | "
-	dat += "Garrison: [wretch_scaling["garrison"]] Holy: [wretch_scaling["holy_warrior"]]"
+	dat += "Garrison: [wretch_scaling["garrison"]] Holy: [wretch_scaling["holy_warrior"]] Acolytes: [wretch_scaling["acolyte"]] (half)"
 	if(wretch_scaling["major_antag_active"])
 		dat += " | <font color='red'>MAJOR ANTAG - T2 LOCKED</font>"
 	dat += "<BR><b>Antag Cap:</b> [SSgamemode.get_antag_count()] / [SSgamemode.get_antag_cap()] (weight used / max)"

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -156,9 +156,11 @@
 	// Tier 2: Garrison-gated expansion from 10 to 15
 	var/garrison_count = SSgamemode.garrison
 	var/holy_count = SSgamemode.holy_warrior
-	var/combat_count = garrison_count + holy_count
+	var/acolyte_count = SSgamemode.half_combatant
+	var/combat_count = garrison_count + holy_count + FLOOR(acolyte_count * 0.5, 1)
 	result["garrison"] = garrison_count
 	result["holy_warrior"] = holy_count
+	result["acolyte"] = acolyte_count
 	result["combat_total"] = combat_count
 
 	var/tier2_max = 0


### PR DESCRIPTION
## About The Pull Request
- Acolytes now count as two person (In contrast to garrison / retinue's 3) for antagonist scaling relative to effective pop
- It counts as half a person for wretch T2 scaling (I.e. 2 acolytes would count for 1 additional wretch slot between 10 to 15)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="670" height="650" alt="i3rGDgHguP" src="https://github.com/user-attachments/assets/c07b2756-7d89-4208-84bc-24c15c3736dd" />
<img width="500" height="500" alt="dreamseeker_C1ZOwUMNCa" src="https://github.com/user-attachments/assets/bfa6945e-1461-457e-aea2-4da944664a5e" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Acolytes generally is very town aligned and has decent impact in combat. But not as much as a "true" combat role. So this scaling should make it a bit more fair.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Acolyte now contributes 2 to effective pop for antagonist scaling instead of 1, in contrast to garrison / holy warriors' 3. They counts as half a person for enabling T2 wretch scaling between 10 to 15.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
