### PR TITLE
crafting pity mechanic

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -297,6 +297,8 @@
 						if(HAS_TRAIT(L, TRAIT_INTELLECTUAL) && L.STAINT > 8)
 							prob2craft += 5
 					prob2craft = CLAMP(prob2craft, 0, 99)
+					if(i == 100 && prob2craft > 0)
+						prob2craft = 100
 					if(!prob(prob2craft))
 						if(user.client?.prefs.showrolls)
 							to_chat(user, span_danger("I've failed to craft \the [R.name]... [prob2craft]%"))


### PR DESCRIPTION
## About The Pull Request
if you manage to get through all 100 loops of failing a low-chance craft—after which point, currently, you just silently stop crafting—as long as the chance to craft isn't zero, you will automatically succeed. this is something it ran into while trying to build tables for the garden as a maid, for instance, which is a 2% craft. you're not going to want to hire a carpenter to put down 3 tables for decoration.

## Testing Evidence
craft pity threshold would be absolutely awful to test. but it compiles, and it's a two-line change, so it should be fine.


## Why It's Good For The Game
if you're willing to spend 100 attempts on a low chance craft, it's likely either a situation where you can't hire help (wretching it) or it would be absurd to (building 3 tables for a garden as a maid). you should, in fact, be able to craft (and thereby, learn a bit) stuff that is not impossible through enough effort and dedication, because... that's how it works

## Changelog

:cl:
qol: crafting attempts now have a 'pity threshold': you will automatically succeed after 99 failed attempts, so long as the recipe is possible for you to make (i.e. not a 0% chance)
/:cl:
