### PR TITLE
Necran care package

### DIFF
--- a/code/datums/gods/patrons/divine/necra.dm
+++ b/code/datums/gods/patrons/divine/necra.dm
@@ -4,17 +4,17 @@
 	desc = "Veiled Lady of the underworld, equally feared and respected by mortals. She taught mortals the inevitability of death and cares for them as they reach the afterlife."
 	worshippers = "The Dead, Mourners, Gravekeepers"
 	mob_traits = list(TRAIT_SOUL_EXAMINE, TRAIT_NOSTINK)	//No stink is generic but they deal with dead bodies so.. makes sense, I suppose?
-	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
-					/obj/effect/proc_holder/spell/invoked/necras_sight			= CLERIC_T0,
-					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/blood_heal			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/avert					= CLERIC_T1,
-					/obj/effect/proc_holder/spell/targeted/locate_dead 			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/fog_ward				= CLERIC_T1, // Not bugged, only appears on fog rounds!
-					// /obj/effect/proc_holder/spell/targeted/abrogation			= CLERIC_T2, // Imagine that, another disabled Necran spell. Replaced with bless_cross for now.
-					/obj/effect/proc_holder/spell/invoked/bless_cross			= CLERIC_T3,
-					/obj/effect/proc_holder/spell/invoked/raise_spirits_vengeance = CLERIC_T2,
-					/obj/effect/proc_holder/spell/invoked/deaths_door			= CLERIC_T4
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison				= CLERIC_ORI,
+					/obj/effect/proc_holder/spell/invoked/necras_sight				= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 				= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/blood_heal				= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/avert						= CLERIC_T1,
+					/obj/effect/proc_holder/spell/targeted/locate_dead 				= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/fog_ward					= CLERIC_T1, // Not bugged, only appears on fog rounds!
+					/obj/effect/proc_holder/spell/invoked/raise_spirits_vengeance 	= CLERIC_T2,
+					/obj/effect/proc_holder/spell/targeted/abrogation				= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/bless_cross				= CLERIC_T3,
+					/obj/effect/proc_holder/spell/invoked/deaths_door				= CLERIC_T4
 	)
 	confess_lines = list(
 		"ALL SOULS FIND THEIR WAY TO NECRA!",

--- a/code/modules/spells/pantheon/divine/necra.dm
+++ b/code/modules/spells/pantheon/divine/necra.dm
@@ -1,5 +1,3 @@
-#define CHURN_FILTER "churn_glow"
-
 // T0: Necra's Sight
 
 /obj/effect/proc_holder/spell/invoked/necras_sight
@@ -392,7 +390,6 @@
 		if(LAZYLEN(things_to_stun))
 			for(var/mob/living/thing in things_to_churn)
 				thing.Stun(2 SECONDS)
-				thing.emote("scream")
 		if(!LAZYLEN(things_to_churn))
 			to_chat(user, span_notice("The rite of Abrogation passes from my lips in silence, having found nothing to assail."))
 			return
@@ -414,7 +411,6 @@
 	effectedstats = list(STATKEY_PER = -2, STATKEY_CON = -2, STATKEY_LCK = -2)
 	status_type = STATUS_EFFECT_REFRESH
 	var/datum/weakref/debuffer
-	var/outline_colour = "#33cabc"
 	var/base_tick = 0.2
 	var/intensity = 1
 	var/range = 7
@@ -426,10 +422,7 @@
 	return ..()
 
 /datum/status_effect/churned/on_apply()
-	var/filter = owner.get_filter(CHURN_FILTER)
 	to_chat(owner, span_warning("Wisps leap from the cloying mists to surround me, their chill disrupting my body! FLEE!"))
-	if (!filter)
-		owner.add_filter(CHURN_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
 	return TRUE
 
 /datum/status_effect/churned/refresh()
@@ -451,11 +444,6 @@
 	if (get_dist(our_debuffer, owner) > range)
 		to_chat(owner, span_notice("I've escaped the cloying mists!"))
 		qdel(src)
-
-/datum/status_effect/churned/on_remove()
-	owner.remove_filter(CHURN_FILTER)
-
-#undef CHURN_FILTER
 
 // Not even used right now.
 /obj/effect/proc_holder/spell/invoked/necra_vow

--- a/code/modules/spells/pantheon/divine/necra.dm
+++ b/code/modules/spells/pantheon/divine/necra.dm
@@ -1,350 +1,6 @@
 #define CHURN_FILTER "churn_glow"
 
-// T1: Avert End (channel on an adjacent target to slowly spend devotion to grant them NODEATH and ticks of oxyloss healing)
-
-/obj/effect/proc_holder/spell/invoked/avert
-	name = "Borrowed Time"
-	desc = "Shield your fellow man from the Undermaiden's gaze, preventing them from slipping into death for as long as your faith and fatigue may muster."
-	overlay_state = "borrowtime"
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
-	associated_skill = /datum/skill/magic/holy
-	miracle = TRUE
-	devotion_cost = 10
-	var/list/near_death_lines = list(
-		"A haze begins to envelop me, but then suddenly recedes, as if warded back by some great light...",
-		"A terrible weight bears down upon me, as if the wyrld itself were crushing me with its heft...",
-		"The sound of a placid river drifts into hearing, followed by the ominous toll of a ferryman's bell...",
-		"Some vast, immeasurably distant figure looms beyond my perception - I feel it, more than I see. It waits. It watches.",
-	)
-
-/obj/effect/proc_holder/spell/invoked/avert/cast(list/targets, mob/living/carbon/human/user)
-	. = ..()
-	var/atom/target = targets[1]
-	if (!isliving(target))
-		revert_cast()
-		return FALSE
-
-	var/mob/living/living_target = target
-	if (!user.Adjacent(target))
-		to_chat(user, span_warning("I must be beside [living_target] to avert Her gaze from [living_target.p_them()]!"))
-		revert_cast()
-		return FALSE
-
-	// add the no-death trait to them....
-	user.visible_message(span_notice("Whispering motes gently bead from [user]'s fingers as [user.p_they()] place a hand near [living_target], scriptures of the Undermaiden spilling from their lips..."), span_notice("I stand beside [living_target] and utter the hallowed words of Aeon's Intercession, staying Her grasp for just a little while longer..."))
-	to_chat(user, span_small("I must remain still and at [living_target]'s side..."))
-	to_chat(living_target, span_warning("An odd sensation blossoms in my chest, cold and unknown..."))
-
-	ADD_TRAIT(living_target, TRAIT_NODEATH, "avert_spell")
-
-	var/our_holy_skill = user.get_skill_level(associated_skill)
-	var/tickspeed = 30 + (5 * our_holy_skill)
-
-	while (do_after(user, tickspeed, target = living_target))
-		user.stamina_add(2.5)
-
-		living_target.adjustOxyLoss(-10)
-		living_target.blood_volume = max((BLOOD_VOLUME_SURVIVE * 1.5), living_target.blood_volume)
-
-		if (living_target.health <= 5)
-			if (prob(5))
-				to_chat(living_target, span_small(pick(near_death_lines)))
-
-		if (user.devotion?.check_devotion(src))
-			user.devotion?.update_devotion(-10)
-		else
-			to_chat(span_warning("My devotion runs dry - the Intercession fades from my lips!"))
-			break
-
-	REMOVE_TRAIT(living_target, TRAIT_NODEATH, "avert_spell")
-
-	user.visible_message(span_danger("[user]'s concentration breaks, the motes receding from [living_target] and into [user.p_their()] hand once more."), span_danger("My concentration breaks, and the Intercession falls silent."))
-
-/obj/effect/proc_holder/spell/targeted/abrogation
-	name = "Abrogation"
-	desc = "Debuffs targeted undead as long as they remain near you, slowly getting set on fire if they stay."
-	range = 8
-	overlay_state = "necra"
-	releasedrain = 30
-	chargedloop = /datum/looping_sound/invokeholy
-	chargetime = 50
-	chargedrain = 0.5
-	recharge_time = 30 SECONDS
-	max_targets = 0
-	cast_without_targets = TRUE
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
-	sound = 'sound/magic/churn.ogg'
-	associated_skill = /datum/skill/magic/holy
-	invocations = list("The Undermaiden rebukes!")
-	invocation_type = "shout" //can be none, whisper, emote and shout
-	miracle = TRUE
-	devotion_cost = 20
-
-/obj/effect/proc_holder/spell/targeted/abrogation/cast(list/targets, mob/living/user = usr)
-	. = ..()
-	var/debuff_power = 1
-	if (user && user.mind)
-		debuff_power = clamp((user.get_skill_level(/datum/skill/magic/holy) / 2), 1, 3)
-
-	var/too_powerful = FALSE
-	var/list/things_to_churn = list()
-	var/list/things_to_stun = list()
-	for (var/mob/living/L in targets)
-		var/is_vampire = FALSE
-		var/is_zombie = FALSE
-		if(L.stat == DEAD)
-			continue
-		if (L.mind)
-			var/datum/antagonist/vampire/V = L.mind.has_antag_datum(/datum/antagonist/vampire)
-			if(V && SEND_SIGNAL(L, COMSIG_DISGUISE_STATUS))
-				is_vampire = TRUE
-			if (L.mind.has_antag_datum(/datum/antagonist/zombie))
-				is_zombie = TRUE
-				things_to_stun += L
-			if (L.mind.special_role == "Vampire Lord")
-				too_powerful = L
-				user.visible_message(span_warning("[user] suddenly pales before an unseen presence, and gasps!"), span_warning("The sound of rushing blood fills my ears and mind, drowning out my abrogation!"))
-				break
-		if (L.mob_biotypes & MOB_UNDEAD || is_vampire || is_zombie)
-			things_to_churn += L
-
-	if (!too_powerful)
-		if (LAZYLEN(things_to_churn))
-			user.visible_message(span_warning("A frigid blue glower suddenly erupts in [user]'s eyes as a whispered prayer summons forth a winding veil of ghostly mists!"), span_notice("I perform the sacred rite of Abrogation, bringing forth Her servants to harry and weaken the unliving!"))
-			for(var/mob/living/thing in things_to_churn)
-				if(spell_guard_check(thing, TRUE))
-					thing.visible_message(span_warning("[thing] resists the abrogation!"))
-					things_to_churn -= thing
-					continue
-				thing.apply_status_effect(/datum/status_effect/churned, user, debuff_power)
-		if(LAZYLEN(things_to_stun))
-			for(var/mob/living/thing in things_to_churn)
-				thing.Stun(100)
-				thing.Knockdown(50)
-				thing.emote("scream")
-		if(!LAZYLEN(things_to_churn))
-			to_chat(user, span_notice("The rite of Abrogation passes from my lips in silence, having found nothing to assail."))
-			return
-	else
-		user.Stun(25)
-		user.throw_at(get_ranged_target_turf(user, get_dir(user,too_powerful), 7), 7, 1, too_powerful, spin = FALSE)
-		user.visible_message(span_warning("[user] ceases their prayer, suddenly choking upon a gout of blood in their throat!"), span_boldwarning("My vision swims in red!"))
-
-/atom/movable/screen/alert/status_effect/churned
-	name = "Churning Essence"
-	desc = "The magicks that bind me into being are being disrupted! I should get away from the source as soon as I can!"
-	icon_state = "stressvb"
-
-/datum/status_effect/churned
-	id = "necra_churned"
-	alert_type = /atom/movable/screen/alert/status_effect/churned
-	duration = 30 SECONDS
-	examine_text = "<b>SUBJECTPRONOUN is wreathed in a wild frenzy of ghostly motes!</b>"
-	effectedstats = list(STATKEY_STR = -2, STATKEY_CON = -2, STATKEY_WIL = -2, STATKEY_SPD = -2)
-	status_type = STATUS_EFFECT_REFRESH
-	var/datum/weakref/debuffer
-	var/outline_colour = "#33cabc"
-	var/base_tick = 0.2
-	var/intensity = 1
-	var/range = 10
-
-/datum/status_effect/churned/on_creation(mob/living/new_owner, mob/living/caster, potency)
-	intensity = potency
-	if (caster)
-		debuffer = WEAKREF(caster)
-	return ..()
-
-/datum/status_effect/churned/on_apply()
-	var/filter = owner.get_filter(CHURN_FILTER)
-	to_chat(owner, span_warning("Wisps leap from the cloying mists to surround me, their chill disrupting my body! FLEE!"))
-	if (!filter)
-		owner.add_filter(CHURN_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
-	return TRUE
-
-/datum/status_effect/churned/refresh()
-	. = ..()
-	intensity += 1
-	to_chat(owner, span_boldwarning("The mists intensify, the glowing wisps steadily disrupting my body..."))
-
-/datum/status_effect/churned/process()
-	. = ..()
-	if (!owner)
-		return
-	if (prob(33))
-		owner.adjustFireLoss(base_tick * intensity)
-	if (prob(10))
-		to_chat(owner, span_warning("A frenzy of ghostly motes assail my form!"))
-		owner.emote("scream")
-
-	var/mob/living/our_debuffer = debuffer.resolve()
-	if (get_dist(our_debuffer, owner) > range)
-		to_chat(owner, span_notice("I've escaped the cloying mists!"))
-		qdel(src)
-
-/datum/status_effect/churned/on_remove()
-	owner.remove_filter(CHURN_FILTER)
-
-#undef CHURN_FILTER
-
-/obj/effect/proc_holder/spell/targeted/locate_dead
-	name = "Locate Corpse"
-	desc = "Call upon the Undermaiden to guide you to a lost soul."
-	overlay_state = "necraeye"
-	sound = 'sound/magic/whiteflame.ogg'
-	releasedrain = 30
-	chargedrain = 0.5
-	max_targets = 0
-	cast_without_targets = TRUE
-	miracle = TRUE
-	associated_skill = /datum/skill/magic/holy
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
-	invocations = list("Undermaiden, guide my hand to those who have lost their way.")
-	invocation_type = "whisper"
-	recharge_time = 15 SECONDS
-	devotion_cost = 35
-
-/obj/effect/proc_holder/spell/targeted/locate_dead/cast(list/targets, mob/living/user = usr)
-	. = ..()
-	var/list/mob/corpses = list()
-	for(var/mob/living/C in GLOB.dead_mob_list)
-		if(!C.mind)
-			continue
-		if(istype(C, /mob/living/carbon/human))
-			var/mob/living/carbon/human/B = C
-			if(B.buried)
-				continue
-		var/time_dead = 0
-		if(C.timeofdeath)
-			time_dead = world.time - C.timeofdeath
-		var/corpse_name
-
-		if(time_dead < 5 MINUTES)
-			corpse_name = "Fresh corpse "
-		else if(time_dead < 10 MINUTES)
-			corpse_name = "Recently deceased "
-		else if(time_dead < 30 MINUTES)
-			corpse_name = "Long dead "
-		else
-			corpse_name = "Forgotten remains of "
-		var/list/d_list = C.get_mob_descriptors()
-		var/trait_desc = "[capitalize(build_coalesce_description_nofluff(d_list, C, list(MOB_DESCRIPTOR_SLOT_TRAIT), "%DESC1%"))]"
-		var/stature_desc = "[capitalize(build_coalesce_description_nofluff(d_list, C, list(MOB_DESCRIPTOR_SLOT_STATURE), "%DESC1%"))]"
-		var/descriptor_name = "[trait_desc] [stature_desc]"
-		if(descriptor_name == " ")
-			descriptor_name = "Unknown"
-
-		corpse_name += " of \a [descriptor_name]..."
-		corpses[corpse_name] = C
-
-	if(!length(corpses))
-		to_chat(user, span_warning("The Undermaiden's grasp lets slip."))
-		return .
-
-	var/mob/selected = tgui_input_list(user, "Which body shall I seek?", "Available Bodies", corpses)
-
-	if(QDELETED(src) || QDELETED(user) || QDELETED(corpses[selected]))
-		to_chat(user, span_warning("The Undermaiden's grasp lets slip."))
-		return .
-
-	var/corpse = corpses[selected]
-
-	var/turf/turf_user = get_turf(user)
-	var/turf/turf_corpse = get_turf(corpse)
-	var/direction_name = "unknown"
-	if(turf_user.z != turf_corpse.z)
-		if(turf_corpse.z > turf_user.z)
-			direction_name = "above"
-		else
-			direction_name = "below"
-	else
-		var/direction = get_dir(user, corpse)
-		switch(direction)
-			if(NORTH)
-				direction_name = "north"
-			if(SOUTH)
-				direction_name = "south"
-			if(EAST)
-				direction_name = "east"
-			if(WEST)
-				direction_name = "west"
-			if(NORTHEAST)
-				direction_name = "northeast"
-			if(NORTHWEST)
-				direction_name = "northwest"
-			if(SOUTHEAST)
-				direction_name = "southeast"
-			if(SOUTHWEST)
-				direction_name = "southwest"
-
-	to_chat(user, span_notice("The Undermaiden pulls on your hand, guiding you [direction_name]."))
-
-/obj/effect/proc_holder/spell/invoked/necra_vow
-	name = "Vow to Necra"
-	desc = "Make a vow to Necra. Your chances of revival or recovery of limb will be greatly reduced. You will harm undeath and heal yourself at a slow rate."
-	range = 1
-	overlay_state = "necra"
-	releasedrain = 30
-	chargedloop = /datum/looping_sound/invokeholy
-	chargetime = 50
-	chargedrain = 0.5
-	recharge_time = 30 SECONDS
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
-	sound = 'sound/magic/churn.ogg'
-	associated_skill = /datum/skill/magic/holy
-	invocations = list("The Undermaiden Protects.")
-	invocation_type = "shout"
-	miracle = TRUE
-	devotion_cost = 100
-
-/obj/effect/proc_holder/spell/invoked/necra_vow/cast(list/targets, mob/living/user = usr)
-	if(ishuman(targets[1]))
-		var/mob/living/carbon/human/H = targets[1]
-		if(HAS_TRAIT(H, TRAIT_ROTMAN) || HAS_TRAIT(H, TRAIT_NOBREATH) || H.mob_biotypes & MOB_UNDEAD)	//No Undead, no Rotcured, no Deathless
-			to_chat(user, span_warning("Necra cares not for the vows of the corrupted."))
-			revert_cast()
-			return FALSE
-		if(H.has_status_effect(/datum/status_effect/buff/necras_vow) || H.patron?.type != /datum/patron/divine/necra)
-			to_chat(user, span_notice("They have already pledged a vow."))
-			revert_cast()
-			return FALSE
-		var/choice = alert(H, "You are being asked to pledge a vow. Your chances of revival or recovery of limb will be greatly reduced. You will harm undeath and heal yourself at a slow rate. Do you agree?", "VOW", "Yes", "No")
-		if(choice != "Yes")
-			to_chat(user, span_notice("They declined."))
-			return TRUE
-		user.visible_message(span_warning("[user] grants [H] the blessing of their promise."))
-		to_chat(H, span_warning("I have committed. There is no going back."))
-		H.apply_status_effect(/datum/status_effect/buff/necras_vow)
-		H.apply_status_effect(/datum/status_effect/buff/healing/necras_vow)
-
-/atom/movable/screen/alert/status_effect/buff/necras_vow
-	name = "Vow to Necra"
-	desc = "I have pledged a promise to Necra. Undeath shall be harmed or lit aflame if they strike me. Rot will not claim me. Lost limbs can only be restored if they are myne."
-	icon_state = "necravow"
-
-#define NECRAVOW_FILTER "necravow_glow"
-
-/datum/status_effect/buff/necras_vow
-	var/outline_colour ="#929186" // A dull grey.
-	id = "necravow"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/necras_vow
-	effectedstats = list(STATKEY_CON = 2)
-	duration = -1
-
-/datum/status_effect/buff/necras_vow/on_apply()
-	. = ..()
-	var/filter = owner.get_filter(NECRAVOW_FILTER)
-	if (!filter)
-		owner.add_filter(NECRAVOW_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
-	ADD_TRAIT(owner, TRAIT_NECRAS_VOW, TRAIT_MIRACLE)
-	owner.rot_type = null
-	to_chat(owner, span_warning("My limbs feel more alive than ever... I feel whole..."))
-
-/datum/status_effect/buff/necras_vow/on_remove()
-	. = ..()
-	owner.remove_filter(NECRAVOW_FILTER)
-	to_chat(owner, span_warning("My body feels strange... hollow..."))
-
-#undef NECRAVOW_FILTER
+// T0: Necra's Sight
 
 /obj/effect/proc_holder/spell/invoked/necras_sight
 	name = "Necra's Sight"
@@ -470,6 +126,162 @@
 	to_chat(user, span_info("I whisper a name and mark the grave for later use..."))
 	marked_objects[O] = label
 
+// T1: Avert End (channel on an adjacent target to slowly spend devotion to grant them NODEATH and ticks of oxyloss healing)
+
+/obj/effect/proc_holder/spell/invoked/avert
+	name = "Borrowed Time"
+	desc = "Shield your fellow man from the Undermaiden's gaze, preventing them from slipping into death for as long as your faith and fatigue may muster."
+	overlay_state = "borrowtime"
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	associated_skill = /datum/skill/magic/holy
+	miracle = TRUE
+	devotion_cost = 10
+	var/list/near_death_lines = list(
+		"A haze begins to envelop me, but then suddenly recedes, as if warded back by some great light...",
+		"A terrible weight bears down upon me, as if the wyrld itself were crushing me with its heft...",
+		"The sound of a placid river drifts into hearing, followed by the ominous toll of a ferryman's bell...",
+		"Some vast, immeasurably distant figure looms beyond my perception - I feel it, more than I see. It waits. It watches.",
+	)
+
+/obj/effect/proc_holder/spell/invoked/avert/cast(list/targets, mob/living/carbon/human/user)
+	. = ..()
+	var/atom/target = targets[1]
+	if (!isliving(target))
+		revert_cast()
+		return FALSE
+
+	var/mob/living/living_target = target
+	if (!user.Adjacent(target))
+		to_chat(user, span_warning("I must be beside [living_target] to avert Her gaze from [living_target.p_them()]!"))
+		revert_cast()
+		return FALSE
+
+	// add the no-death trait to them....
+	user.visible_message(span_notice("Whispering motes gently bead from [user]'s fingers as [user.p_they()] place a hand near [living_target], scriptures of the Undermaiden spilling from their lips..."), span_notice("I stand beside [living_target] and utter the hallowed words of Aeon's Intercession, staying Her grasp for just a little while longer..."))
+	to_chat(user, span_small("I must remain still and at [living_target]'s side..."))
+	to_chat(living_target, span_warning("An odd sensation blossoms in my chest, cold and unknown..."))
+
+	ADD_TRAIT(living_target, TRAIT_NODEATH, "avert_spell")
+
+	var/our_holy_skill = user.get_skill_level(associated_skill)
+	var/tickspeed = 30 + (5 * our_holy_skill)
+
+	while (do_after(user, tickspeed, target = living_target))
+		user.stamina_add(2.5)
+
+		living_target.adjustOxyLoss(-10)
+		living_target.blood_volume = max((BLOOD_VOLUME_SURVIVE * 1.5), living_target.blood_volume)
+
+		if (living_target.health <= 5)
+			if (prob(5))
+				to_chat(living_target, span_small(pick(near_death_lines)))
+
+		if (user.devotion?.check_devotion(src))
+			user.devotion?.update_devotion(-10)
+		else
+			to_chat(span_warning("My devotion runs dry - the Intercession fades from my lips!"))
+			break
+
+	REMOVE_TRAIT(living_target, TRAIT_NODEATH, "avert_spell")
+
+	user.visible_message(span_danger("[user]'s concentration breaks, the motes receding from [living_target] and into [user.p_their()] hand once more."), span_danger("My concentration breaks, and the Intercession falls silent."))
+
+// T1: Locate Dead/Corpse
+
+/obj/effect/proc_holder/spell/targeted/locate_dead
+	name = "Locate Corpse"
+	desc = "Call upon the Undermaiden to guide you to a lost soul."
+	overlay_state = "necraeye"
+	sound = 'sound/magic/whiteflame.ogg'
+	releasedrain = 30
+	chargedrain = 0.5
+	max_targets = 0
+	cast_without_targets = TRUE
+	miracle = TRUE
+	associated_skill = /datum/skill/magic/holy
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	invocations = list("Undermaiden, guide my hand to those who have lost their way.")
+	invocation_type = "whisper"
+	recharge_time = 15 SECONDS
+	devotion_cost = 35
+
+/obj/effect/proc_holder/spell/targeted/locate_dead/cast(list/targets, mob/living/user = usr)
+	. = ..()
+	var/list/mob/corpses = list()
+	for(var/mob/living/C in GLOB.dead_mob_list)
+		if(!C.mind)
+			continue
+		if(istype(C, /mob/living/carbon/human))
+			var/mob/living/carbon/human/B = C
+			if(B.buried)
+				continue
+		var/time_dead = 0
+		if(C.timeofdeath)
+			time_dead = world.time - C.timeofdeath
+		var/corpse_name
+
+		if(time_dead < 5 MINUTES)
+			corpse_name = "Fresh corpse "
+		else if(time_dead < 10 MINUTES)
+			corpse_name = "Recently deceased "
+		else if(time_dead < 30 MINUTES)
+			corpse_name = "Long dead "
+		else
+			corpse_name = "Forgotten remains of "
+		var/list/d_list = C.get_mob_descriptors()
+		var/trait_desc = "[capitalize(build_coalesce_description_nofluff(d_list, C, list(MOB_DESCRIPTOR_SLOT_TRAIT), "%DESC1%"))]"
+		var/stature_desc = "[capitalize(build_coalesce_description_nofluff(d_list, C, list(MOB_DESCRIPTOR_SLOT_STATURE), "%DESC1%"))]"
+		var/descriptor_name = "[trait_desc] [stature_desc]"
+		if(descriptor_name == " ")
+			descriptor_name = "Unknown"
+
+		corpse_name += " of \a [descriptor_name]..."
+		corpses[corpse_name] = C
+
+	if(!length(corpses))
+		to_chat(user, span_warning("The Undermaiden's grasp lets slip."))
+		return .
+
+	var/mob/selected = tgui_input_list(user, "Which body shall I seek?", "Available Bodies", corpses)
+
+	if(QDELETED(src) || QDELETED(user) || QDELETED(corpses[selected]))
+		to_chat(user, span_warning("The Undermaiden's grasp lets slip."))
+		return .
+
+	var/corpse = corpses[selected]
+
+	var/turf/turf_user = get_turf(user)
+	var/turf/turf_corpse = get_turf(corpse)
+	var/direction_name = "unknown"
+	if(turf_user.z != turf_corpse.z)
+		if(turf_corpse.z > turf_user.z)
+			direction_name = "above"
+		else
+			direction_name = "below"
+	else
+		var/direction = get_dir(user, corpse)
+		switch(direction)
+			if(NORTH)
+				direction_name = "north"
+			if(SOUTH)
+				direction_name = "south"
+			if(EAST)
+				direction_name = "east"
+			if(WEST)
+				direction_name = "west"
+			if(NORTHEAST)
+				direction_name = "northeast"
+			if(NORTHWEST)
+				direction_name = "northwest"
+			if(SOUTHEAST)
+				direction_name = "southeast"
+			if(SOUTHWEST)
+				direction_name = "southwest"
+
+	to_chat(user, span_notice("The Undermaiden pulls on your hand, guiding you [direction_name]."))
+
+// T2: Raise Avenging Spirits
+
 /obj/effect/proc_holder/spell/invoked/raise_spirits_vengeance
 	name = "Avenging Spirits"
 	desc = "Summon rancorous spirits to tear at an opponent!"
@@ -495,8 +307,6 @@
 	invocations = list("Awaken, rancor!!")
 	invocation_type = "shout"
 
-
-
 /obj/effect/proc_holder/spell/invoked/raise_spirits_vengeance/cast(list/targets, mob/living/user)
 	. = ..()
 
@@ -521,3 +331,197 @@
 	revert_cast()
 	return FALSE
 
+// T2: Abrogitation
+/obj/effect/proc_holder/spell/targeted/abrogation
+	name = "Abrogation"
+	desc = "Debuffs targeted undead as long as they remain near you, slowly getting set on fire if they stay."
+	overlay_state = "necra"
+	range = 4
+	miracle = TRUE
+	devotion_cost = 30
+	releasedrain = 30
+	chargedloop = /datum/looping_sound/invokeholy
+	chargetime = 5 SECONDS
+	chargedrain = 0.5
+	recharge_time = 45 SECONDS
+	max_targets = 0
+	cast_without_targets = TRUE
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	sound = 'sound/magic/churn.ogg'
+	associated_skill = /datum/skill/magic/holy
+	invocations = list("The Undermaiden rebukes!")
+	invocation_type = "shout" //can be none, whisper, emote and shout
+
+/obj/effect/proc_holder/spell/targeted/abrogation/cast(list/targets, mob/living/user = usr)
+	. = ..()
+	var/debuff_power = 1
+	if (user && user.mind)
+		debuff_power = clamp((user.get_skill_level(/datum/skill/magic/holy) / 2), 1, 3)
+
+	var/too_powerful = FALSE
+	var/list/things_to_churn = list()
+	var/list/things_to_stun = list()
+	for (var/mob/living/L in targets)
+		var/is_vampire = FALSE
+		var/is_zombie = FALSE
+		if(L.stat == DEAD)
+			continue
+		if (L.mind)
+			var/datum/antagonist/vampire/V = L.mind.has_antag_datum(/datum/antagonist/vampire)
+			if(V && SEND_SIGNAL(L, COMSIG_DISGUISE_STATUS))
+				is_vampire = TRUE
+			if (L.mind.has_antag_datum(/datum/antagonist/zombie))
+				is_zombie = TRUE
+				things_to_stun += L
+			if (L.mind.special_role == "Vampire Lord")
+				too_powerful = L
+				user.visible_message(span_warning("[user] suddenly pales before an unseen presence, and gasps!"), span_warning("The sound of rushing blood fills my ears and mind, drowning out my abrogation!"))
+				break
+		if (L.mob_biotypes & MOB_UNDEAD || is_vampire || is_zombie)
+			things_to_churn += L
+
+	if (!too_powerful)
+		if (LAZYLEN(things_to_churn))
+			user.visible_message(span_warning("A frigid blue glower suddenly erupts in [user]'s eyes as a whispered prayer summons forth a winding veil of ghostly mists!"), span_notice("I perform the sacred rite of Abrogation, bringing forth Her servants to harry and weaken the unliving!"))
+			for(var/mob/living/thing in things_to_churn)
+				if(spell_guard_check(thing, TRUE))
+					thing.visible_message(span_warning("[thing] resists the abrogation!"))
+					things_to_churn -= thing
+					continue
+				thing.apply_status_effect(/datum/status_effect/churned, user, debuff_power)
+		if(LAZYLEN(things_to_stun))
+			for(var/mob/living/thing in things_to_churn)
+				thing.Stun(2 SECONDS)
+				thing.emote("scream")
+		if(!LAZYLEN(things_to_churn))
+			to_chat(user, span_notice("The rite of Abrogation passes from my lips in silence, having found nothing to assail."))
+			return
+	else
+		user.Stun(4 SECONDS)
+		user.throw_at(get_ranged_target_turf(user, get_dir(user,too_powerful), 7), 7, 1, too_powerful, spin = FALSE)
+		user.visible_message(span_warning("[user] ceases their prayer, suddenly choking upon a gout of blood in their throat!"), span_boldwarning("My vision swims in red!"))
+
+/atom/movable/screen/alert/status_effect/churned
+	name = "Churning Essence"
+	desc = "The magicks that bind me into being are being disrupted! I should get away from the source as soon as I can!"
+	icon_state = "stressvb"
+
+/datum/status_effect/churned
+	id = "necra_churned"
+	alert_type = /atom/movable/screen/alert/status_effect/churned
+	duration = 30 SECONDS
+	examine_text = "<b>SUBJECTPRONOUN is wreathed in a wild frenzy of ghostly motes!</b>"
+	effectedstats = list(STATKEY_PER = -2, STATKEY_CON = -2, STATKEY_LCK = -2)
+	status_type = STATUS_EFFECT_REFRESH
+	var/datum/weakref/debuffer
+	var/outline_colour = "#33cabc"
+	var/base_tick = 0.2
+	var/intensity = 1
+	var/range = 7
+
+/datum/status_effect/churned/on_creation(mob/living/new_owner, mob/living/caster, potency)
+	intensity = potency
+	if (caster)
+		debuffer = WEAKREF(caster)
+	return ..()
+
+/datum/status_effect/churned/on_apply()
+	var/filter = owner.get_filter(CHURN_FILTER)
+	to_chat(owner, span_warning("Wisps leap from the cloying mists to surround me, their chill disrupting my body! FLEE!"))
+	if (!filter)
+		owner.add_filter(CHURN_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+	return TRUE
+
+/datum/status_effect/churned/refresh()
+	. = ..()
+	intensity += 1
+	to_chat(owner, span_boldwarning("The mists intensify, the glowing wisps steadily disrupting my body..."))
+
+/datum/status_effect/churned/process()
+	. = ..()
+	if (!owner)
+		return
+	if (prob(33))
+		owner.adjustFireLoss(base_tick * intensity)
+	if (prob(10))
+		to_chat(owner, span_warning("A frenzy of ghostly motes assail my form!"))
+		owner.emote("scream")
+
+	var/mob/living/our_debuffer = debuffer.resolve()
+	if (get_dist(our_debuffer, owner) > range)
+		to_chat(owner, span_notice("I've escaped the cloying mists!"))
+		qdel(src)
+
+/datum/status_effect/churned/on_remove()
+	owner.remove_filter(CHURN_FILTER)
+
+#undef CHURN_FILTER
+
+// Not even used right now.
+/obj/effect/proc_holder/spell/invoked/necra_vow
+	name = "Vow to Necra"
+	desc = "Make a vow to Necra. Your chances of revival or recovery of limb will be greatly reduced. You will harm undeath and heal yourself at a slow rate."
+	range = 1
+	overlay_state = "necra"
+	releasedrain = 30
+	chargedloop = /datum/looping_sound/invokeholy
+	chargetime = 50
+	chargedrain = 0.5
+	recharge_time = 30 SECONDS
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
+	sound = 'sound/magic/churn.ogg'
+	associated_skill = /datum/skill/magic/holy
+	invocations = list("The Undermaiden Protects.")
+	invocation_type = "shout"
+	miracle = TRUE
+	devotion_cost = 100
+
+/obj/effect/proc_holder/spell/invoked/necra_vow/cast(list/targets, mob/living/user = usr)
+	if(ishuman(targets[1]))
+		var/mob/living/carbon/human/H = targets[1]
+		if(HAS_TRAIT(H, TRAIT_ROTMAN) || HAS_TRAIT(H, TRAIT_NOBREATH) || H.mob_biotypes & MOB_UNDEAD)	//No Undead, no Rotcured, no Deathless
+			to_chat(user, span_warning("Necra cares not for the vows of the corrupted."))
+			revert_cast()
+			return FALSE
+		if(H.has_status_effect(/datum/status_effect/buff/necras_vow) || H.patron?.type != /datum/patron/divine/necra)
+			to_chat(user, span_notice("They have already pledged a vow."))
+			revert_cast()
+			return FALSE
+		var/choice = alert(H, "You are being asked to pledge a vow. Your chances of revival or recovery of limb will be greatly reduced. You will harm undeath and heal yourself at a slow rate. Do you agree?", "VOW", "Yes", "No")
+		if(choice != "Yes")
+			to_chat(user, span_notice("They declined."))
+			return TRUE
+		user.visible_message(span_warning("[user] grants [H] the blessing of their promise."))
+		to_chat(H, span_warning("I have committed. There is no going back."))
+		H.apply_status_effect(/datum/status_effect/buff/necras_vow)
+		H.apply_status_effect(/datum/status_effect/buff/healing/necras_vow)
+
+/atom/movable/screen/alert/status_effect/buff/necras_vow
+	name = "Vow to Necra"
+	desc = "I have pledged a promise to Necra. Undeath shall be harmed or lit aflame if they strike me. Rot will not claim me. Lost limbs can only be restored if they are myne."
+	icon_state = "necravow"
+
+#define NECRAVOW_FILTER "necravow_glow"
+
+/datum/status_effect/buff/necras_vow
+	var/outline_colour ="#929186" // A dull grey.
+	id = "necravow"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/necras_vow
+	effectedstats = list(STATKEY_CON = 2)
+	duration = -1
+
+/datum/status_effect/buff/necras_vow/on_apply()
+	. = ..()
+	var/filter = owner.get_filter(NECRAVOW_FILTER)
+	if (!filter)
+		owner.add_filter(NECRAVOW_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 200, "size" = 1))
+	ADD_TRAIT(owner, TRAIT_NECRAS_VOW, TRAIT_MIRACLE)
+	owner.rot_type = null
+	to_chat(owner, span_warning("My limbs feel more alive than ever... I feel whole..."))
+
+/datum/status_effect/buff/necras_vow/on_remove()
+	. = ..()
+	owner.remove_filter(NECRAVOW_FILTER)
+	to_chat(owner, span_warning("My body feels strange... hollow..."))
+
+#undef NECRAVOW_FILTER


### PR DESCRIPTION
## About The Pull Request

Returns Aborigation to Necran T2 arsenal with changes of:

It only has 4 tile range now like rest of the "Churns", where as the "stay near" effects are 7 tile instead of 10 now.

It no longer knockdowns the target on cast, stun massively reduced to 2 seconds, increased stun for the user if used on something too powerful.

The churn debuff now amounts to "2 Perception 2 Constitution 2 Fortune" instead of "2 Strenght 2 Constitution 2 Willpower 2 Speed"

EDIT: No longer makes the target glow in any way or scream outside of being exploded for standing near the caster for too long.

## Testing Evidence

Number changes really

## Why It's Good For The Game

Surely 4th time churn undead is the charm.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Readds and rebalances Necran Aborigation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
