### PR TITLE
Ruma Clan Adjustment

### DIFF
--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -577,6 +577,7 @@
 	icon_state = "kazscab_steel"
 	item_state = "kazscab_steel"
 	valid_blade = /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench
+	max_integrity = 220
 
 
 /obj/item/rogueweapon/scabbard/sword/kazengun/gold

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -198,7 +198,7 @@
 	resistance_flags = FIRE_PROOF
 	icon_state = "easttats"
 	armor = ARMOR_PLATE
-	body_parts_covered = COVERAGE_FULL
+	body_parts_covered = FULL_BODY
 	body_parts_inherent = FULL_BODY
 	icon = 'icons/roguetown/clothing/shirts.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -199,12 +199,12 @@
 	icon_state = "easttats"
 	armor = ARMOR_PLATE
 	body_parts_covered = COVERAGE_FULL
-	body_parts_inherent = COVERAGE_FULL
+	body_parts_inherent = FULL_BODY
 	icon = 'icons/roguetown/clothing/shirts.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
 	allowed_race = NON_DWARVEN_RACE_TYPES
-	max_integrity = 250
+	max_integrity = 300
 
 	repairmsg_begin = "The tattoos begin to slowly mend their abuse..."
 	repairmsg_continue = "The tattoos mend some of their abuse..."
@@ -212,7 +212,7 @@
 	repairmsg_end = "The tattoos flow more calmly, as they finish resting and regain their strength."
 
 	interrupt_damount = 20
-	repair_time = 35 SECONDS
+	repair_time = 30 SECONDS
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/gladiator
 	name = "gladiator's skin"

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -198,8 +198,8 @@
 	resistance_flags = FIRE_PROOF
 	icon_state = "easttats"
 	armor = ARMOR_PLATE
-	body_parts_covered = FULL_BODY
-	body_parts_inherent = FULL_BODY
+	body_parts_covered = COVERAGE_NEARLY_FULL
+	body_parts_inherent = COVERAGE_NEARLY_FULL
 	icon = 'icons/roguetown/clothing/shirts.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -204,7 +204,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
 	allowed_race = NON_DWARVEN_RACE_TYPES
-	max_integrity = 300
+	max_integrity = 350
 
 	repairmsg_begin = "The tattoos begin to slowly mend their abuse..."
 	repairmsg_continue = "The tattoos mend some of their abuse..."

--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -43,7 +43,7 @@
 			if("onbelt")
 				return list("shrink" = 0.42,"sx" = -3,"sy" = -8,"nx" = 6,"ny" = -8,"wx" = -1,"wy" = -8,"ex" = 3,"ey" = -8,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/clothing/suit/roguetown/head/helmet/ComponentInitialize()
+/obj/item/clothing/suit/roguetown/helmet/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/negative, TRAIT_HONORBOUND)
 	AddComponent(/datum/component/armour_filtering/negative, TRAIT_FENCERDEXTERITY)
 

--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -43,7 +43,7 @@
 			if("onbelt")
 				return list("shrink" = 0.42,"sx" = -3,"sy" = -8,"nx" = 6,"ny" = -8,"wx" = -1,"wy" = -8,"ex" = 3,"ey" = -8,"nturn" = 180,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 1,"sflip" = 0,"wflip" = 0,"eflip" = 8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
-/obj/item/clothing/suit/roguetown/helmet/ComponentInitialize()
+/obj/item/clothing/head/roguetown/helmet/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/negative, TRAIT_HONORBOUND)
 	AddComponent(/datum/component/armour_filtering/negative, TRAIT_FENCERDEXTERITY)
 


### PR DESCRIPTION
## About The Pull Request

Buffing Ruma Clan's tattoos slightly to give them head coverage, bumped their integrity slightly, and lowered their regen speed (still longer than other skin armors).

## Testing Evidence

<img width="579" height="578" alt="image" src="https://github.com/user-attachments/assets/b940148a-fb2a-446c-bab4-45e39c9f9f28" />

<img width="497" height="493" alt="image" src="https://github.com/user-attachments/assets/ed08719e-ca32-4324-86b2-b69f3febb008" />

<img width="498" height="363" alt="image" src="https://github.com/user-attachments/assets/56241d76-fe87-4f9a-b256-63f4e3cbef9f" />


## Why It's Good For The Game

After playing Ruma Clan for a bit post-nerf and getting into both PvE and PvP, this is really all I'd want for it tbh. Slightly beefier tattoos so they last JUST a little longer in combat because you can't wear ANYTHING else under chest. It's also a Mercenary class, so they should have a bit of OOMFH to them compared to Barbarian or otherwise. Everything else feels good about them though.

I'm fine with the armor restrictions, but if they're going to be restricted they need just a little bit more zest to their tattoos in my honest opinion - especially because they don't spawn with head or neck coverage whatsoever. They also don't spawn with arm coverage, but that's less of a concern because it's already covered by their tattoos. They still don't get face coverage, though, have to buy a mask if you want to feel fully protected.

This also fixes a bug where Frei + Ruma were allowed to wear metal helmets. They were not supposed to, and that was unironically a point of contention in my head when I was coming up with this change. So now they ACTUALLY can't wear metal helmets.

## Changelog

:cl:
balance: Buff to Ruma Clan Tattoos
fix: Fixed Ruma being able to wear metal helmets
fix: Fixed Frei being able to wear certain metal helmets
/:cl:
