### PR TITLE
Fixes AOE damage mutation bug & tweak runes durability

### DIFF
--- a/code/game/objects/structures/rune_ward_structure.dm
+++ b/code/game/objects/structures/rune_ward_structure.dm
@@ -11,7 +11,7 @@
 	anchored = TRUE
 	alpha = 180
 	layer = TURF_LAYER + 0.1
-	max_integrity = 100
+	max_integrity = 300
 
 	var/datum/weakref/owner_ref
 	var/datum/weakref/spell_ref

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -97,9 +97,14 @@
 	next_attack_msg.Cut()
 
 	var/on_hit_state = P.on_hit(src, armor)
+	var/actual_damage = P.damage
+	if(!mind && istype(src, /mob/living/simple_animal))
+		var/datum/component/saddleborn = GetComponent(/datum/component/precious_creature)
+		if(!saddleborn)
+			actual_damage *= P.npc_simple_damage_mult
 	var/nodmg = FALSE
 	if(!P.nodamage && on_hit_state != BULLET_ACT_BLOCK)
-		if(!apply_damage(P.damage, P.damage_type, def_zone, armor))
+		if(!apply_damage(actual_damage, P.damage_type, def_zone, armor))
 			nodmg = TRUE
 			next_attack_msg += VISMSG_ARMOR_BLOCKED
 		apply_effects(stun = P.stun, knockdown = P.knockdown, unconscious = P.unconscious, slur = P.slur, stutter = P.stutter, eyeblur = P.eyeblur, drowsy = P.drowsy, blocked = armor, stamina = P.stamina, jitter = P.jitter, paralyze = P.paralyze, immobilize = P.immobilize)

--- a/code/modules/mob/living/simple_animal/hostile/bosses/lich_boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/lich_boss.dm
@@ -39,7 +39,7 @@
 	/obj/projectile/magic/sickness,
 	/obj/projectile/magic/arcane_barrage, 
 	/obj/projectile/magic/acidsplash,
-	/obj/projectile/magic/aoe/fireball/spitfire)
+	/obj/projectile/magic/spitfire)
 	patron = /datum/patron/inhumen/zizo
 	footstep_type = FOOTSTEP_MOB_SHOE
 	stat_attack = UNCONSCIOUS

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/primordial.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/primordial.dm
@@ -89,7 +89,7 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	retreat_distance = 0
 	minimum_distance = 0
-	projectiletype = /obj/projectile/magic/aoe/fireball/spitfire	//if we ever get ranged toggling working
+	projectiletype = /obj/projectile/magic/spitfire	//if we ever get ranged toggling working
 	projectilesound = 'sound/magic/whiteflame.ogg'
 	next_ability_use
 	STACON = 10

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -279,10 +279,6 @@
 
 	var/mob/living/L = target
 
-	if (!L.mind && istype(L, /mob/living/simple_animal))
-		var/datum/component/saddleborn = L.GetComponent(/datum/component/precious_creature) // Check for Saddleborn status, lets not nuke five billion damage into something that causes a -10 mood debuff
-		if(!saddleborn)
-			damage *= npc_simple_damage_mult // bonus damage against simple.
 	if(blocked != 100) // not completely blocked
 		if(damage && L.blood_volume && damage_type == BRUTE)
 			var/splatter_dir = dir

--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -5,7 +5,7 @@
 	anchored = TRUE
 	icon = 'icons/obj/rune.dmi'
 	icon_state = "6"
-	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = SIGIL_LAYER
 	color = null
 	var/magictype = "arcyne"//"arcyne", "divine", "druid", "blood"
@@ -877,7 +877,7 @@ GLOBAL_LIST(teleport_runes)
 	desc = "A lesser circle of arcyne power, channeling the energy of the leyline to breach the veil between the material plane and the other and bring forth creechurs."
 	icon_state = "summon"
 	invocation = "Evoca et Constringe!"
-	max_integrity = 0
+	max_integrity = -1
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	tier = 1
 	can_be_scribed = TRUE

--- a/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
@@ -9,8 +9,8 @@
 	spell_color = GLOW_COLOR_FIRE
 	glow_intensity = GLOW_INTENSITY_LOW
 
-	projectile_type = /obj/projectile/magic/aoe/fireball/spitfire
-	projectile_type_arc = /obj/projectile/magic/aoe/fireball/spitfire/arc
+	projectile_type = /obj/projectile/magic/spitfire
+	projectile_type_arc = /obj/projectile/magic/spitfire/arc
 	cast_range = SPELL_RANGE_PROJECTILE
 
 	primary_resource_type = SPELL_COST_STAMINA
@@ -32,13 +32,12 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
-/obj/projectile/magic/aoe/fireball/spitfire
+/obj/projectile/magic/spitfire
 	name = "spitfire"
+	icon_state = "fireball"
+	light_color = "#f8af07"
+	light_outer_range = 2
 	speed = MAGE_PROJ_MEDIUM
-	exp_heavy = -1
-	exp_light = -1
-	exp_flash = 0
-	exp_fire = 0
 	damage = 30
 	npc_simple_damage_mult = 2
 	accuracy = 40
@@ -47,15 +46,14 @@
 	nodamage = FALSE
 	flag = "fire"
 	hitsound = 'sound/blank.ogg'
-	aoe_range = 0
 
-/obj/projectile/magic/aoe/fireball/spitfire/arc
+/obj/projectile/magic/spitfire/arc
 	name = "arced spitfire"
 	damage = 23
 	arcshot = TRUE
 
-/obj/projectile/magic/aoe/fireball/spitfire/on_hit(target)
-	. = ..()
+/obj/projectile/magic/spitfire/on_hit(target)
+	..()
 	if(ismob(target))
 		var/mob/living/M = target
 		if(M.anti_magic_check())


### PR DESCRIPTION
## About The Pull Request
- Fixes a bug reported by KatTheFox on discord, where on direct hit with a projectile, the projectile's damage were mutated directly. This meant projectile like fireball and ice burst which reads the damage AFTER for AOE effect has npc_simple_damage_mult applied. I.e. If you shoot a crawler point blank, the AOE effect would be multiplied by 2.5 / 3x if it hits yourself
- Increased permanent rune ward durability
- Made ALL ritualrunes indestructible instead of only some 
- Repathed spitfire away from fireball to avoid it gaining AOE structural damage which is not intended

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="444" height="164" alt="TabTip_vxlEgZ5Gop" src="https://github.com/user-attachments/assets/2ea79846-ca45-4534-ab4f-4d2e17552862" />
<img width="449" height="158" alt="TabTip_UIHfq2zd9o" src="https://github.com/user-attachments/assets/7b24a90b-2730-4a9e-9df0-fefdf586427e" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Batch of bugfixes / oversight

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Point blanking a simple creature with ice burst / fireball should no longer mutates its damage and nuke yourself and everyone in the radius
add: Permanent Rune wards have increased durability (100 -> 300)
add: Spitfire is no longer a fireball subtype that does structural damage around it. Oops.
add: All ritual runes, instead of only summoning runes, are indestructible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
