### PR TITLE
Craftable Pillory

### DIFF
--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -1522,3 +1522,14 @@
 	verbage_simple = "weave"
 	verbage = "weaves"
 	craftdiff = 0
+
+/datum/crafting_recipe/roguetown/structure/pillory
+	name = "pillory"
+	category = "Misc"
+	result = /obj/structure/pillory/crafted
+	reqs = list(/obj/item/grown/log/tree/small = 2,
+				/obj/item/natural/stone = 2)
+	verbage_simple = "construct"
+	verbage = "constructs"
+	skillcraft = /datum/skill/craft/carpentry
+	craftdiff = 2

--- a/modular/code/game/objects/pillory.dm
+++ b/modular/code/game/objects/pillory.dm
@@ -15,6 +15,7 @@
 	plane = GAME_PLANE_UPPER
 	var/latched = FALSE
 	var/locked = FALSE
+	var/makeshift = FALSE
 	var/base_icon = "pillory_single"
 	var/list/lockid = list()
 
@@ -33,6 +34,26 @@
 
 /obj/structure/pillory/town
 	lockid = list("dungeon", "garrison", "walls", "church", "inquisition", "manor")
+
+/obj/structure/pillory/crafted
+	name = "makeshift pillory"
+	makeshift = TRUE
+
+/obj/structure/pillory/crafted/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("This one locks without a key using <b>middle click</b>, but it's a weak lock!")
+
+/obj/structure/pillory/crafted/MiddleClick(mob/user)
+	. = ..()
+	if(!latched)
+		to_chat(user, span_warning("It's not latched shut!"))
+		return
+	if(user in buckled_mobs)
+		to_chat(user, span_warning("I can't reach the lock!"))
+		return
+	else
+		togglelock(user)
+		return
 
 /obj/structure/pillory/Initialize()
 	LAZYINITLIST(buckled_mobs)
@@ -70,6 +91,9 @@
 		var/obj/item/roguekey/K = P
 		if(K.lockid in lockid)
 			togglelock(user)
+			return
+		else if(makeshift == TRUE)
+			to_chat(user, span_warning("There is no keyhole?"))
 			return
 		else
 			to_chat(user, span_warning("Wrong key."))
@@ -167,6 +191,13 @@
 	if(buckled_mob == user)
 		if(buckled_mob.STASTR >= 18)
 			if(do_after(buckled_mob, 2.5 SECONDS))
+				buckled_mob.visible_message(span_warning("[buckled_mob] breaks [src] open!"))
+				locked = FALSE
+				latched = FALSE
+				return ..()
+			return null
+		if(makeshift == TRUE & buckled_mob.STASTR >= 11)
+			if(do_after(buckled_mob, 200 SECONDS))
 				buckled_mob.visible_message(span_warning("[buckled_mob] breaks [src] open!"))
 				locked = FALSE
 				latched = FALSE


### PR DESCRIPTION
## About The Pull Request

A niche market for ineffective pillory usage has been found! This adds a craftable pillory that uses a middle-click deadbolt instead of a key to lock, and allows characters who are 11 strength or stronger to break out through force of will after 200 seconds! We can look into making this less powerful if need be (especially if people start exploiting it).

## Testing Evidence

<img width="321" height="203" alt="image" src="https://github.com/user-attachments/assets/32db0b6e-b83f-43f4-981c-1c4d155db102" />
<img width="434" height="58" alt="image" src="https://github.com/user-attachments/assets/77b37243-3756-4bf3-bf17-eea8315a55de" />
<img width="161" height="26" alt="image" src="https://github.com/user-attachments/assets/8b3882b4-ac82-42ab-9754-62ce7d28e415" />

## Why It's Good For The Game

It's really meant to be a version of the town pillories that **anyone** can unlock, as well as a very easy strength check to escape it to stop wretches from trying to round remove combat roles.

And if this is too powerful, I will reduce the strength check to eight and reduce the resist down to 10 seconds, I don't care if this would make it only good for _that_ roleplay, just let me have this.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: A deadbolt pillory recipe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
