### PR TITLE
fixes azuria being a pineapple under the sea

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2186,15 +2186,15 @@
 
 	var/turf/T = get_turf(src)
 	var/turf/ceiling = get_step_multiz(src, UP)
-	var/water_view = istype(T, /turf/open/water) && istype(ceiling, /turf/open/water)
+	var/water_view = (istype(T, /turf/open/water) && istype(ceiling, /turf/open/water))
 
 	changeNext_move(CLICK_CD_MELEE)
 
-	if(m_intent != MOVE_INTENT_SNEAK)
-		if(water_view)
+	if(water_view)
+		if(m_intent != MOVE_INTENT_SNEAK)
 			visible_message(span_info("[src] peers into the thickness of the water above [src.p_their()] head."))
 		else
-			to_chat(src, span_info("[src] peers into the thickness of the water above his head."))
+			to_chat(src, span_info("[src] peers into the thickness of the water above [src.p_their()] head."))
 	else
 		if(m_intent != MOVE_INTENT_SNEAK)
 			visible_message(span_info("[src] looks up."))


### PR DESCRIPTION
## About The Pull Request
You should no longer get water messages when looking up unless you're actually properly underwater.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed water-related lookup messages appearing when the player is not underwater.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
