### PR TITLE
Enables colorable tabards to be opened with right-click

### DIFF
--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -84,6 +84,7 @@
 
 /obj/item/clothing/cloak/tabard/attack_right(mob/user)
 	if(custom_design)
+		..()
 		return
 	var/the_time = world.time
 	var/design = input(user, "Select a design.","Tabard Design") as null|anything in list("None", "Symbol", "Split", "Quadrants", "Boxes", "Diamonds")
@@ -393,6 +394,7 @@
 
 /obj/item/clothing/cloak/tabard/crusader/attack_right(mob/user)
 	if(custom_design)
+		..()
 		return
 	var/the_time = world.time
 	var/design = input(user, "Select a design.","Tabard Design") as null|anything in list("Default", "Gold Cross", "Jeruah", "BlackGold", "BlackWhite")
@@ -431,6 +433,7 @@
 
 /obj/item/clothing/cloak/tabard/crusader/tief/attack_right(mob/user)
 	if(custom_design)
+		..()
 		return
 	var/the_time = world.time
 	var/design = input(user, "Select a design.","Tabard Design") as null|anything in list("Default", "RedBlack", "BlackRed")
@@ -564,6 +567,7 @@
 	color = CLOTHING_BLACK
 
 /obj/item/clothing/cloak/tabard/stabard/dungeon/attack_right(mob/user)
+	..()
 	return
 
 /obj/item/clothing/cloak/tabard/stabard/mercenary
@@ -1350,6 +1354,7 @@
 
 /obj/item/clothing/cloak/tabard/stabard/guardhood/attack_right(mob/user)
 	if(custom_design)
+		..()
 		return
 	var/the_time = world.time
 	var/chosen = input(user, "Select a design.","Tabard Design") as null|anything in list("Split")


### PR DESCRIPTION
## About The Pull Request

Assuming ..() works the way I think it works, this will make it so higher level code will execute (ie; opening inventory) if you right click on your cloak after applying a coloration to it.

## Testing Evidence

Don't worry about it.

## Why It's Good For The Game

This removes an annoyance where you have to choose between drip and functionality.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
