### PR TITLE
[Hag] - Small hag bugfixes. alist, and tiny cost reduction for deathless.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_blessings.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_blessings.dm
@@ -12,7 +12,7 @@
 /datum/hag_boon/buff/storm_rebirth
 	name = "Deathless"
 	desc = "The first time the bearer dies, they shall be revived completely. Their body animated like a puppet, leaving them with a curse most terrible."
-	points = 85
+	points = 65
 	status_type = /datum/status_effect/buff/hag_boon/storm_rebirth
 
 /datum/hag_boon/buff/natural_communion

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_heart.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_heart.dm
@@ -14,7 +14,7 @@
 	var/max_stages = 3
 	var/timer_id
 	var/datum/hag_rite/chosen_rite
-	var/static/list/rite_requirements = list(
+	var/static/alist/rite_requirements = list(
 		1 = list(/obj/item/reagent_containers/lux = 2, /obj/item/reagent_containers/food/snacks/fish/creepy_squid = 1, /obj/item/reagent_containers/glass/bottle/rogue/elfblue = 1),
 		2 = list(/obj/item/rogueweapon/sword/rapier/lord = 1, /obj/item/magic/voidstone = 1, /obj/item/blueprint/mace_mushroom = 1),
 		3 = list(/obj/item/rogueore/lithmyc = 1, /obj/item/roguegem/blood_diamond = 1, /obj/item/reagent_containers/food/snacks/eoran_aril/ashen = 1, /obj/item/ingot/lithmyc = 1, /obj/item/rogueweapon/mace/mushroom = 1, /obj/item/rogueweapon/spear/dreamscape_trident = 1),


### PR DESCRIPTION
## About The Pull Request
- Deathless cost 85 => 65. Turns out you couldn't tech up to tier 2 and then apply this as intended due to it being too expensive.
- Hag tree list to alist to stop runtimes.

## Testing Evidence
Tree still worked

## Why It's Good For The Game
aaa

## Changelog

:cl:
balance: Hag deathless cost 85 => 65
fix: Hag heart no longer runtimes
/:cl:

