### PR TITLE
Revert "Removes Matthios Dungeon from roguetest, adds dungeon support…

### DIFF
--- a/_maps/dun_world.json
+++ b/_maps/dun_world.json
@@ -1,22 +1,16 @@
 {
-	"map_name": "Dun World",
-	"map_path": "map_files/dun_world",
-	"map_file": ["dun_world.dmm"],
-	"traits": [
-		{ "Name": "Dun World", "Up": true },
-		{ "Up": true, "Down": true },
-		{ "Up": true, "Down": true },
-		{ "Down": true }
-	],
+    "map_name": "Dun World",
+    "map_path": "map_files/dun_world",
+    "map_file": ["dun_world.dmm"],
+	"traits": [{"Name": "Dun World", "Up": true}, {"Up": true, "Down": true}, {"Up": true, "Down": true}, {"Down": true}],
 	"other_z": [
 		"_maps/map_files/otherz/wretch_coast.json"
 	],
 	"space_empty_levels": 0,
 	"space_ruin_levels": 0,
-	"matthios_dungeon": 1,
 	"shuttles": {
-		"cargo": "cargo_rogue",
-		"whiteship": "whiteship_box",
-		"emergency": "emergency_rogue"
-	}
+	    "cargo": "cargo_rogue",
+	    "whiteship": "whiteship_box",
+	    "emergency": "emergency_rogue"
+    }
 }

--- a/_maps/roguetest.json
+++ b/_maps/roguetest.json
@@ -1,15 +1,14 @@
 {
-	"map_name": "Roguetest",
-	"map_path": "map_files/roguetest",
-	"map_file": "roguetest.dmm",
-	"traits": [{ "Name": "Roguetest", "Up": true }, { "Down": true }],
+    "map_name": "Roguetest",
+    "map_path": "map_files/roguetest",
+    "map_file": "roguetest.dmm",
+	"traits": [{"Name": "Roguetest", "Up": true}, {"Down": true}],
 	"minetype": null,
 	"space_empty_levels": 0,
 	"space_ruin_levels": 0,
-	"matthios_dungeon": 0,
 	"shuttles": {
-		"cargo": "cargo_rogue",
-		"whiteship": "whiteship_box",
-		"emergency": "emergency_rogue"
-	}
+	    "cargo": "cargo_rogue",
+	    "whiteship": "whiteship_box",
+	    "emergency": "emergency_rogue"
+    }
 }

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -42,6 +42,8 @@
 #define FORCE_MAP "_maps/roguetest.json"
 #endif
 
+// #define NO_DUNGEON //comment this to load dungeons.
+
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 514
 #if DM_VERSION < MIN_COMPILER_VERSION

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -195,8 +195,9 @@ SUBSYSTEM_DEF(mapping)
 
 	var/list/otherZ = list()
 
-	if(config.matthios_dungeon)
-		otherZ += load_map_config("_maps/map_files/otherz/dungeon.json")
+	#ifndef NO_DUNGEON
+	otherZ += load_map_config("_maps/map_files/otherz/dungeon.json")
+	#endif
 
 	for(var/map_json in config.other_z)
 		otherZ += load_map_config(map_json)

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -22,9 +22,6 @@
 	var/space_ruin_levels = 7
 	var/space_empty_levels = 1
 
-	/// Anything but null will load matthios dungeon
-	var/matthios_dungeon = FALSE
-
 	/// List of unit tests that are skipped when running this map
 	var/list/skipped_tests
 
@@ -129,13 +126,6 @@
 		space_empty_levels = temp
 	else if (!isnull(temp))
 		log_world("map_config space_empty_levels is not a number!")
-		return
-
-	temp = json["matthios_dungeon"]
-	if(isnum(temp))
-		matthios_dungeon = temp
-	else if(!isnull(temp))
-		log_world("map_config matthios_dungeon is not a number!")
 		return
 
 	allow_custom_shuttles = json["allow_custom_shuttles"] != FALSE


### PR DESCRIPTION
## About The Pull Request
I literally added **TWO** config options for you to compile Roguetest without Tomb of Matthios and this PR actually just broke that option making it impossible to boot up Matthios in isolation on Roguetest to test.

The default option has no dungeon for a good reason!!!

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
None.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
<img width="389" height="201" alt="Code_e8nv4f0TaE" src="https://github.com/user-attachments/assets/1e9d4f9a-d39d-4c09-bffb-8f3664960e40" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: You can test Tomb of Alotheos / Matthios on Roguetest by running the options that is not labeled "No Dungeons" now. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
