### PR TITLE
Proper gate NPC dialogue

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -31,6 +31,7 @@
 	var/ai_currently_active = FALSE
 	var/attack_speed = 0
 
+	var/is_silent = FALSE
 	/// (BOOL) If TRUE, the mob will taunt players in certain situations. Psychological warfare!
 	var/rude = FALSE
 	/// (BOOL) If TRUE, the mob will attempt to climb trees to chase players. Evil!
@@ -960,6 +961,20 @@
 	. = ..()
 	if((W.force) && (!target) && (W.damtype != STAMINA) )
 		retaliate(user)
+
+/mob/living/carbon/human/proc/npc_combat_dialogue(list/saylines, list/emotes, prob_chance = 50, cooldown = 15 SECONDS, say_chance = 50)
+	if(is_silent)
+		return FALSE
+	if(!prob(prob_chance))
+		return FALSE
+	if(world.time < (mob_timers["npc_chatter"] + cooldown))
+		return FALSE
+	mob_timers["npc_chatter"] = world.time
+	if(emotes?.len && !prob(say_chance))
+		emote(pick(emotes))
+	else if(saylines?.len)
+		say(pick(saylines), npc_speech = TRUE)
+	return TRUE
 
 /mob/living/carbon/human/proc/npc_taunt_target()
 	var/list/possible_taunts = list("laugh" = null)

--- a/code/modules/mob/living/carbon/human/npc/bum.dm
+++ b/code/modules/mob/living/carbon/human/npc/bum.dm
@@ -25,8 +25,8 @@ GLOBAL_LIST_INIT(bum_aggro, world.file2list("strings/rt/bumaggrolines.txt"))
 		aggressive=1
 		wander = TRUE
 		if(target != newtarg)
-			say(pick(GLOB.bum_aggro), npc_speech = TRUE)
-			pointed(target)
+			if(npc_combat_dialogue(GLOB.bum_aggro, prob_chance = 50, cooldown = 0))
+				pointed(target)
 
 /mob/living/carbon/human/species/human/northern/bum/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)

--- a/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
+++ b/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
@@ -25,7 +25,6 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 		/datum/rmb_intent/weak
 	)
 	npc_max_jump_stamina = 0
-	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 	var/preset = "matthios"
 	var/forced_preset = "" // If set, force a specific preset instead of randomizing.
 
@@ -35,16 +34,19 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	if(target)
 		aggressive=1
 		wander = TRUE
-	if(!is_silent && target != newtarg)
-		if(preset == "matthios")
-			say(pick(GLOB.matthios_aggro), npc_speech = TRUE)
-		else if(preset == "zizo")
-			say(pick(GLOB.zizo_aggro), npc_speech = TRUE)
-		else if(preset == "graggar")
-			say(pick(GLOB.graggar_aggro), npc_speech = TRUE)
-		else if(preset == "hedgeknight")
-			say(pick(GLOB.hedgeknight_aggro), npc_speech = TRUE)
-		pointed(target)
+	if(target != newtarg)
+		var/list/saylines
+		switch(preset)
+			if("matthios")
+				saylines = GLOB.matthios_aggro
+			if("zizo")
+				saylines = GLOB.zizo_aggro
+			if("graggar")
+				saylines = GLOB.graggar_aggro
+			if("hedgeknight")
+				saylines = GLOB.hedgeknight_aggro
+		if(npc_combat_dialogue(saylines, prob_chance = 50, cooldown = 0))
+			pointed(target)
 
 /mob/living/carbon/human/species/human/northern/deranged_knight/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)
@@ -167,20 +169,18 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 		face_atom(get_step(src,pick(GLOB.cardinals)))
 
 /mob/living/carbon/human/species/human/northern/deranged_knight/handle_combat()
-	if(prob(3))
-		if(preset == "matthios")
-			say(pick(GLOB.matthios_aggro), npc_speech = TRUE)
-		else if(preset == "zizo")
-			say(pick(GLOB.zizo_aggro), npc_speech = TRUE)
-		else if(preset == "graggar")
-			say(pick(GLOB.graggar_aggro), npc_speech = TRUE)
-		else if(preset == "hedgeknight")
-			say(pick(GLOB.hedgeknight_aggro), npc_speech = TRUE)
 	if(mode == NPC_AI_HUNT)
-		if(prob(5))
-			emote("laugh")
-		else if(prob(5))
-			emote("warcry")
+		var/list/saylines
+		switch(preset)
+			if("matthios")
+				saylines = GLOB.matthios_aggro
+			if("zizo")
+				saylines = GLOB.zizo_aggro
+			if("graggar")
+				saylines = GLOB.graggar_aggro
+			if("hedgeknight")
+				saylines = GLOB.hedgeknight_aggro
+		npc_combat_dialogue(saylines, list("laugh", "warcry"), prob_chance = 5, say_chance = 50)
 	. = ..()
 
 /mob/living/carbon/human/species/human/northern/deranged_knight/death(gibbed, nocutscene)

--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -10,7 +10,6 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 	flee_in_pain = TRUE
 	d_intent = INTENT_DODGE
 	possible_rmb_intents = list()
-	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 
 /mob/living/carbon/human/species/elf/dark/drowraider/ambush
 	aggressive=1
@@ -22,9 +21,9 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 	if(target)
 		aggressive=1
 		wander = TRUE
-	if(!is_silent && target != newtarg)
-		say(pick(GLOB.drowraider_aggro), npc_speech = TRUE)
-		pointed(target)
+	if(target != newtarg)
+		if(npc_combat_dialogue(GLOB.drowraider_aggro, prob_chance = 50, cooldown = 0))
+			pointed(target)
 
 /mob/living/carbon/human/species/elf/dark/drowraider/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)
@@ -122,12 +121,7 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 
 /mob/living/carbon/human/species/elf/dark/drowraider/handle_combat()
 	if(mode == NPC_AI_HUNT)
-		if(prob(5) && world.time >= (mob_timers["npc_chatter"] + 15 SECONDS))
-			mob_timers["npc_chatter"] = world.time
-			if(prob(60))
-				say(pick(GLOB.drowraider_aggro), npc_speech = TRUE)
-			else
-				emote(pick("laugh", "cackle", "giggle"))
+		npc_combat_dialogue(GLOB.drowraider_aggro, list("laugh", "cackle", "giggle"), prob_chance = 5, say_chance = 60)
 	. = ..()
 
 /datum/outfit/job/roguetown/human/species/elf/dark/drowraider/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/npc/dwarfskeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/dwarfskeleton.dm
@@ -23,8 +23,7 @@ GLOBAL_LIST_INIT(dwarfskeleton_aggro, world.file2list("strings/rt/dskeletonaggro
 
 /mob/living/carbon/human/species/dwarfskeleton/retaliate(mob/living/L)
 	.=..()
-	if(prob(5))
-		say(pick(GLOB.dwarfskeleton_aggro), npc_speech = TRUE)
+	if(npc_combat_dialogue(GLOB.dwarfskeleton_aggro, prob_chance = 5, cooldown = 0))
 		pointed(target)
 
 /mob/living/carbon/human/species/dwarfskeleton/Initialize()

--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -213,19 +213,14 @@ GLOBAL_LIST_INIT(goblin_aggro, world.file2list("strings/rt/goblinaggrolines.txt"
 
 /mob/living/carbon/human/species/goblin/retaliate(mob/living/L)
 	var/newtarg = target
-	.=..()
-	if(target && target != newtarg)
-		say(pick(GLOB.goblin_aggro), npc_speech = TRUE)
+	. = ..()
+	if(target != newtarg && npc_combat_dialogue(GLOB.goblin_aggro, list("laugh", "giggle", "chuckle", "cackle", "screech", "hiss", "growl"), prob_chance = 10))
 		pointed(target)
+
 
 /mob/living/carbon/human/species/goblin/handle_combat()
 	if(mode == NPC_AI_HUNT)
-		if(prob(10) && world.time >= (mob_timers["npc_chatter"] + 15 SECONDS))
-			mob_timers["npc_chatter"] = world.time
-			if(prob(50))
-				say(pick(GLOB.goblin_aggro), npc_speech = TRUE)
-			else
-				emote(pick("laugh", "giggle", "chuckle", "cackle", "screech", "hiss", "growl"))
+		npc_combat_dialogue(GLOB.goblin_aggro, list("laugh", "giggle", "chuckle", "cackle", "screech", "hiss", "growl"), prob_chance = 10)
 	. = ..()
 
 /mob/living/carbon/human/species/goblin/after_creation()

--- a/code/modules/mob/living/carbon/human/npc/heretical_fiends.dm
+++ b/code/modules/mob/living/carbon/human/npc/heretical_fiends.dm
@@ -17,7 +17,6 @@
 		/datum/rmb_intent/riposte,\
 		/datum/rmb_intent/weak
 	)
-	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 	npc_max_jump_stamina = 0
 
 /mob/living/carbon/human/species/human/northern/heretical_fiend_no_gear/retaliate(mob/living/L)
@@ -26,9 +25,9 @@
 	if(target)
 		aggressive=1
 		wander = TRUE
-		if(!is_silent && target != newtarg)
-			say(pick(GLOB.highwayman_aggro))
-			pointed(target)
+		if(target != newtarg)
+			if(npc_combat_dialogue(GLOB.highwayman_aggro, prob_chance = 50, cooldown = 0))
+				pointed(target)
 
 /mob/living/carbon/human/species/human/northern/heretical_fiend_no_gear/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)

--- a/code/modules/mob/living/carbon/human/npc/lizardmen_dungeon.dm
+++ b/code/modules/mob/living/carbon/human/npc/lizardmen_dungeon.dm
@@ -20,7 +20,6 @@
 		/datum/rmb_intent/riposte,\
 		/datum/rmb_intent/weak
 	)
-	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 	npc_max_jump_stamina = 0
 
 /mob/living/carbon/human/species/lizardfolk/psy_vault_guard/ambush
@@ -33,9 +32,9 @@
 	if(target)
 		aggressive=1
 		wander = TRUE
-		if(!is_silent && target != newtarg)
-			say(pick(GLOB.highwayman_aggro), npc_speech = TRUE)
-			pointed(target)
+		if(target != newtarg)
+			if(npc_combat_dialogue(GLOB.highwayman_aggro, prob_chance = 50, cooldown = 0))
+				pointed(target)
 
 /mob/living/carbon/human/species/lizardfolk/psy_vault_guard/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)

--- a/code/modules/mob/living/carbon/human/npc/searaider.dm
+++ b/code/modules/mob/living/carbon/human/npc/searaider.dm
@@ -9,8 +9,6 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 	dodgetime = 30
 	flee_in_pain = TRUE
 	possible_rmb_intents = list()
-	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
-
 
 /mob/living/carbon/human/species/human/northern/searaider/ambush
 	aggressive=1
@@ -23,9 +21,9 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 	if(target)
 		aggressive=1
 		wander = TRUE
-		if(!is_silent && target != newtarg)
-			say(pick(GLOB.searaider_aggro), npc_speech = TRUE)
-			pointed(target)
+		if(target != newtarg)
+			if(npc_combat_dialogue(GLOB.searaider_aggro, prob_chance = 50, cooldown = 0))
+				pointed(target)
 
 /mob/living/carbon/human/species/human/northern/searaider/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)
@@ -117,16 +115,7 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 
 /mob/living/carbon/human/species/human/northern/searaider/handle_combat()
 	if(mode == NPC_AI_HUNT)
-		if(world.time >= (mob_timers["npc_chatter"] + 15 SECONDS))
-			if(prob(50))
-				mob_timers["npc_chatter"] = world.time
-				emote("rage")
-			else if(prob(5))
-				mob_timers["npc_chatter"] = world.time
-				if(prob(60))
-					say(pick(GLOB.searaider_aggro), npc_speech = TRUE)
-				else
-					emote(pick("laugh", "warcry"))
+		npc_combat_dialogue(GLOB.searaider_aggro, list("rage", "laugh", "warcry"), prob_chance = 10, say_chance = 30)
 	. = ..()
 
 /datum/outfit/job/roguetown/human/species/human/northern/searaider/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -102,7 +102,6 @@
 		/datum/rmb_intent/riposte,\
 		/datum/rmb_intent/weak
 	)
-	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 	npc_max_jump_stamina = 0
 
 
@@ -116,9 +115,9 @@
 	if(target)
 		aggressive=1
 		wander = TRUE
-		if(!is_silent && target != newtarg)
-			say(pick(GLOB.highwayman_aggro), npc_speech = TRUE)
-			pointed(target)
+		if(target != newtarg)
+			if(npc_combat_dialogue(GLOB.highwayman_aggro, prob_chance = 50, cooldown = 0))
+				pointed(target)
 
 /mob/living/carbon/human/species/human/northern/bog_deserters/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)
@@ -168,12 +167,7 @@
 
 /mob/living/carbon/human/species/human/northern/bog_deserters/handle_combat()
 	if(mode == NPC_AI_HUNT)
-		if(prob(5) && world.time >= (mob_timers["npc_chatter"] + 15 SECONDS))
-			mob_timers["npc_chatter"] = world.time
-			if(prob(60))
-				say(pick(GLOB.highwayman_aggro), npc_speech = TRUE)
-			else
-				emote(pick("laugh", "warcry", "rage"))
+		npc_combat_dialogue(GLOB.highwayman_aggro, list("laugh", "warcry", "rage"), prob_chance = 5, say_chance = 60)
 	. = ..()
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/npc/soldiers/border_reivers.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/border_reivers.dm
@@ -17,7 +17,6 @@
 		/datum/rmb_intent/riposte,\
 		/datum/rmb_intent/weak
 	)
-	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 	npc_max_jump_stamina = 0
 
 /mob/living/carbon/human/species/human/northern/border_reiver/retaliate(mob/living/L)
@@ -26,9 +25,9 @@
 	if(target)
 		aggressive=1
 		wander = TRUE
-		if(!is_silent && target != newtarg)
-			say(pick(GLOB.highwayman_aggro))
-			pointed(target)
+		if(target != newtarg)
+			if(npc_combat_dialogue(GLOB.highwayman_aggro, prob_chance = 50, cooldown = 0))
+				pointed(target)
 
 /mob/living/carbon/human/species/human/northern/border_reiver/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)
@@ -59,9 +58,7 @@
 
 /mob/living/carbon/human/species/human/northern/border_reiver/handle_combat()
 	if(mode == NPC_AI_HUNT)
-		if(prob(2) && world.time >= (mob_timers["npc_chatter"] + 15 SECONDS))
-			mob_timers["npc_chatter"] = world.time
-			emote("laugh")
+		npc_combat_dialogue(emotes = list("laugh"), prob_chance = 2)
 	. = ..()
 
 //Border Reivers from a nearby state the. To "Reive" is to raid, These guys should be fast, look kind of poor but not be badly equipped.

--- a/code/modules/mob/living/carbon/human/npc/soldiers/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/highwayman.dm
@@ -10,8 +10,6 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	flee_in_pain = TRUE
 	d_intent = INTENT_PARRY
 	possible_rmb_intents = list()
-	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
-
 
 /mob/living/carbon/human/species/human/northern/highwayman/ambush
 	aggressive=1
@@ -24,9 +22,9 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	if(target)
 		aggressive=1
 		wander = TRUE
-		if(!is_silent && target != newtarg)
-			say(pick(GLOB.highwayman_aggro), npc_speech = TRUE)
-			pointed(target)
+		if(target != newtarg)
+			if(npc_combat_dialogue(GLOB.highwayman_aggro, prob_chance = 50, cooldown = 0))
+				pointed(target)
 
 /mob/living/carbon/human/species/human/northern/highwayman/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)
@@ -75,12 +73,7 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 
 /mob/living/carbon/human/species/human/northern/highwayman/handle_combat()
 	if(mode == NPC_AI_HUNT)
-		if(prob(5) && world.time >= (mob_timers["npc_chatter"] + 15 SECONDS))
-			mob_timers["npc_chatter"] = world.time
-			if(prob(60))
-				say(pick(GLOB.highwayman_aggro), npc_speech = TRUE)
-			else
-				emote(pick("laugh", "warcry", "rage"))
+		npc_combat_dialogue(GLOB.highwayman_aggro, list("laugh", "warcry", "rage"), prob_chance = 5, say_chance = 60)
 	. = ..()
 
 /datum/outfit/job/roguetown/human/species/human/northern/highwayman/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/npc/soldiers/militia.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/militia.dm
@@ -9,7 +9,6 @@
 	dodgetime = 30
 	flee_in_pain = TRUE
 	possible_rmb_intents = list()
-	var/is_silent = TRUE /// Determines whether or not we will scream our funny lines at people.
 
 /mob/living/carbon/human/species/human/northern/militia/retaliate(mob/living/L)
 	var/newtarg = target
@@ -17,9 +16,9 @@
 	if(target)
 		aggressive=1
 		wander = TRUE
-		if(!is_silent && target != newtarg)
-			say(pick(GLOB.highwayman_aggro), npc_speech = TRUE)
-			pointed(target)
+		if(target != newtarg)
+			if(npc_combat_dialogue(GLOB.highwayman_aggro, prob_chance = 50, cooldown = 0))
+				pointed(target)
 
 /mob/living/carbon/human/species/human/northern/militia/should_target(mob/living/L)
 	if(L.stat != CONSCIOUS)
@@ -66,12 +65,7 @@
 
 /mob/living/carbon/human/species/human/northern/militia/handle_combat()
 	if(mode == NPC_AI_HUNT)
-		if(prob(5) && world.time >= (mob_timers["npc_chatter"] + 15 SECONDS))
-			mob_timers["npc_chatter"] = world.time
-			if(prob(60))
-				say(pick(GLOB.highwayman_aggro), npc_speech = TRUE)
-			else
-				emote(pick("laugh", "warcry", "rage"))
+		npc_combat_dialogue(GLOB.highwayman_aggro, list("laugh", "warcry", "rage"), prob_chance = 5, say_chance = 60)
 	. = ..()
 
 /datum/outfit/job/roguetown/human/species/human/northern/militia/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/npc/zizoconstruct.dm
+++ b/code/modules/mob/living/carbon/human/npc/zizoconstruct.dm
@@ -24,8 +24,7 @@ GLOBAL_LIST_INIT(zizoconstruct_aggro, world.file2list("strings/rt/zconstructaggr
 
 /mob/living/carbon/human/species/construct/metal/zizoconstruct/retaliate(mob/living/L)
 	.=..()
-	if(prob(5))
-		say(pick(GLOB.zizoconstruct_aggro), npc_speech = TRUE)
+	if(npc_combat_dialogue(GLOB.zizoconstruct_aggro, prob_chance = 5, cooldown = 0))
 		pointed(target)
 
 /mob/living/carbon/human/species/construct/metal/zizoconstruct/should_target(mob/living/L)


### PR DESCRIPTION
## About The Pull Request
- Refactor all NPC dialogue out into a npc_combat_dialogue proc that actually gate them every 15 seconds, including the retaliate taunt (Which was ungated before) leading to combat being FAAAR spammier than intended

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="563" height="296" alt="dreamseeker_8hDGmhHcQB" src="https://github.com/user-attachments/assets/d748f725-f7a8-40a2-933b-691741eadfd7" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Turns out NPC switch aggro rapidly with retaliate() leading to the dialogue gate being bypassed and extreme chat spam

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: NPC should be properly gating their dialogue to not blow up your entire chat when switching aggro now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
