### PR TITLE
Fixes Hangyaku and Chonin preview

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary.dm
@@ -43,6 +43,8 @@
 		/datum/advclass/mercenary/routier,
 		/datum/advclass/mercenary/rumaclan,
 		/datum/advclass/mercenary/rumaclan/sasu,
+		/datum/advclass/mercenary/hangyaku,
+		/datum/advclass/mercenary/chonin,
 		/datum/advclass/mercenary/seonjang,
 		/datum/advclass/mercenary/steppesman,
 		/datum/advclass/mercenary/warscholar,


### PR DESCRIPTION
## About The Pull Request

Hangyaku and Chonin were never added to mercenary.dm
This means they never showed up in the list of mercs until you actually join the round where they jumpscare you by existing.
This led to people gaslighting one another if they even existed in the first place.
Fixes that.

## Testing Evidence
Bad:
<img width="471" height="1019" alt="Screenshot 2026-03-10 152208" src="https://github.com/user-attachments/assets/706e0bb4-c9dc-4d97-831a-1aa60b304e5a" />
Good:
<img width="466" height="957" alt="Screenshot 2026-03-10 152100" src="https://github.com/user-attachments/assets/9caf20af-257b-407a-8d8f-8361dddc14fe" />
...holy we really do have too many mercs...
## Why It's Good For The Game
Bug bad.
Info goog.

## Changelog

:cl:
fix: fixed Hangyaku and Chonin not being included in the merc list
/:cl:
