### PR TITLE
bloak2

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pariah.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pariah.dm
@@ -10,7 +10,7 @@
 	)
 	outfit = /datum/outfit/job/roguetown/wretch/pariah
 	cmode_music = 'sound/music/combat_blackoak.ogg'
-	maximum_possible_slots = 1
+	maximum_possible_slots = 2
 	class_select_category = CLASS_CAT_BATTLEMAGE
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_AZURENATIVE, TRAIT_OUTDOORSMAN, TRAIT_BLACKOAK, TRAIT_DODGEEXPERT, TRAIT_ARCYNE_T2, TRAIT_WOODWALKER)


### PR DESCRIPTION
## About The Pull Request

Increases the role slot capacity of the Black Oaks-exclusive 'Pariah' class for the Wretch by one.

## Testing Evidence

Singular value change.

## Why It's Good For The Game

* Allows a little more representation by an Azurian-specific Wretch class that's racelocked to the elven species, and accounts for the increased amount of overall Wretch slots.
* Opens up supplemental gimmicks without potentially causing the entire balance-based ecosystem to implode. Weight-wise, they're comparable - in general strengths, from what I understand - to the similarly two-slotted Heretics.

## Changelog

:cl:
balance: The amount of Black Oak-specific Pariah slots in the 'Wretch' role has been increased to two.
/:cl: