### PR TITLE
Fixes Spectacles worn in head slot mitigating bad eyesight

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -162,10 +162,13 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	var/mob/living/carbon/human/H = user
 	if(H.wear_mask || H.head)
 		if(isclothing(H.wear_mask) || isclothing(H.head))
-			if(istype(H.wear_mask || H.head, /obj/item/clothing/mask/rogue/spectacles))
+			if(istype(H.wear_mask, /obj/item/clothing/mask/rogue/spectacles))
 				var/obj/item/I = H.wear_mask
+				if(!I.obj_broken)
+					return
+			if(istype(H.head, /obj/item/clothing/mask/rogue/spectacles))
 				var/obj/item/G = H.head
-				if(!I.obj_broken || !G.obj_broken)
+				if(!G.obj_broken)
 					return
 	H.blur_eyes(2)
 	H.apply_status_effect(/datum/status_effect/debuff/badvision)


### PR DESCRIPTION
## About The Pull Request

Title.
Now that they go on the head, they should work on the head.

## Testing Evidence
no spectacles:
<img width="148" height="201" alt="Screenshot 2026-03-12 055914" src="https://github.com/user-attachments/assets/dce9dd41-2211-4d50-8479-f30ed7a7aaeb" />
spectacles on head:
<img width="136" height="210" alt="Screenshot 2026-03-12 055908" src="https://github.com/user-attachments/assets/1635a1ec-ce3f-4589-8ce1-95a655729ee7" />
<img width="430" height="456" alt="Screenshot 2026-03-12 055901" src="https://github.com/user-attachments/assets/0bc502cb-7b17-4be6-9f39-9520c629106f" />

## Why It's Good For The Game

Nerd empowerment.

## Changelog

:cl:
fix: fixed spectacles not working in head slot
/:cl: