### PR TITLE
Ash Must Be Destroyed - Allows sugarglass statues to be uniquely renamed.

### DIFF
--- a/modular/Neu_Food/code/others/sweet.dm
+++ b/modular/Neu_Food/code/others/sweet.dm
@@ -291,6 +291,7 @@
 	slice_path = null
 	rotprocess = null
 	faretype = FARE_FINE
+	obj_flags = CAN_BE_HIT|UNIQUE_RENAME
 	bitesize = 3
 	list_reagents = list(/datum/reagent/consumable/nutriment = SNACK_DECENT)
 	tastes = list("crispy sugarglass" = 1)


### PR DESCRIPTION
## About The Pull Request

Name.

## Testing Evidence

Yeah.

## Why It's Good For The Game

* Lets people fluff sugarglass statues however they wish, without needing to account for the usual '(sugarglass statue)' suffix.

## Changelog

:cl:
add: Sugarglass statues can now be uniquely renamed.
/:cl:
