### PR TITLE
QoL Town Elderjak

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/townelder.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/townelder.dm
@@ -18,8 +18,7 @@
 	)
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_MASTER,
@@ -46,6 +45,7 @@
 	cloak = /obj/item/clothing/cloak/tabard/stabard/guardhood/elder
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/white
 	neck = /obj/item/roguekey/manor
+	backr = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
 	pants = /obj/item/clothing/under/roguetown/tights
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	belt = /obj/item/storage/belt/rogue/leather
@@ -57,7 +57,6 @@
 	if(should_wear_femme_clothes(H))
 		head = /obj/item/clothing/head/roguetown/chaperon/greyscale/elder
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress
-		backr = /obj/item/clothing/cloak/raincloak/furcloak
 	else if(should_wear_masc_clothes(H))
 		head = /obj/item/clothing/head/roguetown/chaperon/greyscale/elder
 		shirt = /obj/item/clothing/suit/roguetown/shirt/tunic

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/townelder.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/townelder.dm
@@ -19,7 +19,7 @@
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_MASTER,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/townelder.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/townelder.dm
@@ -19,6 +19,7 @@
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_MASTER,
@@ -44,6 +45,7 @@
 	..()
 	cloak = /obj/item/clothing/cloak/tabard/stabard/guardhood/elder
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/white
+	neck = /obj/item/roguekey/manor
 	pants = /obj/item/clothing/under/roguetown/tights
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	belt = /obj/item/storage/belt/rogue/leather

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/townelder.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/townelder.dm
@@ -49,7 +49,6 @@
 	pants = /obj/item/clothing/under/roguetown/tights
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/rogueweapon/mace
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backl = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/scomstone/bad


### PR DESCRIPTION
## About The Pull Request

Lazy, unquashed PR jakking a role nobody plays. Gives Town Elder Jman staves and a iron qstaff in favor of a mace with associated skill. Adds Manor Key, so they can do their job. Does nothing else.

## Testing Evidence

Yeah

## Why It's Good For The Game

Look, it's a small jak for a role nobody plays. Maybe with a manor key, they'll be actually played as the Lite Councilor they're meant to be, representing the commonborn of the Duchy.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Gave Town Elder a manor key, removed mace skill in favor of more sovlful staves.
/:cl:

