### PR TITLE
Ruma Bugfixes + Tuning

### DIFF
--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -558,7 +558,7 @@
 	wdefense = 8
 	special = /datum/special_intent/limbguard
 
-	max_integrity = 200
+	max_integrity = 250
 
 /obj/item/rogueweapon/scabbard/sword/kazengun/noparry
 	name = "ceremonial kazengun scabbard"
@@ -577,7 +577,7 @@
 	icon_state = "kazscab_steel"
 	item_state = "kazscab_steel"
 	valid_blade = /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench
-	max_integrity = 220
+	max_integrity = 275
 
 
 /obj/item/rogueweapon/scabbard/sword/kazengun/gold

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -204,15 +204,15 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
 	allowed_race = NON_DWARVEN_RACE_TYPES
-	max_integrity = 350
+	max_integrity = 300
 
 	repairmsg_begin = "The tattoos begin to slowly mend their abuse..."
 	repairmsg_continue = "The tattoos mend some of their abuse..."
 	repairmsg_stop = "The tattoos stops mending from the onslaught!"
 	repairmsg_end = "The tattoos flow more calmly, as they finish resting and regain their strength."
 
-	interrupt_damount = 20
-	repair_time = 30 SECONDS
+	interrupt_damount = 5
+	repair_time = 40 SECONDS
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/gladiator
 	name = "gladiator's skin"

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
@@ -42,6 +42,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
 	backr = /obj/item/storage/backpack/rogue/satchel
+	head = /obj/item/clothing/head/roguetown/mentorhat
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary,
 		/obj/item/flashlight/flare/torch/lantern,


### PR DESCRIPTION
## About The Pull Request

Reduces the skin armor's integrity and regeneration time. Makes the scabbard's integrity actually 220, as was intended. Gives them a little hat. The person who originally rebuffed the rumaclan intended for the skin armor to have light brigandine durability, but accidentally made it full brigandine instead, and they were consulted before this.

## Testing Evidence

<img width="695" height="272" alt="image" src="https://github.com/user-attachments/assets/e9546e64-1dd9-4a9d-92be-cd20aede12c1" />

<img width="287" height="220" alt="image" src="https://github.com/user-attachments/assets/a952e391-f144-45f8-a88e-14bd4afffd80" />

## Why It's Good For The Game

Skin armor regenerates during combat if it's broken. This is fine for most, as they're penned easily and generally will be broken again before it becomes an issue. For skin armor that's as effective as plate, though, this means that every 30 seconds rumaclanners are getting 60 integrity worth of plate armor that adds up over the course of especially long fights.

If a gun-in has skin tats that have already been broken, 90% parry, and they're getting clicked on once every two seconds, you'll damage them around one in every ten hits, or one attack every 20 seconds. If the armor regenerates 17% of it's integrity every 30 seconds, you'll have to chew through around 60 more integrity (or 2-3 hits). If you aren't able to land ripostes, baits, or feints, in slower fights, it can become an extreme uphill battle to even get through the tattoos.

In compensation for the nerfed skin armor, they get a hat they can wear and their scabbard is 220 integrity, as was originally intended - in game it's only 80% of that for some reason.

## Changelog

:cl:
balance: ruma clan
/:cl: