### PR TITLE
Sewerification

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -243,6 +243,12 @@
 "acF" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
+"acG" = (
+/obj/machinery/light/rogue/torchholder/r{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/sewer)
 "acH" = (
 /obj/structure/chair/bench/church/smallbench{
 	dir = 8;
@@ -520,6 +526,12 @@
 /obj/item/rogueweapon/shovel/small/crafted,
 /turf/open/floor/rogue/grassred,
 /area/rogue/druidsgrove)
+"afQ" = (
+/obj/structure/table/church/end,
+/obj/item/roguestatue/gold/loot,
+/obj/item/reagent_containers/glass/bottle/rogue/beer/nocshine,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "afS" = (
 /obj/structure/rack/rogue/shelf,
 /obj/item/natural/bundle/cloth/bandage/full,
@@ -532,12 +544,24 @@
 /obj/item/rogueore/cinnabar,
 /obj/item/rogueore/cinnabar,
 /obj/item/rogueore/cinnabar,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/dwarfin)
 "afY" = (
@@ -725,10 +749,6 @@
 	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/indoors/town/bath)
-"aiH" = (
-/obj/structure/mineral_door/swing_door,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "aiM" = (
 /obj/structure/bed/rogue/inn/double{
 	dir = 1
@@ -855,6 +875,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
+"akb" = (
+/obj/structure/fluff/railing/wood,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "akh" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/flora/roguegrass,
@@ -925,9 +949,6 @@
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/lava/acid,
 /area/rogue/under/cave/his_vault/puzzle)
-"akV" = (
-/turf/open/water/transparent/surface/pond,
-/area/rogue/outdoors/town)
 "akX" = (
 /obj/machinery/light/rogue/lanternpost{
 	dir = 1;
@@ -1106,13 +1127,21 @@
 /area/rogue/indoors/cave/west)
 "ane" = (
 /obj/structure/table/wood/poor/alt,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather{
 	pixel_x = 8;
 	pixel_y = -3
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/cave/dukecourt)
+"ank" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/grass,
+/area/rogue/under/town/sewer)
 "anr" = (
 /obj/structure/fluff/railing/border/north,
 /obj/structure/fluff/railing/corner,
@@ -1158,6 +1187,10 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"anO" = (
+/obj/machinery/light/rogue/firebowl/church/off,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "anR" = (
 /obj/structure/fireaxecabinet/south,
 /turf/open/floor/rogue/hexstone,
@@ -1166,6 +1199,10 @@
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/grass,
 /area/rogue/druidsgrove)
+"anU" = (
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "anX" = (
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
 /turf/open/floor/rogue/dirt,
@@ -1186,7 +1223,9 @@
 /area/rogue/indoors/inq/basement)
 "aoo" = (
 /obj/structure/table/wood/poor,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/manor)
@@ -1702,6 +1741,11 @@
 /mob/living/carbon/human/species/human/northern/bog_deserters,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter)
+"asz" = (
+/obj/structure/mineral_door/wood/donjon/stone/highsecurity,
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/blocks/paving,
+/area/rogue/under/cave)
 "asA" = (
 /obj/structure/table/wood/poor/alt,
 /turf/open/floor/rogue/dirt,
@@ -1921,6 +1965,11 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/woods)
+"auS" = (
+/obj/structure/bed/rogue/inn/wool,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cave)
 "avb" = (
 /obj/structure/roguemachine/atm{
 	location_tag = "Tavern Backroom"
@@ -2069,6 +2118,10 @@
 /obj/structure/table/wood/large_table/north_west,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/physician)
+"axu" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "axw" = (
 /obj/structure/stairs{
 	dir = 1
@@ -2410,6 +2463,13 @@
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/minotaurfort)
+"aBP" = (
+/obj/structure/chair/stool/rogue,
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/under/town/sewer)
 "aCn" = (
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
 /turf/open/floor/rogue/dirt/road,
@@ -2437,6 +2497,10 @@
 /obj/structure/flora/roguetree/pine,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/beach/forest/south)
+"aCF" = (
+/obj/structure/spider/stickyweb,
+/turf/closed/mineral/random/rogue/med,
+/area/rogue/under/town/sewer)
 "aCH" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -2793,6 +2857,11 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/underdark/north)
+"aGH" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/roguetown/shirt/robe/dendor,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "aGJ" = (
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/cobble,
@@ -3000,6 +3069,16 @@
 /obj/effect/decal/cleanable/roguerune/god/psydon,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
+"aIF" = (
+/obj/structure/table/wood/long_table/right,
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 1
+	},
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "aIM" = (
 /obj/structure/handcart,
 /obj/item/natural/stone,
@@ -3013,6 +3092,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/north)
+"aIN" = (
+/obj/effect/decal/cleanable/roguerune/god/dendor,
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/under/cave)
 "aIV" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
@@ -3040,6 +3123,10 @@
 /obj/structure/fluff/railing/corner/south_east,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/outdoors/town)
+"aJb" = (
+/obj/structure/roguewindow/harem3,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/under/town/sewer)
 "aJc" = (
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
@@ -3051,10 +3138,18 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog/south)
+"aJg" = (
+/obj/machinery/light/rogue/candle/floorcandle,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "aJk" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains)
+"aJl" = (
+/obj/structure/roguewindow/harem3,
+/turf/closed/wall/mineral/rogue/craftstone,
+/area/rogue/indoors/town/bath)
 "aJn" = (
 /obj/structure/closet/crate/chest/old_crate/apothseed,
 /obj/item/rogueweapon/hoe,
@@ -3102,8 +3197,6 @@
 "aJH" = (
 /obj/machinery/light/rogue/candle/blue/r,
 /obj/structure/rack/rogue,
-/obj/item/clothing/shoes/roguetown/boots,
-/obj/item/clothing/shoes/roguetown/boots,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/sewer)
 "aJL" = (
@@ -3130,6 +3223,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/scarymaze)
+"aJV" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "aJW" = (
 /obj/structure/fluff/walldeco/chains{
 	icon_state = "chains8"
@@ -3448,6 +3547,14 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"aMW" = (
+/obj/structure/toilet,
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "aMX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -3458,7 +3565,6 @@
 "aNd" = (
 /obj/structure/table/wood/long_table/right,
 /obj/machinery/light/rogue/candle/floorcandle,
-/obj/item/mini_flagpole/bathhouse,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "aNp" = (
@@ -4128,6 +4234,11 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
+"aVb" = (
+/obj/structure/vine/dendor,
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/metal,
+/area/rogue/under/cave)
 "aVe" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassyel,
@@ -4287,9 +4398,8 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
 "aWW" = (
-/obj/structure/table/wood/large_table/middle_east,
-/obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/turf/open/floor/rogue/naturalstone,
+/obj/structure/ritualcircle/abyssor,
+/turf/open/floor/rogue/greenstone/glyph1,
 /area/rogue/under/cave)
 "aWX" = (
 /obj/structure/rack/rogue,
@@ -4374,7 +4484,7 @@
 /area/rogue/under/cave/goblinfort)
 "aXX" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/water/transparent/surface/pond,
+/turf/open/water/pond,
 /area/rogue/outdoors/town)
 "aYi" = (
 /obj/machinery/light/rogue/candle,
@@ -4439,8 +4549,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
@@ -4477,6 +4591,10 @@
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/central)
+"aZF" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "aZG" = (
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/churchmarble,
@@ -4733,6 +4851,10 @@
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
+"bcl" = (
+/mob/living/simple_animal/hostile/rogue/skeleton,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "bco" = (
 /obj/machinery/light/rogue/campfire/fireplace,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -5156,6 +5278,23 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/garrison)
+"bhl" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	layer = 2.05;
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "bhn" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/naturalstone,
@@ -5177,6 +5316,13 @@
 "bhJ" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cave)
+"bhK" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/basement)
 "bhQ" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobblerock{
@@ -5223,6 +5369,11 @@
 /obj/item/storage/belt/rogue/pouch/coins/mid,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
+"biC" = (
+/obj/structure/table/wood/poor,
+/obj/item/toy/cards/deck,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/basement)
 "biD" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon,
 /obj/structure/rack/rogue,
@@ -5527,6 +5678,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/druidsgrove)
+"bmn" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/town/sewer)
 "bmu" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5547,8 +5702,9 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet/bogcaves/west)
 "bmK" = (
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 8
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -5685,6 +5841,17 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town)
+"bnR" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	layer = 2.05;
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "bnX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/tile/masonic{
@@ -5727,6 +5894,10 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/steward)
+"box" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "boA" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/outdoors/mountains)
@@ -5909,6 +6080,12 @@
 /obj/structure/chair/bench/church/smallbench,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"brw" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "brI" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/hexstone,
@@ -6253,6 +6430,11 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"bvb" = (
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/under/cave)
 "bvf" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/blocks,
@@ -6293,8 +6475,12 @@
 /obj/machinery/light/rogue/candle/r,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -6437,6 +6623,10 @@
 /obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"bxh" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "bxl" = (
 /obj/structure/fluff/psycross/crafted,
 /turf/open/floor/rogue/wood,
@@ -6466,6 +6656,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
+"bxB" = (
+/obj/structure/spike_pit,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "bxC" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/blocks,
@@ -6764,7 +6958,9 @@
 /area/rogue/indoors/cave/northern)
 "bBh" = (
 /obj/structure/table/wood/long_table/right,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/structure/fluff/wallclock/r,
 /obj/machinery/light/rogue/candle,
@@ -6852,6 +7048,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/under/cave/dukecourt)
+"bCj" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "bCn" = (
 /obj/structure/bed/rogue/inn/double{
 	can_buckle = 0
@@ -6880,6 +7081,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/mountains)
+"bDc" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/metal,
+/area/rogue/under/town/sewer)
 "bDe" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -7366,9 +7571,6 @@
 /obj/structure/fermentation_keg/random/water,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
-"bJN" = (
-/turf/open/water/transparent/inner/pond,
-/area/underwater)
 "bJO" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic/white,
@@ -7702,6 +7904,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
+"bMV" = (
+/obj/structure/mineral_door/wood/window{
+	lockid = "nightmaiden"
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "bMX" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light/rogue/candle{
@@ -8047,6 +8255,10 @@
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods/southwest)
+"bQR" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cave)
 "bQV" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble/mossy,
@@ -8868,8 +9080,12 @@
 /area/rogue/under/cave/dungeon1/gethsmane)
 "cbx" = (
 /obj/structure/table/wood/large_table/middle_east,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
@@ -8886,8 +9102,8 @@
 /area/rogue/outdoors/beach/forest/south)
 "cbI" = (
 /obj/structure/table/wood/poor,
-/obj/item/lockpick,
 /obj/machinery/light/rogue/campfire/fireplace,
+/obj/item/natural/glass_shard,
 /turf/open/floor/carpet/stellar,
 /area/rogue/under/town/sewer)
 "cbJ" = (
@@ -8996,6 +9212,10 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest/north)
+"cdv" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/revenant/wolf,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "cdw" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -9619,6 +9839,16 @@
 /mob/living/carbon/human/species/goblin/npc/cave,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"cjR" = (
+/obj/structure/table/wood/long_table,
+/obj/machinery/light/rogue/candle/blue/l,
+/obj/effect/decal/cleanable/dirt/cobweb,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "cjT" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -10212,6 +10442,12 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town)
+"cpz" = (
+/obj/structure/fluff/railing/fence{
+	dir = 1
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "cpC" = (
 /obj/machinery/light/rogue/campfire/densefire{
 	fueluse = 1.8e+06
@@ -10500,12 +10736,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/scarymaze)
-"cta" = (
-/obj/structure/fluff/railing/border/east,
-/obj/structure/table/wood/long_table/right,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "ctc" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/churchmarble,
@@ -10758,7 +10988,9 @@
 /area/rogue/under/cave/scarymaze)
 "cvj" = (
 /obj/structure/table/wood/long_table/mid/alt,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
@@ -10832,10 +11064,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/druidsgrove)
-"cvK" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "cvU" = (
 /obj/structure/table/wood/long_table,
 /obj/item/candle/yellow/lit,
@@ -10936,8 +11164,8 @@
 /area/rogue/under/cave/fishmandungeon)
 "cxx" = (
 /obj/effect/decal/remains/saiga,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cave)
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "cxy" = (
 /obj/structure/chair/stool/rogue,
 /obj/item/fishingrod/aalloy,
@@ -11088,8 +11316,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
@@ -11129,14 +11361,6 @@
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
-"czy" = (
-/obj/effect/decal/cleanable/dirt/cobweb{
-	dir = 1
-	},
-/turf/open/floor/rogue/metal{
-	dir = 4
-	},
-/area/rogue/under/town/sewer)
 "czB" = (
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/reagent_containers/glass/bottle/rogue/beer/butterhairs{
@@ -11247,6 +11471,20 @@
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/town/basement/keep)
+"cAA" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "cAE" = (
 /obj/structure/bars/steel,
 /obj/structure/fluff/railing/corner/south_east,
@@ -11327,7 +11565,9 @@
 /area/rogue/indoors/shelter)
 "cBs" = (
 /obj/structure/table/wood/long_table,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -11849,6 +12089,16 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"cHp" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "cHr" = (
 /obj/item/book/rogue/abyssor,
 /obj/structure/rack/rogue/shelf/biggest,
@@ -11946,6 +12196,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/church/basement)
+"cIz" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/neck/roguetown/psicross/dendor,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "cIC" = (
 /turf/open/floor/rogue/greenstone/glyph3,
 /area/rogue/indoors/town/vault)
@@ -11980,9 +12235,6 @@
 /obj/item/reagent_containers/powder/ozium,
 /obj/item/flashlight/flare/torch/lantern,
 /obj/item/flashlight/flare/torch/lantern,
-/obj/item/mini_flagpole/church,
-/obj/item/mini_flagpole/church,
-/obj/item/mini_flagpole/church,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church/chapel)
 "cJi" = (
@@ -12109,6 +12361,14 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"cKQ" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/obj/item/roguebin/water/gross,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "cKR" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -12522,10 +12782,6 @@
 	color = "#3b444b"
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
-"cOP" = (
-/obj/effect/landmark/chimeric_calyx_spawner/fifteen,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/sewer)
 "cOR" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/tile/harem,
@@ -12600,9 +12856,7 @@
 /turf/closed/wall/mineral/rogue/roofwall/middle/dir8,
 /area/rogue/indoors/town)
 "cPt" = (
-/obj/structure/mannequin/male{
-	dir = 1
-	},
+/obj/structure/mannequin,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/town/basement/keep)
 "cPv" = (
@@ -12633,6 +12887,28 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/beach)
+"cPy" = (
+/obj/structure/closet/crate/roguecloset/dark,
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "cPA" = (
 /obj/structure/stairs,
 /obj/machinery/light/rogue/candle/l,
@@ -12662,9 +12938,6 @@
 /obj/item/ash,
 /obj/item/ash,
 /obj/item/ash,
-/obj/item/mini_flagpole/university,
-/obj/item/mini_flagpole/university,
-/obj/item/mini_flagpole/university,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/magician)
 "cPN" = (
@@ -13081,6 +13354,13 @@
 /obj/effect/landmark/start/hostage,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
+"cUQ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "cUT" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8
@@ -13346,6 +13626,10 @@
 /obj/machinery/light/rogue/campfire/densefire,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach/central)
+"cXB" = (
+/obj/structure/spider/cocoon,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "cXE" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/wood,
@@ -13422,7 +13706,7 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "cYA" = (
 /obj/structure/fluff/railing/corner/north_east,
-/turf/open/water/transparent/surface/pond,
+/turf/open/water/pond,
 /area/rogue/outdoors/woods/south)
 "cYB" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -13517,6 +13801,14 @@
 /obj/item/candle/yellow,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"cZf" = (
+/obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/campfire/fireplace,
+/obj/item/candle/skull/lit{
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "cZj" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -13662,6 +13954,11 @@
 /obj/structure/hotspring/border/three,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
+"daH" = (
+/obj/structure/table/wood/large_table,
+/obj/effect/spawner/lootdrop/cheap_tableware_spawner,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "daM" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/grasscold,
@@ -13955,6 +14252,10 @@
 	dir = 4
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"dem" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "den" = (
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/rogue/grassred,
@@ -13973,6 +14274,9 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave/mazedungeon)
+"deJ" = (
+/turf/closed/wall/mineral/rogue/wooddark/window,
+/area/rogue/indoors/town/bath)
 "deK" = (
 /mob/living/carbon/human/species/skeleton/npc/mediumspread,
 /turf/open/floor/rogue/dirt/road,
@@ -14140,6 +14444,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
+"dho" = (
+/obj/structure/bars,
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/under/town/sewer)
 "dhq" = (
 /obj/structure/table/vtable/v2,
 /obj/item/rogueweapon/woodstaff/diamond,
@@ -14194,6 +14502,12 @@
 /obj/effect/landmark/chest_or_mimic/locked_or_trapped,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave)
+"dhV" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5-old"
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "dia" = (
 /turf/open/water/river/flow,
 /area/rogue/outdoors/woods/southwest)
@@ -14382,6 +14696,13 @@
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/forest/hamlet)
+"dke" = (
+/turf/closed/wall/mineral/rogue/wooddark/slitted,
+/area/rogue/under/cave)
+"dkh" = (
+/obj/structure/flora/mushroomcluster,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "dkk" = (
 /obj/machinery/light/rogue/oven/north,
 /turf/closed/wall/mineral/rogue/decowood,
@@ -14825,6 +15146,10 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
+"dpr" = (
+/mob/living/simple_animal/hostile/rogue/skeleton,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "dpt" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/indoors/cave/west)
@@ -14998,6 +15323,10 @@
 "dqV" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/inq/basement)
+"dqX" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "dra" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -15074,6 +15403,12 @@
 "drF" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/garrison)
+"drK" = (
+/obj/structure/fluff/railing/fence{
+	dir = 8
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "drM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/carbon/human/species/skeleton/npc/mediumspread,
@@ -15187,10 +15522,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield/eora)
-"dsP" = (
-/obj/structure/leyline/normal/coast,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/beach/forest/south)
 "dsX" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 1
@@ -15500,6 +15831,10 @@
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"dwH" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/carpet/purple,
+/area/rogue/under/town/sewer)
 "dwI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -15507,6 +15842,9 @@
 /mob/living/carbon/human/species/skeleton/npc/medium,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors)
+"dwL" = (
+/turf/open/floor/rogue/AzureSand,
+/area/rogue/under/town/sewer)
 "dwN" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/cobble,
@@ -15685,6 +16023,11 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave)
+"dzc" = (
+/obj/machinery/light/rogue/campfire/fireplace,
+/obj/structure/closet/crate/chest/old_crate,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "dzd" = (
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/wood,
@@ -15824,6 +16167,9 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/mountains/decap/minotaurfort)
+"dzU" = (
+/turf/open/floor/rogue/grass,
+/area/rogue/under/town/sewer)
 "dzW" = (
 /obj/machinery/light/roguestreet,
 /turf/open/floor/rogue/naturalstone,
@@ -15904,7 +16250,9 @@
 /area/rogue/outdoors/woods/north)
 "dBe" = (
 /obj/structure/table/wood/large_table/south_east,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/church,
 /area/rogue/under/underdark/north)
@@ -16067,10 +16415,8 @@
 /area/rogue/indoors/shelter)
 "dDv" = (
 /obj/structure/table/wood/poor,
-/obj/item/candle/skull/lit{
-	pixel_y = 6
-	},
 /obj/machinery/light/rogue/campfire/fireplace,
+/obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/carpet/stellar,
 /area/rogue/under/town/sewer)
 "dDy" = (
@@ -16359,6 +16705,9 @@
 /obj/structure/fluff/railing/wood/west,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/mountains)
+"dHD" = (
+/turf/open/floor/rogue/metal,
+/area/rogue/under/town/sewer)
 "dHK" = (
 /obj/machinery/light/rogue/candle/blue/l,
 /mob/living/carbon/human/species/skeleton/npc/medium,
@@ -16765,7 +17114,9 @@
 "dLV" = (
 /obj/structure/table/wood/poor/alt,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
@@ -17092,12 +17443,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
-"dPl" = (
-/obj/structure/roguemachine/vendor{
-	keycontrol = "townie_smith_extra"
-	},
-/turf/closed/wall/mineral/rogue/craftstone,
-/area/rogue/indoors/town)
 "dPm" = (
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/dirt,
@@ -17705,6 +18050,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/druidsgrove)
+"dVG" = (
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "dVJ" = (
 /obj/structure/bars,
 /turf/open/water/sewer,
@@ -17778,6 +18127,10 @@
 /obj/item/rogueweapon/spear,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
+"dWs" = (
+/obj/structure/mineral_door/swing_door,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "dWz" = (
 /obj/structure/fluff/railing/border/north,
 /obj/structure/chair/bench,
@@ -17832,6 +18185,10 @@
 /obj/item/alch/salvia,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"dWV" = (
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/under/cave)
 "dWW" = (
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/tile/checker,
@@ -17930,7 +18287,9 @@
 /area/rogue/indoors/town/tavern)
 "dXK" = (
 /obj/structure/table/wood/long_table,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/paper{
 	pixel_x = 4;
 	pixel_y = 4
@@ -18308,6 +18667,10 @@
 	},
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
 /turf/open/transparent/openspace,
 /area/rogue/druidsgrove)
 "ebS" = (
@@ -18497,8 +18860,12 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /obj/item/rope/chain,
@@ -18822,10 +19189,6 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter)
-"ehT" = (
-/obj/structure/flagpole,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town)
 "ehU" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_x = -32
@@ -19165,6 +19528,10 @@
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
+"elN" = (
+/obj/machinery/light/rogue/firebowl/church/off,
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/under/cave)
 "elQ" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/water/swamp,
@@ -19458,7 +19825,9 @@
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
 	},
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/tavern)
@@ -19703,6 +20072,25 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
+"esv" = (
+/obj/structure/fluff/railing/border/north{
+	pixel_y = 3
+	},
+/obj/structure/fluff/railing/border/east,
+/obj/structure/fluff/railing/border/west,
+/obj/machinery/light/rogue/hearth{
+	pixel_y = 6
+	},
+/obj/structure/fluff/railing/border,
+/obj/item/cooking/pan{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "esw" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/infernal/watcher,
 /turf/open/floor/rogue/naturalstone,
@@ -19881,6 +20269,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
+"etZ" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mirespider,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "eum" = (
 /obj/structure/lever/wall{
 	pixel_x = -20;
@@ -19999,6 +20391,11 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church/chapel)
+"evm" = (
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/under/town/sewer)
 "evn" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border/east,
@@ -20030,6 +20427,9 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/inq)
+"evY" = (
+/turf/open/floor/rogue/dark_ice,
+/area/rogue/under/cave)
 "ewb" = (
 /obj/structure/fluff/railing/corner/south_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -20498,6 +20898,10 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
+"eAB" = (
+/obj/structure/table/church,
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/under/cave)
 "eAC" = (
 /obj/structure/spider/stickyweb/mirespider,
 /turf/open/floor/rogue/cobble,
@@ -20719,6 +21123,11 @@
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"eDD" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/roguetown/dendormask,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "eDF" = (
 /obj/structure/standingbell{
 	dir = 1;
@@ -20917,6 +21326,13 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"eFP" = (
+/obj/machinery/light/rogue/campfire/fireplace,
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "eFQ" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/grass,
@@ -21298,6 +21714,11 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/skeletoncrypt)
+"eKk" = (
+/obj/structure/rack/rogue,
+/obj/item/clothing/shoes/roguetown/boots,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/sewer)
 "eKn" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
@@ -21561,7 +21982,9 @@
 /area/rogue/indoors/shelter)
 "eNc" = (
 /obj/structure/table/vtable,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/cave/dukecourt)
 "eNf" = (
@@ -21754,6 +22177,12 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/tavern)
+"ePo" = (
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "ePp" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -21822,6 +22251,10 @@
 /obj/structure/roguerock,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"eQa" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "eQb" = (
 /obj/structure/table/wood/poor,
 /obj/item/reagent_containers/glass/bottle/rogue/beer/hagwoodbitter,
@@ -21953,6 +22386,10 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/minotaurfort)
+"eQS" = (
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/metal,
+/area/rogue/under/town/sewer)
 "eQT" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -22009,6 +22446,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"eRp" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/cloak/tabard/devotee/dendor,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "eRq" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -22040,6 +22483,10 @@
 /obj/structure/table/wood/large_table/north_west,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/orcdungeon)
+"eRO" = (
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "eRR" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -22317,7 +22764,9 @@
 /area/rogue/under/cave/dungeon1/gethsmane)
 "eUx" = (
 /obj/structure/table/wood/long_table,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/paper{
 	pixel_x = 4;
 	pixel_y = 4
@@ -22398,6 +22847,10 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault/four)
+"eVA" = (
+/obj/structure/bars/passage/steel,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "eVD" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8;
@@ -22658,8 +23111,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /turf/open/floor/carpet/stellar,
@@ -23348,6 +23805,12 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
+"ffp" = (
+/obj/structure/fluff/railing/fence{
+	dir = 1
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "ffq" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "prisongate1"
@@ -23476,11 +23939,21 @@
 /obj/item/paper,
 /obj/item/paper,
 /obj/structure/closet/crate/chest/neu,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "fgR" = (
@@ -23493,6 +23966,14 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mossback,
 /turf/open/water/ocean,
 /area/rogue/indoors/cave/east)
+"fgV" = (
+/obj/structure/table/wood/poor,
+/obj/item/rope,
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/stellar,
+/area/rogue/under/town/sewer)
 "fgW" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/woods/south)
@@ -23557,6 +24038,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"fhy" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "fhA" = (
 /obj/effect/landmark/events/deadite_animal_migration_point{
 	order = 3
@@ -23862,6 +24349,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet/bogcaves/west)
+"fks" = (
+/obj/machinery/light/rogue/candle/floorcandle{
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "fkt" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grass,
@@ -24038,6 +24531,10 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark/south)
+"fmP" = (
+/obj/structure/spider/cocoon,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "fmR" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/grass,
@@ -24189,6 +24686,10 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
+"foD" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/under/town/sewer)
 "foE" = (
 /obj/structure/vine,
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
@@ -24368,8 +24869,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield)
 "fqU" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/cobble,
+/obj/machinery/light/rogue/candle/blue/r,
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/under/town/basement)
 "fqX" = (
 /obj/structure/roguemachine/crier,
@@ -24572,6 +25074,13 @@
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors)
+"fsQ" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/obj/structure/flora/mushroomcluster,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "fsV" = (
 /obj/structure/plasticflaps,
 /turf/open/floor/rogue/blocks/green,
@@ -24673,6 +25182,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
+"ftW" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mirespider,
+/turf/open/floor/rogue/grass,
+/area/rogue/under/town/sewer)
 "ftX" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5;
@@ -24792,6 +25305,11 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/troll/bog,
 /turf/open/water/swamp,
 /area/rogue/under/cave/fishmandungeon)
+"fvG" = (
+/obj/machinery/light/rogue/candle/blue/r,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/basement)
 "fvJ" = (
 /obj/structure/flora/rogueshroom,
 /turf/open/floor/rogue/dirt,
@@ -25244,6 +25762,12 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods/southwest)
+"fBv" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/item/rogueweapon/shovel,
+/obj/item/clothing/suit/roguetown/shirt/explorer,
+/turf/open/floor/rogue/grass,
+/area/rogue/under/town/sewer)
 "fBD" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/tunic/white,
@@ -25259,6 +25783,10 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest/north)
+"fBW" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "fCa" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt/road,
@@ -25418,6 +25946,10 @@
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"fDI" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "fDJ" = (
 /obj/structure/table/wood,
 /obj/item/roguestatue/gold{
@@ -25494,6 +26026,12 @@
 /obj/structure/flora/roguetree/burnt,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"fED" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "fEG" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/blocks,
@@ -25555,10 +26093,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark/south)
-"fFs" = (
-/obj/structure/fluff/railing/border/north,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "fFz" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/long,
@@ -25586,6 +26120,11 @@
 /mob/living/carbon/human/species/lizardfolk/psy_vault_guard,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault)
+"fFO" = (
+/obj/structure/bars,
+/obj/structure/roguewindow/harem3,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/basement)
 "fFS" = (
 /turf/closed/wall/mineral/rogue/wooddark/end{
 	dir = 4
@@ -25624,6 +26163,9 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"fGs" = (
+/turf/open/floor/rogue/greenstone/glyph5,
+/area/rogue/under/cave)
 "fGv" = (
 /obj/item/natural/stoneblock{
 	pixel_x = 18;
@@ -25697,6 +26239,10 @@
 /obj/structure/roguemachine/atm,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town)
+"fHt" = (
+/obj/structure/flora/roguegrass/bush/wall/tall,
+/turf/open/floor/rogue/grass,
+/area/rogue/under/cave)
 "fHu" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -26285,6 +26831,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"fOk" = (
+/obj/structure/table/church,
+/obj/item/clothing/neck/roguetown/psicross/noc,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "fOl" = (
 /turf/open/floor/rogue/concrete/bronze,
 /area/rogue/outdoors/mountains/decap/gunduzirak/bossarena)
@@ -26427,10 +26978,6 @@
 /obj/structure/closet/crate/roguecloset/lord/duke_preset,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
-"fPv" = (
-/obj/structure/leyline/tamed,
-/turf/open/floor/rogue/concrete/bronze,
-/area/rogue/indoors/town/magician)
 "fPz" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -26508,10 +27055,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave/southern)
-"fQs" = (
-/obj/structure/leyline/powerful,
-/turf/open/water/swamp/deep,
-/area/rogue/outdoors/bog/south)
 "fQu" = (
 /obj/structure/table/wood/long_table/mid/alt,
 /obj/item/kitchen/fork{
@@ -26648,6 +27191,17 @@
 "fSz" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
+"fSA" = (
+/obj/effect/decal/carpet{
+	pixel_x = -2;
+	pixel_y = -8;
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
+"fSD" = (
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/under/town/basement)
 "fSF" = (
 /obj/structure/fluff/traveltile/bandit{
 	aportalgoesto = "banditin";
@@ -26734,6 +27288,16 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/skeletoncrypt)
+"fTE" = (
+/obj/machinery/light/rogue/candle/floorcandle,
+/obj/machinery/light/rogue/candle/floorcandle{
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "fTF" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -26811,6 +27375,10 @@
 /obj/item/roguecoin/aalloy/pile,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
+"fUN" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/under/cave)
 "fUP" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/rogue,
@@ -26877,7 +27445,9 @@
 /area/rogue/indoors/cave)
 "fVy" = (
 /obj/structure/table/wood/poor,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/tavern)
@@ -27220,6 +27790,10 @@
 "fZr" = (
 /turf/closed/wall/mineral/rogue/stone/unbreakable,
 /area/rogue/under/cave/his_vault/puzzle)
+"fZs" = (
+/obj/structure/bed/rogue/shit,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "fZt" = (
 /obj/structure/flora/hotspring_rocks/small/two,
 /obj/effect/landmark/chimeric_calyx_spawner/thirty,
@@ -27403,6 +27977,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
+"gby" = (
+/obj/structure/bookcase,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "gbD" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/dirt,
@@ -27723,10 +28302,6 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
-"gfy" = (
-/obj/structure/fluff/railing/corner/north_east,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "gfJ" = (
 /obj/structure/closet/crate/drawer,
 /turf/open/floor/carpet/royalblack,
@@ -27891,6 +28466,10 @@
 /obj/item/natural/bundle/bone/full,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"ghS" = (
+/obj/structure/plasticflaps,
+/turf/open/water/ocean/deep,
+/area/rogue/under/town/sewer)
 "ghX" = (
 /obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/church,
@@ -28256,6 +28835,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/scarymaze)
+"glO" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "glP" = (
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/woodturned,
@@ -28338,9 +28921,9 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
 "gmP" = (
-/obj/structure/flora/roguegrass/herb/random,
-/turf/open/floor/rogue/AzureSand,
-/area/rogue/outdoors/rtfield)
+/obj/structure/bars/steel,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "gmT" = (
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/dirt,
@@ -28382,10 +28965,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town)
-"gne" = (
-/obj/structure/bed/rogue/bedroll,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/under/cave)
 "gng" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/fishmandungeon)
@@ -28443,6 +29022,12 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/carpet/purple,
 /area/rogue/outdoors/exposed/town/keep)
+"gnY" = (
+/obj/structure/vine/dendor,
+/obj/structure/spider/stickyweb,
+/obj/structure/mineral_door/wood/donjon/stone/broken,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "goa" = (
 /obj/structure/fluff/psycross,
 /turf/open/floor/rogue/wood,
@@ -28589,6 +29174,10 @@
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"gpX" = (
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "gqf" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/concrete/bronze,
@@ -29224,6 +29813,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/south)
+"gwv" = (
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "gwz" = (
 /obj/machinery/light/rogue/candle/floorcandle/alt,
 /obj/machinery/light/rogue/candle/floorcandle{
@@ -29281,6 +29874,15 @@
 /obj/structure/fluff/railing/wood/west,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/roofs/keep)
+"gxk" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "gxn" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -29516,13 +30118,7 @@
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 1
 	},
-/obj/machinery/light/rogue/oven/south,
-/obj/machinery/light/rogue/hearth,
-/obj/item/cooking/pan{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/tile,
+/turf/closed/mineral/random/rogue/med,
 /area/rogue/under/town/sewer)
 "gBe" = (
 /obj/effect/spawner/roguemap/stump,
@@ -29631,6 +30227,12 @@
 /obj/structure/trap/shock,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dragonden)
+"gCB" = (
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "gCD" = (
 /obj/structure/table/wood/poor,
 /obj/structure/fermentation_keg/random/water{
@@ -29671,6 +30273,18 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/mountains)
+"gDg" = (
+/obj/effect/decal/cleanable/roguerune/god/dendor,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
+"gDh" = (
+/obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "gDi" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/concrete,
@@ -29766,6 +30380,10 @@
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"gEd" = (
+/obj/structure/table/church/m,
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/under/cave)
 "gEj" = (
 /turf/open/water/ocean,
 /area/rogue/indoors/cave/northern)
@@ -29789,10 +30407,6 @@
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/manor)
-"gED" = (
-/obj/structure/roguemachine/bounty,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/town/sewer)
 "gEJ" = (
 /obj/effect/decal/cobbleedge,
 /turf/open/floor/rogue/dirt,
@@ -29804,6 +30418,10 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"gEO" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "gEQ" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -29893,6 +30511,15 @@
 	pixel_x = 0
 	},
 /obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
 /turf/open/transparent/openspace,
 /area/rogue/druidsgrove)
 "gFP" = (
@@ -29903,10 +30530,6 @@
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
-"gFR" = (
-/obj/structure/flagpole,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town)
 "gFS" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
@@ -30266,6 +30889,11 @@
 /obj/item/fishingrod,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest/north)
+"gJi" = (
+/obj/structure/bookcase,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "gJl" = (
 /obj/structure/table/wood/long_table,
 /obj/item/cooking/platter{
@@ -30454,7 +31082,9 @@
 /area/rogue/under/cavewet/bogcaves/west)
 "gLq" = (
 /obj/structure/table/wood/long_table/mid,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/physician)
 "gLr" = (
@@ -30748,6 +31378,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/scarymaze)
+"gOX" = (
+/obj/effect/decal/cleanable/roguerune/god/dendor,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "gOY" = (
 /obj/structure/closet/crate/chest/old_crate,
 /turf/open/floor/rogue/blocks/flipped,
@@ -30781,6 +31415,10 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/shelter)
+"gPn" = (
+/obj/structure/fermentation_keg,
+/turf/open/floor/rogue/grass,
+/area/rogue/under/town/sewer)
 "gPo" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/indoors/cave)
@@ -31036,6 +31674,10 @@
 	color = "#3b444b"
 	},
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"gSv" = (
+/obj/item/rogueweapon/pick/militia,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "gSD" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobblerock,
@@ -31096,6 +31738,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/garrison)
+"gTt" = (
+/obj/structure/glowshroom/dendorite,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "gTw" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobblerock,
@@ -31204,6 +31850,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield)
+"gUH" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "gUI" = (
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
 /turf/open/floor/rogue/dirt,
@@ -31273,6 +31923,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
+"gVz" = (
+/obj/effect/decal/carpet,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "gVA" = (
 /turf/open/floor/rogue/metal{
 	dir = 1;
@@ -31486,6 +32140,12 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
+"gXy" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "gXC" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -31828,6 +32488,12 @@
 /obj/item/chair/stool/bar/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
+"hbl" = (
+/obj/machinery/light/rogue/candle/floorcandle{
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "hbt" = (
 /obj/structure/fluff/railing/wood/west{
 	pixel_y = -1
@@ -32279,6 +32945,21 @@
 /obj/structure/bookcase,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter)
+"hgM" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	layer = 2.05;
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/druidsgrove)
 "hgP" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
@@ -32699,11 +33380,11 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
 "hkV" = (
+/obj/machinery/light/rogue/smelter,
 /obj/effect/decal/cobbleedge{
 	dir = 8;
 	pixel_y = 1
 	},
-/obj/machinery/light/rogue/smelter/hiron,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
 "hkY" = (
@@ -32937,10 +33618,6 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
-"hnl" = (
-/obj/effect/decal/cleanable/dirt/cobweb,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/sewer)
 "hnn" = (
 /obj/structure/bars/passage{
 	density = 0;
@@ -33068,6 +33745,11 @@
 /obj/machinery/light/rogue/candle/off,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault)
+"hoK" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/bush/wall/tall,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "hoL" = (
 /obj/structure/fluff/railing/border/west,
 /obj/structure/fluff/walldeco/wantedposter,
@@ -33076,7 +33758,7 @@
 "hoM" = (
 /obj/structure/fluff/buysign{
 	desc = "This is a coarsely carved sign willing 'Curses variede and terrible be upon ye who interrupts the resting cadavers of this place!' The sign of the Necran cross is marked roughly into one corner. It's rather doubtful it has stopped anyone.";
-	name = "CURSES UPON YE"
+	name = "Remember the miners that died here"
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap)
@@ -33191,6 +33873,14 @@
 /obj/structure/fermentation_keg/crafted,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"hqp" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/chest,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "hqs" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -33209,6 +33899,12 @@
 /obj/item/bedsheet/rogue/fabric_double,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/town)
+"hqD" = (
+/obj/structure/closet/crate/chest/old_crate{
+	name = "meat chest"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "hqF" = (
 /obj/structure/table/wood/poor,
 /obj/item/paper,
@@ -33680,6 +34376,12 @@
 /obj/effect/landmark/chest_or_mimic/loot_chest/locked,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
+"huM" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "huQ" = (
 /obj/structure/fluff/walldeco/bigpainting{
 	pixel_x = 2;
@@ -33779,6 +34481,10 @@
 "hwl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/under/underdark/north)
+"hwp" = (
+/obj/structure/ritualcircle/pestra,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "hwB" = (
 /obj/structure/flora/hotspring_rocks/small/three,
 /turf/open/floor/rogue/naturalstone,
@@ -34119,6 +34825,10 @@
 /obj/structure/fluff/railing/corner/south_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"hAp" = (
+/obj/effect/landmark/chimeric_calyx_spawner,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "hAu" = (
 /obj/structure/roguemachine/mail/r{
 	mailtag = "Meeting Room"
@@ -34466,6 +35176,14 @@
 /obj/structure/ritualcircle/undivided,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/scarymaze)
+"hDL" = (
+/obj/structure/flora/roguegrass/herb/mentha,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
+"hDO" = (
+/obj/structure/fluff/railing/border/west,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "hEb" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/black,
@@ -34490,7 +35208,16 @@
 /area/rogue/under/cave/his_vault/three)
 "hEq" = (
 /obj/machinery/light/rogue/candle/blue/l,
-/turf/open/floor/rogue/tile/brownbrick,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
+"hEt" = (
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
+/obj/structure/fluff/sellsign{
+	name = "Leave now, and know his peace."
+	},
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/sewer)
 "hEv" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -34564,6 +35291,11 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin)
+"hFd" = (
+/obj/structure/glowshroom/dendorite,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "hFg" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/town/basement/keep)
@@ -34596,8 +35328,12 @@
 "hFB" = (
 /obj/structure/closet/crate/drawer,
 /obj/machinery/light/rogue/candle/l,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/rope/chain,
@@ -34690,6 +35426,12 @@
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains)
+"hGb" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/metal{
+	icon_state = "plating2"
+	},
+/area/rogue/under/town/sewer)
 "hGm" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cave/fishmandungeon)
@@ -34806,6 +35548,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/minotaurfort)
+"hHV" = (
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/grass,
+/area/rogue/under/cave)
 "hHW" = (
 /obj/structure/fluff/railing/border/west,
 /obj/effect/decal/edge{
@@ -34857,10 +35603,21 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/under/cave/scarymaze)
+"hIu" = (
+/obj/machinery/light/rogue/campfire/fireplace,
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "hIv" = (
 /obj/structure/closet/crate/chest/neu,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"hIw" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mirespider,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "hIE" = (
 /obj/structure/bars/cemetery,
 /obj/structure/fluff/railing/corner/south_west,
@@ -34937,6 +35694,10 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/underdark/north)
+"hIY" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "hJb" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/dirt,
@@ -34954,6 +35715,10 @@
 "hJk" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/woods/southeast)
+"hJm" = (
+/obj/item/rogueweapon/pick,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "hJo" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -35019,10 +35784,18 @@
 /area/rogue/indoors/town/garrison)
 "hKc" = (
 /obj/structure/closet/crate/chest/crate,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
 "hKd" = (
@@ -35333,6 +36106,14 @@
 "hNq" = (
 /turf/open/water/swamp,
 /area/rogue/under/underdark/north)
+"hNJ" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "hNK" = (
 /obj/effect/decal/mossy{
 	dir = 4
@@ -35438,9 +36219,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/druidsgrove)
 "hOT" = (
-/obj/structure/mannequin/male{
-	dir = 1
-	},
+/obj/structure/mannequin,
 /obj/item/clothing/suit/roguetown/armor/leather/studded,
 /obj/item/clothing/head/roguetown/helmet/kettle,
 /turf/open/floor/rogue/tile,
@@ -35492,11 +36271,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
-"hPK" = (
-/obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/candle/blue,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "hPN" = (
 /obj/structure/table/church,
 /turf/open/floor/rogue/blocks,
@@ -35583,6 +36357,10 @@
 /obj/item/rogueweapon/spear/partizan,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"hRe" = (
+/obj/effect/decal/cleanable/blood,
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/under/town/sewer)
 "hRh" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
@@ -35778,9 +36556,8 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors)
 "hTD" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/robber,
-/turf/open/floor/rogue/blocks,
+/obj/structure/fluff/statue,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/under/town/sewer)
 "hTJ" = (
 /obj/structure/flora/roguegrass/herb/manabloom,
@@ -35852,6 +36629,10 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach)
+"hUw" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "hUL" = (
 /obj/structure/hotspring/border/five,
 /obj/machinery/light/rogue/candle/floorcandle,
@@ -35865,7 +36646,9 @@
 /area/rogue/indoors/town/tavern)
 "hUN" = (
 /obj/structure/table/wood/map,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/inq)
@@ -36966,6 +37749,10 @@
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"igh" = (
+/obj/structure/flora/roguegrass/water,
+/turf/open/floor/rogue/AzureSand,
+/area/rogue/under/town/sewer)
 "igl" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -37051,7 +37838,9 @@
 /area/rogue/outdoors/rtfield)
 "ihg" = (
 /obj/structure/table/wood/long_table,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/paper{
 	pixel_x = 4;
 	pixel_y = 4
@@ -37059,6 +37848,10 @@
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/cave/orcdungeon)
+"ihk" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/AzureSand,
+/area/rogue/under/town/sewer)
 "ihm" = (
 /obj/structure/vine,
 /turf/open/floor/rogue/naturalstone,
@@ -37144,6 +37937,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/forest/hamlet)
+"iib" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/pick,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "iic" = (
 /obj/effect/decal/cleanable/debris/woody,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -37219,6 +38017,10 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town/garrison)
+"iiK" = (
+/obj/structure/flora/mushroomcluster,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "iiQ" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/corner,
@@ -37407,6 +38209,10 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/inq)
+"ikC" = (
+/obj/structure/flora/roguegrass/bush/westleach,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "ikG" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -37932,6 +38738,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"iqy" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "iqE" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/corner/north_east,
@@ -37971,6 +38783,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach/forest/south)
+"iqR" = (
+/obj/item/chair/rogue/fancy,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cave)
 "iqS" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood,
@@ -38388,6 +39204,11 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"ivA" = (
+/obj/structure/rack/rogue,
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "ivB" = (
 /obj/effect/decal/carpet/kover_black{
 	pixel_x = 0;
@@ -38812,6 +39633,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cavewet/bogcaves/south)
+"iAu" = (
+/obj/structure/glowshroom/dendorite,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "iAv" = (
 /obj/structure/table/wood/poor,
 /obj/item/rogueweapon/huntingknife/wood,
@@ -38887,12 +39712,6 @@
 "iBk" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
-"iBl" = (
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
 "iBo" = (
 /obj/structure/table/wood/map/six,
 /obj/item/clothing/neck/roguetown/psicross/wood,
@@ -39377,6 +40196,10 @@
 "iGU" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/town)
+"iGX" = (
+/obj/structure/flora/roguegrass/water,
+/turf/open/water/ocean/deep,
+/area/rogue/under/town/sewer)
 "iGY" = (
 /obj/structure/table/wood/long_table/mid/alt,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -39481,6 +40304,9 @@
 /obj/item/grown/log/tree/stake,
 /turf/open/water/river/flow,
 /area/rogue/under/town/sewer)
+"iIb" = (
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/basement)
 "iId" = (
 /obj/effect/decal/carpet{
 	pixel_x = -2;
@@ -39560,7 +40386,9 @@
 /area/rogue/indoors/shelter/mountains/decap)
 "iIT" = (
 /obj/structure/table/wood/long_table/mid/alt,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark/south)
 "iIW" = (
@@ -39626,6 +40454,11 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"iJE" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/cloak/tabard/devotee/dendor,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "iJM" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/dirt/road,
@@ -39851,6 +40684,10 @@
 /obj/effect/spawner/lootdrop/general_loot_mid/x3,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/abandonedhotsprings)
+"iMB" = (
+/obj/effect/landmark/chimeric_calyx_spawner,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "iMG" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/blocks/flipped,
@@ -40020,6 +40857,10 @@
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet/bogcaves/north)
+"iOE" = (
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "iOG" = (
 /obj/structure/ritualcircle/matthios,
 /turf/open/floor/rogue/churchmarble,
@@ -40174,6 +41015,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"iQb" = (
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/basement)
 "iQn" = (
 /obj/item/roguekey/physician,
 /obj/item/roguekey/physician,
@@ -40308,6 +41152,16 @@
 "iSm" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/magician)
+"iSr" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "iSt" = (
 /obj/structure/stairs{
 	dir = 1
@@ -40798,6 +41652,11 @@
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
+"iYe" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/silver_weapon_spawner,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "iYj" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -41179,6 +42038,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault/four)
+"jdg" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mole,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "jdh" = (
 /obj/structure/closet/crate/roguecloset/inn/chest,
 /obj/item/reagent_containers/food/snacks/grown/tea,
@@ -41457,6 +42320,11 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
+"jfX" = (
+/obj/structure/gravemarker,
+/obj/structure/closet/dirthole/grave,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "jfZ" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/transparent/openspace,
@@ -41527,6 +42395,15 @@
 /obj/structure/rogue/trophy/deer,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor)
+"jha" = (
+/obj/structure/roguemachine/bounty,
+/obj/effect/decal/cleanable/debris/glassy,
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/town/sewer)
 "jhb" = (
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/cobble,
@@ -41833,6 +42710,11 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/beach)
+"jkh" = (
+/obj/structure/vine/dendor,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "jki" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt,
@@ -41873,6 +42755,10 @@
 /obj/effect/landmark/chest_or_mimic/loot_chest,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/goblinfort)
+"jkB" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "jkD" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -42946,13 +43832,6 @@
 /obj/structure/wild_plant/nospread/manabloom,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods/southwest)
-"jwY" = (
-/obj/structure/table/wood/long_table,
-/obj/machinery/light/rogue/candle/blue,
-/obj/item/rogueweapon/huntingknife/stoneknife,
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "jxc" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -43327,8 +44206,12 @@
 	},
 /obj/effect/decal/wood/herringbone2,
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /obj/item/rope/chain,
@@ -44142,7 +45025,6 @@
 /area/rogue/outdoors/exposed/town/keep)
 "jKa" = (
 /obj/structure/table/wood/long_table,
-/obj/item/mini_flagpole/blacksmith,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/dwarfin)
 "jKf" = (
@@ -44256,15 +45138,6 @@
 /obj/item/storage/belt/rogue/pouch/coins/poor,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
-"jLB" = (
-/obj/structure/table/wood/poor,
-/obj/item/paper{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/natural/feather,
-/turf/open/floor/carpet/stellar,
-/area/rogue/under/town/sewer)
 "jLF" = (
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble,
@@ -44561,6 +45434,13 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/cave/northern)
+"jPg" = (
+/obj/structure/roguemachine/scomm,
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/town/sewer)
 "jPi" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -44695,6 +45575,15 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woods/southeast)
+"jQE" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 4.2
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "jQG" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/wood,
@@ -44838,6 +45727,10 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"jRN" = (
+/mob/living/simple_animal/hostile/rogue/deepone/spit,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "jRO" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -44857,7 +45750,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
 "jSi" = (
-/obj/structure/leyline/tamed,
+/obj/structure/table/wood/large_table/south_west,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/town/dwarfin)
 "jSn" = (
@@ -44961,6 +45854,15 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
+"jTI" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "jTJ" = (
 /obj/structure/table/wood/large_table/north_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -45167,6 +46069,10 @@
 "jVw" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/exposed/town/keep)
+"jVx" = (
+/obj/structure/ritualcircle/xylix,
+/turf/open/floor/rogue/greenstone/glyph3,
+/area/rogue/under/cave)
 "jVy" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/cobble,
@@ -45405,6 +46311,10 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
+"jXG" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "jXH" = (
 /obj/structure/bed/rogue/inn{
 	dir = 1
@@ -45638,6 +46548,12 @@
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter/mountains/decap)
+"kaa" = (
+/obj/machinery/light/rogue/torchholder/l{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "kag" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/natural/hide/cured,
@@ -45739,7 +46655,9 @@
 /area/rogue/under/town/sewer)
 "kbb" = (
 /obj/structure/table/wood/poor/alt,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
@@ -46006,6 +46924,10 @@
 "kdW" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield/eora)
+"kdX" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mirespider,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "kec" = (
 /obj/structure/lever/wall{
 	pixel_y = 29;
@@ -46121,8 +47043,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault/two)
 "keT" = (
-/obj/machinery/light/rogue/firebowl,
-/turf/open/floor/rogue/cobble,
+/obj/structure/mineral_door/wood/deadbolt,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/under/town/basement)
 "keV" = (
 /obj/structure/closet/crate/chest/crate,
@@ -46139,6 +47061,9 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
+"kff" = (
+/turf/open/water/ocean/deep,
+/area/rogue/under/town/sewer)
 "kfi" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -46233,6 +47158,11 @@
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
+"kfS" = (
+/obj/structure/table/church/end,
+/obj/item/clothing/head/roguetown/roguehood/ravoxgorget,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "kfV" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
@@ -46368,6 +47298,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/west)
+"kht" = (
+/obj/structure/ritualcircle/eora,
+/turf/open/floor/rogue/greenstone/glyph2,
+/area/rogue/under/cave)
 "khx" = (
 /obj/structure/table/wood/long_table/mid/alt,
 /obj/item/mundane/puzzlebox/medium{
@@ -46419,6 +47353,9 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/town)
+"kih" = (
+/turf/open/floor/rogue/metal,
+/area/rogue/under/cave)
 "kii" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -46518,12 +47455,25 @@
 /obj/item/clothing/cloak/matron,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/underdark/south)
+"kjv" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "kjC" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/carpet/red,
 /area/rogue/under/town/sewer)
 "kjO" = (
-/obj/structure/fluff/statue,
+/obj/structure/table/wood/poor,
+/obj/item/bodypart/l_arm/goblin,
+/obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "kjR" = (
@@ -46685,6 +47635,12 @@
 /obj/structure/fluff/walldeco/bigpainting/lake,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
+"klm" = (
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "klq" = (
 /obj/structure/lever/wall{
 	dir = 8;
@@ -46796,6 +47752,10 @@
 /obj/structure/globe,
 /turf/open/floor/carpet/stellar,
 /area/rogue/outdoors/mountains/decap/gunduzirak/bossarena)
+"knn" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/revenant/mirespider,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "knp" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/AzureSand,
@@ -46992,6 +47952,11 @@
 /obj/structure/fluff/walldeco/customflag,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/outdoors/exposed/town/keep)
+"kpy" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "kpO" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
@@ -47285,6 +48250,10 @@
 /obj/item/rogueweapon/flail/sflail,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"ktS" = (
+/obj/structure/ritualcircle/astrata,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "ktW" = (
 /obj/structure/fluff/statue/gargoyle/candles,
 /turf/open/floor/rogue/church,
@@ -47314,6 +48283,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"kuj" = (
+/obj/structure/fluff/statue/tdummy,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/town/sewer)
 "kuk" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -48009,7 +48982,9 @@
 /area/rogue/outdoors/exposed/town/keep)
 "kAC" = (
 /obj/structure/table/wood/long_table/north_east,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/paper{
 	pixel_x = 4;
 	pixel_y = 4
@@ -48025,6 +49000,18 @@
 /mob/living/simple_animal/hostile/rogue/dragger,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/shelter)
+"kAK" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 5
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "kAO" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/underdark/north)
@@ -48334,6 +49321,10 @@
 	dir = 4
 	},
 /area/rogue/outdoors/mountains)
+"kEg" = (
+/obj/structure/table/wood/large_table/middle,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "kEi" = (
 /turf/closed/mineral/rogue/copper,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
@@ -48341,6 +49332,10 @@
 /obj/structure/meathook,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
+"kEo" = (
+/obj/structure/tent_wall,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "kEJ" = (
 /obj/structure/mineral_door/wood/window{
 	name = "Main Hallway";
@@ -48419,6 +49414,10 @@
 /obj/machinery/light/rogue/campfire/fireplace,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/forest/north)
+"kFg" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "kFh" = (
 /obj/structure/hotspring/border/five,
 /obj/structure/flora/sakura{
@@ -48519,6 +49518,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/under/cave/dukecourt)
+"kFN" = (
+/obj/structure/mineral_door/wood/donjon/stone/broken,
+/obj/structure/barricade/crude,
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/blocks/paving,
+/area/rogue/under/cave)
 "kFS" = (
 /obj/structure/closet/dirthole/grave,
 /obj/item/natural/dirtclod{
@@ -48635,6 +49640,13 @@
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"kHP" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/obj/effect/decal/cleanable/dirt/cobweb,
+/obj/machinery/light/rogue/candle/blue/l,
+/obj/structure/fluff/walldeco/wantedposter,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "kHS" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -49669,7 +50681,7 @@
 /area/rogue/indoors/abandonedhotsprings)
 "kTw" = (
 /obj/structure/fluff/railing/corner/south_east,
-/turf/open/water/transparent/surface/pond,
+/turf/open/water/pond,
 /area/rogue/outdoors/woods/south)
 "kTx" = (
 /obj/structure/fluff/railing/border,
@@ -49738,6 +50750,11 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave/orcdungeon)
+"kUf" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/bars,
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/under/town/sewer)
 "kUj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
@@ -50382,7 +51399,9 @@
 	pixel_x = -16;
 	pixel_y = 23
 	},
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
@@ -50461,6 +51480,9 @@
 /obj/structure/table/church/end,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
+"lbS" = (
+/turf/open/water/ocean,
+/area/rogue/under/town/sewer)
 "lbT" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/naturalstone,
@@ -50667,10 +51689,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/underdark/north)
-"lew" = (
-/obj/structure/flagpole,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/town)
 "lex" = (
 /obj/structure/fluff/railing/border/west,
 /obj/structure/fluff/railing/border/north,
@@ -50975,6 +51993,9 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"lhr" = (
+/turf/closed/wall/mineral/rogue/stone/red_moss,
+/area/rogue/under/cave)
 "lhs" = (
 /obj/structure/table/wood/poor,
 /obj/item/clothing/mask/cigarette/pipe{
@@ -51247,7 +52268,9 @@
 /area/rogue/outdoors/mountains/decap/gunduzirak/bossarena)
 "lkC" = (
 /obj/structure/table/wood/large_table/south_east,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -51748,6 +52771,15 @@
 "lnL" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/indoors/shelter)
+"lnM" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "lnN" = (
 /obj/structure/mineral_door/wood/window{
 	locked = 1;
@@ -51881,7 +52913,6 @@
 "lpl" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/infernal/watcher,
 /obj/effect/decal/cleanable/roguerune/arcyne/summoning/max,
-/obj/structure/leyline/normal/decap,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/goblinfort)
 "lpr" = (
@@ -51935,6 +52966,10 @@
 /obj/machinery/light/rogue/candle/floorcandle/alt,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
+"lpQ" = (
+/obj/structure/plasticflaps,
+/turf/open/water/swamp,
+/area/rogue/under/town/basement)
 "lpV" = (
 /obj/structure/chair/bench/coucha,
 /turf/open/floor/carpet/inn,
@@ -52289,6 +53324,10 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/underdark/north)
+"lti" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "ltk" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains/decap)
@@ -52889,12 +53928,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement/keep)
-"lAa" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/metal{
-	dir = 4
-	},
-/area/rogue/under/town/sewer)
 "lAe" = (
 /obj/structure/roguewindow/stained/zizo{
 	opacity = 0
@@ -53162,6 +54195,10 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
+"lDh" = (
+/obj/machinery/light/rogue/campfire/densefire,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "lDl" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/festus,
@@ -53463,10 +54500,6 @@
 /obj/structure/chair/bench/couch/r,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/magician)
-"lFf" = (
-/obj/structure/flagpole,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/beach/forest/hamlet)
 "lFj" = (
 /obj/structure/fluff/big_chain,
 /turf/open/floor/rogue/concrete,
@@ -53558,6 +54591,10 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"lGw" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "lGA" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -53599,6 +54636,17 @@
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	layer = 2.05;
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/druidsgrove)
 "lGX" = (
@@ -53752,6 +54800,12 @@
 	},
 /turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/outdoors/town/roofs)
+"lIo" = (
+/obj/structure/fluff/railing/fence{
+	dir = 1
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "lIs" = (
 /obj/structure/table/wood/poor,
 /obj/item/paper,
@@ -53990,7 +55044,9 @@
 /area/rogue/indoors/town/tavern)
 "lLx" = (
 /obj/structure/table/wood/large_table/south_east,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
@@ -54075,6 +55131,10 @@
 	},
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
 /turf/open/transparent/openspace,
 /area/rogue/druidsgrove)
 "lMp" = (
@@ -54178,6 +55238,12 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"lNq" = (
+/obj/structure/table/wood/poor,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "lNr" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap)
@@ -54191,6 +55257,10 @@
 /obj/effect/landmark/chest_or_mimic/locked_or_trapped,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/mazedungeon)
+"lNy" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "lNz" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/scabbard/gwstrap,
@@ -54237,6 +55307,10 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/grass,
 /area/rogue/druidsgrove)
+"lNV" = (
+/obj/structure/bookcase/random/archive,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "lNZ" = (
 /obj/structure/table/wood/long_table/mid/alt,
 /obj/item/candle/candlestick/gold/lit,
@@ -54356,6 +55430,15 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/underdark/south)
+"lPm" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/druidsgrove)
 "lPq" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woods/southeast)
@@ -54440,6 +55523,12 @@
 "lPN" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	layer = 2.05;
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/druidsgrove)
 "lPP" = (
@@ -54550,6 +55639,10 @@
 /obj/machinery/light/rogue/candle/floorcandle/alt,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"lRr" = (
+/obj/structure/chair/bench/church,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "lRv" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
@@ -54616,6 +55709,13 @@
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
+"lSx" = (
+/obj/structure/roguemachine/withdraw{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "lSB" = (
 /obj/structure/closet/dirthole/closed/loot,
 /obj/structure/gravemarker{
@@ -54626,6 +55726,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
+"lSE" = (
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "lSL" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/skeletoncrypt)
@@ -54824,6 +55928,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/druidsgrove)
+"lVj" = (
+/obj/structure/closet/crate/chest/neu,
+/obj/item/reagent_containers/food/snacks/rogue/meat/spider/fried,
+/obj/item/reagent_containers/food/snacks/rogue/meat/spider/fried,
+/obj/item/reagent_containers/food/snacks/rogue/honey/spider,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "lVk" = (
 /obj/structure/table/wood/poor,
 /turf/open/floor/carpet/stellar,
@@ -54855,6 +55967,11 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog/south)
+"lVZ" = (
+/obj/structure/gravemarker,
+/obj/structure/closet/dirthole/grave,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "lWa" = (
 /obj/structure/hotspring/border/three,
 /obj/machinery/light/rogue/candle/floorcandle,
@@ -54976,6 +56093,10 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"lWY" = (
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "lXa" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains)
@@ -55036,14 +56157,30 @@
 /area/rogue/outdoors/exposed/town/keep)
 "lXM" = (
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/tavern)
 "lXN" = (
@@ -55211,6 +56348,10 @@
 	},
 /turf/open/water/sewer,
 /area/rogue/under/cave/dungeon1/gethsmane)
+"lZn" = (
+/mob/living/simple_animal/hostile/rogue/deepone,
+/turf/open/floor/rogue/greenstone/glyph3,
+/area/rogue/under/cave)
 "lZs" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/neck/roguetown/chaincoif,
@@ -55273,8 +56414,12 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/rope/chain,
 /obj/item/natural/feather,
@@ -55619,7 +56764,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
 "mdA" = (
-/obj/structure/mineral_door/bars,
+/obj/structure/mineral_door/wood/window{
+	lockid = "nightmaiden"
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "mdB" = (
@@ -55759,7 +56906,9 @@
 /obj/structure/table/wood/poor{
 	pixel_y = -4
 	},
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
@@ -56081,6 +57230,9 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
+"min" = (
+/turf/open/floor/rogue/greenstone/glyph2,
+/area/rogue/under/cave)
 "mip" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/dirt/road,
@@ -56312,16 +57464,15 @@
 /mob/living/carbon/human/species/orc/npc/berserker,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
+"mlF" = (
+/obj/item/rogueweapon/pick/copper,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "mlG" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
-"mlH" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/sewer)
 "mlL" = (
 /obj/structure/table/wood/poor,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -56359,6 +57510,10 @@
 	},
 /turf/closed/wall/mineral/rogue/decostone/fluffstone,
 /area/rogue/indoors/town/tavern)
+"mlT" = (
+/obj/effect/landmark/quest_spawner/hard,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "mlU" = (
 /obj/structure/fluff/railing/wood/west{
 	pixel_y = -1
@@ -56803,11 +57958,21 @@
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /obj/item/clothing/mask/cigarette/pipe/westman,
 /obj/item/clothing/mask/cigarette/pipe/westman,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/magician)
 "mrv" = (
@@ -56957,6 +58122,10 @@
 /obj/structure/fluff/railing/corner/south_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/central)
+"mti" = (
+/obj/structure/table/church,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "mtk" = (
 /obj/structure/fluff/railing/border/east,
 /obj/structure/fluff/railing/border,
@@ -57300,7 +58469,7 @@
 /obj/effect/decal/cobbleedge{
 	pixel_y = 1
 	},
-/obj/structure/mannequin/male,
+/obj/structure/mannequin,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/town/basement/keep)
 "mxi" = (
@@ -57442,6 +58611,10 @@
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/cave/east)
+"myK" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "myM" = (
 /obj/structure/fluff/railing/fence{
 	dir = 8
@@ -57678,6 +58851,10 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/beach/forest/south)
+"mBg" = (
+/obj/structure/flora/mushroomcluster,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "mBr" = (
 /obj/structure/chair/bench/ultimacouch/r,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -58072,6 +59249,12 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/mountains)
+"mGm" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
+/turf/open/floor/rogue/metal{
+	dir = 4
+	},
+/area/rogue/under/town/sewer)
 "mGt" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -58745,6 +59928,11 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/under/underdark/north)
+"mON" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/neck/roguetown/psicross/dendor,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "mOU" = (
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
 /turf/open/floor/rogue/church,
@@ -58904,6 +60092,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
+"mQW" = (
+/obj/structure/fluff/customsign{
+	name = "TURN BACK NOW!!!"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "mQX" = (
 /obj/structure/fluff/railing/border/west{
 	dir = 9
@@ -58931,6 +60125,13 @@
 	},
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/mountains)
+"mRj" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/closed/wall/mineral/rogue/wooddark/window,
+/area/rogue/under/town/sewer)
 "mRo" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/wood,
@@ -59218,6 +60419,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/woods)
+"mVs" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "mVu" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/storage/roguebag,
@@ -59227,6 +60432,14 @@
 /obj/item/broom,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"mVw" = (
+/obj/structure/table/wood/long_table/right,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "mVD" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/church,
@@ -59432,7 +60645,9 @@
 /area/rogue/under/cave/his_vault)
 "mYc" = (
 /obj/structure/table/wood/long_table/right,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/structure/fluff/wallclock/r,
 /turf/open/floor/rogue/woodturned,
@@ -59458,6 +60673,12 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
+"mYp" = (
+/obj/structure/mineral_door/wood/fancywood{
+	name = "Rogue's Den"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "mYq" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -59497,8 +60718,12 @@
 /area/rogue/outdoors/beach/forest/hamlet)
 "mYM" = (
 /obj/structure/closet/crate/drawer,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/rope/chain,
@@ -59700,6 +60925,10 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/cave/his_vault)
+"nbe" = (
+/obj/item/clothing/suit/roguetown/shirt/explorer,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "nbg" = (
 /obj/structure/roguerock,
 /turf/open/floor/rogue/dirt,
@@ -59781,7 +61010,9 @@
 /area/rogue/indoors/town/physician)
 "ncn" = (
 /obj/structure/table/wood/poor,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
@@ -60062,6 +61293,18 @@
 /obj/structure/fluff/railing/wood/east,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
+"ngy" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "ngB" = (
 /obj/structure/bars/cemetery,
 /obj/structure/fluff/railing/corner,
@@ -60071,6 +61314,10 @@
 /obj/effect/spawner/roguemap/stump,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield)
+"ngD" = (
+/obj/item/clothing/shoes/roguetown/shortboots,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "ngE" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/closet/crate/roguecloset/dark,
@@ -60269,6 +61516,11 @@
 /obj/structure/spider/stickyweb/mirespider,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault)
+"njr" = (
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "njs" = (
 /obj/structure/roguemachine/scomm{
 	scom_tag = "Wall Tower - Southwest"
@@ -60457,12 +61709,6 @@
 /obj/structure/flora/rock/pile,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave)
-"nlK" = (
-/obj/structure/bed/rogue/shit{
-	name = "makeshift bed"
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/sewer)
 "nlL" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/skeletoncrypt)
@@ -60714,7 +61960,9 @@
 /area/rogue/under/cave/mazedungeon)
 "noj" = (
 /obj/structure/table/wood/long_table/mid/alt,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor)
 "noo" = (
@@ -61113,6 +62361,12 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/dwarfin)
+"nsQ" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "nsT" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains)
@@ -61229,6 +62483,11 @@
 /obj/structure/fluff/railing/corner/south_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"nux" = (
+/obj/structure/table/wood/large_table/north,
+/obj/effect/spawner/lootdrop/cheap_candle_spawner,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "nuE" = (
 /obj/structure/table/wood/long_table/mid/alt,
 /obj/structure/bars/shop,
@@ -61329,10 +62588,6 @@
 /obj/item/rogueore/iron,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
-"nvE" = (
-/obj/effect/decal/cleanable/dirt/cobweb,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/under/town/sewer)
 "nvF" = (
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/shelter/mountains/decap)
@@ -61492,6 +62747,15 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/underdark/north)
+"nxt" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/town/sewer)
 "nxD" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread";
@@ -61550,6 +62814,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"nyp" = (
+/obj/structure/tent_wall,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "nyq" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread"
@@ -61745,6 +63013,10 @@
 /obj/effect/landmark/quest_spawner/medium,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave/east)
+"nAX" = (
+/obj/random/spider,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "nBc" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/churchmarble,
@@ -61915,6 +63187,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
+"nCK" = (
+/obj/structure/table/church/end,
+/obj/effect/spawner/lootdrop/cheap_jewelry_spawner,
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/under/cave)
 "nCL" = (
 /obj/machinery/light/rogue/candle/floorcandle/pink,
 /obj/machinery/light/rogue/candle/floorcandle{
@@ -62257,6 +63534,13 @@
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/town/sewer)
+"nGX" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "nHb" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/ocean,
@@ -62301,6 +63585,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods/southeast)
+"nHI" = (
+/obj/structure/flora/roguegrass/bush/westleach,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/town)
 "nHK" = (
 /obj/structure/fluff/walldeco/stone/bronze{
 	pixel_y = 32
@@ -62442,10 +63730,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/magician)
-"nJD" = (
-/obj/structure/flagpole,
-/turf/open/floor/rogue/dirt,
-/area/rogue/outdoors/woods/south)
 "nJH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -62827,6 +64111,10 @@
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/exposed/town/keep)
+"nOb" = (
+/mob/living/simple_animal/hostile/rogue/mirespider_lurker/mushroom,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "nOd" = (
 /obj/machinery/light/rogue/torchholder/c,
 /obj/structure/roguemachine/scomm/r{
@@ -63072,14 +64360,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield)
-"nQT" = (
-/obj/structure/table/wood/long_table/mid/alt,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 8;
-	pixel_y = 16
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "nQX" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -63250,6 +64530,13 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter)
+"nSV" = (
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "nSW" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains/decap)
@@ -63718,6 +65005,15 @@
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/woods)
+"nWY" = (
+/obj/structure/fluff/railing/fence{
+	dir = 1
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
+"nWZ" = (
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/sewer)
 "nXb" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor6-old"
@@ -63761,6 +65057,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/fae/sprite,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woods/north)
+"nXt" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "nXu" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/wood,
@@ -63969,6 +65269,10 @@
 "oal" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/forest/south)
+"oan" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "oaq" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider,
 /turf/open/floor/rogue/hexstone,
@@ -64122,9 +65426,8 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave/his_vault)
 "ocg" = (
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 4
-	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/decal/carpet/kover_darkred,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "och" = (
@@ -64213,6 +65516,11 @@
 "ocX" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
+"ocZ" = (
+/obj/structure/flora/roguegrass,
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/town)
 "ode" = (
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /obj/structure/table/wood/poor,
@@ -64256,6 +65564,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
+"odB" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/obj/item/clothing/suit/roguetown/shirt/formal,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "odC" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border/east,
@@ -64290,6 +65605,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town)
+"odU" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat/gethsmane,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "odX" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/dirt,
@@ -64514,6 +65833,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors)
+"oga" = (
+/obj/structure/table/wood/large_table/middle_east,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "ogb" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -64603,6 +65926,10 @@
 "ogR" = (
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/beach)
+"ogS" = (
+/obj/structure/flora/roguegrass/water,
+/turf/open/floor/rogue/AzureSand,
+/area/rogue/outdoors/rtfield)
 "ogY" = (
 /obj/structure/fluff/statue/myth,
 /turf/open/floor/rogue/cobblerock,
@@ -64737,10 +66064,6 @@
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
-"oiS" = (
-/obj/effect/landmark/chimeric_calyx_spawner/fifteen,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/basement)
 "oiT" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/stairs{
@@ -64761,6 +66084,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"ojb" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "ojl" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/twig,
@@ -65101,8 +66428,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -65118,6 +66449,9 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woods/south)
+"ooe" = (
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cave)
 "ook" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -65133,6 +66467,13 @@
 /obj/structure/underworld/barrier,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town)
+"oom" = (
+/obj/structure/bars,
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "ooq" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood/west{
@@ -65146,9 +66487,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor)
 "oov" = (
-/obj/structure/mannequin/male{
-	dir = 1
-	},
+/obj/structure/mannequin,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/town/basement/keep)
 "ooy" = (
@@ -65164,8 +66503,12 @@
 /area/rogue/under/cave/scarymaze)
 "ooB" = (
 /obj/structure/closet/crate/drawer,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/rope/chain,
@@ -65299,6 +66642,10 @@
 /obj/item/roguecoin/copper,
 /turf/open/water/sewer,
 /area/rogue/under/cavewet/bogcaves/north)
+"oqj" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "oql" = (
 /mob/living/carbon/human/species/goblin/npc/sea,
 /turf/open/floor/rogue/dirt/road,
@@ -65626,6 +66973,10 @@
 "otQ" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/cave/northern)
+"otZ" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "oud" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/exposed/town/keep)
@@ -65884,7 +67235,7 @@
 "owj" = (
 /obj/effect/decal/cleanable/debris/glassy,
 /obj/effect/landmark/chimeric_calyx_spawner/fifteen,
-/turf/open/floor/rogue/tile/brownbrick,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/sewer)
 "owk" = (
 /obj/structure/fluff/psycross/psycrucifix/stone,
@@ -66267,6 +67618,10 @@
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"oAx" = (
+/obj/structure/roguetent,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "oAy" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -66320,6 +67675,10 @@
 /obj/machinery/light/rogue/candle/off,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
+"oBg" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/revenant/wolf,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "oBl" = (
 /obj/structure/fluff/railing/corner,
 /obj/effect/decal/cobble/mossy{
@@ -66416,6 +67775,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/manor)
+"oCl" = (
+/obj/effect/decal/cleanable/roguerune/god/ravox,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "oCm" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -66838,6 +68201,17 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town)
+"oFS" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/grassred,
+/area/rogue/druidsgrove)
 "oFU" = (
 /obj/effect/decal/carpet/square{
 	pixel_x = 16;
@@ -67121,16 +68495,36 @@
 "oIA" = (
 /obj/machinery/light/rogue/candle/blue,
 /obj/structure/closet/crate/chest,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/inq/basement)
 "oID" = (
@@ -67159,7 +68553,9 @@
 /area/rogue/outdoors/town)
 "oII" = (
 /obj/structure/table/wood/long_table/right,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/machinery/light/rogue/candle/floorcandle/pink,
 /turf/open/floor/rogue/churchbrick,
@@ -67341,8 +68737,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /turf/open/floor/carpet/stellar,
@@ -67496,6 +68896,10 @@
 /obj/structure/fluff/statue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave/fishmandungeon)
+"oMj" = (
+/obj/structure/plasticflaps,
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "oMk" = (
 /obj/machinery/light/rogue/candle/blue,
 /obj/structure/bars/pipe{
@@ -67616,9 +69020,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/roofs)
-"oNr" = (
-/turf/open/water/transparent/surface/pond,
-/area/rogue/outdoors/woods/south)
 "oNs" = (
 /obj/structure/mannequin,
 /obj/item/clothing/mask/rogue/facemask/goldmask,
@@ -67717,12 +69118,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/shop)
-"oOU" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/structure/table/wood/large_table/middle_west,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "oOV" = (
 /obj/item/natural/stone,
 /turf/open/floor/rogue/naturalstone,
@@ -67820,6 +69215,10 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"oPU" = (
+/obj/effect/spawner/lootdrop/roguetown/dungeon,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "oPV" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -68128,6 +69527,11 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/woods)
+"oSI" = (
+/obj/structure/mineral_door/swing_door,
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "oSJ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -68169,6 +69573,11 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"oSZ" = (
+/obj/structure/toilet,
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "oTb" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -68208,6 +69617,15 @@
 "oTx" = (
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach/south)
+"oTy" = (
+/obj/effect/decal/carpet/square/black{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 16
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "oTA" = (
 /obj/structure/table/wood,
 /obj/item/book/rogue/law{
@@ -68440,6 +69858,10 @@
 /obj/structure/fluff/railing/wood/north,
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/beach/forest/south)
+"oWe" = (
+/obj/structure/table/wood/large_table/middle,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "oWi" = (
 /obj/structure/roguemachine/stockpile{
 	pixel_x = -32;
@@ -68573,6 +69995,16 @@
 /mob/living/simple_animal/hostile/rogue/dragger,
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/dukecourt)
+"oXo" = (
+/obj/structure/stairs{
+	dir = 4
+	},
+/obj/structure/fluff/railing/fence{
+	dir = 4
+	},
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "oXr" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -68839,6 +70271,10 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault)
+"oZR" = (
+/obj/effect/landmark/quest_spawner/hard,
+/turf/open/floor/rogue/AzureSand,
+/area/rogue/outdoors/beach/south)
 "oZT" = (
 /obj/structure/fluff/statue/gargoyle/candles,
 /turf/open/floor/rogue/blocks,
@@ -68955,6 +70391,14 @@
 "paV" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/shelter)
+"paY" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "pbb" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/blocks,
@@ -69352,6 +70796,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"pgy" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "pgD" = (
 /obj/effect/landmark/quest_spawner/medium,
 /turf/open/water/sewer,
@@ -69544,6 +70992,9 @@
 /obj/item/needle/thorn,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"pig" = (
+/turf/closed/wall/mineral/rogue/pipe/corners/eight,
+/area/rogue/under/cave)
 "pim" = (
 /obj/structure/table/wood/poor,
 /obj/item/cooking/platter{
@@ -69634,6 +71085,15 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/mountains)
+"pjm" = (
+/obj/structure/roguemachine/talkstatue/mercenary{
+	pixel_y = 32
+	},
+/obj/structure/table/finestone,
+/obj/machinery/light/rogue/candle/floorcandle,
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/town/sewer)
 "pju" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -69873,11 +71333,10 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/forest/hamlet)
 "pmo" = (
-/obj/structure/closet/crate/chest/old_crate,
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
 	},
-/turf/open/floor/rogue/blocks,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/town/sewer)
 "pmx" = (
 /obj/structure/table/wood/large_table/middle_west,
@@ -69952,6 +71411,10 @@
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/woods/south)
+"pnI" = (
+/obj/structure/flora/mushroomcluster,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "pnO" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/grassred,
@@ -70184,10 +71647,18 @@
 /area/rogue/indoors/shelter)
 "prx" = (
 /obj/structure/closet/crate/roguecloset,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/carpet/royalblack,
@@ -70503,6 +71974,15 @@
 /obj/item/reagent_containers/food/snacks/grown/wheat,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter)
+"pvn" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/item/rogueweapon/huntingknife/stoneknife,
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "pvp" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/cobblerock,
@@ -70553,6 +72033,12 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault)
+"pvW" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "pvX" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/wood,
@@ -70681,6 +72167,10 @@
 /obj/structure/glowshroom,
 /turf/open/water/swamp,
 /area/rogue/druidsgrove)
+"pxM" = (
+/mob/living/simple_animal/hostile/rogue/deepone,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "pxT" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -70776,11 +72266,6 @@
 /obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/basement)
-"pzm" = (
-/obj/structure/table/wood/poor,
-/obj/item/toy/cards/deck,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "pzp" = (
 /obj/effect/decal/remains/human,
 /turf/open/water/swamp,
@@ -70926,11 +72411,6 @@
 /obj/effect/landmark/quest_spawner/easy,
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach/north)
-"pAT" = (
-/obj/structure/table/wood/poor,
-/obj/machinery/light/rogue/candle/floorcandle/pink,
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
 "pAU" = (
 /obj/item/chair/stool/bar/rogue/crafted,
 /turf/open/floor/rogue/naturalstone,
@@ -71057,6 +72537,10 @@
 /obj/machinery/light/rogue/candle/off/r,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
+"pCg" = (
+/obj/structure/barricade,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "pCi" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp/deep,
@@ -71139,9 +72623,13 @@
 /area/rogue/under/town/sewer)
 "pDu" = (
 /obj/structure/table/wood/large_table/north_east,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
 "pDz" = (
@@ -71376,6 +72864,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/bog/south)
+"pGi" = (
+/obj/structure/ritualcircle/xylix,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "pGk" = (
 /obj/structure/flora/roguetree,
 /obj/structure/flora/roguegrass/water/reeds,
@@ -72040,11 +73532,6 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/scarymaze)
-"pNQ" = (
-/obj/structure/table/wood/poor,
-/obj/item/book/rogue/cooking,
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
 "pNR" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
@@ -72434,6 +73921,10 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves/north)
+"pSN" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "pSP" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/roguegrass,
@@ -72522,6 +74013,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/druidsgrove)
+"pTU" = (
+/mob/living/simple_animal/hostile/rogue/deepone/wiz,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "pTV" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 4
@@ -72787,6 +74282,10 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town)
+"pXe" = (
+/obj/structure/mineral_door/wood/donjon/stone/broken,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "pXf" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -72848,6 +74347,10 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor)
+"pYg" = (
+/mob/living/simple_animal/hostile/rogue/deepone,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "pYk" = (
 /obj/structure/roguemachine/mail/paired_hermes/bathhouse,
 /turf/closed/wall/mineral/rogue/craftstone,
@@ -73140,6 +74643,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"qbl" = (
+/obj/structure/bars,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "qbm" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -73216,6 +74723,10 @@
 /obj/item/roguekey/warden,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"qbU" = (
+/obj/machinery/light/rogue/firebowl/church/off,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "qbZ" = (
 /turf/closed/wall/mineral/rogue/decostone/end,
 /area/rogue/indoors/town/church/chapel)
@@ -73258,6 +74769,10 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/dungeon1/gethsmane/inner)
+"qcv" = (
+/obj/effect/spawner/lootdrop/valuable_candle_spawner,
+/turf/open/floor/rogue/grass,
+/area/rogue/under/town/sewer)
 "qcy" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/red,
@@ -74094,10 +75609,6 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/underdark/south)
-"qmy" = (
-/obj/structure/flora/roguegrass/water,
-/turf/open/water/transparent/surface/pond,
-/area/rogue/outdoors/woods/south)
 "qmI" = (
 /obj/effect/decal/cleanable/blood,
 /mob/living/carbon/human/species/human/northern/bog_deserters,
@@ -74492,10 +76003,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement/keep)
-"qqY" = (
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/under/town/sewer)
 "qra" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grass,
@@ -74716,6 +76223,14 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement)
+"qtQ" = (
+/obj/structure/table/wood/long_table/mid/alt,
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "qtR" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newleaf,
@@ -75169,6 +76684,14 @@
 "qyR" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"qyT" = (
+/obj/effect/decal/carpet/square/black{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 16
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "qze" = (
 /obj/effect/particle_effect/smoke{
 	lifetime = 144000;
@@ -75581,6 +77104,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"qDg" = (
+/obj/machinery/light/rogue/campfire/densefire,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "qDh" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
@@ -76164,10 +77691,6 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
-"qJp" = (
-/obj/structure/flagpole,
-/turf/open/floor/rogue/dirt/road,
-/area/rogue/outdoors/town)
 "qJr" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/roguekey/bathworker,
@@ -76645,6 +78168,10 @@
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"qOn" = (
+/obj/structure/table/wood/long_table/mid/alt,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "qOo" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/floor/rogue/wood/herringbone,
@@ -76698,6 +78225,10 @@
 	},
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/garrison)
+"qPi" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "qPj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -76707,6 +78238,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/under/underdark/north)
+"qPm" = (
+/obj/item/natural/glass_shard,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "qPo" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/spellbook_unfinished/pre_arcyne,
@@ -76718,6 +78253,11 @@
 "qPv" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/indoors/cave)
+"qPy" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/spawner/lootdrop/roguetown/dungeon,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "qPG" = (
 /obj/structure/fermentation_keg/crafted,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -76738,6 +78278,10 @@
 "qPQ" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/town/basement)
+"qPS" = (
+/obj/structure/ritualcircle/xylix,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "qPT" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/blocks,
@@ -76779,6 +78323,14 @@
 "qQo" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/magician)
+"qQq" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/fermentation_keg/redwine,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "qQr" = (
 /obj/structure/table/wood/crafted,
 /obj/item/candle/silver/lit,
@@ -76991,6 +78543,9 @@
 /obj/structure/hotspring/border/three,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/mountains)
+"qSV" = (
+/turf/open/floor/rogue/blocks/flipped,
+/area/rogue/under/town/sewer)
 "qSY" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -77636,7 +79191,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault/four)
 "qZR" = (
-/obj/structure/leyline/normal/grove,
+/obj/structure/leyline,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/outdoors/woods/southeast)
 "qZS" = (
@@ -77720,9 +79275,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
 "rbe" = (
-/obj/structure/mannequin/male{
-	dir = 1
-	},
+/obj/structure/mannequin,
 /obj/item/clothing/suit/roguetown/armor/leather/studded,
 /obj/item/clothing/head/roguetown/helmet/kettle,
 /obj/machinery/light/rogue/candle{
@@ -77784,6 +79337,12 @@
 "rbu" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
+"rbA" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "rbD" = (
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/tile/brick,
@@ -78327,6 +79886,11 @@
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave/east)
+"rig" = (
+/obj/machinery/light/rogue/campfire/fireplace,
+/obj/structure/table/wood/long_table,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "rij" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
@@ -78398,6 +79962,17 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
+"rjE" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/druidsgrove)
 "rjK" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 4
@@ -78484,7 +80059,9 @@
 /area/rogue/under/town/sewer)
 "rkH" = (
 /obj/structure/table/wood/long_table,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/paper{
 	pixel_x = 4;
 	pixel_y = 4
@@ -78525,6 +80102,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/saigabuck/tame/saddled,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
+"rle" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "rlk" = (
 /obj/machinery/light/rogue/candle/off/r,
 /obj/effect/decal/cobbleedge{
@@ -78628,6 +80209,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault/four)
+"rlU" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor6-old"
+	},
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "rlV" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/shelter/woods)
@@ -78663,7 +80250,9 @@
 /area/rogue/indoors/town/church/basement)
 "rmh" = (
 /obj/structure/table/wood/poor,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/structure/fluff/walldeco/painting/queen{
 	pixel_y = 32
 	},
@@ -78914,10 +80503,18 @@
 	mailtag = "Wardens"
 	},
 /obj/structure/rack/rogue,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town)
 "roI" = (
@@ -78933,6 +80530,10 @@
 	icon_state = "wooden_floort"
 	},
 /area/rogue/outdoors/town)
+"roP" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "roT" = (
 /obj/item/roguecoin/aalloy,
 /obj/item/roguecoin/aalloy,
@@ -79023,6 +80624,15 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach)
+"rqg" = (
+/obj/structure/table/wood/poor,
+/obj/item/natural/feather,
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/carpet/stellar,
+/area/rogue/under/town/sewer)
 "rqn" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/grass,
@@ -79119,6 +80729,10 @@
 /obj/structure/gravemarker,
 /turf/open/water/swamp,
 /area/rogue/outdoors/rtfield)
+"rrN" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "rrP" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/grasscold,
@@ -79317,6 +80931,14 @@
 /obj/effect/landmark/mapGenerator/rogue/decap,
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/cave)
+"rtA" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "rtE" = (
 /obj/structure/spider/stickyweb{
 	dir = 8;
@@ -79362,6 +80984,9 @@
 /obj/structure/flora/hotspring_rocks/grassy,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault/puzzle)
+"rtX" = (
+/turf/open/floor/rogue/greenstone/glyph3,
+/area/rogue/under/cave)
 "rtY" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/concrete,
@@ -79473,6 +81098,10 @@
 /obj/machinery/light/rogue/candle/floorcandle/alt,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"ruM" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "rva" = (
 /mob/living/carbon/human/species/skeleton/npc/no_equipment,
 /obj/structure/fluff/walldeco/chains,
@@ -79580,9 +81209,15 @@
 /area/rogue/indoors/town/magician)
 "rwA" = (
 /obj/structure/closet/crate/roguecloset,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/roguekey/manor,
 /obj/item/roguekey/manor,
 /obj/item/roguekey/manor,
@@ -79602,6 +81237,9 @@
 	},
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/dukecourt)
+"rwO" = (
+/turf/open/floor/rogue/greenstone/glyph1,
+/area/rogue/under/cave)
 "rwQ" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -79777,6 +81415,10 @@
 /obj/effect/spawner/lootdrop/valuable_candle_spawner,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/abandonedhotsprings)
+"rzm" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "rzr" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/hexstone,
@@ -79837,6 +81479,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"rzL" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "rzS" = (
 /obj/structure/chair/stool/rogue,
 /obj/item/clothing/cloak/tabard/abyssortabard,
@@ -79993,6 +81641,10 @@
 "rBq" = (
 /turf/open/water/ocean,
 /area/rogue/indoors/cave/east)
+"rBs" = (
+/obj/structure/vine/dendor,
+/turf/closed/wall/mineral/rogue/stone/red_moss,
+/area/rogue/under/cave)
 "rBw" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -80061,6 +81713,11 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
+"rCi" = (
+/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "rCj" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -80157,10 +81814,6 @@
 /obj/effect/spawner/lootdrop/potion_vitals,
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave)
-"rDj" = (
-/obj/effect/landmark/chimeric_calyx_spawner/fifteen,
-/turf/open/floor/rogue/AzureSand,
-/area/rogue/outdoors/rtfield)
 "rDp" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/magician)
@@ -80319,6 +81972,10 @@
 /obj/structure/flora/newbranch/leafless,
 /turf/open/floor/rogue/snow,
 /area/rogue/outdoors/beach/forest/south)
+"rFh" = (
+/obj/structure/chair/bench/church/mid,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "rFj" = (
 /turf/closed/wall/mineral/rogue/wooddark/end/west,
 /area/rogue/indoors/inq/office)
@@ -80334,6 +81991,14 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/north)
+"rFn" = (
+/obj/structure/mineral_door/bars{
+	locked = 1;
+	lockid = "manor"
+	},
+/obj/structure/bars,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "rFr" = (
 /obj/structure/table/wood/long_table,
 /obj/machinery/light/rogue/candle/floorcandle,
@@ -80399,9 +82064,15 @@
 /area/rogue/indoors/town/dwarfin)
 "rFZ" = (
 /obj/structure/closet/crate/chest/old_crate,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/machinery/light/rogue/candle/off/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woods)
@@ -80452,6 +82123,10 @@
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/central)
+"rGL" = (
+/obj/structure/spider/stickyweb/solo,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "rGT" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -80527,7 +82202,9 @@
 /area/rogue/under/cave/licharena/bossroom)
 "rHU" = (
 /obj/structure/table/wood/long_table/right,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
@@ -80622,6 +82299,20 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"rJf" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 4.2
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "rJj" = (
 /turf/open/water/ocean/deep,
 /area/rogue/indoors/town/church/basement)
@@ -80666,10 +82357,8 @@
 /area/rogue/indoors/town)
 "rJE" = (
 /obj/structure/fluff/railing/corner,
-/obj/structure/mineral_door/wood/window{
-	lockid = "nightmaiden"
-	},
-/turf/open/floor/rogue/tile/brownbrick,
+/obj/structure/roguewindow/harem3,
+/turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/bath)
 "rJJ" = (
 /obj/effect/decal/cobbleedge{
@@ -81046,6 +82735,10 @@
 "rNq" = (
 /turf/open/floor/rogue/rooftop/green/north,
 /area/rogue/indoors/town/steward)
+"rNA" = (
+/obj/structure/ritualcircle/xylix,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "rNE" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/cobble/mossy,
@@ -81232,6 +82925,11 @@
 /obj/effect/landmark/chest_or_mimic/locked_or_trapped,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark/south)
+"rQg" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "rQo" = (
 /obj/structure/bookcase,
 /obj/item/book/rogue/sword,
@@ -81476,10 +83174,22 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield)
+"rSB" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/water/river/flow,
+/area/rogue/under/town/sewer)
 "rSF" = (
 /obj/structure/hotspring/border/seven,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/rtfield/abandonedhotsprings)
+"rSH" = (
+/obj/item/clothing/neck/roguetown/psicross/pestra,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "rSN" = (
 /mob/living/carbon/human/species/skeleton/npc/easy,
 /turf/open/floor/rogue/cobble/mossy,
@@ -81504,8 +83214,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -81755,6 +83469,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains/decap)
+"rVA" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/AzureSand,
+/area/rogue/under/cave)
 "rVF" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/cave/east)
@@ -81838,6 +83556,10 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
+"rWz" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/under/town/sewer)
 "rWE" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -81910,6 +83632,10 @@
 	lockid = "keeper2"
 	},
 /turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
+"rXn" = (
+/obj/structure/fluff/grindwheel,
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "rXp" = (
 /turf/open/floor/rogue/cobble,
@@ -81990,12 +83716,24 @@
 /area/rogue/outdoors/beach/forest/hamlet)
 "rXZ" = (
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/dwarfin)
 "rYb" = (
@@ -82188,6 +83926,10 @@
 /obj/item/bedsheet/rogue/cloth,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/under/underdark/south)
+"say" = (
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/greenstone/runed,
+/area/rogue/under/cave)
 "saH" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
@@ -82555,6 +84297,10 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach/north)
+"sfC" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/grass,
+/area/rogue/under/town/sewer)
 "sfE" = (
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/blocks/green,
@@ -82675,6 +84421,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"she" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "shi" = (
 /turf/open/water/ocean,
 /area/rogue/indoors/cave/central)
@@ -82763,6 +84513,10 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/under/cave)
+"sij" = (
+/mob/living/simple_animal/hostile/rogue/deepone/wiz,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "sik" = (
 /obj/structure/fluff/railing/border/west,
 /obj/structure/stairs/stone,
@@ -82772,6 +84526,10 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/underdark/north)
+"sin" = (
+/obj/structure/fermentation_keg/random/water,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "sip" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bog/south)
@@ -82970,7 +84728,9 @@
 /area/rogue/under/town/sewer)
 "skF" = (
 /obj/structure/table/wood/long_table,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/paper{
 	pixel_x = 4;
 	pixel_y = 4
@@ -83186,6 +84946,10 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/woods/southwest)
+"snb" = (
+/obj/item/grown/log/tree/stake,
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "snl" = (
 /obj/machinery/light/rogue/candle/blue/r,
 /obj/structure/fluff/clodpile,
@@ -83212,6 +84976,21 @@
 "sns" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town)
+"snt" = (
+/obj/structure/flora/newleaf,
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "snv" = (
 /obj/structure/lever/wall{
 	pixel_y = 4;
@@ -83911,6 +85690,10 @@
 /obj/structure/fluff/railing/border/west,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/beach)
+"stO" = (
+/obj/effect/decal/cleanable/black_rot_vomit,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "stS" = (
 /obj/effect/landmark/start/keeper,
 /turf/open/floor/rogue/concrete,
@@ -83930,6 +85713,10 @@
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor)
+"suk" = (
+/obj/structure/ritualcircle/xylix,
+/turf/open/floor/rogue/dirt,
+/area/rogue/druidsgrove)
 "suo" = (
 /obj/structure/bars/pipe{
 	dir = 5
@@ -84356,6 +86143,12 @@
 	},
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/manor)
+"syM" = (
+/obj/structure/fluff/railing/fence{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/cave)
 "syN" = (
 /obj/structure/fluff/statue/tdummy,
 /obj/machinery/light/rogue/torchholder/c,
@@ -84783,6 +86576,9 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/grass,
 /area/rogue/druidsgrove)
+"sEm" = (
+/turf/closed/mineral/random/rogue/med,
+/area/rogue/under/town/sewer)
 "sEo" = (
 /obj/structure/flora/roguetree/pine,
 /turf/open/floor/rogue/grasscold,
@@ -84799,6 +86595,10 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/inq/basement)
+"sEu" = (
+/obj/structure/ritualcircle/necra,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "sEw" = (
 /obj/structure/vine,
 /turf/open/floor/rogue/cobblerock,
@@ -84833,6 +86633,10 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"sEP" = (
+/obj/structure/flora/roguegrass/bush/wall/tall,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "sES" = (
 /obj/structure/chair/bench/couch,
 /obj/machinery/light/rogue/campfire/fireplace{
@@ -84911,6 +86715,11 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/mountains)
+"sFW" = (
+/obj/structure/table/wood/long_table/mid/alt,
+/obj/machinery/light/rogue/candle/blue/l,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "sFZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/fluff/walldeco/chains,
@@ -85041,6 +86850,12 @@
 /obj/effect/spawner/lootdrop/armored_boots_spawner,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/scarymaze)
+"sHp" = (
+/obj/structure/mineral_door/wood/window{
+	lockid = "nightmaiden"
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "sHr" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
@@ -85203,6 +87018,12 @@
 /obj/item/clothing/neck/roguetown/psicross/inhumen/aalloy,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/inq/basement)
+"sJa" = (
+/obj/structure/table/optable,
+/obj/item/bedsheet/rogue/cloth,
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "sJc" = (
 /obj/structure/closet/crate/chest/loot_chest/locked,
 /turf/open/floor/rogue/metal/barograte,
@@ -85256,6 +87077,9 @@
 /obj/structure/table/optable,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/scarymaze)
+"sJJ" = (
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/beach/south)
 "sJK" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -85334,6 +87158,9 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/steward)
+"sKA" = (
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/cave)
 "sKC" = (
 /obj/item/reagent_containers/powder/moondust,
 /turf/open/floor/rogue/cobble,
@@ -85386,12 +87213,20 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq/basement)
+"sKZ" = (
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/grassyel,
+/area/rogue/outdoors/town)
 "sLa" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/church/chapel)
+"sLh" = (
+/obj/structure/flora/roguegrass/water,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "sLj" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town)
@@ -85889,7 +87724,7 @@
 /obj/effect/decal/cleanable/debris/woody{
 	dir = 1
 	},
-/turf/open/floor/rogue/tile,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/under/town/sewer)
 "sRk" = (
 /obj/structure/fermentation_keg/beer,
@@ -86064,6 +87899,19 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor)
+"sSM" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "sSO" = (
 /obj/structure/well,
 /obj/item/reagent_containers/glass/bucket{
@@ -86106,6 +87954,10 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"sTh" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "sTr" = (
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
@@ -86194,7 +88046,6 @@
 	pixel_x = 10;
 	pixel_y = 10
 	},
-/obj/item/mini_flagpole/duke,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/indoors/town/manor)
 "sUp" = (
@@ -86255,6 +88106,10 @@
 "sVd" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/druidsgrove)
+"sVe" = (
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "sVf" = (
 /obj/effect/decal/cleanable/debris/glassy,
 /turf/open/floor/rogue/wood,
@@ -86449,6 +88304,10 @@
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/water/swamp,
 /area/rogue/druidsgrove)
+"sXO" = (
+/obj/effect/decal/cleanable/roguerune/god/dendor,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "sXQ" = (
 /obj/structure/flora/roguetree/stump,
 /turf/open/floor/rogue/grass,
@@ -86749,6 +88608,9 @@
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
+"tbh" = (
+/turf/open/floor/rogue/greenstone/glyph6,
+/area/rogue/under/cave)
 "tbl" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8;
@@ -86854,6 +88716,11 @@
 /obj/item/candle/silver/lit,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
+"tcK" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/effect/spawner/lootdrop/roguetown/dungeon/money,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "tcL" = (
 /obj/structure/table/wood/long_table,
 /obj/structure/rack/rogue/shelf,
@@ -87148,6 +89015,10 @@
 /obj/structure/fluff/railing/border/west,
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains)
+"tfx" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/basement)
 "tfQ" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/naturalstone,
@@ -87863,6 +89734,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"tod" = (
+/obj/structure/gate/bars,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "tof" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -87946,6 +89821,12 @@
 "tpk" = (
 /turf/closed/wall/mineral/rogue/pipe/corners,
 /area/rogue/under/cave/dungeon1/gethsmane)
+"tpl" = (
+/obj/machinery/light/rogue/candle/floorcandle{
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "tpn" = (
 /turf/open/floor/rogue/metal{
 	dir = 1;
@@ -88046,6 +89927,10 @@
 /obj/structure/fluff/railing/corner/south_east,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"tqk" = (
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "tqt" = (
 /obj/structure/fluff/walldeco/psybanner/red,
 /turf/closed/wall/mineral/rogue/stone,
@@ -88492,6 +90377,12 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/south)
+"tvd" = (
+/obj/structure/fluff/walldeco/customflag{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "tvk" = (
 /obj/effect/decal/carpet/kover_black{
 	pixel_x = 8;
@@ -88677,6 +90568,10 @@
 /obj/machinery/light/rogue/candle/floorcandle,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"txj" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/revenant/mirespider,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "txk" = (
 /obj/structure/hotspring/border/two,
 /obj/machinery/light/rogue/candle/floorcandle,
@@ -88917,6 +90812,11 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"tyX" = (
+/obj/structure/ritualcircle/noc,
+/mob/living/simple_animal/hostile/retaliate/rogue/revenant/mirespider_lurker,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "tyZ" = (
 /obj/effect/landmark/chest_or_mimic/locked_or_trapped,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -88992,6 +90892,14 @@
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/dwarfin)
+"tzM" = (
+/obj/effect/decal/carpet/kover_purple{
+	dir = 4;
+	pixel_x = 20;
+	pixel_y = -15
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "tzO" = (
 /obj/structure/roguewindow,
 /obj/structure/bars/grille{
@@ -89269,8 +91177,12 @@
 /area/rogue/under/cave)
 "tDp" = (
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /obj/item/rope/chain,
@@ -89766,6 +91678,10 @@
 /obj/item/clothing/neck/roguetown/psicross/malum,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"tJQ" = (
+/obj/structure/spider/cocoon,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "tJR" = (
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/twig,
@@ -90095,7 +92011,9 @@
 "tMo" = (
 /obj/machinery/light/rogue/candle/r,
 /obj/structure/table/wood/poor,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
@@ -90463,6 +92381,13 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/cave/scarymaze)
+"tQY" = (
+/obj/structure/bed/rogue/shit{
+	name = "makeshift bed"
+	},
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "tRh" = (
 /obj/item/clothing/mask/rogue/facemask/goldmask{
 	pixel_x = -2;
@@ -90544,10 +92469,18 @@
 /area/rogue/outdoors/beach/central)
 "tRY" = (
 /obj/structure/closet/crate/chest/gold,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town)
 "tSh" = (
@@ -90664,6 +92597,17 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor)
+"tTo" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "tTw" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/cobble,
@@ -91125,8 +93069,12 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /obj/item/rope/chain,
 /obj/item/rope/chain,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /turf/open/floor/carpet/red,
@@ -91136,9 +93084,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "tYh" = (
-/obj/structure/mannequin/male{
-	dir = 1
-	},
+/obj/structure/mannequin,
 /obj/item/clothing/suit/roguetown/armor/plate/cuirass,
 /obj/item/clothing/head/roguetown/helmet/sallet,
 /obj/item/clothing/gloves/roguetown/chain,
@@ -91238,12 +93184,6 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
-"tZv" = (
-/obj/effect/decal/cleanable/dirt/cobweb{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/under/town/sewer)
 "tZS" = (
 /obj/effect/decal/wood/herringbone2{
 	dir = 8
@@ -91385,7 +93325,9 @@
 /area/rogue/indoors/town)
 "uaM" = (
 /obj/structure/table/wood/poor,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor)
 "uaN" = (
@@ -91424,6 +93366,13 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"ubp" = (
+/obj/structure/fluff/buysign{
+	desc = "This is a coarsely carved sign willing 'Curses variede and terrible be upon ye who interrupts the resting cadavers of this place!' The sign of the Necran cross is marked roughly into one corner. It's rather doubtful it has stopped anyone.";
+	name = "Remember the miners that died here"
+	},
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "uby" = (
 /obj/structure/table/wood/long_table/right,
 /obj/structure/fluff/walldeco/psybanner/red{
@@ -91463,7 +93412,9 @@
 /area/rogue/outdoors/mountains)
 "ubR" = (
 /obj/structure/table/wood/long_table,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -91870,6 +93821,11 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"ugQ" = (
+/obj/structure/closet/dirthole/grave,
+/obj/structure/gravemarker,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "ugV" = (
 /mob/living/carbon/human/species/goblin/npc/ambush/sea,
 /turf/open/floor/rogue/AzureSand,
@@ -92025,6 +93981,21 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
+"uiA" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	layer = 2.05;
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	layer = 2.05
+	},
+/turf/open/transparent/openspace,
+/area/rogue/druidsgrove)
 "uiH" = (
 /obj/structure/stairs/stone/d{
 	dir = 4
@@ -92368,8 +94339,6 @@
 	pixel_y = 5
 	},
 /obj/item/storage/roguebag,
-/obj/item/mini_flagpole/freeform2,
-/obj/item/mini_flagpole,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/steward)
 "umy" = (
@@ -92514,7 +94483,9 @@
 "uoH" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/table/wood/fancy/black,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
@@ -92623,27 +94594,6 @@
 /obj/item/ingot/copper,
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/mountains/decap/minotaurfort)
-"upZ" = (
-/obj/item/reagent_containers/glass/bottle/alchemical/healthpot{
-	pixel_x = -9;
-	pixel_y = 18
-	},
-/obj/item/reagent_containers/glass/bottle/alchemical/healthpot{
-	pixel_x = -11;
-	pixel_y = 14
-	},
-/obj/item/natural/bundle/cloth/bandage/full,
-/obj/item/natural/bundle/cloth/bandage/full,
-/obj/item/natural/bundle/cloth/bandage/full,
-/obj/item/natural/bundle/cloth/bandage/full,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/item/needle/thorn,
-/obj/structure/table/wood/poor,
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement/keep)
 "uqf" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -92689,6 +94639,17 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/gunduzirak)
+"uqC" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/rack/rogue{
+	density = 0;
+	pixel_y = 18
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "uqD" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -93040,6 +95001,10 @@
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
+"uub" = (
+/obj/effect/decal/cleanable/black_rot_vomit,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "uuc" = (
 /obj/structure/table/vtable,
 /obj/item/roguegem/random,
@@ -93159,6 +95124,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town)
+"uvX" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "uwc" = (
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/woodturned,
@@ -93243,6 +95214,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/physician)
+"uwP" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "uwU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5
@@ -93524,6 +95501,11 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
+"uzQ" = (
+/obj/structure/table/wood/poor,
+/obj/item/lockpick,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "uzT" = (
 /obj/machinery/light/rogue/candle/r,
 /obj/item/roguebin/water,
@@ -93771,6 +95753,14 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet/bogcaves/north)
+"uCi" = (
+/obj/structure/flora/roguegrass/water,
+/turf/open/water/cleanshallow,
+/area/rogue/outdoors/beach/south)
+"uCj" = (
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "uCk" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -94122,6 +96112,10 @@
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
+"uGm" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "uGn" = (
 /obj/structure/mineral_door/swing_door{
 	keylock = 1;
@@ -94138,10 +96132,6 @@
 	},
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors/town)
-"uGp" = (
-/obj/structure/fermentation_keg,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "uGs" = (
 /obj/item/paper{
 	pixel_y = 7
@@ -94488,6 +96478,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"uJL" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "uJM" = (
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
 /obj/structure/flora/roguegrass,
@@ -94939,6 +96933,10 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach)
+"uPY" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/metal,
+/area/rogue/under/town/sewer)
 "uQa" = (
 /obj/structure/roguewindow/harem3,
 /turf/open/floor/rogue/tile/brownbrick,
@@ -94953,6 +96951,19 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor)
+"uQl" = (
+/obj/machinery/light/rogue/candle/blue/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "uQn" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -95051,10 +97062,6 @@
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
 /turf/open/floor/rogue/woodturned/nosmooth,
 /area/rogue/outdoors/mountains)
-"uRz" = (
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/basement)
 "uRA" = (
 /obj/effect/decal/carpet{
 	dir = 4;
@@ -95380,11 +97387,20 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield)
+"uUP" = (
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "uUQ" = (
 /obj/structure/table/wood/large_table/middle_west,
 /obj/item/reagent_containers/food/snacks/rogue/meat/salami,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/underdark/north)
+"uUT" = (
+/obj/effect/decal/cleanable/debris/glassy,
+/obj/machinery/light/rogue/oven/east,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "uUU" = (
 /mob/living/carbon/human/species/skeleton/no_equipment,
 /turf/open/floor/rogue/cobble,
@@ -95635,12 +97651,6 @@
 	density = 0
 	},
 /turf/open/water/swamp,
-/area/rogue/under/town/sewer)
-"uXf" = (
-/obj/structure/bookcase,
-/obj/item/book/rogue/sword,
-/obj/item/book/rogue/naledi4,
-/turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
 "uXh" = (
 /obj/structure/fluff/walldeco/bsmith{
@@ -95907,7 +97917,9 @@
 /area/rogue/outdoors/mountains)
 "var" = (
 /obj/machinery/light/rogue/candle,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/structure/table/wood/long_table,
 /obj/item/natural/feather,
 /turf/open/floor/carpet/royalblack,
@@ -95988,14 +98000,6 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/scarymaze)
-"vaP" = (
-/obj/structure/table/wood/long_table,
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 6;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "vaR" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -96014,6 +98018,9 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/basement/keep)
+"vaV" = (
+/turf/closed/wall/mineral/rogue/pipe/line/four,
+/area/rogue/under/town/basement)
 "vbf" = (
 /obj/structure/chair/wood,
 /turf/open/floor/rogue/blocks,
@@ -96042,6 +98049,11 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet/bogcaves/west)
+"vbt" = (
+/obj/structure/table/church/m,
+/obj/item/book/rogue/arcyne,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cave)
 "vbv" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -96138,6 +98150,10 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cave/orcdungeon)
+"vdf" = (
+/obj/item/roguebin/water/gross,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "vdp" = (
 /obj/structure/stairs{
 	dir = 1
@@ -96839,6 +98855,10 @@
 "vkY" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/indoors/town/church/chapel)
+"vla" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mirespider,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "vlb" = (
 /obj/structure/fluff/railing/corner,
 /obj/structure/flora/roguegrass,
@@ -96893,7 +98913,7 @@
 /area/rogue/outdoors/rtfield)
 "vlH" = (
 /obj/structure/roguerock,
-/turf/open/floor/rogue/AzureSand,
+/turf/open/water/river/flow/east,
 /area/rogue/under/cave)
 "vlI" = (
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -97266,6 +99286,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/minotaurfort)
+"vqj" = (
+/obj/structure/tent_wall,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "vql" = (
 /obj/structure/table/church/end,
 /obj/item/recipe_book/magic{
@@ -97338,12 +99362,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
-"vqD" = (
-/obj/structure/mineral_door/wood/window{
-	lockid = "nightmaiden"
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
 "vqJ" = (
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/AzureSand,
@@ -98151,6 +100169,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains/decap)
+"vzw" = (
+/obj/structure/glowshroom{
+	icon_state = "glowshroom2"
+	},
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "vzB" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood,
@@ -98299,6 +100323,11 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
+"vBb" = (
+/obj/structure/bed/rogue/inn/hay,
+/obj/item/bedsheet/rogue/cloth,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "vBc" = (
 /obj/structure/bars/pipe{
 	dir = 4
@@ -98550,6 +100579,10 @@
 "vDJ" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/basement)
+"vDT" = (
+/obj/structure/spider/stickyweb,
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "vDV" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/shelter)
@@ -98755,6 +100788,11 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/underdark/south)
+"vGC" = (
+/obj/structure/closet/crate/chest/old_crate,
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/ruinedwood/herringbone,
+/area/rogue/under/town/sewer)
 "vGE" = (
 /obj/structure/bars/passage{
 	max_integrity = 3000;
@@ -98921,10 +100959,6 @@
 /obj/structure/fluff/statue/astrata/gold,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
-"vIJ" = (
-/obj/structure/flagpole,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/exposed/town/keep)
 "vIN" = (
 /obj/machinery/light/rogue/candle/weak/r,
 /turf/open/floor/rogue/cobble,
@@ -99007,6 +101041,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town/tavern)
+"vJL" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/town/sewer)
 "vJN" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5;
@@ -99018,6 +101056,9 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/his_vault/four)
+"vJO" = (
+/turf/open/water/bloody,
+/area/rogue/under/cave)
 "vJP" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-sread";
@@ -99318,6 +101359,10 @@
 "vNc" = (
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/under/cave/licharena)
+"vNf" = (
+/obj/structure/bookcase,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "vNl" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -99347,6 +101392,10 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest/hamlet)
+"vNw" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/basement)
 "vNz" = (
 /obj/structure/table/wood/poor,
 /obj/item/rogueweapon/mace/wsword,
@@ -99580,6 +101629,14 @@
 "vPQ" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/cave/southern)
+"vPR" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	layer = 2.8;
+	pixel_x = 8
+	},
+/turf/open/water/river/flow/north,
+/area/rogue/under/town/sewer)
 "vPU" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
@@ -99684,6 +101741,10 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
+"vQY" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "vRh" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/newbranch/leafless{
@@ -99812,6 +101873,10 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town)
+"vSw" = (
+/obj/structure/fluff/statue/aasimar,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "vSK" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/church,
@@ -99880,6 +101945,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town)
+"vTW" = (
+/obj/structure/chair/bench/church/r,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "vTY" = (
 /obj/structure/stairs{
 	dir = 1
@@ -100526,10 +102595,6 @@
 	},
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/outdoors/mountains/decap/gunduzirak/bossarena)
-"wbi" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/under/town/sewer)
 "wbl" = (
 /obj/structure/fluff/railing/border/west,
 /obj/structure/fluff/railing/border,
@@ -100650,7 +102715,6 @@
 /obj/structure/wonder{
 	name = "graggarite altar"
 	},
-/obj/structure/leyline/normal/coast,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/orcdungeon)
 "wcX" = (
@@ -100865,6 +102929,11 @@
 "wfe" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/beach)
+"wfg" = (
+/obj/effect/decal/remains/human,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "wfl" = (
 /obj/structure/fluff/walldeco/customflag{
 	pixel_y = 32
@@ -101129,7 +103198,9 @@
 /area/rogue/under/town/basement/keep)
 "wie" = (
 /obj/structure/table/wood/fancy/red,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
@@ -101795,8 +103866,12 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/rope/chain,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -101823,6 +103898,10 @@
 	},
 /turf/open/floor/rogue/tile/bfloorz,
 /area/rogue/under/cave/orcdungeon)
+"wpv" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cave)
 "wpE" = (
 /obj/structure/fluff/railing/wood,
 /obj/effect/decal/cleanable/blood/old,
@@ -101843,7 +103922,9 @@
 "wpP" = (
 /obj/machinery/light/rogue/candle/l,
 /obj/structure/table/wood/fancy/royalblue,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/paper/scroll{
 	pixel_x = 2
 	},
@@ -102045,6 +104126,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woods/north)
+"wrO" = (
+/obj/structure/spider/cocoon,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "wrU" = (
 /obj/structure/lever/wall{
 	redstone_id = "mazedungeonglory"
@@ -102264,6 +104349,11 @@
 /obj/item/ingot/blacksteel,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/licharena/bossroom)
+"wva" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/mineral_door/wood/donjon/stone/broken,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/cave)
 "wvc" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt,
@@ -102293,6 +104383,10 @@
 /obj/item/clothing/suit/roguetown/shirt/tunic/silktunic,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
+"wvo" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "wvp" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/corner/north_east,
@@ -102842,6 +104936,10 @@
 /obj/item/natural/fibers,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/underdark/north)
+"wBh" = (
+/obj/structure/vine/dendor,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "wBl" = (
 /obj/structure/fluff/signage{
 	dir = 1;
@@ -103147,6 +105245,16 @@
 /obj/item/natural/bone,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/shelter/mountains/decap)
+"wEN" = (
+/obj/structure/flora/roguegrass/bush/wall,
+/obj/structure/flora/newleaf,
+/obj/structure/fluff/railing/border{
+	dir = 1;
+	layer = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/druidsgrove)
 "wEP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10
@@ -103474,12 +105582,18 @@
 /area/rogue/under/cave/his_vault)
 "wHQ" = (
 /obj/structure/table/wood/large_table/middle_west,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /obj/machinery/light/rogue/candle/r,
 /obj/item/roguekey/church,
 /turf/open/floor/rogue/wood/herringbone,
 /area/rogue/indoors/town/church/chapel)
+"wIb" = (
+/obj/structure/ladder,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town)
 "wIc" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/woodturned,
@@ -103787,6 +105901,11 @@
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/mountains/decap/stepbelow)
+"wLR" = (
+/obj/structure/rack/rogue,
+/obj/structure/spider/stickyweb/solo,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "wLW" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/clothing/head/roguetown/wizhat/random,
@@ -104118,6 +106237,10 @@
 /obj/structure/chair/bench,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/forest/north)
+"wON" = (
+/obj/effect/spawner/lootdrop/valuable_candle_spawner,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "wOS" = (
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
@@ -104184,9 +106307,15 @@
 "wPE" = (
 /obj/structure/fluff/wallclock,
 /obj/structure/closet/crate/drawer,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "wPY" = (
@@ -104393,9 +106522,7 @@
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors/cave)
 "wRZ" = (
-/obj/structure/mannequin/male{
-	dir = 1
-	},
+/obj/structure/mannequin,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
 "wSa" = (
@@ -104423,6 +106550,10 @@
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town/garrison)
+"wSm" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/rogue/blocks/green,
+/area/rogue/under/town/sewer)
 "wSn" = (
 /obj/structure/table/wood/poor,
 /obj/machinery/light/rogue/candle/floorcandle/pink,
@@ -104700,6 +106831,13 @@
 /obj/structure/fluff/railing/corner,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
+"wVn" = (
+/obj/structure/table/wood/poor,
+/obj/item/candle/skull/lit{
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "wVs" = (
 /obj/effect/landmark/quest_spawner/medium,
 /turf/open/floor/rogue/dirt/road,
@@ -105230,6 +107368,10 @@
 /obj/item/rope/chain,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/his_vault)
+"xbt" = (
+/obj/item/rogueweapon/shovel,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cave)
 "xbx" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/bog/north)
@@ -105453,6 +107595,10 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena/bossroom)
+"xeg" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/carpet/red,
+/area/rogue/under/town/sewer)
 "xel" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -105656,7 +107802,9 @@
 /area/rogue/outdoors/mountains/decap/minotaurfort)
 "xhd" = (
 /obj/structure/table/wood/fancy/black,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/town/basement/keep)
@@ -105722,6 +107870,11 @@
 	},
 /obj/structure/fluff/walldeco/wantedposter,
 /turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town)
+"xhK" = (
+/obj/structure/flora/roguegrass,
+/obj/machinery/tanningrack,
+/turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
 "xhL" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/dragon/broodmother,
@@ -106329,6 +108482,10 @@
 /obj/structure/globe,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/magician)
+"xpv" = (
+/obj/effect/decal/cleanable/blood/splatter/walls,
+/turf/closed/wall/mineral/rogue/stone,
+/area/rogue/under/town/sewer)
 "xpw" = (
 /obj/structure/fluff/railing/corner/south_east,
 /obj/structure/bed/rogue/shit,
@@ -106752,6 +108909,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"xup" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/under/town/sewer)
 "xuq" = (
 /obj/effect/decal/cobbleedge{
 	dir = 5;
@@ -107500,7 +109661,9 @@
 /obj/item/paper,
 /obj/item/paper,
 /obj/item/paper,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cave/scarymaze)
 "xDx" = (
@@ -107536,10 +109699,21 @@
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town)
+"xDR" = (
+/obj/item/clothing/neck/roguetown/psicross/dendor,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/cave)
 "xDU" = (
 /mob/living/carbon/human/species/skeleton/npc/hardspread,
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/cave/licharena)
+"xDW" = (
+/obj/structure/bookcase{
+	density = 0;
+	name = "suspicious bookcase"
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "xDY" = (
 /obj/structure/table/wood/large_table/south_west,
 /obj/item/reagent_containers/glass/cup/wooden{
@@ -107974,6 +110148,10 @@
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"xJk" = (
+/obj/structure/bars,
+/turf/closed/basic,
+/area/rogue/under/town/sewer)
 "xJo" = (
 /obj/structure/closet/crate/drawer,
 /obj/item/book/rogue/cardgame,
@@ -108051,7 +110229,9 @@
 	name = "Drawbridge";
 	pixel_x = -2
 	},
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor)
@@ -108103,6 +110283,10 @@
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cave/licharena)
+"xKF" = (
+/obj/structure/table/church/m,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cave)
 "xKH" = (
 /obj/structure/stairs,
 /obj/item/natural/poo{
@@ -108331,6 +110515,9 @@
 /obj/structure/closet/crate/chest/lootbox,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bog/south)
+"xNI" = (
+/turf/open/floor/rogue/greenstone/glyph4,
+/area/rogue/under/cave)
 "xNK" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/metal,
@@ -108542,6 +110729,10 @@
 "xPN" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/church/chapel)
+"xPT" = (
+/obj/structure/flora/roguegrass/water,
+/turf/open/floor/rogue/AzureSand,
+/area/rogue/outdoors/beach/south)
 "xPV" = (
 /turf/open/lava,
 /area/rogue/outdoors/mountains/decap/stepbelow)
@@ -108586,11 +110777,19 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/mountains/decap/minotaurfort)
+"xQm" = (
+/turf/open/floor/rogue/metal/barograte,
+/area/rogue/under/town/sewer)
 "xQn" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town/garrison)
+"xQr" = (
+/obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/candle/blue/l,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/basement)
 "xQt" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/candle/candlestick/silver/single/lit{
@@ -108816,15 +111015,9 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/orcdungeon)
 "xSt" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Town Smith - Workshop"
-	},
+/obj/structure/roguemachine/scomm/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town)
-"xSz" = (
-/obj/structure/fluff/walldeco/chains,
-/turf/open/floor/rogue/blocks,
-/area/rogue/under/town/sewer)
 "xSA" = (
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/carpet/royalblack,
@@ -109560,7 +111753,9 @@
 "yaG" = (
 /obj/structure/table/wood/poor/alt,
 /obj/machinery/light/rogue/torchholder/r,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/natural/feather,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter)
@@ -109713,6 +111908,10 @@
 /mob/living/carbon/human/species/lizardfolk/psy_vault_guard,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/his_vault)
+"ycm" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/mirespider,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "yco" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/wood,
@@ -109871,11 +112070,6 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/garrison)
-"ydL" = (
-/obj/structure/table/wood/long_table/right,
-/obj/item/rope,
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
 "ydM" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/dirt/road,
@@ -109947,8 +112141,12 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /obj/item/rope/chain,
@@ -110384,8 +112582,12 @@
 /area/rogue/indoors/town/garrison)
 "yiG" = (
 /obj/structure/closet/crate/roguecloset/inn,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
+/obj/item/paper/scroll{
+	desc = "The writting in ancient azurian reads: Elves disappeared. We are besieged. The sanctum has fallen."
+	},
 /obj/item/storage/belt/rogue/pouch,
 /obj/item/natural/feather,
 /obj/item/rope/chain,
@@ -119220,7 +121422,7 @@ miF
 miF
 ckW
 toJ
-toJ
+htN
 miF
 miF
 miF
@@ -119673,7 +121875,7 @@ toJ
 toJ
 toJ
 toJ
-toJ
+htN
 miF
 miF
 miF
@@ -120125,8 +122327,8 @@ toJ
 toJ
 miF
 toJ
-toJ
-toJ
+htN
+tQC
 miF
 miF
 miF
@@ -120578,9 +122780,9 @@ miF
 miF
 miF
 toJ
-toJ
-toJ
-toJ
+orc
+drf
+drf
 miF
 miF
 miF
@@ -121030,10 +123232,10 @@ miF
 miF
 miF
 miF
-toJ
-toJ
-toJ
-toJ
+orc
+gUH
+orc
+tQC
 miF
 miF
 miF
@@ -121482,12 +123684,12 @@ miF
 miF
 miF
 miF
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
+sMT
+ylh
+ylh
+ylh
+tQC
+tQC
 miF
 miF
 miF
@@ -121938,9 +124140,9 @@ miF
 miF
 miF
 miF
-toJ
-toJ
-toJ
+uvk
+orc
+tQC
 miF
 miF
 miF
@@ -122391,9 +124593,9 @@ miF
 miF
 miF
 miF
-toJ
-toJ
-toJ
+uvk
+orc
+tQC
 miF
 miF
 miF
@@ -122843,10 +125045,10 @@ miF
 miF
 miF
 miF
-toJ
-toJ
-toJ
-toJ
+uvk
+orc
+orc
+tQC
 miF
 miF
 miF
@@ -123296,10 +125498,10 @@ miF
 miF
 miF
 miF
-toJ
-toJ
-toJ
-toJ
+uvk
+orc
+orc
+daP
 miF
 miF
 dNb
@@ -123750,10 +125952,10 @@ miF
 miF
 miF
 miF
-toJ
-toJ
-toJ
-toJ
+orc
+orc
+cYK
+cYK
 dNb
 dNb
 dNb
@@ -124203,9 +126405,9 @@ miF
 miF
 qHj
 qHj
-toJ
-toJ
-toJ
+ylh
+gUH
+cYK
 miF
 miF
 miF
@@ -124655,9 +126857,9 @@ qHj
 qHj
 qHj
 qHj
-qHj
-toJ
-toJ
+iud
+ylh
+daP
 miF
 miF
 miF
@@ -125059,8 +127261,8 @@ qHj
 qHj
 qHj
 qHj
-dIV
-toJ
+qHj
+qHj
 fju
 fju
 fju
@@ -125107,9 +127309,9 @@ qHj
 qHj
 qHj
 qHj
-qHj
-toJ
-toJ
+skC
+ylh
+daP
 miF
 miF
 miF
@@ -125505,15 +127707,15 @@ qHj
 qHj
 qHj
 qHj
+gau
+iZp
+iZp
+iZp
+sIr
 qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-toJ
-toJ
 qHj
 qHj
 qHj
@@ -125559,10 +127761,10 @@ qHj
 qHj
 qHj
 qHj
-toJ
-toJ
-toJ
-toJ
+cqm
+ylh
+daP
+daP
 miF
 miF
 miF
@@ -125957,19 +128159,11 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
+cqm
+mMx
+mMx
+mMx
+cqm
 qHj
 qHj
 qHj
@@ -125980,6 +128174,14 @@ qHj
 qHj
 qHj
 qHj
+qHj
+qHj
+qHj
+qHj
+qHj
+qHj
+qHj
+ogs
 fju
 fju
 fju
@@ -126011,10 +128213,10 @@ qHj
 qHj
 qHj
 qHj
-toJ
-toJ
-toJ
-toJ
+cqm
+ylh
+orc
+daP
 miF
 miF
 miF
@@ -126408,31 +128610,31 @@ miF
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-ogs
+dlK
+tZm
+mMx
+dlK
+mMx
+ltb
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+skC
+skC
 fju
 fju
 fju
@@ -126463,11 +128665,11 @@ qHj
 qHj
 qHj
 qHj
-qHj
-toJ
-toJ
-toJ
-toJ
+ogs
+sMT
+orc
+cYK
+xCK
 miF
 miF
 miF
@@ -126860,32 +129062,32 @@ miF
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-ogs
-ogs
+cqm
+mMx
+mMx
+cqm
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+xCK
 fju
 fju
 toJ
@@ -126915,11 +129117,11 @@ qHj
 qHj
 qHj
 qHj
-qHj
-toJ
-toJ
-toJ
-toJ
+ogs
+ylh
+orc
+cYK
+xCK
 miF
 miF
 miF
@@ -127301,45 +129503,45 @@ qHj
 qHj
 qHj
 miF
-miF
-miF
-miF
+oxx
+oxx
+oxx
 miF
 miF
 miF
 bhJ
 bhJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-ogs
-gau
-dVJ
-iZp
+bhJ
+bhJ
+bhJ
+cqm
+mMx
+ylh
+cqm
+urZ
+kpy
+dxA
+ylh
+urZ
+urZ
+ylh
+sMT
+ylh
+urZ
+urZ
+dxA
+ylh
+dxA
+ylh
+urZ
+urZ
+urZ
+ylh
+ylh
+mMx
+mMx
+xCK
+xCK
 sIr
 bhJ
 bhJ
@@ -127367,11 +129569,11 @@ ogs
 ogs
 ogs
 ogs
-qHj
-qHj
-toJ
-toJ
-toJ
+ogs
+ogs
+ylh
+daP
+xCK
 miF
 miF
 miF
@@ -127751,47 +129953,47 @@ miF
 miF
 qHj
 qHj
+oxx
+oxx
+oxx
+vJL
+oxx
+oxx
+oxx
 miF
-miF
 bhJ
 bhJ
 bhJ
 bhJ
 bhJ
-miF
-bhJ
-bhJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-ogs
 cqm
 mMx
-urZ
+ylh
+gBf
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+sIr
+mMx
+mMx
+uvk
 cqm
 bhJ
 bhJ
@@ -127819,12 +130021,12 @@ rqY
 rqY
 rqY
 ogs
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+ogs
+ogs
+ogs
+ylh
+xCK
+xCK
 miF
 miF
 miF
@@ -128203,23 +130405,23 @@ miF
 miF
 miF
 miF
-miF
-bhJ
-bhJ
-mlz
-jyo
-bhJ
-bhJ
+oxx
+acG
+nWZ
+nWZ
+nWZ
+acG
+oxx
 bhJ
 bhJ
 bhJ
 qHj
+bhJ
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+cqm
+mMx
+ylh
+cqm
 llO
 llO
 llO
@@ -128241,7 +130443,7 @@ llO
 llO
 qHj
 ogs
-cqm
+skC
 mMx
 xNL
 cqm
@@ -128271,12 +130473,12 @@ xOk
 rqY
 rqY
 ogs
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
+ogs
+ogs
+ogs
+cqm
+ylh
+xCK
 miF
 miF
 miF
@@ -128655,23 +130857,23 @@ miF
 miF
 miF
 bhJ
+oxx
+nWZ
+nWZ
+nWZ
+nWZ
+nWZ
+oxx
 bhJ
 bhJ
-fju
-htN
-htN
-htN
-fju
-fju
-bhJ
 qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
+cqm
+mMx
+dxA
+cqm
 llO
 rSU
 pai
@@ -128725,12 +130927,12 @@ rqY
 idG
 pYk
 idG
-qHj
-qHj
-toJ
-htN
-toJ
-miF
+ogs
+cqm
+ylh
+xCK
+ylh
+dlK
 rTB
 rTB
 rTB
@@ -129107,23 +131309,23 @@ miF
 miF
 bhJ
 bhJ
+oxx
+hDO
+iqy
+iqy
+iqy
+hDO
+oxx
 bhJ
-fju
-htN
-htN
-htN
-htN
-htN
-fju
 qHj
 qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
+cqm
+mMx
+sMT
+cqm
 llO
 oLi
 xts
@@ -129177,12 +131379,12 @@ rXc
 pSX
 pyt
 idG
-qHj
-qHj
-toJ
-toJ
-htN
-rTB
+ogs
+cqm
+ylh
+xCK
+urZ
+drf
 rTB
 miF
 miF
@@ -129559,23 +131761,23 @@ miF
 miF
 bhJ
 bhJ
-htN
-htN
-htN
-htN
-htN
-htN
-bhJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+oxx
+qSV
+qSV
+qSV
+qSV
+qSV
+dlK
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+tZm
+mMx
+ylh
+cqm
 llO
 oZj
 xts
@@ -129629,12 +131831,12 @@ dnY
 pSX
 cJN
 idG
-fju
-toJ
-toJ
-htN
-htN
-miF
+xCK
+oxx
+ylh
+xCK
+urZ
+dlK
 miF
 miF
 miF
@@ -130009,25 +132211,25 @@ tum
 tum
 miF
 bhJ
-tum
-tum
-tum
-tum
-htN
-htN
-htN
-fju
-bhJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+dlK
+daP
+daP
+qSV
+qSV
+qSV
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+urZ
+cqm
 llO
 llO
 vKx
@@ -130081,13 +132283,13 @@ rqY
 idG
 idG
 idG
-fju
-htN
-htN
-htN
-toJ
-miF
-miF
+xCK
+oxx
+ylh
+xCK
+ylh
+ltb
+sIr
 miF
 miF
 miF
@@ -130461,25 +132663,25 @@ tum
 tum
 tum
 tum
-tum
-tum
-tum
+gpX
+daP
+daP
 bhJ
-fju
-htN
-bhJ
-bhJ
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ylh
+sMT
+ylh
+ylh
+ylh
+urZ
+urZ
+urZ
+urZ
+ylh
+ylh
+ylh
+urZ
+kpy
+cqm
 llO
 jxF
 eTz
@@ -130530,16 +132732,16 @@ rqY
 rqY
 rqY
 rqY
-ogs
-htN
-fju
-fju
-fju
-fju
-htN
-htN
-ckW
-miF
+skC
+drf
+xCK
+xCK
+xCK
+xCK
+xCK
+ylh
+ylh
+cqm
 miF
 miF
 miF
@@ -130913,25 +133115,25 @@ toJ
 tum
 tum
 miF
+dlK
 miF
-miF
 bhJ
 bhJ
-fju
-htN
+xCK
+tQC
 bhJ
-bhJ
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+tZm
 llO
 sOn
 rsk
@@ -130981,18 +133183,18 @@ rqY
 wTp
 rqY
 rqY
-ogs
-ogs
-htN
-htN
-fju
-fju
-fju
-fju
-fju
-toJ
-miF
-miF
+skC
+skC
+tQC
+drf
+xCK
+xCK
+xCK
+xCK
+xCK
+ylh
+ltb
+sIr
 miF
 miF
 miF
@@ -131369,8 +133571,8 @@ miF
 miF
 miF
 bhJ
-fju
-fju
+xCK
+xCK
 bhJ
 llO
 llO
@@ -131433,18 +133635,18 @@ haH
 haH
 haH
 wDF
-htN
-htN
-htN
-toJ
-toJ
-fju
-fju
-fju
-fju
-fju
-toJ
-miF
+tQC
+tQC
+tQC
+oxx
+oxx
+xCK
+xCK
+xCK
+xCK
+xCK
+urZ
+cqm
 miF
 miF
 miF
@@ -131821,7 +134023,7 @@ miF
 miF
 miF
 bhJ
-fju
+xCK
 bhJ
 bhJ
 llO
@@ -131892,12 +134094,12 @@ egF
 rqY
 rqY
 rqY
-fju
-fju
-fju
-toJ
-miF
-miF
+xCK
+xCK
+xCK
+urZ
+ltb
+sIr
 miF
 miF
 miF
@@ -132344,17 +134546,17 @@ egF
 haH
 tbw
 rqY
-toJ
-fju
-fju
-htN
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
+ylh
+xCK
+xCK
+xCK
+ylh
+ltb
+dlK
+iZp
+iZp
+iZp
+dlK
 miF
 miF
 miF
@@ -132796,17 +134998,17 @@ fcL
 haH
 haH
 rqY
-toJ
-fju
-fju
-htN
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
+ylh
+xCK
+xCK
+xCK
+ylh
+skC
+tQC
+uvm
+cHC
+tQC
+cqm
 miF
 miF
 miF
@@ -133248,17 +135450,17 @@ fcL
 haH
 haH
 rqY
-toJ
-fju
-fju
-fju
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
+ylh
+xCK
+xCK
+xCK
+ylh
+ylh
+cHC
+cHC
+orc
+rle
+cqm
 miF
 miF
 miF
@@ -133700,17 +135902,17 @@ egF
 haH
 dNs
 rqY
-toJ
-toJ
-fju
-fju
-fju
-fju
-miF
-miF
-miF
-miF
-miF
+sMT
+ylh
+xCK
+xCK
+xCK
+xCK
+cUQ
+cHC
+cHC
+cHC
+cqm
 miF
 miF
 miF
@@ -134153,16 +136355,16 @@ egF
 rqY
 rqY
 rqY
-bhJ
-toJ
-toJ
-fju
-fju
-fju
-miF
-miF
-miF
-miF
+qPr
+ylh
+odU
+xCK
+xCK
+kAK
+orc
+tQC
+uvm
+cqm
 miF
 miF
 miF
@@ -134171,11 +136373,11 @@ miF
 miF
 miF
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+skC
+skC
+skC
+skC
+skC
 qHj
 qHj
 qHj
@@ -134607,14 +136809,14 @@ tbw
 rqY
 bhJ
 bhJ
-toJ
-fju
-fju
-fju
-miF
-miF
-miF
-miF
+ylh
+xCK
+xCK
+xCK
+dlK
+iZp
+iZp
+dlK
 miF
 miF
 miF
@@ -134623,11 +136825,11 @@ miF
 miF
 miF
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+skC
+tpl
+kuj
+fks
+skC
 qHj
 qHj
 qHj
@@ -135059,10 +137261,10 @@ haH
 rqY
 bhJ
 bhJ
-toJ
-toJ
-fju
-fju
+ylh
+orc
+xCK
+xCK
 miF
 miF
 miF
@@ -135075,11 +137277,11 @@ miF
 miF
 miF
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+skC
+cHC
+orc
+cHC
+skC
 qHj
 qHj
 qHj
@@ -135511,10 +137713,10 @@ haH
 rqY
 bhJ
 bhJ
-toJ
-toJ
-fju
-miF
+ylh
+orc
+xCK
+sEm
 miF
 miF
 miF
@@ -135527,11 +137729,11 @@ miF
 miF
 miF
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+skC
+uwP
+brw
+brw
+skC
 qHj
 qHj
 qHj
@@ -135963,27 +138165,27 @@ dNs
 rqY
 ogs
 ogs
-ogs
-dIV
+skC
+uvk
+iud
+sEm
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
 qHj
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+skC
+dVG
+aJV
+cHC
+skC
 qHj
 qHj
 qHj
@@ -136431,11 +138633,11 @@ miF
 miF
 miF
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+skC
+rXn
+aJV
+orc
+skC
 qHj
 qHj
 qHj
@@ -136879,21 +139081,21 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+ogs
+ogs
+ogs
+skC
+skC
+oxx
+cHC
+oxx
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 qHj
 qHj
 ogs
@@ -137331,21 +139533,21 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+oxx
+oxx
+oxx
+oxx
+oxx
+oxx
+bMV
+oxx
+oxx
+oxx
+oxx
+oxx
+oxx
+ogs
 qHj
 qHj
 ogs
@@ -137783,21 +139985,21 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+oxx
+dzc
+mwk
+lnM
+oxx
+kHP
+qlg
+dwH
+cjR
+uUT
+lSx
+qQq
+oxx
+ogs
 qHj
 qHj
 ogs
@@ -138235,21 +140437,21 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+oxx
+nsQ
+fSA
+mwk
+gXy
+qlg
+qlg
+xeg
+qtQ
+jtd
+jtd
+hqD
+oxx
+ogs
 qHj
 qHj
 ogs
@@ -138680,7 +140882,6 @@ eHa
 dIV
 htN
 htN
-rTB
 miF
 miF
 miF
@@ -138688,20 +140889,21 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+oxx
+oxx
+oxx
+oxx
+oxx
+gDh
+qlg
+aBP
+qtQ
+jtd
+she
+lNq
+oxx
+ogs
 qHj
 qHj
 ogs
@@ -139132,7 +141334,6 @@ eHa
 dIV
 htN
 htN
-fju
 miF
 miF
 miF
@@ -139140,20 +141341,21 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+oxx
+cPy
+uvX
+nsQ
+oxx
+cZf
+nXt
+xeg
+mVw
+jtd
+jtd
+esv
+oxx
+ogs
 qHj
 qHj
 ogs
@@ -139585,27 +141787,27 @@ xPZ
 rTB
 fju
 fju
+fju
+fju
+fju
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+oxx
+rig
+uvX
+mwk
+aJb
+nlj
+qlg
+qlg
+bDl
+pvn
+dWs
+mRj
+oxx
+ogs
 qHj
 ogs
 ogs
@@ -140037,26 +142239,26 @@ xPZ
 fju
 fju
 fju
+fju
+fju
+fju
+fju
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-fAm
-fAm
-fAm
-fAm
-fAm
-fAm
-fAm
-fAm
+ogs
+oxx
+aIF
+mwk
+mwk
+gXy
+huM
+qlg
+rQg
+huM
+aBP
+cHC
+cKQ
+oxx
 ogs
 ogs
 ogs
@@ -140489,28 +142691,28 @@ xPZ
 wlp
 fju
 fju
+fju
+fju
+fju
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-fAm
-jsZ
-tyl
-fAm
-ual
-vsI
-bzs
-fAm
-fAm
-fAm
+ogs
+oxx
+oxx
+oxx
+oxx
+oxx
+uqC
+nlj
+uUP
+nlj
+qlg
+cHC
+luk
+oxx
+oxx
+oxx
 ogs
 ogs
 "}
@@ -140924,7 +143126,7 @@ uIl
 uIl
 tNb
 rqY
-pAT
+uIl
 enQ
 sgN
 xPZ
@@ -140940,29 +143142,29 @@ vsI
 hri
 fju
 fju
-qHj
+gau
+dlK
+glO
+dlK
+sIr
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-uRN
-hSR
-hSR
-qrI
-hSR
-mtL
-vsI
-vsI
-fAm
-fAm
+ogs
+oxx
+vGC
+tzM
+mwk
+oxx
+hIu
+qlg
+oTy
+nXt
+qyT
+aJV
+cHC
+aJV
+nGX
+oxx
 ogs
 ogs
 "}
@@ -141376,7 +143578,7 @@ uIl
 uIl
 uIl
 rqY
-cvK
+rqY
 rqY
 rqY
 xPZ
@@ -141392,29 +143594,29 @@ mzy
 xPZ
 fju
 rTB
+dlK
+ylh
+mMx
+urZ
+cqm
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-rek
-hSR
-hSR
-nKZ
-hSR
-oco
-vsI
-rsw
-fAm
-fAm
+ogs
+oxx
+eFP
+mwk
+uvX
+gXy
+qlg
+qlg
+nlj
+wVn
+uzQ
+tYe
+gVz
+rle
+cHC
+oxx
 ogs
 ogs
 "}
@@ -141826,11 +144028,11 @@ tSz
 hku
 uIl
 uIl
-iBl
+sQT
+sFW
+uIl
+paY
 rqY
-qqY
-dlK
-ogs
 ogs
 ogs
 ogs
@@ -141844,29 +144046,29 @@ idG
 idG
 htN
 htN
+glO
+ylh
+mMx
+urZ
+cqm
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-xfX
-hSR
-hSR
-qrI
-hSR
-tHs
-vsI
-rsw
-fAm
-fAm
+ogs
+oxx
+oxx
+oxx
+oxx
+oxx
+tvd
+qlg
+huM
+qlg
+nXt
+cHC
+cHC
+cHC
+uQl
+oxx
 ogs
 ogs
 "}
@@ -142279,46 +144481,46 @@ hku
 uIl
 uIl
 ocg
+qOn
+uIl
+oui
 rqY
-spI
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+htN
+htN
+htN
+miF
+dlK
+ylh
+mMx
+ylh
 cqm
+miF
+miF
 ogs
 ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-ogs
-htN
-htN
-htN
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-hSR
-hSR
-hgP
-fAm
-aMm
-iEk
-fMB
-fAm
-fAm
-fAm
+oxx
+pjm
+bmn
+qlg
+qlg
+qlg
+nlj
+rqg
+fgV
+tYe
+cHC
+oxx
+oxx
+oxx
 ogs
 ogs
 "}
@@ -142730,11 +144932,11 @@ rqY
 rqY
 uIl
 uIl
-pNQ
+sQT
+qOn
+uIl
+oui
 rqY
-lAa
-cqm
-ogs
 ogs
 ogs
 ogs
@@ -142748,27 +144950,27 @@ htN
 htN
 mhy
 miF
+cqm
+ylh
+mMx
+ylh
+cqm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-eVP
-hSR
-fAm
-fAm
-fAm
-fAm
-fAm
-fAm
+ogs
+oxx
+jha
+qjh
+qlg
+nXt
+hNJ
+oxx
+oxx
+oxx
+oxx
+oxx
+oxx
 ogs
 ogs
 ogs
@@ -143183,10 +145385,10 @@ nPv
 uIl
 uIl
 bmK
+deJ
+uIl
+hqp
 rqY
-lAa
-cqm
-ogs
 ogs
 ogs
 ogs
@@ -143200,23 +145402,23 @@ rTB
 ogs
 miF
 miF
+cqm
+urZ
+mMx
+sMT
+cqm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-qNM
-ebs
-fAm
 ogs
+oxx
+jPg
+nxt
+eKk
+eKk
+aJx
+oxx
+skC
 ogs
 ogs
 ogs
@@ -143634,12 +145836,12 @@ fJw
 uyQ
 uIl
 uIl
-iBl
+uIl
+oSI
+uIl
+sin
 rqY
-tQC
-ltb
-sIr
-toJ
+ogs
 ogs
 sKF
 toJ
@@ -143652,24 +145854,24 @@ toJ
 ogs
 miF
 miF
+cqm
+urZ
+mMx
+ylh
+cqm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-fAm
-fAm
-fAm
-fAm
-miF
-miF
+ogs
+idG
+idG
+idG
+oxx
+oxx
+mYp
+oxx
+oxx
+ogs
 miF
 miF
 miF
@@ -144085,13 +146287,13 @@ xPZ
 fJw
 uIl
 uIl
-bmK
-oui
+uIl
+vdf
+deJ
+uIl
+uIl
 rqY
-tZv
-tQC
-dlK
-toJ
+ogs
 rTB
 htN
 htN
@@ -144104,24 +146306,24 @@ toJ
 ogs
 miF
 miF
+cqm
+ylh
+mMx
+ylh
+cqm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+ogs
+ogs
+ogs
+oxx
+njr
+uyr
+nSV
+oxx
+ogs
 miF
 miF
 miF
@@ -144536,13 +146738,13 @@ sQg
 xPZ
 uQa
 rJE
-vqD
-uQa
+sHp
+sHp
+aJl
+rqY
 rqY
 rqY
 xPZ
-spI
-fju
 fju
 fju
 fju
@@ -144556,24 +146758,24 @@ toJ
 ogs
 miF
 miF
+cqm
+ylh
+mMx
+ylh
+cqm
 miF
 miF
 miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+oxx
+hbl
+jtd
+hbl
+oxx
+ogs
 miF
 miF
 miF
@@ -144985,22 +147187,22 @@ vsI
 vsI
 vsI
 vsI
-qPT
-kfk
-vsI
-vsI
-vsI
-hSR
+fFO
+tfx
+iQb
+iQb
+iQb
+iQb
 keT
+hSR
+xQr
 xPZ
-sSq
 fju
 fju
 fju
 fju
 fju
-fju
-htN
+rNA
 mhy
 htN
 htN
@@ -145008,24 +147210,24 @@ rTB
 ogs
 miF
 miF
+cqm
+dhV
+mMx
+ylh
+cqm
 miF
 miF
 miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+oxx
+jtd
+pGi
+jtd
+oxx
+ogs
 miF
 miF
 miF
@@ -145438,15 +147640,15 @@ vsI
 vsI
 vsI
 mdA
-vsI
-vsI
-vsI
-vsI
-hSR
-hSR
+iQb
+iQb
+iQb
+iQb
+bhK
 xPZ
-sSq
-fju
+hSR
+aMW
+xPZ
 fju
 fju
 fju
@@ -145460,24 +147662,24 @@ htN
 htN
 miF
 miF
+cqm
+ylh
+mMx
+urZ
+cqm
 miF
 miF
 miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+oxx
+she
+jtd
+fTE
+oxx
+ogs
 miF
 miF
 miF
@@ -145889,16 +148091,16 @@ efn
 vsI
 vsI
 vsI
-qPT
-vsI
-vsI
-sDU
-sDU
-hSR
-oiS
+fFO
+iIb
+vNw
+iIb
+iIb
+vNw
 xPZ
-czy
-fju
+hSR
+hSR
+lpQ
 fju
 fju
 dIV
@@ -145912,24 +148114,24 @@ htN
 toJ
 miF
 miF
+cqm
+ylh
+mMx
+urZ
+cqm
 miF
 miF
 miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+dlK
+nmh
+vVx
+oxx
+oxx
+ogs
 miF
 miF
 miF
@@ -146342,15 +148544,15 @@ sDU
 vsI
 vsI
 xPZ
-sQg
-sDU
-uRz
-pzm
+fvG
+biC
+vNw
+vNw
 fqU
 xPZ
-xPZ
-nUV
-dlK
+xDW
+axu
+fSD
 uWT
 dlK
 ogs
@@ -146364,6 +148566,11 @@ htN
 rTB
 qHj
 miF
+cqm
+ylh
+mMx
+urZ
+cqm
 miF
 miF
 miF
@@ -146371,17 +148578,12 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+cqm
+ylh
+mMx
+cqm
+ogs
+ogs
 miF
 miF
 miF
@@ -146800,11 +149002,11 @@ eXr
 eXr
 xPZ
 xPZ
-nvE
 spI
-cqm
+spI
+vaV
 sFg
-cqm
+skC
 ogs
 ogs
 ogs
@@ -146816,6 +149018,11 @@ htN
 htN
 htN
 jaT
+cqm
+ylh
+mMx
+wSm
+cqm
 miF
 miF
 miF
@@ -146823,15 +149030,10 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+cqm
+ylh
+mMx
+cqm
 miF
 miF
 miF
@@ -147256,9 +149458,9 @@ bQg
 edq
 tZm
 sFg
-ltb
-iZp
-sIr
+skC
+skC
+skC
 ogs
 ogs
 ogs
@@ -147268,6 +149470,11 @@ htN
 htN
 mlz
 miF
+cqm
+sMT
+mMx
+ylh
+cqm
 miF
 miF
 miF
@@ -147275,15 +149482,10 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
+cqm
+dhV
+mMx
+cqm
 miF
 miF
 miF
@@ -147652,7 +149854,7 @@ bhJ
 bhJ
 bhJ
 bhJ
-htN
+mhy
 htN
 qHj
 rVQ
@@ -147706,11 +149908,11 @@ sRj
 aAV
 spI
 cqm
-hnl
-xCK
-xCK
-xCK
-cqm
+skC
+skC
+skC
+skC
+skC
 ogs
 ogs
 ogs
@@ -147720,6 +149922,11 @@ toJ
 htN
 miF
 miF
+cqm
+qPS
+mMx
+ylh
+cqm
 miF
 miF
 miF
@@ -147727,15 +149934,10 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
+cqm
+ylh
+mMx
+cqm
 miF
 miF
 miF
@@ -148154,15 +150356,15 @@ ylh
 mMx
 cqm
 cbI
-jLB
+lVk
 spI
 spI
 xyd
 pmo
-jtd
-xCK
-xCK
-cqm
+skC
+skC
+skC
+skC
 ogs
 ogs
 ogs
@@ -148172,6 +150374,11 @@ toJ
 htN
 miF
 miF
+cqm
+ylh
+mMx
+dxA
+cqm
 miF
 miF
 miF
@@ -148179,15 +150386,10 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
+cqm
+urZ
+mMx
+cqm
 miF
 miF
 miF
@@ -148608,13 +150810,13 @@ cqm
 nlj
 nlj
 spI
-spI
+tQC
 cqm
-mlH
-nlK
-xSz
-cOP
-cqm
+skC
+skC
+skC
+skC
+skC
 ogs
 ogs
 ogs
@@ -148624,6 +150826,11 @@ htN
 htN
 miF
 miF
+cqm
+urZ
+mMx
+ylh
+cqm
 miF
 miF
 miF
@@ -148631,15 +150838,10 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+cqm
+urZ
+mMx
+cqm
 miF
 miF
 miF
@@ -149059,14 +151261,14 @@ mMx
 dlK
 hvw
 hvw
-spI
+orc
 ouk
 ltb
 iZp
 edq
-iZp
-iZp
-dNN
+skC
+skC
+skC
 ogs
 ogs
 ogs
@@ -149076,22 +151278,22 @@ htN
 htN
 htN
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+cqm
+urZ
+mMx
+ylh
+ltb
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+tZm
+urZ
+mMx
+cqm
 miF
 miF
 miF
@@ -149509,7 +151711,7 @@ xPZ
 ylh
 mMx
 cqm
-nlj
+hUw
 dCm
 spI
 cII
@@ -149528,22 +151730,22 @@ htN
 htN
 htN
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
+cqm
+mMx
+mMx
+mMx
+rlU
+ylh
+urZ
+urZ
+ylh
+ylh
+ylh
+ylh
+ylh
+ylh
+mMx
+cqm
 miF
 miF
 miF
@@ -149907,11 +152109,11 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+sKA
+sKA
+sKA
+sKA
+sKA
 htN
 htN
 qHj
@@ -149964,12 +152166,12 @@ cqm
 dDv
 lVk
 qKn
-spI
-spI
-aAV
+orc
+rrN
+rbA
 cqm
 spI
-spI
+orc
 cqm
 ogs
 ogs
@@ -149980,22 +152182,22 @@ htN
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-bhJ
+dlK
+qbl
+dlK
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+ylh
+mMx
+cqm
 miF
 miF
 miF
@@ -150360,7 +152562,7 @@ tsN
 eMU
 eMU
 eMU
-eMU
+sSq
 eMU
 tsN
 tsN
@@ -150413,41 +152615,41 @@ ylh
 mMx
 ylh
 dlK
-hPK
+nlj
 nlj
 lFd
 spI
 spI
 spI
 aMg
-spI
+tQC
 spI
 cqm
 ogs
 ogs
 ogs
-rVQ
-rVQ
-rVQ
-rVQ
+eMU
+eMU
+eMU
+eMU
 rVQ
 iHV
 rVQ
 rVQ
-miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-bhJ
-bhJ
-bhJ
+dlK
+xJk
+xJk
+xJk
+xJk
+dho
+sEm
+sEm
+sEm
+skC
+mMx
+tuP
+mMx
+cqm
 miF
 miF
 miF
@@ -150809,11 +153011,11 @@ ehs
 tsN
 tsN
 tsN
-tsN
-tsN
-tsN
-tsN
-tsN
+eMU
+eMU
+eMU
+sSq
+eMU
 tsN
 tsN
 tsN
@@ -150867,21 +153069,21 @@ ylh
 cqm
 uWR
 uWR
-aiH
-bDl
+spI
+spI
 xAW
 spI
 cqm
 ybM
 lEx
-cqm
-ogs
-ogs
-rVQ
-iHV
-rVQ
-rVQ
-rVQ
+oMj
+ixP
+ixP
+eMU
+snb
+eMU
+eMU
+eMU
 rVQ
 rVQ
 rVQ
@@ -150892,14 +153094,14 @@ rVQ
 rVQ
 rVQ
 ehs
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+miF
+miF
+miF
+kBx
+mMx
+ylh
+mMx
+cqm
 miF
 miF
 miF
@@ -151264,9 +153466,9 @@ tsN
 eMU
 eMU
 eMU
-bhJ
-bhJ
-bhJ
+sKA
+sKA
+sKA
 dlK
 pkx
 pkx
@@ -151317,11 +153519,11 @@ ylh
 mMx
 urZ
 cqm
-oOU
-qlg
-qlg
-vaP
-wbi
+sEm
+sEm
+sEm
+spI
+orc
 spI
 dlK
 iZp
@@ -151347,11 +153549,11 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+kBx
+mMx
+ojb
+mMx
+cqm
 miF
 miF
 miF
@@ -151714,9 +153916,9 @@ tsN
 tsN
 tsN
 eMU
-orc
+eMU
 vpg
-bhJ
+sKA
 ckW
 bhJ
 cqm
@@ -151769,11 +153971,11 @@ ylh
 mMx
 xNL
 dlK
-jwY
-qlg
-qlg
-nQT
-wbi
+sEm
+sEm
+sEm
+spI
+spI
 spI
 hEq
 aJx
@@ -151793,17 +153995,17 @@ tQC
 ltb
 iZp
 sIr
-xCK
+eMU
 ehs
 ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+kBx
+mMx
+dxA
+mMx
+cqm
 miF
 miF
 miF
@@ -152162,14 +154364,14 @@ bhJ
 ehs
 ehs
 tsN
-bhJ
-bhJ
-bhJ
+sKA
+sKA
+sKA
 jcb
-orc
-orc
-toJ
-toJ
+mMx
+mMx
+uZt
+uZt
 bhJ
 cqm
 rzr
@@ -152221,16 +154423,16 @@ ylh
 mMx
 urZ
 cqm
-cta
-gfy
-qlg
-ydL
-wbi
+sEm
+sEm
+sEm
+sEm
+spI
 spI
 spI
 aJx
 tjc
-uyr
+aJx
 qjh
 kjO
 qjh
@@ -152251,11 +154453,11 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+kBx
+mMx
+sMT
+mMx
+cqm
 miF
 miF
 miF
@@ -152613,12 +154815,12 @@ bhJ
 bhJ
 ehs
 ehs
-bhJ
-bhJ
+sKA
+sKA
 bhJ
 bhJ
 jcb
-mdL
+jjU
 bhJ
 bhJ
 bhJ
@@ -152674,15 +154876,15 @@ mMx
 ylh
 cqm
 gAZ
-fFs
-uGp
-bDl
-gED
-spI
-spI
+sEm
+tQC
+orc
+orc
+orc
+qPm
 aJH
 dlK
-uXf
+hTD
 qjh
 qjh
 hAY
@@ -152703,11 +154905,11 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+kBx
+mMx
+urZ
+mMx
+cqm
 miF
 miF
 miF
@@ -153065,7 +155267,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -153124,14 +155326,14 @@ cqm
 ylh
 mMx
 ylh
-ltb
-iZp
-iZp
-iZp
-iZp
-iZp
-iZp
-iZp
+dlK
+sEm
+sEm
+sEm
+orc
+mMx
+qjh
+sEm
 iZp
 iIm
 dlK
@@ -153155,11 +155357,11 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+ogs
+mMx
+urZ
+mMx
+cqm
 miF
 miF
 miF
@@ -153517,7 +155719,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -153576,14 +155778,14 @@ dlK
 ylh
 mMx
 ylh
-wUW
+nmh
 ylh
 urZ
 ylh
-ylh
-ylh
-urZ
-xNL
+sMT
+mMx
+aCF
+sEm
 ylh
 ylh
 ylh
@@ -153607,11 +155809,11 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+mMx
+mMx
+urZ
+mMx
+cqm
 miF
 miF
 miF
@@ -153969,7 +156171,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -154028,7 +156230,7 @@ amm
 mMx
 mMx
 mMx
-mMx
+amm
 mMx
 mMx
 mMx
@@ -154059,11 +156261,11 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+mMx
+ylh
+gau
+iZp
+tZm
 miF
 miF
 miF
@@ -154421,7 +156623,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -154480,7 +156682,7 @@ dlK
 ylh
 mMx
 ylh
-urZ
+nmh
 ylh
 ylh
 urZ
@@ -154511,9 +156713,9 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
+mMx
+wSm
+cqm
 miF
 miF
 miF
@@ -154873,7 +157075,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -154960,12 +157162,12 @@ tQC
 cqm
 ehs
 ehs
-rVQ
+sEm
 miF
 miF
-miF
-miF
-miF
+mMx
+ylh
+cqm
 miF
 miF
 miF
@@ -155325,7 +157527,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -155412,18 +157614,18 @@ rcl
 cqm
 ehs
 utm
-ehs
+eMU
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+mMx
+ylh
+gBf
+iZp
+iZp
+iZp
+iZp
+iZp
+sIr
 miF
 miF
 miF
@@ -155777,7 +157979,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -155864,20 +158066,20 @@ iZp
 dNN
 ehs
 ehs
-ehs
+eMU
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+mMx
+ylh
+cqm
+oSZ
+dzU
+orc
+myK
+pVs
+ltb
+iZp
+sIr
 miF
 miF
 ogs
@@ -156229,7 +158431,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -156316,20 +158518,20 @@ ylh
 cqm
 ehs
 ehs
-ehs
+eMU
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+mMx
+ylh
+cqm
+fZs
+orc
+dzU
+uCj
+daP
+tQC
+dzU
+cqm
 miF
 miF
 ogs
@@ -156681,7 +158883,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -156768,20 +158970,20 @@ urZ
 cqm
 ehs
 ehs
-ehs
+eMU
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+mMx
+sMT
+cqm
+oom
+oom
+oom
+oom
+tQC
+wvo
+foD
+cqm
 miF
 miF
 ogs
@@ -157133,7 +159335,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -157164,9 +159366,9 @@ tNJ
 tNJ
 pib
 smL
-ltb
-iZp
-iZp
+dlK
+jkB
+dlK
 iZp
 dlK
 iZp
@@ -157220,20 +159422,20 @@ xNL
 cqm
 ehs
 ehs
-ehs
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+eMU
+dlK
+sEm
+mMx
+ylh
+cqm
+urZ
+ylh
+ylh
+ylh
+ojb
+tQC
+daP
+cqm
 miF
 miF
 ogs
@@ -157585,7 +159787,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -157616,9 +159818,9 @@ lGX
 lGX
 lGX
 lGX
-ogs
-ogs
-ogs
+kBx
+mMx
+kBx
 ogs
 ogs
 ogs
@@ -157672,20 +159874,20 @@ urZ
 cqm
 ehs
 ehs
-ehs
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+eMU
+qbl
+sEm
+mMx
+ylh
+cqm
+sTd
+xCK
+xCK
+xCK
+ylh
+jtd
+tQC
+cqm
 miF
 miF
 ogs
@@ -158037,7 +160239,7 @@ bhJ
 ogs
 ehs
 ehs
-bhJ
+sKA
 bhJ
 bhJ
 bhJ
@@ -158068,9 +160270,9 @@ iZp
 iZp
 iZp
 iZp
-iZp
-iZp
-iZp
+dlK
+amm
+dlK
 dlK
 iZp
 iZp
@@ -158124,20 +160326,20 @@ ylh
 cqm
 ehs
 ehs
-ehs
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+eMU
+qbl
+drf
+mMx
+tuP
+cqm
+akb
+daP
+wgv
+daP
+ylh
+jtd
+daP
+cqm
 miF
 miF
 ogs
@@ -158489,6 +160691,7 @@ bhJ
 ogs
 ehs
 ehs
+sKA
 bhJ
 bhJ
 bhJ
@@ -158500,9 +160703,8 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-ehs
+sKA
+ylh
 ehs
 ehs
 ehs
@@ -158576,20 +160778,20 @@ urZ
 cqm
 ehs
 ehs
-tsN
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+eMU
+qbl
+drf
+mMx
+ylh
+cqm
+ylh
+xCK
+xCK
+xCK
+ylh
+jtd
+drf
+cqm
 miF
 miF
 ogs
@@ -158941,24 +161143,24 @@ bhJ
 ogs
 ehs
 ehs
+sKA
+sKA
+sKA
+sKA
+sKA
+sKA
+sKA
+sKA
 bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-ehs
-ehs
-ehs
-ehs
-xCK
+sKA
+evm
+evm
+evm
+evm
+evm
 amm
 mMx
 mMx
@@ -159029,19 +161231,19 @@ cqm
 ehs
 ehs
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+dlK
+tQC
+mMx
+urZ
+cqm
+ylh
+daP
+ebJ
+wgv
+ylh
+jtd
+tQC
+cqm
 miF
 miF
 ogs
@@ -159398,19 +161600,19 @@ rVQ
 rVQ
 eMU
 eMU
-orc
-orc
+eMU
+eMU
+sKA
+sKA
+sKA
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+sKA
+ylh
 ehs
 ehs
 ehs
 ehs
-xCK
 cqm
 ylh
 vqP
@@ -159481,19 +161683,19 @@ cqm
 ehs
 ehs
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+sEm
+eRO
+mMx
+urZ
+cqm
+ylh
+xCK
+xCK
+xCK
+ylh
+jtd
+daP
+cqm
 miF
 miF
 ogs
@@ -159851,13 +162053,13 @@ rVQ
 rVQ
 eMU
 eMU
-orc
-orc
+eMU
+eMU
 llH
+sKA
+sKA
 bhJ
-bhJ
-bhJ
-bhJ
+sKA
 ehs
 ehs
 ehs
@@ -159933,19 +162135,19 @@ tZm
 ehs
 ehs
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+sEm
+sEm
+mMx
+urZ
+dlK
+sTd
+wgv
+daP
+fDI
+ylh
+daP
+tQC
+cqm
 miF
 miF
 ogs
@@ -160307,9 +162509,9 @@ bhJ
 orc
 orc
 jcb
-bhJ
-bhJ
-orc
+sKA
+sKA
+ylh
 ehs
 ehs
 ehs
@@ -160386,18 +162588,18 @@ utm
 ehs
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+sEm
+mMx
+ylh
+mVs
+wSm
+xCK
+xCK
+xCK
+ylh
+jtd
+wWz
+cqm
 miF
 miF
 ogs
@@ -160759,9 +162961,9 @@ bhJ
 uvk
 mdL
 orc
-orc
-orc
-orc
+eMU
+eMU
+eMU
 ehs
 ehs
 ehs
@@ -160838,18 +163040,18 @@ ehs
 ehs
 rVQ
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+dlK
+mMx
+ylh
+anU
+ylh
+daP
+daP
+wgv
+ylh
+tQC
+daP
+cqm
 miF
 miF
 ogs
@@ -161211,9 +163413,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-uvk
-uvk
-uvk
+vDT
+vDT
+vDT
 ehs
 ehs
 ehs
@@ -161290,18 +163492,18 @@ ehs
 ehs
 ehs
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+ylh
+dlK
+ojb
+xCK
+xCK
+xCK
+ylh
+jtd
+tQC
+cqm
 miF
 miF
 ogs
@@ -161664,7 +163866,7 @@ tsN
 tsN
 tsN
 tsN
-uvk
+vDT
 bhJ
 ehs
 ehs
@@ -161742,18 +163944,18 @@ ehs
 ehs
 ehs
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+ylh
+cqm
+ylh
+ylh
+ylh
+ylh
+ylh
+jtd
+cYK
+cqm
 miF
 miF
 ogs
@@ -162194,18 +164396,18 @@ ehs
 ehs
 ehs
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+ojb
+cqm
+kaa
+lGw
+jtd
+jtd
+kaa
+drf
+drf
+cqm
 miF
 miF
 ogs
@@ -162646,18 +164848,18 @@ ehs
 ehs
 tsN
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+odU
+gBf
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+tZm
 miF
 miF
 ogs
@@ -163098,10 +165300,10 @@ ehs
 ehs
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+ylh
+cqm
 miF
 miF
 miF
@@ -163550,10 +165752,10 @@ utm
 ehs
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+ylh
+cqm
 miF
 miF
 miF
@@ -164002,10 +166204,10 @@ ehs
 tsN
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+urZ
+cqm
 miF
 miF
 miF
@@ -164454,10 +166656,10 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+dlK
+mMx
+urZ
+cqm
 miF
 miF
 miF
@@ -164906,10 +167108,10 @@ ehs
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+sEm
+mMx
+urZ
+cqm
 miF
 miF
 miF
@@ -165355,13 +167557,13 @@ rVQ
 rVQ
 ehs
 ehs
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+kUf
+sSq
+mMx
+mMx
+mMx
+ylh
+cqm
 miF
 miF
 miF
@@ -165807,13 +168009,13 @@ iHV
 rVQ
 ehs
 ehs
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+kUf
+sSq
+urZ
+urZ
+urZ
+sMT
+cqm
 miF
 miF
 miF
@@ -166246,26 +168448,26 @@ mMx
 cqm
 ehs
 ehs
-eMU
-qHj
-qHj
-ogs
-rVQ
-rVQ
-rVQ
-rVQ
-rVQ
-rVQ
-rVQ
-tsN
-tsN
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ylh
+ylh
+urZ
+urZ
+rSB
+rSB
+rSB
+rSB
+rSB
+ylh
+rSB
+vPR
+vPR
+hRe
+sSq
+dlK
+edq
+nUV
+edq
+tZm
 miF
 miF
 miF
@@ -166698,25 +168900,25 @@ mMx
 cqm
 ehs
 utm
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ylh
+leX
+leX
+sMT
+ojb
+ylh
+ylh
+ylh
+ylh
+odU
+ylh
+ylh
+ylh
+ylh
+ojb
+sEm
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -167150,25 +169352,25 @@ mMx
 cqm
 ehs
 ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
+ylh
+leX
+leX
+leX
+leX
+leX
+leX
+leX
+leX
+rGL
+leX
+sEm
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -167602,25 +169804,25 @@ mMx
 cqm
 ehs
 ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
+ylh
+leX
+cYK
+eMU
+eMU
+eMU
+uvk
+eMU
+leX
+orc
+eMU
+sEm
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -168054,25 +170256,25 @@ iZp
 tZm
 ehs
 ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+ylh
+leX
+hAp
+wWz
+eMU
+daP
+orc
+cXB
+leX
+leX
+eMU
+uvk
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+cqm
 miF
 miF
 miF
@@ -168506,25 +170708,25 @@ qHj
 qHj
 ehs
 ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+ylh
+leX
+tJQ
+ycm
+daP
+pnI
+tQC
+orc
+wAg
+leX
+eMU
+uvk
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+cqm
 miF
 miF
 miF
@@ -168958,25 +171160,25 @@ qHj
 qHj
 ehs
 ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+ylh
+leX
+sVe
+daP
+daP
+wgv
+xup
+uub
+orc
+leX
+orc
+orc
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+mMx
+cqm
 miF
 miF
 miF
@@ -169410,25 +171612,25 @@ qHj
 qHj
 ehs
 ehs
-ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+ylh
+leX
+gPn
+dzU
+nOb
+rzL
+tQC
+jXG
+uvk
+leX
+uvk
+eMU
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+ylh
+cqm
 miF
 miF
 miF
@@ -169847,7 +172049,7 @@ jNJ
 aST
 aST
 xVh
-fPv
+hke
 iSm
 cqm
 ylh
@@ -169862,25 +172064,25 @@ qHj
 qHj
 ehs
 ehs
-ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-ckW
-toJ
-toJ
+ylh
+leX
+lVj
+orc
+orc
+dzU
+dzU
+ftW
+drf
+leX
+uvk
+eMU
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+sSq
+cqm
 miF
 miF
 miF
@@ -170314,25 +172516,25 @@ qHj
 qHj
 ehs
 utm
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
+ylh
+leX
+qcv
+odB
+uGm
+rSH
+uub
+daP
+drf
+leX
+uvk
+orc
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+sSq
+cqm
 miF
 miF
 miF
@@ -170766,25 +172968,25 @@ qHj
 qHj
 ehs
 ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
+ylh
+leX
+sfC
+daP
+daP
+lDh
+daP
+tQY
+drf
+leX
+leX
+ePo
+sEm
 miF
 miF
 miF
-miF
-miF
-miF
-miF
+cqm
+sSq
+cqm
 miF
 miF
 miF
@@ -171216,27 +173418,27 @@ cqm
 ogs
 qHj
 qHj
-ehs
-ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+rtA
+rtA
+ylh
+leX
+sfC
+fsQ
+wWz
+fBv
+dzU
+daP
+tQC
+dkh
+leX
+orc
+orc
 miF
 miF
 miF
-miF
-miF
-miF
+cqm
+ylh
+cqm
 miF
 miF
 miF
@@ -171666,29 +173868,29 @@ mMx
 mMx
 cqm
 ogs
-qHj
-qHj
-ehs
-ehs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
+dlK
+dlK
+xQm
+xQm
+ylh
+leX
+drf
+dzU
+dzU
+ank
+daP
+nOb
+dzU
+tQC
+leX
+leX
+orc
 miF
 miF
 miF
-miF
-miF
-miF
+cqm
+mMx
+cqm
 miF
 miF
 miF
@@ -172118,29 +174320,29 @@ mMx
 mMx
 cqm
 ogs
-qHj
-qHj
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
+cqm
+urZ
+evm
+evm
+ylh
+leX
+ivA
+orc
+wON
+dzU
+daP
+daP
+dzU
+wWz
+drf
+leX
+orc
 miF
 miF
 miF
-miF
-miF
-miF
+cqm
+mMx
+cqm
 miF
 miF
 miF
@@ -172570,29 +174772,29 @@ mMx
 gau
 tZm
 ogs
-qHj
-qHj
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
+cqm
+ylh
+evm
+evm
+ylh
+leX
+iib
+orc
+kdX
+tQC
+wWz
+tQC
+foD
+orc
+drf
+leX
+orc
 miF
 miF
 miF
-miF
-miF
-miF
+cqm
+ylh
+cqm
 miF
 miF
 miF
@@ -173022,29 +175224,29 @@ mMx
 cqm
 ogs
 ogs
-qHj
-qHj
-toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
+cqm
+sSq
+dlK
+rWz
+urZ
+leX
+wLR
+orc
+orc
+orc
+tQC
+tQC
+etZ
+orc
+drf
+leX
+eMU
 miF
 miF
 miF
-miF
-miF
-miF
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -173474,29 +175676,29 @@ urZ
 cqm
 ogs
 ogs
-qHj
-qHj
-qHj
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
+cqm
+sSq
+cqm
+orc
+hEt
+leX
+tQC
+tQC
+fmP
+orc
+orc
+dzU
+dzU
+cXB
+leX
+leX
+eMU
+uvk
 miF
 miF
-miF
-miF
-miF
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -173926,29 +176128,29 @@ iZp
 tZm
 ogs
 ogs
-qHj
-qHj
-qHj
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+cqm
+sSq
+cqm
+orc
+orc
+leX
+rCi
+drf
+wWz
+iOE
+stO
+orc
+orc
+dzU
+leX
+orc
+eMU
+uvk
 miF
 miF
-miF
-miF
-miF
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -174378,29 +176580,29 @@ ogs
 ogs
 ogs
 ogs
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+cqm
+sSq
+cqm
+orc
+kFg
+leX
+leX
+xpv
+aZF
+uJL
+tQC
+tQC
+sfC
+wAg
+leX
+orc
+orc
+orc
 miF
 miF
-miF
-miF
-miF
+cqm
+ylh
+cqm
 miF
 miF
 miF
@@ -174830,29 +177032,29 @@ ogs
 ogs
 ogs
 ogs
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
+cqm
+sSq
+cqm
+iud
+orc
+orc
+orc
+leX
+kEo
+oAx
+kEo
+kEo
+leX
+leX
+leX
+cpz
+uvk
+orc
 miF
 miF
-miF
-miF
-miF
+cqm
+ylh
+cqm
 miF
 miF
 miF
@@ -175282,29 +177484,29 @@ ogs
 ogs
 ogs
 ogs
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-qHj
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
+cqm
+sSq
+cqm
+iud
+uvk
+uvk
+kFg
+pCg
+orc
+axX
+otZ
+axX
+leX
+cpz
+bxB
+cpz
+uvk
+orc
+orc
 miF
-miF
-miF
-miF
+cqm
+mMx
+cqm
 miF
 miF
 miF
@@ -175734,29 +177936,29 @@ ogs
 ogs
 ogs
 ogs
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-qHj
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
+cqm
+sSq
+dlK
+iZp
+fCP
+fBW
+orc
+pCg
+orc
+orc
+orc
+orc
+orc
+cpz
+bxB
+cpz
+uvk
+orc
+orc
 miF
-miF
-miF
-miF
+cqm
+mMx
+cqm
 miF
 miF
 miF
@@ -176186,29 +178388,29 @@ ogs
 ogs
 ogs
 ogs
+cqm
+mGm
+skC
+skC
+kBx
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-qHj
-toJ
-toJ
-toJ
-qHj
-toJ
-toJ
-toJ
-toJ
+orc
+pCg
+kFg
+orc
+orc
+orc
+iMB
+cpz
+iud
+cpz
+orc
+lSE
+daP
 miF
-miF
-miF
-miF
+cqm
+ylh
+cqm
 miF
 miF
 miF
@@ -176638,18 +178840,11 @@ ogs
 ogs
 ogs
 ogs
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+cqm
+sSq
+mMx
+skC
+kBx
 qHj
 qHj
 qHj
@@ -176657,10 +178852,17 @@ qHj
 toJ
 toJ
 toJ
+qHj
+qHj
+qHj
+ogs
+orc
+orc
+daP
 miF
-miF
-miF
-miF
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -177090,6 +179292,11 @@ ogs
 ogs
 ogs
 ogs
+cqm
+sSq
+mMx
+uvk
+kBx
 qHj
 qHj
 qHj
@@ -177100,19 +179307,14 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
+ogs
+tQC
+gUH
+daP
 miF
-miF
-miF
-miF
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -177534,7 +179736,7 @@ iZp
 iZp
 iZp
 dlK
-hAd
+rFn
 vVx
 dlK
 ogs
@@ -177542,6 +179744,11 @@ ogs
 ogs
 ogs
 ogs
+cqm
+ylh
+mMx
+uvk
+kBx
 qHj
 qHj
 qHj
@@ -177552,19 +179759,14 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
+ogs
+tQC
+tQC
+orc
 miF
-miF
-miF
+cqm
+urZ
+cqm
 miF
 miF
 miF
@@ -177985,15 +180187,20 @@ ogs
 ogs
 ogs
 ogs
-xCK
-xCK
-xCK
+eMU
+eMU
+eMU
 ogs
 ogs
 ogs
 ogs
 ogs
 ogs
+cqm
+sMT
+mMx
+mMx
+kBx
 qHj
 qHj
 qHj
@@ -178004,20 +180211,15 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
+ogs
+ogs
+ogs
+orc
+orc
+sEm
+nUV
+skC
+ogs
 miF
 miF
 miF
@@ -178437,15 +180639,20 @@ ogs
 ogs
 ogs
 ogs
-xCK
-xCK
-xCK
+eMU
+eMU
+eMU
 ogs
 ogs
 ogs
 ogs
 ogs
 ogs
+cqm
+skC
+mMx
+mMx
+kBx
 qHj
 qHj
 qHj
@@ -178458,18 +180665,13 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+htN
 toJ
-toJ
-toJ
-miF
-miF
-miF
+htN
+ngD
+vzw
+ogs
 miF
 miF
 miF
@@ -178789,8 +180991,8 @@ miF
 miF
 miF
 miF
-ogs
-ogs
+bhJ
+miF
 qHj
 qHj
 qHj
@@ -178889,15 +181091,20 @@ ogs
 ogs
 ogs
 ogs
-xCK
-xCK
-xCK
+eMU
+eMU
+eMU
 ogs
 ogs
 ogs
 ogs
 ogs
 ogs
+cqm
+skC
+skC
+mMx
+kBx
 qHj
 qHj
 qHj
@@ -178910,19 +181117,14 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+xbt
 toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
+tum
+htN
+htN
+ogs
+ogs
 miF
 miF
 miF
@@ -179240,10 +181442,10 @@ miF
 miF
 miF
 miF
-ogs
-bJN
-bJN
-ogs
+miF
+bhJ
+miF
+miF
 miF
 qHj
 qHj
@@ -179341,15 +181543,20 @@ ogs
 ogs
 ogs
 ogs
-xCK
-xCK
-xCK
-xCK
+eMU
+eMU
+eMU
+eMU
 ogs
 ogs
 ogs
 ogs
 ogs
+cqm
+skC
+skC
+mMx
+kBx
 qHj
 qHj
 qHj
@@ -179362,20 +181569,15 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
+ogs
+ogs
+htN
+tum
+tum
+hJm
+ogs
+ogs
+ogs
 miF
 miF
 miF
@@ -179691,12 +181893,12 @@ bhJ
 bhJ
 bhJ
 miF
-ogs
-bJN
-bJN
-bJN
-bJN
-ogs
+miF
+miF
+bhJ
+miF
+miF
+miF
 miF
 miF
 qHj
@@ -179794,14 +181996,19 @@ ogs
 ogs
 ogs
 ogs
-xCK
-xCK
-xCK
-xCK
+eMU
+eMU
+eMU
+eMU
 ogs
 ogs
 ogs
 ogs
+cqm
+skC
+mMx
+orc
+kBx
 qHj
 qHj
 qHj
@@ -179814,20 +182021,15 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
+ogs
+tum
+htN
+tum
+tum
+tum
+htN
+iiK
+ogs
 miF
 miF
 miF
@@ -180143,12 +182345,12 @@ bhJ
 bhJ
 bhJ
 miF
-ogs
-bJN
-bJN
-bJN
-bJN
-ogs
+miF
+miF
+bhJ
+qHj
+miF
+miF
 miF
 miF
 qHj
@@ -180246,14 +182448,19 @@ ogs
 ogs
 ogs
 ogs
-xCK
-xCK
-xCK
-xCK
-xCK
+eMU
+eMU
+eMU
+eMU
+eMU
 ogs
 ogs
 ogs
+cqm
+uvk
+mMx
+orc
+kBx
 qHj
 qHj
 qHj
@@ -180266,20 +182473,15 @@ qHj
 qHj
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
+ogs
+fhy
+htN
+sto
+sto
+htN
+htN
+vzw
+ogs
 miF
 miF
 miF
@@ -180595,12 +182797,12 @@ bhJ
 bhJ
 bhJ
 miF
-ogs
-bJN
-bJN
-bJN
-bJN
-ogs
+miF
+miF
+bhJ
+qHj
+qHj
+qHj
 miF
 miF
 qHj
@@ -180699,46 +182901,46 @@ ogs
 ogs
 ogs
 ogs
-xCK
-xCK
-xCK
-xCK
-xCK
+urZ
+ylh
+eMU
+eMU
+eMU
 ogs
 ogs
+cqm
+uvk
+mMx
+orc
+kBx
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+dke
+tum
+htN
+htN
+htN
+dke
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 ogs
 ogs
 "}
@@ -181047,12 +183249,12 @@ bhJ
 bhJ
 bhJ
 miF
-ogs
-bJN
-bJN
-bJN
-bJN
-ogs
+miF
+miF
+bhJ
+miF
+qHj
+qHj
 qHj
 miF
 miF
@@ -181152,45 +183354,45 @@ ogs
 ogs
 ogs
 ogs
+urZ
+ylh
+orc
+orc
 xCK
 xCK
-bEt
-bEt
-bEt
-bEt
+cqm
+gUH
+mMx
+ylh
+kBx
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+bUi
+exj
+fju
+fju
+gwv
+tqk
+gwv
+ogs
+ogs
+ogs
+ixP
+htN
+gSv
 toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ugQ
+htN
+ogs
+ogs
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+ogs
 ogs
 ogs
 "}
@@ -181500,10 +183702,10 @@ bhJ
 bhJ
 miF
 miF
-ogs
-bJN
-bJN
-ogs
+miF
+bhJ
+miF
+miF
 miF
 qHj
 qHj
@@ -181604,45 +183806,45 @@ ogs
 ogs
 ogs
 ogs
+skC
+ylh
+ylh
+xCK
+xCK
+xCK
+cqm
+mMx
+mMx
+skC
+kBx
+qHj
+qHj
 ogs
-bEt
-bEt
-bEt
-ujG
-ujG
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+jFJ
+mON
+jFJ
+sto
+sto
+quj
+bUi
+ogs
+ogs
+iiK
+ixP
+ixP
+tum
+tum
+tum
+dpr
+tum
+ogs
+lhr
+fOk
+iqR
+tum
+lNV
+lhr
+ogs
 ogs
 ogs
 "}
@@ -181953,8 +184155,8 @@ miF
 miF
 miF
 miF
-ogs
-ogs
+bhJ
+miF
 miF
 miF
 miF
@@ -182056,45 +184258,45 @@ ogs
 ogs
 ogs
 ogs
-bEt
-bEt
-vcr
-ujG
-ujG
-ujG
+xCK
+xCK
+ylh
+xCK
+xCK
+xCK
+cqm
+mMx
+skC
+skC
+kBx
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+tqk
+eQa
+jFJ
+kKQ
+jFJ
+iYe
+tqk
+ogs
+ogs
+htN
+htN
 toJ
+bxh
+tum
 toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+htN
+fhy
+ogs
+lhr
+vbt
+ooe
+ooe
+ooe
+lhr
+ogs
 ogs
 ogs
 "}
@@ -182507,46 +184709,46 @@ ogs
 ogs
 ogs
 ogs
-ujG
-bEt
-bEt
-ujG
-ujG
-sWq
-sWq
+xCK
+xCK
+xCK
+ylh
+xCK
+skC
+skC
+dlK
+ylh
+skC
+skC
+kBx
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+gwv
+htN
+bUi
+jFJ
+gCB
+jFJ
+tqk
+ogs
+ogs
+vzw
+dke
+mQW
 toJ
-toJ
-toJ
-ckW
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+tum
+ubp
+dke
+fhy
+ogs
+lhr
+afQ
+htN
+ooe
+wpv
+lhr
+ogs
 ogs
 ogs
 "}
@@ -182962,43 +185164,43 @@ miF
 miF
 miF
 miF
-miF
-toJ
-toJ
-toJ
-toJ
+ogs
+xCK
+sSq
+lbS
+lbS
+ylh
+eMU
+skC
+kBx
 qHj
 qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+gwv
+tum
+gEO
+sXO
+jFJ
+jFJ
+ixP
+ogs
+ogs
+ogs
+bCj
+jfX
+nbe
+htN
+tum
+mBg
+ogs
+ogs
+lhr
+bQR
+ooe
+ooe
+auS
+lhr
+ogs
 ogs
 ogs
 "}
@@ -183397,6 +185599,8 @@ miF
 miF
 miF
 miF
+ihk
+dwL
 miF
 miF
 miF
@@ -183413,44 +185617,42 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
+skC
+ylh
+lbS
+lbS
+ylh
+eMU
+skC
+kBx
+qHj
+qHj
+ogs
+sto
+eDD
+jFJ
+exj
+sto
+vQY
+jFJ
+ogs
+ogs
+ogs
+ogs
+bcl
 toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+htN
+lVZ
+ixP
+ogs
+ogs
+lhr
+lhr
+lhr
+eVA
+lhr
+lhr
+ogs
 ogs
 ogs
 "}
@@ -183845,6 +186047,15 @@ miF
 miF
 miF
 miF
+cYK
+sMT
+evm
+evm
+evm
+evm
+ylh
+skC
+skC
 miF
 miF
 miF
@@ -183858,51 +186069,42 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+skC
+urZ
+lbS
+lbS
+ylh
+evm
+urZ
+kBx
+qHj
+qHj
+ogs
+lNy
+jFJ
+jFJ
+jdg
+jFJ
+jFJ
+bUi
+ogs
+ogs
+ogs
+ogs
+aJg
+htN
 toJ
-toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+evY
+ixP
+ixP
+ogs
+lhr
+vBb
+fVz
+iJE
+vBb
+lhr
+ogs
 ogs
 ogs
 "}
@@ -184288,73 +186490,73 @@ ogs
 ogs
 ogs
 ogs
+gau
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+sIr
+miF
+xCK
+sSq
+skC
+xCK
+xCK
+xCK
+sSq
+orc
+skC
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+skC
+skC
+ylh
+lbS
+lbS
+lbS
+sMT
+kBx
+qHj
+qHj
 ogs
+tqk
+tqk
+jFJ
+fju
+fju
+cIz
+sto
 ogs
+ixP
 ogs
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+dke
+evY
+jfX
 toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+mlF
+dke
+tum
+ogs
+lhr
+dqX
+htN
+tum
+dem
+lhr
+ogs
 ogs
 ogs
 "}
@@ -184740,73 +186942,73 @@ bhJ
 bhJ
 bhJ
 bhJ
+cqm
+hGb
+evm
+evm
+urZ
+urZ
+ylh
+ltb
+iZp
+dlK
+sSq
+skC
+xCK
+xCK
+skC
+sSq
+dwL
+ihk
+sEm
+sEm
+sEm
+sEm
+sEm
 miF
 miF
-tum
 miF
+miF
+miF
+miF
+miF
+miF
+sEm
+skC
+skC
+ylh
+lbS
+lbS
+ylh
+kBx
 qHj
 qHj
-qHj
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+ogs
+ogs
+lWY
+jFJ
+jFJ
 toJ
+aGH
+sto
+ixP
+ogs
+ogs
+fhy
 toJ
-toJ
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+bcl
+aJg
+evY
+ogs
+ogs
+lhr
+gTt
+jFJ
+jFJ
+sJa
+lhr
+ogs
 ogs
 ogs
 "}
@@ -185192,73 +187394,73 @@ bhJ
 bhJ
 bhJ
 bhJ
-miF
-tum
-tum
-fUw
-nbg
-qHj
-qHj
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-toJ
-toJ
-miF
-qHj
+cqm
+rVQ
+ehs
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+sSq
+skC
+skC
+skC
+skC
+sSq
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+sEm
+sEm
+sEm
+sEm
+sEm
+sEm
+sEm
+sEm
+skC
+skC
+skC
+lbS
+lbS
+ylh
+kBx
 qHj
 goi
 goi
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
+ogs
+ogs
+jFJ
 toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+bUi
+ogs
+toJ
+toJ
+xDR
+ogs
+ogs
+lhr
+kFN
+asz
+lhr
+ogs
+ogs
+ogs
+lhr
+tum
+htN
+jFJ
+pYg
+lhr
+ogs
 ogs
 ogs
 "}
@@ -185644,73 +187846,73 @@ bhJ
 bhJ
 bhJ
 bhJ
-miF
-tum
-pvf
-tum
-tum
-tum
-qHj
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-toJ
-toJ
-toJ
-toJ
-qHj
-goi
+cqm
+ehs
+ehs
+eMU
+eMU
+eMU
+ylh
+ylh
+ylh
+ylh
+pgy
+skC
+skC
+skC
+skC
+ylh
+ylh
+ylh
+ylh
+urZ
+urZ
+urZ
+ylh
+pgy
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+mMx
+sEm
+ylh
+lbS
+igh
+dlK
+kff
 goi
 lro
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+ogs
+jFJ
+jFJ
+gEO
+lhr
+ogs
+sto
+hHV
+ogs
+lhr
+sXO
+pSX
+pSX
+gOX
+lhr
+ogs
+ogs
+lhr
+jFJ
+jFJ
+vqj
+nyp
+lhr
+ogs
 ogs
 ogs
 "}
@@ -186096,73 +188298,73 @@ bhJ
 bhJ
 bhJ
 bhJ
-miF
-tum
-tum
-tum
-tum
-tum
-tum
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-toJ
-toJ
-toJ
-toJ
-goi
-goi
+cqm
+ehs
+ehs
+eMU
+eMU
+eMU
+ylh
+urZ
+urZ
+dlK
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+dlK
+sMT
+evm
+evm
+evm
+ylh
+ylh
+ylh
+ylh
+ylh
+ylh
+ylh
+pgy
+lbS
+dwL
+kff
+kff
 lro
 lro
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-ldQ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+htN
+tqk
+gwv
+lhr
+ogs
+sto
+tqk
+ogs
+lhr
+htN
+htN
+tum
+quj
+lhr
+ogs
+ogs
+lhr
+quj
+jFJ
+dqX
+nyf
+lhr
+ogs
 ogs
 ogs
 "}
@@ -186547,14 +188749,14 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-tum
-tum
-tum
-tum
-fUw
-qHj
+ogs
+dlK
+sMT
+evm
+evm
+ylh
+ylh
+pgy
 miF
 miF
 miF
@@ -186571,50 +188773,50 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+pig
+qBy
+qBy
+qBy
+iZp
+iZp
+dlK
+sEm
+sEm
+sEm
+sEm
+sEm
+dHD
+lbS
+lbS
+dwL
+igh
 toJ
-toJ
-toJ
-goi
-goi
-goi
-lro
-toJ
-lro
-toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+uxr
+ogs
+lhr
+jFJ
+htN
+gwv
+lhr
+ogs
+tcK
+wBh
+ogs
+lhr
+quj
+pSX
+pSX
+fVz
+lhr
+ogs
+ogs
+lhr
+bvb
+bvb
+bvb
+bvb
+lhr
+ogs
 ogs
 ogs
 "}
@@ -186992,25 +189194,22 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-bhJ
-bhJ
-tum
-tum
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+dlK
+iZp
+iZp
+iZp
+iZp
+dlK
+skC
+skC
+ylh
+ehs
+eMU
+uxr
+uxr
+uxr
+wBZ
 miF
 miF
 miF
@@ -187032,41 +189231,44 @@ miF
 miF
 miF
 miF
-qHj
-qHj
-goi
-goi
-goi
-lro
-lro
-lro
+fCP
+qBy
+qBy
+qBy
+qBy
+fCP
+dHD
+lbS
+lbS
+dwL
+dwL
 nvH
 toJ
-toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-toJ
-toJ
-lro
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+jFJ
+jFJ
+fVz
+lhr
+ogs
+ogs
+ogs
+ogs
+lhr
+oan
+tum
+pSX
+oan
+lhr
+lhr
+lhr
+lhr
+sij
+dem
+bUi
+bUi
+lhr
+ogs
 ogs
 ogs
 "}
@@ -187444,81 +189646,81 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-mJb
-nhu
-tum
-tum
+ogs
+skC
+urZ
+pgy
+ylh
+ylh
+skC
+skC
+ylh
+eMU
+ehs
 miF
-miF
+wBZ
+uxr
+uxr
 nbg
+qHj
+qHj
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+qHj
+kBx
+bDc
+lbS
+lbS
+lbS
+igh
+dIV
+dIV
+ogs
+lhr
+pSN
 tum
-bhJ
-miF
-miF
-miF
-miF
-qHj
-qHj
-qHj
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-qHj
-lro
-lro
-lro
-lro
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-lro
-lro
-lro
-lro
-miF
-miF
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+jFJ
+lhr
+ogs
+lhr
+lhr
+lhr
+lhr
+rBs
+oXo
+gxk
+lhr
+lhr
+wBh
+lIo
+jFJ
+htN
+jFJ
+quj
+hFd
+lhr
+ogs
 ogs
 ogs
 "}
@@ -187896,23 +190098,23 @@ bhJ
 bhJ
 bhJ
 bhJ
+ogs
+xNL
+ylh
+eMU
+eMU
+eMU
+eMU
+eMU
+sSq
+eMU
+ehs
 bhJ
-mJb
-mJb
-mJb
+miF
+miF
 tum
 tum
 tum
-miF
-tum
-tum
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
 qHj
 miF
 miF
@@ -187938,39 +190140,39 @@ miF
 miF
 miF
 qHj
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-ldQ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-lro
-goi
-goi
-goi
-lro
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+kBx
+bDc
+dwL
+lbS
+dwL
+dlK
+dIV
+ogs
+ogs
+lhr
+say
+tqk
+htN
+lhr
+ogs
+lhr
+elN
+eAB
+xNI
+tum
+tum
+htN
+pxM
+aVb
+gwv
+ffp
+xNI
+rwO
+gTt
+jFJ
+jFJ
+lhr
+ogs
 ogs
 ogs
 "}
@@ -188348,23 +190550,23 @@ bhJ
 bhJ
 bhJ
 bhJ
-mJb
-mJb
-mJb
-mJb
-mJb
-tum
-tum
-tum
-tum
-tum
+urZ
+ylh
+dwL
+eMU
+eMU
+eMU
+eMU
+eMU
+sSq
+eMU
+ehs
 bhJ
-bhJ
 miF
 miF
-miF
-miF
-miF
+tum
+fUw
+tum
 miF
 miF
 miF
@@ -188390,39 +190592,39 @@ miF
 miF
 miF
 qHj
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-lro
-goi
-lro
-lro
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+kBx
+bDc
+dwL
+lbS
+igh
+cqm
+ogs
+ogs
+lhr
+lhr
+gwv
+jFJ
+rzm
+lhr
+lhr
+lhr
+vSw
+gEd
+fGs
+min
+jFJ
+jFJ
+bUi
+kih
+wBh
+ffp
+fGs
+bUi
+min
+jFJ
+pYg
+lhr
+ogs
 ogs
 ogs
 "}
@@ -188799,26 +191001,26 @@ bhJ
 bhJ
 bhJ
 bhJ
-hMh
-mJb
-mJb
-mJb
-mJb
-mJb
-miF
-miF
-tum
+urZ
+ylh
+ylh
+evm
+evm
+evm
+ylh
+ylh
+ylh
 cxx
+orc
+ehs
+uxr
+miF
+miF
+miF
+miF
 tum
-uxr
-uxr
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+nhu
+fUw
 miF
 miF
 bhJ
@@ -188835,46 +191037,46 @@ miF
 miF
 miF
 miF
+wAQ
+pvW
 miF
 miF
 miF
 miF
-miF
-miF
-toJ
-toJ
-toJ
 qHj
-miF
-toJ
-toJ
-toJ
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-toJ
-lro
-lro
-lro
-toJ
-toJ
-nvH
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+kBx
+dHD
+lbS
+lbS
+lbS
+cqm
+ogs
+lhr
+lhr
+qbU
+fED
+fED
+fED
+anO
+lhr
+lhr
+elN
+nCK
+tbh
+lZn
+htN
+quj
+quj
+kih
+jFJ
+htN
+tbh
+rtX
+jFJ
+jFJ
+htN
+lhr
+ogs
 ogs
 ogs
 "}
@@ -189233,6 +191435,10 @@ miF
 miF
 bhJ
 bhJ
+qHj
+qHj
+qHj
+qHj
 bhJ
 bhJ
 bhJ
@@ -189247,30 +191453,26 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-mJb
-mJb
-mJb
-mJb
-mJb
-bhJ
-miF
-miF
-tum
-tum
-uxr
-uxr
+urZ
+ylh
+dwL
+eMU
+eMU
+eMU
+ylh
+sEm
+ylh
+skC
+skC
+rVQ
 vlH
-uxr
+ixP
 miF
 miF
 miF
-miF
-miF
-miF
+tum
+pvf
+tum
 miF
 bhJ
 bhJ
@@ -189287,46 +191489,46 @@ miF
 miF
 miF
 miF
+qDg
+dUU
 miF
 miF
 miF
-miF
-miF
-miF
-toJ
-toJ
+oqj
 qHj
-qHj
-miF
-miF
-miF
-toJ
-miF
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-qHj
-toJ
-miF
-miF
-miF
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+kBx
+dHD
+lbS
+lbS
+lbS
+cqm
+ogs
+lhr
+jFJ
+jFJ
+jFJ
+jFJ
+tum
+jFJ
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+rBs
+rBs
+ogs
+fVz
+htN
+jFJ
+jFJ
+dem
+iAu
+lhr
+ogs
 ogs
 ogs
 "}
@@ -189685,100 +191887,100 @@ miF
 miF
 miF
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-mJb
-mJb
-mJb
-mJb
-mJb
-bhJ
-bhJ
-miF
-miF
-bhJ
-bhJ
-bhJ
-uxr
-uxr
-uxr
-bhJ
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-toJ
-toJ
 qHj
 qHj
 qHj
-miF
-miF
-miF
-miF
-miF
-miF
 qHj
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+qPr
+qPr
+urZ
+urZ
+ylh
+eMU
+eMU
+eMU
+bhJ
+miF
+miF
+bhJ
+bhJ
+ogs
+ogs
+jOq
+ixP
+bhJ
+miF
+miF
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+pvW
+dUU
+mlT
+dUU
+toJ
+nWY
+dUU
 qHj
-qHj
-miF
-miF
-toJ
-toJ
-miF
-miF
-miF
-miF
-toJ
-ckW
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+kBx
+eQS
+lbS
+lbS
+lbS
+cqm
+ogs
+lhr
+fVz
+sTh
+sTh
+gby
+oBg
+lti
+lhr
+htN
+iAu
+jFJ
+rzm
+box
+jFJ
+ogs
+ogs
+ogs
+ogs
+ogs
+pYg
+jFJ
+drK
+lhr
+lhr
+lhr
+ogs
 ogs
 ogs
 "}
@@ -190132,105 +192334,105 @@ svv
 qHj
 bhJ
 quj
-bhJ
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-mJb
-mJb
-mJb
-mJb
-mJb
-bhJ
-bhJ
-bhJ
-miF
-miF
-bhJ
-bhJ
-bhJ
-bhJ
-uxr
-uxr
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
 toJ
+miF
+miF
+miF
+miF
+qHj
+qHj
+qHj
+miF
+miF
+miF
+gau
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+iZp
+dlK
+urZ
+ylh
+cxx
+dwL
+dwL
+eMU
+qPr
+bhJ
+bhJ
+miF
+miF
+bhJ
+bhJ
+bhJ
+bhJ
+jOq
+ixP
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+dUU
+dUU
+dUU
+dUU
+dUU
+syM
 toJ
 qHj
-qHj
-qHj
-qHj
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+kBx
+dHD
+lbS
+lbS
+lbS
+cqm
+ogs
+lhr
+sTh
+hDL
+fju
+gby
+xNI
 aWW
-miF
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-toJ
-toJ
-lro
-lro
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+rBs
+anO
+vJO
+vJO
+vJO
+vJO
+vJO
+vJO
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+jFJ
+rTB
+ogs
+lhr
+ogs
 ogs
 ogs
 "}
@@ -190584,33 +192786,33 @@ svv
 qHj
 qHj
 tum
-bhJ
-bhJ
+toJ
 miF
 miF
 miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-rDj
-mJb
-mJb
-mJb
-mJb
-mJb
-mJb
-mJb
-bhJ
-bhJ
+miF
+qHj
+qHj
+qHj
+miF
+miF
+miF
+cqm
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+eMU
+qPr
 bhJ
 miF
 miF
@@ -190619,9 +192821,9 @@ bhJ
 bhJ
 bhJ
 uxr
+ixP
+ixP
 uxr
-uxr
-uxr
 bhJ
 bhJ
 bhJ
@@ -190644,45 +192846,45 @@ miF
 miF
 miF
 miF
-miF
-miF
-miF
-bhJ
-miF
+nvH
+dUU
+dUU
 toJ
 toJ
-qHj
-qHj
-qHj
-qHj
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-gne
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-lro
-lro
-goi
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+dIV
+kBx
+dHD
+lbS
+lbS
+dwL
+dlK
+ogs
+lhr
+jFJ
+txj
+rzm
+hwp
+fGs
+min
+rBs
+jFJ
+vJO
+tum
+jRN
+jFJ
+eRp
+tum
+gTt
+lhr
+mti
+ogs
+ogs
+jFJ
+rzm
+lRr
+nyf
+lhr
+ogs
 ogs
 ogs
 "}
@@ -191037,104 +193239,104 @@ svv
 tDo
 tum
 bhJ
-bhJ
 miF
 miF
 miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-mJb
-mJb
-mJb
-mJb
-mJb
-gmP
-mJb
-mJb
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-bhJ
-bhJ
-bhJ
-uxr
-uxr
-uxr
-uxr
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-miF
-toJ
-toJ
 miF
 qHj
+qHj
+qHj
+qHj
+bhJ
+bhJ
+cqm
+eMU
+gau
+iZp
+iZp
+iZp
+iZp
+iZp
+dlK
+gmP
+gmP
+gmP
+ruM
+dlK
+qPr
+qPr
+miF
+miF
+miF
+miF
+bhJ
+bhJ
+bhJ
+uxr
+ixP
+ixP
+wBZ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+mls
+klm
+dUU
 toJ
 toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-lro
-goi
-goi
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+uxr
+kBx
+dHD
+lbS
+lbS
+dwL
+urZ
+ogs
+lhr
+sTh
+jFJ
+ktS
+xNI
+bUi
+min
+tod
+jFJ
+vJO
+pTU
+bUi
+jFJ
+fVz
+fVz
+jFJ
+lhr
+xKF
+tum
+rFh
+jFJ
+jFJ
+rFh
+dqX
+lhr
+ogs
 ogs
 ogs
 "}
@@ -191486,22 +193688,22 @@ iTM
 iTM
 svv
 svv
-bhJ
-bhJ
-bhJ
-bhJ
 qHj
+bhJ
+bhJ
+bhJ
 miF
 miF
 miF
+miF
 bhJ
 bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
+cqm
+eMU
+cqm
 bhJ
 bhJ
 bhJ
@@ -191523,70 +193725,70 @@ bhJ
 bhJ
 bhJ
 uxr
+ixP
+ixP
 uxr
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+bhJ
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+miF
+oqj
+dIV
+gYq
+toJ
+toJ
 uxr
-uxr
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-bhJ
-miF
-toJ
-toJ
-miF
-miF
-toJ
-toJ
-miF
-miF
-miF
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+fCP
+dHD
+lbS
+lbS
+igh
+dHD
+ogs
+lhr
+sTh
+tyX
+fGs
+fGs
+gDg
+kht
+gwv
+jFJ
+vJO
+bUi
+aIN
+bUi
+jFJ
+jFJ
+jFJ
+lhr
+kfS
+jFJ
+vTW
+htN
+jFJ
+vTW
+tum
+lhr
+ogs
 ogs
 ogs
 "}
@@ -191951,9 +194153,9 @@ miF
 miF
 miF
 miF
-bhJ
-bhJ
-bhJ
+cqm
+eMU
+cqm
 bhJ
 bhJ
 ogs
@@ -191964,8 +194166,8 @@ mJb
 mJb
 mJb
 mJb
-mJb
-mJb
+ogS
+ogS
 bhJ
 bhJ
 miF
@@ -191975,13 +194177,13 @@ bhJ
 bhJ
 bhJ
 cLo
-kcd
+uCi
+sJJ
 cLo
 cLo
 cLo
 cLo
 cLo
-cLo
 bhJ
 bhJ
 bhJ
@@ -192004,41 +194206,41 @@ miF
 miF
 miF
 bhJ
-miF
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+uxr
+uxr
+uxr
+ylh
+igh
+lbS
+dwL
+uPY
+ogs
+lhr
+qPi
+jFJ
+oCl
+tbh
+bUi
+min
+gwv
+gwv
+vJO
+pTU
+bUi
+lti
+fVz
+jFJ
+jFJ
+lhr
+qPi
+jFJ
+jFJ
+fVz
+wfg
+jFJ
+tum
+lhr
+ogs
 ogs
 ogs
 "}
@@ -192403,13 +194605,13 @@ miF
 miF
 miF
 miF
-bhJ
-bhJ
-bhJ
+cqm
+eMU
+cqm
 bhJ
 bhJ
 ogs
-mJb
+ogS
 mJb
 oYL
 egQ
@@ -192427,8 +194629,8 @@ bhJ
 bhJ
 cLo
 cLo
-cLo
-cLo
+sJJ
+sJJ
 cLo
 cLo
 kcd
@@ -192457,40 +194659,40 @@ miF
 miF
 bhJ
 bhJ
-ckW
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+uxr
+rVA
+ylh
+ylh
+lbS
+ylh
+ylh
+ogs
+lhr
+sTh
+knn
+quj
+sEu
+fGs
+min
+lhr
+gwv
+vJO
+jFJ
+jRN
+iAu
+jFJ
+jFJ
+jFJ
+pXe
+tum
+ogs
+oPU
+jFJ
+jFJ
+lRr
+ogs
+lhr
+ogs
 ogs
 ogs
 "}
@@ -192855,13 +195057,13 @@ bhJ
 bhJ
 bhJ
 bhJ
-miF
-bhJ
-bhJ
+cqm
+eMU
+cqm
 bhJ
 bhJ
 ogs
-mJb
+ogS
 mJb
 egQ
 tuY
@@ -192912,37 +195114,37 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
+fCP
+lbS
+dHD
 toJ
-toJ
-toJ
-toJ
-toJ
-toJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+gby
+gJi
+vNf
+fVz
+tbh
+jVx
+lhr
+ogs
+vJO
+vJO
+vJO
+vJO
+vJO
+vJO
+jFJ
+lhr
+ogs
+ogs
+ogs
+pYg
+jFJ
+ogs
+ogs
+lhr
+ogs
 ogs
 ogs
 "}
@@ -193307,9 +195509,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
+dlK
+eMU
+cqm
 bhJ
 bhJ
 ogs
@@ -193364,37 +195566,37 @@ bhJ
 bhJ
 bhJ
 bhJ
+kBx
+lbS
+dHD
 bhJ
-toJ
-toJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+jFJ
+quj
+tum
+jFJ
+cdv
+rzm
+lhr
+ogs
+ogs
+ogs
+jFJ
+jFJ
+jFJ
+jFJ
+jFJ
+lhr
+ogs
+ogs
+ogs
+htN
+ogs
+ogs
+ogs
+lhr
+ogs
 ogs
 ogs
 "}
@@ -193756,12 +195958,12 @@ miF
 miF
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+urZ
+orc
+kff
+eMU
+eMU
+cqm
 bhJ
 bhJ
 ogs
@@ -193770,7 +195972,7 @@ qxc
 egQ
 qxc
 qxc
-qxc
+oZR
 jXh
 qxc
 qxc
@@ -193816,37 +196018,37 @@ bhJ
 bhJ
 bhJ
 bhJ
+kBx
+lbS
+dHD
 bhJ
-toJ
-toJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+tum
+nyf
+jFJ
+jFJ
+fju
+fju
+lhr
+ogs
+ogs
+ogs
+box
+jFJ
+htN
+gwv
+jFJ
+lhr
+ogs
+ogs
+nyf
+nyf
+ogs
+ogs
+ogs
+lhr
+ogs
 ogs
 ogs
 "}
@@ -194208,12 +196410,12 @@ bhJ
 miF
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+ylh
+orc
+iGX
+gau
+iZp
+tZm
 bhJ
 bhJ
 ogs
@@ -194268,37 +196470,37 @@ bhJ
 bhJ
 bhJ
 bhJ
+kBx
+lbS
+dHD
 bhJ
-toJ
-toJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+sTh
+gby
+jFJ
+bUi
+sTh
+sTh
+lhr
+ogs
+ogs
+lhr
+lhr
+lhr
+lhr
+gnY
+gnY
+jkh
+wBh
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+ogs
 ogs
 ogs
 "}
@@ -194658,12 +196860,12 @@ bhJ
 bhJ
 bhJ
 miF
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+urZ
+ylh
+iGX
+kff
+kff
+cqm
 bhJ
 bhJ
 bhJ
@@ -194720,37 +196922,37 @@ bhJ
 bhJ
 bhJ
 bhJ
+kBx
+lbS
+dHD
 bhJ
-toJ
-toJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+nAX
+fVz
+lhr
+dqX
+dqX
+jFJ
+fju
+fju
+dqX
+jkh
+jFJ
+jFJ
+hIw
+lhr
+ogs
+ogs
+ogs
+ogs
 ogs
 ogs
 "}
@@ -195110,12 +197312,12 @@ qHj
 bhJ
 bhJ
 qHj
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+ylh
+sLh
+kff
+gau
+iZp
+dlK
 bhJ
 bhJ
 bhJ
@@ -195130,7 +197332,7 @@ qxc
 qxc
 qxc
 qxc
-qxc
+xPT
 cLo
 cLo
 cLo
@@ -195172,37 +197374,37 @@ cLo
 cLo
 bhJ
 bhJ
+kBx
+lbS
+ylh
 bhJ
-toJ
-toJ
+ogs
+ogs
+ogs
+ogs
+ogs
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+tum
+wrO
+oPU
+jFJ
+htN
+wva
+vla
+htN
+jFJ
+jFJ
+jFJ
+iJE
+jFJ
+rzm
+jFJ
+nyf
+lhr
+ogs
 miF
 miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
 ogs
 ogs
 "}
@@ -195562,10 +197764,10 @@ qHj
 qHj
 qHj
 bhJ
-bhJ
-qHj
-bhJ
-bhJ
+ylh
+orc
+kff
+cqm
 bhJ
 bhJ
 bhJ
@@ -195581,77 +197783,77 @@ vLc
 qxc
 qxc
 qxc
+xPT
+cLo
+cLo
+kcd
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+oTx
+cLo
+cLo
+cLo
+kcd
 qxc
-cLo
-cLo
-kcd
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-oTx
-cLo
-cLo
-cLo
-kcd
-cLo
-bhJ
-toJ
-toJ
+fCP
+lbS
+dlK
 bhJ
 bhJ
 bhJ
 bhJ
 bhJ
+ogs
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+ogs
+ogs
+lhr
+tum
+tum
+nux
+oga
+oWe
+kEg
+kEg
+daH
+dqX
+nyf
+lhr
+ogs
 miF
 miF
 miF
@@ -196014,10 +198216,10 @@ bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+urZ
+kff
+kff
+cqm
 bhJ
 bhJ
 bhJ
@@ -196075,35 +198277,35 @@ oTx
 oTx
 cLo
 cLo
+qxc
+qxc
 cLo
 cLo
-cLo
-cLo
 bhJ
 bhJ
 bhJ
 bhJ
 bhJ
+ogs
 bhJ
 bhJ
 bhJ
+ogs
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+dqX
+nyf
+hIY
+jFJ
+quj
+hIw
+jFJ
+jFJ
+qPy
+nyf
+lhr
+ogs
 miF
 miF
 miF
@@ -196466,10 +198668,10 @@ sTT
 fce
 cLo
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
+ylh
+kff
+iGX
+cqm
 bhJ
 bhJ
 bhJ
@@ -196536,26 +198738,26 @@ cLo
 cLo
 cLo
 bhJ
+ogs
+ogs
+ogs
+ogs
+ogs
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
-miF
-miF
-miF
-miF
-miF
+ogs
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+lhr
+ogs
 miF
 miF
 miF
@@ -196918,10 +199120,10 @@ tXb
 tXb
 cLo
 cLo
-bhJ
-bhJ
-bhJ
-bhJ
+dlK
+ghS
+ghS
+dlK
 bhJ
 bhJ
 bhJ
@@ -196989,25 +199191,25 @@ cLo
 cLo
 cLo
 cLo
+lro
 bhJ
 bhJ
 bhJ
 bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-bhJ
-miF
-miF
-miF
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
+ogs
 miF
 miF
 miF
@@ -197371,8 +199573,8 @@ tXb
 cLo
 cLo
 kcd
-cLo
-cLo
+oTx
+oTx
 cLo
 cLo
 cLo
@@ -197823,8 +200025,8 @@ tXb
 cLo
 cLo
 cLo
-cLo
-cLo
+oTx
+oTx
 cLo
 kcd
 cLo
@@ -198980,10 +201182,10 @@ bdN
 bdN
 oBQ
 mhC
-uyh
-uyh
-uyh
-uyh
+mhC
+mhC
+mhC
+oBQ
 fLd
 uao
 fLd
@@ -199431,12 +201633,12 @@ vjY
 bdN
 bdN
 bdN
-uyh
-bJN
-bJN
-bJN
-bJN
-uyh
+mhC
+mhC
+mhC
+mhC
+oBQ
+oBQ
 oBQ
 oBQ
 oBQ
@@ -199883,12 +202085,12 @@ vjY
 bdN
 bdN
 bdN
-uyh
-bJN
-bJN
-bJN
-bJN
-uyh
+mhC
+mhC
+mhC
+mhC
+oBQ
+oBQ
 oBQ
 oBQ
 oBQ
@@ -200335,12 +202537,12 @@ aYF
 bdN
 bdN
 bdN
-uyh
-bJN
-bJN
-bJN
-bJN
-uyh
+bdN
+mhC
+mhC
+mhC
+mhC
+mhC
 mhC
 oBQ
 oBQ
@@ -200787,12 +202989,12 @@ cak
 uir
 bdN
 bdN
-uyh
-bJN
-bJN
-bJN
-bJN
-uyh
+bdN
+mhC
+mhC
+uir
+uir
+mhC
 mhC
 oBQ
 oBQ
@@ -201240,10 +203442,10 @@ uir
 bdN
 bdN
 bdN
-uyh
-uyh
-uyh
-uyh
+mhC
+mhC
+uir
+uir
 uir
 mhC
 oBQ
@@ -242562,9 +244764,9 @@ qHj
 qHj
 miF
 miF
-miF
-miF
-miF
+idG
+idG
+idG
 miF
 bhJ
 njB
@@ -243014,9 +245216,9 @@ qHj
 miF
 miF
 miF
-miF
-miF
-miF
+idG
+fUN
+dWV
 njB
 njB
 pWT
@@ -243466,10 +245668,10 @@ qHj
 miF
 miF
 miF
-bhJ
-bhJ
-njB
-njB
+idG
+idG
+nlW
+ocZ
 pWT
 pWT
 fpx
@@ -248515,10 +250717,10 @@ njB
 pWT
 aFv
 aFv
-aFv
+jQH
 pWT
-njB
-njB
+exD
+wIb
 phl
 phl
 phl
@@ -248968,10 +251170,10 @@ taS
 taS
 taS
 taS
-aFv
+jQH
 pWT
-njB
-pWp
+exD
+yhF
 phl
 phl
 phl
@@ -249420,10 +251622,10 @@ taS
 yed
 ecD
 taS
-aFv
-aFv
+jQH
 pWT
-pWT
+aFv
+exD
 lKo
 phl
 lKo
@@ -251250,7 +253452,7 @@ aDx
 gVI
 gVI
 gVI
-gVI
+suk
 gVI
 ogs
 ogs
@@ -254413,7 +256615,7 @@ iTF
 aDx
 aDx
 bhJ
-bhJ
+sEP
 bhJ
 bhJ
 ogs
@@ -254865,7 +257067,7 @@ iTF
 aDx
 aDx
 bhJ
-bhJ
+fHt
 bhJ
 qHj
 ogs
@@ -255317,7 +257519,7 @@ iTF
 aDx
 sxW
 bhJ
-bhJ
+fHt
 bhJ
 miF
 ogs
@@ -255750,7 +257952,7 @@ tlI
 hQS
 tHu
 taS
-njB
+hoK
 njB
 cDX
 gyu
@@ -255769,8 +257971,8 @@ iTF
 aDx
 bhJ
 bhJ
-bhJ
-miF
+tum
+htN
 qHj
 ogs
 ogs
@@ -256202,7 +258404,7 @@ nqD
 fla
 gti
 taS
-njB
+hoK
 pWT
 lKo
 pqo
@@ -256221,8 +258423,8 @@ iTF
 aDx
 bhJ
 bhJ
-bhJ
-miF
+dUU
+dUU
 qHj
 ogs
 ogs
@@ -256654,7 +258856,7 @@ ybl
 uai
 tlp
 taS
-njB
+hoK
 pWT
 lKo
 jtR
@@ -256673,8 +258875,8 @@ dNr
 bhJ
 bhJ
 bhJ
-bhJ
-miF
+roP
+dUU
 qHj
 ogs
 ogs
@@ -257106,7 +259308,7 @@ mwh
 mwh
 rQx
 taS
-pWT
+teB
 pWT
 cDX
 gyu
@@ -257125,8 +259327,8 @@ dNr
 bhJ
 bhJ
 bhJ
-miF
-miF
+dUU
+dUU
 miF
 ogs
 ogs
@@ -257558,7 +259760,7 @@ kUG
 kUG
 gRo
 dJN
-pWT
+ikC
 qyR
 lKo
 pqo
@@ -257577,8 +259779,8 @@ dNr
 bhJ
 bhJ
 bhJ
-bhJ
-miF
+sto
+htN
 miF
 ogs
 ogs
@@ -258010,7 +260212,7 @@ nPg
 vqr
 dJN
 dJN
-qyR
+nHI
 qyR
 lKo
 jtR
@@ -258030,7 +260232,7 @@ bhJ
 bhJ
 bhJ
 bhJ
-miF
+bhJ
 miF
 ogs
 ogs
@@ -258461,7 +260663,7 @@ taS
 taS
 dJN
 dJN
-qyR
+nHI
 qyR
 qyR
 cDX
@@ -258482,7 +260684,7 @@ bhJ
 bhJ
 bhJ
 bhJ
-miF
+bhJ
 miF
 ogs
 ogs
@@ -258896,26 +261098,26 @@ taS
 klx
 poe
 sfa
+mWD
 pWT
 pWT
 pWT
 pWT
 pWT
-yaF
-aFv
-aFv
 pWT
-yaF
+pWT
+pWT
+pWT
 njB
 pWT
 aFv
 aFv
-aFv
-aFv
-aFv
+wMX
+eHU
+eHU
 qyR
 qyR
-qyR
+nHI
 lKo
 pqo
 lKo
@@ -259358,16 +261560,16 @@ phl
 phl
 phl
 pLh
-njB
+hoK
 njB
 pWT
 pWT
+wMX
 aFv
-aFv
 qyR
 qyR
 qyR
-wyE
+xhK
 pLh
 phl
 phl
@@ -259811,14 +262013,14 @@ lkC
 adW
 pLh
 pLh
-njB
+hoK
 njB
 pWT
 aFv
 qyR
 qyR
 qyR
-qyR
+sKZ
 pLh
 pLh
 phl
@@ -263395,7 +265597,7 @@ fpx
 mYC
 bkm
 wxP
-ehT
+pWT
 exD
 sns
 sns
@@ -263806,7 +266008,7 @@ sZi
 txL
 waf
 fpx
-qJp
+fpx
 exD
 exD
 exD
@@ -266515,7 +268717,7 @@ pWT
 fpx
 fpx
 cDX
-dPl
+eKH
 idV
 idV
 idV
@@ -267392,7 +269594,7 @@ fzO
 fzO
 fzO
 aFv
-gFR
+exD
 fpx
 fpx
 exD
@@ -281449,7 +283651,7 @@ dzO
 iad
 iad
 iad
-upZ
+lIc
 bHV
 bHV
 bHV
@@ -285547,7 +287749,7 @@ prz
 afY
 afY
 uVv
-vIJ
+weQ
 iSm
 kEP
 btu
@@ -292572,7 +294774,7 @@ jIb
 jIb
 jIb
 jIb
-nJD
+fML
 jIb
 jIb
 jIb
@@ -294503,7 +296705,7 @@ bhJ
 bhJ
 bhJ
 aXX
-akV
+pJb
 sDH
 pWT
 oHH
@@ -294953,9 +297155,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-akV
-akV
-akV
+pJb
+pJb
+pJb
 aXX
 pWT
 oHH
@@ -295405,10 +297607,10 @@ bhJ
 bhJ
 bhJ
 bhJ
-akV
-akV
-akV
-akV
+pJb
+pJb
+pJb
+pJb
 njB
 oHH
 nvq
@@ -295857,10 +298059,10 @@ bhJ
 bhJ
 bhJ
 bhJ
-akV
-akV
-akV
-akV
+pJb
+pJb
+pJb
+pJb
 pWT
 oHH
 xvX
@@ -296309,9 +298511,9 @@ bhJ
 bhJ
 bhJ
 bhJ
-akV
-akV
-akV
+pJb
+pJb
+pJb
 aXX
 pWT
 oHH
@@ -296763,7 +298965,7 @@ bhJ
 bhJ
 bhJ
 aXX
-akV
+pJb
 pUg
 pWT
 oHH
@@ -298143,7 +300345,7 @@ aFv
 pWT
 pWT
 aFv
-lew
+aFv
 aFv
 toa
 exD
@@ -298632,7 +300834,7 @@ iad
 khy
 khy
 khy
-bsL
+vET
 bsL
 bsL
 aoe
@@ -299083,8 +301285,8 @@ khy
 khy
 khy
 aoe
-bsL
-bsL
+vET
+vET
 bsL
 bsL
 bsL
@@ -314693,10 +316895,10 @@ jaH
 jaH
 fML
 itZ
-oNr
-qmy
-oNr
-oNr
+itZ
+scK
+itZ
+itZ
 itZ
 scK
 itZ
@@ -315145,10 +317347,10 @@ jaH
 fML
 fML
 itZ
-oNr
-oNr
-oNr
-oNr
+itZ
+itZ
+itZ
+itZ
 itZ
 itZ
 fML
@@ -315597,10 +317799,10 @@ jaH
 fML
 fML
 itZ
-oNr
-oNr
-oNr
-oNr
+itZ
+itZ
+itZ
+itZ
 fLV
 fML
 jaH
@@ -317746,7 +319948,7 @@ xFI
 xFI
 sfX
 sfX
-lFf
+sfX
 kQQ
 xoB
 auC
@@ -352433,7 +354635,7 @@ wVa
 lTi
 bdr
 sCz
-sRt
+bhl
 pvh
 tUF
 tUF
@@ -352885,7 +355087,7 @@ dnn
 kUw
 kUw
 kCO
-pvh
+iSr
 tUF
 tUF
 tUF
@@ -353337,7 +355539,7 @@ guR
 kUw
 kUw
 kCO
-pvh
+iSr
 tUF
 tUF
 tUF
@@ -353789,7 +355991,7 @@ xMC
 bRs
 kUw
 kCO
-pvh
+iSr
 tUF
 tUF
 tUF
@@ -354241,7 +356443,7 @@ xMC
 kUw
 kUw
 kCO
-pvh
+iSr
 tUF
 tUF
 tUF
@@ -354693,7 +356895,7 @@ wFb
 kUw
 kUw
 kCO
-pvh
+iSr
 tUF
 tUF
 tUF
@@ -355145,7 +357347,7 @@ mtN
 lTi
 pPf
 bWA
-pvh
+rJf
 pvh
 tUF
 tUF
@@ -355598,10 +357800,10 @@ urR
 giY
 kUw
 kUw
-pvh
-pvh
-pvh
-pvh
+rJf
+jQE
+jQE
+jQE
 kCO
 kCO
 cgp
@@ -365857,7 +368059,7 @@ xcc
 xcc
 jYu
 jYu
-fQs
+jYu
 jYu
 eCO
 lCD
@@ -433957,7 +436159,7 @@ idM
 oal
 eTa
 oal
-dsP
+oal
 idM
 oal
 aCH
@@ -464082,8 +466284,8 @@ aBB
 gWZ
 nNr
 gWZ
-pvh
-pvh
+jTI
+jTI
 mgP
 wQw
 wQw
@@ -464533,10 +466735,10 @@ aBB
 gWZ
 cgp
 iMU
-pvh
+sSM
 mTN
 upA
-pvh
+cAA
 sRt
 cgp
 oTO
@@ -464989,7 +467191,7 @@ vkX
 hsf
 hsf
 mha
-mZb
+snt
 mZb
 cgp
 cgp
@@ -465436,9 +467638,9 @@ cgp
 cgp
 lVb
 cBB
-fyE
-pvh
-pvh
+tTo
+uiA
+bnR
 fjH
 kiW
 jzh
@@ -465891,7 +468093,7 @@ pvh
 gOd
 hsf
 gFN
-pvh
+jTI
 kiW
 ihE
 eQz
@@ -466346,7 +468548,7 @@ mha
 mha
 kiW
 mts
-pvh
+iSr
 pvh
 cgp
 cgp
@@ -466792,8 +468994,8 @@ cBB
 mZb
 cBB
 cgp
-umY
-umY
+hgM
+hgM
 qNE
 umY
 umY
@@ -467689,10 +469891,10 @@ aBB
 aBB
 cgp
 cBB
-mZb
+cHp
 muS
-xsE
-xsE
+lPm
+lPm
 tUF
 lmA
 kUw
@@ -468140,7 +470342,7 @@ aBB
 aBB
 aBB
 gWZ
-wnj
+ngy
 oKf
 oKf
 kUw
@@ -468592,7 +470794,7 @@ aBB
 aBB
 sSo
 sAu
-mZb
+kjv
 smy
 dHk
 fnl
@@ -469059,7 +471261,7 @@ tUF
 wtA
 kUw
 kUw
-xsE
+wEN
 wzC
 sVd
 sVd
@@ -469496,7 +471698,7 @@ aBB
 aBB
 sSo
 wDo
-mZb
+kjv
 aEr
 jis
 fnl
@@ -469948,7 +472150,7 @@ aBB
 aBB
 aBB
 gWZ
-mZb
+kjv
 gmB
 gmB
 kUw
@@ -469963,7 +472165,7 @@ qef
 mvG
 kUw
 xnr
-iAY
+rjE
 mrW
 lUa
 sVd
@@ -471311,7 +473513,7 @@ uGA
 mZb
 mZb
 mZb
-hjc
+oFS
 hsO
 mha
 mha
@@ -471763,7 +473965,7 @@ cgp
 qqg
 qqg
 pvh
-pvh
+iSr
 cvU
 mha
 mha
@@ -472215,7 +474417,7 @@ aBB
 oTO
 qqg
 vuo
-pvh
+iSr
 oGh
 mha
 jkm


### PR DESCRIPTION
SEWERIFICATION:
Mind you i never mapped in this game, so i did my best to ensure that everything looked servicable.

Details: Made few changes, mainly vastly expanding the sewer system. Moving the thief's guild to a more servicable location. Adding in general more ways to traverse the underground through many tunnels. And a secret [archeological] site for those looking for something to do.

I cross my fingers it is mergable as is, and will not cause the admin team nor the maintainers to beat me with hammers. 


## Why It's Good For The Game
By having more to do in the sewers, be it traverse, or hunt. People who aren't good at fighting certain more difficult enemies could get their baby mode expirence. And those who want to be absolute sewer kings, can do so as well. In general this map has been hurting for the longest time for a sewer touch up and i hope with this, it should be good.

## Changelog

1. Moves the location of the thieves guild to a more suitable one. (servicable as a speak-easy)
2. Adjusts space in the bathouse lobby, as well as puts a hole in the old thieves guild.
3. Adds an entire new part of the sewers, as well as additional nooks to have an easier traversal of the sewers.
4. Adds few new locations, as well as ladders for surface acess.
5. Adds an archeological site (find out yourselves)
6. Adds rats. more rats, and more sewers. Go ham new adventurers.
