### PR TITLE
Vaquero Untanglement

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/vaquero.dm
@@ -64,13 +64,11 @@
 					/obj/item/roguekey/mercenary = 1,
 					/obj/item/rogueweapon/scabbard/sheath = 1
 					)
-	var/datum/inspiration/I = new /datum/inspiration(H)
-	I.grant_inspiration(H, bard_tier = BARD_T2)
 	if(H.mind)
-		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute", "Psyaltery")
-		var/weapon_choice = input(H, "Choose your instrument.", "TAKE UP ARMS") as anything in weapons
+		var/instrument = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman","Flute", "Psyaltery")
+		var/instrument_choice = input(H, "Choose your instrument.", "TAKE UP SONGS") as anything in instrument
 		H.set_blindness(0)
-		switch(weapon_choice)
+		switch(instrument_choice)
 			if("Harp")
 				backr = /obj/item/rogue/instrument/harp
 			if("Lute")
@@ -89,4 +87,12 @@
 				backr = /obj/item/rogue/instrument/flute
 			if("Psyaltery")
 				backr = /obj/item/rogue/instrument/psyaltery
+		var/weapons = list("Maille Training","Bardic Inspiration")
+		var/weapon_choice = input(H, "Choose your discipline.", "TAKE A PATH") as anything in weapons
+		switch(weapon_choice)
+			if("Maille Training")
+				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+			if("Bardic Inspiration")
+				var/datum/inspiration/I = new /datum/inspiration(H)
+				I.grant_inspiration(H, bard_tier = BARD_T2)
 	H.merctype = 13


### PR DESCRIPTION
## About The Pull Request

Vaquero can choose between Medium Armor or the Bardic Inspiration.

## Testing Evidence

<img width="155" height="180" alt="image" src="https://github.com/user-attachments/assets/1fa9be01-49b3-438c-b350-5ffefba1674f" />

## Why It's Good For The Game

I don't like Bard stuff. This is a 100% self-serving PR. I liked having a cuirass and helm in my horse's saddlebags for when War was necessary.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Vaquero can choose between their classic medium armor setup or the new Bardic Inspiration
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
