### PR TITLE
properly exclude hag allies from grand rite

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_heart.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_heart.dm
@@ -193,7 +193,7 @@
 
 	// Distribute the spite
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
-		if(H.stat == DEAD || !H.mind || HAS_TRAIT(H, TRAIT_ANCIENT_HAG))
+		if(H.stat == DEAD || !H.mind || HAS_TRAIT(H, TRAIT_ANCIENT_HAG) || HAS_TRAIT(H, TRAIT_FEYTOUCHED))
 			continue
 		// People who are enjoying only boons are technically allies.
 		if(HCT.boon_registry[H.real_name])


### PR DESCRIPTION
## About The Pull Request
the logic for the grand rite currently skips the hag, mindless npcs, and anyone with boons and no curses, with a comment saying the hag's allies should be excluded. this extends that to anyone with TRAIT_FEYTOUCHED, since they are also hag allies

## Testing Evidence
<img width="843" height="269" alt="image" src="https://github.com/user-attachments/assets/1703d4ec-8b71-4172-85ab-70cd2aaadbd4" />
not able to do a grand rite ingame to test rn but it's a very simple change

## Why It's Good For The Game
feytouched takers are told at roundstart that they're sympathetic to the hag's cause, and generally form a sort of awesome hag coven minifaction, and lorewise they're deeply affected by fae nature anyway, it would make 0 sense for them to get fucked over by the mortal-targeting hag-ally-sparing grand rite

## Changelog

:cl:
fix: grand rite now excludes faetouched alongside other hag allies
/:cl:
