### PR TITLE
prevent 1h weapons from being wielded again

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1484,8 +1484,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				update_force_dynamic()
 				wdefense_dynamic = (wdefense + wdefense_wbonus)
 
+
 /obj/item/proc/wield(mob/living/carbon/user, show_message = TRUE)
 	if(wielded)
+		return
+	if(!gripped_intents)
 		return
 	if(user.get_inactive_held_item())
 		to_chat(user, span_warning("I need a free hand first."))

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -6,7 +6,7 @@
 	force = 22
 	force_wielded = 25
 	possible_item_intents = list(/datum/intent/sword/cut/arming, /datum/intent/sword/thrust/arming, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut/arming, /datum/intent/sword/thrust/arming, /datum/intent/sword/strike)
+	gripped_intents = null
 	damage_deflection = 14
 	icon_state = "sword1"
 	sheathe_icon = "sword1"
@@ -1282,8 +1282,8 @@
 	inhand_y_dimension = 64
 	dropshrink = 0.75
 	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier)
-	special = /datum/special_intent/piercing_lunge
 	gripped_intents = null
+	special = /datum/special_intent/piercing_lunge
 	parrysound = list(
 		'sound/combat/parry/bladed/bladedthin (1).ogg',
 		'sound/combat/parry/bladed/bladedthin (2).ogg',


### PR DESCRIPTION
## About The Pull Request

as it says on the tin

## Testing Evidence

yes

## Why It's Good For The Game

no more 2h rapier (???). this needs a better fix but ill do it when i ahve time

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: prevent one handed weapons from being wieldable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
