### PR TITLE
ARPG Time: Add Combat Mode Fixed Eye Mouse Snapping

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -90,10 +90,42 @@ SUBSYSTEM_DEF(input)
 		user.update_movement_keys()
 
 /datum/controller/subsystem/input/fire()
-	var/list/clients = GLOB.clients // Let's sing the list cache song
+	var/list/clients = GLOB.clients
 	for(var/i in 1 to clients.len)
 		var/client/C = clients[i]
 		C.keyLoop()
+		cursor_face_update(C)
+
+/// ARPG cursor-facing: faces mob toward cursor when in combat mode + fixed eye.
+/// Close range (<=2 tiles): cardinal-only (90 degree zones).
+/// Far range: 8-dir hysteresis (diagonals keep current facing).
+/datum/controller/subsystem/input/proc/cursor_face_update(client/C)
+	var/mob/M = C.mob
+	if(!isliving(M))
+		return
+	var/mob/living/L = M
+	if(!L.cmode || !L.fixedeye)
+		return
+	if(!L.canface())
+		L.pending_cursor_dir = TRUE
+		return
+	var/angle = mouse_angle_from_client(C)
+	if(isnull(angle))
+		return
+	var/new_dir = angle2dir_cardinal(angle)
+	if(!new_dir)
+		return
+	// If pending, always snap to current cursor position even if dir matches
+	if(L.pending_cursor_dir)
+		L.pending_cursor_dir = FALSE
+		if(L.dir != new_dir)
+			L.setDir(new_dir)
+			L.last_dir_change = world.time
+		return
+	if(L.dir == new_dir)
+		return
+	L.setDir(new_dir)
+	L.last_dir_change = world.time
 
 /// A verb that does nothing, used for clearing keybinds faster.
 /client/verb/NONSENSICAL_VERB_THAT_DOES_NOTHING()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -176,6 +176,7 @@
 	var/last_integ_sound
 
 	var/last_dir_change = 0
+	var/pending_cursor_dir = 0
 
 	var/list/death_trackers = list()
 


### PR DESCRIPTION
## About The Pull Request
- When you are in combat mode and fixed eye mode, your facing will snap to your cursor's facing automatically.
- This respects can_face()'s 0.5 seconds gate 
- If your cursor is still in the same cardinal direction as your current direction, it will not snap - only when you cross the cardinal will it snaps
- Like current behavior, it can snap 180 backward ignoring intermediary distance (this is as of now, intentional, you can snap 180 degree without an issue. If this is to be changed I'll change it in one go)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
![dreamseeker_8VUmvCRV7f](https://github.com/user-attachments/assets/69609015-0421-4e32-badf-62bf60362242)

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- The ARPG-ization of AP will continue unabated. This makes it much easier to manage facing in combat.
- Recommends a TM since I hooked this into SSInputs for any performance pitfall, just in case. I'd say this is worth 0.5 - 1 percent CPU but hopefully should cost far less.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: While in Combat Mode and Fixed Eye Mode, your character will snap to face your cursor direction if you crosses a cardinal direction. It will respect facing gate (0.5 second)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
