### PR TITLE
Fixes the Noc Helmet fov

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -933,7 +933,7 @@
 	emote_environment = 3
 	body_parts_covered = HEAD|HAIR|EARS
 	flags_inv = HIDEEARS|HIDEHAIR
-	block2add = FOV_BEHIND
+	block2add = FOV_DEFAULT
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 


### PR DESCRIPTION
## About The Pull Request
The Noc helmet is an open faced helmet yet had the 180 degree vision cone restriction, this fixes it to be in line with other helmets that do not cover the face.

## Testing Evidence

Nothing exploded when i tested this on my PC

## Why It's Good For The Game

Its more consistent, there is an issue where INGAME it shows it covers face but ive been told this is a backend issue and im not smart enough to fix that so instead I will fix the FOV thing

## Changelog




:cl:
fix: makes Noc Helmet use default FOV as intended

/:cl:


