### PR TITLE
Flatten the hunger curves and stats

### DIFF
--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -83,13 +83,9 @@
 
 /mob/living/proc/stamina_nutrition_mod(amt)
 	// to simulate exertion, we deduct a mob's nutrition whenever it takes an action that would give us fatigue.
-	var/nutrition_amount = amt * 0.15 // nutrition goes up to 1k at max (but constantly ticks down) so we need to work at a slightly bigger scale
-	var/athletics_skill = get_skill_level(/datum/skill/misc/athletics)
-	var/chip_amt = 2 + ceil(athletics_skill / 2)
+	var/nutrition_amount = amt * 0.075 // flat 1/2 of the old 0.15 rate
 
-	if (amt <= chip_amt)
-		if (athletics_skill && prob(athletics_skill * 16)) // 16% chance per athletics skill to straight up negate nutrition loss
-			return 0
+	if (amt <= 2)
 		if (amt == 2 && prob(STACON * 5)) // only sprinting knocks off 2 stamina at a time, so test this vs our con to see if we drop it
 			return 0
 
@@ -99,18 +95,6 @@
 
 	if (stamina >= (max_stamina * 0.7)) // if you've spent 70% of your max fatigue, the base amount you lose is doubled
 		nutrition_amount *= 2
-	if (STACON <= 9) // 10% extra nutrition loss for every CON below 9
-		var/low_end_malus = (10 - STACON) * 0.1
-		nutrition_amount *= (1 + low_end_malus)
-	if (STACON >= 11) // 5% less nutrition loss for every CON above 11
-		var/high_end_buff = (STACON - 10) * 0.05
-		nutrition_amount *= (1 - high_end_buff)
-	if (STASTR >= 11) // 7.5% increased nutrition loss for every STR above 11. the gainz don't come cheap
-		var/swole_malus = (10 - STASTR) * 0.075
-		nutrition_amount *= (1 + swole_malus)
-	if (athletics_skill)
-		var/athletics_bonus = athletics_skill * 0.05 //each rank of athletics gives us 5% less nutrition loss
-		nutrition_amount *= (1 - athletics_bonus)
 
 	if (nutrition >= NUTRITION_LEVEL_WELL_FED) // we've only just eaten recently so just flat out reduce the total loss by half
 		nutrition_amount *= 0.5

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -96,6 +96,10 @@
 	if (stamina >= (max_stamina * 0.7)) // if you've spent 70% of your max fatigue, the base amount you lose is doubled
 		nutrition_amount *= 2
 
+	if (STASTR >= 11) // 5% increased nutrition loss for every STR above 11. the gainz don't come cheap
+		var/swole_malus = (10 - STASTR) * 0.05
+		nutrition_amount *= (1 + swole_malus)
+
 	if (nutrition >= NUTRITION_LEVEL_WELL_FED) // we've only just eaten recently so just flat out reduce the total loss by half
 		nutrition_amount *= 0.5
 


### PR DESCRIPTION
## About The Pull Request
Okay so, hunger works on a really obscure and complex formula, which means some roles basically never experience hunger and others go hungry every 5 minutes. 

First. Hunger is multiplied by 0.15 * amount of energy spent. Fine by me. 

And then - based on your athletics skills, there's a 16% chance per skills level to negate any hunger:
```Athletics negation: If amt <= (2 + ceil(athletics/2)), roll prob(athletics * 16) — on success, zero nutrition loss. So at athletics 6, that's a 96% chance to ignore small actions entirely.```

If you have lower con, you get +10% nutrition
At higher con, -5% per point above 10
High str, gives you +7.5%

So certain builds basically do not deal with hunger whereas a low con low athletics is in the hunger game gobbling everything up. 

This entirely remove Athletics and Con's influence on hunger and then just flat out halve the rate. If this turns out to make EVERYONE too hungry - I will tweak it to 1/3 of the original rate. 

Str now gives +5% hunger rate per point above 10.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yes
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It just make no sense that certain high con martials never go hungry and then some roles go hungry non-stop based on your stat it is just non transparent everyone should have to eat.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Removed most stats and athletics skills influence on hunger rate and then halved the flat hunger rate gain. Report if hunger happens too often. Str above 10 increases hunger rate by 5% per point instead of 7.5%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
