### PR TITLE
dodge fixes & tweaks

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -376,6 +376,10 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define TEMPO_TAG_RCLICK_CD_BONUS "rclickcd"
 #define TEMPO_TAG_FEINTBAIT_FOV "feintbaitfov"
 #define TEMPO_TAG_DEF_BONUS	"defbonus"
+#define TEMPO_TAG_DODGE_LOSS "dodgeloss"
+	#define TEMPO_DODGE_LOSS_NORMAL 0
+	#define TEMPO_DODGE_LOSS_LESS 1
+	#define TEMPO_DODGE_LOSS_NONE 2
 
 
 /*

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -261,6 +261,9 @@
 			var/datum/component/arousal/CAR = user.GetComponent(/datum/component/arousal)
 			if(CAR)
 				CAR.adjust_arousal_special(src, 2)
+
+		user.changeMaxDodge(2)
+		user.dodgetime = clamp(user.dodgetime - 2, 0, CLICK_CD_DODGE)
 				
 	log_combat(user, M, "attacked", src.name, "(INTENT: [uppertext(user.used_intent.name)]) (DAMTYPE: [uppertext(damtype)])")
 

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -433,3 +433,13 @@
 				return TRUE
 			if(has_status_effect(/datum/status_effect/buff/tempo_three))
 				return TRUE
+		//Whether we lose max dodge and increase our dodge delay after a dodge.
+		if(TEMPO_TAG_DODGE_LOSS)
+			if(has_status_effect(/datum/status_effect/buff/tempo_one))
+				return TEMPO_DODGE_LOSS_LESS
+			if(has_status_effect(/datum/status_effect/buff/tempo_two))
+				return TEMPO_DODGE_LOSS_NONE
+			if(has_status_effect(/datum/status_effect/buff/tempo_three))
+				return TEMPO_DODGE_LOSS_NONE
+			else
+				return TEMPO_DODGE_LOSS_NORMAL

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -128,6 +128,7 @@
 		else
 			theirskill = UH.get_skill_level(/datum/skill/combat/unarmed)
 	var/prob2defend = U.defprob
+	var/ignore_DE_bonus = FALSE
 	var/is_in_cone = L.can_see_cone(user)
 	if(!is_in_cone && H)
 		is_in_cone = H?.get_tempo_bonus(TEMPO_TAG_NOLOS_DODGE)
@@ -171,7 +172,6 @@
 					if(U.STASPD > L.STASPD) //unarmed is inherently swift
 						prob2defend = prob2defend - ((U.STASPD - L.STASPD) * 10)
 
-		var/ignore_DE_bonus = FALSE
 
 		if(HAS_TRAIT(L, TRAIT_GUIDANCE))
 			prob2defend += 20
@@ -329,13 +329,17 @@
 			playsound(user, 'sound/misc/weapon_clip.ogg', 100)
 	dodgecd = FALSE
 	var/ignore_penalty = FALSE
-	if(L.fixedeye && L.goodluck(5))
+	if((L.fixedeye && L.goodluck(5)))
 		ignore_penalty = TRUE
-	if(!ignore_penalty)
+	if(!ignore_penalty && !ignore_DE_bonus && has_trait)
 		var/max_mod = 0
 		max_mod = ourskill - theirskill
-		L.changeNext_def(clamp(dodgetime + 1, 0, CLICK_CD_DODGE))
-		L.changeMaxDodge(-1 + ((max_mod < 0) ? max_mod : 0))
+
+		var/tempo_result = L.get_tempo_bonus(TEMPO_TAG_DODGE_LOSS)
+		//TEMPO_DODGE_LOSS_NONE results in this not being accessed at all, so no loss. We're in a 1v4 in that context, so, like, yeah.
+		if(tempo_result == TEMPO_DODGE_LOSS_NORMAL || (tempo_result == TEMPO_DODGE_LOSS_LESS && prob(33)))
+			L.changeNext_def(clamp(dodgetime + 1, 0, CLICK_CD_DODGE))
+			L.changeMaxDodge(-1 + ((max_mod < 0) ? max_mod : 0))
 //		if(H)
 //			if(H.IsOffBalanced())
 //				H.Knockdown(1)


### PR DESCRIPTION
## About The Pull Request
- All the dodge stuff now works properly with simple mobs:
<img width="276" height="209" alt="dreamseeker_gKpLGEzVPo" src="https://github.com/user-attachments/assets/4a42e84b-7e9f-4a0d-b08c-72b6115444fa" />

(You can see 95 go down to 94 and go back up after hitting the mob)
Getting hit by simple mobs however doesn't restore dodge, atm. Reminder that you can parry most simple mobs very easily and parrying restores all that.

- Fixed an issue where non-dodge experts got their dodge% reduced.
- Added a new tempo interaction, outnumbered dodgers will have their dodge be reduced at a lesser rate, or not at all in a 1v4+.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
THE TM!! WA THERE!! FOR A WEEK!!! I ONLY GET REPORTED STUFF!! AFTER THE MERGE!!! DAMN!!!!!!!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed simple mobs not interacting with dodge correctly.
balance: Being outnumbered (having Tempo) will reduce the frequency of dodge loss for dodge experts, or remove it entirely, depending on the situation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
