### PR TITLE
Adds Consent to Marriage

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1321,87 +1321,71 @@
 		// if there's no bishop inround, you can still get married... as long as there's an eoran. heretics can do it too!
 		if((user.mind.assigned_role == "Bishop") || (istype(living_user) && HAS_TRAIT(living_user, TRAIT_MARRIAGE_CAPABLE) && (living_user.patron.type == /datum/patron/divine/eora)))
 			if(istype(W, /obj/item/reagent_containers/food/snacks/grown/apple))
-				var/marriage
 				var/obj/item/reagent_containers/food/snacks/grown/apple/A = W
 				//The MARRIAGE TEST BEGINS
-				if(A.bitten_names.len)
-					if(A.bitten_names.len == 2)
-						//Groom provides the surname that the bride will take
-						var/mob/living/carbon/human/thegroom
-						var/mob/living/carbon/human/thebride
-						//Did anyone get cold feet on the wedding?
-						for(var/mob/M in viewers(src, 7))
+				if(A.bitten_names.len == 2)
+					// Find the groom and bride from those who bit the apple
+					var/mob/living/carbon/human/thegroom
+					var/mob/living/carbon/human/thebride
+					for(var/mob/M in viewers(src, 7))
+						// You cannot marry an animal, a corpse, a brainless mob, or someone who is already married.
+						if(!ishuman(M)) 
+							continue
+						var/mob/living/carbon/human/C = M
 
-							if(thegroom && thebride)
-								break
-							if(!ishuman(M))
-								continue
-							var/mob/living/carbon/human/C = M
-							/*
-							* This is for making the first biters name
-							* always be applied to the groom.
-							* second. This seems to be the best way
-							* to use the least amount of variables.
-							*/
-							//I think that guy is dead.
-							if(C.stat == DEAD)
-								continue
-							//That person is not a player or afk.
-							if(!C.client)
-								continue
-							//Gotta get a divorce first
-							if(C.marriedto)
-								continue
-							if(C.real_name == A.bitten_names[1])
-								thegroom = C
-							if(C.real_name == A.bitten_names[2])
-								thebride = C
-						//WE FOUND THEM LETS GET THIS SHOW ON THE ROAD!
-						if(!thegroom || !thebride)
-							to_chat(user, span_warn("nonexistent"))
-							return
-						//Alright now for the boring surname formatting.
-						var/surname2use
-						var/index = findtext(thegroom.real_name, " ")
-						var/bridefirst
-						thegroom.original_name = thegroom.real_name
-						thebride.original_name = thebride.real_name
-						if(!index)
-							surname2use = thegroom.dna.species.random_surname()
-						else
-							/*
-							* This code prevents inheriting the last name of
-							* " of wolves" or " the wolf"
-							* remove this if you want "Skibbins of wolves" to
-							* have his bride become "Sarah of wolves".
-							*/
-							if(findtext(thegroom.real_name, " of ") || findtext(thegroom.real_name, " the "))
-								surname2use = thegroom.dna.species.random_surname()
-								thegroom.change_name(copytext(thegroom.real_name, 1,index))
-							else
-								surname2use = copytext(thegroom.real_name, index)
-								thegroom.change_name(copytext(thegroom.real_name, 1,index))
-						index = findtext(thebride.real_name, " ")
-						if(index)
-							thebride.change_name(copytext(thebride.real_name, 1,index))
-						bridefirst = thebride.real_name
-						thegroom.change_name(thegroom.real_name + surname2use)
-						thebride.change_name(thebride.real_name + surname2use)
-						thegroom.marriedto = thebride.real_name
-						thebride.marriedto = thegroom.real_name
-						thegroom.adjust_triumphs(1)
-						thebride.adjust_triumphs(1)
-						//Bite the apple first if you want to be the groom.
-						priority_announce("[thegroom.real_name] has married [bridefirst]!", title = "Holy Union!", sound = 'sound/misc/bell.ogg')
-						record_round_statistic(STATS_MARRIAGES_MADE)
-						marriage = TRUE
-						qdel(A)
+						if(C.stat == DEAD || !C.client || C.marriedto)
+							continue
+						
+						if(C.real_name == A.bitten_names[1])
+							thegroom = C
+						if(C.real_name == A.bitten_names[2])
+							thebride = C
+					
+					if(!thegroom || !thebride)
+						to_chat(user, span_warn("nonexistent"))
+						return
+					
+					// Astounding update: marriage now requires consent (it didn't before)
+					var/groom_confirm = input(thegroom, "Do you want to marry [thebride]?") as null|anything in list("Yes", "No")
+					if(groom_confirm != "Yes")
+						to_chat(user, span_warning("The groom has declined the marriage!"))
+						return ..()
+					
+					var/bride_confirm = input(thebride, "Do you want to marry [thegroom]?") as null|anything in list("Yes", "No")
+					if(bride_confirm != "Yes")
+						to_chat(user, span_warning("The bride has declined the marriage!"))
+						return ..()
+					
+					// Horrible terrible last name necromancy (sometimes works)
+					var/groom_index = findtext(thegroom.real_name, " ")
+					var/bride_index = findtext(thebride.real_name, " ")
+					var/bride_firstname = bride_index ? copytext(thebride.real_name, 1, bride_index) : thebride.real_name
+					
+					// Get groom's surname
+					var/groom_surname = copytext(thegroom.real_name, groom_index + 1)
+					if(!groom_index)
+						groom_surname = null
+					else if(findtext(thegroom.real_name, " of ") || findtext(thegroom.real_name, " the "))
+						groom_surname = null
+					
+					var/final_bride_name
+					// Ask bride if she wants to take the groom's surname
+					if(groom_surname != null)
+						var/bride_surname_choice = input(thebride, "Do you want to take [thegroom]'s surname? (Your new name will be [bride_firstname] [groom_surname])") as null|anything in list("Yes", "No")
+						final_bride_name = (bride_surname_choice == "Yes") ? (bride_firstname + " " + groom_surname) : thebride.real_name
+					
+					// Apply the changes
+					thebride.change_name(final_bride_name)
+			
+					thegroom.marriedto = thebride.real_name
+					thebride.marriedto = thegroom.real_name
 
-				if(!marriage)
-					A.burn()
-					return
+					thegroom.adjust_triumphs(1)
+					thebride.adjust_triumphs(1)
+
+					priority_announce("[thegroom.real_name] has married [thebride.real_name]!", title = "Holy Union!", sound = 'sound/misc/bell.ogg')
+					return ..()
 	return ..()
-
 
 /obj/structure/fluff/psycross/copper/Destroy()
 	addomen("psycross")


### PR DESCRIPTION


## About The Pull Request

You are now asked if you want to marry the other party. 

You are also asked and shown your new name if you are the "bride" to confirm before locking in.

## Testing Evidence

<img width="408" height="240" alt="image" src="https://github.com/user-attachments/assets/ca14d7dc-a4c9-4a15-8f8a-75a24868a84a" />


<img width="424" height="263" alt="image" src="https://github.com/user-attachments/assets/a2df62e8-e6be-4f63-b9b4-c1803cc16665" />



## Why It's Good For The Game

So like, marriage just didn't work apparently. The last name stuff was buggy (it's still buggy, just now you can choose not to do it if it looks buggy) and you also could force two people to get married by feeding them both a bite of an apple then touch a cross without asking them.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Marriage now requires consent.
fix: The second person who bites the apple can choose if they want the first person's last name or not when being married.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
