### PR TITLE
Minor grammar fix for the 'Drowcraft' armor elixir.

### DIFF
--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -261,10 +261,10 @@
 
 /obj/item/enchantingkit/triumph_armorkit_drow
 	name = "'Drowcraft' armor morphing elixir"
-	desc = "A small container of special morphing dust, perfect to make a specific item. . It can be used to alter the appearance of.. </br>..a set of Hardened Leather Armor.. </br>.. or a set of Studded Armor"
+	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of.. </br>..a set of Hardened Leather Armor.. </br>.. or a set of Studded Leather Armor."
 	target_items = list(
 		/obj/item/clothing/suit/roguetown/armor/leather/heavy 		= /obj/item/clothing/suit/roguetown/armor/leather/heavy/shadowvest,
-		/obj/item/clothing/suit/roguetown/armor/leather/studded		=/obj/item/clothing/suit/roguetown/armor/leather/heavy/shadowvest
+		/obj/item/clothing/suit/roguetown/armor/leather/studded		= /obj/item/clothing/suit/roguetown/armor/leather/heavy/shadowvest
 		)
 	result_item = null
 


### PR DESCRIPTION
## About The Pull Request

* Slightly touches up the grammar of the 'Drowcraft' armor morphing elixir.

## Testing Evidence

* One-line change.

## Why It's Good For The Game

* Very minor, but it just ensures that everything's looking nice and up to code.

## Changelog

:cl:
code: Slightly touches up grammar of the 'Drowcraft' armor morphing elixer.
/:cl:
