### PR TITLE
love wins... 2!

### DIFF
--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -366,6 +366,7 @@
 /obj/item/clothing/ring/band/get_mechanics_examine(mob/user)
     . = ..()
     . += span_info("Right-click to add a custom name and description to the weddingband.")
+    . += span_info("If your character is meant to be already married to someone else, offer the ring to them while they are offering theirs to you. This will mark you as spouses, but will not change your names.")
 
 /obj/item/clothing/ring/band/gold
 	name = "gold weddingband"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2388,8 +2388,8 @@
 		addtimer(CALLBACK(offered_to, PROC_REF(stop_offering_item)), 0.6 SECONDS)
 		self.marriedto = other.real_name
 		other.marriedto = self.real_name
-		to_chat(self, span_notice("[other] is my beloved spouse! Time may pass, but our love endures."))
-		to_chat(other, span_notice("[self] is my beloved spouse! Time may pass, but our love endures."))
+		to_chat(self, span_notice("[other] is my beloved spouse! Time passes, but our love endures."))
+		to_chat(other, span_notice("[self] is my beloved spouse! Time passes, but our love endures."))
 	else
 		visible_message(
 			span_notice("[src] offers [offered_item] to [offered_to] with an outstretched hand."), \

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2360,15 +2360,20 @@
 	offered_item_ref = WEAKREF(offered_item)
 
 	var/stealthy = (m_intent == MOVE_INTENT_SNEAK)
-	var/obj/item/reagent_containers/glass/offered_item_other = null
+	var/obj/item/reagent_containers/glass/offered_glass_other = null
+	var/obj/item/clothing/ring/band/offered_band_other = null
+	var/mob/living/carbon/human/self = src
+	var/mob/living/carbon/human/other = offered_to
 	if(istype(offered_item, /obj/item/reagent_containers/glass) && offered_item?.reagents?.maximum_volume > 0) // we have a drink in our hand
-		offered_item_other = offered_to.offered_item_ref?.resolve()
+		offered_glass_other = offered_to.offered_item_ref?.resolve()
+	if(istype(offered_item, /obj/item/clothing/ring/band)) // love wins
+		offered_band_other = offered_to.offered_item_ref?.resolve()
 
 	if(stealthy)
 		to_chat(src, span_notice("I secretly offer [offered_item] to [offered_to]."))
 		to_chat(offered_to, span_notice("[offered_to] secretly offers [offered_item] to me..."))
-	else if(!isnull(offered_item_other) && istype(offered_item_other) && offered_item_other?.reagents?.maximum_volume > 0) // Credit to tmyqlfpir; allows for the clinking of everything up to blacksteel tankards.
-		playsound(src,offered_item_other.reagents.maximum_volume > 50 ? 'sound/misc/clink_drink_big.ogg' : 'sound/misc/clink_drink.ogg', 100, TRUE) //Adds a new sound if the clinked container is above 50 drams in size.
+	else if(!isnull(offered_glass_other) && istype(offered_glass_other) && offered_glass_other?.reagents?.maximum_volume > 0) // Credit to tmyqlfpir; allows for the clinking of everything up to blacksteel tankards.
+		playsound(src,offered_glass_other.reagents.maximum_volume > 50 ? 'sound/misc/clink_drink_big.ogg' : 'sound/misc/clink_drink.ogg', 100, TRUE) //Adds a new sound if the clinked container is above 50 drams in size.
 		addtimer(CALLBACK(src, PROC_REF(stop_offering_item)), 0.6 SECONDS)
 		addtimer(CALLBACK(offered_to, PROC_REF(stop_offering_item)), 0.6 SECONDS)
 		visible_message(
@@ -2378,6 +2383,13 @@
 			ignored_mobs = list(offered_to)
 		)
 		to_chat(offered_to, span_notice("[src] clinks [offered_item] with me!"))
+	else if(!isnull(offered_band_other) && istype(offered_band_other) && ishuman(src) && ishuman(offered_to) && !self.marriedto && !other.marriedto)
+		addtimer(CALLBACK(src, PROC_REF(stop_offering_item)), 0.6 SECONDS)
+		addtimer(CALLBACK(offered_to, PROC_REF(stop_offering_item)), 0.6 SECONDS)
+		self.marriedto = other.real_name
+		other.marriedto = self.real_name
+		to_chat(self, span_notice("[other] is my beloved spouse! Time may pass, but our love endures."))
+		to_chat(other, span_notice("[self] is my beloved spouse! Time may pass, but our love endures."))
 	else
 		visible_message(
 			span_notice("[src] offers [offered_item] to [offered_to] with an outstretched hand."), \

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/valuables.dm
@@ -177,6 +177,30 @@
 	created_item = /obj/item/clothing/ring/blacksteel
 	createditem_num = 3
 
+/datum/anvil_recipe/valuables/weddingrings
+	name = "Weddingbands, Silver (x2)"
+	req_bar = /obj/item/ingot/silver
+	created_item = /obj/item/clothing/ring/band
+	createditem_num = 2
+
+/datum/anvil_recipe/valuables/weddingringg
+	name = "Weddingbands, Gold (x2)"
+	req_bar = /obj/item/ingot/gold
+	created_item = /obj/item/clothing/ring/band/gold
+	createditem_num = 2
+
+/datum/anvil_recipe/valuables/weddingringb
+	name = "Weddingbands, Bronze (x2)"
+	req_bar = /obj/item/ingot/bronze
+	created_item = /obj/item/clothing/ring/band/bronze
+	createditem_num = 2
+
+/datum/anvil_recipe/valuables/weddingringp
+	name = "Weddingbands, Ancient (x2)"
+	req_bar = /obj/item/ingot/purifiedaalloy
+	created_item = /obj/item/clothing/ring/band/paalloy
+	createditem_num = 2
+
 /datum/anvil_recipe/valuables/ornateamulet
 	name = "Ornate Amulet"
 	req_bar = /obj/item/ingot/gold


### PR DESCRIPTION
## About The Pull Request
first: weddingbands are now craftable at anvils. requires one bar of the respective type (silver, gold, bronze, or gilbranze) and makes two rings.
second: as requested, there is now a way to set your spouse if your character got married in a past round/their backstory, using the same mechanic as clinking glasses. simply offer a weddingband to your spouse while they are offering one to you, and you will be marked as spouses. doesn't work if you're already married. that info is also in the mechanics examine for weddingbands

## Testing Evidence
<img width="622" height="408" alt="2026-03-29_16-46" src="https://github.com/user-attachments/assets/00177e6d-3363-48e9-8438-3f8b45825c01" />
<img width="625" height="90" alt="2026-03-29_16-47" src="https://github.com/user-attachments/assets/16566f15-e1a0-44a2-801f-538ec69978c0" />
(the message has since been tweaked, "time may pass" → "time passes")

## Why It's Good For The Game
a way to set your spouse without needing the bishop to marry you every round was requested on #6510 and this was the sanest way to do it. love wins once more.

## Changelog

:cl:
add: if your character is meant to already be married, you can set your spouse by offering weddingbands to each other. for if you were married in a past round or your backstory; church weddings are still a thing for new couples.
/:cl:
