### PR TITLE
hoe intent ordering fix

### DIFF
--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -130,7 +130,7 @@
 	force = 10
 	force_wielded = 15
 	possible_item_intents = list(/datum/intent/pick)
-	gripped_intents = list(/datum/intent/pick, SPEAR_BASH, TILL_INTENT)
+	gripped_intents = list(TILL_INTENT, /datum/intent/pick, SPEAR_BASH)
 	name = "hoe"
 	desc = "A humble tool for humble tillage. Would you be more concerned if it wasn't dirty and worn?"
 	icon_state = "hoe"


### PR DESCRIPTION
## About The Pull Request
makes till intent first in the list of wielded intents for hoes

## Testing Evidence
compiles

## Why It's Good For The Game
two-handing a hoe and then trying to till dirt with it and attacking the air because the first intent is a weapon intent is, uh, bad. nobody is using hoes as weapons often enough to justify that being their first intent. this also brings them in line with threshers and shovels, both of which can be used as a weapon but have their tool intents first

## Changelog

:cl:
qol: hoes now have till intent as their first intent when two-handed
/:cl:
