### PR TITLE
Staff / Polearm no longer gives longstrider. Reduce mud slowdown impact from 2 to 1

### DIFF
--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -491,11 +491,6 @@
 	. = ..()
 	var/negate_slowdown = FALSE
 
-	for(var/obj/item/stick in user.held_items)
-		if(stick.walking_stick && !stick.wielded && !user.cmode)
-			negate_slowdown = TRUE
-			break
-
 	if((isliving(user))&&(user?.movement_type == FLYING))
 		negate_slowdown = TRUE
 	if(HAS_TRAIT(user, TRAIT_LONGSTRIDER))

--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -446,7 +446,7 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = FALSE
 	landsound = 'sound/foley/jumpland/dirtland.wav'
-	slowdown = 2
+	slowdown = 1
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/turf/open/floor/rogue/grass,
 						/turf/open/floor/rogue/grassred,
@@ -471,7 +471,7 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = FALSE
 	landsound = 'sound/foley/jumpland/dirtland.wav'
-	slowdown = 2
+	slowdown = 1
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/turf/open/floor/rogue/grass,
 						/turf/open/floor/rogue/grassred,
@@ -592,7 +592,7 @@
 		muddy = TRUE
 		icon_state = "mud[rand (1,3)]"
 		name = "mud"
-		slowdown = 2
+		slowdown = 1
 		footstep = FOOTSTEP_MUD
 		barefootstep = FOOTSTEP_MUD
 		heavyfootstep = FOOTSTEP_MUD


### PR DESCRIPTION
## About The Pull Request
We can wait for a massive remap that will unlikely happen within 21 days or I can just cut the problem at its source: 
- Staff / Polearm no longer give longstrider when one handed and not in Cmode. (It won't give longstrider under any circumstances)
- Mud slowdown impact reduced from 2 to 1

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Walked on dirt locally with a staff in my hand

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
With the death of longstrider on most accessible roles including by magic, only Mage or say Staff - Sling retains the ability to exploit it. When someone duck with CMode off into mud, there's basically no counterplay or counter for melee except a gear check. For the ranged character, having Cmode off is not an issue - they are not gonna be parrying, for the melee character, they might as well kick rock and eat sand. 

This remove the last major non-character source and should make kiting mage less frustrating to fight, especially in the coast. They will still have mobility spells to make up for it but wouldn't have a massive always on mobility advantage by 1 handing a staff.

In compensation, I've made mud less miserable without making it a non factor (1 instead of 2 slowdown)

Staff's ability to act as a walking stick remains unchanged.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Onehanding a polearm while off Cmode no longer give you longstrider advantage (ignore mud slowdown)
add: Mud slowdown reduced from 2 to 1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
