### PR TITLE
Adds Volf face helm to heretic spellblade and disgraced knight

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -127,6 +127,7 @@
 			"Shishak"	= /obj/item/clothing/head/roguetown/helmet/sallet/shishak,
 			"Visored Barbute" = /obj/item/clothing/head/roguetown/helmet/heavy/barbute/visor,
 			"Great Barbute" = /obj/item/clothing/head/roguetown/helmet/heavy/barbute/great,
+			"Volf-Face Helm"		= /obj/item/clothing/head/roguetown/helmet/heavy/volfplate,
 			"None"
 		)
 		var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
@@ -130,6 +130,7 @@
 			pants = /obj/item/clothing/under/roguetown/chainlegs
 			shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
 			cloak = /obj/item/clothing/cloak/tabard/black
+
 			var/helmets = list(
 				"Pigface Bascinet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 				"Guard Helmet"			= /obj/item/clothing/head/roguetown/helmet/heavy/guard,
@@ -140,8 +141,10 @@
 				"Klappvisier Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
 				"Hounskull Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
 				"Slitted Kettle"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/skettle,
+				"Volf-Face Helm"		= /obj/item/clothing/head/roguetown/helmet/heavy/volfplate,
 				"None"
 			)
+		
 			var/helmchoice = input(H, "Choose your Helm.", "LIGHT SHINES THROUGH") as anything in helmets
 			if(helmchoice != "None")
 				head = helmets[helmchoice]


### PR DESCRIPTION
## About The Pull Request

Since heretics can now choose the volf face helm i decided why not add it to the heretic spellblades as well, and disgraced knight by request

## Testing Evidence

yeah it works trust :3

## Why It's Good For The Game

Drip or drown babey!!!!!!!

## Changelog


:cl:
add: Lets heretic spellblade and disgraced knight choose volf face helm when spawning

/:cl:

