### PR TITLE
Puts pork back on the menu

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile_animal.dm
+++ b/code/modules/roguetown/roguestock/stockpile_animal.dm
@@ -44,20 +44,14 @@
 	name = "Pork"
 	desc = "Edible flesh harvested from swines."
 	item_type = /obj/item/reagent_containers/food/snacks/rogue/meat/fatty
-
 	held_items = list(0, 0)
-	held_random_upper = 5
-	held_random_lower = 1
-	nothing_chance = 40
-	export_only = TRUE
-
-	payout_price = 5
-	withdraw_price = 8
-	transport_fee = 8
-	export_price = 7
+	payout_price = 4
+	withdraw_price = 4
+	transport_fee = 2
+	export_price = 8
 	importexport_amt = 5
 	stockpile_limit = 25
-	passive_generation = 0
+	passive_generation = 1
 	category = "Animal"
 
 /datum/roguestock/stockpile/fat


### PR DESCRIPTION
## About The Pull Request

Reverts the changes to the stockpile for pork.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Pork continues to be the least available food resource in the game since before it was added to the stockpile originally. 

Ranching is one of the least-done activities by soilsons, already a fairly rare job to see.

Ranching pigs still has incentive to produce hams, but it will continue to be unlikely that the server ever sees ham outside of the PR author remembering their own code on occasion.

Pork, being a ubiquitous meat in basically every era, never made much sense to begin with as overpriced and under-available.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Ham now imports again, for the same price and availability as bird meat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
