### PR TITLE
Transfix fix

### DIFF
--- a/code/modules/vampire_neu/spells/transfix_neu.dm
+++ b/code/modules/vampire_neu/spells/transfix_neu.dm
@@ -61,12 +61,12 @@
 		user.visible_message("<font color='red'>[user]'s eyes glow a ghastly red as they project their will outwards!</font>")
 
 	for(var/mob/living/carbon/human/target as anything in targets)
-			var/current_will_dice = will_dice
-			if(target.cmode)
-				current_will_dice += 1
+		var/current_will_dice = will_dice
+		if(target.cmode)
+			current_will_dice += 1
 
-			var/willpower = round(target.STAINT / int_divisor, 1)
-			var/willroll = roll(willpower, current_will_dice)
+		var/willpower = round(target.STAINT / int_divisor, 1)
+		var/willroll = roll(willpower, current_will_dice)
 
 		// If the vampire failed badly
 		var/knowledgable = (willroll - bloodroll) >= 3


### PR DESCRIPTION
## About The Pull Request

Fixed a bug where the will_dice variable would permanently increment every time a target was in combat mode.

Replaced the permanent increment with a local variable to ensure the spell's difficulty resets after each cast.

Eye close proc refactor

## Testing Evidence

Verified via View Variables: will_dice now remains at its base value (6) after multiple casts against targets in cmode.

Tested 1v1 combat: roll math now correctly scales with the target's stats rather than inflating infinitely.

## Why It's Good For The Game

Prevents the "Transfix" spell from becoming mathematically impossible to land as the round progresses.

Ensures fair mechanics where success depends on skills and stats, not on how many times the spell was previously used.

## Changelog
:cl:
fix: Fixed a bug with the Transfix spell that caused its difficulty to infinitely increase each time it was used against targets in combat mode.
/:cl: