### PR TITLE
fixes divine strike description

### DIFF
--- a/code/modules/spells/roguetown/acolyte/ravox.dm
+++ b/code/modules/spells/roguetown/acolyte/ravox.dm
@@ -1,9 +1,10 @@
 //These are all Vanderlin ports, simply redone values and additions to fit Azure. Credit for the code and idea goes to them!
 
-//Divine Strike - Enhance your held weapon to have the next strike do extra damage and slow the target. Undead debuffed more.
+//Divine Strike - Enhance your held weapon to have the next strike ~~do extra damage~~ and slow the target. Undead debuffed more.
+//03/21/2026: Spell does not add extra damage. Leaving comment bc maybe it's supposed to, but, uhhh. IDK I'm fixing the description for now. -- MUMBLEMANCER
 /obj/effect/proc_holder/spell/self/divine_strike
 	name = "Divine Strike"
-	desc = "Bless your next strike to do extra damage and slow the target."
+	desc = "Bless your next strike to slow the target."
 	action_icon = 'icons/mob/actions/ravoxmiracles.dmi'
 	overlay_icon = 'icons/mob/actions/ravoxmiracles.dmi'
 	overlay_state = "divine_strike"
@@ -184,7 +185,7 @@
 
 /atom/movable/screen/alert/status_effect/buff/divine_strike
 	name = "Divine Strike"
-	desc = "Your next attack deals additional damage and slows your target."
+	desc = "Your next attack slows your target, lowering their WIL and SPD."
 	icon_state = "stressvg"
 
 /obj/effect/proc_holder/spell/invoked/tug_of_war


### PR DESCRIPTION
## About The Pull Request
- title
- request
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
compiles
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
