### PR TITLE
Fixes small oversight in Seneschal.dm.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/seneschal.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/seneschal.dm
@@ -28,6 +28,7 @@
 /datum/advclass/seneschal
 	traits_applied = list(TRAIT_CICERONE, TRAIT_HOMESTEAD_EXPERT, TRAIT_SEWING_EXPERT, TRAIT_ROYALSERVANT) // They have Expert Sewing
 	category_tags = list(CTAG_SENESCHAL)
+	age_mod = /datum/class_age_mod/seneschal
 
 /datum/advclass/seneschal/seneschal
 	name = "Seneschal"
@@ -39,7 +40,6 @@
 		STATKEY_LCK = 1, // Usual leadership carrot.
 		STATKEY_SPD = 1
 	)
-	age_mod = /datum/class_age_mod/seneschal
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
@@ -83,7 +83,6 @@
 		STATKEY_LCK = 1, // Usual leadership carrot.
 		STATKEY_SPD = 1
 	)
-	age_mod = /datum/class_age_mod/seneschal
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
@@ -123,7 +122,6 @@
 		STATKEY_LCK = 1, // Usual leadership carrot.
 		STATKEY_SPD = 1
 	)
-	age_mod = /datum/class_age_mod/seneschal
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,


### PR DESCRIPTION
## About The Pull Request
Realized that the Senechal advclasses weren't getting the agemods. Fixed this, because you shouldn't be punished for wanting a cool alt title. I also did a sweep of all jobs that have agemods, but senechal is the only one affected ( or well technically mage apprentice Azurcaephan is also affected but since it's commented out who cares

## Testing Evidence

it's a one line change, sire.

## Why It's Good For The Game

fixed a oversight

## Changelog

miniscule change that needs no changelog