### PR TITLE
cap wretch slots to 10

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -1,4 +1,6 @@
-// Wretch, soft antagonists. Giving them 9 points as stat (matching mercs) on average since they're a driving antagonist on AP or assistant antagonist. 
+// Wretch, soft antagonists. Giving them 9 points as stat (matching mercs) on average since they're a driving antagonist on AP or assistant antagonist.
+#define MAX_WRETCH_SLOTS 10
+
 /datum/job/roguetown/wretch
 	title = "Wretch"
 	flag = WRETCH
@@ -153,7 +155,7 @@
 			break
 	result["major_antag_active"] = major_antag_active
 
-	// Tier 2: Garrison-gated expansion from 10 to 15
+	// Tier 2: Garrison-gated expansion metadata. Final wretch slots remain capped at 10.
 	var/garrison_count = SSgamemode.garrison
 	var/holy_count = SSgamemode.holy_warrior
 	var/acolyte_count = SSgamemode.half_combatant
@@ -168,6 +170,7 @@
 		tier2_max = min(max(0, combat_count - 10), 5)
 		slots += tier2_max
 	result["tier2_extra"] = tier2_max
+	slots = min(slots, MAX_WRETCH_SLOTS)
 	result["final_slots"] = slots
 
 	return result
@@ -226,3 +229,5 @@
 /proc/update_scaling_slots(override_player_count)
 	update_wretch_slots(override_player_count)
 	update_adventurer_slots(override_player_count)
+
+#undef MAX_WRETCH_SLOTS


### PR DESCRIPTION
## About The Pull Request

as it says on the tin

## Testing Evidence

cannot.

## Why It's Good For The Game

if people want to complain that 15 slots are too much while being bodied by 3 (whilst outnumbering them). we can test that hypothesis. either it works or those same people move to complaining about something else when they get killed after being bested.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: cap wretch slots to 10.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
