### PR TITLE
Adds fixes quiver/bolt pouches in tailor silverface

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/apparel.dm
+++ b/code/modules/cargo/packsrogue/merchant/apparel.dm
@@ -195,8 +195,15 @@
 					/obj/item/rogueweapon/scabbard/sword
 				)
 
-/datum/supply_pack/rogue/apparel/quiver/bolt
+/datum/supply_pack/rogue/apparel/quiver
 	name = "Empty Quiver"
+	cost = 20
+	contains = list(
+					/obj/item/quiver
+				)
+
+/datum/supply_pack/rogue/apparel/quiver/bolt
+	name = "Empty Bolt Pouch"
 	cost = 20
 	contains = list(
 					/obj/item/quiver/bolt


### PR DESCRIPTION
## About The Pull Request

empty quiver is now actually an empty quiver
figured may as well keep the ability to buy bolt pouches

## Testing Evidence

<img width="458" height="328" alt="Screenshot 2026-03-26 055206" src="https://github.com/user-attachments/assets/6e5a1ea9-c16b-4d8c-b374-6dec588a83ad" />

## Why It's Good For The Game

bug bad.
stuff goog.

## Changelog

:cl:
fix: fixed bolt pouch and quiver buying from the tailor silverface
/:cl:
