### PR TITLE
Fixes errant price on Steel Greatplumed Armets.

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
@@ -203,7 +203,7 @@
 
 /datum/supply_pack/rogue/armor_steel/helmet_knight_armetgreatplume
 	name = "Helmet, Armet, Greatplumed"
-	cost = 40
+	cost = 90
 	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/knight/greatplume)
 
 /datum/supply_pack/rogue/armor_steel/helmet_knight


### PR DESCRIPTION
## About The Pull Request

* Steel Greatplumed Armets now properly cost the same as their counterparts, when bought by the Merchant.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Unintended price. Ensures equilibrium.

## Changelog

:cl:
fix: Steel Greatplumed Armets now properly cost the same as a regular armet, when bought from the Merchant's machines.
/:cl: