### PR TITLE
Remove Void Dragon binding ritual.

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
@@ -157,13 +157,3 @@
 	tier = 4
 	mob_to_bind = /mob/living/simple_animal/hostile/retaliate/rogue/elemental/colossus
 	required_atoms = list(/obj/item/magic/elemental/relic = 1, /obj/item/magic/melded/t4 = 1, /obj/item/magic/artifact = 4)
-
-// ----- Void Dragon Binding -----
-
-/datum/runeritual/binding/void_dragon
-	name = "Bind Void Dragon"
-	desc = "Sacrifice the spoils of a slain void dragon to bind another to your service. Only those who have already felled one may attempt this."
-	blacklisted = FALSE
-	tier = 5
-	mob_to_bind = /mob/living/simple_animal/hostile/retaliate/rogue/voiddragon
-	required_atoms = list(/obj/item/clothing/ring/dragon_ring = 3, /obj/item/book/granter/spell_points/voiddragon = 3)


### PR DESCRIPTION
## About The Pull Request
Remove Void Dragon binding ritual.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Did not

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
After last night I've came to the conclusion that having a controllable void dragon is just not a great experience for anyone involved on the other side. So I am making this bug a by design thing instead. 

If T4 turns out to be too overbearing I might take a crack at it. Else I am leaving it be until Mage 2 happens.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Void Dragon binding ritual no longer exist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
