### PR TITLE
Renameable/describable underwear

### DIFF
--- a/code/game/objects/items/rogueitems/undies.dm
+++ b/code/game/objects/items/rogueitems/undies.dm
@@ -5,7 +5,7 @@
 	icon_state = "briefs"
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
-	obj_flags = CAN_BE_HIT
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	break_sound = 'sound/foley/cloth_rip.ogg'
 	blade_dulling = DULLING_CUT
 	max_integrity = 200


### PR DESCRIPTION
## About The Pull Request

Azure is saved.
You can now use feathers to rename/describe all undies sub-objects.

## Testing Evidence

I tested it. It works. It's one obj flag.

## Why It's Good For The Game

Flavor and RP. Probably an oversight that this wasn't already like this.

## Changelog

:cl:
qol: Underwear is describable/renamable now
/:cl:
