### PR TITLE
fix: edge case with necran crosses and rotcuring/revival

### DIFF
--- a/code/modules/spells/roguetown/acolyte/necra/necra_cross.dm
+++ b/code/modules/spells/roguetown/acolyte/necra/necra_cross.dm
@@ -196,8 +196,8 @@
 	// Remove effects from mobs that left range or are no longer undead
 	for(var/mob/living/L in affected_mobs)
 		if(!(L in current_mobs))
+			remove_undead_debuff(L)
 			if(is_undead(L))
-				remove_undead_debuff(L)
 				undead_found = max(0, undead_found - 1)
 			else
 				remove_necran_buff(L)


### PR DESCRIPTION
## About The Pull Request
due to a poorly-reasoned check, having your corpse brought near a necran cross, then being revived, then leaving the necran cross aoe, would permanently halve your speed and screw up your stats for the round. woe.

## Testing Evidence
it's 1 line moved. will test later when it has more time

## Why It's Good For The Game
having your speed halved for the entire round after a death sucks, from personal experience

## Changelog

:cl:
fix: necran crosses can no longer soak your legs in molasses due to an edge case
/:cl:
