### PR TITLE
Makes spectacles able to be worn on head slots

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -58,6 +58,7 @@
 	integrity_failure = 0.5
 	resistance_flags = FIRE_PROOF
 	body_parts_covered = EYES
+	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HEAD
 	anvilrepair = /datum/skill/craft/armorsmithing
 //	block2add = FOV_BEHIND
 


### PR DESCRIPTION
## About The Pull Request

Very niche change but with the prevalence of using the face slot for cosmetics and such, allows spectacles to be worm on head slot so you can still easily have them on and take them off without needing to adjust your other items

## Testing Evidence

Tis a one line change sire, but yes i tested it and nothing broke

## Why It's Good For The Game

I believe having more freedom with our cosmetics is always nice, especially for small things like this that have no real affect on balance

## Changelog

:cl:
add: Allows spectacles to be worn on head slots
/:cl:


