### PR TITLE
Sloppily Refactors some weapon enchanting kits

### DIFF
--- a/code/datums/loadout/loadout_donators.dm
+++ b/code/datums/loadout/loadout_donators.dm
@@ -83,13 +83,13 @@
 
 /datum/loadout_item/donator_eiren
 	name = "Donator Kit - Regret"
-	path = /obj/item/enchantingkit/eiren
+	path = /obj/item/enchantingkit/weapon/eiren
 	ckeywhitelist = list("eirenxiv")
 	sort_category = "Donator"
 
 /datum/loadout_item/donator_eiren2
 	name = "Donator Kit - Lunae"
-	path = /obj/item/enchantingkit/eirensabre
+	path = /obj/item/enchantingkit/weapon/eirensabre
 	ckeywhitelist = list("eirenxiv")
 	sort_category = "Donator"
 
@@ -119,7 +119,7 @@
 
 /datum/loadout_item/donator_inverserun
 	name = "Donator Kit - Votive Thorns"
-	path = /obj/item/enchantingkit/inverserun
+	path = /obj/item/enchantingkit/weapon/inverserun
 	ckeywhitelist = list("inverserun")
 	sort_category = "Donator"
 

--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -223,7 +223,7 @@
 
 /datum/loadout_item/triumph_weaponkitsword
 	name = "Morphing Elixir, 'Valorian Sword'"
-	path = /obj/item/enchantingkit/triumph_weaponkit_sword
+	path = /obj/item/enchantingkit/weapon/triumph_weaponkit_sword
 	triumph_cost = 3
 	sort_category = "Triumphs"
 

--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -253,7 +253,7 @@
 
 /datum/loadout_item/triumph_weaponkitrock
 	name = "Morphing Elixir, 'Rockhillian Longsword'"
-	path = /obj/item/enchantingkit/triumph_weaponkit_rock
+	path = /obj/item/enchantingkit/weapon/triumph_weaponkit_rock
 	triumph_cost = 3
 	sort_category = "Triumphs"
 

--- a/code/game/objects/items/donator_fluff_items.dm
+++ b/code/game/objects/items/donator_fluff_items.dm
@@ -144,39 +144,6 @@
 	mob_overlay_icon = 'icons/clothing/onmob/donor_clothes.dmi'
 
 
-//Eiren's donator items - zweihander and sabres
-/obj/item/rogueweapon/greatsword/zwei/eiren
-	name = "Regret"
-	desc = "People bring the small flames of their wishes together... to keep them from burning out, we cast our own flames into the biggest fire we can find. But you know... I didn't bring a flame with me. As for me, maybe I just wandered up to the campfire to warm myself a little..."
-	icon_state = "eiren"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
-
-/obj/item/rogueweapon/greatsword/eiren
-	name = "Regret"
-	desc = "People bring the small flames of their wishes together... to keep them from burning out, we cast our own flames into the biggest fire we can find. But you know... I didn't bring a flame with me. As for me, maybe I just wandered up to the campfire to warm myself a little..."
-	icon_state = "eiren"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
-
-/obj/item/rogueweapon/greatsword/grenz/flamberge/eiren
-	name = "Regret"
-	desc = "People bring the small flames of their wishes together... to keep them from burning out, we cast our own flames into the biggest fire we can find. But you know... I didn't bring a flame with me. As for me, maybe I just wandered up to the campfire to warm myself a little..."
-	icon_state = "eiren"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
-
-/obj/item/rogueweapon/sword/sabre/eiren
-	name = "Lunae"
-	desc = "Two blades, one forged in Noc's light, a soothing breath of clarity. Here, and here alone, were moon and fire ever together."
-	icon_state = "eiren2"
-	icon = 'icons/obj/items/donor_weapons.dmi'
-	sheathe_icon = "eiren2"
-
-/obj/item/rogueweapon/sword/sabre/eiren/small
-	name = "Cinis"
-	desc = "Two blades, the other born of Astrata's ire, a raging flame of passion. Here, and here alone, were fates severed and torn."
-	icon_state = "eiren3"
-	icon = 'icons/obj/items/donor_weapons.dmi'
-	sheathe_icon = "eiren3"
-
 /obj/item/clothing/suit/roguetown/armor/longcoat/eiren //Longcoat has no armor, ignore the /armor/ path.
 	name = "Darkwood's Embrace"
 	desc = "A tough leather coat, taken from one of the few remaining arcyne studies of Lord Darkwood. Ancient, but in remarkably good condition as the weight of memory and sin tries to drag you down."
@@ -205,12 +172,6 @@
 			pic.color = get_detail_color()
 		add_overlay(pic)
 
-//pretzel's special things
-/obj/item/rogueweapon/greatsword/weeperslathe
-	name = "Weeper's Lathe"
-	desc = "A recreation of a gilbronze greatsword, wrought in steel. Inscribed on the blade is a declaration: \"I HAVE ONLY A SHORT TYME TO LYVE, BUT I AM NOT AFRAID TO DIE.\""
-	icon_state = "weeperslathe"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
 
 /obj/item/clothing/head/roguetown/duelhat/pretzel
 	name = "rethrifted gravedigger's hat" 
@@ -222,25 +183,6 @@
 	item_state = "pretzel_stolenhat"
 	icon = 'icons/clothing/donor_clothes.dmi'
 	mob_overlay_icon = 'icons/clothing/onmob/donor_clothes.dmi'
-
-//inverserun's claymore
-/obj/item/rogueweapon/greatsword/zwei/inverserun
-	name = "Votive Thorns"
-	desc = "Promises hurt, but so does plucking rosa. Hoping hurts, but so does looking at the beauty of Astrata's light. Pick yourself back up. Remember your promise, despite the thorns."
-	icon_state = "inverse"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
-
-/obj/item/rogueweapon/greatsword/inverserun
-	name = "Votive Thorns"
-	desc = "Promises hurt, but so does plucking rosa. Hoping hurts, but so does looking at the beauty of Astrata's light. Pick yourself back up. Remember your promise, despite the thorns."
-	icon_state = "inverse"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
-
-/obj/item/rogueweapon/greatsword/grenz/flamberge/inverserun
-	name = "Votive Thorns"
-	desc = "Promises hurt, but so does plucking rosa. Hoping hurts, but so does looking at the beauty of Astrata's light. Pick yourself back up. Remember your promise, despite the thorns."
-	icon_state = "inverse"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
 
 /obj/item/clothing/cloak/raincloak/feather_cloak
 	name = "Shroud of the Undermaiden"
@@ -407,19 +349,6 @@
 	worn_x_dimension = 64
 	worn_y_dimension = 64
 	bloody_icon = 'icons/effects/blood64.dmi'
-
-//STINKETHSTONKETH
-/obj/item/rogueweapon/sword/sabre/steppesman/stinketh
-	name = "fencer's shashka"
-	desc = "A heirloom shashka with guardless hilt plated in silver and adorned  with a Mamuk hide grip. A sabre's blade has been added in place of the old one, affording it lethality and reach whilst dismounted."
-	icon_state = "stinketh_shashka"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
-
-/obj/item/rogueweapon/sword/sabre/freifechter/stinketh
-	name = "fencer's shashka"
-	desc = "A heirloom shashka with guardless hilt plated in silver and adorned  with a Mamuk hide grip. A sabre's blade has been added in place of the old one, affording it lethality and reach whilst dismounted."
-	icon_state = "stinketh_shashka"
-	icon = 'icons/obj/items/donor_weapons_64.dmi'
 
 /obj/item/rogueweapon/spear/boar/frei/pike/stinketh
 	name = "Kindness of Ravens Standard"

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -7,6 +7,7 @@
 	icon_state = "enchanting_kit"
 	w_class = WEIGHT_CLASS_SMALL	//So can fit in a bag, we don't need these large. They're just used to apply to items.
 	var/list/target_items = list()
+	/// Result item we'll exchange it to. Currently /weapon/ type kits use this as an example they'll copy all the visual data from. Keep this in mind if this never gets properly refactored!
 	var/result_item = null
 
 /obj/item/enchantingkit/pre_attack(obj/item/I, mob/user)

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -365,7 +365,7 @@
 		)
 	result_item = null
 
-/obj/item/enchantingkit/triumph_weaponkit_rock
+/obj/item/enchantingkit/weapon/triumph_weaponkit_rock
 	name = "'Rockhillian' longsword morphing elixir"
 	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of.. </br>..a Steel Longsword.. </br>..a Steel Broadsword.. </br>..or an Executioner Sword."
 	target_items = list(

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -65,7 +65,8 @@
 		return ..()
 
 	if(!isturf(I.loc))
-		return ..()
+		to_chat(user, span_info("This should be on the floor, lest I spill it onto myself."))
+		return
 
 	if(!istype(I, /obj/item/rogueweapon))
 		return ..()

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -23,8 +23,11 @@
 				R_type = target_items[T]
 				break
 
-	if(!R_type)
+	if(!R_type && result_item)
 		R_type = result_item
+
+	if(!R_type && !result_item)
+		CRASH("No result_item on a donator kit while R_type was empty. Something went wrong.")
 
 	if(!R_type)
 		to_chat(user, span_warning("[src] doesn't know how to morph [I]."))
@@ -48,6 +51,47 @@
 	qdel(I)
 	if(!user.put_in_hands(R))
 		R.forceMove(get_turf(user))
+
+	if(ismob(user))
+		var/mob/M = user
+		M.update_body()
+
+	qdel(src)
+	return TRUE
+
+/obj/item/enchantingkit/weapon/pre_attack(obj/item/I, mob/user)
+	if(!I || !user)
+		return ..()
+
+	if(!isturf(I.loc))
+		return ..()
+
+	if(!istype(I, /obj/item/rogueweapon))
+		return ..()
+
+	if(!is_type_in_list(I, target_items))
+		return ..()
+
+	var/R_type = result_item
+
+	if(!R_type)
+		to_chat(user, span_warning("[src] doesn't know how to morph [I]."))
+		return TRUE
+	
+	var/obj/item/rogueweapon/RI = R_type
+	var/obj/item/rogueweapon/TI = I
+	TI.icon = RI::icon
+	TI.icon_state = RI::icon_state
+	TI.item_state = RI::item_state
+	TI.toggle_state = RI::icon_state
+	TI.lefthand_file = RI::lefthand_file
+	TI.righthand_file = RI::righthand_file
+	TI.sheathe_icon = RI::sheathe_icon ? RI::sheathe_icon : TI.sheathe_icon
+
+	to_chat(user, span_notice("You apply the [src] to [I], using the enchanting dust and tools to turn it into [RI::name]."))
+	I.name = "[RI::name] <font size = 1>([I.name])</font>"
+	I.desc = RI::desc
+	I.update_transform()
 
 	if(ismob(user))
 		var/mob/M = user
@@ -134,40 +178,40 @@
 	result_item = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron/zydrasiconosash
 
 //Eiren - Zweihander and sabres
-/obj/item/enchantingkit/eiren
+/obj/item/enchantingkit/weapon/eiren
 	name = "'Regret' morphing elixir"
 	target_items = list(
-		/obj/item/rogueweapon/greatsword/grenz/flamberge 	= /obj/item/rogueweapon/greatsword/grenz/flamberge/eiren,
-		/obj/item/rogueweapon/greatsword/zwei 				= /obj/item/rogueweapon/greatsword/zwei/eiren,
-		/obj/item/rogueweapon/greatsword	  				= /obj/item/rogueweapon/greatsword/eiren
+		/obj/item/rogueweapon/greatsword/grenz/flamberge,
+		/obj/item/rogueweapon/greatsword/zwei,
+		/obj/item/rogueweapon/greatsword
 		)
-	result_item = null
+	result_item = /obj/item/rogueweapon/example/eiren_greatsword
 
-/obj/item/enchantingkit/eirensabre
+/obj/item/enchantingkit/weapon/eirensabre
 	name = "'Lunae' morphing elixir"
 	target_items = list(/obj/item/rogueweapon/sword/sabre)
-	result_item = /obj/item/rogueweapon/sword/sabre/eiren
+	result_item = /obj/item/rogueweapon/example/eiren_sabre
 
 /obj/item/enchantingkit/eirensabre2
 	name = "'Cinis' morphing elixir"
-	target_items = list(/obj/item/rogueweapon/sword/sabre)
-	result_item = /obj/item/rogueweapon/sword/sabre/eiren/small
+	target_items = list(/obj/item/rogueweapon/sword/saber)
+	result_item = /obj/item/rogueweapon/example/eiren_sabre_alt
 
 //pretzel - custom steel greatsword. PSYDON LYVES. PSYDON ENDVRES.
 /obj/item/enchantingkit/waff
 	name = "'Weeper's Lathe' morphing elixir"
-	target_items = list(/obj/item/rogueweapon/greatsword)		// i, uh. i really do promise i'm only gonna use it on steel greatswords.
-	result_item = /obj/item/rogueweapon/greatsword/weeperslathe
+	target_items = list(/obj/item/rogueweapon/greatsword)
+	result_item = /obj/item/rogueweapon/example/waffai_greatsword
 
 //inverserun claymore
-/obj/item/enchantingkit/inverserun
+/obj/item/enchantingkit/weapon/inverserun
 	name = "'Votive Thorns' morphing elixir"
 	target_items = list(
-		/obj/item/rogueweapon/greatsword/grenz/flamberge 	= /obj/item/rogueweapon/greatsword/grenz/flamberge/inverserun,
-		/obj/item/rogueweapon/greatsword/zwei 				= /obj/item/rogueweapon/greatsword/zwei/inverserun,
-		/obj/item/rogueweapon/greatsword	  				= /obj/item/rogueweapon/greatsword/inverserun
+		/obj/item/rogueweapon/greatsword/grenz/flamberge,
+		/obj/item/rogueweapon/greatsword/zwei,
+		/obj/item/rogueweapon/greatsword
 		)
-	result_item = null
+	result_item = /obj/item/rogueweapon/example/inverserun_greatsword
 
 //Zoe - Tytos Blackwood cloak
 /obj/item/enchantingkit/zoe
@@ -219,10 +263,10 @@
 /obj/item/enchantingkit/stinketh_shashka
 	name = "'fencer's shashka' morphing elixir"
 	target_items = list(
-		/obj/item/rogueweapon/sword/sabre/freifechter	= /obj/item/rogueweapon/sword/sabre/freifechter/stinketh,
-		/obj/item/rogueweapon/sword/sabre/steppesman	= /obj/item/rogueweapon/sword/sabre/steppesman/stinketh
-		)
-	result_item = null
+		/obj/item/rogueweapon/sword/sabre/freifechter,
+		/obj/item/rogueweapon/sword/sabre/steppesman
+	)
+	result_item = /obj/item/rogueweapon/example/stinketh_sabre
 
 /obj/item/enchantingkit/stinketh_pike
 	name = "'Kindness of Ravens Standard' morphing elixir"
@@ -296,15 +340,15 @@
 		)
 	result_item = null
 
-/obj/item/enchantingkit/triumph_weaponkit_sword
+/obj/item/enchantingkit/weapon/triumph_weaponkit_sword
 	name = "'Valorian' sword morphing elixir"
 	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of.. </br>..an Iron Arming Sword.. </br>..an Iron Dueling Sword.. </br>..or a Maciejowski."
 	target_items = list(
-		/obj/item/rogueweapon/sword/iron										= /obj/item/rogueweapon/sword/iron/triumph,
-		/obj/item/rogueweapon/sword/short/messer/iron/virtue					= /obj/item/rogueweapon/sword/short/messer/iron/virtue/triumph,
-		/obj/item/rogueweapon/sword/falchion/militia	  						= /obj/item/rogueweapon/sword/falchion/militia/triumph
+		/obj/item/rogueweapon/sword/iron,
+		/obj/item/rogueweapon/sword/short/messer/iron/virtue,
+		/obj/item/rogueweapon/sword/falchion/militia
 		)
-	result_item = null
+	result_item = /obj/item/rogueweapon/example/valorian_sword
 
 /obj/item/enchantingkit/triumph_weaponkit_tri
 	name = "'Valorian' longsword morphing elixir"
@@ -317,7 +361,7 @@
 	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of.. </br>..a Steel Longsword </br>..or a Rapier."
 	target_items = list(
 		/obj/item/rogueweapon/sword/long					= /obj/item/rogueweapon/sword/long/triumph/wideguard,
-		/obj/item/rogueweapon/sword/rapier	  			= /obj/item/rogueweapon/sword/rapier/wideguard
+		/obj/item/rogueweapon/sword/rapier	  				= /obj/item/rogueweapon/sword/rapier/wideguard
 		)
 	result_item = null
 
@@ -325,12 +369,12 @@
 	name = "'Rockhillian' longsword morphing elixir"
 	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of.. </br>..a Steel Longsword.. </br>..a Steel Broadsword.. </br>..or an Executioner Sword."
 	target_items = list(
-		/obj/item/rogueweapon/sword/long/broadsword/bronze		= /obj/item/rogueweapon/sword/long/broadsword/bronze/rockhill,
-		/obj/item/rogueweapon/sword/long/broadsword/steel		= /obj/item/rogueweapon/sword/long/broadsword/steel/rockhill,
-		/obj/item/rogueweapon/sword/long/broadsword				= /obj/item/rogueweapon/sword/long/broadsword/rockhill,
-		/obj/item/rogueweapon/sword/long/exe	  				= /obj/item/rogueweapon/sword/long/exe/rockhill
+		/obj/item/rogueweapon/sword/long/broadsword/bronze,
+		/obj/item/rogueweapon/sword/long/broadsword/steel,
+		/obj/item/rogueweapon/sword/long/broadsword,
+		/obj/item/rogueweapon/sword/long/exe
 		)
-	result_item = null
+	result_item = /obj/item/rogueweapon/example/valorian_broadsword
 
 /obj/item/enchantingkit/triumph_weaponkit_sabre
 	name = "'Sabreguard' longsword morphing elixir"

--- a/code/game/objects/items/rogueweapons/enchanting_examples.dm
+++ b/code/game/objects/items/rogueweapons/enchanting_examples.dm
@@ -1,0 +1,59 @@
+// Eirenxiv
+/obj/item/rogueweapon/example/eiren_sabre
+	name = "Lunae"
+	desc = "Two blades, one forged in Noc's light, a soothing breath of clarity. Here, and here alone, were moon and fire ever together."
+	icon_state = "eiren2"
+	icon = 'icons/obj/items/donor_weapons.dmi'
+	sheathe_icon = "eiren2"
+
+/obj/item/rogueweapon/example/eiren_sabre_alt
+	name = "Cinis"
+	desc = "Two blades, the other born of Astrata's ire, a raging flame of passion. Here, and here alone, were fates severed and torn."
+	icon_state = "eiren3"
+	icon = 'icons/obj/items/donor_weapons.dmi'
+	sheathe_icon = "eiren3"
+
+/obj/item/rogueweapon/example/eiren_greatsword
+	name = "Regret"
+	desc = "People bring the small flames of their wishes together... to keep them from burning out, we cast our own flames into the biggest fire we can find. But you know... I didn't bring a flame with me. As for me, maybe I just wandered up to the campfire to warm myself a little..."
+	icon_state = "eiren"
+	icon = 'icons/obj/items/donor_weapons_64.dmi'
+// Eirenxiv -- End
+
+// Inverserun
+/obj/item/rogueweapon/example/inverserun_greatsword
+	name = "Votive Thorns"
+	desc = "Promises hurt, but so does plucking rosa. Hoping hurts, but so does looking at the beauty of Astrata's light. Pick yourself back up. Remember your promise, despite the thorns."
+	icon_state = "inverse"
+	icon = 'icons/obj/items/donor_weapons_64.dmi'
+
+// waffai
+/obj/item/rogueweapon/example/waffai_greatsword
+	name = "Weeper's Lathe"
+	desc = "A recreation of a gilbronze greatsword, wrought in steel. Inscribed on the blade is a declaration: \"I HAVE ONLY A SHORT TYME TO LYVE, BUT I AM NOT AFRAID TO DIE.\""
+	icon_state = "weeperslathe"
+	icon = 'icons/obj/items/donor_weapons_64.dmi'
+
+// stinkethstoneth
+/obj/item/rogueweapon/example/stinketh_sabre
+	name = "fencer's shashka"
+	desc = "A heirloom shashka with guardless hilt plated in silver and adorned  with a Mamuk hide grip. A sabre's blade has been added in place of the old one, affording it lethality and reach whilst dismounted."
+	icon_state = "stinketh_shashka"
+	icon = 'icons/obj/items/donor_weapons_64.dmi'
+
+// Triumphs
+/obj/item/rogueweapon/example/valorian_sword
+	name = "valorian sword"
+	desc = "A modest take on a mythical design, hailing from the blood-splattered crossroads \
+	between Valoria and Rockhill. It feels right at home, in the palm of your hand."
+	icon_state = "iswordalt"
+	sheathe_icon = "iswordalt"
+
+/obj/item/rogueweapon/example/valorian_broadsword
+	name = "valorian broadsword"
+	icon = 'icons/roguetown/weapons/64.dmi'
+	desc = "A lethal and well-balanced weapon. The broadsword - better known as a 'hand-and-a-halfer' - has dutifully served the \
+	swordsmen of Psydonia in their clashes against man-and-monster alike since time immemmorial. The edge glimmers with the hopes \
+	and dreams of the Weeping God's children, imbuing your very soul with determination. </br>'There's a light inside your \
+	soul, that’s still shining in the cold: the truth, the promise in our hearts.. ..don't forget, I'm with you in the dark.'"
+	icon_state = "longsword_rockhill"

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -2201,45 +2201,6 @@
 			if("onbelt")
 				return list("shrink" = 0.4,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/rogueweapon/sword/long/broadsword/steel/rockhill //Alternate version of the Broadsword.
-	name = "valorian broadsword"
-	icon = 'icons/roguetown/weapons/64.dmi'
-	desc = "A lethal and well-balanced weapon. The broadsword - better known as a 'hand-and-a-halfer' - has dutifully served the \
-	swordsmen of Psydonia in their clashes against man-and-monster alike since time immemmorial. The edge glimmers with the hopes \
-	and dreams of the Weeping God's children, imbuing your very soul with determination. ‎</br>‎‎ </br>'There's a light inside your \
-	soul, that’s still shining in the cold: the truth, the promise in our hearts.. ..don't forget, I'm with you in the dark.'"
-	icon_state = "longsword_rockhill"
-
-/obj/item/rogueweapon/sword/long/broadsword/rockhill //always worked on the iron version anyway
-	name = "valorian broadsword"
-	icon = 'icons/roguetown/weapons/64.dmi'
-	desc = "A lethal and well-balanced weapon. The broadsword - better known as a 'hand-and-a-halfer' - has dutifully served the \
-	swordsmen of Psydonia in their clashes against man-and-monster alike since time immemmorial. The edge glimmers with the hopes \
-	and dreams of the Weeping God's children, imbuing your very soul with determination. ‎</br>‎‎ </br>'There's a light inside your \
-	soul, that’s still shining in the cold: the truth, the promise in our hearts.. ..don't forget, I'm with you in the dark.'"
-	icon_state = "longsword_rockhill"
-
-/obj/item/rogueweapon/sword/long/broadsword/bronze/rockhill //colours will be off but at least stats work
-	name = "valorian broadsword"
-	icon = 'icons/roguetown/weapons/64.dmi'
-	desc = "A lethal and well-balanced weapon. The broadsword - better known as a 'hand-and-a-halfer' - has dutifully served the \
-	swordsmen of Psydonia in their clashes against man-and-monster alike since time immemmorial. The edge glimmers with the hopes \
-	and dreams of the Weeping God's children, imbuing your very soul with determination. ‎</br>‎‎ </br>'There's a light inside your \
-	soul, that’s still shining in the cold: the truth, the promise in our hearts.. ..don't forget, I'm with you in the dark.'"
-	icon_state = "longsword_rockhill"
-
-/obj/item/rogueweapon/sword/long/broadsword/steel/rockhill/getonmobprop(tag)
-	. = ..()
-	if(tag)
-		switch(tag)
-			if("gen")
-				return list("shrink" = 0.5,"sx" = -14,"sy" = -8,"nx" = 15,"ny" = -7,"wx" = -10,"wy" = -5,"ex" = 7,"ey" = -6,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -13,"sturn" = 110,"wturn" = -60,"eturn" = -30,"nflip" = 1,"sflip" = 1,"wflip" = 8,"eflip" = 1)
-			if("onback")
-				return list("shrink" = 0.5,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
-			if("wielded")
-				return list("shrink" = 0.6,"sx" = 5,"sy" = -2,"nx" = -6,"ny" = -2,"wx" = -6,"wy" = -2,"ex" = 7,"ey" = -2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -28,"sturn" = 29,"wturn" = -35,"eturn" = 32,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
-			if("onbelt")
-				return list("shrink" = 0.4,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/rogueweapon/sword/long/triumph/sabreguard
 	desc = "A lethal and perfectly balanced weapon, the longsword is the protagonist of endless tales and myths \
@@ -2327,28 +2288,5 @@
 				return list("shrink" = 0.6,"sx" = 5,"sy" = -2,"nx" = -6,"ny" = -2,"wx" = -6,"wy" = -2,"ex" = 7,"ey" = -2,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -28,"sturn" = 29,"wturn" = -35,"eturn" = 32,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
 			if("onbelt")
 				return list("shrink" = 0.4,"sx" = -4,"sy" = -6,"nx" = 5,"ny" = -6,"wx" = 0,"wy" = -6,"ex" = -1,"ey" = -6,"nturn" = 100,"sturn" = 156,"wturn" = 90,"eturn" = 180,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
-
-/obj/item/rogueweapon/sword/iron/triumph
-	name = "valorian arming sword"
-	desc = "A modest take on a mythical design, hailing from the blood-splattered crossroads \
-	between Valoria and Rockhill. It feels right at home, in the palm of your hand."
-	icon_state = "iswordalt"
-	sheathe_icon = "iswordalt"
-
-/obj/item/rogueweapon/sword/short/messer/iron/virtue/triumph
-	name = "valorian sword"
-	desc = "A modest take on a mythical design, hailing from the blood-splattered crossroads \
-	between Valoria and Rockhill. The flangs along its crossguard excel at catching the strikes \
-	of another, leaving them unable to persist against the following riposte."
-	icon_state = "iswordalt"
-	sheathe_icon = "iswordalt"
-
-/obj/item/rogueweapon/sword/falchion/militia/triumph
-	name = "valorian messer"
-	desc = "A modest take on a mythical design, hailing from the blood-splattered crossroads \
-	between Valoria and Rockhill. Rumors purport that mercenaries would intentionally chip the \
-	edge of these blades, as the crude serrations left behind could rend goblin-flesh with far more potency."
-	icon_state = "iswordalt"
-	sheathe_icon = "iswordalt"
 
 ////////////////////////

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1193,6 +1193,7 @@
 #include "code\game\objects\items\rogueitems\ropechainbola\chain.dm"
 #include "code\game\objects\items\rogueitems\ropechainbola\net.dm"
 #include "code\game\objects\items\rogueitems\ropechainbola\rope.dm"
+#include "code\game\objects\items\rogueweapons\enchanting_examples.dm"
 #include "code\game\objects\items\rogueweapons\integrity.dm"
 #include "code\game\objects\items\rogueweapons\intent_alert.dm"
 #include "code\game\objects\items\rogueweapons\intents.dm"


### PR DESCRIPTION
## About The Pull Request
Tries to wrangle some of the absolute pathrot we're experiencing due to the enchanting kits requiring dud subtypes for every possible variant of weapon they wish to affect.

This PR is mainly targeted at enchanting kits where many weapon types are meant to "morph" into one, by making a new `/enchantingkit/weapon/` subtype as well as a `/obj/item/rogueweapon/example`, which is meant to store the icon, desc, etc.

No user-facing changes.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
We do not need a custom path for every subvariant of an enchanting kit, especially if they're meant to be reskins. This -tries- to get the kits to function as reskins. It will probably need more bugfixes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
