### PR TITLE
Set-Pose Keybind!

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -116,3 +116,17 @@
 	var/mob/living/carbon/human/H = user.mob
 	H.toggle_eye_intent(H)
 	return TRUE
+
+/datum/keybinding/human/set_pose
+	hotkey_keys = list("Unbound")
+	name = "set_pose"
+	full_name = "Set Pose"
+	description = "Set your pose."
+
+/datum/keybinding/human/set_pose/down(client/user)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = user.mob
+	H.set_pose(H)
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

This adds a simple hotkey to the keybinding menu that activates the Set Pose command.

## Testing Evidence

<img width="413" height="30" alt="Screenshot 2026-03-12 032029" src="https://github.com/user-attachments/assets/8b58ad67-f1dc-4b3f-8822-be0504107b4f" /> (It also works in game I just didn't screencap it)

## Why It's Good For The Game

I love poses! However, I don't love walking out of a tavern, still magically levitating on a invisible chair for the next ten minutes like I'm doing a Mystery of the Druids tribute. This is just a nice quality of life keybind that starts automatically unbounded for people who wanted to make a mouse key set pose or the likes.

## Changelog

:cl:
add: Added keybind for set pose.
/:cl:
