### PR TITLE
consume threads on stopping bleed + successful repair (for hammer too)

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -70,7 +70,7 @@
 			return
 
 		to_chat(user, "I begin threading the needle with additional fibers...")
-		if(do_after(user, 6 SECONDS - user.get_skill_level(/datum/skill/craft/sewing), target = I))
+		if(do_after(user, 3 SECONDS, target = I))
 			var/refill_amount
 			refill_amount = min(5, (maxstring - stringamt))
 			stringamt += refill_amount
@@ -152,6 +152,7 @@
 				return
 			else
 				playsound(loc, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
+				use(1)
 				user.visible_message(span_info("[user] repairs [I]!"))
 				if(I.body_parts_covered != I.body_parts_covered_dynamic)
 					user.visible_message(span_info("[user] repairs [I]'s coverage!"))
@@ -229,6 +230,7 @@
 			else
 				patient.visible_message(span_smallgreen("One last drop of blood trickles from the [(target_wound?.name)] on [patient]'s [affecting.name] before it closes."), span_smallgreen("The throbbing warmth coming out of the [target_wound] soothes and stops. It no longer bleeds."))
 			informed = TRUE
+			use(1)
 		if(istype(target_wound, /datum/wound/dynamic))
 			var/datum/wound/dynamic/dynwound = target_wound
 			if(dynwound.is_maxed)
@@ -239,7 +241,6 @@
 			continue
 		if(doctor.mind)
 			doctor.mind.add_sleep_experience(/datum/skill/misc/medicine, doctor.STAINT * 2.5)
-		use(1)
 		target_wound.sew_wound()
 		if(patient == doctor)
 			if(is_simple_animal)

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -43,6 +43,9 @@
 /obj/item/rogueweapon/hammer/attack_obj(obj/attacked_object, mob/living/user)
 	if(!isliving(user) || !user.mind)
 		return
+	if(obj_broken)
+		to_chat(user, span_warning("[src] is too damaged to repair anything."))
+		return
 
 	if(isbodypart(attacked_object) && !user.cmode)
 		repair_bodypart(attacked_object, user)
@@ -138,6 +141,8 @@
 				if(attacked_item.body_parts_covered != attacked_item.body_parts_covered_dynamic)
 					user.visible_message(span_info("[user] repairs [attacked_item]'s coverage!"))
 					attacked_item.repair_coverage()
+				if(!(locate(/obj/machinery/anvil) in attacked_item.loc))
+					take_damage(10, BRUTE, "blunt", FALSE)
 			if(attacked_item.obj_broken && attacked_item.obj_integrity == attacked_item.max_integrity)
 				attacked_item.obj_fix()
 			user.mind.add_sleep_experience(attacked_item.anvilrepair, exp_gained/2) //We gain as much exp as we fix divided by 2
@@ -230,7 +235,7 @@
 	desc = "A makeshift hammer, made with a crudly chisled-down rock."
 	icon_state = "hammer_r"
 	force = 18
-	max_integrity = 15
+	max_integrity = 50
 
 /obj/item/rogueweapon/hammer/aalloy
 	name = "decrepit hammer"
@@ -255,7 +260,7 @@
 	desc = "A copper hammer, slightly better than a stone hammer."
 	icon_state = "hammer_c"
 	force = 20
-	max_integrity = 100
+	max_integrity = 150
 
 /obj/item/rogueweapon/hammer/iron	// iron hammer
 	name = "hammer"


### PR DESCRIPTION
## About The Pull Request

as it says on the tin. you'll consume threads when you stop bleeds rather than when you sew a wound and when you complete one cycle of a successful repair stitch

## Testing Evidence

tested

## Why It's Good For The Game

always irked me weird that you can stop a bleed then forget about the wound entirely without consuming a thread. likewise for repairs. Now for hammers as well. 15% drained per successful strike. number adjustible.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: needle uses consume on successful repairs.
balance: needle uses consume on stopping bleeds.
balance: needle uses can be replenished in a base 3s now. 
balance: hammer uses on repairs successfully drains 10units of integrity. 0u on an anvil.
balance: Copper hammer is now 150 integ (from 100). Stone is now 50 integ (from 15)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
