### PR TITLE
add scissors to arcyne forge

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/arcyne_forge.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/arcyne_forge.dm
@@ -60,6 +60,7 @@
 		"Hammer" = /obj/item/rogueweapon/hammer/iron,
 		"Shovel" = /obj/item/rogueweapon/shovel,
 		"Handsaw" = /obj/item/rogueweapon/handsaw,
+		"Scissors" = /obj/item/rogueweapon/huntingknife/scissors,
 		"Fishing Rod" = /obj/item/fishingrod,
 		"Frying Pan" = /obj/item/cooking/pan,
 		"Pot" = /obj/item/reagent_containers/glass/bucket/pot,


### PR DESCRIPTION
## About The Pull Request
adds scissors to arcyne forge conjuration list

## Testing Evidence
<img width="562" height="519" alt="image" src="https://github.com/user-attachments/assets/642b1bce-8b80-4889-a17c-475b6d41684d" />
<img width="769" height="163" alt="image" src="https://github.com/user-attachments/assets/c6f963f8-2f82-482f-b841-afac24be1d88" />

## Why It's Good For The Game
eoran mage woes (you need scissors specifically for trees, why can we conjure anything from spoons to bowls to handsaws but not a pair of scissors)

## Changelog

:cl:
add: Added iron scissors to arcyne forge
/:cl:
