### PR TITLE
No more Sneaky Grand Mace in the pocket + psydonic handmace 

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -679,7 +679,7 @@
 	icon_state = "polemace"
 	force = 15
 	force_wielded = 35
-	slot_flags = null
+	slot_flags = ITEM_SLOT_BACK
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 	wdefense_wbonus = 5


### PR DESCRIPTION
## About The Pull Request

Grand mace/goden is now on-par with other bigboy weapons in that they fit on your back without a strap, but no longer on the hip.

Removed swift balance on Psydonic Handmace. Why did they think this was a good idea? 

## Testing Evidence

It compiles

## Why It's Good For The Game
<img width="763" height="67" alt="image" src="https://github.com/user-attachments/assets/787d7a65-f14b-479d-9a41-edd3ebf7e00a" />
It was an oversight nobody bothered to fix because it was convenient. Grand Maces are pathed from Maces themselves, which fit on back and hip, and carried over to the Goedendang and the Grand Mace. I do not believe this was an intended feature of the GM, considering it's a massive fucking hammer that crushes skulls and helmets.


In terms of the Psydonic Handmace, spawning with the only blunt, swift-balanced, silver-sundering weapon in the game on a class that you can easily build for 14-15 speed, dodge expert/skin armor with is genuinely absurd. Who thought this was a good idea? This shouldn't have to be said. 

## Changelog


:cl:
del: Removed swift balance on Psydonic handmace.
balance: Fixes an oversight with the Grand Mace that allowed it to fit in both the back and hip slot.

/:cl:

