### PR TITLE
Allows opening and closing doors with keys in hand

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -387,8 +387,7 @@
 	user.changeNext_move(CLICK_CD_FAST)
 	if(istype(I, /obj/item/roguekey) || istype(I, /obj/item/storage/keyring))
 		if(!locked)
-			to_chat(user, span_warning("It won't turn this way. Try turning to the right."))
-			door_rattle()
+			TryToSwitchState(user) //try to open/close
 			return
 		if(autobump == TRUE) //Attackby passes UI coordinate onclick stuff, so forcing check to TRUE
 			trykeylock(I, user, autobump)
@@ -491,7 +490,7 @@
 	var/obj/item = user.get_active_held_item()
 	if(istype(item, /obj/item/roguekey) || istype(item, /obj/item/storage/keyring))
 		if(locked)
-			to_chat(user, span_warning("It won't turn this way. Try turning to the left."))
+			to_chat(user, span_warning("The lock won't turn this way. Try turning to the left."))
 			door_rattle()
 			return
 		trykeylock(item, user)


### PR DESCRIPTION
## About The Pull Request

You can now open and close unlocked doors with left-click while holding a key or key ring. No more need to do the ole' hand switcheroo every single time.

## Testing Evidence

https://github.com/user-attachments/assets/bdd57590-397b-4b1f-9c9d-c67b537a8893

## Why It's Good For The Game

Arguably the single most consequential update in the history of Roguetown.

## Changelog

:cl:
qol: You can now open and close unlocked doors with left-click while holding a key or key ring.
/:cl:
