### PR TITLE
Caedo no longer exposes attacker on block

### DIFF
--- a/code/modules/spells/spell_types/classunique/spellblade/caedo.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/caedo.dm
@@ -102,8 +102,14 @@
 
 	var/locked_zone = H.zone_selected || BODY_ZONE_CHEST
 
+	// Snapshot guard state NOW so victims can't reactively press G during the strike delay
+	var/list/guarded_at_dash = list()
+	for(var/mob/living/M in mobs_in_path)
+		if(M.has_status_effect(/datum/status_effect/buff/clash) || M.has_status_effect(/datum/status_effect/buff/parry_buffer))
+			guarded_at_dash += M
+
 	if(length(mobs_in_path))
-		addtimer(CALLBACK(src, PROC_REF(execute_path_strikes), H, mobs_in_path, held_weapon, locked_zone, empowered), 5)
+		addtimer(CALLBACK(src, PROC_REF(execute_path_strikes), H, mobs_in_path, held_weapon, locked_zone, empowered, guarded_at_dash), 5)
 
 	return TRUE
 
@@ -114,7 +120,7 @@
 		return far_side
 	return get_turf(target_mob)
 
-/datum/action/cooldown/spell/caedo/proc/execute_path_strikes(mob/living/carbon/human/user, list/victims, obj/item/weapon, def_zone, empowered = FALSE)
+/datum/action/cooldown/spell/caedo/proc/execute_path_strikes(mob/living/carbon/human/user, list/victims, obj/item/weapon, def_zone, empowered = FALSE, list/guarded_at_dash)
 	if(!user || QDELETED(user))
 		return
 	var/deflected = FALSE
@@ -122,7 +128,8 @@
 	for(var/mob/living/victim in victims)
 		if(QDELETED(victim) || victim.stat == DEAD)
 			continue
-		if(spell_guard_check(victim, FALSE, deflected ? null : user))
+		// Only allow guard deflection if the victim had guard up BEFORE the dash, not reactively
+		if((victim in guarded_at_dash) && spell_guard_check(victim, FALSE, deflected ? null : user))
 			deflected = TRUE
 			continue
 		var/total_damage = strike_damage

--- a/code/modules/spells/spell_types/classunique/spellblade/caedo.dm
+++ b/code/modules/spells/spell_types/classunique/spellblade/caedo.dm
@@ -2,8 +2,7 @@
 	name = "Caedo"
 	desc = "In the old tongue, caedo - to strike or to cut down. Dash forward at blinding speed, \
 		leaving afterimages that strike every enemy in your path. \
-		Empowered (3 Momentum): Consumes 3 stacks to strike twice. \
-		If any of them defend against the strike, you will be left exposed at the end of your dash!"
+		Empowered (3 Momentum): Consumes 3 stacks to strike twice."
 	button_icon = 'icons/mob/actions/classuniquespells/spellblade.dmi'
 	button_icon_state = "caedo"
 	sound = 'sound/magic/blink.ogg'
@@ -102,14 +101,8 @@
 
 	var/locked_zone = H.zone_selected || BODY_ZONE_CHEST
 
-	// Snapshot guard state NOW so victims can't reactively press G during the strike delay
-	var/list/guarded_at_dash = list()
-	for(var/mob/living/M in mobs_in_path)
-		if(M.has_status_effect(/datum/status_effect/buff/clash) || M.has_status_effect(/datum/status_effect/buff/parry_buffer))
-			guarded_at_dash += M
-
 	if(length(mobs_in_path))
-		addtimer(CALLBACK(src, PROC_REF(execute_path_strikes), H, mobs_in_path, held_weapon, locked_zone, empowered, guarded_at_dash), 5)
+		addtimer(CALLBACK(src, PROC_REF(execute_path_strikes), H, mobs_in_path, held_weapon, locked_zone, empowered), 5)
 
 	return TRUE
 
@@ -120,17 +113,15 @@
 		return far_side
 	return get_turf(target_mob)
 
-/datum/action/cooldown/spell/caedo/proc/execute_path_strikes(mob/living/carbon/human/user, list/victims, obj/item/weapon, def_zone, empowered = FALSE, list/guarded_at_dash)
+/datum/action/cooldown/spell/caedo/proc/execute_path_strikes(mob/living/carbon/human/user, list/victims, obj/item/weapon, def_zone, empowered = FALSE)
 	if(!user || QDELETED(user))
 		return
-	var/deflected = FALSE
 	var/hit_count = 0
 	for(var/mob/living/victim in victims)
 		if(QDELETED(victim) || victim.stat == DEAD)
 			continue
-		// Only allow guard deflection if the victim had guard up BEFORE the dash, not reactively
-		if((victim in guarded_at_dash) && spell_guard_check(victim, FALSE, deflected ? null : user))
-			deflected = TRUE
+		// Guard blocks the strike but does NOT expose the attacker (null attacker)
+		if(spell_guard_check(victim, FALSE))
 			continue
 		var/total_damage = strike_damage
 		arcyne_strike(user, victim, weapon, total_damage, def_zone, spell_name = "Caedo", skip_animation = TRUE)


### PR DESCRIPTION
## About The Pull Request
Caedo can still be defended against, but no longer exposes the attacker on block. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
None actually this has to be tested live.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This allows you to counterplay and parry Caedo without it exposing the attacker.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Blocking a Caedo no longer exposes the attacker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
