### PR TITLE
allow healing eora trees + bugfix

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -516,7 +516,7 @@
 			var/mob/living/carbon/human/sacrifice = user
 			visible_message(span_danger("[user] begins altruistically channeling the crimson aril's power to restore the tree."),
 	 		 span_info("I begin channeling the crimson aril's power into the tree using my own blood."))
-			if(!do_after(sacrifice, 0.6 SECONDS))
+			if(!do_after(sacrifice, 15 SECONDS))
 				return
 			// same blood loss as using it to heal someone
 			sacrifice.blood_volume = max(0, sacrifice.blood_volume - ((BLOOD_VOLUME_NORMAL * 0.03) + (sacrifice.blood_volume * 0.06)))

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -581,8 +581,12 @@
 			return TRUE
 
 		var/has_water = FALSE
+		var/water_blessed = FALSE
 		if(container.reagents.has_reagent(/datum/reagent/water, 1))
 			has_water = TRUE
+		if(container.reagents.has_reagent(/datum/reagent/water/blessed))
+			has_water = TRUE
+			water_blessed = TRUE
 
 		if(!has_water)
 			to_chat(user, span_warning("The tree accepts only fresh, clean water."))
@@ -595,7 +599,10 @@
 		var/action_time = get_skill_delay(skill, fastest = 0.5, slowest = 3)
 
 		if(do_after(user, action_time, target = src))
-			container.reagents.remove_reagent(/datum/reagent/water, 1)
+			if(water_blessed)
+				container.reagents.remove_reagent(/datum/reagent/water/blessed, 1)
+			else
+				container.reagents.remove_reagent(/datum/reagent/water, 1)
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
 				add_sleep_experience(user, /datum/skill/labor/farming, C.STAINT * 0.5)

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -513,14 +513,18 @@
 /obj/structure/eoran_pomegranate_tree/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/reagent_containers/food/snacks/eoran_aril/crimson))
 		if(iscarbon(user))
+			var/mob/living/carbon/human/sacrifice = user
 			visible_message(span_danger("[user] begins altruistically channeling the crimson aril's power to restore the tree."),
 	 		 span_info("I begin channeling the crimson aril's power into the tree using my own blood."))
-			if(!do_after(user, M, time = 0.6 SECONDS, double_progress = TRUE, can_move = FALSE))
+			if(!do_after(sacrifice, 0.6 SECONDS))
 				return
 			// same blood loss as using it to heal someone
-			user.blood_volume = max(0, user.blood_volume - (BLOOD_VOLUME_NORMAL * 0.03) + (eater.blood_volume * 0.06))
+			sacrifice.blood_volume = max(0, sacrifice.blood_volume - ((BLOOD_VOLUME_NORMAL * 0.03) + (sacrifice.blood_volume * 0.06)))
 			// 50 healing; slightly more than healing a player, but you'll lose a lot of blood trying to fully heal a tree still
-			obj_integrity = min(max_integrity, obj_integrity + max_integrity / 4); 
+			obj_integrity = min(max_integrity, obj_integrity + max_integrity / 4)
+			qdel(I)
+			update_icon()
+			return TRUE
 	if(istype(I, /obj/item/ash))
 		if(iscarbon(user))
 			var/mob/living/carbon/c = user

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -511,6 +511,16 @@
 		happiness_tier = 1
 
 /obj/structure/eoran_pomegranate_tree/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/reagent_containers/food/snacks/eoran_aril/crimson))
+		if(iscarbon(user))
+			visible_message(span_danger("[user] begins altruistically channeling the crimson aril's power to restore the tree."),
+	 		 span_info("I begin channeling the crimson aril's power into the tree using my own blood."))
+			if(!do_after(user, M, time = 0.6 SECONDS, double_progress = TRUE, can_move = FALSE))
+				return
+			// same blood loss as using it to heal someone
+			user.blood_volume = max(0, user.blood_volume - (BLOOD_VOLUME_NORMAL * 0.03) + (eater.blood_volume * 0.06))
+			// 50 healing; slightly more than healing a player, but you'll lose a lot of blood trying to fully heal a tree still
+			obj_integrity = min(max_integrity, obj_integrity + max_integrity / 4); 
 	if(istype(I, /obj/item/ash))
 		if(iscarbon(user))
 			var/mob/living/carbon/c = user

--- a/code/modules/spells/roguetown/acolyte/eora/eora_arils.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_arils.dm
@@ -83,7 +83,7 @@
 	//Instant heal, but you can only eat a couple before the next will make you pass out.
 	var/list/wCount = eater.get_wounds()
 	//No undead because they kinda don't have blood to give for this.
-	if(!eater.construct && !(eater.mob_biotypes & MOB_UNDEAD))
+	if(!user.construct && !(user.mob_biotypes & MOB_UNDEAD))
 		var/current_brute_loss = eater.getBruteLoss()
 		blood_loss += (user.blood_volume * 0.08)
 		if(wCount.len > 0)


### PR DESCRIPTION
## About The Pull Request
lets you use crimson (healing) arils to heal eoran trees, while incurring the same blood loss to the user as healing another player. also, fixes an existing bug where crimson arils would check the wrong player for blood when using them to heal someone else

## Testing Evidence
<img width="641" height="646" alt="image" src="https://github.com/user-attachments/assets/dee96f6f-edf9-4802-a1d7-0f55be1e5ffb" />
<img width="98" height="91" alt="image" src="https://github.com/user-attachments/assets/ba677edf-5051-4e89-b71a-c0005185f097" />


## Why It's Good For The Game
sacrificing your own blood to tend to the tree you failed to protect is VERY eoran, and there's currently... no other way to fix the trees if you accidentally hit one with a knife instead of pruning it with scissors or something. also bugfix good

## Changelog

:cl:
qol: you can now heal eoran trees with your own blood using crimson arils
fix: altruistic crimson arils checked the wrong player for blood
qol: you can now water eoran trees with blessed (but not cursed) water
/:cl:
