### PR TITLE
Reduces weight class of bottlebombs and smokebombs to SMALL > NORMAL.

### DIFF
--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -4,7 +4,7 @@
 	desc = "A fiery explosion waiting to be coaxed from its glass prison."
 	icon_state = "bbomb"
 	icon = 'icons/roguetown/items/misc.dmi'
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 0
 	slot_flags = ITEM_SLOT_HIP
 	throw_speed = 0.5
@@ -251,7 +251,7 @@
 	desc = "A soft sphere with an alchemical mixture and a dispersion mechanism hidden inside. Any pressure will detonate it."
 	icon_state = "smokebomb"
 	icon = 'icons/roguetown/items/misc.dmi'
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 0
 	slot_flags = ITEM_SLOT_HIP
 	throw_speed = 0.5


### PR DESCRIPTION
## About The Pull Request

* Bottlebombs and smokebombs are now SMALL instead of NORMAL.
* Their actual size doesn't change at all. This just means they can be stowed in smaller containers.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Matches size with all other non-deployable explosives, ensuring cohesion.
* Slightly increases the chance of someone blowing up like a flametrooper on Omaha Beach, which is always good.

## Changelog

:cl:
balance: Bottlebombs and smokebombs can now fit in belts and other small-tiered containers.
/:cl:
