### PR TITLE
Announcening 2

### DIFF
--- a/code/modules/antagonists/roguetown/villain/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich.dm
@@ -337,7 +337,7 @@
 
 /obj/effect/proc_holder/spell/self/lich_announce_global
 	name = "Bellow Will"
-	desc = "Bellow a commandment, which will be heard by all undead creechers - irregardless of their location - underneath your command."
+	desc = "Bellow a commandment, which will be heard by all creechers - irregardless of their location."
 	recharge_time = 10 MINUTES
 
 /obj/effect/proc_holder/spell/self/lich_announce_global/cast(list/targets, mob/user)

--- a/code/modules/antagonists/roguetown/villain/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich.dm
@@ -151,6 +151,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/suicidebomb)
 		H.mind.AddSpell(new	/obj/effect/proc_holder/spell/invoked/remotebomb)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/lich_announce)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/lich_announce_global)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tame_undead)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_deadite)
@@ -333,3 +334,22 @@
 		skele.current.playsound_local(get_turf(A.owner), 'sound/misc/deadbell.ogg', 50, FALSE)
 
 	..()
+
+/obj/effect/proc_holder/spell/self/lich_announce_global
+	name = "Bellow Will"
+	desc = "Bellow a commandment, which will be heard by all undead creechers - irregardless of their location - underneath your command."
+	recharge_time = 10 MINUTES
+
+/obj/effect/proc_holder/spell/self/lich_announce_global/cast(list/targets, mob/user)
+	if(user.stat)
+		return
+	var/announcementinput = input("Bellow to the Peaks", "Make an Announcement") as text|null
+	if(announcementinput)
+		visible_message(span_warning("[usr] gathers their power."))
+		if(do_after(usr, 10 SECONDS, target = usr))
+			say(announcementinput)
+			var/sanitized_input = trim(copytext(sanitize(announcementinput), 1, MAX_MESSAGE_LEN))
+			priority_announce("[sanitized_input]", "The Lich Rattles", 'sound/misc/deadbell.ogg', sender = usr)
+		else
+			to_chat(usr, span_warning("Your announcement was interrupted!"))
+			return FALSE

--- a/code/modules/jobs/job_types/roguetown/burghers/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/guildmaster.dm
@@ -1,5 +1,3 @@
-#define GUILDMASTER_ANNOUNCEMENT_COOLDOWN (2 MINUTES)
-
 /datum/job/roguetown/guildmaster
 	title = "Guildmaster"
 	flag = GUILDMASTER
@@ -78,7 +76,6 @@
 	if(H.mind)
 		// Skillset is a combo of Artificer + Blacksmith with Labor Skills.
 		// And Tailor / Leathercrafting
-		H.verbs += /mob/living/carbon/human/proc/guild_announcement
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/jacket/artijacket
 		pants = /obj/item/clothing/under/roguetown/trou/artipants
 		shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
@@ -102,32 +99,3 @@
 
 /datum/outfit/job/roguetown/guildmaster/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
-
-/mob/living/carbon/human/proc/guild_announcement()
-	set name = "Announcement"
-	set category = "GUILDMASTER"
-	if(stat)
-		return
-	var/announcementinput = input("Bellow to the Peaks", "Make an Announcement") as text|null
-	if(announcementinput)
-		if(!src.can_speak_vocal())
-			to_chat(src,span_warning("I can't speak!"))
-			return FALSE
-		if(!istype(get_area(src), /area/rogue/indoors/town/dwarfin))//Nuh uh
-			to_chat(src, span_warning("I can only speak from within the Guild."))
-			return FALSE
-		if (!COOLDOWN_FINISHED(src, guildmaster_announcement))
-			to_chat(src, span_warning("You must wait before speaking again."))
-			return FALSE
-		visible_message(span_warning("[src] takes a deep breath, preparing to make an announcement."))
-		if(do_after(src, 15 SECONDS, target = src)) // Reduced to 15 seconds from 30 on the original Herald PR. 15 is well enough time for sm1 to shove you.
-			say(announcementinput)
-			var/sanitized_input = trim(copytext(sanitize(announcementinput), 1, MAX_MESSAGE_LEN))
-			var/treated_input = treat_message(sanitized_input, /datum/language/common)
-			priority_announce("[treated_input]", "The Guildmaster Heralds", 'sound/misc/bell.ogg', sender = src)
-			COOLDOWN_START(src, guildmaster_announcement, GUILDMASTER_ANNOUNCEMENT_COOLDOWN)
-		else
-			to_chat(src, span_warning("Your announcement was interrupted!"))
-			return FALSE
-
-#undef GUILDMASTER_ANNOUNCEMENT_COOLDOWN


### PR DESCRIPTION
## About The Pull Request

Removes guildmaster announcements, it's used exclusively for shitposting and nothing of value, I'd accept crier having it but eh.
Gives Lich global announcement so that the WAR antag can actually somewhat communicate his intentions with the town and such.

## Testing Evidence

(the logging got fixed after)
<img width="550" height="171" alt="image" src="https://github.com/user-attachments/assets/397d4a16-edfa-4b34-80d6-acd16d99d5b1" />


## Why It's Good For The Game

Byeah
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Lich announcements
del: Guildmaster announcements
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
