### PR TITLE
More variety of fellas who are big.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -213,13 +213,16 @@
 
 	var/prefixs = list(
 		"Skinny" = "Skinny", // Why
+		"Fat" = "Fat",
 		"Big" = "Big", // Yes, There is two cases where if someone calls themselves "Boss", we need to explode them.
 		"Small" = "Small",
-		"Little" = "Little",
-		"Wide" = "Wide",
 		"Huge" = "Huge",
+		"Little" = "Little",
 		"Thick" = "Thick",
+		"Thin" = "Thin",
 		"Long" = "Long",
+		"Short" = "Short",
+		"Wide" = "Wide",
 		"Slug" = "Slug",
 		"Molasses" = "Molasses",
 		"Stony" = "Stony",


### PR DESCRIPTION
## About The Pull Request

I agree it's vital as a debuff to the Big Fella class that there is a silly prefix before the name. However there is more things then what Joseph Salvatore "Skinny Joey" Merlino was called, and honestly, the charm goes away after you keep encountering different characters with the same start of the name.

## Testing Evidence

<img width="291" height="258" alt="image" src="https://github.com/user-attachments/assets/266d37f1-8b3e-42ec-91a3-e116e09b0f01" />
<img width="191" height="128" alt="image" src="https://github.com/user-attachments/assets/830f255e-6f97-40c6-9060-496cdf945ae4" />

## Why It's Good For The Game

More silly prefixes to keep Big Fella players different from each other while still preserving the classes identity.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: More Big Fella Nicknames.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
