### PR TITLE
Telegraph penalty for using untrained armor better

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/jump.dm
+++ b/code/game/objects/items/rogueweapons/mmb/jump.dm
@@ -83,6 +83,7 @@
 		if(!H.check_armor_skill() || H.legcuffed)
 			jadded += 50
 			jrange = 1
+			to_chat(H, span_warning("My armor is too heavy to jump effectively!"))
 
 	jump_action_resolve(A, jadded, jrange, jextra, jroot)
 	return TRUE

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -140,6 +140,7 @@
 		if(!H?.check_armor_skill() || H?.legcuffed)
 			H.Knockdown(1)
 			H.drop_all_held_items()
+			to_chat(H, span_warning("I can't dodge in such unfitting armor! I'm knocked down!"))
 			return FALSE
 		if(I) //the enemy attacked us with a weapon
 			if(!I.associated_skill) //the enemy weapon doesn't have a skill because its improvised, so penalty to attack

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -158,9 +158,11 @@
 	prob2defend = clamp(prob2defend, 5, 90)
 	if(HAS_TRAIT(user, TRAIT_HARDSHELL) && H.client)	//Dwarf-merc specific limitation w/ their armor on in pvp
 		prob2defend = clamp(prob2defend, 5, 70)
+	var/untrained_armor = FALSE
 	if(!H?.check_armor_skill())
 		prob2defend = clamp(prob2defend, 5, 75)			//Caps your max parry to 75 if using armor you're not trained in. Bad dexerity.
 		drained = drained + 5							//More stamina usage for not being trained in the armor you're using.
+		untrained_armor = TRUE
 
 	//Dual Wielding
 	var/defender_dualw
@@ -224,7 +226,7 @@
 		attacker_skill_type = /datum/skill/combat/unarmed
 
 	if(weapon_parry == TRUE)
-		if(do_parry(used_weapon, drained, user)) //show message
+		if(do_parry(used_weapon, drained, user, untrained_armor)) //show message
 			//only gain experience if attacker and defender aren't using non-combat skills for their weapons
 			if(ispath(attacker_skill_type, /datum/skill/combat) && ispath(used_weapon.associated_skill, /datum/skill/combat))
 				if ((mobility_flags & MOBILITY_STAND))
@@ -287,7 +289,7 @@
 			return FALSE
 
 	if(weapon_parry == FALSE)
-		if(do_unarmed_parry(drained, user))
+		if(do_unarmed_parry(drained, user, untrained_armor))
 			//only gain experience if attacker isn't using a non-combat skill for their weapon
 			if(ispath(attacker_skill_type, /datum/skill/combat))
 				if((mobility_flags & MOBILITY_STAND))
@@ -309,7 +311,7 @@
 
 			return FALSE
 
-/mob/proc/do_parry(obj/item/W, parrydrain as num, mob/living/user)
+/mob/proc/do_parry(obj/item/W, parrydrain as num, mob/living/user, untrained_armor = FALSE)
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		//Tempo bonus
@@ -320,7 +322,7 @@
 			if(src.client)
 				record_round_statistic(STATS_PARRIES)
 				log_combat(src, user, "parried")
-				
+
 
 			var/def_verb = "parries"
 			var/att_verb = ""
@@ -329,6 +331,8 @@
 			if(istype(user.rmb_intent, /datum/rmb_intent/strong))
 				att_verb = "'s [pick("hefty", "strong")] attack"
 			var/def_msg = "<b>[src]</b> [def_verb] [user][att_verb] with [W]!"
+			if(untrained_armor)
+				def_msg += " Untrained Armor Penalty!"
 
 			visible_message(span_combatsecondary(def_msg), span_boldwarning(def_msg), COMBAT_MESSAGE_RANGE, list(user))
 			to_chat(user, span_boldwarning(def_msg))
@@ -354,7 +358,7 @@
 			playsound(get_turf(src), pick(W.parrysound), 100, FALSE)
 		return TRUE
 
-/mob/proc/do_unarmed_parry(parrydrain as num, mob/living/user)
+/mob/proc/do_unarmed_parry(parrydrain as num, mob/living/user, untrained_armor = FALSE)
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		//Tempo bonus
@@ -362,7 +366,10 @@
 
 		if(H.stamina_add(parrydrain))
 			playsound(get_turf(src), pick(parry_sound), 100, FALSE)
-			src.visible_message(span_warning("<b>[src]</b> parries [user]!"))
+			var/parry_msg = "<b>[src]</b> parries [user]!"
+			if(untrained_armor)
+				parry_msg += " Untrained Armor Penalty!"
+			src.visible_message(span_warning(parry_msg))
 			if(src.client)
 				record_round_statistic(STATS_PARRIES)
 				log_combat(src, user, "parried")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -680,6 +680,7 @@
 					if(ishuman(L))
 						var/mob/living/carbon/human/H = L
 						if(!H.check_armor_skill() || H.legcuffed)
+							to_chat(H, span_warning("My armor is too heavy to run effectively!"))
 							return
 
 				m_intent = MOVE_INTENT_RUN


### PR DESCRIPTION
## About The Pull Request
- Improves the telegraph by explicitly stating in your parry / dodge message that you are using untrained armor
- Give you a message when you try to run, or jump, that you are in the wrong armor

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested locally. Have screenshot, forgot where it is placed. 

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It removes another source of frustration of "why I can't run" without giving user any feedbacks. Or why are they getting stunlocked.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: When you can't run / jump due to wearing armor you are not trained for, or get knocked down on dodge, or suffer parry penalty, message in chat will indicates why.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
