### PR TITLE
Armor with integrity stops crit from going through

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -152,6 +152,10 @@
 	armor = owner.getarmor(zone_precise, acheck_dflag)
 	if((owner.mind || HAS_TRAIT(owner, TRAIT_CRIT_THRESHOLD)) && (get_damage() <= (max_damage * CRIT_DISMEMBER_DAMAGE_THRESHOLD))) //No crits unless the limb is at 75%+ damage.
 		do_crit = FALSE
+	if(do_crit && ishuman(owner)) // Armor with integrity prevents crits
+		var/mob/living/carbon/human/H = owner
+		if(H.get_best_worn_armor(zone_precise, acheck_dflag))
+			do_crit = FALSE
 	if(user)
 		if(user.goodluck(2))
 			dam += 10

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -157,9 +157,6 @@
 		var/obj/item/clothing/worn_armor = H.get_best_worn_armor(zone_precise, acheck_dflag)
 		if(worn_armor)
 			do_crit = FALSE
-			if(crit_message)
-				owner.balloon_alert_to_viewers("<font color = '#bb2b2b'>crit stopped!</font>")
-				owner.visible_message(span_combatprimary("[worn_armor] absorbs what could have been a critical hit!"))
 	if(user)
 		if(user.goodluck(2))
 			dam += 10

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -152,10 +152,14 @@
 	armor = owner.getarmor(zone_precise, acheck_dflag)
 	if((owner.mind || HAS_TRAIT(owner, TRAIT_CRIT_THRESHOLD)) && (get_damage() <= (max_damage * CRIT_DISMEMBER_DAMAGE_THRESHOLD))) //No crits unless the limb is at 75%+ damage.
 		do_crit = FALSE
-	if(do_crit && ishuman(owner)) // Armor with integrity prevents crits
+	if(do_crit && ishuman(owner)) // Armor with integrity above 25% prevents crits
 		var/mob/living/carbon/human/H = owner
-		if(H.get_best_worn_armor(zone_precise, acheck_dflag))
+		var/obj/item/clothing/worn_armor = H.get_best_worn_armor(zone_precise, acheck_dflag)
+		if(worn_armor && worn_armor.obj_integrity > (worn_armor.max_integrity * 0.25))
 			do_crit = FALSE
+			if(crit_message)
+				owner.balloon_alert_to_viewers("<font color = '#bb2b2b'>crit stopped!</font>")
+				owner.visible_message(span_combatprimary("[worn_armor] absorbs what could have been a critical hit!"))
 	if(user)
 		if(user.goodluck(2))
 			dam += 10

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -152,10 +152,10 @@
 	armor = owner.getarmor(zone_precise, acheck_dflag)
 	if((owner.mind || HAS_TRAIT(owner, TRAIT_CRIT_THRESHOLD)) && (get_damage() <= (max_damage * CRIT_DISMEMBER_DAMAGE_THRESHOLD))) //No crits unless the limb is at 75%+ damage.
 		do_crit = FALSE
-	if(do_crit && ishuman(owner)) // Armor with integrity above 25% prevents crits
+	if(do_crit && ishuman(owner)) // Armor with integrity prevents crits
 		var/mob/living/carbon/human/H = owner
 		var/obj/item/clothing/worn_armor = H.get_best_worn_armor(zone_precise, acheck_dflag)
-		if(worn_armor && worn_armor.obj_integrity > (worn_armor.max_integrity * 0.25))
+		if(worn_armor)
 			do_crit = FALSE
 			if(crit_message)
 				owner.balloon_alert_to_viewers("<font color = '#bb2b2b'>crit stopped!</font>")


### PR DESCRIPTION
## About The Pull Request
Having armor with integrity left gives you resistance to critical hits, again. 

In an attempt to simplify the system I went for one of the choice (removing armor granting critical resistance), but it seems like two weeks on this was an overcorrection and I shot light classes in the head with pen weapon becoming completely dominant. This seeks to remedy that.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="600" height="638" alt="dreamseeker_godzYHbFRT" src="https://github.com/user-attachments/assets/c30a7e7f-ab8b-4cdc-a434-2909d9228309" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Remedy the fact that pen weapon became utterly domineering and light classes are on life support again with omnipen + omnicrit

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: While armor integrity holds above, critical hits will not roll on the limb underneath. Damage still goes through. Clearer messages when this happens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
