### PR TITLE
Copper and Tin alchemy transmutation

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -246,6 +246,22 @@
 	craftdiff = 2
 	verbage_simple = "transmute"
 
+/datum/crafting_recipe/roguetown/alchemy/cl2st2copp
+	name = "stone & clay to copper"
+	category = "Transmutation"
+	result = list(/obj/item/rogueore/copper = 1)
+	reqs = list(/obj/item/natural/stone = 2, /obj/item/natural/clay = 2)
+	craftdiff = 3
+	verbage_simple = "transmute"
+
+/datum/crafting_recipe/roguetown/alchemy/st2di2tin
+	name = "stone & dirt to tin"
+	category = "Transmutation"
+	result = list(/obj/item/rogueore/tin = 1)
+	reqs = list(/obj/item/natural/stone = 2, /obj/item/natural/dirtclod = 2)
+	craftdiff = 3
+	verbage_simple = "transmute"
+
 /datum/crafting_recipe/roguetown/alchemy/c2irn
 	name = "coal to iron"
 	category = "Transmutation"


### PR DESCRIPTION
## About The Pull Request

Adds two recipes for alchemy. Copper can be transmute from 2 stones and 2 clay. Tin - 2 stones and 2 dirtclod.

## Testing Evidence

Was tested on https://github.com/Twilight-Fortress-SS13/Twilight-Axis/pull/862

## Why It's Good For The Game

You can transmute iron, coal, even gold but not copper and tin (wtf)

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: New recipes for alchemy transmutation, tin and copper.
/:cl: