### PR TITLE
BALANCEJAK_UNTITLED.MOV (jannissary oopsie)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_janissary.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_janissary.dm
@@ -12,8 +12,7 @@
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
-		STATKEY_SPD = 2,
-		STATKEY_PER = -1
+		STATKEY_SPD = 2
 	)
 	subclass_skills = list(
 		/datum/skill/combat/maces = SKILL_LEVEL_JOURNEYMAN,


### PR DESCRIPTION
## About The Pull Request

Removes Jannissary's PER debuff. I forgot to push a commit that involved it as part of https://github.com/Azure-Peak/Azure-Peak/pull/5790 while I was touching desert rider's skills/stats. My bad.

## Testing Evidence

Linechange.

## Why It's Good For The Game

Not a big deal, but someone pointed it out and I realized I messed up, and that annoys me a bit. Their stats r at 7 weighted rn too which isn't a big deal but yeah

We have a balancejak freeze and I don't rly consider this a balancejak thing but yeah idk up 2 free obvs

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: jannisary NO LONGER loses 1 per (literally unbeatable in combat)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
