### PR TITLE
Remove Unholy Silence from Gnolls

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_shaman.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_shaman.dm
@@ -41,6 +41,7 @@
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MINOR, start_maxed = TRUE)
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
+		H.mind?.RemoveSpell(/obj/effect/proc_holder/spell/invoked/silence/graggar)
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/shaman
 	icon_state = "shaman"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
@@ -33,7 +33,7 @@
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, start_maxed = FALSE)
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
-		H.mind?.RemoveSpell(/obj/effect/proc_holder/spell/invoked/silence/graggar) 
+		H.mind?.RemoveSpell(/obj/effect/proc_holder/spell/invoked/silence/graggar)
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/templar
 	icon_state = "templar"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
@@ -33,6 +33,7 @@
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, start_maxed = FALSE)
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
+		H.mind?.RemoveSpell(/obj/effect/proc_holder/spell/invoked/silence/graggar)
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/templar
 	icon_state = "templar"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
@@ -31,7 +31,7 @@
 		neck = /obj/item/storage/belt/rogue/pouch
 		don_pelt(H)
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
-		C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, start_maxed = FALSE)
+		C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, start_maxed = TRUE, devotion_limit = CLERIC_REQ_2)
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
 		H.mind?.RemoveSpell(/obj/effect/proc_holder/spell/invoked/silence/graggar)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
@@ -33,7 +33,7 @@
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, start_maxed = FALSE)
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
-		H.mind?.RemoveSpell(/obj/effect/proc_holder/spell/invoked/silence/graggar)
+		H.mind?.RemoveSpell(/obj/effect/proc_holder/spell/invoked/silence/graggar) 
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/templar
 	icon_state = "templar"


### PR DESCRIPTION
## About The Pull Request

Remove bad tool that was benched for removal from these classes but never removed

## Testing Evidence

2 line additions, i'm familiar with H.mind?.RemoveSpell as there is the same thing on mystic to remove blood boon 
funny bad eyesight gnoll for the bit, you can't even keep your spectacles on nerd! 
<img width="1894" height="1055" alt="image" src="https://github.com/user-attachments/assets/ab88e469-fedd-4c0a-963f-aab4016a495a" />


## Why It's Good For The Game

having a 1 button to turn off the entire concept of a class is bad, even badder when this tool was abused by said antagonist when they weren't supposed to even get it in the first place

## Changelog


:cl:
del: Remove Unholy Silence from Gnoll templar and Shaman miracle list
/:cl:
