### PR TITLE
Fluvian Origin Fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/underdweller.dm
@@ -8,6 +8,7 @@
 		/datum/species/dwarf/gnome,
 		/datum/species/elf/dark,
 		/datum/species/kobold,
+		/datum/species/moth,				//They are from the Underdark. source: moth.dm
 		/datum/species/goblinp,				//Might be a little weird but goblins do reside in caves, and they could use a unique merc class type.
 		/datum/species/anthromorphsmall,	//Basically all under-ground races. Perfect for cave-clearing.
 	)
@@ -40,7 +41,7 @@
 		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,	//Accompanies mining; they know how to smelt, not make armor though.
 	)
 	subclass_languages = list(/datum/language/undercommon)
-	extra_context = "This subclass is race-limited to: Dwarves, Dark Elves, Kobolds, Goblins & Verminvolk."
+	extra_context = "This subclass is race-limited to: Dwarves, Dark Elves, Fluvians, Kobolds, Goblins & Verminvolk."
 
 /datum/outfit/job/roguetown/mercenary/underdweller/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/moth.dm
@@ -5,8 +5,8 @@
 	name = "Fluvian"
 	id = "moth"
 	is_subrace = TRUE
-	origin_default = /datum/virtue/origin/racial/underdark
-	origin = "the Underdark"
+	origin_default = /datum/virtue/origin/unknown
+	origin = "The Seven Winds" // I am going to be doing a larger PR with the permission and use of Sarkness lore. Let us just please get this bug fixed.
 	base_name = "Beastvolk"
 	desc = "Many comparisons have been made to the common moths in an attempt to describe this unique species. From the appetite for clothing to the disconcertingly insectoid appearance, the name 'Moth' is forever stamped onto the common vocabulary. The comparison, however, falls short on the matter of flight.<br>\
 	<span style='color: #6a8cb7;text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>+1 SPD</b></span><br>"

--- a/code/modules/virtues/origin.dm
+++ b/code/modules/virtues/origin.dm
@@ -196,6 +196,7 @@
 				/datum/species/dwarf/mountain,
 				/datum/species/dwarf/gnome,
 				/datum/species/goblinp,
+				/datum/species/moth,			//They are from the Underdark. source: moth.dm
 				/datum/species/anthromorphsmall
 )
 	origin_desc = "Underdwellers are those who are descendants of their lengthy lineage that settled, lived and toiled in the darkest and deepest \


### PR DESCRIPTION
## About The Pull Request

Old: Fluvians weren't allowed to pick their default origin. Which is odd! Also it just makes sense to let a underdark race be the underdark mercenaries.
New: This was a oversight from @FreeStylaLT and discussion has been done on this. This is still a bugfix PR, but default origin has been changed to Nowhere.

## Testing Evidence

<img width="819" height="48" alt="image" src="https://github.com/user-attachments/assets/4de14622-8ed3-4ee8-9af7-954cab238b3c" />
They start as Underdark, but weren't allowed to pick it if they swapped off it. This just reeks of bug.

## Why It's Good For The Game

I got clearance from Lombax on the discord that this was indeed a bug.

## Changelog

:cl:
fix: Fluvians can now select underdark origin, they weren't available previously despite it being default.
code: Fluvians default origin changed to Nowhere. A larger update to explain Fluvian society, communities, and colors will be done once I have time for it, but default origin being underdark was a oversight when the origins system was added.
code: Fluvians added to underdweller since I assume that is meant to be all underdark origins.
/:cl:
