### PR TITLE
prevent heretic knight mobs from dropping weapons

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
+++ b/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
@@ -28,6 +28,7 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 	var/preset = "matthios"
 	var/forced_preset = "" // If set, force a specific preset instead of randomizing.
+	var/obj/item/outfit_weapon
 
 /mob/living/carbon/human/species/human/northern/deranged_knight/retaliate(mob/living/L)
 	var/newtarg = target
@@ -62,7 +63,23 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	var/head = get_bodypart(BODY_ZONE_HEAD)
 	if(head)
 		UnregisterSignal(head, COMSIG_MOB_DISMEMBER)
+	if(outfit_weapon)
+		if(iscarbon(outfit_weapon.loc))
+			var/mob/living/carbon/looter = outfit_weapon.loc
+			to_chat(loc, span_warning("[outfit_weapon]'s energies fade, as [src] breathes their last, and it crumbles to dust.."))
+		QDEL_NULL(outfit_weapon)
 	return ..()
+
+/mob/living/carbon/human/species/human/northern/deranged_knight/proc/outfit_dk(datum/outfit/outfit)
+	if(!outfit)
+		return
+	equipOutfit(outfit)
+	if(!outfit.r_hand)
+		return
+	for(var/obj/item/equipped_item in held_items)
+		if(istype(equipped_item, outfit.r_hand))
+			outfit_weapon = equipped_item
+			break
 
 /// Snowflake DK behavior for decaps. Yes, they turn to dust prior to decaps.
 /mob/living/carbon/human/species/human/northern/deranged_knight/proc/handle_drop_limb(obj/item/bodypart/bodypart, special)
@@ -97,18 +114,18 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	switch(preset)
 		if("graggar")
 			ADD_TRAIT(src, TRAIT_HORDE, TRAIT_GENERIC)
-			equipOutfit(new /datum/outfit/job/roguetown/quest_miniboss/graggar)
+			outfit_dk(new /datum/outfit/job/roguetown/quest_miniboss/graggar)
 		if ("matthios")
 			ADD_TRAIT(src, TRAIT_FREEMAN, TRAIT_GENERIC)
-			equipOutfit(new /datum/outfit/job/roguetown/quest_miniboss/matthios)
+			outfit_dk(new /datum/outfit/job/roguetown/quest_miniboss/matthios)
 		if ("zizo")
 			ADD_TRAIT(src, TRAIT_CABAL, TRAIT_GENERIC)
-			equipOutfit(new /datum/outfit/job/roguetown/quest_miniboss/zizo)
+			outfit_dk(new /datum/outfit/job/roguetown/quest_miniboss/zizo)
 		if ("hedgeknight")
 			if(prob(50))
-				equipOutfit(new /datum/outfit/job/roguetown/quest_miniboss/hedge_knight)
+				outfit_dk(new /datum/outfit/job/roguetown/quest_miniboss/hedge_knight)
 			else
-				equipOutfit(new /datum/outfit/job/roguetown/quest_miniboss/blacksteel)
+				outfit_dk(new /datum/outfit/job/roguetown/quest_miniboss/blacksteel)
 			// No special trait for hedgeknight, he's just a generic tough guy.
 
 	gender = pick(MALE,FEMALE)
@@ -206,6 +223,11 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	. = ..()
 	if(!gibbed)
 		dust(FALSE, FALSE, TRUE)
+	if(outfit_weapon)
+		if(iscarbon(outfit_weapon.loc))
+			var/mob/living/carbon/looter = outfit_weapon.loc
+			to_chat(loc, span_warning("[outfit_weapon]'s energies fade, as [src] breathes their last, and it crumbles to dust.."))
+		QDEL_NULL(outfit_weapon)
 
 /datum/outfit/job/roguetown/quest_miniboss/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

heretic knight mobs, upon death, ash the weapon they spawned with too. Regardless of locale.

## Testing Evidence

tested.

## Why It's Good For The Game

no more people farming more coins on them. no more towner heretics taking those weapons, enchanting them and using them against antags or w/e either. powergame sucks.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: heretic mob weapons ash on heretic mob death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
