### PR TITLE
Removes unique sneaking sounds

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -656,12 +656,6 @@
 		switch(intent)
 			if(MOVE_INTENT_SNEAK)
 				m_intent = MOVE_INTENT_SNEAK
-				if(isliving(src))
-					var/mob/living/L = src
-					if((/datum/mob_descriptor/prominent/prominent_bottom in L.mob_descriptors) || (/datum/mob_descriptor/prominent/prominent_thighs in L.mob_descriptors))
-						L.loud_sneaking = TRUE
-					else
-						L.loud_sneaking = FALSE
 				update_sneak_invis()
 
 			if(MOVE_INTENT_WALK)


### PR DESCRIPTION
## About The Pull Request

Taking prominent posterior no longer makes your character emit a wet clapping sound while they're trying to sneak.

## Testing Evidence

Loaded up a local test, it works!

## Why It's Good For The Game

Yes, haha, funny, sovl, but every time I hear someone bring up this mechanic it's either "Oh, I had to take the descriptor off because it messed up my stealth" or "I literally didn't know why my character made so much noise while sneaking for multiple rounds before somebody told me it was the descriptor." 

The sound effect sounds like wanking, it's a completely hidden mechanic for a joke that's not even that funny to begin with, and it's the _only_ option that tangibly changes gameplay out of the entire descriptors menu. Flavor should stay flavor.

## Changelog

:cl:
del: ass clapping while sneaking
/:cl: