### PR TITLE
aggressively makes sure clickcd status effect works

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -926,8 +926,16 @@
 /datum/status_effect/debuff/clickcd/on_creation(mob/living/new_owner, new_dur)
 	if(new_dur)
 		duration = new_dur
+	RegisterSignal(new_owner, COMSIG_MOB_CLICKON, PROC_REF(onclick))
 	new_owner.changeNext_move(duration)
 	return ..()
+
+/datum/status_effect/debuff/clickcd/proc/onclick()
+	return COMSIG_MOB_CANCEL_CLICKON
+
+/datum/status_effect/debuff/clickcd/on_remove()
+	UnregisterSignal(owner, COMSIG_MOB_CLICKON)
+	. = ..()
 
 /atom/movable/screen/alert/status_effect/debuff/clickcd
 	name = "Action Delayed"


### PR DESCRIPTION
## About The Pull Request
Got a report of lightning bolts not "doing anything" (clickCD included). Couldn't replicate it locally, but took the opportunity to make damn sure you cannot click on anything while the dedicated status effect is applied to you.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Hard to show, but clicks were denied even when my next_move was changed around due to other effects.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This isn't really a user-facing PR, unless people were circumventing the status effect somehow. Now they won't be able to, if they did.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
