### PR TITLE
Final Hand armour adjustment

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -111,29 +111,6 @@
 	body_parts_covered = CHEST|GROIN
 	armor_class = ARMOR_CLASS_LIGHT //placed in the medium category to keep it with its parent obj
 
-//Hand's armored coat. Expensive and unique brigandine armour. the only one in the game to give it some gimmick back
-
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/hand //hauberk subtype now, meaning no stacking but gambeson compatible
-	name = "hand's armored coat"
-	desc = "Sturdy leather, fine silks, ornaments of gold and enough steel to stop a blade. Opulent and imperial, for any one who must say <i>\"I am in charge.\"</i> holds no power at all."
-	icon = 'icons/roguetown/clothing/special/hand.dmi'
-	icon_state = "handgambeson"
-	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/hand.dmi'
-	sleeved = 'icons/roguetown/clothing/special/onmob/hand.dmi'
-	detail_tag = "_detail"
-	detail_color = "#6e423a"
-	body_parts_covered = COVERAGE_ALL_BUT_ARMFEET //no arm cover, with the bracers = full cover
-	armor_class = ARMOR_CLASS_LIGHT //wearable by spymaster and advisor
-	armor = ARMOR_BRIGANDINE //only chest armour which uses this
-	sellprice = 250
-	unenchantable = TRUE
-
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/hand/advisor
-	detail_color = "#6678c9"
-
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/hand/spymaster
-	detail_color = "#742277"
-
 //HEAVY ARMOR//
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/heavy

--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -260,3 +260,22 @@
 	icon_state = "shadowrobe"
 	armor = ARMOR_PADDED
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM + 30 //280
+
+//Hand's gambeson, looks fancy
+
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hand
+	name = "hand's gambeson"
+	desc = "Sturdy leather, fine silks and ornaments of gold. Opulent and imperial, for any one who must say <i>\"I am in charge.\"</i> holds no power at all."
+	icon = 'icons/roguetown/clothing/special/hand.dmi'
+	icon_state = "handgambeson"
+	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/hand.dmi'
+	sleeved = 'icons/roguetown/clothing/special/onmob/hand.dmi'
+	detail_tag = "_detail"
+	detail_color = "#6e423a"
+	shiftable = FALSE
+
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hand/advisor
+	detail_color = "#6678c9"
+
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hand/spymaster
+	detail_color = "#742277"

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -418,14 +418,14 @@
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_HORDE, "ARMOR", "RENDERED ASUNDER")
 
-/obj/item/clothing/wrists/roguetown/bracers/brigandine/hand
+/obj/item/clothing/wrists/roguetown/bracers/hand
 	name = "hand's bracers"
 	desc = "Discretion had always been the better part of valour, and nobody understands that better than the one holding an ace up their sleeve."
 	color = null
-	sellprice = 250
+	armor = ARMOR_MAILLE //chausses parity, unique
 	icon = 'icons/roguetown/clothing/special/hand.dmi'
 	icon_state = "bracersheath"
 
-/obj/item/clothing/wrists/roguetown/bracers/brigandine/hand/ComponentInitialize()
+/obj/item/clothing/wrists/roguetown/bracers/hand/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/holster, /obj/item/rogueweapon/huntingknife, null, list(/obj/item/rogueweapon/huntingknife/idagger/stake, /obj/item/rogueweapon/huntingknife/idagger/silver/stake))

--- a/code/modules/jobs/job_types/roguetown/courtier/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/hand.dm
@@ -31,8 +31,8 @@
 /datum/outfit/job/roguetown/hand
 	backr = /obj/item/storage/backpack/rogue/satchel/short
 	shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine/hand
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/light //regular
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/hand
 	belt = /obj/item/storage/belt/rogue/leather/steel
 	id = /obj/item/scomstone/garrison/hand
 	job_bitflag = BITFLAG_ROYALTY
@@ -90,7 +90,7 @@
 	r_hand = /obj/item/rogueweapon/sword/long/hand
 	beltr = /obj/item/rogueweapon/scabbard/sword/royal
 	head = /obj/item/clothing/head/roguetown/chaperon/noble/hand
-	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/hand
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hand
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/dtace = 1,
@@ -137,7 +137,7 @@
 	)
 
 /datum/outfit/job/roguetown/hand/spymaster
-	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/hand/spymaster
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hand/spymaster
 
 //Spymaster start. More similar to the rogue adventurer - loses heavy armor and sword skills for more sneaky stuff.
 /datum/outfit/job/roguetown/hand/spymaster/pre_equip(mob/living/carbon/human/H)
@@ -196,7 +196,7 @@
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 	)
 /datum/outfit/job/roguetown/hand/advisor
-	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/hand/advisor
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hand/advisor
 	r_hand = /obj/item/rogueweapon/sword/rapier/hand
 	beltr = /obj/item/rogueweapon/scabbard/sheath/courtphysician/hand
 	beltl = /obj/item/rogueweapon/huntingknife/idagger/dtace


### PR DESCRIPTION
## About The Pull Request

~~this will conflict with #6452, as mentioned on the discord.~~ should no longer confict
turns the hand armour back into a gambeson, but with drip.
nothing special.
nothing problematic.
nothing hard to maintain.
perfectly viable.
everybody wins.

returns the besilked haubergeon, but the not shit version.
changes bracers to be maille, no reason to drop them for plate anymore.

removes value from both gambeson and bracers, no more encouraged strip and steal.

## Testing Evidence

<img width="703" height="958" alt="Screenshot 2026-03-26 053058" src="https://github.com/user-attachments/assets/77413667-b775-4552-8601-33f07f710217" />


## Why It's Good For The Game

this is my last straw, take it or leave it.
its inoffensive and serviceable.

## Changelog

:cl:
balance: changed hand armour back into a regular gambeson
balance: returned besilked haubergeon to the hand
balance: hand bracers -> maille
balance: no more value on unique hand drip
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
