### PR TITLE
fixed EVERY RING being invisible for female characters??? holy shit???

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -419,11 +419,7 @@ There are several things that need to be remembered:
 		if(client && hud_used && hud_used.hud_shown)
 			client.screen += wear_ring
 		update_observer_view(wear_ring)
-		if(dna && dna.species.sexes)
-			if((gender == FEMALE && !dna.species.use_m) || dna.species.use_f)
-				id_overlay = wear_ring.build_worn_icon(default_layer = RING_LAYER, default_icon_file = 'icons/mob/clothing/feet.dmi', female = TRUE)
-			else
-				id_overlay = wear_ring.build_worn_icon(default_layer = RING_LAYER, default_icon_file = 'icons/mob/clothing/feet.dmi', female = FALSE)
+		id_overlay = wear_ring.build_worn_icon(default_layer = RING_LAYER, default_icon_file = 'icons/mob/clothing/feet.dmi', female = FALSE)
 		if(gender == MALE)
 			if(OFFSET_ID in dna.species.offset_features)
 				id_overlay.pixel_x += dna.species.offset_features[OFFSET_ID][1]


### PR DESCRIPTION
## About The Pull Request
so fun fact. the code that renders rings was looking for (rings sprite)_f variant icons. neither rings nor amulets had those variant icons. this mean they were COMPLETELY INVISIBLE for female characters, this entire time. lmao? anyway uh this fixes that by making it. not do that. yeah.

## Testing Evidence
(first image: gold ring equipped, second image: eoran amulet equipped in ring slot, set to display around neck)
before:
<img width="116" height="115" alt="image" src="https://github.com/user-attachments/assets/50a31f5b-90e4-489b-a7b2-3164e26a6223" />
<img width="126" height="129" alt="image" src="https://github.com/user-attachments/assets/e034d03c-b49d-434d-aedf-23c34501b42c" />
after:
<img width="128" height="131" alt="image" src="https://github.com/user-attachments/assets/2b189fca-4a52-4f49-a4bd-b4eebbede36c" />
<img width="108" height="127" alt="image" src="https://github.com/user-attachments/assets/f5a3d882-d93f-4f1d-be08-c8e7fccd951c" />

## Why It's Good For The Game
me when i change sexism = TRUE to sexism = FALSE (game is fixed)

## Changelog

:cl:
fix: rings and ring-slot amulets are no longer invisible for women specifically
/:cl: