### PR TITLE
Ranged Adjustment - Intdamfactor and Skeleton Broadhead Options

### DIFF
--- a/code/game/objects/items/quiver.dm
+++ b/code/game/objects/items/quiver.dm
@@ -316,6 +316,13 @@
 		arrows += A
 	update_icon()
 
+/obj/item/quiver/broadhead_aalloy/Initialize()
+	..()
+	for(var/i in 1 to max_storage)
+		var/obj/item/ammo_casing/caseless/rogue/arrow/iron/aalloy/A = new()
+		arrows += A
+	update_icon()
+
 /obj/item/quiver/silver/Initialize()
 	..()
 	for(var/i in 1 to max_storage)

--- a/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
@@ -139,10 +139,9 @@
 	name = "decrepit broadhead arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/arrow/iron/aalloy
 	icon_state = "ancientarrow_proj"
-	damage = 40
+	damage = 50
 	armor_penetration = PEN_LIGHT
 	flag = "piercing"
-	embedchance = 40
 
 // Bodkins should penetrate essentially any armour in the game with decent perception, as
 // recompense for their very low damage. Better for lower perception characters without

--- a/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
@@ -88,6 +88,8 @@
 	range = 15
 	hitsound = 'sound/combat/hits/hi_arrow2.ogg'
 	embedchance = 25
+	intdamfactor = 1.25 // Attempt to make it so that arrows do more damage to armor
+	// Without instantly killing people when armor breaks
 	woundclass = BCLASS_PIERCE
 	flag = "piercing"
 	speed = 0.4

--- a/code/game/objects/items/rogueweapons/ranged/ammo_bullets.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bullets.dm
@@ -147,6 +147,7 @@
 	hitsound = 'sound/combat/hits/blunt/bluntsmall (1).ogg'
 	embedchance = 0
 	woundclass = BCLASS_BLUNT
+	intdamfactor = BLUNT_DEFAULT_INT_DAMAGEFACTOR // Slings are meant to break armor so this will help
 	flag = "blunt"
 	speed = 0.4
 	npc_simple_damage_mult = 2.5 // Deals roughly ~75-95 damage against a simplemob, compared to the ~140 damage of a crossbolt or arrow.

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -145,7 +145,7 @@ LICH SKELETONS
 		/obj/item/ammo_casing/caseless/rogue/heavy_bolt = 1
 	)
 	H.adjust_blindness(-3)
-	var/weapons = list("Bow & 20 Arrows", "Longbow & 20 Arrows", "Crossbow & 16 Bolts", "Sling")
+	var/weapons = list("Bow & 20 Arrows", "Bow & 20 Broadheads", "Longbow & 20 Arrows", "Longbow & 20 Broadheads", "Crossbow & 16 Bolts", "Sling")
 	var/weapon_choice = input(H, "Choose your MISSILE.", "CONDEMN THE LYVING FROM AFAR.") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
@@ -153,9 +153,17 @@ LICH SKELETONS
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			beltl = /obj/item/quiver/paalloy
 			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+		if("Bow & 20 Broadheads")
+			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
+			beltl = /obj/item/quiver/broadhead_aalloy
+			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 		if("Longbow & 20 Arrows")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 			beltl = /obj/item/quiver/paalloy
+			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
+		if("Longbow & 20 Broadheads")
+			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
+			beltl = /obj/item/quiver/broadhead_aalloy
 			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 		if("Crossbow & 16 Bolts")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow


### PR DESCRIPTION
## About The Pull Request
- Since I fixed the bug that was introduced by Ranged Ammo Expansion that accidentally **doubled** all ranged damage from baseline, Ranged has been in dire spot, especially compared to the New and Hot Mage
- This is a PR to attempt to fix it:
- Sling bullets get the 1.6x blunt integrity damage modifier 
- Normal arrows get 1.25x, I have no idea what to do with bodkins yet
- Skeleton's decrepit broadhead arrows (Which they don't have access to) buffed to 50 damage, and now lich skeletons have the options for broadhead arrows

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
My bugfix left ranged in a dire state and this is meant to put it back in a better state. I might include bodkin adjustment later.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Skeleton archers gain options to use decrepit broadhead arrows, which is now a reflavor of iron broadhead.
balance: Sling bullets now deal 1.6x damage to integrity
balance: Arrows now deals 1.25x damage to integrity 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
