### PR TITLE
Fix orison reagent double production by making it a rebalanced feature.

### DIFF
--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -321,7 +321,7 @@
 			if (thing.reagents.holder_full() || (user.devotion.devotion - fatigue_used <= 0))
 				break
 
-			var/water_qty = max(1, holy_skill) + 1
+			var/water_qty = max(2, 2 * holy_skill) + 2
 			var/list/water_contents = list(/datum/reagent/water/cursed = water_qty)
 			if(user.patron.undead_hater == TRUE)
 				water_contents = list(/datum/reagent/water/blessed = water_qty)
@@ -329,11 +329,11 @@
 				water_contents = list(/datum/reagent/water/medicine = water_qty)
 			var/datum/reagents/reagents_to_add = new()
 			reagents_to_add.add_reagent_list(water_contents)
-			reagents_to_add.trans_to(thing, reagents_to_add.total_volume, transfered_by = user, method = INGEST)
+			reagents_to_add.trans_to(thing, reagents_to_add.total_volume, transfered_by = user)
 
 			fatigue_spent += fatigue_used
 			user.stamina_add(fatigue_used)
-			user.devotion?.update_devotion(-1.0)
+			user.devotion?.update_devotion(-1.5)
 
 			if (prob(80))
 				playsound(user, 'sound/items/fillcup.ogg', 55, TRUE)


### PR DESCRIPTION
## About The Pull Request

It used to double produce when used on container you could drink from, now it produce double all the time at the cost of slightly more devotion

## Testing Evidence
At Journeymand Holy skill (3) with var/water_qty = max(2, 2 * holy_skill) + 2
Before fix (1 doafter on keg and bucket) - 
<img width="1177" height="701" alt="image" src="https://github.com/user-attachments/assets/ce318b54-2b39-4a1c-9b8a-1fcc56c5bf10" />
After fix (1 doafter on keg and bucket) - 
<img width="1208" height="642" alt="image" src="https://github.com/user-attachments/assets/3d18dce8-5d60-434b-9929-093747a6bb47" />


## Why It's Good For The Game

Fixing an edge case with Orison bug, turning the bug into a feature number wise with some balance

## Changelog
Orison produces double the amount of reagent when used on a container you can drink from. this PR fixes the issue by removing the drinkeable container check and doubling the baseline produced amount, at the cost of increasing the devotion cost slightly.
Now it always produces "2 + Twice your Holy Skill level" drams of reagent with each doafter (instead of only producing that same amount with container you can drink from), increases devotion cost by 50% (from 1 devotion to 1.5 devotion per doafter)

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: double reagent production trigger on using orison on container you can drink from, it now always produce that same amount at the cost of slightly more devotion.
/:cl:

