### PR TITLE
Light brig store

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
@@ -16,6 +16,11 @@
 	cost = 40
 	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron)
 
+/datum/supply_pack/rogue/armor_iron/brigandine_light//It's made with iron and melts into iron it's not steel.
+	name = "Brigandine, Light"
+	cost = 55 //1 Iron, 1 Leather
+	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine/light)
+
 /datum/supply_pack/rogue/armor_iron/chaincoif_iron
 	name = "Chain Coif"
 	cost = 25

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_steel.dm
@@ -66,11 +66,6 @@
 	cost = 100 // 2 Steel, 2 Cloth
 	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine)
 
-/datum/supply_pack/rogue/armor_steel/brigandine_light
-	name = "Brigandine, Light"
-	cost = 55 //1 Steel, 1 Leather
-	contains = list(/obj/item/clothing/suit/roguetown/armor/brigandine/light)
-
 /datum/supply_pack/rogue/armor_steel/chaincoif_steel
 	name = "Chain Coif"
 	cost = 50 // 1 Steel


### PR DESCRIPTION
## About The Pull Request

Lightweight brigandine is now under IRON armour instead of STEEL (it's made with iron and smelts into it too)

## Testing Evidence

Byeah

## Why It's Good For The Game

Yeah
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Lightweight Brigandine being in wrong store category
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
