### PR TITLE
[Adjustments?] - Hag mindlink 1 range, makes weathered mask not reduce FOV

### DIFF
--- a/code/datums/mindlink_hag.dm
+++ b/code/datums/mindlink_hag.dm
@@ -32,7 +32,7 @@
 		for(var/mob/living/M in members)
 			// Slightly more secretive!
 			M.playsound_local(M, 'sound/magic/mindlink.ogg', 75, TRUE)
-			M.audible_message(formatted, runechat_message = message, custom_spans = list("mindlink", "italic"))
+			M.audible_message(formatted, hearing_distance = 0, runechat_message = message, custom_spans = list("mindlink", "italic"))
 		
 		speaker.log_talk(message, LOG_SAY, tag="Coven Link")
 		speech_args[SPEECH_MESSAGE] = null

--- a/code/datums/mindlink_hag.dm
+++ b/code/datums/mindlink_hag.dm
@@ -32,7 +32,7 @@
 		for(var/mob/living/M in members)
 			// Slightly more secretive!
 			M.playsound_local(M, 'sound/magic/mindlink.ogg', 75, TRUE)
-			M.audible_message(formatted, hearing_distance = 0, runechat_message = message, custom_spans = list("mindlink", "italic"))
+			M.audible_message(formatted, hearing_distance = 1, runechat_message = message, custom_spans = list("mindlink", "italic"))
 		
 		speaker.log_talk(message, LOG_SAY, tag="Coven Link")
 		speech_args[SPEECH_MESSAGE] = null

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -707,3 +707,5 @@
 	desc = "An ancient ceramic face. It looks weathered, the sort molded by Xylixian worshippers of many yils past. Even when cast aside, it feels like the hardened clay has never left your hands. As if it always finds a way back into your palms."
 	// No armor anyways
 	max_integrity = 200
+	// Not messing with jester mask, but again, it has no armor. many other masks also don't block vision.
+	block2add = FOV_DEFAULT


### PR DESCRIPTION
## About The Pull Request
- Hag mindlink can now only be heard when on the same tile. Given it links multiple people and is a major antag tool, it was a bit too easy to listen in on her.

## Testing Evidence
Tested, works.

## Changelog

:cl:
balance: Hag mindlink is harder to listen in on.
fix: weathered xylix mask cosmetic no longer reduces FOV
/:cl:
