### PR TITLE
inquisitor inspector buff

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -147,7 +147,7 @@
 	is_silver = TRUE
 	force = 25
 	possible_item_intents = list(/datum/intent/whip/lash/master, /datum/intent/whip/crack, /datum/intent/whip/punish)
-	minstr = 11
+	minstr = 10
 	wdefense = 0
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/silver

--- a/code/modules/jobs/job_types/roguetown/Inquisition/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/inquisitor.dm
@@ -51,12 +51,11 @@
 		)
 	subclass_stats = list(
 		STATKEY_CON = 1,
-		STATKEY_PER = 2,
-		STATKEY_INT = 2,
+		STATKEY_PER = 3,
+		STATKEY_INT = 3,
 		STATKEY_STR = 1,
 		STATKEY_WIL = 1,
 		STATKEY_SPD = 1,
-		STATKEY_STR = 1,
 	)
 	subclass_skills = list(
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_MASTER,


### PR DESCRIPTION


## About The Pull Request

makes daybreak 10 str to wield so you don't screw yourself over building spd.

This also returns the inspector to their first niche, which was being very versatile. In turn, they get expert weapons in almost every combat skill besides shields and wrestling. Their combat skills look like this now. Picking a weapon no longer changes your skills at all.
<img width="357" height="267" alt="image" src="https://github.com/user-attachments/assets/cfba25a8-3f0d-4a74-8c09-245856aa9097" />

it also adds two confessor weapons to their spawn gear, so they aren't forced to pick from only sharp weapons that are nerfed from default weapons because they are silver. (also they use to be confessors or whatever.)
## Testing Evidence
compiles, works.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I didn't import the dmi of that sick ass coat and hat for the class to be terrible compared to the larp ordinator guy.
atleast inspector now gets something unique being their sheer amount of skills. Now, with their decent starting cash inquisitors can literally use anything they want, letting inquisitors use their brain to create cool and unique loadouts.

or just use the starting gear im not your boss.  

this also gives you a real choice between these sublcasses where you can take ordinator to get (1) master weapon combat skill or inspector to get everything. 
