### PR TITLE
Blacksteel Pickaxe Addendum

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -203,15 +203,15 @@
 
 /turf/closed/mineral/proc/gets_drilled(mob/living/user, triggered_by_explosion = FALSE, give_exp = TRUE)
 	new /obj/item/natural/stone(src)
+	var/autodestroy = FALSE
+	if(!isnull(user))
+		var/held = user.get_active_held_item()
+		if(istype(held, /obj/item/rogueweapon/pick))
+			var/obj/item/rogueweapon/pick/P = held
+			autodestroy = P.auto_boulder
 	if(prob(30))
 		new /obj/item/natural/stone(src)
 	if (mineralType && (mineralAmt > 0))
-		var/autodestroy = FALSE
-		if(!isnull(user))
-			var/held = user.get_active_held_item()
-			if(istype(held, /obj/item/rogueweapon/pick))
-				var/obj/item/rogueweapon/pick/P = held
-				autodestroy = P.auto_boulder
 		if(prob(33)) //chance to spawn ore directly
 			new mineralType(src)
 		if(rockType) //always spawn at least 1 rock
@@ -222,7 +222,7 @@
 	else if(user?.goodluck(2))
 		var/newthing = pickweight(list(/obj/item/natural/rock/salt = 2, /obj/item/natural/rock/iron = 1, /obj/item/natural/rock/coal = 2))
 //		to_chat(user, "<span class='notice'>Bonus ducks!</span>")
-		new newthing(src)
+		new newthing(src, autodestroy)
 	var/flags = NONE
 	if(defer_change) // TODO: make the defer change var a var for any changeturf flag
 		flags = CHANGETURF_DEFER_CHANGE

--- a/code/modules/roguetown/roguejobs/miner/tools.dm
+++ b/code/modules/roguetown/roguejobs/miner/tools.dm
@@ -63,7 +63,7 @@
 	name = "blacksteel pick"
 	desc = "Glimmering with silvered blackness, this is a pretigious tool for miners delving into the darkness. It looks like it will strike hard enough to shatter any boulders within a rocky surface instantly."
 	possible_item_intents = list(/datum/intent/pick/bad)
-	gripped_intents = list(/datum/intent/pick/good)
+	gripped_intents = list(/datum/intent/pick)
 	force = 25
 	force_wielded = 32
 	icon_state = "blacksteelpick1"


### PR DESCRIPTION
## About The Pull Request
- Cost back to 1 Blacksteel Ingot
- "Good" pick removed from wielded
- Fixed a bug that sometimes resulted in undestroyed boulders.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The pick is for picking rocks now and its combat potential was reduced so it doesn't need an extra cost now. Simpler, imo.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed blacksteel pickaxe sometimes leaving boulders behind.
balance: Blacksteel pickaxe lost its 'better' pick intent.
balance: Blacksteel pickaxe now costs 1 ingot to forge again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
