### PR TITLE
added purple halfmask to loadout

### DIFF
--- a/code/datums/loadout/loadout_accessories.dm
+++ b/code/datums/loadout/loadout_accessories.dm
@@ -45,6 +45,11 @@
 	path = /obj/item/clothing/mask/rogue/shepherd
 	sort_category = "Accessories"
 
+/datum/loadout_item/shadowmask
+	name = "Purple Halfmask"
+	path = /obj/item/clothing/mask/rogue/shepherd/shadowmask
+	sort_category = "Accessories"
+
 /datum/loadout_item/dendormask
 	name = "Briar Mask"
 	path = /obj/item/clothing/head/roguetown/dendormask


### PR DESCRIPTION
## About The Pull Request
adds the purple halfmask that drow used to drop to loadout

## Testing Evidence
cant. tgui doesn't work on local, probably a linux byond thing. compiles, though

## Why It's Good For The Game
the purple halfmask that used to drop from drow in the underdark, and no longer does, has a unique sprite set, which looks cool (its item sprite especially is way better than the normal halfmask) and is a vital part of astrachan's best outfit. it has no stats and is identical to a normal halfmask otherwise, so... there's not really a reason to restrict it

## Changelog

:cl:
add: purple halfmask added to loadout
/:cl:
