### PR TITLE
Replaces wildshape making you nude, to removing select gear instead

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1606,6 +1606,15 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/on_embed(obj/item/bodypart/bp)
 	return
 
+/obj/item/proc/has_armor_value()
+	if(istype(src, /obj/item/clothing))
+		var/obj/item/clothing/C = src
+		if(C.armor)
+			var/datum/armor/def_armor = C.armor
+			return def_armor.blunt || def_armor.slash || def_armor.stab || def_armor.piercing
+
+	return FALSE
+
 /obj/item/proc/defense_examine()
 	var/list/str = list()
 	if(istype(src, /obj/item/clothing))

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -27,6 +27,12 @@
 
 		obj_destruction(damage_flag)
 
+//forces the object to reach the integrity failure and break if it has one
+/obj/proc/force_obj_break(damage_flag = "")
+	if(!obj_broken && integrity_failure)
+		obj_integrity = integrity_failure * max_integrity
+		obj_break(damage_flag)
+
 
 ///returns the damage value of the attack after processing the obj's various armor protections
 /obj/proc/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armor_penetration = 0, object_damage_multiplier = 1)

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -3,6 +3,28 @@
 /mob/living/carbon/human/species/wildshape/death(gibbed, nocutscene = FALSE)
 	wildshape_untransform(TRUE, gibbed)
 
+//Will drop or destroy items depending on their allowed status within the proc
+/mob/living/carbon/human/proc/wildshape_drop_destroy_items()
+	var/list/allowed_equipment_Type = list(	/obj/item/rogueweapon/woodstaff,
+											/obj/item/storage/belt
+											)
+	
+	drop_all_held_items() //Drop what were in your hands
+
+	for(var/obj/item/I in src)
+		if(is_type_in_list(I, allowed_equipment_Type))
+			continue
+		if(istype(I, /obj/item/storage)) //Drops storage bags
+			dropItemToGround(I)
+		else if(istype(I, /obj/item/rogueweapon/scabbard)) //Break sheated weapons
+			var/obj/item/rogueweapon/scabbard/scab = I
+			if(scab.hol_comp.sheathed && !is_type_in_list(scab.hol_comp.sheathed, allowed_equipment_Type))
+				scab.hol_comp.sheathed.force_obj_break()
+		else if(istype(I, /obj/item/rogueweapon))
+			I.force_obj_break()
+		else if(I.has_armor_value()) //Break armor
+			I.force_obj_break()
+
 /mob/living/carbon/human/proc/wildshape_transformation(shapepath)
 	if(!mind)
 		log_runtime("NO MIND ON [src.name] WHEN TRANSFORMING")
@@ -10,9 +32,11 @@
 	//before we shed our items, save our neck and ring, if we have any, so we can quickly rewear them
 	var/obj/item/stored_neck = wear_neck
 	var/obj/item/stored_ring = wear_ring
-	for(var/obj/item/I in src)
-		if (I != underwear && I != cloak && I != legwear_socks) // keep underwear (+ socks) and our cloak, even if said cloak remains inaccessible.
-			dropItemToGround(I)
+	dropItemToGround(stored_neck)
+	dropItemToGround(stored_ring)
+
+	wildshape_drop_destroy_items()
+
 	regenerate_icons()
 	icon = null
 	var/oldinv = invisibility
@@ -106,8 +130,11 @@
 	// as before, save our worn stuff and prepare to move it back to the mob
 	var/obj/item/stored_neck = wear_neck
 	var/obj/item/stored_ring = wear_ring
-	for(var/obj/item/W in src)
-		dropItemToGround(W)
+	dropItemToGround(stored_neck)
+	dropItemToGround(stored_ring)
+
+	wildshape_drop_destroy_items()
+
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
 

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -4,7 +4,12 @@
 	wildshape_untransform(TRUE, gibbed)
 
 //Will drop or destroy items depending on their allowed status within the proc
-/mob/living/carbon/human/proc/wildshape_drop_destroy_items()
+/mob/living/carbon/human/proc/wildshape_drop_items()
+
+	var/list/disallowed_equipment_Type = list(	/obj/item/storage,
+											/obj/item/rogueweapon,
+											)
+
 	var/list/allowed_equipment_Type = list(	/obj/item/rogueweapon/woodstaff,
 											/obj/item/storage/belt
 											)
@@ -12,18 +17,12 @@
 	drop_all_held_items() //Drop what were in your hands
 
 	for(var/obj/item/I in src)
-		if(is_type_in_list(I, allowed_equipment_Type))
+		if(is_type_in_list(I, allowed_equipment_Type)) //Allow items of allowed type no matter what
 			continue
-		if(istype(I, /obj/item/storage)) //Drops storage bags
+		if(is_type_in_list(I, disallowed_equipment_Type)) //Drops all items of the disallowed type
 			dropItemToGround(I)
-		else if(istype(I, /obj/item/rogueweapon/scabbard)) //Break sheated weapons
-			var/obj/item/rogueweapon/scabbard/scab = I
-			if(scab.hol_comp.sheathed && !is_type_in_list(scab.hol_comp.sheathed, allowed_equipment_Type))
-				scab.hol_comp.sheathed.force_obj_break()
-		else if(istype(I, /obj/item/rogueweapon))
-			I.force_obj_break()
-		else if(I.has_armor_value()) //Break armor
-			I.force_obj_break()
+		else if(I.has_armor_value()) //Drop armor
+			dropItemToGround(I)
 
 /mob/living/carbon/human/proc/wildshape_transformation(shapepath)
 	if(!mind)
@@ -35,7 +34,7 @@
 	dropItemToGround(stored_neck)
 	dropItemToGround(stored_ring)
 
-	wildshape_drop_destroy_items()
+	wildshape_drop_items()
 
 	regenerate_icons()
 	icon = null
@@ -133,7 +132,7 @@
 	dropItemToGround(stored_neck)
 	dropItemToGround(stored_ring)
 
-	wildshape_drop_destroy_items()
+	wildshape_drop_items()
 
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM

--- a/code/modules/spells/spell_types/wildshape.dm
+++ b/code/modules/spells/spell_types/wildshape.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/self/wildshape
 	name = "Beast Form"
-	desc = "Take on the form of one of Dendor's sacred beasts, destroying all man-made weapons and armor in the process."
+	desc = "Take on the form of one of Dendor's sacred beasts."
 	overlay_state = "tamebeast"
 	clothes_req = FALSE
 	human_req = FALSE

--- a/code/modules/spells/spell_types/wildshape.dm
+++ b/code/modules/spells/spell_types/wildshape.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/self/wildshape
 	name = "Beast Form"
-	desc = "Take on the form of one of Dendor's sacred beasts."
+	desc = "Take on the form of one of Dendor's sacred beasts, destroying all man-made weapons and armor in the process."
 	overlay_state = "tamebeast"
 	clothes_req = FALSE
 	human_req = FALSE


### PR DESCRIPTION
## About The Pull Request

Changes the way wildshape works, instead of dropping all worn items. It will instead do the following:

- Drop storage items (Except belts)
- Drop gear that has armor values
- Drop weapons and scabbards (Except staves)

It will not do the above if the item is in a allowed_list

## Testing Evidence

<img width="2547" height="1345" alt="image" src="https://github.com/user-attachments/assets/82683f56-27fb-41a2-999b-7ea9a3ef2e99" />
<img width="2544" height="1361" alt="image" src="https://github.com/user-attachments/assets/d626fb17-c9ef-4f4f-a0c4-54ca664c496d" />



Tried wearing various items, wild shaping in and out. Checking what drops.

## Why It's Good For The Game

https://discord.com/channels/1264916899653746808/1489379351370793031

The game has many clothing options afforded to the playerbase, and a player wished to be able to use wildshape without having to reform completely nude somewhere else.

Another one argued that it makes it hard to feel useful if you have to leave your equipment behind to help someone (Becoming a saiga to give someone a ride for example?)

The changes should allow to not worry about leaving gear behind, while preventing powergaming by running around with hidden worn armor on your person to turn into. (No cabbit turning into full-plated man with a zweihander)

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:Kelshark
balance: wildshape does not drop everything, instead drops selective storage, armor and weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
