### PR TITLE
[Virtues] - Preemptively nerfs feytouched into the ground.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_tree.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_tree.dm
@@ -255,6 +255,9 @@
 		user.forceMove(destination)
 		user.visible_message(span_notice("[user] emerges from the roots of [target]."), \
 							 span_boldnotice("The roots spit you back out into [get_area(target)]."))
+		if(HAS_TRAIT(user, TRAIT_ROOT_WALKER))
+			to_chat(user, span_notice("Your affinity with the roots falls away again, demanding more tribute."))
+			REMOVE_TRAIT(user, TRAIT_ROOT_WALKER, TRAIT_HAG_BOON)
 		if(passenger && get_dist(src, passenger) <= 2)
 			passenger.forceMove(destination)
 			to_chat(passenger, span_userdanger("You are dragged through the suffocating, muddy darkness of the roots!"))


### PR DESCRIPTION
## About The Pull Request
- Feytouched now requires a lux per travel rather than a lux per person to unlock the travel ability.
- Keep in mind that lux offering has a built in cooldown for moss trees. You can travel from A to B, but then it takes a minute or two before you can travel back from B to A.
- This invariably means that the more people with feytouched, the worse the virtue becomes.
- Hag hut can't ever be travelled to by anyone except the hag, this is unchanged.
- Stat penalty of 2 str 1 int unchanged.

## Testing Evidence
Tested on local, tree allowed one travel per lux.

## Why It's Good For The Game
Primarily an RP virtue, might as well curb potential abuse early?
People should be taking this to RP being indebted, or being a weird fey creature. not primarily for the benefit it provides.

Effect might be changed entirely to not be allowing root travel or limited / made worse further should it be too good still.

## Changelog

:cl:
balance: Feytouched now require a lux (any type) per travel.
/:cl:
