### PR TITLE
Fixes psydonian thorns cover flags

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/blacksteel.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/blacksteel.dm
@@ -103,6 +103,7 @@
 	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_MASK
 	armor_class = ARMOR_CLASS_NONE
 	block2add = FOV_DEFAULT
+	flags_cover = null
 
 /obj/item/clothing/head/roguetown/helmet/blacksteel/psythorns/attack_self(mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

blacksteel thorns are a helmet subtype, meaning they are flagged to cover eyes and mouth, preventing eating and drinking
they don't actually protect either however
and the sprite doesn't hide either
so, no more coverage flags

## Testing Evidence

i ate 2 handpies with them, in mask and helmet slot
<img width="449" height="105" alt="Screenshot 2026-03-25 052801" src="https://github.com/user-attachments/assets/8172b556-e799-486c-9c79-ff2b5c431b7f" />
<img width="325" height="283" alt="Screenshot 2026-03-25 052804" src="https://github.com/user-attachments/assets/a811ebcf-e408-4196-985e-b6e9d903f4b7" />

## Why It's Good For The Game

bug bad.
handpie goog.

## Changelog

:cl:
fix: fixed psydonian thorns coverage flags
/:cl: