### PR TITLE
Macebearer E Tweak

### DIFF
--- a/code/modules/antagonists/roguetown/villain/unbound_spellblade.dm
+++ b/code/modules/antagonists/roguetown/villain/unbound_spellblade.dm
@@ -178,7 +178,7 @@
 			if("macebearer")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/charge)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -159,7 +159,7 @@
 			if("macebearer")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/charge)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/spellblade_chant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/spellblade_chant.dm
@@ -320,7 +320,7 @@ a.choose-btn:hover {
 <ul>
 <li><b>Shatter</b> — 3-tile line smash that devastates armor integrity and knocks targets back 1 tile. Empowered: doubles damage.</li>
 <li><b>Tremor</b> — Slam the ground, damaging and pushing back everyone adjacent 1 tile. Empowered: doubles damage.</li>
-<li><b>Charge!</b> — Charge forward 5 paces, ramming everyone in the path aside, then bash at the end. Knocks the final target back 1 tile. Empowered: doubles damage. Brief chargeup before moving.</li>
+<li><b>Charge!</b> — Instantly dash forward 4 paces, shoving everyone in the path to the sides. Deals no damage — pure mobility and disruption.</li>
 <li><b>Cataclysm</b> — Conjure and hurl an arcyne hammer at a target area. Crushes a 5x5 area and leaves victims Vulnerable. Bonus damage at max momentum.</li>
 </ul>
 </div>

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
@@ -102,7 +102,7 @@
 			if("macebearer")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/charge)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
@@ -108,7 +108,7 @@
 			if("macebearer")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/charge)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pariah.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pariah.dm
@@ -113,7 +113,7 @@
 			if("macebearer")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/charge)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)

--- a/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/mage_apprentice.dm
@@ -311,7 +311,7 @@
 			if("macebearer")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/charge)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)

--- a/code/modules/jobs/job_types/roguetown/church/templar_noc_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar_noc_spellblade.dm
@@ -100,7 +100,7 @@
 			if("macebearer")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/charge)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -564,7 +564,7 @@ LICH SKELETONS
 			if("macebearer")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shatter)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tremor)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/charge)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/charge)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/cataclysm)
 
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall_weapon)

--- a/code/modules/spells/spell_types/classunique/spellblade/charge.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/charge.dm
@@ -1,80 +1,44 @@
-/* Charge! - Macebearer ramming charge.
-5 rapid steps forward in the user's facing direction, shoving
+/* Charge! - Spellblade combat dash.
+4 rapid steps forward in the user's facing direction, shoving
 anyone in the path to the sides for zero damage.
-Only strikes at the final tile (or wherever the charge stops).
+Instant self-cast, no empowerment, pure mobility/utility. */
 
-Knockback on final hit is 1 tile regardless of empowerment.
-At 3+ momentum: consumes 3 stacks, doubles strike damage.
-Does NOT build momentum on hit — use normal melee for that. */
-
-/obj/effect/proc_holder/spell/invoked/charge
+/obj/effect/proc_holder/spell/self/charge
 	name = "Charge!"
-	desc = "Infuse mana into your legs, charging forth five paces — \
-		ramming everyone in your path to the sides for no damage. \
-		Bashes everything at the destination and knocks them back 1 tile. \
-		At 3+ momentum: consumes 3 to double damage. \
-		Strikes your aimed bodypart. Can be deflected by Defend stance."
+	desc = "Infuse mana into your legs, dashing forward four paces — \
+		ramming everyone in your path to the sides for no damage."
 	clothes_req = FALSE
-	range = 15
 	action_icon = 'icons/mob/actions/spellblade.dmi'
-	overlay_state = "advance" // Icon by Prominence. Shared with Advance since the spells are very similar.
+	overlay_state = "advance"
 	releasedrain = 15
 	chargedrain = 0
-	chargetime = 5
-	recharge_time = 15 SECONDS
-	warnie = "spellwarning"
-	no_early_release = TRUE
-	movement_interrupt = FALSE
-	charging_slowdown = 0
-	chargedloop = /datum/looping_sound/invokegen
+	chargetime = 0
+	recharge_time = 12 SECONDS
 	invocations = list()
-	invocation_type = "shout"
-	gesture_required = TRUE
+	invocation_type = "none"
+	gesture_required = FALSE
 	xp_gain = FALSE
-	var/charge_steps = 5
-	var/base_damage = 45
-	var/empowered_mult = 2
-	var/base_push = 1
-	var/momentum_cost = 3
+	var/charge_steps = 4
 	var/step_delay = 2
 
-/obj/effect/proc_holder/spell/invoked/charge/cast(list/targets, mob/user = usr)
+/obj/effect/proc_holder/spell/self/charge/cast(list/targets, mob/user = usr)
 	var/mob/living/carbon/human/H = user
 	if(!istype(H))
 		revert_cast()
 		return
 
-	var/obj/item/held_weapon = arcyne_get_weapon(H)
-	if(!held_weapon)
-		to_chat(H, span_warning("I need my bound weapon in hand!"))
-		revert_cast()
-		return
-
-	H.say("Impete!", forced = "spell")
-
-	var/atom/target = targets[1]
-	var/turf/target_turf = get_turf(target)
+	var/facing = H.dir
 	var/turf/start = get_turf(H)
-	var/facing = get_dir(start, target_turf) || H.dir
-
 	var/turf/first_step = get_step(start, facing)
 	if(!first_step || first_step.density)
 		to_chat(H, span_warning("There's no room to charge!"))
 		revert_cast()
 		return
 
-	var/empowered = FALSE
-	var/datum/status_effect/buff/arcyne_momentum/M = H.has_status_effect(/datum/status_effect/buff/arcyne_momentum)
-	if(M && M.stacks >= momentum_cost)
-		M.consume_stacks(momentum_cost)
-		empowered = TRUE
-		to_chat(H, span_notice("[momentum_cost] momentum released — empowered charge!"))
-
-	var/damage = empowered ? (base_damage * empowered_mult) : base_damage
-
 	if(H.buckled)
 		H.buckled.unbuckle_mob(H, TRUE)
 
+	H.say("Impete!", forced = "spell")
 	H.visible_message(
 		span_warning("[H] barrels forward!"),
 		span_notice("I charge!"))
@@ -82,7 +46,7 @@ Does NOT build momentum on hit — use normal melee for that. */
 
 	// Compute perpendicular directions for side-shoving
 	var/list/perp_dirs = get_perpendicular_dirs(facing)
-	var/shove_toggle = 0 // Alternate left/right
+	var/shove_toggle = 0
 
 	var/steps_taken = 0
 	for(var/i in 1 to charge_steps)
@@ -122,55 +86,10 @@ Does NOT build momentum on hit — use normal melee for that. */
 		to_chat(H, span_warning("My charge is blocked!"))
 		return
 
-	var/hit_count = 0
-	var/turf/dest = get_turf(H)
-
-	for(var/mob/living/victim in dest)
-		if(victim == H || victim.stat == DEAD)
-			continue
-		if(spell_guard_check(victim, FALSE, hit_count == 0 ? H : null))
-			continue
-		if(empowered)
-			arcyne_strike(H, victim, held_weapon, round(damage / 2), H.zone_selected, BCLASS_BLUNT, spell_name = "Charge!", skip_message = TRUE)
-			arcyne_strike(H, victim, held_weapon, round(damage / 2), H.zone_selected, BCLASS_BLUNT, spell_name = "Charge!")
-		else
-			arcyne_strike(H, victim, held_weapon, damage, H.zone_selected, BCLASS_BLUNT, spell_name = "Charge!")
-		hit_count++
-		var/push_dir = get_dir(H, victim)
-		if(!push_dir)
-			push_dir = facing
-		victim.safe_throw_at(get_ranged_target_turf(victim, push_dir, base_push), base_push, 1, H, force = MOVE_FORCE_STRONG)
-
-	// If no one was hit at destination, check the next tile ahead
-	if(!hit_count)
-		var/turf/ahead = get_step(dest, facing)
-		if(ahead)
-			for(var/mob/living/victim in ahead)
-				if(victim == H || victim.stat == DEAD)
-					continue
-				if(spell_guard_check(victim, FALSE, hit_count == 0 ? H : null))
-					continue
-				if(empowered)
-					arcyne_strike(H, victim, held_weapon, round(damage / 2), H.zone_selected, BCLASS_BLUNT, spell_name = "Charge!", skip_message = TRUE)
-					arcyne_strike(H, victim, held_weapon, round(damage / 2), H.zone_selected, BCLASS_BLUNT, spell_name = "Charge!")
-				else
-					arcyne_strike(H, victim, held_weapon, damage, H.zone_selected, BCLASS_BLUNT, spell_name = "Charge!")
-				hit_count++
-				var/push_dir = get_dir(H, victim)
-				if(!push_dir)
-					push_dir = facing
-				victim.safe_throw_at(get_ranged_target_turf(victim, push_dir, base_push), base_push, 1, H, force = MOVE_FORCE_STRONG)
-
-	if(!hit_count)
-		H.visible_message(span_notice("[H] finishes the charge with a swing at the air."))
-		return
-
-	playsound(dest, pick('sound/combat/ground_smash1.ogg', 'sound/combat/ground_smash2.ogg', 'sound/combat/ground_smash3.ogg'), 80, TRUE)
-
 	log_combat(H, null, "used Charge!")
 	return TRUE
 
-/obj/effect/proc_holder/spell/invoked/charge/proc/get_perpendicular_dirs(dir)
+/obj/effect/proc_holder/spell/self/charge/proc/get_perpendicular_dirs(dir)
 	switch(dir)
 		if(NORTH, SOUTH)
 			return list(WEST, EAST)


### PR DESCRIPTION
## About The Pull Request
Redo Macebearer E into an instant 4 tiles charge

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yes, tested locally
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It didn't feels *good* enough to weave in with the combo. So I moved it back to its original identity, without damage, and with displacement as a 4 tiles instant cast dash on a slightly shorter cooldown for Macebearer to outmaneuver their opponent.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Redo Macebearer E to be a damageless, unempowered 4 tiles dash that displace.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
