### PR TITLE
Freifechter Fencer Mini-Rework

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -538,7 +538,7 @@
 
 /atom/movable/screen/alert/status_effect/debuff/dazed/longsword2h
 	name = "CAN'T FUCKING SEE"
-	desc = "WHAT THE HELL DID THEY DO TO ME?! I NEED TO ATTACK THEM WHILE THEY'RE SWINGING SO THEY CAN'T POKE MY EYES!!"
+	desc = "WHAT THE HELL DID THEY DO TO ME?! I NEED TO RIPOSTE THEM WHILE THEY'RE SWINGING SO THEY CAN'T POKE MY EYES!!"
 	icon_state = "mstrike"
 
 /datum/status_effect/debuff/dazed/freisabre

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -533,7 +533,7 @@
 	id = "zorn ort"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/dazed/longsword2h
 	effectedstats = list(STATKEY_PER = -4, STATKEY_LCK = -3)
-	duration = 18 SECONDS
+	duration = 16 SECONDS
 	status_type = STATUS_EFFECT_REFRESH
 
 /atom/movable/screen/alert/status_effect/debuff/dazed/longsword2h

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -520,25 +520,25 @@
 /datum/status_effect/debuff/dazed/longsword
 	id = "durchlauffen"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/dazed/longsword
-	effectedstats = list(STATKEY_SPD = -3, STATKEY_INT = -1)
-	duration = 10 SECONDS
+	effectedstats = list(STATKEY_WIL = -4, STATKEY_INT = -1)
+	duration = 18 SECONDS
 	status_type = STATUS_EFFECT_REFRESH
 
 /atom/movable/screen/alert/status_effect/debuff/dazed/longsword
-	name = "Master Strike"
-	desc = "How the fuck did they do that!? My ears are ringing!"
+	name = "CAN'T FUCKING BREATHE"
+	desc = "WHAT THE HELL DID THEY DO TO ME?! I NEED TO ATTACK THEM WHILE THEY'RE SWINGING SO THEY CAN'T SHATTER MY WINDPIPE!!"
 	icon_state = "mstrike"
 
 /datum/status_effect/debuff/dazed/longsword2h
 	id = "zorn ort"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/dazed/longsword2h
 	effectedstats = list(STATKEY_PER = -4, STATKEY_LCK = -3)
-	duration = 8 SECONDS
+	duration = 18 SECONDS
 	status_type = STATUS_EFFECT_REFRESH
 
 /atom/movable/screen/alert/status_effect/debuff/dazed/longsword2h
-	name = "Master Strike"
-	desc = "How the fuck did they do that!? My eye!"
+	name = "CAN'T FUCKING SEE"
+	desc = "WHAT THE HELL DID THEY DO TO ME?! I NEED TO ATTACK THEM WHILE THEY'RE SWINGING SO THEY CAN'T POKE MY EYES!!"
 	icon_state = "mstrike"
 
 /datum/status_effect/debuff/dazed/freisabre

--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -642,17 +642,19 @@
 /datum/alt_grip/halfsword/frei
 	trait_applied = list(TRAIT_LONGSWORDSMAN)
 	additive_var_overrides = list(
-		"wdefense" = 3
+		"wdefense" = 2 
 	)
 	grip_intents = list(
 		/datum/intent/sword/thrust/long/halfsword/frei,
-		/datum/intent/effect/daze/longsword/clinch,
 		/datum/intent/effect/daze/longsword2h
 	)
 
 /datum/alt_grip/roof_guard
 	name = "roof guard"
 	two_handed = TRUE
+	additive_var_overrides = list(
+		wdefense = -2 //HOWEVER. this gives me the idea that using roof guard will reduce your parry by a good amount. usually, it'll be mostly offset by your master skills - but it'll still bring you from 90% to 80% parry against an expert opponent.
+	)
 	trait_applied = list(TRAIT_LONGSWORDSMAN)
 	grip_intents = list(
 		/datum/intent/sword/cut/master,

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -328,7 +328,9 @@
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/effect/daze/longsword/clinch)
 	gripped_intents = list(/datum/intent/sword/cut/master, /datum/intent/sword/thrust/long/master)
 	alt_grips = list( /datum/alt_grip/roof_guard, /datum/alt_grip/halfsword/frei)
-	wlength = WLENGTH_NORMAL
+	//wlength = WLENGTH_NORMAL //they're all about exploiting weaknesses, given their damage nerfs i think feet are okay
+	wdefense = 5
+	wdefense_wbonus = 3
 	max_blade_int = 300
 	max_integrity = 225
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -325,7 +325,9 @@
 	icon_state = "elongsword"
 	sheathe_icon = "elongsword"
 	icon = 'icons/roguetown/weapons/special/freifechter.dmi'
-	alt_grips = list(/datum/alt_grip/halfsword/frei, /datum/alt_grip/roof_guard, /datum/alt_grip/mordhau/sword)
+	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/effect/daze/longsword/clinch)
+	gripped_intents = list(/datum/intent/sword/cut/master, /datum/intent/sword/thrust/long/master)
+	alt_grips = list( /datum/alt_grip/roof_guard, /datum/alt_grip/halfsword/frei)
 	wlength = WLENGTH_NORMAL
 	max_blade_int = 300
 	max_integrity = 225

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -167,7 +167,7 @@
 
 /datum/intent/effect/daze/longsword
 	name = "durchlauffen"
-	desc = "Quickly flip your weapon around to the blunt end and slam an opponent in the throat, mouth, or nose, affecting their ability to breathe properly. Slow, and can be cancelled by being hit, but applies a long-lasting debuff. Can only be performed two handed."
+	desc = "Quickly flip your weapon around to the blunt end and slam an opponent in the throat, mouth, or nose, affecting their ability to breathe properly. Slow, and can be cancelled by being hit, but applies a long-lasting debuff. Can only be performed in roof guardw."
 	attack_verb = list("masterfully pummels")
 	intent_effect = /datum/status_effect/debuff/dazed/longsword
 	target_parts = list(BODY_ZONE_PRECISE_NOSE, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_NECK)

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -111,13 +111,13 @@
 /datum/intent/sword/cut/master
 	name = "fendente"
 	icon_state = "incutmaster"
-	desc = "Strike the opponent from above with the true edge of the sword and penetrate light armour. A cut so perfect requires precision and time."
+	desc = "Strike the opponent with the true edge of the sword and penetrate lighter armour. A cut so perfect requires precision and time."
 	attack_verb = list("masterfully tears", "artfully slits", "adroitly hacks")
-	damfactor = 1.01
-	penfactor = PEN_MEDIUM // Master cut — penetrates leather/padded
-	max_intent_damage = 35
+	damfactor = 1.15
+	penfactor = PEN_LIGHT // Master cut — cuts are for damaging armor, not penning it. Leave pen to the stabbin'
+	max_intent_damage = 36
 	min_intent_damage = 31
-	swingdelay = 1
+	swingdelay = 2 //sure
 
 /datum/intent/sword/thrust/long/master
 	name = "stoccato"
@@ -125,22 +125,23 @@
 	desc = "Enter a long guard and thrust forward with your entire upper body while advancing, maximizing the effectiveness of the thrust."
 	attack_verb =  list("skillfully perforates", "artfully punctures", "deftly sticks")
 	damfactor = 1.15
-	max_intent_damage = 40.5
+	max_intent_damage = 36 //they do the same damage. one is for bleeding, the other is for critfishing. feels weird but they get a lot of toys
 
 /datum/intent/effect/daze/longsword/clinch
 	name = "clinch & swipe"
-	desc = "Get up in your opponent's face and force them into a clinch, then swipe their face with the crossguard while they're distracted. Good against baited or exhausted opponents."
+	desc = "Get too close to your opponent for them to attack you easily, slamming the pommel of your sword into their face. Very briefly reduces opponent's strength and constitution, making it more difficult for them to escape grabs. Can only be performed one-handed. Works on the head, skull, nose, and mouth."
 	icon_state = "inpunish"
 	attack_verb = list("forcibly clinches and swipes")
 	animname = "strike"
-	target_parts = list(BODY_ZONE_HEAD)
+	target_parts = list(BODY_ZONE_HEAD, BODY_ZONE_PRECISE_NOSE, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_SKULL)
 	blade_class = BCLASS_BLUNT
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')
-	damfactor = 0.8
-	max_intent_damage = 24
-	swingdelay = 8
+	damfactor = 0.7
+	max_intent_damage = 22
+	swingdelay = 3
+	swingdelay_type = SWINGDELAY_NORMAL
 	clickcd = CLICK_CD_QUICK
-	recovery = 15
+	recovery = 6
 	item_d_type = "blunt"
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
 	canparry = FALSE
@@ -150,13 +151,13 @@
 /datum/intent/sword/thrust/long/halfsword/frei
 	name = "mezza spada"
 	icon_state = "inimpale"
-	desc = "Grip the dull portion of your longsword with either hand and use it as leverage to deliver precise, powerful strikes that can dig into gaps in plate and push past maille."
+	desc = "Grip the dull portion of your longsword with either hand and use it as leverage to deliver precise, powerful strikes that can dig into gaps in plate and push past maille. Can only be performed half-sworded."
 	attack_verb = list("skewers", "impales")
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
 	penfactor = PEN_HEAVY
 	clickcd = CLICK_CD_MELEE
 	swingdelay = 1.2 SECONDS
-	damfactor = 1
+	damfactor = 0.95 //slightly nerfed. go use your debuffs dude
 	blade_class = BCLASS_PICK
 	max_intent_damage = 30
 
@@ -166,28 +167,38 @@
 
 /datum/intent/effect/daze/longsword
 	name = "durchlauffen"
-	desc = "Lock the opponent's arm in place and strike their nose with the pommel of your sword before tossing them, affecting their ability to dodge and feint. Can only be performed one-handed."
+	desc = "Quickly flip your weapon around to the blunt end and slam an opponent in the throat, mouth, or nose, affecting their ability to breathe properly. Slow, and can be cancelled by being hit, but applies a long-lasting debuff. Can only be performed two handed."
 	attack_verb = list("masterfully pummels")
 	intent_effect = /datum/status_effect/debuff/dazed/longsword
-	target_parts = list(BODY_ZONE_PRECISE_NOSE)
-	damfactor = 0.8
-	clickcd = 14
-	swingdelay = 8
+	target_parts = list(BODY_ZONE_PRECISE_NOSE, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_NECK)
+	damfactor = 0.3
+	clickcd = 20
+	swingdelay = 1.3 SECONDS
+	swingdelay_type = SWINGDELAY_CANCEL //that debuff is fucking terrifying, and this should mostly be used when you have a big opening or are confident in your ability to dodge multiple attacks
 
 /datum/intent/effect/daze/longsword2h
 	name = "zorn ort"
-	desc = "Block the opponent's weapon with a strike of your own and advance into a thrust towards the eyes, affecting their vision severely. Can only be performed two-handed."
+	desc = "Block the opponent's weapon with a strike of your own and advance into a thrust towards the eyes, affecting their vision severely. Can only be performed in half-sword, and can only target the eyes."
 	attack_verb = list("masterfully pokes")
 	intent_effect = /datum/status_effect/debuff/dazed/longsword2h
 	target_parts = list(BODY_ZONE_PRECISE_R_EYE, BODY_ZONE_PRECISE_L_EYE)
 	blade_class = BCLASS_STAB
-	damfactor = 1.1 //Same as master stab
-	clickcd = CLICK_CD_CHARGED
-	swingdelay = 7
+	damfactor = 0.7 //they're stabbing you and it's going to hurt a little
+	clickcd = 20
+	swingdelay = 1.3 SECONDS
+	swingdelay_type = SWINGDELAY_PENALTY //less scary but still debilitating debuff. you should be riposting against these on reaction if you can
 
 // A weaker strike for sword with high damage so that it don't end up becoming better than mace
 /datum/intent/sword/strike/bad
-	damfactor = 0.7 
+	damfactor = 0.5
+
+/datum/intent/sword/strike/master 
+	name = "ganvale"
+	desc = "Hit your opponent with your sword's special crossguard, dealing slightly more damage than a regular sword's bash."
+	attack_verb = list("deftly slams")
+	damfactor = 0.75 //replaces clinch as the actual blunt damage dealer
+	max_intent_damage = 24
+
 
 /datum/intent/sword/chop
 	name = "chop"

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -192,7 +192,7 @@
 /datum/intent/sword/strike/bad
 	damfactor = 0.5
 
-/datum/intent/sword/strike/master 
+/datum/intent/sword/strike/master //unused
 	name = "ganvale"
 	desc = "Hit your opponent with your sword's special crossguard, dealing slightly more damage than a regular sword's bash."
 	attack_verb = list("deftly slams")

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -113,7 +113,7 @@
 	icon_state = "incutmaster"
 	desc = "Strike the opponent with the true edge of the sword and penetrate lighter armour. A cut so perfect requires precision and time."
 	attack_verb = list("masterfully tears", "artfully slits", "adroitly hacks")
-	damfactor = 1.15
+	damfactor = 1.2
 	penfactor = PEN_LIGHT // Master cut — cuts are for damaging armor, not penning it. Leave pen to the stabbin'
 	max_intent_damage = 36
 	min_intent_damage = 31
@@ -124,7 +124,7 @@
 	icon_state = "instabmaster"
 	desc = "Enter a long guard and thrust forward with your entire upper body while advancing, maximizing the effectiveness of the thrust."
 	attack_verb =  list("skillfully perforates", "artfully punctures", "deftly sticks")
-	damfactor = 1.15
+	damfactor = 1.2
 	max_intent_damage = 36 //they do the same damage. one is for bleeding, the other is for critfishing. feels weird but they get a lot of toys
 
 /datum/intent/effect/daze/longsword/clinch

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -167,7 +167,7 @@
 
 /datum/intent/effect/daze/longsword
 	name = "durchlauffen"
-	desc = "Quickly flip your weapon around to the blunt end and slam an opponent in the throat, mouth, or nose, affecting their ability to breathe properly. Slow, and can be cancelled by being hit, but applies a long-lasting debuff. Can only be performed in roof guardw."
+	desc = "Quickly flip your weapon around to the blunt end and slam an opponent in the throat, mouth, or nose, affecting their ability to breathe properly. Slow, and can be cancelled by being hit, but applies a long-lasting debuff. Can only be performed in roof guard."
 	attack_verb = list("masterfully pummels")
 	intent_effect = /datum/status_effect/debuff/dazed/longsword
 	target_parts = list(BODY_ZONE_PRECISE_NOSE, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_PRECISE_NECK)


### PR DESCRIPTION
## "I'm so tired of the constant Freifechter changes, just tell me what the PR does."

**I've totally got you covered.** Shifts Freifechter fencer's power budget from their basic attacks into their debuffs, reduces their defenses situationally, encourages them to use multiple different alt-grips, adds counterplay with the newly-added red and yellow swingdelay types, and rewrites their tooltips to be more useful and informative. Overall, it's expected to be slightly power negative, but more fun for everyone involved, including the Freifechters.

## Long-winded explanation

In their current iteration, Freifechters are defensive and offensive powerhouses, and in-game they're abused for what is (essentially) guy with master weaponskills and a longsword that pens plate for no good reason. While the alt intents are cool, they're often neglected, and you're left with a class that simply outclicks you.

This PR reworks fencer, the longswordsman, into being the most complicated melee class in the entire game. They now have two alt-grips in ADDITION to one-handed and two-handed that they are expected to mix-and-match. The rework makes use of the new swingdelay systems and the alt grip refactor to make freifechter what it was always meant to be - a difficult to use but extremely rewarding mercenary subclass that struggles in group fights but has a great time in 1v1s.

## The Nitty-Gritty for Powergamers and Mains

Here is a list of every alt grip and intent available to the new longswords.

**ONE-HANDED:** 5 defense, 70% chance to parry against expert opponents.
1. Longsword cut. Identical to the stock two-handed longsword.
2. Longsword stab, same as above.
3. Clinch & Swipe. Updated from live to deal slightly less damage, but be faster. The tooltip has been updated to be more clear in it's gameplay implications as well as it's intended use cases. Change is ultimately very little.
<img width="600" height="140" alt="image" src="https://github.com/user-attachments/assets/ec8565f6-390c-4457-b9a8-e89df8947d56" />


**TWO-HANDED:** 8 defense, 90% chance to parry against expert opponents.
1. Fendente. Similar to old Master Slash. Damage is boosted, but capped to 36 - in layman's terms, they deal good damage, but will not benefit from investing in more than 10 STR. Now only has pen_light, which usually will not penetrate armor aside from certain NPC's.
2. Stoccato. Same as above, except it's analogous to longsword stab instead of longsword cut and has medium pen like longswords do.

**ROOF GUARD:** 6 defense, 80% chance to parry against expert opponents. Suffers greatly against swift balanced weapons.
1. Fendente.
2. Stoccato.
3. Durchlauffen. Entirely reworked from base - now, on a very long red swingdelay, causes a long-lasting WIL nuke. If you get hit by this, your stamina is going to be considerably easier to drain, however it can be very easily cancelled with a strike. Landing this will take a feint and creative footwork, most likely.
<img width="600" height="150" alt="image" src="https://github.com/user-attachments/assets/070c1b6a-ad93-4f28-a859-1ca214c43e5e" />


**SZORENDNIZINE SHELL:** 10 defense, 90% chance to parry against expert opponents.
1. Mezza Spada. Nearly identical to freifechter's current half-sword pick, but deals slightly less damage.
2. Zorn Ort. Similar to live, but now takes longer to wind up and has a yellow swingdelay, reducing your chance to parry considerably. Instead of nuking your willpower, it reduces your perception and fortune.
<img width="600" height="142" alt="image" src="https://github.com/user-attachments/assets/07026b41-4d20-4943-9e84-a8940110eb5c" />


## Why It's Good For The Game

Freifechter's raw offensive power, armor penetration, and damage have been reduced. In exchange, they have gotten some risky but devastatingly effective debuffs that they can juggle to debilitate and outplay opponents. It's very difficult to stay on just one grip; One-handed has awful defense, two-handed struggles to penetrate armor and isn't significantly better than a longsword, roof guard reduces your parry chance against even lower-level opponents and shell is slow and unwieldy. 

You are **absolutely required**, now, to interface with the unique mechanics of the class. If you simply try to use them like a regular longswordsman, you will get out-statted and out-armored. Master the unique buffs, stances, and tactics, and you will be a terrifying force of nature on the battlefield, able to outduel anyone you need to on your own merit.

## Changelog

:cl:
balance: retools and rebalances freifechter fencers, using the new swingdelay and alt grip refactors
qol: rewrites freifechter's debuffs and intents to be more helpful/terrifying
/:cl:
