### PR TITLE
Mantraps can be triggered by more things

### DIFF
--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -189,11 +189,30 @@
 					snap = FALSE
 			if(snap)
 				close_trap()
-				L.visible_message("<span class='danger'>[L] triggers \the [src].</span>", \
-						"<span class='danger'>I trigger \the [src]!</span>")
+				L.visible_message(span_danger("[L] triggers \the [src]."), \
+						span_danger("I trigger \the [src]!"))
 				if(L.apply_damage(trap_damage, BRUTE, def_zone, L.run_armor_check(def_zone, "stab", damage = trap_damage)))
 					L.Stun(80)
+		if(isitem(AM))
+			var/obj/item/I = AM
+			if(I.w_class >= WEIGHT_CLASS_NORMAL && prob(33))
+				I.take_damage(50, BRUTE, "stab")
+				close_trap()
+				visible_message(span_warning("[AM] triggers \the [src]."))
 	..()
+
+/obj/item/restraints/legcuffs/beartrap/attacked_by(obj/item/I, mob/living/user)
+	. = ..()
+	if(armed && istype(I, /obj/item/rogueweapon) || istype(I, /obj/item/clothing/suit))
+		if(prob(10))
+			var/msg = "[I] triggers \the [src]."
+			if(prob(80))
+				msg += " \the [src] digs into \the [I], damaging it!"
+				I.take_damage(50, BRUTE, "stab")
+			visible_message(span_warning(msg))
+			close_trap()
+		
+	
 
 /obj/item/restraints/legcuffs/beartrap/dropped(mob/living/carbon/human/user)
 	..()

--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -204,7 +204,7 @@
 /obj/item/restraints/legcuffs/beartrap/attacked_by(obj/item/I, mob/living/user)
 	. = ..()
 	if(armed && istype(I, /obj/item/rogueweapon) || istype(I, /obj/item/clothing/suit))
-		if(prob(10))
+		if(prob(20))
 			var/msg = "[I] triggers \the [src]."
 			if(prob(80))
 				msg += " \the [src] digs into \the [I], damaging it!"


### PR DESCRIPTION
## About The Pull Request
- Objects of weight class "normal" or above (so armor, logs, etc) will have a 1/3 chance to trigger beartraps, taking integrity damage.
- Any weapon used directly on a bear trap will also have a 10% chance to trigger the trap, though doing so will cost integrity to the weapon.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
For demonstration purposes the probabilities were altered in the video.

https://github.com/user-attachments/assets/d837bc40-a296-41a8-b53b-03d8d67c79fd

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Kinda wanted to hook this into an item getting directly thrown *at* the bear trap, but because it has collision disabled it is a more difficult thing to code vs catching when a thrown item "crosses" the bear trap. Alas.

Anyway, more options (though, a bit costly integ wise) to disable mantraps quickly doesn't seem like a bad idea.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Mantraps can be triggered by heavier thrown objects as well as directly hitting them with a weapon. In both cases it will cost integrity, and it is not guaranteed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
