### PR TITLE
lore in bore, ready to score - fills out Azuria's placeholder origin text, adds Lakkari to the primer, and touches up the 'Nowhere' origin

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -388,7 +388,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			dat += "<td style='width:33%;text-align:left'>"
 			dat += "</td>"
 			dat += "<td style='width:33%;text-align:center'>"
-			dat += "<a href='?_src_=prefs;preference=lore_primer'>* Lore Primer *</a>"
+			dat += "<a href='?_src_=prefs;preference=lore_primer'>Lore Primer</a>"
 			dat += "</td>"
 			dat += "<td style='width:33%;text-align:right'>"
 			dat += "</td>"

--- a/code/modules/virtues/origin.dm
+++ b/code/modules/virtues/origin.dm
@@ -1,9 +1,11 @@
 // Race list means RESTRICTED from the LISTED races.
 /datum/virtue/origin/unknown
 	name = "Nowhere"
-	origin_name = "Unknown"
-	desc = "I hail from nowhere in particular, thus I know no regional tongue in particular.<br>"
-	origin_desc = "Wanderers, peasantry, abandoned orphans or souls left to wander the bygone world, with no identity associated with them."
+	origin_name = "Elsewhere"
+	desc = "I originate from one of the many lesser settlements dotted around Psydonia, oft-too demure or distant for the Azurian layman to recall. Since I hail from nowhere in particular, I know no regional tongue in particular. <br>"
+	origin_desc = "For every greater kingdom that crests Psydonia, there lies a hundred lesser settlements; villages and fiefdoms, cursed to bare a legacy that will \
+	only be carried by the few who travel abroad. More distressingly, such a fate is strongly associated with the many souls who've been left to wander this bygone \
+	world, bereft of an identity to call their own - peasants, refugees, orphans, erranteers and more."
 
 /datum/virtue/origin/azuria
 	name = "Azurian"
@@ -13,9 +15,9 @@
 	added_languages = list(/datum/language/oldazurian)
 	origin_desc = "Originally unsettled, Azuria's forested plateaus bore witness to the greatest miracle in history; the Comet Syon, which saved the world from complete \
 	destruction. The missile's resting place - just off Azuria's coast - established the locale as a holy site for worshippers of both Psydon and the Pantheon, which \
-	eventually led to a Church-funded displacement of its ancestral elven inhabitants. The recent surge of villainous monsters and misfortune is said to be attributed \
+	eventually led to a Celestian-funded displacement of its ancestral elven inhabitants. The recent surge of villainous monsters and misfortune is said to be attributed \
 	to such injustices; a belated curse from Dendor's scornful hand. </br> Azuria houses a uniquely diverse culture, borne from generations-upon-generations of pilgrims \
-	from all over the world. Likewise, the lesser kingdom's proximity to the Comet Syon has spawned a deluge of anomalous quirks in both the land and its people; a facet \
+	from all over Psydonia. Likewise, the lesser kingdom's proximity to the Comet Syon has spawned a deluge of anomalous quirks in both the land and its people; a facet \
 	that has drawn the attention of both opportunistic villains and desperate heroes."
 
 /datum/virtue/origin/grenzelhoft
@@ -189,15 +191,6 @@
 	Now, centuries after Zizo's ascendance, Lirvas has become one of the few places no adventurer dares travel to. To describe the kingdom as \
 	a hierarchy would hardly be apt; it stands proudly with different rings of social status, shrinking gradually in size as one climbs to the top. \
 	In Lirvas, wealth is everything in determining which ring you stand on, and how hard it is to climb higher."
-
-/datum/virtue/origin/valoria
-	name = "Valorian"
-	origin_name = "Valoria"
-	desc = "I originate from the mountainous tundras of Valoria, a lesser domain known for both its non-conforming Psydonic sects and deliciously spiced handpies.<br>"
-	origin_desc = "One of many lesser kingdoms dotted across the world, Valoria happens to be one of the few - of relative note - that is still ruled by a lineage of \
-	Psydonic crusader-kings. Once predominately inhabited by Man, it has recently seen a massive surge of Mer; most humorously, in the form of husbands and wives \
-	that've been romanced-from-abroad by Valoria's returning crusaders. Such a quirk has made Valoria the butt of many jokes, much to Grenzelhoft's delight and \
-	Otava's ire. Even so, however, none can deny the virtuousness and chivalriousness that seems to be inherent to all of its people."
 
 /datum/virtue/origin/racial/underdark
 	name = "Underdweller"

--- a/code/modules/virtues/origin.dm
+++ b/code/modules/virtues/origin.dm
@@ -8,10 +8,15 @@
 /datum/virtue/origin/azuria
 	name = "Azurian"
 	origin_name = "Azuria"
-	desc = "I originate from the settled lands of Azuria, an independent domain sandwiched between Otava and Grenzelhoft. Famed for its delicious waffles and many ancient ruins, it is neither prosperous nor well-respected.<br>"
+	desc = "I originate from the settled lands of Azuria, an independent kingdom sandwiched between Otava and Grenzelhoft. Famed for its delicious waffles and ancient ruins, the Duchy is uniquely situated at the forefront of many worldly affairs - both past and present.<br>"
 	restricted = FALSE
 	added_languages = list(/datum/language/oldazurian)
-	origin_desc = "PING THE LORE TEAM TO ADD THIS"
+	origin_desc = "Originally unsettled, Azuria's forested plateaus bore witness to the greatest miracle in history; the Comet Syon, which saved the world from complete \
+	destruction. The missile's resting place - just off Azuria's coast - established the locale as a holy site for worshippers of both Psydon and the Pantheon, which \
+	eventually led to a Church-funded displacement of its ancestral elven inhabitants. The recent surge of villainous monsters and misfortune is said to be attributed \
+	to such injustices; a belated curse from Dendor's scornful hand. </br> Azuria houses a uniquely diverse culture, borne from generations-upon-generations of pilgrims \
+	from all over the world. Likewise, the lesser kingdom's proximity to the Comet Syon has spawned a deluge of anomalous quirks in both the land and its people; a facet \
+	that has drawn the attention of both opportunistic villains and desperate heroes."
 
 /datum/virtue/origin/grenzelhoft
 	name = "Grenzelhoftian"
@@ -184,6 +189,15 @@
 	Now, centuries after Zizo's ascendance, Lirvas has become one of the few places no adventurer dares travel to. To describe the kingdom as \
 	a hierarchy would hardly be apt; it stands proudly with different rings of social status, shrinking gradually in size as one climbs to the top. \
 	In Lirvas, wealth is everything in determining which ring you stand on, and how hard it is to climb higher."
+
+/datum/virtue/origin/valoria
+	name = "Valorian"
+	origin_name = "Valoria"
+	desc = "I originate from the mountainous tundras of Valoria, a lesser domain known for both its non-conforming Psydonic sects and deliciously spiced handpies.<br>"
+	origin_desc = "One of many lesser kingdoms dotted across the world, Valoria happens to be one of the few - of relative note - that is still ruled by \ 
+	a lineage of Psydonic crusader-kings. Once predominately inhabited by Man, it has recently seen a massive surge of Mer; most humorously, in the form \
+	of husbands and wives that've been romanced-from-abroad by Valoria's returning crusaders. Such a quirk has made Valoria the butt of many jokes, much to \
+	Grenzelhoft's delight and Otava's ire. Even so, however, none can deny the virtuousness and chivalriousness that seems to be inherent to all of its people."
 
 /datum/virtue/origin/racial/underdark
 	name = "Underdweller"

--- a/code/modules/virtues/origin.dm
+++ b/code/modules/virtues/origin.dm
@@ -194,10 +194,10 @@
 	name = "Valorian"
 	origin_name = "Valoria"
 	desc = "I originate from the mountainous tundras of Valoria, a lesser domain known for both its non-conforming Psydonic sects and deliciously spiced handpies.<br>"
-	origin_desc = "One of many lesser kingdoms dotted across the world, Valoria happens to be one of the few - of relative note - that is still ruled by \ 
-	a lineage of Psydonic crusader-kings. Once predominately inhabited by Man, it has recently seen a massive surge of Mer; most humorously, in the form \
-	of husbands and wives that've been romanced-from-abroad by Valoria's returning crusaders. Such a quirk has made Valoria the butt of many jokes, much to \
-	Grenzelhoft's delight and Otava's ire. Even so, however, none can deny the virtuousness and chivalriousness that seems to be inherent to all of its people."
+	origin_desc = "One of many lesser kingdoms dotted across the world, Valoria happens to be one of the few - of relative note - that is still ruled by a lineage of \
+	Psydonic crusader-kings. Once predominately inhabited by Man, it has recently seen a massive surge of Mer; most humorously, in the form of husbands and wives \
+	that've been romanced-from-abroad by Valoria's returning crusaders. Such a quirk has made Valoria the butt of many jokes, much to Grenzelhoft's delight and \
+	Otava's ire. Even so, however, none can deny the virtuousness and chivalriousness that seems to be inherent to all of its people."
 
 /datum/virtue/origin/racial/underdark
 	name = "Underdweller"

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -417,22 +417,11 @@ Mostly known for its exportation of the fogbeast: a prized hybrid of the saiga a
 	</details>
 
 	<details>
-		<summary><strong> BLACKSTONE </strong></summary>
-		<br>
-		<em>The Crater, Hole of Naught But Dust-And-Echoes</em>
-		<br><br>
-		While not originally named 'Blackstone', this fief was retroactively termed as such following a minor incident which - involving the accidental collision of two Syonic fragments in transit - had resulted it being completely vaporized. 
-<br><br>
-The remaining crater had left a curious surprise, however, for its survivors: a glassy surface, not unlike obsidian, that seems to glimmer with unnatural energy. As of now, a sect of the Holy Psydonic Inquisition garrisons the crater.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> ROTWOOD </strong></summary>
+		<summary><strong> ROTWOAD </strong></summary>
 		<br>
 		<em>The Vale, Laborers of the Terrorbog</em>
 		<br><br>
-		Originally formed as a camp for those overlooking the Terrorbog, the 'Rotwood Vale' - as it's most commonly known as now - has since grown into a lesser kingdom, renowned for hosting some of Psydonia's most battle-hardened Wardens. 
+		Originally formed as a camp for those overlooking the Terrorbog, the 'Rotwoad Vale' - as it's most commonly known as now - has since grown into a lesser kingdom, renowned for hosting some of Psydonia's most battle-hardened Wardens. 
 <br><br>
 Their proximity to the Terrorbog, however, means that they're also oft-beleaguered by deadly plagues: a matter that has only served to further enforce the unusually high level of segregation between the noblemen and their peasantry.
 		<br>
@@ -463,9 +452,9 @@ Intermingleance with Otavan refugees and Ranesheni freemen, throughout the centu
 	<details>
 		<summary><strong> RUDMARSCH </strong></summary>
 		<br>
-		<em>The Reach, Fallen Kingdom of Sanguine Fields</em>
+		<em>The Reach, Fallen Kingdom of Crimson Fields</em>
 		<br><br>
-		Colloquially known as the 'Scarlet Reach', this lesser kingdom once had the misfortune of being in the middle of a century-long war between Grenzelhoft and Otava. While the fighting has long since ceased, its fields have forever retained an unnaturally red hue. 
+		Colloquially known as the 'Sanguine Reach', this lesser kingdom once had the misfortune of being in the middle of a century-long war between Grenzelhoft and Otava. While the fighting has long since ceased, its fields have forever retained an unnaturally red hue. 
 <br><br>
 		Now, there is nothing left. 
 <br><br>
@@ -497,7 +486,7 @@ Intermingleance with Otavan refugees and Ranesheni freemen, throughout the centu
 		<p><strong> Underworld </strong> - Hell. A spiteful inversion of reality, created by the Archdevil. It is the home of devils, demons, and taxmen. </p>
 		<p><strong> Holy See </strong> - The premiere worshippers of the Pantheon, and the governing body of the Church. Ruled by a Pope.</p>
 		<p><strong> Ecclesial </strong> - A splinter-faction of the Holy See, which has instead embraced the Ascendants. Sporadically present in hidden enclaves. </p>
-		<p><strong> Orthodoxy </strong> - The Holy See's eternal rival, whom gives praise to the ancient God of Psydon. Ruled by an Archbishop.</p>
+		<p><strong> Orthodoxy </strong> - The Holy See's eternal rival, whom gives praise to the ancient God of Psydon. Ruled by the High Scholar of Otava.</p>
 		<p><strong> Inquisition </strong> - The militant arm of the Orthodoxy, notorious for hunting both nitebeasts and suspected worshippers with overzealous impunity. </p>
 		<p><strong> Duchy </strong> - Azuria's royal family, and the rulers of the Azure Peak. Traditionally helmed by a Grand Duke or Grand Duchess. </p>
 		<p><strong> Alotheos </strong> - A labyrinthian tomb, located within Azuria. Though its origins aren't known, its said to hold untold riches within. </p>
@@ -521,7 +510,7 @@ Intermingleance with Otavan refugees and Ranesheni freemen, throughout the centu
 		<p><strong> Deadite </strong> - Luxless corpses, resurrected through unholy means. Interchangeably used to describe both zombies and skeletons. </p>
 		<p><strong> Nitebeast </strong> - Monsters who rely on night-and-darkness to prowl. Primarily references werewolves, but can reference vampires as well. </p>
 		<p><strong> Lycker </strong> - Vampires. These luxless revenants are said to drink the blood of the living, and are empowered with unholy magicks. </p>
-		<p><strong> Gnoll </strong> - Lesser nitebeasts, borne of Graggar's malice towards the worthiest - or most valuable - prey. </p>
+		<p><strong> Gnoll </strong> - Lesser nitebeasts, borne of Graggar's malice towards the worthiest - or most valuable - prey. Like verevolves, they were once men; unlike them, they embrace their inhumenity. </p>
 		<p><strong> Verevolf </strong> - Greater nitebeasts, said to've been caused by Dendor's curses. When nite comes, even the meekest blightee turns into a fierce beast. </p>
 		<p><strong> Lich </strong> - Necromancers, ancient and well-versed in unholy magicka. They serve as the self-proclaimed lieutenants of Zizo, and are one of Azuria's gravest threats. </p>
 		<p><strong> Vampyre-Lord </strong> - Lords of lyckerdom, thought only to be restricted to the legends of antiquity. Should one resurface, terrible events are surely to follow. </p>

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -355,20 +355,20 @@ Though similar in size to Azuria, its self-contained nature means that it is mor
 		<br>
 		<em>The Republic, Cultivators of the Weeping God's Order</em>
 		<br><br>
-		Valoria is a lesser kingdom that straddles the western coasts, just a stone's throw away from Lyndvhar. They practice an optimistic variant of the Orthodoxy, and - though largely independent from Otava's influence - often helps out whenever the Archbishop calls for holy warfare. 
+		Valoria is a lesser kingdom that straddles the western coasts, just a stone's throw away from Zyndvhartia. They practice an optimistic variant of the Orthodoxy, and - though largely independent from Otava's influence - often helps out whenever the Archbishop calls for holy warfare. 
 <br><br>
 Residing within Valoria's walls is the Order of the Silver Psycross: a faith-militance that's renowned for its intoxicating mirth, adherence to chivalry, and remarkably delicious handpies. 
 		<br>
 	</details>
 
 	<details>
-		<summary><strong> LYNDVHAR </strong></summary>
+		<summary><strong> ZYNDVHARTIA </strong></summary>
 		<br>
 		<em>The Port, Receiver of Psydonia's Merchant-Fleets</em>
 		<br><br>
-		Lyndvhar might be similar in size to Azuria, but has a far more vital presence in Psydonia's economic affairs. Due to their positioning on the western coast, they're considered the closest - and most neutral - port for nearly every major kingdom with a mercantile fleet. 
+		Zyndvhartia might be similar in size to Azuria, but has a far more vital presence in Psydonia's economic affairs. Due to their positioning on the western coast, they're considered the closest - and most neutral - port for nearly every major kingdom with a mercantile fleet. 
 <br><br>
-Fried salmoncakes, jellied eels, and pints of Fjall-iced liquor keep Lyndvhar's dockworkers strong: both when laboring at the harbor, and when rioting against nobility after a particularly close game of lampternball.
+Fried salmoncakes, jellied eels, and pints of Fjall-iced liquor keep Zyndvhartia's dockworkers strong: both when laboring at the harbor, and when rioting against nobility after a particularly close game of lampternball.
 		<br>
 	</details>
 
@@ -413,17 +413,6 @@ Though a force of Psydonic crusaders had managed to stop the ritual before its c
 		Kaizoku occupies a smaller series of isles that're at the edge of known civilization, and - if the scholars are to be believed - is an ancestral relative to the twinned-empires of Kazengun and Lingyue. It is perpetually shrouded in fog, so thick that only its well-accustomed sailors could ever hope to safely navigate through it.
 <br><br>
 Mostly known for its exportation of the fogbeast: a prized hybrid of the saiga and horse, and the favored steed of Kingsfield's stout-postured knight-commander.
-		<br>
-	</details>
-
-	<details>
-		<summary><strong> ROTWOAD </strong></summary>
-		<br>
-		<em>The Vale, Laborers of the Terrorbog</em>
-		<br><br>
-		Originally formed as a camp for those overlooking the Terrorbog, the 'Rotwoad Vale' - as it's most commonly known as now - has since grown into a lesser kingdom, renowned for hosting some of Psydonia's most battle-hardened Wardens. 
-<br><br>
-Their proximity to the Terrorbog, however, means that they're also oft-beleaguered by deadly plagues: a matter that has only served to further enforce the unusually high level of segregation between the noblemen and their peasantry.
 		<br>
 	</details>
 

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -368,16 +368,16 @@ Residing within Valoria's walls is the Order of the Silver Psycross: a faith-mil
 		<br><br>
 		Lyndvhar might be similar in size to Azuria, but has a far more vital presence in Psydonia's economic affairs. Due to their positioning on the western coast, they're considered the closest - and most neutral - port for nearly every major kingdom with a mercantile fleet. 
 <br><br>
-Fried salmoncakes, jellied eels, and pints of Fjall-iced liquor keep Lyndvhar's dockworkers strong: both when laboring at the harbor, and when rioting against the wealthy elite after a particularly close game of lampternball.
+Fried salmoncakes, jellied eels, and pints of Fjall-iced liquor keep Lyndvhar's dockworkers strong: both when laboring at the harbor, and when rioting against nobility after a particularly close game of lampternball.
 		<br>
 	</details>
 
 	<details>
-		<summary><strong> VANDERLIN </strong></summary>
+		<summary><strong> DAFTMARSH </strong></summary>
 		<br>
-		<em>The Progressive, Harnessers of Artificery</em>
+		<em>The Compact, Harnessers of Artificery</em>
 		<br><br>
-		Vanderlin - like Hammerhold - is one of the few kingdoms that has dabbled in the oft-misunderstood techniques of artificery. It's rumored that their plumbing exceeds even Grenzelhoft's own in terms of cleanliness, and that bronze spigots can ferry water where no bucket could normally reach in a timely manner.
+		Daftmarsh - like Hammerhold - is one of the few kingdoms that has dabbled in the oft-misunderstood techniques of artificery. It's rumored that their plumbing exceeds even Grenzelhoft's own in terms of cleanliness, and that bronze spigots can ferry water where no bucket could normally reach in a timely manner.
 <br><br>
 Standing far above the king's manor is a massive clocktower, allegedly powered by a strange crystal that had been unearthed within their copper-and-tin mines.
 		<br>
@@ -450,6 +450,17 @@ Trouble has recently tickled its underbelly, however, with the steadying presenc
 	</details>
 
 	<details>
+		<summary><strong> LAKKARI </strong></summary>
+		<br>
+		<em>The Parish, Bayou of Innovation</em>
+		<br><br>
+		Nestled along the swamps of Naledi's northeasternly edge, Lakkari is a lesser kingdom that has long-dabbled in the arts of metallurgy and medicine. In ancient tymes, they held renown for being among the first surfacedwellers to solve the riddle of steel; now, they're more commonly praised for pioneering the Pestran art of surgery.
+<br><br>
+Intermingleance with Otavan refugees and Ranesheni freemen, throughout the centuries, has given rise to a richly diverse culture - and more importantly, some of the finest cuisine in Psydonia's southern reaches. Pestra, Malum and Necra are worshipped with reverance in Lakkari; a facet only strengthened in the face of a recent outbreak, pitting the pious against hordes of uniquely virulent deadites.
+		<br>
+	</details>
+
+	<details>
 		<summary><strong> RUDMARSCH </strong></summary>
 		<br>
 		<em>The Reach, Fallen Kingdom of Sanguine Fields</em>
@@ -486,10 +497,19 @@ Trouble has recently tickled its underbelly, however, with the steadying presenc
 		<p><strong> Underworld </strong> - Hell. A spiteful inversion of reality, created by the Archdevil. It is the home of devils, demons, and taxmen. </p>
 		<p><strong> Holy See </strong> - The premiere worshippers of the Pantheon, and the governing body of the Church. Ruled by a Pope.</p>
 		<p><strong> Ecclesial </strong> - A splinter-faction of the Holy See, which has instead embraced the Ascendants. Sporadically present in hidden enclaves. </p>
-		<p><strong> Orthodoxy </strong> - The Holy See's rival and occasional ally, whom gives praise to Psydon. Ruled by an Archbishop.</p>
+		<p><strong> Orthodoxy </strong> - The Holy See's eternal rival, whom gives praise to the ancient God of Psydon. Ruled by an Archbishop.</p>
+		<p><strong> Inquisition </strong> - The militant arm of the Orthodoxy, notorious for hunting both nitebeasts and suspected worshippers with overzealous impunity. </p>
+		<p><strong> Duchy </strong> - Azuria's royal family, and the rulers of the Azure Peak. Traditionally helmed by a Grand Duke or Grand Duchess. </p>
 		<p><strong> Alotheos </strong> - A labyrinthian tomb, located within Azuria. Though its origins aren't known, its said to hold untold riches within. </p>
 		<p><strong> Arcyne </strong> - Magicka. A blessing of Noc, which allows for the manipulation of Psydonia's latent energies. </p>
 		<p><strong> Leyline </strong> - Channels of pure magicka, running across Psydonia like the arteries in a body. Most arcyne acts draw from these veins. </p>
+		<p><strong> Phlogiston </strong> - The star-speckled space that cradles the Sun, the Moon, Psydonia, and all the various astralities surrounding them. </p>
+		<p><strong> Murderwoods </strong> - Azuria's northern forests, better known in the current dae as the 'Grove'. Temperate, but teeming with brigandry.</p>
+		<p><strong> Terrorbog </strong> - Azuria's western swamps, notoriously difficult to traverse and hazardous to even the most well-seasoned Adventurers.</p>
+		<p><strong> Coast </strong> - Azuria's eastern coastline. It usually refers to its most popular point of entry, sandwiched between the Grove and Hamlet.</p>
+		<p><strong> Hamlet </strong> - The northernmost point of Azuria's reach; a former settlement that has recently fallen to ducal neglect.</p>
+		<p><strong> Keep </strong> - The seat of power, located to the east of Azuria's town square. It is inhabited by the Duchy's royal family, court, and guardsmen.</p>
+		<p><strong> Church </strong> - The seat of faith, located to the west of Azuria's town square. It preaches the glory of the Pantheon to Azuria's faithful.</p>
 		<br>
 	</details>
 
@@ -501,11 +521,18 @@ Trouble has recently tickled its underbelly, however, with the steadying presenc
 		<p><strong> Deadite </strong> - Luxless corpses, resurrected through unholy means. Interchangeably used to describe both zombies and skeletons. </p>
 		<p><strong> Nitebeast </strong> - Monsters who rely on night-and-darkness to prowl. Primarily references werewolves, but can reference vampires as well. </p>
 		<p><strong> Lycker </strong> - Vampires. These luxless revenants are said to drink the blood of the living, and are empowered with unholy magicks. </p>
+		<p><strong> Gnoll </strong> - Lesser nitebeasts, borne of Graggar's malice towards the worthiest - or most valuable - prey. </p>
+		<p><strong> Verevolf </strong> - Greater nitebeasts, said to've been caused by Dendor's curses. When nite comes, even the meekest blightee turns into a fierce beast. </p>
+		<p><strong> Lich </strong> - Necromancers, ancient and well-versed in unholy magicka. They serve as the self-proclaimed lieutenants of Zizo, and are one of Azuria's gravest threats. </p>
+		<p><strong> Vampyre-Lord </strong> - Lords of lyckerdom, thought only to be restricted to the legends of antiquity. Should one resurface, terrible events are surely to follow. </p>
 		<p><strong> Avantyne </strong> - A so-called 'evil' alloy, wielded by Zizo's most devoted worshippers. More commonly known as 'darksteel'.</p>
+		<p><strong> Inquisitor </strong> - Eesoteric lieutenants of the Orthodoxy's militant branch, equally respected and reviled for their techniques in handling the unholiest-of-foes. </p>
+		<p><strong> Taff </strong> - A profanity that happens to be quite popular amongst the peasantry. In the crudest terms, it refers to intercourse or despair.</p>
 		<p><strong> Saiga </strong> - Large antelopes, and Psydonia's most popular choice for cavalrymen and travelers. Analogous to the far-rarer horse. </p>
+		<p><strong> Fogbeast </strong> - Horses. A rarely-seen alternative to the Saiga, due to its regional exclusivity to a few specific plains in Psydonia. </p>
 		<p><strong> Red </strong> - A healing potion - specifically, the regenerative juices inside. Additionally known as 'lifeblood'.  </p>
 		<p><strong> Blue </strong> - A fatigue potion - or, rather, the energy-boosting juices inside. Additionally known as 'manna'. </p>
-		<p><strong> Cackleberry </strong> - Eggs. The favored pronunciation amongst the peasantry and antiquated. </p>
+		<p><strong> Cackleberry </strong> - Eggs. The favored pronunciation amongst the peasantry and antiquated. Doubles as an allusion to one's lowest-hanging fruits. </p>
 		<p><strong> Mammon </strong> - Currency. A copper zenny is one mammon, a silver ziliquae is five mammons, and a gold zenar is ten mammons. </p>
 		<p><strong> Scom </strong> - A rous-powered communication machine. Also functions as a verb, when used to describe 'calling' or 'contacting' someone. </p>
 		<p><strong> Meister </strong> - A coinage-machine that - with the cost of a bloodied finger - allows one to access their personal reserve of mammons. </p>

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -504,7 +504,7 @@ Intermingleance with Otavan refugees and Ranesheni freemen, throughout the centu
 		<p><strong> Arcyne </strong> - Magicka. A blessing of Noc, which allows for the manipulation of Psydonia's latent energies. </p>
 		<p><strong> Leyline </strong> - Channels of pure magicka, running across Psydonia like the arteries in a body. Most arcyne acts draw from these veins. </p>
 		<p><strong> Phlogiston </strong> - The star-speckled space that cradles the Sun, the Moon, Psydonia, and all the various astralities surrounding them. </p>
-		<p><strong> Murderwoods </strong> - Azuria's northern forests, better known in the current dae as the 'Grove'. Temperate, but teeming with brigandry.</p>
+		<p><strong> Murderwood </strong> - Azuria's northern forests, better known in the current dae as the 'Grove'. Temperate, but teeming with brigandry.</p>
 		<p><strong> Terrorbog </strong> - Azuria's western swamps, notoriously difficult to traverse and hazardous to even the most well-seasoned Adventurers.</p>
 		<p><strong> Coast </strong> - Azuria's eastern coastline. It usually refers to its most popular point of entry, sandwiched between the Grove and Hamlet.</p>
 		<p><strong> Hamlet </strong> - The northernmost point of Azuria's reach; a former settlement that has recently fallen to ducal neglect.</p>

--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -304,7 +304,7 @@ It is ruled not by a man, but a dragon: an ancient megabeast who's power has all
 	</details>
 
 	<details>
-		<summary><strong> KAZENGUN-LINGYUE </strong></summary>
+		<summary><strong> KAZENGUN & LINGYUE </strong></summary>
 		<br>
 		<em>The Dynasty, Sister-Kingdoms of Mystique</em>
 		<br><br>


### PR DESCRIPTION
## About The Pull Request

* Finally fills out Azuria's placeholder text in the Origins tab, and adjusts the appendix to divorce it from Scarlet Reach's variant.
* Touches up the 'Nowhere' origin, replaces its examination test with 'Elsewhere' instead of 'Unknown'.
* Adjusts Vanderlin to have the less-on-the-nose name of Daftmarsh, following some minor concerns.
* Adds supplemental details and concepts to the Primer.
* Adds Lakkari to the Primer; a lesser nation mentioned in descriptions, similar to Valoria in relevancy.
_(Similar to the entry on Naledi, this has been both co-authored and approved by its creator, 7erracotta.)_

## Testing Evidence

Should be good to go, barring any freak accidents.

## Why It's Good For The Game

* Azurians that take their region's origin now have a proper wiki-and-community-sourced description, instead of a placeholder.
* A little more depth in character customization is always nice. Could see if it's what people'd want, too, in practice.
* Helps to round out any fringe cases of confusion, should eyes discover the name of another rarely-mentioned fief.

## Changelog

:cl:
add: Replaces the placeholder text in the 'Azurian' origin with something properly sourced from the wiki and community.
add: Touches up the 'Nowhere' option with a little more fluff.
add: Adds more commonly-found words and concepts to the Primer.
fix: Mentions of 'Vanderlin' in the code have been appropriately adjusted to the more agnostic term of 'Daftmarsh'.
fix: Slightly agnostifies(?) Rudmarsch's maiden name into the 'Sanguine Reach', and the Rotwood Vale into the Rotwoad Vale.
fix: Modifies 'Lyndvhar' mention to 'Zyndhardia', at request.
add: Adds 'Lakkari' to the Primer, to avoid any potential confusion regarding some descriptions. Similar to Monkberry's Naledi, this entry has also been co-authored and approved by its original creator, 7erracotta.
del: Mentions of Blackstone - from the Primer - have been fittingly nuked out of existence.
del: Rotwood, likewise, has been left to rot.
/:cl: