### PR TITLE
Crier's hat onmob fix

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -548,6 +548,7 @@
 	icon_state = "loudmouth"
 	item_state = "loudmouth"
 	color = CLOTHING_RED
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/head.dmi'
 
 /obj/item/clothing/head/roguetown/maidhead
 	name = "maid headdress"


### PR DESCRIPTION
## About The Pull Request

Fix: onmob crier hat. Someone just forgot to put correct path for sprites.

## Testing Evidence

Before:
<img width="1071" height="363" alt="image" src="https://github.com/user-attachments/assets/32bd985c-6fc5-4d01-b317-c826cbab8a39" />

After:
<img width="1076" height="507" alt="image" src="https://github.com/user-attachments/assets/3a750b12-d817-49ff-b7f9-1351696fdfed" />


## Why It's Good For The Game

Fix.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fixed Crier's hat onmob sprite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
