### PR TITLE
[TM ONLY] PSYDON prevents wretches/antags of any kind + other changes

### DIFF
--- a/code/__HELPERS/player_helpers.dm
+++ b/code/__HELPERS/player_helpers.dm
@@ -23,6 +23,7 @@
 				continue
 			J.current_positions = max(J.current_positions-1, 0)
 			reopened_jobs += L.job
+	enforce_storyteller_soft_antag_slots()
 
 //////////////////////////
 //Reports player logouts//

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -95,7 +95,7 @@ SUBSYSTEM_DEF(events)
 	SSgamemode.event_panel(user)
 
 /client/proc/forceGamemode()
-	set name = "Open Storyteller Panel"
+	set name = "Storyteller - Panel"
 	set category = "-GameMaster-"
 	if(!holder ||!check_rights(R_FUN))
 		return
@@ -107,3 +107,63 @@ SUBSYSTEM_DEF(events)
 /datum/controller/subsystem/events/proc/resetFrequency()
 	frequency_lower = initial(frequency_lower)
 	frequency_upper = initial(frequency_upper)
+
+/client/proc/view_storyteller_vote_log()
+	set category = "-GameMaster-"
+	set name = "Storyteller - Log"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/mob/user = mob
+	if(!user)
+		return
+
+	var/file_path = "data/last_round/storyteller_vote.json"
+	if(!fexists(file_path))
+		to_chat(src, span_warning("No storyteller vote log found."))
+		return
+
+	var/file_text = file2text(file_path)
+	var/list/file_data = safe_json_decode(file_text)
+	if(!islist(file_data))
+		var/datum/browser/raw_popup = new(user, "storyteller_vote_log", "Storyteller Vote Log", 700, 500)
+		raw_popup.set_content("<pre>[html_encode(file_text)]</pre>")
+		raw_popup.open()
+		return
+
+	var/state = file_data["state"]
+	if(!state)
+		state = "unknown"
+
+	var/winner = file_data["winner"]
+	if(!winner)
+		winner = "None"
+
+	var/list/dat = list()
+	dat += "<h2>Storyteller Vote Log</h2>"
+	dat += "<b>State:</b> [html_encode(state)]<br>"
+	dat += "<b>Winner:</b> [html_encode(winner)]<br><hr>"
+
+	var/list/votes = file_data["votes"]
+	if(!islist(votes) || !length(votes))
+		dat += "No votes recorded."
+	else
+		dat += "<table width='100%' style='text-align:left'>"
+		dat += "<tr><th>Ckey</th><th>Choice</th><th>Vote Power</th></tr>"
+		for(var/voter_ckey in votes)
+			var/list/vote_data = votes[voter_ckey]
+			if(!islist(vote_data))
+				continue
+			var/choice = vote_data["choice"]
+			if(!choice)
+				choice = "Unknown"
+			var/vote_power = vote_data["vote_power"]
+			if(isnull(vote_power))
+				vote_power = 0
+			dat += "<tr><td>[html_encode(voter_ckey)]</td><td>[html_encode(choice)]</td><td>[vote_power]</td></tr>"
+		dat += "</table>"
+
+	var/datum/browser/popup = new(user, "storyteller_vote_log", "Storyteller Vote Log", 700, 500)
+	popup.set_content(dat.Join())
+	popup.open()

--- a/code/controllers/subsystem/rogue/gnolls_subsystem.dm
+++ b/code/controllers/subsystem/rogue/gnolls_subsystem.dm
@@ -6,6 +6,13 @@ SUBSYSTEM_DEF(gnoll_scaling)
 	var/gnoll_playercount_lock = TRUE
 	var/desired_gnoll_slots = 1
 
+/datum/controller/subsystem/gnoll_scaling/proc/get_storyteller_for_gnoll_scaling()
+	if(ispath(SSgamemode.roundstart_storyteller, /datum/storyteller))
+		return SSgamemode.storytellers?[SSgamemode.roundstart_storyteller]
+	if(SSgamemode.current_storyteller)
+		return SSgamemode.current_storyteller
+	return SSgamemode.storytellers?[SSgamemode.selected_storyteller]
+
 /datum/controller/subsystem/gnoll_scaling/proc/unlock_gnoll_scaling()
 	var/players_amt = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
 	if(players_amt < 25)
@@ -13,6 +20,15 @@ SUBSYSTEM_DEF(gnoll_scaling)
 		return
 
 	gnoll_playercount_lock = FALSE
+	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
+	if(!gnoll_job)
+		return
+	if(is_storyteller_soft_antag_blocked())
+		var/peaceful_slots = gnoll_job.current_positions
+		gnoll_job.total_positions = peaceful_slots
+		gnoll_job.spawn_positions = peaceful_slots
+		desired_gnoll_slots = peaceful_slots
+		return
 
 	var/mode = get_gnoll_scaling()
 	var/target_slots = 1
@@ -24,13 +40,13 @@ SUBSYSTEM_DEF(gnoll_scaling)
 			target_slots = 2
 		if(GNOLL_SCALING_DYNAMIC)
 			target_slots = 3
+	desired_gnoll_slots = target_slots
 
 	// Increase this automatically even if no further people with hunted join.
-	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
-
 	if(gnoll_job.total_positions < target_slots)
-		gnoll_job.total_positions = target_slots
-		gnoll_job.spawn_positions = target_slots
+		var/final_slots = max(gnoll_job.current_positions, target_slots)
+		gnoll_job.total_positions = final_slots
+		gnoll_job.spawn_positions = final_slots
 
 		for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
 			if(player.client)
@@ -43,7 +59,10 @@ SUBSYSTEM_DEF(gnoll_scaling)
 	// Aiming for rougly 30 minutes into the round
 	// Will not unlock scaling if there's too few players
 	addtimer(CALLBACK(src, .proc/unlock_gnoll_scaling), 24000)
-	var/datum/storyteller/ST = SSgamemode.selected_storyteller
+	var/datum/storyteller/ST = get_storyteller_for_gnoll_scaling()
+	if(!ST)
+		gnoll_scaling_mode = GNOLL_SCALING_SINGLE
+		return gnoll_scaling_mode
 	// Roll a coinflip to decide the round's behavior when default value is supplied.
 	if(ST.preferred_gnoll_mode == GNOLL_SCALING_RANDOM)
 		gnoll_scaling_mode = pick(GNOLL_SCALING_FLAT, GNOLL_SCALING_SINGLE)

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -3,6 +3,8 @@
 #define DEFAULT_STORYTELLER_VOTE_OPTIONS 4
 ///amount of players we can have before no longer running votes for storyteller
 #define MAX_POP_FOR_STORYTELLER_VOTE 25
+#define LAST_ROUND_STATS_FILE "data/last_round/storyteller_vote.json"
+#define LAST_ROUND_STATS_STORYTELLER_VOTE "storyteller_vote"
 ///the duration into the round for which roundstart events are still valid to run
 #define ROUNDSTART_VALID_TIMEFRAME 3 MINUTES
 /// Width of a popup window that opens when user presses (?) and contains storyteller description
@@ -13,6 +15,36 @@
 #define TOWN_COMBATANT_ADDITIONAL_WEIGHT 2
 /// A half combatant (acolyte) counts as 1 + this value towards effective population
 #define HALF_COMBATANT_ADDITIONAL_WEIGHT 1
+
+/proc/is_storyteller_pending_or_roundstart(storyteller_type)
+	if(!ispath(storyteller_type, /datum/storyteller))
+		return FALSE
+	if(SSticker && SSticker.current_state != GAME_STATE_PLAYING && SSticker.current_state != GAME_STATE_FINISHED)
+		return SSgamemode.selected_storyteller == storyteller_type
+	if(ispath(SSgamemode.roundstart_storyteller, /datum/storyteller))
+		return SSgamemode.roundstart_storyteller == storyteller_type
+	return istype(SSgamemode.current_storyteller, storyteller_type)
+
+
+/proc/is_storyteller_villain_blocked()
+	return is_storyteller_pending_or_roundstart(/datum/storyteller/eora) || is_storyteller_pending_or_roundstart(/datum/storyteller/psydon)
+
+/proc/is_storyteller_soft_antag_blocked()
+	return is_storyteller_pending_or_roundstart(/datum/storyteller/psydon)
+
+/proc/enforce_storyteller_soft_antag_slots()
+	if(!is_storyteller_soft_antag_blocked())
+		return
+	for(var/job_title in list("Wretch", "Gnoll", "Assassin"))
+		var/datum/job/blocked_job = SSjob.GetJob(job_title)
+		if(!blocked_job)
+			continue
+		var/allowed_slots = max(0, blocked_job.current_positions)
+		blocked_job.total_positions = allowed_slots
+		blocked_job.spawn_positions = allowed_slots
+
+/proc/is_roundstart_roles_blocked_storyteller()
+	return is_storyteller_villain_blocked()
 
 SUBSYSTEM_DEF(gamemode)
 	name = "Gamemode"
@@ -32,8 +64,12 @@ SUBSYSTEM_DEF(gamemode)
 	var/datum/storyteller/current_storyteller
 	/// Result of the storyteller vote/pick. Defaults to Astrata.
 	var/selected_storyteller = /datum/storyteller/astrata
+	/// Storyteller that won the roundstart vote/pick for this round. Remains fixed after the round begins.
+	var/roundstart_storyteller
 	/// List of all the storytellers. Populated at init. Associative from type
 	var/list/storytellers = list()
+	/// Cached storyteller type that won the previous round's storyteller vote.
+	var/last_storyteller_vote
 	/// Next process for our storyteller. The wait time is STORYTELLER_WAIT_TIME
 	var/next_storyteller_process = 0
 	/// Associative list of even track points.
@@ -436,9 +472,11 @@ SUBSYSTEM_DEF(gamemode)
 		calc_value *= current_storyteller?.starting_point_multipliers[track]
 		calc_value *= (rand(100 - current_storyteller?.roundstart_points_variance,100 + current_storyteller?.roundstart_points_variance)/100)
 		event_track_points[track] = min(round(calc_value), round(point_thresholds[track] * 1.25))
+		if(track == EVENT_TRACK_CHARACTER_INJECTION && is_roundstart_roles_blocked_storyteller())
+			event_track_points[track] = 0
 
 	/// If the storyteller guarantees an antagonist roll, add points to make it so.
-	if(current_storyteller?.guarantees_roundstart_roleset && event_track_points[EVENT_TRACK_CHARACTER_INJECTION] < point_thresholds[EVENT_TRACK_CHARACTER_INJECTION])
+	if(!is_roundstart_roles_blocked_storyteller() && current_storyteller?.guarantees_roundstart_roleset && event_track_points[EVENT_TRACK_CHARACTER_INJECTION] < point_thresholds[EVENT_TRACK_CHARACTER_INJECTION])
 		event_track_points[EVENT_TRACK_CHARACTER_INJECTION] = point_thresholds[EVENT_TRACK_CHARACTER_INJECTION]
 
 	/// If we have any forced events, ensure we get enough points for them
@@ -560,7 +598,10 @@ SUBSYSTEM_DEF(gamemode)
 			to_chat(world, span_reallybig("[initialized_storyteller.name] is ascendant!"))
 			to_chat(world, "<br>")
 
-	pick_most_influential(TRUE)
+	if(!current_storyteller || current_storyteller.type != selected_storyteller)
+		init_storyteller()
+	if(!ispath(roundstart_storyteller, /datum/storyteller))
+		roundstart_storyteller = selected_storyteller
 	calculate_ready_players()
 	roll_pre_setup_points()
 	//handle_pre_setup_roundstart_events()
@@ -583,6 +624,7 @@ SUBSYSTEM_DEF(gamemode)
 	refresh_alive_stats()
 	handle_post_setup_roundstart_events()
 	handle_post_setup_points()
+	enforce_storyteller_soft_antag_slots()
 	roundstart_event_view = FALSE
 	return TRUE
 
@@ -710,7 +752,12 @@ SUBSYSTEM_DEF(gamemode)
 /datum/controller/subsystem/gamemode/proc/storyteller_vote_choices()
 	var/list/final_choices = list()
 	var/list/pick_from = list()
-	for(var/datum/storyteller/storyboy in get_valid_storytellers())
+	var/list/valid_storytellers = get_valid_storytellers()
+	var/previous_storyteller = get_last_storyteller_vote()
+	var/can_exclude_previous = length(valid_storytellers) > 1
+	for(var/datum/storyteller/storyboy in valid_storytellers)
+		if(can_exclude_previous && previous_storyteller == storyboy.type)
+			continue
 		if(storyboy.always_votable)
 			final_choices["<b>[storyboy.name]</b><a href='?src=[REF(src)];storyboy_details=[storyboy.type]'>(?)</a>"] = 0
 		else
@@ -733,16 +780,54 @@ SUBSYSTEM_DEF(gamemode)
 
 
 /datum/controller/subsystem/gamemode/proc/storyteller_vote_result(html_contaminated)
+	var/matched_storyteller = FALSE
 	for(var/storyteller_type in storytellers)
 		var/datum/storyteller/storyboy = storytellers[storyteller_type]
 		if(findtext(html_contaminated, storyboy.name))
 			selected_storyteller = storyboy.type
+			matched_storyteller = TRUE
 			SSgnoll_scaling.get_gnoll_scaling() // Calling this here as to make sure scaling holds true as per the roundstart vote, not a latejoin hunted character joining.
 			break
+	if(matched_storyteller)
+		save_last_storyteller_vote(selected_storyteller)
 
 	var/datum/storyteller/storytypecasted = selected_storyteller
 	to_chat(world, span_notice("<b>Storyteller is [initial(storytypecasted.name)]!</b>"))
 	to_chat(world, span_notice("[initial(storytypecasted.vote_desc)]"))
+
+/datum/controller/subsystem/gamemode/proc/get_last_storyteller_vote()
+	if(last_storyteller_vote)
+		return last_storyteller_vote
+	var/json_file = file(LAST_ROUND_STATS_FILE)
+	if(!fexists(json_file))
+		return null
+	var/list/last_round_stats = safe_json_decode(file2text(json_file))
+	if(!islist(last_round_stats))
+		return null
+	if(last_round_stats["state"] != "completed")
+		return null
+	var/loaded_path = text2path(trim(last_round_stats[LAST_ROUND_STATS_STORYTELLER_VOTE]))
+	if(!ispath(loaded_path, /datum/storyteller))
+		return null
+	last_storyteller_vote = loaded_path
+	return last_storyteller_vote
+
+/datum/controller/subsystem/gamemode/proc/save_last_storyteller_vote(storyteller_type)
+	if(!ispath(storyteller_type, /datum/storyteller))
+		return
+	last_storyteller_vote = storyteller_type
+	var/json_file = file(LAST_ROUND_STATS_FILE)
+	var/list/last_round_stats = list()
+	if(!fexists(json_file))
+		WRITE_FILE(json_file, "{}")
+	else
+		last_round_stats = safe_json_decode(file2text(json_file))
+	if(!islist(last_round_stats))
+		last_round_stats = list()
+	last_round_stats[LAST_ROUND_STATS_STORYTELLER_VOTE] = "[storyteller_type]"
+	fdel(json_file)
+	WRITE_FILE(json_file, json_encode(last_round_stats))
+	message_admins("Storyteller vote was saved as [storyteller_type]")
 
 ///return a weighted list of all storytellers that are currently valid to roll, if return_types is set then we will return types instead of instances
 /datum/controller/subsystem/gamemode/proc/get_valid_storytellers(return_types = FALSE)
@@ -767,7 +852,12 @@ SUBSYSTEM_DEF(gamemode)
 	var/datum/storyteller/chosen_storyteller = storytellers[passed_type]
 	chosen_storyteller.times_chosen++
 	GLOB.featured_stats[FEATURED_STATS_STORYTELLERS]["entries"][initial(chosen_storyteller.name)] = chosen_storyteller.times_chosen
+	selected_storyteller = passed_type
 	current_storyteller = chosen_storyteller
+	if(SSjob?.occupations?.len)
+		gnollslot_update()
+		update_scaling_slots()
+		enforce_storyteller_soft_antag_slots()
 	if(!secret_storyteller)
 		send_to_playing_players(span_notice("<b>Storyteller is [current_storyteller.name]!</b>"))
 		send_to_playing_players(span_notice("[current_storyteller.welcome_text]"))
@@ -1477,6 +1567,8 @@ SUBSYSTEM_DEF(gamemode)
 
 #undef DEFAULT_STORYTELLER_VOTE_OPTIONS
 #undef MAX_POP_FOR_STORYTELLER_VOTE
+#undef LAST_ROUND_STATS_FILE
+#undef LAST_ROUND_STATS_STORYTELLER_VOTE
 #undef ROUNDSTART_VALID_TIMEFRAME
 #undef DESC_POPUP_WIDTH
 #undef DESC_POPUP_HEIGHT

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -343,6 +343,7 @@ SUBSYSTEM_DEF(ticker)
 		if(player.ready == PLAYER_READY_TO_PLAY)
 			readied_count++
 	var/estimated_pop = round(readied_count * 1.1)
+	gnollslot_update()
 	update_scaling_slots(estimated_pop)
 
 	can_continue = can_continue && SSjob.DivideOccupations(list()) 				//Distribute jobs

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -1,3 +1,7 @@
+#define LAST_STORYTELLER_VOTE_LOG_FILE "data/last_round/storyteller_vote.json"
+#define DEFAULT_VOTE_PANEL_REFRESH_INTERVAL 2 SECONDS
+#define STORYTELLER_VOTE_PANEL_REFRESH_INTERVAL 5 SECONDS
+
 SUBSYSTEM_DEF(vote)
 	name = "Vote"
 	wait = 10
@@ -14,9 +18,14 @@ SUBSYSTEM_DEF(vote)
 	var/question = null
 	var/vote_height = 400
 	var/vote_width = 400
+	var/panel_refresh_interval = DEFAULT_VOTE_PANEL_REFRESH_INTERVAL
+	var/next_panel_refresh = 0
 	var/list/choices = list()
 	var/list/voted = list()
 	var/list/voting = list()
+	var/list/vote_selections = list()
+	var/list/vote_powers = list()
+	var/list/storyteller_vote_log = list()
 	var/list/generated_actions = list()
 	var/static/list/everyone_is_equal = list("custom")
 
@@ -30,15 +39,21 @@ SUBSYSTEM_DEF(vote)
 			for(var/client/C in voting)
 				C << browse(null, "window=vote;can_close=0;size=[vote_width]x[vote_height]")
 			reset()
-		else
-			var/datum/browser/noclose/client_popup
+		else if(world.time >= next_panel_refresh)
+			next_panel_refresh = world.time + panel_refresh_interval
 			for(var/client/C in voting)
-				client_popup = new(C, "vote", "Voting Panel", nwidth = vote_width, nheight = vote_height)
-				client_popup.set_window_options("can_close=0")
-				client_popup.width = vote_width
-				client_popup.height = vote_height
-				client_popup.set_content(interface(C))
-				client_popup.open(FALSE)
+				show_vote(C)
+
+
+/datum/controller/subsystem/vote/proc/show_vote(client/C)
+	if(!C)
+		return
+	var/datum/browser/noclose/client_popup = new(C, "vote", "Voting Panel", nwidth = vote_width, nheight = vote_height)
+	client_popup.set_window_options("can_close=0")
+	client_popup.width = vote_width
+	client_popup.height = vote_height
+	client_popup.set_content(interface(C))
+	client_popup.open(FALSE)
 
 
 /datum/controller/subsystem/vote/proc/reset()
@@ -47,14 +62,218 @@ SUBSYSTEM_DEF(vote)
 	custom_vote_period = 0
 	vote_width = initial(vote_width)
 	vote_height = initial(vote_height)
+	panel_refresh_interval = initial(panel_refresh_interval)
+	next_panel_refresh = 0
 	mode = null
 	question = null
 	choices.Cut()
 	voted.Cut()
 	voting.Cut()
+	vote_selections.Cut()
+	vote_powers.Cut()
+	storyteller_vote_log.Cut()
 	remove_action_buttons()
 
+/datum/controller/subsystem/vote/proc/get_storyteller_vote_pool(storyteller_type)
+	if(!ispath(storyteller_type, /datum/storyteller))
+		return null
+	switch(storyteller_type)
+		if(/datum/storyteller/psydon)
+			return "Psydon"
+		if(/datum/storyteller/graggar, /datum/storyteller/matthios, /datum/storyteller/zizo, /datum/storyteller/baotha)
+			return "Ascendants"
+	return "The Ten"
+
+/datum/controller/subsystem/vote/proc/get_storyteller_gnoll_display(storyteller_type)
+	if(storyteller_type == /datum/storyteller/psydon)
+		return "Gnolls: OFF"
+	var/datum/storyteller/storyboy = SSgamemode.storytellers[storyteller_type]
+	if(!storyboy)
+		return "Gnolls: NORMAL"
+	switch(storyboy.preferred_gnoll_mode)
+		if(GNOLL_SCALING_DYNAMIC)
+			return "Gnolls: DYNAMIC"
+		if(GNOLL_SCALING_FLAT)
+			return "Gnolls: FLAT"
+		if(GNOLL_SCALING_RANDOM)
+			return "Gnolls: RANDOM"
+	return "Gnolls: SOLO"
+
+/datum/controller/subsystem/vote/proc/get_storyteller_roll_summary(storyteller_type)
+	if(!ispath(storyteller_type, /datum/storyteller))
+		return list()
+	var/list/summary = list()
+	if(storyteller_type == /datum/storyteller/eora)
+		summary += "Villain rolls: OFF"
+		summary += "Wretches: NORMAL"
+		summary += get_storyteller_gnoll_display(storyteller_type)
+		return summary
+	if(storyteller_type == /datum/storyteller/psydon)
+		summary += "Villain rolls: OFF"
+		summary += "Wretches: OFF"
+		summary += get_storyteller_gnoll_display(storyteller_type)
+		return summary
+	summary += "Villain rolls: NORMAL"
+	summary += "Wretches: NORMAL"
+	summary += get_storyteller_gnoll_display(storyteller_type)
+	return summary
+
+/datum/controller/subsystem/vote/proc/render_storyteller_summary(choice_text)
+	var/storyteller_type = get_storyteller_choice_type(choice_text)
+	var/list/summary = get_storyteller_roll_summary(storyteller_type)
+	if(!length(summary))
+		return ""
+	var/pool_name = get_storyteller_vote_pool(storyteller_type)
+	var/list/theme = get_storyteller_pool_theme(pool_name)
+	var/summary_color = theme["summary"] || "#b8b1d8"
+	var/dat = "<div style='margin-top:3px;color:[summary_color];font-size:0.78rem;line-height:1.25;'>"
+	dat += jointext(summary, " | ")
+	dat += "</div>"
+	return dat
+
+/datum/controller/subsystem/vote/proc/get_storyteller_pool_totals()
+	var/list/pool_totals = list()
+	for(var/option in choices)
+		var/storyteller_type = get_storyteller_choice_type(option)
+		var/pool_name = get_storyteller_vote_pool(storyteller_type)
+		if(!pool_name)
+			continue
+		pool_totals[pool_name] = (pool_totals[pool_name] || 0) + (choices[option] || 0)
+	return pool_totals
+
+/datum/controller/subsystem/vote/proc/get_storyteller_pool_winners()
+	var/list/pool_totals = get_storyteller_pool_totals()
+	var/greatest_votes = 0
+	for(var/pool_name in pool_totals)
+		var/pool_votes = pool_totals[pool_name] || 0
+		if(pool_votes > greatest_votes)
+			greatest_votes = pool_votes
+	var/list/winning_pools = list()
+	if(!greatest_votes)
+		return winning_pools
+	for(var/pool_name in pool_totals)
+		if((pool_totals[pool_name] || 0) == greatest_votes)
+			winning_pools += pool_name
+	return winning_pools
+
+/datum/controller/subsystem/vote/proc/get_storyteller_winning_choices(list/winning_pools)
+	var/list/winners = list()
+	if(!length(winning_pools))
+		return winners
+	var/greatest_votes = 0
+	for(var/option in choices)
+		var/storyteller_type = get_storyteller_choice_type(option)
+		var/pool_name = get_storyteller_vote_pool(storyteller_type)
+		if(!(pool_name in winning_pools))
+			continue
+		var/option_votes = choices[option] || 0
+		if(option_votes > greatest_votes)
+			greatest_votes = option_votes
+			winners = list(option)
+		else if(option_votes == greatest_votes && option_votes > 0)
+			winners += option
+	return winners
+
+/datum/controller/subsystem/vote/proc/get_storyteller_pool_theme(pool_name)
+	var/list/theme = list(
+		"border" = "#5a5670",
+		"background" = "rgba(34,31,45,0.82)",
+		"title" = "#d8d2ff",
+		"meta" = "#bcb4e9",
+		"summary" = "#b8b1d8",
+		"entry" = "rgba(255,255,255,0.03)",
+		"link" = "#d8d2ff",
+		"selection_color" = "#ffdc7a",
+	)
+	switch(pool_name)
+		if("Psydon")
+			theme["border"] = "#7f878d"
+			theme["background"] = "#8e9499"
+			theme["title"] = "#1f2428"
+			theme["meta"] = "#3f474d"
+			theme["summary"] = "#4d565c"
+			theme["entry"] = "rgba(255,255,255,0.12)"
+			theme["link"] = "#d7fffb"
+			theme["selection_color"] = "#1f2428"
+		if("Ascendants")
+			theme["border"] = "#a43c3c"
+			theme["background"] = "#581414"
+			theme["title"] = "#ffd6d6"
+			theme["meta"] = "#f0aaaa"
+			theme["summary"] = "#e2a2a2"
+			theme["entry"] = "rgba(255,214,214,0.08)"
+			theme["link"] = "#ffd6d6"
+			theme["selection_color"] = "#ffd6d6"
+		if("The Ten")
+			theme["border"] = "#2b8c87"
+			theme["background"] = "#10464a"
+			theme["title"] = "#d7fffb"
+			theme["meta"] = "#98ddd8"
+			theme["summary"] = "#8ed0cb"
+			theme["entry"] = "rgba(215,255,251,0.08)"
+			theme["link"] = "#d7fffb"
+			theme["selection_color"] = "#d7fffb"
+	return theme
+
+/datum/controller/subsystem/vote/proc/render_storyteller_pool(list/choice_indices, pool_name, can_vote, selected_option)
+	if(!length(choice_indices))
+		return ""
+	var/list/pool_totals = get_storyteller_pool_totals()
+	var/pool_votes = pool_totals[pool_name] || 0
+	var/list/theme = get_storyteller_pool_theme(pool_name)
+	var/dat = "<div style='border:1px solid [theme["border"]];border-radius:8px;padding:8px 10px;background:[theme["background"]];min-height:100%;box-sizing:border-box;'>"
+	dat += "<div style='font-size:1rem;font-weight:bold;margin-bottom:6px;color:[theme["title"]];'>[pool_name] <span style='float:right;font-size:0.82rem;color:[theme["meta"]];'>[pool_votes] votepwr</span></div>"
+	dat += "<div style='display:flex;flex-direction:column;gap:6px;'>"
+	for(var/index in choice_indices)
+		var/option_index = text2num(index)
+		var/choice_text = choices[option_index]
+		var/votes = choices[choice_text] || 0
+		var/is_selected = (selected_option == choice_text)
+		var/selected_color = theme["selection_color"]
+		var/selected_text = is_selected ? " <span style='color:[selected_color];font-size:0.82rem;font-weight:bold;'>(current vote)</span>" : ""
+		var/entry = "<div style='padding:6px 8px;border-radius:6px;background:[theme["entry"]];'>"
+		if(can_vote)
+			entry += "<a href='?src=[REF(src)];vote=[option_index]' style='font-size:0.95rem;color:[theme["link"]];'>[choice_text]</a>[selected_text] <span style='color:[theme["meta"]];font-size:0.82rem;'>([votes] votepwr)</span>"
+		else
+			entry += "<span style='font-size:0.95rem;'>[choice_text]</span>[selected_text] <span style='color:[theme["meta"]];font-size:0.82rem;'>([votes] votepwr)</span>"
+		entry += render_storyteller_summary(choice_text)
+		entry += "</div>"
+		dat += entry
+	dat += "</div></div>"
+	return dat
+
+/datum/controller/subsystem/vote/proc/render_storyteller_choices(can_vote, client/C)
+	var/list/pool_order = list("Psydon", "Ascendants", "The Ten")
+	var/list/pooled_indices = list()
+	var/selected_option = null
+	if(C)
+		selected_option = vote_selections[C.ckey]
+	for(var/pool_name in pool_order)
+		pooled_indices[pool_name] = list()
+
+	for(var/i = 1, i <= choices.len, i++)
+		var/choice_text = choices[i]
+		var/storyteller_type = get_storyteller_choice_type(choice_text)
+		var/pool_name = get_storyteller_vote_pool(storyteller_type)
+		if(!pool_name)
+			continue
+		var/list/pool_choices = pooled_indices[pool_name]
+		pool_choices += "[i]"
+
+	var/dat = "<div style='margin-top:8px;display:grid;grid-template-columns:repeat(3, minmax(0, 1fr));gap:10px;align-items:start;'>"
+	for(var/pool_name in pool_order)
+		var/list/pool_choices = pooled_indices[pool_name]
+		if(!length(pool_choices))
+			continue
+		dat += render_storyteller_pool(pool_choices, pool_name, can_vote, selected_option)
+	dat += "</div>"
+	return dat
+
 /datum/controller/subsystem/vote/proc/get_result()
+	if(mode == "storyteller")
+		var/list/winning_pools = get_storyteller_pool_winners()
+		return get_storyteller_winning_choices(winning_pools)
+
 	//get the highest number of votes
 	var/greatest_votes = 0
 	var/total_votes = 0
@@ -113,9 +332,18 @@ SUBSYSTEM_DEF(vote)
 			if(!votes)
 				votes = 0
 			text += "\n<b>[choices[i]]:</b> [votes]"
+		if(mode == "storyteller")
+			var/list/pool_totals = get_storyteller_pool_totals()
+			if(pool_totals.len)
+				text += "\n<hr><b>Pool Totals</b>"
+				for(var/pool_name in pool_totals)
+					text += "\n<b>[pool_name]:</b> [pool_totals[pool_name]]"
 		if(mode != "custom")
 			if(winners.len > 1)
-				text = "\n<b>Vote Tied Between:</b>"
+				if(mode == "storyteller")
+					text += "\n<b>Vote Tied Between:</b>"
+				else
+					text = "\n<b>Vote Tied Between:</b>"
 				for(var/option in winners)
 					text += "\n\t[option]"
 				if(mode == "endround")
@@ -164,6 +392,7 @@ SUBSYSTEM_DEF(vote)
 					SSgamemode.roundvoteend = TRUE
 					SSgamemode.round_ends_at = world.time + ROUND_END_TIME
 			if("storyteller")
+				save_storyteller_vote_log(., "completed")
 				SSgamemode.storyteller_vote_result(.)
 
 	if(restart)
@@ -180,35 +409,119 @@ SUBSYSTEM_DEF(vote)
 
 	return .
 
+/datum/controller/subsystem/vote/proc/can_client_vote(client/C)
+	return !isnull(C)
+
+/datum/controller/subsystem/vote/proc/get_vote_power(mob/voter)
+	var/vote_power = 1
+	if(ishuman(voter))
+		var/mob/living/carbon/H = voter
+		if(H.stat != DEAD)
+			vote_power += 3
+		if(H.job)
+			var/list/list_of_powerful = list("Grand Duke", "Bishop")
+			if(H.job in list_of_powerful)
+				vote_power += 5
+			else
+				if(H.mind)
+					for(var/datum/antagonist/D in H.mind.antag_datums)
+						if(D.increase_votepwr)
+							vote_power += 3
+	if(mode in everyone_is_equal)
+		vote_power = 1
+	return vote_power
+
+/datum/controller/subsystem/vote/proc/get_storyteller_choice_name(choice_text)
+	if(!choice_text)
+		return null
+	for(var/storyteller_type in SSgamemode.storytellers)
+		var/datum/storyteller/storyboy = SSgamemode.storytellers[storyteller_type]
+		if(findtext(choice_text, storyboy.name))
+			return storyboy.name
+	return strip_html("[choice_text]")
+
+/datum/controller/subsystem/vote/proc/get_storyteller_choice_type(choice_text)
+	if(!choice_text)
+		return null
+	for(var/storyteller_type in SSgamemode.storytellers)
+		var/datum/storyteller/storyboy = SSgamemode.storytellers[storyteller_type]
+		if(findtext(choice_text, storyboy.name))
+			return storyboy.type
+	return null
+
+/datum/controller/subsystem/vote/proc/save_storyteller_vote_log(winning_choice = null, state = "active")
+	var/json_file = file(LAST_STORYTELLER_VOTE_LOG_FILE)
+	var/list/file_data = list()
+	if(!fexists(json_file))
+		WRITE_FILE(json_file, "{}")
+	else
+		file_data = safe_json_decode(file2text(json_file))
+	if(!islist(file_data))
+		file_data = list()
+	file_data["state"] = state
+	var/winner_name = get_storyteller_choice_name(winning_choice)
+	var/winner_type = get_storyteller_choice_type(winning_choice)
+	if(winner_name)
+		file_data["winner"] = winner_name
+	else
+		file_data -= "winner"
+	if(winner_type)
+		file_data["storyteller_vote"] = "[winner_type]"
+	var/list/votes = list()
+	for(var/voter_ckey in storyteller_vote_log)
+		var/list/vote_data = storyteller_vote_log[voter_ckey]
+		if(!islist(vote_data))
+			continue
+		votes[voter_ckey] = list(
+			"choice" = vote_data["choice"],
+			"vote_power" = vote_data["vote_power"],
+		)
+	file_data["votes"] = votes
+	fdel(json_file)
+	WRITE_FILE(json_file, json_encode(file_data))
+
+/datum/controller/subsystem/vote/proc/remove_vote_for_ckey(voter_ckey)
+	if(!(voter_ckey in voted))
+		return FALSE
+	var/selected_option = vote_selections[voter_ckey]
+	var/vote_power = vote_powers[voter_ckey] || 0
+	if(selected_option && (selected_option in choices))
+		choices[selected_option] = max(0, choices[selected_option] - vote_power)
+	voted -= voter_ckey
+	vote_selections -= voter_ckey
+	vote_powers -= voter_ckey
+	storyteller_vote_log -= voter_ckey
+	if(mode == "storyteller")
+		save_storyteller_vote_log(null, "active")
+	return TRUE
+
 /datum/controller/subsystem/vote/proc/submit_vote(vote)
 	// Voting where vote power is equal for all
 	if(mode)
-//		if(CONFIG_GET(flag/no_dead_vote) && usr.stat == DEAD && !usr.client.holder)
-//			return 0
-		if(!(usr.ckey in voted))
-			if(vote && 1<=vote && vote<=choices.len)
-				voted += usr.ckey
-				var/vote_power = 1
-				/*if(usr.client.holder)
-					vote_power += 5*/
-				if(ishuman(usr))
-					var/mob/living/carbon/H = usr
-					if(H.stat != DEAD)
-						vote_power += 3
-					if(H.job)
-						var/list/list_of_powerful = list("Grand Duke", "Bishop")
-						if(H.job in list_of_powerful)
-							vote_power += 5
-						else
-							if(H.mind)
-								for(var/datum/antagonist/D in H.mind.antag_datums)
-									if(D.increase_votepwr)
-										vote_power += 3
-				if(mode in everyone_is_equal)
-					vote_power = 1
-				choices[choices[vote]] += vote_power //check this
+		if(!can_client_vote(usr.client))
+			return FALSE
+		if(vote && 1<=vote && vote<=choices.len)
+			var/selected_option = choices[vote]
+			if(vote_selections[usr.ckey] == selected_option)
 				return vote
-	return 0
+			if(usr.ckey in voted)
+				remove_vote_for_ckey(usr.ckey)
+			voted += usr.ckey
+			var/vote_power = get_vote_power(usr)
+			var/choice_name = selected_option
+			if(mode == "storyteller")
+				choice_name = get_storyteller_choice_name(selected_option)
+			vote_selections[usr.ckey] = selected_option
+			vote_powers[usr.ckey] = vote_power
+			if(mode == "storyteller")
+				storyteller_vote_log[usr.ckey] = list(
+					"choice" = choice_name,
+					"vote_power" = vote_power,
+				)
+				save_storyteller_vote_log(null, "active")
+			choices[selected_option] += vote_power //check this
+			return vote
+	return FALSE
 
 /datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, vote_period)
 	var/sound/vote_alert = new()
@@ -226,7 +539,7 @@ SUBSYSTEM_DEF(vote)
 			var/next_allowed_time = (started_time + CONFIG_GET(number/vote_delay))
 			if(mode)
 				to_chat(usr, span_warning("There is already a vote in progress! please wait for it to finish."))
-				return 0
+				return FALSE
 
 			var/admin = FALSE
 			var/ckey = ckey(initiator_key)
@@ -235,7 +548,7 @@ SUBSYSTEM_DEF(vote)
 
 			if(next_allowed_time > world.time && !admin)
 				to_chat(usr, span_warning("A vote was initiated recently, you must wait [DisplayTimeText(next_allowed_time-world.time)] before a new vote can be started!"))
-				return 0
+				return FALSE
 
 		reset()
 		switch(vote_type)
@@ -257,7 +570,7 @@ SUBSYSTEM_DEF(vote)
 			if("custom")
 				question = stripped_input(usr,"What is the vote for?")
 				if(!question)
-					return 0
+					return FALSE
 				for(var/i=1,i<=10,i++)
 					var/option = capitalize(stripped_input(usr,"Please enter an option or hit cancel to finish"))
 					if(!option || mode || !usr.client)
@@ -269,9 +582,11 @@ SUBSYSTEM_DEF(vote)
 				vote_alert.file = 'sound/roundend/roundend-vote-sound.ogg'
 			if("storyteller")
 				choices.Add(SSgamemode.storyteller_vote_choices())
-				vote_height = 800 // Give more room for storyteller
+				vote_width = 1200
+				vote_height = 900 // Give more room for storyteller
+				panel_refresh_interval = STORYTELLER_VOTE_PANEL_REFRESH_INTERVAL
 			else
-				return 0
+				return FALSE
 		message_admins(span_danger("Admin [key_name_admin(usr)] start a vote of [vote_type]!"))
 		log_admin("Admin [key_name_admin(usr)] start a vote of [vote_type]!")
 		mode = vote_type
@@ -292,18 +607,16 @@ SUBSYSTEM_DEF(vote)
 		if(vote_alert.file)
 			for(var/mob/M in GLOB.player_list)
 				SEND_SOUND(M, vote_alert)
+		if(mode == "storyteller")
+			save_storyteller_vote_log(null, "active")
 		to_chat(world, "\n<font color='purple'><b>[text]</b>\nClick <a href='?src=[REF(src)]'>here</a> to place your vote.\nYou have [DisplayTimeText(vp)] to vote.</font>")
+		for(var/client/C in GLOB.clients)
+			if(!isliving(C.mob))
+				show_vote(C)
+		next_panel_refresh = world.time + panel_refresh_interval
 		time_remaining = round(vp/10)
-//		for(var/c in GLOB.clients)
-//			var/client/C = c
-//			var/datum/action/vote/V = new
-//			if(question)
-//				V.name = "Vote: [question]"
-//			C.player_details.player_actions += V
-//			V.Grant(C.mob)
-//			generated_actions += V
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 // Helper for sending an active vote to someone who has just logged in 
 /datum/controller/subsystem/vote/proc/send_vote(client/C)
@@ -314,6 +627,8 @@ SUBSYSTEM_DEF(vote)
 		text += "\n[question]"
 	var/remaining_time = time_remaining * 10
 	to_chat(C, "\n<font color='purple'><b>[text]</b>\nClick <a href='?src=[REF(src)]'>here</a> to place your vote.\nYou have [DisplayTimeText(remaining_time)] to vote.</font>")
+	if(!isliving(C.mob))
+		show_vote(C)
 
 /datum/controller/subsystem/vote/proc/interface(client/C)
 	if(!C)
@@ -331,13 +646,26 @@ SUBSYSTEM_DEF(vote)
 			. += "<h2>Vote: '[question]'</h2>"
 		else
 			. += "<h2>Vote: [capitalize(mode)]</h2>"
-		. += "Time Left: [time_remaining] s<hr><ul>"
-		for(var/i=1,i<=choices.len,i++)
-			var/votes = choices[choices[i]]
-			if(!votes)
-				votes = 0
-			. += "<li><a href='?src=[REF(src)];vote=[i]'>[choices[i]]</a> ([votes] votepwr)</li>"
-		. += "</ul><hr>"
+		. += "Time Left: [time_remaining] s<hr>"
+		var/can_vote = can_client_vote(C)
+		if(mode == "storyteller")
+			. += "<div style='color:#992414;font-size:0.95rem;margin-bottom:6px;'>Storytellers are grouped by weighted pool. Last round's vote is not votable this round.</div>"
+			. += render_storyteller_choices(can_vote, C)
+		else
+			. += "<ul>"
+			var/selected_option = vote_selections[C.ckey]
+			for(var/i=1,i<=choices.len,i++)
+				var/choice_text = choices[i]
+				var/votes = choices[choice_text]
+				if(!votes)
+					votes = 0
+				var/selected_text = selected_option == choice_text ? " <b>(current vote)</b>" : ""
+				if(can_vote)
+					. += "<li><a href='?src=[REF(src)];vote=[i]'>[choice_text]</a>[selected_text] ([votes] votepwr)</li>"
+				else
+					. += "<li>[choice_text][selected_text] ([votes] votepwr)</li>"
+			. += "</ul>"
+		. += "<hr>"
 		if(admin)
 			. += "(<a href='?src=[REF(src)];vote=cancel'>Cancel Vote</a>) "
 	else
@@ -375,7 +703,7 @@ SUBSYSTEM_DEF(vote)
 		if(trialmin)
 			. += "<li><a href='?src=[REF(src)];vote=custom'>Custom</a></li>"
 		. += "</ul><hr>"
-	. += "<a href='?src=[REF(src)];vote=close' style='position:absolute;right:50px'>Close</a>"
+	. += "<a href='?src=[REF(src)];vote=close' style='position:absolute;top:8px;right:18px;padding:3px 8px;border:1px solid #6e2b33;border-radius:999px;background:rgba(18,12,14,0.96);color:#e06b75;font-size:0.8rem;font-weight:bold;text-decoration:none;line-height:1.2;'>Close</a>"
 	return .
 
 
@@ -395,6 +723,8 @@ SUBSYSTEM_DEF(vote)
 			return
 		if("cancel")
 			if(usr.client.holder)
+				if(mode == "storyteller")
+					save_storyteller_vote_log(null, "cancelled")
 				if(mode == "endround")
 					GLOB.round_timer = world.time + ROUND_EXTENSION_TIME // admin cancels an endround, defaults to same as continue playing
 					log_admin("[key_name(usr)] canceled end round vote.")
@@ -437,12 +767,7 @@ SUBSYSTEM_DEF(vote)
 /mob/verb/vote()
 	set category = "OOC"
 	set name = "Vote"
-	var/datum/browser/noclose/popup = new(src, "vote", "Voting Panel")
-	popup.set_window_options("can_close=0")
-	popup.width = SSvote.vote_width
-	popup.height = SSvote.vote_height
-	popup.set_content(SSvote.interface(client))
-	popup.open(FALSE)
+	SSvote.show_vote(client)
 
 /datum/action/vote
 	name = "Vote!"
@@ -455,7 +780,7 @@ SUBSYSTEM_DEF(vote)
 		Remove(owner)
 
 /datum/action/vote/IsAvailable()
-	return 1
+	return TRUE
 
 /datum/action/vote/proc/remove_from_client()
 	if(!owner)
@@ -466,3 +791,7 @@ SUBSYSTEM_DEF(vote)
 		var/datum/player_details/P = GLOB.player_details[owner.ckey]
 		if(P)
 			P.player_actions -= src
+
+#undef LAST_STORYTELLER_VOTE_LOG_FILE
+#undef DEFAULT_VOTE_PANEL_REFRESH_INTERVAL
+#undef STORYTELLER_VOTE_PANEL_REFRESH_INTERVAL

--- a/code/datums/storytellers/_base.dm
+++ b/code/datums/storytellers/_base.dm
@@ -101,10 +101,10 @@
 	if(!round_started || disable_distribution) // we are differing roundstarted ones until base roundstart so we can get cooler stuff
 		return
 
-	if(!guarantees_roundstart_roleset && prob(roundstart_prob) && !roundstart_checks)
+	if(!is_roundstart_roles_blocked_storyteller() && !guarantees_roundstart_roleset && prob(roundstart_prob) && !roundstart_checks)
 		roundstart_checks = TRUE
 
-	if(SSgamemode.current_roundstart_event && !SSgamemode.ran_roundstart && (guarantees_roundstart_roleset || roundstart_checks))
+	if(!is_roundstart_roles_blocked_storyteller() && SSgamemode.current_roundstart_event && !SSgamemode.ran_roundstart && (guarantees_roundstart_roleset || roundstart_checks))
 		buy_event(SSgamemode.current_roundstart_event, EVENT_TRACK_CHARACTER_INJECTION, TRUE)
 		if(EVENT_TRACK_CHARACTER_INJECTION in SSgamemode.forced_next_events)
 			SSgamemode.forced_next_events[EVENT_TRACK_CHARACTER_INJECTION] = null

--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -35,6 +35,8 @@
 	always_votable = TRUE
 	color_theme = "#80ced8"
 	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	guarantees_roundstart_roleset = FALSE
+	roundstart_prob = 0
 
 	//Has no influence, your actions will not impact him his spawn rates. Cus he's asleep.
 	//Tl;dr - higher event spawn rates to keep stuff interesting, no god intervention, no antags. (Raids and omens will still happen at normal rate.)
@@ -347,11 +349,23 @@
 
 /datum/storyteller/eora
 	name = "Eora"
-	vote_desc = " Love reigns. Positive affairs occur more often, and raids will rarely transpire. Her favor shines upon romance."
-	desc = "Eora hates death and promotes love. Raids will never naturally progress, only death will bring them."
+	vote_desc = " Love reigns. Positive affairs occur more often, and She wills for none to be ill. Her favor shines upon romance."
+	desc = "Eora hates death and promotes love. There is no possibility for ill-will from external forces. Though deaths will anger."
 	welcome_text = "\"Love is in the air? Nay; tis the smell of freshly-baked pies upon the windowsills!\""
 	color_theme = "#9966CC"
 	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	guarantees_roundstart_roleset = FALSE
+	roundstart_prob = 0
+
+	starting_point_multipliers = list(
+		EVENT_TRACK_MUNDANE = 1,
+		EVENT_TRACK_PERSONAL = 1,
+		EVENT_TRACK_MODERATE = 1,
+		EVENT_TRACK_INTERVENTION = 1,
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
+		EVENT_TRACK_OMENS = 1,
+		EVENT_TRACK_RAIDS = 1,
+	)
 
 	tag_multipliers = list(
 		TAG_WIDESPREAD = 1.5,
@@ -363,7 +377,7 @@
 		EVENT_TRACK_PERSONAL = 1.4,
 		EVENT_TRACK_MODERATE = 1,
 		EVENT_TRACK_INTERVENTION = 2,
-		EVENT_TRACK_CHARACTER_INJECTION = 0.3,	//Low-chance antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 0,	//No antagonist spawns.
 		EVENT_TRACK_OMENS = 1,
 		EVENT_TRACK_RAIDS = 0,
 	)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -147,6 +147,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/reset_ooc,
 	/client/proc/forceEvent,
 	/client/proc/forceGamemode,
+	/client/proc/view_storyteller_vote_log,
 //	/client/proc/admin_change_sec_level,
 //	/client/proc/run_weather,
 	/client/proc/run_particle_weather,

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -930,7 +930,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 		//The job before the current job. I only use this to get the previous jobs color when I'm filling in blank rows.
 		var/datum/job/lastJob
 		for(var/datum/job/job in sortList(SSjob.occupations, GLOBAL_PROC_REF(cmp_job_display_asc)))
-			if(!job.spawn_positions)
+			if(!job.spawn_positions && !job.always_show_on_latechoices)
 				continue
 
 			index += 1

--- a/code/modules/events/antagonist/migrant_waves/assassins.dm
+++ b/code/modules/events/antagonist/migrant_waves/assassins.dm
@@ -13,6 +13,11 @@
 		TAG_VILLIAN,
 	)
 
+/datum/round_event_control/antagonist/migrant_wave/assassins/preRunEvent()
+	if(is_storyteller_soft_antag_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/migrant_wave/assassins/start()
 	var/datum/job/assassin_job = SSjob.GetJob("Assassin")
 	assassin_job.total_positions = min(assassin_job.total_positions + 1, 2)

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/antagonist/migrant_wave/banditsorgnolls
-	name = "Bandits or gnolls Migration"
+	name = "Bandits or Gnolls Migration"
 	typepath = /datum/round_event/migrant_wave/banditsorgnolls
 	wave_type = /datum/migrant_wave/bandit
 	max_occurrences = 2
@@ -14,8 +14,13 @@
 		TAG_VILLIAN,
 	)
 
+/datum/round_event_control/antagonist/migrant_wave/banditsorgnolls/preRunEvent()
+	if(is_storyteller_soft_antag_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/migrant_wave/banditsorgnolls/start()
-	var/evilmode = pick("gnolls", "bandits")
+	var/evilmode = is_storyteller_villain_blocked() ? "gnolls" : pick("gnolls", "bandits")
 	if(evilmode == "bandits")
 		var/datum/job/bandit_job = SSjob.GetJob("Bandit")
 		bandit_job.total_positions = min(bandit_job.total_positions + 4, 10)

--- a/code/modules/events/antagonist/migrant_waves/exiled_adventurer.dm
+++ b/code/modules/events/antagonist/migrant_waves/exiled_adventurer.dm
@@ -13,6 +13,11 @@
 		TAG_COMBAT,
 	)
 
+/datum/round_event_control/antagonist/migrant_wave/werewolf/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/migrant_wave/werewolf
 	name = "Exiled Adventurer (Verevolf)"
 	roles = list(
@@ -40,6 +45,11 @@
 		TAG_VILLIAN,
 	)
 
+/datum/round_event_control/antagonist/migrant_wave/vampire/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/migrant_wave/vampire
 	name = "Exiled Adventurer (Vampire)"
 	roles = list(
@@ -66,6 +76,11 @@
 		TAG_COMBAT,
 		TAG_VILLIAN,
 	)
+
+/datum/round_event_control/antagonist/migrant_wave/unbound_death_knight/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
 
 /datum/migrant_wave/unbound_death_knight
 	name = "Death knight (Unbound)"

--- a/code/modules/events/antagonist/migrant_waves/gnolls.dm
+++ b/code/modules/events/antagonist/migrant_waves/gnolls.dm
@@ -12,6 +12,11 @@
 		TAG_VILLIAN,
 	)
 
+/datum/round_event_control/antagonist/migrant_wave/gnolls/preRunEvent()
+	if(is_storyteller_soft_antag_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/migrant_wave/gnolls/start()
 	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
 	gnoll_job.total_positions = min(gnoll_job.total_positions + 2, 10)

--- a/code/modules/events/antagonist/migrant_waves/lich.dm
+++ b/code/modules/events/antagonist/migrant_waves/lich.dm
@@ -13,6 +13,11 @@
 		TAG_VILLIAN,
 	)
 
+/datum/round_event_control/antagonist/migrant_wave/lich/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/migrant_wave/lich
 	name = "Wandering Lich"
 	roles = list(

--- a/code/modules/events/antagonist/solo/assassins.dm
+++ b/code/modules/events/antagonist/solo/assassins.dm
@@ -52,10 +52,15 @@
 	typepath = /datum/round_event/antagonist/solo/assassins
 	antag_datum = /datum/antagonist/assassin
 
+/datum/round_event_control/antagonist/solo/assassins/preRunEvent()
+	if(is_storyteller_soft_antag_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/assassins/start()
 	var/datum/job/assassin_job = SSjob.GetJob("Assassin")
 	assassin_job.total_positions = length(setup_minds)
-	assassin_job.total_positions = length(setup_minds)
+	assassin_job.spawn_positions = length(setup_minds)
 	for(var/datum/mind/antag_mind as anything in setup_minds)
 		var/datum/job/J = SSjob.GetJob(antag_mind.current?.job)
 		J?.current_positions = max(J?.current_positions-1, 0)

--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -23,6 +23,11 @@
 /datum/round_event/antagonist/solo/bandits
 	var/leader = FALSE
 
+/datum/round_event_control/antagonist/solo/bandits/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/bandits/start()
 	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
 	bandit_job.total_positions = length(setup_minds)

--- a/code/modules/events/antagonist/solo/lich.dm
+++ b/code/modules/events/antagonist/solo/lich.dm
@@ -24,4 +24,9 @@
 
 	restricted_roles = DEFAULT_ANTAG_BLACKLISTED_ROLES
 
+/datum/round_event_control/antagonist/solo/lich/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/lich

--- a/code/modules/events/antagonist/solo/vampires.dm
+++ b/code/modules/events/antagonist/solo/vampires.dm
@@ -24,6 +24,11 @@
 
 	restricted_roles = DEFAULT_ANTAG_BLACKLISTED_ROLES
 
+/datum/round_event_control/antagonist/solo/vampires/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/vampire
 	var/leader = FALSE
 

--- a/code/modules/events/antagonist/solo/vampires_and_werewolves.dm
+++ b/code/modules/events/antagonist/solo/vampires_and_werewolves.dm
@@ -22,6 +22,11 @@
 
 	restricted_roles = DEFAULT_ANTAG_BLACKLISTED_ROLES
 
+/datum/round_event_control/antagonist/solo/vampires_and_werewolves/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/vampires_and_werewolves
 	var/leader = FALSE
 

--- a/code/modules/events/antagonist/solo/werewolf.dm
+++ b/code/modules/events/antagonist/solo/werewolf.dm
@@ -23,4 +23,9 @@
 
 	restricted_roles = DEFAULT_ANTAG_BLACKLISTED_ROLES
 
+/datum/round_event_control/antagonist/solo/werewolf/preRunEvent()
+	if(is_storyteller_villain_blocked())
+		return EVENT_CANT_RUN
+	return ..()
+
 /datum/round_event/antagonist/solo/werewolf

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -4,8 +4,8 @@
 	department_flag = ANTAGONIST
 	antag_job = TRUE // whoever wrote this, I'm- gghrhhah!
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = RACES_SHUNNED_UP
 	tutorial = "You have proven yourself worthy to Graggar, and he's granted you his blessing most divine. Now you hunt for worthy opponents, seeking out those strong enough to make you bleed."
 	outfit = null
@@ -45,6 +45,16 @@
 		/datum/advclass/gnoll/templar,
 		/datum/advclass/gnoll/shaman,
 	)
+
+/datum/job/roguetown/gnoll/special_job_check(mob/dead/new_player/player)
+	if(is_storyteller_soft_antag_blocked())
+		return FALSE
+	return ..()
+
+/datum/job/roguetown/gnoll/special_check_latejoin(client/C)
+	if(is_storyteller_soft_antag_blocked())
+		return FALSE
+	return ..()
 
 /datum/job/roguetown/gnoll/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()
@@ -95,6 +105,23 @@
 					to_chat(H, span_notice("Your name is now [H.real_name]."))
 				if("Keep Current Name")
 					to_chat(H, span_notice("You keep your name as [H.real_name]."))
+
+/proc/gnollslot_calc()
+	var/list/result = list()
+	if(is_storyteller_soft_antag_blocked())
+		result["final_slots"] = 0
+		return result
+	result["final_slots"] = 1
+	return result
+
+/proc/gnollslot_update()
+	var/datum/job/gnoll_job = SSjob.GetJob("Gnoll")
+	if(!gnoll_job)
+		return
+	var/list/scaling = gnollslot_calc()
+	var/slots = max(0, scaling["final_slots"])
+	gnoll_job.total_positions = max(gnoll_job.current_positions, slots)
+	gnoll_job.spawn_positions = max(gnoll_job.current_positions, slots)
 
 /mob/living/carbon/human/proc/gnoll_inspect_skin()
 	set name = "Inspect Pelt"

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -4,8 +4,8 @@
 	flag = WRETCH
 	department_flag = ANTAGONIST
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Somewhere in your lyfe, you fell to the wrong side of civilization. Hounded by the consequences of your actions, you spend your daes prowling the roads for easy marks and loose purses, scraping to get by."
 	outfit = null
@@ -50,6 +50,16 @@
 		/datum/advclass/wretch/ancient_spellblade,
 		/datum/advclass/wretch/ancient_deathknight
 	)
+
+/datum/job/roguetown/wretch/special_job_check(mob/dead/new_player/player)
+	if(is_storyteller_soft_antag_blocked())
+		return FALSE
+	return ..()
+
+/datum/job/roguetown/wretch/special_check_latejoin(client/C)
+	if(is_storyteller_soft_antag_blocked())
+		return FALSE
+	return ..()
 
 /datum/job/roguetown/wretch/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()
@@ -135,6 +145,16 @@
 	var/list/result = list()
 	var/player_count = override_player_count || length(GLOB.joined_player_list)
 	result["player_count"] = player_count
+	if(is_storyteller_soft_antag_blocked())
+		result["tier1_slots"] = 0
+		result["major_antag_active"] = FALSE
+		result["garrison"] = SSgamemode.garrison
+		result["holy_warrior"] = SSgamemode.holy_warrior
+		result["acolyte"] = SSgamemode.half_combatant
+		result["combat_total"] = SSgamemode.garrison + SSgamemode.holy_warrior + FLOOR(SSgamemode.half_combatant * 0.5, 1)
+		result["tier2_extra"] = 0
+		result["final_slots"] = 0
+		return result
 
 	// Tier 1: Population scaling, +1 per 10 players above 40, max 10
 	var/slots = 5
@@ -168,7 +188,7 @@
 		tier2_max = min(max(0, combat_count - 10), 5)
 		slots += tier2_max
 	result["tier2_extra"] = tier2_max
-	result["final_slots"] = slots
+	result["final_slots"] = max(0, slots)
 
 	return result
 
@@ -177,7 +197,7 @@
 	if(!wretch_job)
 		return
 	var/list/scaling = calculate_wretch_scaling(override_player_count)
-	var/slots = scaling["final_slots"]
+	var/slots = max(0, scaling["final_slots"])
 	// Never reduce below current occupancy
 	wretch_job.total_positions = max(wretch_job.current_positions, slots)
 	wretch_job.spawn_positions = max(wretch_job.current_positions, slots)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -62,54 +62,6 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	return
 
 /mob/dead/new_player/proc/new_player_panel()
-/*
-	var/output = "<center>"
-	if(SSticker.current_state <= GAME_STATE_PREGAME)
-		switch(ready)
-			if(PLAYER_NOT_READY)
-				output += "<p>[LINKIFY_READY("READY", PLAYER_READY_TO_PLAY)] | <b>UNREADY</b></p>"
-			if(PLAYER_READY_TO_PLAY)
-				output += "<p><b>READY</b> | [LINKIFY_READY("UNREADY", PLAYER_NOT_READY)]</p>"
-			if(PLAYER_READY_TO_OBSERVE)
-				output += "<p>[LINKIFY_READY("READY", PLAYER_READY_TO_PLAY)]</p>"
-				output += "<p>[LINKIFY_READY("UNREADY", PLAYER_NOT_READY)]</p>"
-	else
-//		output += "<p><a href='byond://?src=[REF(src)];manifest=1'>View the Crew Manifest</a></p>"
-//		output += "<p><a href='byond://?src=[REF(src)];manifest=1'>FOLK</a></p>"
-		output += "<p><a href='byond://?src=[REF(src)];late_join=1'>LATEJOIN</a></p>"
-	output += "<p><a href='byond://?src=[REF(src)];show_preferences=1'>CHARACTER</a></p>"
-
-//	output += "<p><a href='byond://?src=[REF(src)];show_options=1'>OPTIONS</a></p>"
-
-	output += "<p><a href='byond://?src=[REF(src)];show_keybinds=1'>KEYBINDS</a></p>"
-
-	if(!IsGuestKey(src.key))
-		if (SSdbcore.Connect())
-			var/isadmin = 0
-			if(src.client && src.client.holder)
-				isadmin = 1
-			var/datum/DBQuery/query_get_new_polls = SSdbcore.NewQuery("SELECT id FROM [format_table_name("poll_question")] WHERE [(isadmin ? "" : "adminonly = false AND")] Now() BETWEEN starttime AND endtime AND id NOT IN (SELECT pollid FROM [format_table_name("poll_vote")] WHERE ckey = \"[sanitizeSQL(ckey)]\") AND id NOT IN (SELECT pollid FROM [format_table_name("poll_textreply")] WHERE ckey = \"[sanitizeSQL(ckey)]\")")
-			var/rs = REF(src)
-			if(query_get_new_polls.Execute())
-				var/newpoll = 0
-				if(query_get_new_polls.NextRow())
-					newpoll = 1
-
-				if(newpoll)
-					output += "<p><b><a href='byond://?src=[rs];showpoll=1'>Show Player Polls</A> (NEW!)</b></p>"
-				else
-					output += "<p><a href='byond://?src=[rs];showpoll=1'>Show Player Polls</A></p>"
-			qdel(query_get_new_polls)
-			if(QDELETED(src))
-				return
-
-	output += "</center>"
-
-	//src << browse(output,"window=playersetup;size=210x240;can_close=0")
-	var/datum/browser/popup = new(src, "playersetup", "<div align='center'>LOBBY MENU</div>", 250, 200)
-	popup.set_window_options("can_close=0")
-	popup.set_content(output)
-	popup.open(FALSE)*/
 	if(client)
 		if(client.prefs)
 			client.prefs.ShowChoices(src, 4)
@@ -121,7 +73,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	if(!client)
 		return 0
 
-	//Determines Relevent Population Cap
+	// Determine relevant population cap.
 	var/relevant_cap
 	var/hpc = CONFIG_GET(number/hard_popcap)
 	var/epc = CONFIG_GET(number/extreme_popcap)
@@ -144,13 +96,10 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 
 	if(href_list["ready"])
 		var/tready = text2num(href_list["ready"])
-		//Avoid updating ready if we're after PREGAME (they should use latejoin instead)
-		//This is likely not an actual issue but I don't have time to prove that this
-		//no longer is required
-		if(tready == PLAYER_NOT_READY)
-			if(SSticker.job_change_locked)
-				return
-		if(SSticker.current_state <= GAME_STATE_PREGAME)
+		var/is_pregame = SSticker.current_state <= GAME_STATE_PREGAME
+		if(tready == PLAYER_NOT_READY && SSticker.job_change_locked)
+			return
+		if(is_pregame)
 			if(tready == PLAYER_READY_TO_PLAY)
 				if(length(client.prefs.flavortext) < MINIMUM_FLAVOR_TEXT)
 					to_chat(src, span_boldwarning("You need a minimum of [MINIMUM_FLAVOR_TEXT] characters in your flavor text in order to play."))
@@ -170,12 +119,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	if(href_list["refresh"])
 		winshow(src, "preferencess_window", FALSE)
 		src << browse(null, "window=preferences_browser")
-//		src << browse(null, "window=playersetup") //closes the player setup window
 		new_player_panel()
-
-//	if(href_list["rpprompt"])
-//		do_rp_prompt()
-//		return
 
 	if(href_list["late_join"])
 		if(!SSticker?.IsRoundInProgress())
@@ -189,11 +133,6 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 		if(href_list["late_join"] == "override")
 			LateChoices()
 			return
-/*#ifdef MATURESERVER
-		if(key && (world.time < GLOB.respawntimes[key] + RESPAWNTIME))
-			to_chat(usr, span_warning("I can return in [GLOB.respawntimes[key] + RESPAWNTIME - world.time]."))
-			return
-#else*/
 
 
 		var/timetojoin = 5 MINUTES
@@ -433,7 +372,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	return JOB_AVAILABLE
 
 /mob/dead/new_player/proc/AttemptLateSpawn(rank)
-	var/error = IsJobUnavailable(rank)
+	var/error = IsJobUnavailable(rank, TRUE)
 	if(error != JOB_AVAILABLE)
 		to_chat(src, span_warning("[get_job_unavailable_error_message(error, rank)]"))
 		return FALSE
@@ -544,6 +483,10 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 		character.client.update_ooc_verb_visibility()
 
 /mob/dead/new_player/proc/LateChoices()
+	if(SSticker?.HasRoundStarted() && SSgamemode?.current_storyteller)
+		gnollslot_update()
+		update_scaling_slots()
+		enforce_storyteller_soft_antag_slots()
 	var/list/dat = list("<div class='notice' style='font-style: normal; font-size: 14px; margin-bottom: 2px; padding-bottom: 0px'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time, 1)]</div>")
 	for(var/datum/job/prioritized_job in SSjob.prioritized_jobs)
 		if(prioritized_job.current_positions >= prioritized_job.total_positions)
@@ -575,7 +518,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			if(!job_datum)
 				continue
 			// Make sure hiv+ jobs always appear on list, even if unavailable
-			var/is_job_available = (IsJobUnavailable(job_datum.title, TRUE) == JOB_AVAILABLE)
+			var/is_job_available = (IsJobUnavailable(job_datum.title) == JOB_AVAILABLE)
 			if(job_datum.always_show_on_latechoices)
 				is_job_available = TRUE
 			if(is_job_available)


### PR DESCRIPTION
## About The Pull Request

PSYDON is true extended. Eora disables roundstart antags and bandits.

1. If a round had a vote, that same vote cannot be made next round.
2. You need to be readied up to vote (though this is kinda redundant since there's time before roundstart anyhow. will need to see this)
3. Admins can check Storyteller - Log under GameMaster to see who vote for what last round.
4. Votes are now pooled. Ascendant/Ten/Psydon. If a pool has more votes than another pool, then that pool's storytellers will count. And the actual storyteller will b the one with the most votes in that pool.

## Testing Evidence

More or less. 

## Why It's Good For The Game

sick of this shit

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: extended/greenshift for psydon
add: vote panel now pops up on vote start.
add: new vote panel + vote measures.
add: vote log for admins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
