### PR TITLE
Gives druid divine blast

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -13,6 +13,7 @@
 	outfit = /datum/outfit/job/roguetown/druid
 	tutorial = "You have always been drawn to the wild, and the wild drawn to you. When your calling came, it was from Dendor. Your patron claims dominion over all nature--promising bounties to those who act in his name to bring balance to His domain. The forest is the most comfortable place for you, toiling alongside soilsons and soilbrides...although sometimes what lies beyond the gates fills your soul with a feral yearning."
 
+    spells = list(/obj/effect/proc_holder/spell/invoked/projectile/divineblast)
 	display_order = JDO_DRUID
 	give_bank_account = TRUE
 	min_pq = 0

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -13,7 +13,7 @@
 	outfit = /datum/outfit/job/roguetown/druid
 	tutorial = "You have always been drawn to the wild, and the wild drawn to you. When your calling came, it was from Dendor. Your patron claims dominion over all nature--promising bounties to those who act in his name to bring balance to His domain. The forest is the most comfortable place for you, toiling alongside soilsons and soilbrides...although sometimes what lies beyond the gates fills your soul with a feral yearning."
 
-    spells = list(/obj/effect/proc_holder/spell/invoked/projectile/divineblast)
+	spells = list(/obj/effect/proc_holder/spell/invoked/projectile/divineblast)
 
 	display_order = JDO_DRUID
 	give_bank_account = TRUE

--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -14,6 +14,7 @@
 	tutorial = "You have always been drawn to the wild, and the wild drawn to you. When your calling came, it was from Dendor. Your patron claims dominion over all nature--promising bounties to those who act in his name to bring balance to His domain. The forest is the most comfortable place for you, toiling alongside soilsons and soilbrides...although sometimes what lies beyond the gates fills your soul with a feral yearning."
 
     spells = list(/obj/effect/proc_holder/spell/invoked/projectile/divineblast)
+
 	display_order = JDO_DRUID
 	give_bank_account = TRUE
 	min_pq = 0


### PR DESCRIPTION
## About The Pull Request

Adds the divine blast miracle to the druid class, since they're basically a dendor acolyte but didnt recieve it.

## Testing Evidence

Compiles and runs fine.

## Why It's Good For The Game
Felt odd that druids didnt have access to this miracle, when they are in a very similar place as acolyte in terms of role and capabilities apart from this one thing.

## Changelog

:cl:
add: added divine blast to druid characters on spawn.

/:cl: