### PR TITLE
adds plague doctor/physician mask to loadout

### DIFF
--- a/code/datums/loadout/loadout_accessories.dm
+++ b/code/datums/loadout/loadout_accessories.dm
@@ -66,6 +66,11 @@
 	path = /obj/item/clothing/mask/rogue/duelmask
 	sort_category = "Accessories"
 
+/datum/loadout_item/physician
+	name = "Plague Mask"
+	path = /obj/item/clothing/mask/rogue/physician
+	sort_category = "Accessories"
+
 /datum/loadout_item/pipe
 	name = "Pipe"
 	path = /obj/item/clothing/mask/cigarette/pipe


### PR DESCRIPTION
title self-explanatory, i asked in dev-general if anybody would be opposed and i got no opposition so i figured id add it. would help with the drip of traveling doctors/pestran missionaries, pestran acolytes, etc.