### PR TITLE
Councillors can now give out quests.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -9,7 +9,10 @@
 	allowed_races = RACES_SHUNNED_UP		//Nobility, so no constructs.
 	allowed_sexes = list(MALE, FEMALE)
 	display_order = JDO_COUNCILLOR
+	is_quest_giver = TRUE
+
 	tutorial = "You may have inherited this position, bought your way into it, or were appointed to it by merit--perish the thought! Whatever the case though, you work as an assistant and agent of the crown in matters of state. Whether this be aiding the steward, the sheriff, or the crown itself, or simply enjoying the free food of the keep, your duties vary day by day. You may be the lowest rung of the ladder, but that rung still towers over everyone else in town."
+	
 	whitelist_req = FALSE
 	outfit = /datum/outfit/job/roguetown/councillor
 	advclass_cat_rolls = list(CTAG_COUNCILLOR = 2)

--- a/code/modules/roguetown/roguemachine/questing/contract_ledger.dm
+++ b/code/modules/roguetown/roguemachine/questing/contract_ledger.dm
@@ -246,7 +246,7 @@
 		var/deposit_return = scroll.assigned_quest.calculate_deposit()
 		total_deposit_return += deposit_return
 
-		// Apply Steward/Mechant bonus if applicable (only to the base reward)
+		// Apply bonus to the base reward, if appliciable (Steward, Merchant, Clerk, Councillor, Shophand, Duke)
 		var/datum/job/mob_job = user.job ? SSjob.GetJob(user.job) : null
 		if(mob_job?.is_quest_giver)
 			reward += base_reward * QUEST_HANDLER_REWARD_MULTIPLIER


### PR DESCRIPTION
## About The Pull Request

Adds the Gives councillor is_quest_giver = TRUE flag to councillors, so they can now get the quest handling bonus. Councillors de facto handle the stewardry a lot of the time, and there's even a subclass centered around it. 

Also clears up some documentation related to the contract ledger, as the comments in it previously were inaccurate.

## Testing Evidence

y

## Why It's Good For The Game

Lowpop QoL improvement. If a councilor insists on doing the Steward's job despite there being an actual steward, they can literally be booted out.

## Changelog
:cl:
qol: Councillors can now hand out quests at the stewardry.
/:cl: