### PR TITLE
Aquatic Compulsion tweaks

### DIFF
--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -121,19 +121,20 @@
 //T0 The Fishing
 /obj/effect/proc_holder/spell/invoked/aquatic_compulsion
 	name = "Aquatic Compulsion"
-	desc = "Compel a fish to leap out from targeted water tile and towards you."
+	desc = "Compel a random fish to leap out from targeted water tile and towards you. Standing still may yield you continuously, as long as your Devotion and stamina holds. Costs will increase over time."
 	overlay_state = "aqua"
 	releasedrain = 20
 	chargedrain = 0
-	range = 5
+	range = 6 // so people can appreciate them leaps in fishing events
 	movement_interrupt = FALSE
 	chargedloop = null
 	sound = 'sound/foley/bubb (5).ogg'
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
-	recharge_time = 10 SECONDS
+	recharge_time = 30 SECONDS
 	miracle = TRUE
 	devotion_cost = 10
+	var/channeling
 	//Horrendous carry-over from fishing code
 	var/list/fishingMods = list(
 		"commonFishingMod" = 0.8,
@@ -186,7 +187,14 @@
 
 	var/dist = max(1, get_dist(T, target_turf))
 
-	if(dist <= 1)
+	if(dist == 1)
+		AF.forceMove(target_turf)
+		AF.pixel_x = 0
+		AF.pixel_y = 0
+		AF.pixel_z = 0
+		return
+
+	if(dist <= 0)
 		AF.forceMove(user_turf)
 		AF.pixel_x = 0
 		AF.pixel_y = 0
@@ -197,13 +205,13 @@
 	var/dy = (target_turf.y - T.y) * 32
 
 	var/time_total = max(4, dist * 2)
-	var/time_up = round(time_total * 0.35)
+	var/time_up = round(time_total * 0.25)
 	var/time_down = time_total - time_up
 
 	var/arc_height = clamp(dist * 10 + rand(-4, 8), 12, 48)
 
 	if(abs(dx) > abs(dy))
-		arc_height *= 1.3
+		arc_height *= 1.2
 
 	var/wobble_x = rand(-4, 4)
 	var/wobble_y = rand(-4, 4)
@@ -236,42 +244,144 @@
 
 /obj/effect/proc_holder/spell/invoked/aquatic_compulsion/cast(list/targets, mob/user = usr)
 	. = ..()
+	if(!user || !user.client)
+		return 
+	var/mob/living/carbon/human/H = user
+	var/turf/T = targets[1]
 
-	if(isturf(targets[1]))
-		var/turf/T = targets[1]
+	to_chat(user, "CAST START")
 
-		var/A = getfishingloot(user, fishingMods, T, 0.5)
-		if(A)
-			var/atom/movable/AF = new A(T)
-			if(!AF)
-				return FALSE
+	if(channeling)
+		to_chat(user, "FAIL: already channeling")
+		to_chat(H, span_notice("<i>You are already inducing compulsion upon the abyssals.</i>"))
+		revert_cast()
+		return FALSE
 
-			AF.pixel_x = 0
-			AF.pixel_y = 0
-			AF.pixel_z = 0
+	if(!isturf(targets[1]))
+		to_chat(user, "FAIL: invalid turf target")
+		revert_cast()
+		return FALSE
 
-			if(istype(AF, /obj/item/reagent_containers/food/snacks/fish))
-				var/obj/item/reagent_containers/food/snacks/fish/F = AF
-				F.sinkable = FALSE
-				spawn(1)
-					abyssor_fish_arc(F, T, user)
-			else
-				spawn(1)
-					abyssor_fish_arc(AF, T, user)
+	if(!H)
+		to_chat(user, "FAIL: user not human")
+		revert_cast()
+		return FALSE
 
-			record_featured_stat(FEATURED_STATS_FISHERS, user)
-			record_round_statistic(STATS_FISH_CAUGHT)
-			playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)
-			teleport_to_dream(user, 10000, 1)
-			user.visible_message("<font color='yellow'>[user] makes a beckoning gesture at [T]!</font>")
-			return TRUE
+	var/miracleskill = H.get_skill_level(/datum/skill/magic/holy)
+	to_chat(user, "Skill: [miracleskill]")
 
-		else
-			revert_cast()
-			return FALSE
+	channeling = TRUE
+	var/streak = 0
+	var/delay = clamp(((10 - miracleskill) + streak), 5, 10)
 
-	revert_cast()
-	return FALSE
+	to_chat(user, "Initial delay: [delay]")
+
+	to_chat(user, span_blue("<i>[user] makes a beckoning gesture at [T] as a white fog swirls momentarily!</i>"))
+	user.say(pick("The Dreamer commands you, splash forth.","By Abyssor's will, spring forth.","Splash forth.","Come hither, abyssals.","Leap in Abyssor's name.","I call to you, denizens of the depths."))
+
+	// === FIRST INSTANT PULL ===
+	if(!H.devotion || H.devotion.devotion < devotion_cost)
+		to_chat(user, "FAIL: not enough devotion ([H.devotion?.devotion])")
+		to_chat(H, span_notice("<i>Your connection to the Dreamer is too faint...</i>"))
+		H.emote("yawn")
+		channeling = FALSE
+		revert_cast()
+		return FALSE
+
+	var/A = getfishingloot(user, fishingMods, T, 0.5)
+	if(!A)
+		to_chat(user, "FAIL: no loot roll")
+		to_chat(user, span_warning("The waters remain still."))
+		channeling = FALSE
+		revert_cast()
+		return FALSE
+
+	to_chat(user, "First pull success: [A]")
+
+	var/atom/movable/AF = new A(T)
+	if(!AF)
+		to_chat(user, "FAIL: spawn failed")
+		channeling = FALSE
+		revert_cast()
+		return FALSE
+
+	var/cost = clamp((devotion_cost + (streak)), devotion_cost, 15)
+	H.devotion.devotion -= cost
+	to_chat(user, "Devotion spent: [cost], remaining: [H.devotion.devotion]")
+
+	streak++
+	to_chat(user, "Streak now: [streak]")
+
+	AF.pixel_x = 0
+	AF.pixel_y = 0
+	AF.pixel_z = 0
+
+	spawn(1)
+		abyssor_fish_arc(AF, T, user)
+
+	record_featured_stat(FEATURED_STATS_FISHERS, user)
+	record_round_statistic(STATS_FISH_CAUGHT)
+	playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)
+	teleport_to_dream(user, 10000, 1)
+
+	// === LOOPED PULLING ===
+	while(TRUE)
+		if(!user || !user.client)
+			break // me when I gib myself and crash the server, on god
+
+		delay = clamp(((10 - miracleskill) + streak), 5, 10)
+		to_chat(user, "Loop start | streak=[streak] delay=[delay] devotion=[H.devotion?.devotion]")
+
+		if(!H || !H.devotion || H.devotion.devotion < devotion_cost)
+			to_chat(user, "BREAK: devotion too low ([H?.devotion?.devotion])")
+			to_chat(H, span_notice("<i>Your connection to the Dreamer is too faint...</i>"))
+			H?.emote("yawn")
+			break
+
+		if(!do_after(user, delay SECONDS, target = user))
+			to_chat(user, "BREAK: do_after failed (movement/interruption)")
+			to_chat(user, span_warning("Your focus breaks, and Abyssor's pull fades."))
+			break
+
+		to_chat(user, "do_after success")
+
+		var/A2 = getfishingloot(user, fishingMods, T, 0.5)
+		if(!A2)
+			to_chat(user, "BREAK: no loot roll")
+			to_chat(user, span_warning("The waters remain still."))
+			break
+
+		to_chat(user, "Loop pull success: [A2]")
+
+		var/atom/movable/AF2 = new A2(T)
+		if(!AF2)
+			to_chat(user, "BREAK: spawn failed")
+			break
+
+		var/cost2 = clamp((devotion_cost + (streak)), devotion_cost, 15)
+		H.devotion.devotion -= cost2
+		to_chat(user, "Devotion spent: [cost2], remaining: [H.devotion.devotion]")
+
+		streak++
+		to_chat(user, "Streak now: [streak]")
+
+		AF2.pixel_x = 0
+		AF2.pixel_y = 0
+		AF2.pixel_z = 0
+
+		spawn(1)
+			abyssor_fish_arc(AF2, T, user)
+
+		record_featured_stat(FEATURED_STATS_FISHERS, user)
+		record_round_statistic(STATS_FISH_CAUGHT)
+		playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)
+		teleport_to_dream(user, 10000, 1)
+
+	// === CLEANUP ===
+	to_chat(user, "CLEANUP: channeling ended at streak=[streak]")
+
+	channeling = FALSE
+	return TRUE
 
 //T2, Abyssal Healing. Totally stole most of this from lesser heal.
 /obj/effect/proc_holder/spell/invoked/abyssheal

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -172,13 +172,22 @@
 
 /proc/abyssor_fish_arc(atom/movable/AF, turf/T, mob/user)
 	var/turf/user_turf = get_turf(user)
-	var/dir_to_water = get_dir(user_turf, T)
+
+	var/dx_dir = T.x - user_turf.x
+	var/dy_dir = T.y - user_turf.y
+
+	var/dir_to_water
+	if(abs(dx_dir) > abs(dy_dir))
+		dir_to_water = (dx_dir > 0) ? EAST : WEST
+	else
+		dir_to_water = (dy_dir > 0) ? NORTH : SOUTH
+
 	var/turf/target_turf = get_step(user_turf, dir_to_water) || user_turf
 
 	var/dist = max(1, get_dist(T, target_turf))
 
 	if(dist <= 1)
-		AF.forceMove(target_turf)
+		AF.forceMove(user_turf)
 		AF.pixel_x = 0
 		AF.pixel_y = 0
 		AF.pixel_z = 0
@@ -187,29 +196,35 @@
 	var/dx = (target_turf.x - T.x) * 32
 	var/dy = (target_turf.y - T.y) * 32
 
-	var/time_total = max(3, dist * 2)
+	var/time_total = max(4, dist * 2)
+	var/time_up = round(time_total * 0.35)
+	var/time_down = time_total - time_up
 
 	var/arc_height = clamp(dist * 10 + rand(-4, 8), 12, 48)
 
-	// boost arc for east/west travel so it’s visible
 	if(abs(dx) > abs(dy))
 		arc_height *= 1.3
 
-	// slight sideways wobble for natural motion
 	var/wobble_x = rand(-4, 4)
 	var/wobble_y = rand(-4, 4)
 
-	animate(AF,
-		pixel_x = dx + wobble_x,
-		pixel_y = dy + wobble_y,
-		pixel_z = arc_height,
-		time = time_total,
-		easing = SINE_EASING)
+	AF.pixel_x = 0
+	AF.pixel_y = 0
+	AF.pixel_z = 0
 
 	animate(AF,
+		pixel_x = (dx * 0.5) + wobble_x,
+		pixel_y = (dy * 0.5) + wobble_y,
+		pixel_z = arc_height,
+		time = time_up,
+		easing = QUAD_EASING|EASE_OUT)
+
+	animate(
+		pixel_x = dx,
+		pixel_y = dy,
 		pixel_z = 0,
-		time = time_total,
-		easing = SINE_EASING)
+		time = time_down,
+		easing = QUAD_EASING|EASE_IN)
 
 	spawn(time_total)
 		if(!AF)
@@ -218,7 +233,7 @@
 		AF.pixel_x = 0
 		AF.pixel_y = 0
 		AF.pixel_z = 0
-		
+
 /obj/effect/proc_holder/spell/invoked/aquatic_compulsion/cast(list/targets, mob/user = usr)
 	. = ..()
 

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -146,7 +146,7 @@
 		"dangerFishingMod" = 0.1,
 		"ceruleanFishingMod" = 0 // 1 on cerulean aril, 0 on everything else
 	)
-
+	
 /obj/effect/proc_holder/spell/invoked/aquatic_compulsion/cast(list/targets, mob/user = usr)
 	. = ..()
 	if(isturf(targets[1]))
@@ -154,12 +154,24 @@
 		var/A = getfishingloot(user, fishingMods, T, 0.5)
 		if(A)
 			var/atom/movable/AF = new A(T)
+
+			var/turf/target_turf = get_step(get_turf(user), turn(get_dir(T, get_turf(user)), 180)) || get_turf(user)
+
 			if(istype(AF, /obj/item/reagent_containers/food/snacks/fish))
 				var/obj/item/reagent_containers/food/snacks/fish/F = AF
 				F.sinkable = FALSE
-				F.throw_at(get_turf(user), 5, 1, null)
+				animate(F, pixel_x = (target_turf.x - T.x) * 32, pixel_y = (target_turf.y - T.y) * 32, time = 5)
+				spawn(5)
+					F.forceMove(target_turf)
+					F.pixel_x = 0
+					F.pixel_y = 0
 			else
-				AF.throw_at(get_turf(user), 5, 1, null)
+				animate(AF, pixel_x = (target_turf.x - T.x) * 32, pixel_y = (target_turf.y - T.y) * 32, time = 5)
+				spawn(5)
+					AF.forceMove(target_turf)
+					AF.pixel_x = 0
+					AF.pixel_y = 0
+
 			record_featured_stat(FEATURED_STATS_FISHERS, user)
 			record_round_statistic(STATS_FISH_CAUGHT)
 			playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -131,7 +131,7 @@
 	sound = 'sound/foley/bubb (5).ogg'
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
-	recharge_time = 30 SECONDS
+	recharge_time = 45 SECONDS // still too short
 	miracle = TRUE
 	devotion_cost = 10
 	var/channeling
@@ -144,32 +144,6 @@
 		"dangerFishingMod" = 0.1,
 		"ceruleanFishingMod" = 0 // 1 on cerulean aril, 0 on everything else
 	)
-/*
-/obj/effect/proc_holder/spell/invoked/aquatic_compulsion/cast(list/targets, mob/user = usr)
-	. = ..()
-	if(isturf(targets[1]))
-		var/turf/T = targets[1]
-		var/A = getfishingloot(user, fishingMods, T, 0.5)
-		if(A)
-			var/atom/movable/AF = new A(T)
-			if(istype(AF, /obj/item/reagent_containers/food/snacks/fish))
-				var/obj/item/reagent_containers/food/snacks/fish/F = AF
-				F.sinkable = FALSE
-				F.throw_at(get_turf(user), 5, 1, null)
-			else
-				AF.throw_at(get_turf(user), 5, 1, null)
-			record_featured_stat(FEATURED_STATS_FISHERS, user)
-			record_round_statistic(STATS_FISH_CAUGHT)
-			playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)
-			teleport_to_dream(user, 10000, 1)
-			user.visible_message("<font color='yellow'>[user] makes a beckoning gesture at [T]!</font>")
-			return TRUE
-		else
-			revert_cast()
-			return FALSE
-	revert_cast()
-	return FALSE
-*/
 
 /proc/abyssor_fish_arc(atom/movable/AF, turf/T, mob/user)
 	var/turf/user_turf = get_turf(user)
@@ -252,36 +226,36 @@
 	to_chat(user, "CAST START")
 
 	if(channeling)
-		to_chat(user, "FAIL: already channeling")
+//		to_chat(user, "FAIL: already channeling")
 		to_chat(H, span_notice("<i>You are already inducing compulsion upon the abyssals.</i>"))
 		revert_cast()
 		return FALSE
 
 	if(!isturf(targets[1]))
-		to_chat(user, "FAIL: invalid turf target")
+//		to_chat(user, "FAIL: invalid turf target")
 		revert_cast()
 		return FALSE
 
 	if(!H)
-		to_chat(user, "FAIL: user not human")
+//		to_chat(user, "FAIL: user not human")
 		revert_cast()
 		return FALSE
 
 	var/miracleskill = H.get_skill_level(/datum/skill/magic/holy)
-	to_chat(user, "Skill: [miracleskill]")
+//	to_chat(user, "Skill: [miracleskill]")
 
 	channeling = TRUE
 	var/streak = 0
 	var/delay = clamp(((10 - miracleskill) + streak), 5, 10)
 
-	to_chat(user, "Initial delay: [delay]")
+//	to_chat(user, "Initial delay: [delay]")
 
 	to_chat(user, span_blue("<i>[user] makes a beckoning gesture at [T] as a white fog swirls momentarily!</i>"))
 	user.say(pick("The Dreamer commands you, splash forth.","By Abyssor's will, spring forth.","Splash forth.","Come hither, abyssals.","Leap in Abyssor's name.","I call to you, denizens of the depths."))
 
 	// === FIRST INSTANT PULL ===
 	if(!H.devotion || H.devotion.devotion < devotion_cost)
-		to_chat(user, "FAIL: not enough devotion ([H.devotion?.devotion])")
+//		to_chat(user, "FAIL: not enough devotion ([H.devotion?.devotion])")
 		to_chat(H, span_notice("<i>Your connection to the Dreamer is too faint...</i>"))
 		H.emote("yawn")
 		channeling = FALSE
@@ -290,27 +264,27 @@
 
 	var/A = getfishingloot(user, fishingMods, T, 0.5)
 	if(!A)
-		to_chat(user, "FAIL: no loot roll")
+//		to_chat(user, "FAIL: no loot roll")
 		to_chat(user, span_warning("The waters remain still."))
 		channeling = FALSE
 		revert_cast()
 		return FALSE
 
-	to_chat(user, "First pull success: [A]")
+//	to_chat(user, "First pull success: [A]")
 
 	var/atom/movable/AF = new A(T)
 	if(!AF)
-		to_chat(user, "FAIL: spawn failed")
+//		to_chat(user, "FAIL: spawn failed")
 		channeling = FALSE
 		revert_cast()
 		return FALSE
 
 	var/cost = devotion_cost + (streak * (miracleskill/2))
 	H.devotion.devotion -= cost
-	to_chat(user, "Devotion spent: [cost], remaining: [H.devotion.devotion]")
+//	to_chat(user, "Devotion spent: [cost], remaining: [H.devotion.devotion]")
 
 	streak++
-	to_chat(user, "Streak now: [streak]")
+//	to_chat(user, "Streak now: [streak]")
 
 	AF.pixel_x = 0
 	AF.pixel_y = 0
@@ -330,40 +304,40 @@
 			break // me when I gib myself and crash the server, on god
 
 		delay = clamp(((10 - miracleskill) + streak), 5, 10)
-		to_chat(user, "Loop start | streak=[streak] delay=[delay] devotion=[H.devotion?.devotion]")
+//		to_chat(user, "Loop start | streak=[streak] delay=[delay] devotion=[H.devotion?.devotion]")
 
 		if(!H || !H.devotion || H.devotion.devotion < devotion_cost)
-			to_chat(user, "BREAK: devotion too low ([H?.devotion?.devotion])")
+//			to_chat(user, "BREAK: devotion too low ([H?.devotion?.devotion])")
 			to_chat(H, span_notice("<i>Your connection to the Dreamer is too faint...</i>"))
 			H?.emote("yawn")
 			break
 
 		if(!do_after(user, delay SECONDS, target = user))
-			to_chat(user, "BREAK: do_after failed (movement/interruption)")
+//			to_chat(user, "BREAK: do_after failed (movement/interruption)")
 			to_chat(user, span_warning("Your focus breaks, and Abyssor's pull fades."))
 			break
 
-		to_chat(user, "do_after success")
+//		to_chat(user, "do_after success")
 
 		var/A2 = getfishingloot(user, fishingMods, T, 0.5)
 		if(!A2)
-			to_chat(user, "BREAK: no loot roll")
+//			to_chat(user, "BREAK: no loot roll")
 			to_chat(user, span_warning("The waters remain still."))
 			break
 
-		to_chat(user, "Loop pull success: [A2]")
+//		to_chat(user, "Loop pull success: [A2]")
 
 		var/atom/movable/AF2 = new A2(T)
 		if(!AF2)
-			to_chat(user, "BREAK: spawn failed")
+//			to_chat(user, "BREAK: spawn failed")
 			break
 
 		var/cost2 = devotion_cost + (streak * (miracleskill/2))
 		H.devotion.devotion -= cost2
-		to_chat(user, "Devotion spent: [cost2], remaining: [H.devotion.devotion]")
+//		to_chat(user, "Devotion spent: [cost2], remaining: [H.devotion.devotion]")
 
 		streak++
-		to_chat(user, "Streak now: [streak]")
+//		to_chat(user, "Streak now: [streak]")
 
 		AF2.pixel_x = 0
 		AF2.pixel_y = 0
@@ -378,7 +352,7 @@
 		teleport_to_dream(user, 10000, 1)
 
 	// === CLEANUP ===
-	to_chat(user, "CLEANUP: channeling ended at streak=[streak]")
+//	to_chat(user, "CLEANUP: channeling ended at streak=[streak]")
 
 	channeling = FALSE
 	return TRUE

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -305,7 +305,7 @@
 		revert_cast()
 		return FALSE
 
-	var/cost = clamp((devotion_cost + (streak)), devotion_cost, 15)
+	var/cost = devotion_cost + (streak * min(1, miracleskill/2))
 	H.devotion.devotion -= cost
 	to_chat(user, "Devotion spent: [cost], remaining: [H.devotion.devotion]")
 
@@ -358,7 +358,7 @@
 			to_chat(user, "BREAK: spawn failed")
 			break
 
-		var/cost2 = clamp((devotion_cost + (streak)), devotion_cost, 15)
+		var/cost2 = devotion_cost + (streak * min(1, miracleskill/2))
 		H.devotion.devotion -= cost2
 		to_chat(user, "Devotion spent: [cost2], remaining: [H.devotion.devotion]")
 

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -123,15 +123,12 @@
 	name = "Aquatic Compulsion"
 	desc = "Compel a fish to leap out from targeted water tile and towards you."
 	overlay_state = "aqua"
-	releasedrain = 15
+	releasedrain = 20
 	chargedrain = 0
-	chargetime = 0.5 SECONDS
-	range = 3
+	range = 5
 	movement_interrupt = FALSE
 	chargedloop = null
 	sound = 'sound/foley/bubb (5).ogg'
-	invocations = list("Splash forth.")
-	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
 	recharge_time = 10 SECONDS
@@ -146,7 +143,7 @@
 		"dangerFishingMod" = 0.1,
 		"ceruleanFishingMod" = 0 // 1 on cerulean aril, 0 on everything else
 	)
-	
+/*
 /obj/effect/proc_holder/spell/invoked/aquatic_compulsion/cast(list/targets, mob/user = usr)
 	. = ..()
 	if(isturf(targets[1]))
@@ -154,24 +151,12 @@
 		var/A = getfishingloot(user, fishingMods, T, 0.5)
 		if(A)
 			var/atom/movable/AF = new A(T)
-
-			var/turf/target_turf = get_step(get_turf(user), turn(get_dir(T, get_turf(user)), 180)) || get_turf(user)
-
 			if(istype(AF, /obj/item/reagent_containers/food/snacks/fish))
 				var/obj/item/reagent_containers/food/snacks/fish/F = AF
 				F.sinkable = FALSE
-				animate(F, pixel_x = (target_turf.x - T.x) * 32, pixel_y = (target_turf.y - T.y) * 32, time = 5)
-				spawn(5)
-					F.forceMove(target_turf)
-					F.pixel_x = 0
-					F.pixel_y = 0
+				F.throw_at(get_turf(user), 5, 1, null)
 			else
-				animate(AF, pixel_x = (target_turf.x - T.x) * 32, pixel_y = (target_turf.y - T.y) * 32, time = 5)
-				spawn(5)
-					AF.forceMove(target_turf)
-					AF.pixel_x = 0
-					AF.pixel_y = 0
-
+				AF.throw_at(get_turf(user), 5, 1, null)
 			record_featured_stat(FEATURED_STATS_FISHERS, user)
 			record_round_statistic(STATS_FISH_CAUGHT)
 			playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)
@@ -181,6 +166,95 @@
 		else
 			revert_cast()
 			return FALSE
+	revert_cast()
+	return FALSE
+*/
+
+/proc/abyssor_fish_arc(atom/movable/AF, turf/T, mob/user)
+	var/turf/user_turf = get_turf(user)
+	var/dir_to_water = get_dir(user_turf, T)
+	var/turf/target_turf = get_step(user_turf, dir_to_water) || user_turf
+
+	var/dist = max(1, get_dist(T, target_turf))
+
+	if(dist <= 1)
+		AF.forceMove(target_turf)
+		AF.pixel_x = 0
+		AF.pixel_y = 0
+		AF.pixel_z = 0
+		return
+
+	var/dx = (target_turf.x - T.x) * 32
+	var/dy = (target_turf.y - T.y) * 32
+
+	var/time_total = max(3, dist * 2)
+
+	var/arc_height = clamp(dist * 10 + rand(-4, 8), 12, 48)
+
+	// boost arc for east/west travel so it’s visible
+	if(abs(dx) > abs(dy))
+		arc_height *= 1.3
+
+	// slight sideways wobble for natural motion
+	var/wobble_x = rand(-4, 4)
+	var/wobble_y = rand(-4, 4)
+
+	animate(AF,
+		pixel_x = dx + wobble_x,
+		pixel_y = dy + wobble_y,
+		pixel_z = arc_height,
+		time = time_total,
+		easing = SINE_EASING)
+
+	animate(AF,
+		pixel_z = 0,
+		time = time_total,
+		easing = SINE_EASING)
+
+	spawn(time_total)
+		if(!AF)
+			return
+		AF.forceMove(target_turf)
+		AF.pixel_x = 0
+		AF.pixel_y = 0
+		AF.pixel_z = 0
+		
+/obj/effect/proc_holder/spell/invoked/aquatic_compulsion/cast(list/targets, mob/user = usr)
+	. = ..()
+
+	if(isturf(targets[1]))
+		var/turf/T = targets[1]
+
+		var/A = getfishingloot(user, fishingMods, T, 0.5)
+		if(A)
+			var/atom/movable/AF = new A(T)
+			if(!AF)
+				return FALSE
+
+			AF.pixel_x = 0
+			AF.pixel_y = 0
+			AF.pixel_z = 0
+
+			if(istype(AF, /obj/item/reagent_containers/food/snacks/fish))
+				var/obj/item/reagent_containers/food/snacks/fish/F = AF
+				F.sinkable = FALSE
+				spawn(1)
+					abyssor_fish_arc(F, T, user)
+			else
+				spawn(1)
+					abyssor_fish_arc(AF, T, user)
+
+			record_featured_stat(FEATURED_STATS_FISHERS, user)
+			record_round_statistic(STATS_FISH_CAUGHT)
+			playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)
+			teleport_to_dream(user, 10000, 1)
+			user.visible_message("<font color='yellow'>[user] makes a beckoning gesture at [T]!</font>")
+			return TRUE
+
+		else
+			revert_cast()
+			return FALSE
+
 	revert_cast()
 	return FALSE
 

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -223,7 +223,7 @@
 	var/mob/living/carbon/human/H = user
 	var/turf/T = targets[1]
 
-	to_chat(user, "CAST START")
+//	to_chat(user, "CAST START")
 
 	if(channeling)
 //		to_chat(user, "FAIL: already channeling")

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -305,7 +305,7 @@
 		revert_cast()
 		return FALSE
 
-	var/cost = devotion_cost + (streak * min(1, miracleskill/2))
+	var/cost = devotion_cost + (streak * (miracleskill/2))
 	H.devotion.devotion -= cost
 	to_chat(user, "Devotion spent: [cost], remaining: [H.devotion.devotion]")
 
@@ -358,7 +358,7 @@
 			to_chat(user, "BREAK: spawn failed")
 			break
 
-		var/cost2 = devotion_cost + (streak * min(1, miracleskill/2))
+		var/cost2 = devotion_cost + (streak * (miracleskill/2))
 		H.devotion.devotion -= cost2
 		to_chat(user, "Devotion spent: [cost2], remaining: [H.devotion.devotion]")
 


### PR DESCRIPTION
## About The Pull Request

Basically adjusted Aquatic Compulsion to be automatic, toggle-cast, with increasing costs and casting time by the streak to prevent AFK farming at higher Miracle levels.

That's pretty much it.

Nothing else was changed about this skill's balance, just the 'how' it works for QoL and sovl's sake. Similar to what I did to Locate Corpse.

## Testing Evidence

It works, I'm running the game just fine. Da fish go bwoing every time, and doesn't explode your Arcyne Ward anymore cause it's now an animation proc, not a throw proc.

<img width="987" height="583" alt="image" src="https://github.com/user-attachments/assets/9c79ec0e-10c4-4226-969f-c3c9789903ab" />

Shucks I can't make a gif, oh well. But yeah, runs. If you need to check the entrails of it, just uncomment the debug prints.

At Legendary Miracle skill level, maximum streak was 27 fishes.

## Why It's Good For The Game

The changes were originally planned to make spawned fish no longer slam-bump into you whenever you cast this, due to an annoying interaction with Arcyne Ward draining your blue stamina on loop, but I kept breaking the miracle when trying to do so. Then I went 'ah fuck it' and deciding to turn it into an animation. Which ended up better than I expected. It's a direct upgrade from the old, bland one.

The fact this only invokes once also cleans up a lot of spam from constant "SPLASH FORTH SPLASH FORTH SPLASH FORTH", which was way too immersion-breaking for me, personally.

## Changelog
:cl:
qol: Aquatic Compulsion is now a toggle Miracle and has a new animation.
/:cl: