### PR TITLE
Flawless no longer grants passive triumph gain

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -111,5 +111,8 @@ SUBSYSTEM_DEF(nightshift)
 	towner_jobs = GLOB.peasant_positions | GLOB.burgher_positions | GLOB.sidefolk_positions
 	if(mind.assigned_role != "Unassigned" && istype(mind.assigned_role, /datum/job) && (mind.assigned_role.title in towner_jobs)) //If you play a towner-related role, you get an additonal triumph
 		triumphs_to_add++
-	adjust_triumphs(triumphs_to_add)
+	if(get_flaw(/datum/charflaw/noflaw))
+		triumphs_to_add = 0
+	if(triumphs_to_add)
+		adjust_triumphs(triumphs_to_add)
 	to_chat(src, span_danger("Days Survived: \Roman[allmig_reward]"))

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -101,20 +101,8 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	desc = "I'm untempted by even the simplest vices. Am I riding the high of my latest TRIUMPH, or am I simply a rarity amongst rarities?" //Originally 'No Flaw', with "I'm a normal person, how rare!" as the desc.
 
 /datum/charflaw/noflaw
-	name = "Flawless (-3 TRI)"
+	name = "Flawless (No Passive TRI Gain)"
 	desc = "I'm untempted by even the simplest vices. Am I riding the high of my latest TRIUMPH, or am I simply a rarity amongst rarities?"
-
-/datum/charflaw/noflaw/apply_post_equipment(mob/user)
-	var/mob/living/carbon/human/H = user
-	if(H.get_triumphs() < 3)
-		var/flawz = GLOB.character_flaws.Copy()
-		var/charflaw = pick_n_take(flawz)
-		charflaw = GLOB.character_flaws[charflaw]
-		var/datum/charflaw/new_flaw = new charflaw()
-		H.charflaws.Add(new_flaw)
-		new_flaw.on_mob_creation(H)
-	else
-		H.adjust_triumphs(-3)
 
 /datum/charflaw/randflaw
 	name = "Random"


### PR DESCRIPTION
## About The Pull Request
Recent PRs highlighted that Flawless can "punish" players for latejoining (entirely normal behaviour, people have lives) by taking away triumphs that they may otherwise not be able to get in the course of the round.

This addresses that by removing passive gen from flawless entirely in place of the regular TRI cost, which will also help resolve both https://github.com/Azure-Peak/Azure-Peak/pull/6526 and https://github.com/Azure-Peak/Azure-Peak/pull/6517 (as Hunted could now give TRI w/o a feedback loop with Flawless in that PR)

This PR does not affect any other source of TRI gain like from Good lover, Lux-related activities, etc.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
you know I probably should test it
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
In some ways this is a harsher downside, in some ways it isn't. Entirely depends on how and when the user joins the round.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Flawless vice now restricts passive Triumph gain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
