### PR TITLE
Face wounds are no longer permanent

### DIFF
--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -2,7 +2,7 @@
 	name = "facial trauma"
 	sound_effect = 'sound/combat/crit.ogg'
 	severity = WOUND_SEVERITY_SEVERE
-	whp = null
+	whp = 70 //Bit harder to heal than regular wounds but not impossible
 	woundpain = 0
 	can_sew = FALSE
 	can_cauterize = FALSE
@@ -163,7 +163,6 @@
 	check_name = span_warning("FACE")
 	severity = 0
 	crit_message = "The face is mangled beyond recognition!"
-	whp = null
 	woundpain = 20
 	mob_overlay = "cut"
 	can_sew = FALSE


### PR DESCRIPTION
## About The Pull Request

Harder to heal than regular wounds but not impossible anymore, eye gouges - disfigurment and blunt ear crits can now be healed using miracles and red. Eye gouge of both eyes (when they pop out) still cannot without shoving them back in.

To note is that cyclops is still unchanged with how it works, you cannot get rid of THAT.

## Testing Evidence

Byeah

## Why It's Good For The Game

Should make eye gouging and ear bashing even less desirable and punishing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Face wounds being unhealable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
