### PR TITLE
last second adjustment i am so sorry free - locks MINSTR_REQ var to miniboss-exclusive axes

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -379,7 +379,6 @@
 	blade_dulling = DULLING_SHAFT_METAL
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
-	minstr_req = TRUE
 
 /obj/item/rogueweapon/stoneaxe/battle/psyaxe/ComponentInitialize()
 	AddComponent(\
@@ -540,7 +539,6 @@
 	max_blade_int = 350
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
-	minstr_req = TRUE
 
 /obj/item/rogueweapon/greataxe/silver/ComponentInitialize()
 	AddComponent(\
@@ -567,7 +565,6 @@
 	max_blade_int = 350
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
-	minstr_req = TRUE
 
 /obj/item/rogueweapon/greataxe/psy/ComponentInitialize()
 	AddComponent(\
@@ -602,7 +599,6 @@
 	icon_state = "doublegreataxe"
 	max_blade_int = 175
 	minstr = 13
-	minstr_req = TRUE
 
 /obj/item/rogueweapon/greataxe/steel/doublehead/graggar
 	name = "vicious greataxe"
@@ -610,7 +606,6 @@
 	power, it is only your hands that can determine whether it will defy fate.. ..or fufill it."
 	icon_state = "graggargaxe"
 	minstr = 12
-	minstr_req = FALSE //Retains same performance as before, as a precaution.
 	force = 20
 	force_wielded = 40
 	max_blade_int = 250
@@ -632,6 +627,7 @@
 	max_blade_int = 333
 	minstr = 14 //Double-headed greataxe with extra durability. Rare dungeon loot in minotaur dungeons; no longer drops from every single minotaur.
 	wbalance = WBALANCE_HEAVY
+	minstr_req = TRUE
 
 /obj/item/rogueweapon/stoneaxe/woodcut/troll
 	name = "crude heavy axe"


### PR DESCRIPTION
## About The Pull Request

* Removes the minimum strength requirement variable from silver axes and double-headed axes.

## Testing Evidence

* Linechange. Will rehost later, post-PR, if now isn't the best time.

## Why It's Good For The Game

* Experimental change that I made before the advent of axes _(and weapons in general)_ being overhauled - doesn't really work as intended, so I'm rescinding it. Now, it's only restricted to the special 'impromptu' weapons that you can get from butchering boss monsters.
* As it turns out, this isn't very fun to interact with - in most cases. Solves a minor incongruence as well, where polearms with axe-inherent abilities were left untouched as well.

## Changelog

:cl:
balance: Removes the 'minimum strength requirement' variable from most greataxes and silver axes. It remains present on the Minotaur Greataxe and Troll Axe, however.
/:cl: