### PR TITLE
Categorizes Berserker Classes, Improves Choices + Tweaks

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/manual.dm
+++ b/code/modules/clothing/rogueclothes/armor/manual.dm
@@ -57,10 +57,11 @@
 	. += span_info("Repairable via push-up emotes.")
 
 /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather
-    armor = ARMOR_LEATHER
+	armor = ARMOR_LEATHER
 
-/obj/item/clothing/suit/roguetown/armor/manual/pushups/leather/good
-    armor = ARMOR_LEATHER
+/obj/item/clothing/suit/roguetown/armor/manual/pushups/leather/good // Honestly wasn't even sure what the diff was to the parent of this subtype, this one actually is GOOD and it's for Berzerker
+	armor = ARMOR_LEATHER
+	max_integrity = 400 //Now actually matches desciple and bersekers unarmed discpline armor int, drawback is it doesnt natrually regen without push-ups
 
 
 /*

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -72,13 +72,14 @@
 					if("Discipline - Unarmed")
 						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
 						ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+						gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted // apperantly normal barb gets em so for consistency sake
 						armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker
 					if("Katar")
 						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
 						beltr = /obj/item/rogueweapon/katar
 					if("Knuckledusters")
 						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-						r_hand = /obj/item/clothing/gloves/roguetown/knuckles
+						gloves = /obj/item/clothing/gloves/roguetown/knuckles
 					if("Punch Dagger")
 						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
 						beltr = /obj/item/rogueweapon/katar/punchdagger

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -63,7 +63,7 @@
 		H.set_blindness(0)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rage)
 		var/list/main_choices = list("Unarmed Master", "Martial Expert") // Unarmed focuses on master punching and wrestling moves, Martial gives you two expert weapon skills to be flexible
-		var/category_choice = input(H, "Choose your TOOLS FOR BATTLE.", "SMASH OR SLASH!!") as anything in main_choices
+		var/category_choice = input(H, "Choose your MEANS OF VIOLENCE.", "SMASH OR SLASH!!") as anything in main_choices
 		switch(category_choice)
 			if("Unarmed Master") //still incredibly strong btw, apply punch to skull
 				var/list/unarmed_options = list("Discipline - Unarmed", "Katar", "Knuckledusters", "Punch Dagger", )

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -9,11 +9,11 @@
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_STRONGBITE, TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_NOPAINSTUN, TRAIT_BLOOD_RESISTANCE, TRAIT_RAGE)
 	extra_context = "This subclass gains access to the RAGE ability."
-	// total of 6 because int gets nuked by 2 similar to barbarian, still better then adv barb for +1 spd and wil diff
+	// total of 5 because int gets nuked by 2 similar to barbarian, still better then adv barb for +1
 	subclass_stats = list(
 		STATKEY_STR = 3,
 		STATKEY_CON = 2,
-		STATKEY_WIL = 2,
+		STATKEY_WIL = 1,
 		STATKEY_SPD = 1,
 		STATKEY_INT = -2,
 	)
@@ -47,8 +47,7 @@
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	backr = /obj/item/storage/backpack/rogue/satchel
-	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/hip/headhook //Standard iron version. More-so for style than substance.
+	belt = /obj/item/storage/belt/rogue/leather/rope // more wild look + aura
 	neck = /obj/item/clothing/neck/roguetown/coif/heavypadding //Used to be a reinforced leather coif, but crit resist kinda leaves your head open to shit
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 	backpack_contents = list(
@@ -63,13 +62,12 @@
 	if(H.mind)
 		H.set_blindness(0)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rage)
-		// Main Category Choice
-		var/list/main_choices = list("Unarmed Master", "Martial Expert")
-		var/category_choice = input(H, "Choose your WEAPON.", "SPILL THEIR ENTRAILS.") as anything in main_choices
+		var/list/main_choices = list("Unarmed Master", "Martial Expert") // Unarmed focuses on master punching and wrestling moves, Martial gives you two expert weapon skills to be flexible
+		var/category_choice = input(H, "Choose your TOOLS FOR BATTLE.", "SMASH OR SLASH!!") as anything in main_choices
 		switch(category_choice)
-			if("Unarmed Master")
+			if("Unarmed Master") //still incredibly strong btw, apply punch to skull
 				var/list/unarmed_options = list("Discipline - Unarmed", "Katar", "Knuckledusters", "Punch Dagger", )
-				var/weapon_choice = input(H, "Choose how you PUNCH.", "BREAK THEIR BONES.") as anything in unarmed_options
+				var/weapon_choice = input(H, "Choose how you PUNCH!", "BREAK THEIR BONES.") as anything in unarmed_options
 				switch(weapon_choice)
 					if("Discipline - Unarmed")
 						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
@@ -84,12 +82,24 @@
 					if("Punch Dagger")
 						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
 						beltr = /obj/item/rogueweapon/katar/punchdagger
-			if("Martial Expert")
-				var/list/martial_options = list("Discipline - Bodybuilder", "Battle Axe", "Grand Mace", "Falx")
-				var/weapon_choice = input(H, "Choose your WEAPON of war.", "SPILL THEIR ENTRAILS.") as anything in martial_options
+				var/techniques = list("Dropkick - Pushback + Extra Damage", "Chokeslam - Stamina Damage", "Stunner - Dazed Debuff", "Headbutt - Vulnerable Debuff") // cool wrestling moves
+				var/technique_choice = input(H,"Choose your TECHNIQUE.", "TOSS THEM.") as anything in techniques
+				switch(technique_choice)
+					if("Dropkick - Pushback + Extra Damage")
+						H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/dropkick)
+					if("Chokeslam - Stamina Damage")
+						H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/chokeslam)
+					if("Stunner - Dazed Debuff")
+						H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stunner)
+					if("Headbutt - Vulnerable Debuff")
+						H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/headbutt)
+			if("Martial Expert") // designed to compete with unarmed by giving you alternatives to approaching fights- only expert 
+				var/list/martial_options = list("Discipline - Bodybuilder", "Battle Axe", "Grand Mace", "Longsword")
+				var/weapon_choice = input(H, "Choose your WEAPONS of WAR!", "SPILL THEIR ENTRAILS.") as anything in martial_options
 				switch(weapon_choice)
-					if("Discipline - Bodybuilder")
+					if("Discipline - Bodybuilder") //Actually not a meme anymore
 						H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+						H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_MASTER, TRUE) //they need this to actually do pushups, it's the only way they can fix their armor
 						r_hand = /obj/item/rogueweapon/greatsword/paalloy
 						armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather/good
 						backl = /obj/item/rogueweapon/scabbard/gwstrap
@@ -99,28 +109,25 @@
 					if("Grand Mace")
 						H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
 						beltr = /obj/item/rogueweapon/mace/goden/steel
-					if("Falx")
+					if("Longsword") //Swapped out the falx for this, it's a primary weapon afterall
 						H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 						beltr = /obj/item/rogueweapon/scabbard/sword
 						r_hand = /obj/item/rogueweapon/sword/falx
+				var/list/sidearm_options = list("Iron Arming Sword", "Iron Axe", "Mace")
+				var/sidearm_choice = input(H, "Choose your secondary WEAPON!", "SPILL THEIR ENTRAILS.") as anything in sidearm_options
+				switch(sidearm_choice)
+					if("Iron Arming Sword")
+						H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+						beltl = /obj/item/rogueweapon/sword/iron
+					if("Iron Axe")
+						H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+						beltl = /obj/item/rogueweapon/stoneaxe/woodcut
+					if("Mace")
+						H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
+						beltl = /obj/item/rogueweapon/mace
 
-		var/techniques = list("Dropkick - Pushback + Extra Damage", "Chokeslam - Stamina Damage", "Stunner - Dazed Debuff", "Headbutt - Vulnerable Debuff") // cool wrestling moves
-		var/technique_choice = input(H,"Choose your TECHNIQUE.", "TOSS THEM.") as anything in techniques
-		switch(technique_choice)
-			if("Dropkick - Pushback + Extra Damage")
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/dropkick)
-			if("Chokeslam - Stamina Damage")
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/chokeslam)
-			if("Stunner - Dazed Debuff")
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stunner)
-			if("Headbutt - Vulnerable Debuff")
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/headbutt)
-		
 		var/helmets = list("Berserker's Volfskulle Bascinet","Steel Kettle + Wildguard")
 		var/helmet_choice = input(H, "Choose your HELMET.", "STEEL YOURSELF.") as anything in helmets
-
-
-		
 		switch(helmet_choice)
 			if("Berserker's Volfskulle Bascinet")
 				head = /obj/item/clothing/head/roguetown/helmet/heavy/volfplate/berserker //Pseudoantagonistic-exclusive. Light AC with an on-wear trait for HELMBITING.

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -9,14 +9,13 @@
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_STRONGBITE, TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_NOPAINSTUN, TRAIT_BLOOD_RESISTANCE, TRAIT_RAGE)
 	extra_context = "This subclass gains access to the RAGE ability."
-	// Literally same stat spread as Atgervi Shaman
+	// total of 6 because int gets nuked by 2 similar to barbarian, still better then adv barb for +1 spd and wil diff
 	subclass_stats = list(
 		STATKEY_STR = 3,
 		STATKEY_CON = 2,
-		STATKEY_WIL = 1,
+		STATKEY_WIL = 2,
 		STATKEY_SPD = 1,
-		STATKEY_INT = -1,
-		STATKEY_PER = -1
+		STATKEY_INT = -2,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,
@@ -38,6 +37,9 @@
         "Sewing Kit" =  /obj/item/repair_kit,
     )
 
+/datum/outfit/job/roguetown/wretch/berserker
+	var/subclass_selected
+
 /datum/outfit/job/roguetown/wretch/berserker/pre_equip(mob/living/carbon/human/H)
 	cloak = /obj/item/clothing/cloak/raincloak/furcloak/brown
 	gloves = /obj/item/clothing/gloves/roguetown/plate
@@ -47,7 +49,7 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/hip/headhook //Standard iron version. More-so for style than substance.
-	neck = /obj/item/clothing/neck/roguetown/leather
+	neck = /obj/item/clothing/neck/roguetown/coif/heavypadding //Used to be a reinforced leather coif, but crit resist kinda leaves your head open to shit
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/combat = 1, //Steel variant of the hunting knife. Pseudoantagonist-tier, plus an avenue to hack limbs with.
@@ -59,41 +61,49 @@
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	if(H.mind)
-		var/weapons = list("Discipline - Unarmed","Discipline - Bodybuilder","Katar","Knuckledusters","Punch Dagger","Battle Axe","Grand Mace","Falx")
-		var/weapon_choice = input(H, "Choose your WEAPON.", "SPILL THEIR ENTRAILS.") as anything in weapons
 		H.set_blindness(0)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rage)
-		switch(weapon_choice)
-			if("Discipline - Unarmed")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-				ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
-				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker
-			if("Discipline - Bodybuilder") //its really not that good
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-				r_hand = /obj/item/rogueweapon/greatsword/paalloy
-				armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather/good
-				backl = /obj/item/rogueweapon/scabbard/gwstrap
-			if("Katar")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-				beltr = /obj/item/rogueweapon/katar
-			if("Knuckledusters")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-				r_hand = /obj/item/clothing/gloves/roguetown/knuckles
-			if("Punch Dagger")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-				beltr = /obj/item/rogueweapon/katar/punchdagger
-			if("Battle Axe")
-				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
-				beltr = /obj/item/rogueweapon/stoneaxe/battle
-			if("Grand Mace")
-				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
-				beltr = /obj/item/rogueweapon/mace/goden/steel
-			if("Falx")
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-				beltr = /obj/item/rogueweapon/scabbard/sword
-				r_hand = /obj/item/rogueweapon/sword/falx
-		
-		
+		// Main Category Choice
+		var/list/main_choices = list("Unarmed Master", "Martial Expert")
+		var/category_choice = input(H, "Choose your WEAPON.", "SPILL THEIR ENTRAILS.") as anything in main_choices
+		switch(category_choice)
+			if("Unarmed Master")
+				var/list/unarmed_options = list("Discipline - Unarmed", "Katar", "Knuckledusters", "Punch Dagger", )
+				var/weapon_choice = input(H, "Choose how you PUNCH.", "BREAK THEIR BONES.") as anything in unarmed_options
+				switch(weapon_choice)
+					if("Discipline - Unarmed")
+						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+						ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+						armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker
+					if("Katar")
+						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+						beltr = /obj/item/rogueweapon/katar
+					if("Knuckledusters")
+						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+						r_hand = /obj/item/clothing/gloves/roguetown/knuckles
+					if("Punch Dagger")
+						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
+						beltr = /obj/item/rogueweapon/katar/punchdagger
+			if("Martial Expert")
+				var/list/martial_options = list("Discipline - Bodybuilder", "Battle Axe", "Grand Mace", "Falx")
+				var/weapon_choice = input(H, "Choose your WEAPON of war.", "SPILL THEIR ENTRAILS.") as anything in martial_options
+				switch(weapon_choice)
+					if("Discipline - Bodybuilder")
+						H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+						r_hand = /obj/item/rogueweapon/greatsword/paalloy
+						armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather/good
+						backl = /obj/item/rogueweapon/scabbard/gwstrap
+					if("Battle Axe")
+						H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+						beltr = /obj/item/rogueweapon/stoneaxe/battle
+					if("Grand Mace")
+						H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
+						beltr = /obj/item/rogueweapon/mace/goden/steel
+					if("Falx")
+						H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+						beltr = /obj/item/rogueweapon/scabbard/sword
+						r_hand = /obj/item/rogueweapon/sword/falx
+
 		var/techniques = list("Dropkick - Pushback + Extra Damage", "Chokeslam - Stamina Damage", "Stunner - Dazed Debuff", "Headbutt - Vulnerable Debuff") // cool wrestling moves
 		var/technique_choice = input(H,"Choose your TECHNIQUE.", "TOSS THEM.") as anything in techniques
 		switch(technique_choice)


### PR DESCRIPTION
## About The Pull Request

Currently, the unarmed discipline sub-class for Berzerker is the dominant choice due to having a lot going for it. This PR mostly avoids improving that sub-class (unarmed) and focuses on separating it into two alternative playstyles—unarmed and martial.

Unarmed proficiency inherits wrestling moves and the four previous choices that already existed. Unarmed- Disc, Katar, Knuckle Dusters, and Punch Dagger. It continues to keep it's MASTER level weapon skill and avoids really buffing it.

![dreamseeker_ZyiSakaWoy](https://github.com/user-attachments/assets/07e7ddeb-0656-4838-80c3-7bd1610704f4)

Martial proficiency gives you the option to have two EXPERT level weapons. You lose the previous wrestling moves, but you get to use the previous loadouts that existed, those being: Musclebuilder- Disc, Battle Axe, Greatmace, and the Falx, which has been changed to a Longsword to be viable as a starting. You get a side choice of an iron-arming sword, an iron axe, or a regular mace with it's expert skills. So you can ideally have expert swords and maces, or maces and axes, etc etc - Mix and match.

![dreamseeker_E0FmOG47bG](https://github.com/user-attachments/assets/ed856ec7-c908-4434-b4f9-45ae0297686c)

Also buffs the Musclebuilder class to not be a meme anymore. Consistently, it's been considered a joke choice, but now it can actually go toe to toe with its opposing alternative skin of the unarmed discipline. Still locks your armor to wearing it, but its integrity has doubled to match berserker skin and still requires pushups to fix. They also get master athletics to actually fix their armor and not awkwardly struggle to do more than twenty push-ups.

<img width="351" height="182" alt="dreamseeker_eACUeczbpK" src="https://github.com/user-attachments/assets/685ea704-12e6-4cc7-a9a2-3700b6bba513" />

Other minor changes/tweaks
- Berserker no longer has a -1 PER stat, and instead shares Barbarians -2 INT stat.
- Changed the reinforced leather coif for a heavy padded coif. They also get a rope belt cause it looks cooler (aura)
- Gave the Unarmed - Discipline weighted bandages (because the Barbarian mirror class had it, so it seems only fair) (plus new unarmed glove weapons got added.)
- Fixed Steel Knucklers, and now it gives you the gloves! (It had a bad typepath)

## Testing Evidence

yep, working in game and classes

## Why It's Good For The Game
Ideally, this PR aims to help Berserkers in a few ways. Firstly, it's to reduce the number of people running unarmed and explore other options inside the class. The weapon choices for anything that wasn't unarmed, due to it being a master skill, were obviously not equal to what you picked. Now, having two strong hands instead of one amazing hand can lead to a lot more diversity. Unarmed is still strong, but now it's actually got competition with its martial choices.

Secondly, it adjusts some of their equipment and stats to better reflect their fighting styles. Being a Light armored heavy hitter with weak intelligence and a simple loadout. Since the removal of crit resistance and nerfing of wrestling, the class needs a bit of fresh air to really help it stick out and not be seen as the puncher-only class. 

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Berserker has been split into two methods of battle: Unarmed, with a focus on punching, grappling, and wrestling. And martial expertise that gives you two weapons to choose.
balanced: Berserkers now have -2 INT instead of -1 PER and -1 INT.
balanced: Changed Berserkers loadout with a few clothing swaps
balance: Berserkers Falx option has been replaced with a Longsword, rejoice!
balance: Adjust Berserker's Musclebuilder armor integrity to be doubled, matching its sister subclass in the Unarmed Discipline. They also get bonus master athletics to help fix their armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
