### PR TITLE
familiar notifs for casters

### DIFF
--- a/code/modules/client/familiar_prefs.dm
+++ b/code/modules/client/familiar_prefs.dm
@@ -208,6 +208,13 @@
 					GLOB.familiar_queue += user.client
 					to_chat(user, "<span class='notice'>You have been added to the Familiar queue.</span>")
 
+					for(var/client/advertisee in (GLOB.clients - src))
+						var/mob/living/char = get_mob_by_key(advertisee.ckey)
+						if(!char || !istype(char))
+							continue
+						if(HAS_TRAIT(char, TRAIT_ARCYNE))
+							to_chat(advertisee, span_info("A new familiar is available to summon."))
+
 			else if (task == "leave")
 				if (user.client in GLOB.familiar_queue)
 					GLOB.familiar_queue -= user.client


### PR DESCRIPTION
## About The Pull Request
NOTE: DEPENDS ON #6406 DUE TO THE TRAIT CHANGES

simply adds a message broadcast to all mages (defined as alive players with the arcyne trait) when a player joins the familiar queue

## Testing Evidence
<img width="525" height="54" alt="image" src="https://github.com/user-attachments/assets/a3cb0801-e556-4956-9b55-a6593e5555fc" />
<img width="647" height="56" alt="image" src="https://github.com/user-attachments/assets/924ea4bd-675c-418c-b80c-f958d283dd7a" />

## Why It's Good For The Game
currently, nobody uses familiars except for the niche undocumented stat boost feature of npc familiars that you drop in a safe place and never touch. part of this is because there is no way to tell if there is a familar in the queue, at all—so most people don't even take the spell. however, people _do_ play mage summons, and much of the difference is probably just in readability. while it has a plan for a bigger familiar/summoning overhaul, this works fine as an intermediary effort, if you're a mage you get notified when someone joins the queue, so you can summon them and have familiar rp

## Changelog

:cl:
qol: mages are now notified when a player joins the familiar queue
/:cl: