### PR TITLE
Lesser Silver implementation + Silver-ize silverwares again

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -622,17 +622,23 @@
 	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_EFFECT_SELF, user, affecting, intent, victim, selzone)
 
 	if(is_silver && HAS_TRAIT(victim, TRAIT_SILVER_WEAK))
-		SEND_SIGNAL(victim, COMSIG_FORCE_UNDISGUISE)
-		var/datum/component/silverbless/blesscomp = GetComponent(/datum/component/silverbless)
-		if(blesscomp?.is_blessed)
-			if(!victim.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder))
-				to_chat(victim, span_danger("Silver rebukes my presence! My vitae smolders, and my powers wane!"))
-			victim.adjust_fire_stacks(thrown ? 1 : 3, /datum/status_effect/fire_handler/fire_stacks/sunder/blessed)
+		if(is_lesser_silver)
+			// Lesser silver only flares meaningfully on a deliberate melee strike — thrown contact does nothing,
+			// and the hit never forces a disguise off. Stacks accumulate without ignition.
+			if(!thrown)
+				victim.adjust_fire_stacks(1, /datum/status_effect/fire_handler/fire_stacks/sunder/lesser)
 		else
-			if(!victim.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
-				to_chat(victim, span_danger("Blessed silver rebukes my presence! These fires are lashing at my very soul!"))
-			victim.adjust_fire_stacks(thrown ? 1 : 3, /datum/status_effect/fire_handler/fire_stacks/sunder)
-		victim.ignite_mob()
+			SEND_SIGNAL(victim, COMSIG_FORCE_UNDISGUISE)
+			var/datum/component/silverbless/blesscomp = GetComponent(/datum/component/silverbless)
+			if(blesscomp?.is_blessed)
+				if(!victim.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder))
+					to_chat(victim, span_danger("Silver rebukes my presence! My vitae smolders, and my powers wane!"))
+				victim.adjust_fire_stacks(thrown ? 1 : 3, /datum/status_effect/fire_handler/fire_stacks/sunder/blessed)
+			else
+				if(!victim.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+					to_chat(victim, span_danger("Blessed silver rebukes my presence! These fires are lashing at my very soul!"))
+				victim.adjust_fire_stacks(thrown ? 1 : 3, /datum/status_effect/fire_handler/fire_stacks/sunder)
+			victim.ignite_mob()
 
 /mob/living/attacked_by(obj/item/I, mob/living/user)
 	var/hitlim = simple_limb_hit(user.zone_selected)

--- a/code/datums/status_effects/firestacker.dm
+++ b/code/datums/status_effects/firestacker.dm
@@ -292,6 +292,70 @@
 		victim?.dna?.species?.handle_fire(victim, no_protection)
 	victim.adjustFireLoss(8)
 
+/// Lesser silver sunder. Tracks how long the silver-weak owner has been in continuous contact with
+/// any is_lesser_silver item, escalating in stages: a stress event after a brief grace period (so
+/// "force them to hold silver for two seconds" metachecks can't instantly out a vampyre), and a
+/// real sunder ignition once they've been holding it long enough to count as a true exposure.
+#define LESSER_SILVER_STRESS_DELAY    (10 SECONDS)
+#define LESSER_SILVER_IGNITE_DELAY    (30 SECONDS)
+#define LESSER_SILVER_IGNITE_STACKS   3
+
+/datum/status_effect/fire_handler/fire_stacks/sunder/lesser
+	id = "fire_stacks_sunder_lesser"
+	tick_interval = 1 SECONDS
+	stack_limit = 20
+	/// World time at which contact with lesser silver began (or was last refreshed). Reset whenever
+	/// the owner stops touching any lesser silver.
+	var/contact_started_at = 0
+	/// Whether the stress event has been applied this exposure.
+	var/stress_applied = FALSE
+	/// Whether the real sunder ignition has been triggered this exposure.
+	var/ignited_from_lesser = FALSE
+
+/datum/status_effect/fire_handler/fire_stacks/sunder/lesser/on_creation(mob/living/new_owner, new_stacks, forced = FALSE)
+	. = ..()
+	contact_started_at = world.time
+	to_chat(new_owner, span_warning("The silver stings against my flesh - a slow, smoldering reminder of what I am."))
+
+/datum/status_effect/fire_handler/fire_stacks/sunder/lesser/on_remove()
+	if(stress_applied && owner)
+		owner.remove_stress(/datum/stressevent/lesser_silver)
+	return ..()
+
+/datum/status_effect/fire_handler/fire_stacks/sunder/lesser/tick(wait)
+	if(!isliving(owner) || QDELETED(owner))
+		qdel(src)
+		return TRUE
+	// Antimagic wards off the slow burn entirely.
+	if(owner.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
+		qdel(src)
+		return TRUE
+	var/touching_lesser_silver = FALSE
+	for(var/obj/item/checked in (owner.get_equipped_items(TRUE) | owner.held_items))
+		if(checked?.is_lesser_silver)
+			touching_lesser_silver = TRUE
+			break
+	if(!touching_lesser_silver)
+		// They've let go. Tear down the exposure entirely — stress and timers reset, so picking
+		// silver back up gives them another grace window.
+		qdel(src)
+		return TRUE
+	var/elapsed = world.time - contact_started_at
+	if(!stress_applied && elapsed >= LESSER_SILVER_STRESS_DELAY)
+		owner.add_stress(/datum/stressevent/lesser_silver)
+		stress_applied = TRUE
+	if(!ignited_from_lesser && elapsed >= LESSER_SILVER_IGNITE_DELAY)
+		owner.adjust_fire_stacks(LESSER_SILVER_IGNITE_STACKS, /datum/status_effect/fire_handler/fire_stacks/sunder)
+		owner.ignite_mob()
+		ignited_from_lesser = TRUE
+		// At this point a real sunder effect is now driving the burn — our work is done.
+		qdel(src)
+		return TRUE
+
+#undef LESSER_SILVER_STRESS_DELAY
+#undef LESSER_SILVER_IGNITE_DELAY
+#undef LESSER_SILVER_IGNITE_STACKS
+
 /datum/status_effect/fire_handler/wet_stacks
 	id = "wet_stacks"
 

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -389,6 +389,11 @@
 	timer = 999 MINUTES
 	desc = span_green("I'm wielding a BLESSED weapon!")
 
+/datum/stressevent/lesser_silver
+	stressadd = 8
+	timer = 999 MINUTES
+	desc = span_boldred("The silver burns! It claws at the curse within me, and I can scarcely bear its touch!")
+
 /datum/stressevent/naledimasklost
 	stressadd = 3
 	desc = span_boldred("I have lost my mask! Anyone here could be a djinn! I'm dangerously exposed!")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -271,6 +271,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/smelted = FALSE
 	/// Determines whether this item is silver or not.
 	var/is_silver = FALSE
+	/// "Lesser" silver items still count as silver, but their bite against the silver-weak is muted: no pickup ignition,
+	/// no force-undisguise on hit, and only a slow accumulation of (non-igniting) sunder stacks while held/worn.
+	var/is_lesser_silver = FALSE
 	var/last_used = 0
 	var/toggle_state = null
 	var/icon_x_offset = 0
@@ -959,7 +962,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 //If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.
 //Set disable_warning to TRUE if you wish it to not give you outputs.
 /obj/item/proc/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
-	if((is_silver || smeltresult == /obj/item/ingot/silver) && (HAS_TRAIT(M, TRAIT_SILVER_WEAK) &&  !M.has_status_effect(STATUS_EFFECT_ANTIMAGIC)))
+	if((is_silver || smeltresult == /obj/item/ingot/silver) && !is_lesser_silver && (HAS_TRAIT(M, TRAIT_SILVER_WEAK) &&  !M.has_status_effect(STATUS_EFFECT_ANTIMAGIC)))
 		var/datum/antagonist/vampire/V_lord = M.mind?.has_antag_datum(/datum/antagonist/vampire/)
 		if(V_lord?.generation >= GENERATION_METHUSELAH)
 			return
@@ -971,6 +974,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		M.adjust_fire_stacks(3, /datum/status_effect/fire_handler/fire_stacks/sunder)
 		M.ignite_mob()
 		return FALSE
+	if(is_lesser_silver && HAS_TRAIT(M, TRAIT_SILVER_WEAK) && !M.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
+		// Kick off the lesser silver exposure timer. The status effect handles grace period,
+		// stress event, and eventual ignition; it self-removes when no lesser silver remains.
+		if(!M.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/lesser))
+			M.apply_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/lesser, 1)
 	//else if(is_blessed && slot == SLOT_HANDS)
 	//	user.add_stress(/datum/stressevent/blessed_weapon)
 	if(twohands_required)

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -147,7 +147,8 @@
 	icon_state = "scandelabra"
 	infinite = TRUE
 	sellprice = 60
-	is_silver = FALSE //temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 	possible_item_intents = list(/datum/intent/use, /datum/intent/hit)
 	force = 12 //Bludgeons!
 
@@ -182,7 +183,8 @@
 	sellprice = 50
 	possible_item_intents = list(/datum/intent/use, /datum/intent/hit)
 	force = 12 //Bludgeons!
-	is_silver = FALSE //Ditto.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/candle/candlestick/silver/single/update_icon()
 	icon_state = "singlescandelabra[lit ? "_lit" : ""]"
@@ -211,7 +213,8 @@
 	icon_state = "scandle"
 	infinite = TRUE
 	sellprice = 50
-	is_silver = FALSE
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/candle/silver/update_icon()
 	icon_state = "scandle[lit ? "_lit" : ""]"

--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -50,7 +50,8 @@
 	desc = "A ring of silvered glimmerance."
 	icon_state = "ring_s"
 	sellprice = 33
-	is_silver = FALSE //Temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/clothing/ring/silver/cleric
 	name = "clerical silver ring"
@@ -253,7 +254,8 @@
 	icon_state = "signet_silver"
 	desc = "A ring of blessed silver, bearing the Archbishop's symbol. By dipping it in melted redtallow, it can seal writs of religious importance."
 	sellprice = 90
-	is_silver = FALSE //Temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/clothing/ring/signet/silver/get_mechanics_examine(mob/user)
     . = ..()
@@ -281,7 +283,8 @@
 	icon_state = "s_ring_emerald"
 	smeltresult = /obj/item/roguegem/green
 	sellprice = 155
-	is_silver = FALSE //Temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/clothing/ring/rubys
 	name = "silver rontz ring"
@@ -289,7 +292,8 @@
 	icon_state = "s_ring_ruby"
 	smeltresult = /obj/item/roguegem/ruby
 	sellprice = 215
-	is_silver = FALSE //Ditto.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/clothing/ring/topazs
 	name = "silver toper ring"
@@ -297,7 +301,8 @@
 	icon_state = "s_ring_topaz"
 	smeltresult = /obj/item/roguegem/yellow
 	sellprice = 140
-	is_silver = FALSE
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/clothing/ring/quartzs
 	name = "silver blortz ring"
@@ -305,7 +310,8 @@
 	icon_state = "s_ring_quartz"
 	smeltresult = /obj/item/roguegem/blue
 	sellprice = 205
-	is_silver = FALSE
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/clothing/ring/sapphires
 	name = "silver saffira ring"
@@ -313,7 +319,8 @@
 	icon_state = "s_ring_sapphire"
 	smeltresult = /obj/item/roguegem/violet
 	sellprice = 160
-	is_silver = FALSE
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/clothing/ring/diamonds
 	name = "silver dorpel ring"
@@ -321,7 +328,8 @@
 	icon_state = "s_ring_diamond"
 	smeltresult = /obj/item/roguegem/diamond
 	sellprice = 230
-	is_silver = FALSE
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/clothing/ring/duelist
 	name = "duelist's ring"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -200,7 +200,7 @@
 /mob/living/put_in_hand_check(obj/item/I)
 	if(I.twohands_required && get_inactive_held_item())
 		return FALSE
-	if((I.is_silver || I.smeltresult == /obj/item/ingot/silver) && (HAS_TRAIT(src, TRAIT_SILVER_WEAK) &&  !has_status_effect(STATUS_EFFECT_ANTIMAGIC)))
+	if((I.is_silver || I.smeltresult == /obj/item/ingot/silver) && !I.is_lesser_silver && (HAS_TRAIT(src, TRAIT_SILVER_WEAK) &&  !has_status_effect(STATUS_EFFECT_ANTIMAGIC)))
 		var/datum/antagonist/vampire/V_lord = mind?.has_antag_datum(/datum/antagonist/vampire)
 		if(!istype(V_lord) || V_lord?.generation < GENERATION_METHUSELAH)
 			to_chat(src, span_userdanger("I can't pick up the silver, it is my BANE!"))
@@ -210,6 +210,11 @@
 			adjust_fire_stacks(3, /datum/status_effect/fire_handler/fire_stacks/sunder)
 			ignite_mob()
 			return FALSE
+	if(I.is_lesser_silver && HAS_TRAIT(src, TRAIT_SILVER_WEAK) && !has_status_effect(STATUS_EFFECT_ANTIMAGIC))
+		// Kick off the lesser silver exposure timer. The status effect handles grace period,
+		// stress event, and eventual ignition; it self-removes when no lesser silver remains.
+		if(!has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/lesser))
+			apply_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/lesser, 1)
 	if(istype(I) && ((mobility_flags & MOBILITY_PICKUP) || (I.item_flags & ABSTRACT)))
 		return TRUE
 	return FALSE

--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -254,7 +254,8 @@
 	icon_state = "ingotsilv"
 	smeltresult = /obj/item/ingot/silver
 	sellprice = 80
-	is_silver = FALSE //temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/ingot/steel
 	name = "steel bar"
@@ -288,7 +289,8 @@
 	icon_state = "ingotsilvblessed"
 	smeltresult = /obj/item/ingot/silver //Smelting it removes the blessing
 	sellprice = 100
-	is_silver = FALSE //Ditto.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/ingot/silverblessed/Initialize()
   ..()
@@ -300,7 +302,8 @@
 	icon_state = "ingotsilvblessed_psy"
 	smeltresult = /obj/item/ingot/silverblessed //Minor failsafe to ensure bullion can always be used for blessed silver recipes, in case of a filepath conflict.
 	sellprice = 100
-	is_silver = FALSE
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/ingot/aalloy
 	name = "decrepit ingot"

--- a/modular/Neu_Food/code/cookware/bowl.dm
+++ b/modular/Neu_Food/code/cookware/bowl.dm
@@ -45,7 +45,8 @@
 	name = "silver bowl"
 	icon_state = "bowl_silver"
 	sellprice = 60
-	is_silver = FALSE //temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/reagent_containers/glass/bowl/carved
 	name = "carved bowl"

--- a/modular/Neu_Food/code/cookware/cup.dm
+++ b/modular/Neu_Food/code/cookware/cup.dm
@@ -201,7 +201,8 @@
 	icon_state = "silver"
 	sellprice = 30
 	last_used = 0
-	is_silver = FALSE //temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 	force = 10
 	throwforce = 15
 
@@ -214,7 +215,8 @@
 	desc = "A silver cup, its surface adorned with intricate carvings and runes."
 	icon_state = "scup"
 	sellprice = 20
-	is_silver = FALSE //Ditto.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 	force = 5
 	throwforce = 10
 

--- a/modular/Neu_Food/code/cookware/fork.dm
+++ b/modular/Neu_Food/code/cookware/fork.dm
@@ -49,7 +49,8 @@
 	name = "silver fork"
 	icon_state = "fork_silver"
 	sellprice = 20
-	is_silver = FALSE //temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/kitchen/fork/carved
 	name = "carved fork"

--- a/modular/Neu_Food/code/cookware/platter.dm
+++ b/modular/Neu_Food/code/cookware/platter.dm
@@ -138,7 +138,8 @@ What it does:
 	desc = "A fancy silver plate often used by the nobility as a symbol of class."
 	icon_state = "platter_silver"
 	sellprice = 30
-	is_silver = FALSE
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/item/cooking/platter/gold
 	name = "gold platter"

--- a/modular/Neu_Food/code/cookware/spoon.dm
+++ b/modular/Neu_Food/code/cookware/spoon.dm
@@ -37,7 +37,8 @@
 /obj/item/kitchen/spoon/silver
 	name = "silver spoon"
 	icon_state = "spoon_silver"
-	is_silver = FALSE //temporary measure to prevent people from easily metachecking vampyres. Replace with a more sophisticated alternative if-or-when available.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 	sellprice = 20
 
 /obj/item/kitchen/spoon/carved


### PR DESCRIPTION
## About The Pull Request
- Give silverwares which was turned into Not Silver from Pintle's anti-meta measures is_lesser_silver a variable
- When you touch a lesser silver ware, you gain a slowly accumulating debuff - after 10 seconds, it moodnukes you (buffer to prevent easy meta), and after 30 seconds you are set on actual fire if you holds it for too long

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1045" height="615" alt="dreamseeker_qth80nyskG" src="https://github.com/user-attachments/assets/b75209c5-0bd2-482d-954e-3e7225b12126" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Common silverware not setting vampires or silver weak people on fire is needed to prevent meta check but it ends up kinda making the whole thing sorta pointless so instead, I am implementing a variation of what Pintle proposed with lesser silver. 

I might or might not add in a way for Vampire to suppresses these weaknesses but it is a bit too technically complicated for my personal taste.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Silverwares counts as lesser silver (again) and will nuke a silver weak person's mood after holding onto it for 10 seconds and set them on fire after 30 seconds
add: Psyodn willing I'll smite anyone who uses this to metacheck vampire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
