### PR TITLE
[EXPERIMENT] Ranged Dodge Expert Nuke

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -8,7 +8,6 @@
 	subclass_languages = list(/datum/language/otavan)
 	cmode_music = 'sound/music/cmode/antag/combat_deadlyshadows.ogg'
 	traits_applied = list(
-		TRAIT_DODGEEXPERT,
 		TRAIT_BLACKBAGGER,
 		TRAIT_PERFECT_TRACKER,
 		TRAIT_PSYDONITE,
@@ -75,7 +74,6 @@
 				armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fencer/psydon
 				shirt = /obj/item/clothing/suit/roguetown/armor/manual/sewable/confessor
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
-				REMOVE_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 5, TRUE)
 				H.change_stat(STATKEY_CON, 1)
 				H.change_stat(STATKEY_STR, 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -629,7 +629,7 @@
 		/datum/species/elf/wood,
 		/datum/species/elf/dark,
 	)
-	traits_applied = list(TRAIT_OUTDOORSMAN, TRAIT_BLACKOAK, TRAIT_DODGEEXPERT, TRAIT_WOODWALKER)
+	traits_applied = list(TRAIT_OUTDOORSMAN, TRAIT_BLACKOAK, TRAIT_WOODWALKER)
 	outfit = /datum/outfit/job/roguetown/adventurer/lesserblackoak
 	subclass_languages = list(/datum/language/oldazurian)
 	cmode_music = 'sound/music/combat_blackoak.ogg'
@@ -668,12 +668,14 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				l_hand = /obj/item/rogueweapon/sword/long/elvish/autumn
 				beltr = /obj/item/rogueweapon/scabbard/sword
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			if("Autumned Glaive")
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				l_hand = /obj/item/rogueweapon/halberd/bardiche/elvish/autumn
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
+				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			if("Autumned Bow")
-				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE)
 				l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/autumn
 				beltr = /obj/item/quiver/arrows
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/elven_helm/autumn/light

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -6,7 +6,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/ranger
 	class_select_category = CLASS_CAT_RANGER
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
-	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_OUTDOORSMAN)
+	traits_applied = list(TRAIT_OUTDOORSMAN)
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	subclass_stats = list(
 		STATKEY_PER = 3,
@@ -74,7 +74,6 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/assassin
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander.ogg'
 	subclass_languages = list(/datum/language/thievescant)
-	traits_applied = list(TRAIT_DODGEEXPERT)
 	subclass_stats = list(
 		STATKEY_PER = 2,
 		STATKEY_SPD = 2,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/poacher.dm
@@ -7,7 +7,7 @@
 	cmode_music = 'sound/music/combat_poacher.ogg'
 	class_select_category = CLASS_CAT_RANGER
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_AZURENATIVE, TRAIT_DODGEEXPERT, TRAIT_WOODSMAN, TRAIT_OUTDOORSMAN, TRAIT_SURVIVAL_EXPERT)
+	traits_applied = list(TRAIT_AZURENATIVE, TRAIT_WOODSMAN, TRAIT_OUTDOORSMAN, TRAIT_SURVIVAL_EXPERT)
 	// No straight upgrade to perception / speed to not stack one stat too high, but still stronger than MAA Skirm out of town.
 	subclass_stats = list(
 		STATKEY_PER = 3,

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
@@ -173,14 +173,16 @@
 	outfit = /datum/outfit/job/roguetown/manorguard/skirmisher
 
 	category_tags = list(CTAG_MENATARMS)
+	traits_applied = list(TRAIT_MEDIUMARMOR)
 	//Garrison ranged/speed class. Time to go wild
 	subclass_stats = list(
 		STATKEY_STR = 1, //Xbow
-		STATKEY_SPD = 2,// seems kinda lame but remember guardsman bonus!!
-		STATKEY_PER = 2,
-		STATKEY_WIL = 1
+		STATKEY_SPD = 1,// seems kinda lame but remember guardsman bonus!!
+		STATKEY_PER = 3,
+		STATKEY_WIL = 2
 	)
 	subclass_skills = list(
+		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE, 		// Still have a cugel.
 		/datum/skill/combat/crossbows = SKILL_LEVEL_MASTER,		//Only effects draw and reload time.
@@ -228,13 +230,11 @@
 				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy
 				wrists = /obj/item/clothing/wrists/roguetown/bracers
 				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			if("Brigandine Armor") //New MAA skirmisher
 				head = /obj/item/clothing/head/roguetown/helmet/kettle
 				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
 				pants = /obj/item/clothing/under/roguetown/brigandinelegs
-				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 		backpack_contents = list(
 			/obj/item/rogueweapon/huntingknife/combat/messser = 1,
@@ -244,8 +244,6 @@
 			/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
 			)
 		H.verbs |= /mob/proc/haltyell
-
-	if(H.mind)
 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
 
 

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -25,7 +25,7 @@
 	round_contrib_points = 2
 
 	cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg'
-	job_traits = list(TRAIT_AZURENATIVE, TRAIT_OUTDOORSMAN, TRAIT_WOODSMAN, TRAIT_SURVIVAL_EXPERT)
+	job_traits = list(TRAIT_AZURENATIVE, TRAIT_MEDIUMARMOR, TRAIT_OUTDOORSMAN, TRAIT_WOODSMAN, TRAIT_SURVIVAL_EXPERT)
 	job_subclasses = list(/datum/advclass/warden/warden)
 
 /datum/outfit/job/roguetown/warden
@@ -34,6 +34,7 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/warden
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 	belt = /obj/item/storage/belt/rogue/leather
@@ -96,16 +97,6 @@
 	H.set_blindness(0)
 
 	if(H.mind)
-		var/armor_options = list("Dodge Expert", "Maille Training")
-		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMS") as anything in armor_options
-		switch(armor_choice)//Like skirmisher, you are not getting both
-			if("Dodge Expert")
-				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-			if("Maille Training")
-				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
-				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
-
 		var/helmets = list(
 			"Path of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,
 			"Path of the Volf"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf,
@@ -126,5 +117,6 @@
 		var/hoodchoice = input(H, "Choose your shroud.", "HOOD SELECTION") as anything in hoods
 		if(hoodchoice != "None")
 			mask = hoods[hoodchoice]
-	if(H.mind)
+
 		SStreasury.give_money_account(ECONOMIC_LOWER_MIDDLE_CLASS, H, "Savings.")
+

--- a/code/modules/jobs/job_types/roguetown/retinue/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/knight.dm
@@ -408,7 +408,7 @@
 	tutorial = "Your skillset is abnormal for a knight. Your swift maneuvers and masterful technique impress both lords and ladies alike, and you have a preference for quicker, more elegant blades. While you are an effective fighting force in medium armor, your evasive skills will only truly shine if you don even lighter protection."
 	outfit = /datum/outfit/job/roguetown/knight/irregularknight
 
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_DODGEEXPERT, TRAIT_GOODTRAINER)
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_GOODTRAINER)
 	category_tags = list(CTAG_ROYALGUARD)
 	subclass_stats = list(
 		STATKEY_STR = 1,

--- a/code/modules/jobs/job_types/roguetown/retinue/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/squire.dm
@@ -167,7 +167,6 @@
 	outfit = /datum/outfit/job/roguetown/squire/skirmisher
 
 	category_tags = list(CTAG_SQUIRE)
-	traits_applied = list(TRAIT_DODGEEXPERT)
 	subclass_stats = list(
 		STATKEY_SPD = 2,
 		STATKEY_PER = 1,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/etrusca.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/etrusca.dm
@@ -84,7 +84,6 @@
 	category_tags = list(CTAG_MERCENARY)
 	subclass_languages = list(/datum/language/etruscan, /datum/language/thievescant)
 	cmode_music = 'sound/music/combat_condottiero.ogg'
-	traits_applied = list(TRAIT_DODGEEXPERT)
 	subclass_stats = list(
 		STATKEY_WIL = 2,
 		STATKEY_PER = 3, //sharpshooters

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/grenzelhoft.dm
@@ -142,7 +142,6 @@
 	category_tags = list(CTAG_MERCENARY)
 	cmode_music = 'sound/music/combat_grenzelhoft.ogg'
 	subclass_languages = list(/datum/language/grenzelhoftian)
-	traits_applied = list(TRAIT_DODGEEXPERT)
 	subclass_stats = list(
 		STATKEY_SPD = 2,
 		STATKEY_WIL = 2,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/steppesman.dm
@@ -142,7 +142,6 @@
 				H.change_stat(STATKEY_PER, 3)
 				H.change_stat(STATKEY_WIL, 2)
 				H.change_stat(STATKEY_SPD, 2)
-				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			if("Kozak - Light Infantry")		//Tl;dr - Old Steppesman whip build, light armor, be the glass canon you always wanted to be. Live your life, king. 
 				H.set_blindness(0)
 				to_chat(H, span_warning("Being a Kozak is not a title one earns, nor is born with. It's a way of life. Known to be eccentric, living life on the edge - but living as free as possible. Skilled with whips, these madmen are the bane of civilized warriors."))


### PR DESCRIPTION
## About The Pull Request

Consider this experiment for a TESTMERGE rather than actual PR for the time being.
Any primarily ranged class (poacher, ranger) loses Dodge Expert entirely.
Any hybrid class (warden, irregular knight, outlaw) on individual bases keeps it or loses it (mostly loses).
Skirmisher is just footman with PER bonus more or less (got his sword skill back).

## Testing Evidence

Line changes, compiles

## Why It's Good For The Game

Ranged advantage combined with superior defense with how reworked Dodge Expert works kind of blows to fight against, it is an experiment nothing else on how the classes would be without it and would need ton of changes to said  classes who lost it as compensation buffs are definetely something they'd require.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Dodge Expert Distribution
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
