### PR TITLE
Psydon Storyteller requires absolute majority

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -144,11 +144,19 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/proc/get_storyteller_pool_winners()
 	var/list/pool_totals = get_storyteller_pool_totals()
 	var/greatest_votes = 0
+	var/majority = 0
 	for(var/pool_name in pool_totals)
+		if(pool_name == "Psydon")
+			continue
 		var/pool_votes = pool_totals[pool_name] || 0
+		majority += pool_votes
 		if(pool_votes > greatest_votes)
 			greatest_votes = pool_votes
 	var/list/winning_pools = list()
+	if(pool_totals["Psydon"] || 0)
+		if(pool_totals["Psydon"] > majority)
+			greatest_votes = pool_totals["Psydon"]
+			winning_pools += "Psydon"
 	if(!greatest_votes)
 		return winning_pools
 	for(var/pool_name in pool_totals)


### PR DESCRIPTION
## About The Pull Request
Psydon will only be counted as the winner if his storyteller option has more than the other two combined (or equal).
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
dude I need like 7 people to test this properly it's awful
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Miss Lion & her Cubs (30 of them) vote for the Tennites, they're all spread out, but that's OK, as long as the Tennites win.
- Mister Porcupine & his goons (25 of them) all spread their votes among Graggar and Zizo, as they like a bit more antaggery and wretches.
- Psycho Steve gets 30 other alts and votes Psydon, resulting in 31 total votes.

Psydon Wins, but 55 out of 86 voters now get a round that is absent of wretches AND antags despite them having voted for both to various degrees.

Now Psycho Steve would need to get 43 out of 86 votes (50%+) to win, thus representing at least half of the active voter base.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Psydon Storyteller now requires 50% of all votes to win.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
