### PR TITLE
Fix Vicious Mockery expiring giving permanent stats

### DIFF
--- a/code/modules/spells/spell_types/bardic/vicious_mockery.dm
+++ b/code/modules/spells/spell_types/bardic/vicious_mockery.dm
@@ -140,7 +140,6 @@ GLOBAL_LIST_INIT(mockery_insults, list(
 	linked_alert.name = "Vicious Mockery ([stacks]/[MOCKERY_STACKS_MAX])"
 
 /datum/status_effect/debuff/mockery_stack/on_remove()
-	remove_stack_effects()
 	to_chat(owner, span_info("The sting of mockery fades."))
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
Fix Vicious Mockery expiring giving permanent stats because I called remove_stack_effects on on_remove() leading to it being removed twice = permanent stat gain. 

Oops.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="400" height="300" alt="dreamseeker_NYv45GNKdi" src="https://github.com/user-attachments/assets/364f64e4-fdd4-463f-be2a-bdbae329ec63" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fix Vicious Mockery expiring giving permanent stats
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Vicious Mockery no longer permanently buff your opponent on removal of the status effect. Oops.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
