### PR TITLE
Standardized Bearer

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -1064,7 +1064,7 @@
 	force_wielded = 30
 	throwforce = 40 // It'll be funny. Trust.
 	possible_item_intents = list(SPEAR_BASH)
-	gripped_intents = list(/datum/intent/spear/thrust/ducal_standard, /datum/intent/spear/bash/ranged, /datum/intent/mace/smash/eaglebeak) // GET THEM OFF OF ME!!! OOOUGH!!!
+	gripped_intents = list(/datum/intent/spear/thrust, /datum/intent/spear/bash/ranged, /datum/intent/mace/smash/eaglebeak) // GET THEM OFF OF ME!!! OOOUGH!!!
 	icon = 'icons/roguetown/weapons/polearms64.dmi'
 	icon_state = "standard"
 	max_blade_int = 200
@@ -1133,6 +1133,3 @@
 /obj/item/rogueweapon/spear/keep_standard/Destroy()
 	GLOB.lordcolor -= src
 	return ..()
-
-/datum/intent/spear/thrust/ducal_standard
-	penfactor = PEN_MEDIUM

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
@@ -404,45 +404,46 @@
 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
 
 // Carries the ducal standard.
-// When carrying it, he's granted a few unique traits.
-// Bonuses, relaying location, etc.
-// The stats are middling, as a result. Really bad, honestly.
-// No armour trait, but gets crit resist. STAY STANDING!!!
+// When carrying it, they're granted a few unique traits;
+// +fortune, +perception, mood spell
 /datum/advclass/manorguard/standard_bearer
 	name = "Standard Bearer"
 	tutorial = "You are one of the Man at Arms entrusted with the keep's standard when you sally out into battle. \
 	Your fellow soldiers know to rally around you, should you keep it safe."
 	outfit = /datum/outfit/job/roguetown/manorguard/standard_bearer
 	category_tags = list(CTAG_MENATARMS)
-	traits_applied = list(TRAIT_STANDARD_BEARER)
-	// on-par with footman, with one less CON and INT swapped out for PER
+	traits_applied = list(TRAIT_STANDARD_BEARER, TRAIT_MEDIUMARMOR)
 	subclass_stats = list(
-		STATKEY_STR = 2, // seems kinda lame but remember guardsman bonus!!
-		STATKEY_PER = 1,
+		STATKEY_STR = 2, // Wielding the banner gives +3 fortune and +2 Perception, as seen in special.dm
 		STATKEY_CON = 2,
-		STATKEY_WIL = 1
+		STATKEY_WIL = 3 // Flag must never fall.
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT, // SWING THAT THING.
-		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT, // OR THOSE ARMS, I GUESS.
-		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN, 
+		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN, // On par with Footman, but journeyman.
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/maces = SKILL_LEVEL_EXPERT, // Although they still have a cudgel for cop duties.
+		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/slings = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
 	)
 	maximum_possible_slots = 1 // Haha... no... unless...?
 
 /datum/outfit/job/roguetown/manorguard/standard_bearer/pre_equip(mob/living/carbon/human/H)
 	..()
-	H.adjust_blindness(-3)
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
-	head = /obj/item/clothing/head/roguetown/helmet/kettle
-	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
-	pants = /obj/item/clothing/under/roguetown/brigandinelegs
 	r_hand = /obj/item/rogueweapon/spear/keep_standard
 	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	backpack_contents = list(
@@ -453,6 +454,39 @@
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
 	)
 	H.verbs |= /mob/proc/haltyell
+
+	H.adjust_blindness(-3)
+	if(H.mind)
+		var/armor_options = list("Light Brigandine Set", "Maille Set")
+		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMS") as anything in armor_options
+
+		switch(armor_choice)
+			if("Light Brigandine Set")
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
+				pants = /obj/item/clothing/under/roguetown/brigandinelegs
+
+			if("Maille Set")
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+
+		var/helmets = list(
+		"Simple Helmet" 	= /obj/item/clothing/head/roguetown/helmet,
+		"Kettle Helmet" 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+		"Bascinet Helmet"	= /obj/item/clothing/head/roguetown/helmet/bascinet,
+		"Sallet Helmet"		= /obj/item/clothing/head/roguetown/helmet/sallet,
+		"Winged Helmet" 	= /obj/item/clothing/head/roguetown/helmet/winged,
+		"Skull Cap"			= /obj/item/clothing/head/roguetown/helmet/skullcap,
+		"None"
+		)
+		var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
+	if(H.mind)
+		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.") // It'd be soulful to give them a level up, but that's sergeant's already.
 
 // These are really hacky, but it works.
 // One proc to moodbuff.
@@ -470,7 +504,7 @@
 
 /datum/emote/living/standard_position/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	if(do_after(user, 8 SECONDS)) // SCORE SOME GOALS!!!
+	if(do_after(user, 6 SECONDS)) // SCORE SOME GOALS!!!
 		playsound(user.loc, 'sound/combat/shieldraise.ogg', 100, FALSE, -1)
 		if(.)
 			for(var/mob/living/carbon/human/L in viewers(7, user))


### PR DESCRIPTION
## About The Pull Request

it's been a minute!

This is all for the Standard Bearer MAA subclass.

- Gives them skills on parity with their other MAA, if with journeyman in the weapons they aren't applicable for.
- Gives them medium armor training, as they don't actually have crit resist.
- Gives them a mirror of the Footman's equipment choice between light and medium, as well as a helmet. Cavalry also gets medium, although doesn't get a choice, so they've been an odd duck out.
- Makes the rally channel slightly shorter. It's a screenwide mood boost for the garrison, it doesn't need to be eight whole seconds.
- Puts the Banner, as used as a weapon, back on par with all the other polearms by way of restoring penetration factor. I dunno why the blacksteel marked spear was earmarked as the same as a short spear...
- Jaks their stats, I welcome feedback here; the intent is for them to endure. The inherent, odd bonuses of the Banner probably inflate them too much, but that can be disarmed. Eh...
- Gives the Bearer money!

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="652" height="391" alt="image" src="https://github.com/user-attachments/assets/e7b4de64-30b8-4e68-91f0-f01ebcb1f328" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

The original design port of the standard bearer was that they were a relatively fragile, supportive element of the MAA squad. Except here we don't really fill out the roster, so having a bum player isn't ideal. The mechanical buff provided by the Banner's rally is _only_ a screenwide mood boost, which while helpful isn't going to be breaking the tide. So we'll give them a gentle nudge to make them combat capable as a spear guy in their own right. The sergeant already exists for actual buffs.

A power goal would be to remove the banner's functions from an evil bepoke tab and make them action buttons, as well as maybe a spell-blade recall function to lean on the apparent magical nature of the spear. That is for another person at another time, though.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: The Standard Bearer has a more nuanced skill set and is more combat capable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
