### PR TITLE
Fixes Martyr weapons being dulled on Oath activiation

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -412,14 +412,14 @@
 				adjust_stats(current_state)	//Lowers the damage of the sword due to safe activation.
 				current_holder.energy = current_holder.max_energy
 				current_holder.stamina = 0
-				I.sharpness = I.max_blade_int
+				I.blade_int = I.max_blade_int
 			if(STATE_MARTYR)
 				end_activation = world.time + martyr_duration
 				I.max_integrity = 2000				//If you're committing, we repair the weapon and give it a boost so it lasts the whole fight
 				I.obj_integrity = I.max_integrity
 
 				I.max_blade_int = 9999
-				I.sharpness = I.max_blade_int
+				I.blade_int = I.max_blade_int
 				adjust_stats(current_state)	//Gives them extra stats.
 
 				current_holder.stamina = 0
@@ -432,7 +432,7 @@
 				I.obj_integrity = I.max_integrity
 
 				I.max_blade_int = 9999
-				I.sharpness = I.max_blade_int
+				I.blade_int = I.max_blade_int
 				
 				current_holder.adjust_skillrank(/datum/skill/misc/athletics, 6, FALSE)
 


### PR DESCRIPTION
## About The Pull Request

Invoking your martyr oath set the sharpness of a weapon to 9999
but it never actually sharpened the weapon.
So you were stuck with a near fully blunted weapon, actually getting weaker than outside of your ult.

## Testing Evidence
blunt bad
<img width="692" height="713" alt="Screenshot 2026-03-17 060715" src="https://github.com/user-attachments/assets/6c13beb5-5a7d-441b-af98-476304ffc3a1" />
sharp goog
<img width="433" height="348" alt="Screenshot 2026-03-17 063753" src="https://github.com/user-attachments/assets/789b7ee4-ae9f-419e-b32e-e4684b4c7ecd" />

## Why It's Good For The Game

Bug bad.
protag moment ruined.
Now saved.
Do crime.

## Changelog

:cl:
fix: fixed martyr weapon no longer blunting on oath use
/:cl: