### PR TITLE
Fixes psydonian thorns flags, again

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/blacksteel.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/blacksteel.dm
@@ -104,6 +104,7 @@
 	armor_class = ARMOR_CLASS_NONE
 	block2add = FOV_DEFAULT
 	flags_cover = null
+	flags_inv = null
 
 /obj/item/clothing/head/roguetown/helmet/blacksteel/psythorns/attack_self(mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

I thought I checked for this but turns out when I did it was only in the mask slot
anyway, the thorns no longer hide facial and racial features

## Testing Evidence

now with ears
<img width="75" height="105" alt="Screenshot 2026-03-25 134704" src="https://github.com/user-attachments/assets/4a0d4392-78f1-4d27-acb3-81cea882a5a8" />


## Why It's Good For The Game

I'm stupid apparently, this should have been part of the first fix.

## Changelog

:cl:
fix: fixed psydonian thorns flags, again
/:cl:
