### PR TITLE
Fixes Malum T3 "Repair"

### DIFF
--- a/code/modules/spells/roguetown/acolyte/malum.dm
+++ b/code/modules/spells/roguetown/acolyte/malum.dm
@@ -576,7 +576,7 @@ var/global/list/anvil_recipe_prices[][]
 
 /obj/effect/proc_holder/spell/self/repair
 	name = "Order: Repair"
-	desc = "Repair a metal item in your hands."
+	desc = "Repairs metal items on your person." //it literally repairs everything
 	action_icon = 'icons/mob/actions/malummiracles.dmi'
 	overlay_icon = 'icons/mob/actions/malummiracles.dmi'
 	overlay_state = "repair"


### PR DESCRIPTION
## About The Pull Request

Title.
Severely broken spell, made it functional and updated description to actually reflect what it does.

Bad: (ignore increased integrity, different miracle)
<img width="729" height="640" alt="Screenshot 2026-03-11 193157" src="https://github.com/user-attachments/assets/52420b14-f582-4a70-bd12-e405b5cf4f38" />


Fixes:
- Repair no longer sets armour rating to null
- No longer "Overrepairs" items
- Properly makes it fix peel layers when needed
- Now actually does cast the spell instead of forever returning FALSE

## Testing Evidence

<img width="725" height="773" alt="Screenshot 2026-03-12 164758" src="https://github.com/user-attachments/assets/91d3271a-08e9-4f8a-9a73-b773d2c6249e" />


## Why It's Good For The Game

I should write something here...
Bug bad.
Armour goog.
Fixing goog.
This is a cry for help.

## Changelog

:cl:
fix: fixed malum T3 Repair overcapping, removing armour rating and more
/:cl:

