### PR TITLE
New great sword stance and great sword rebalance

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -718,3 +718,79 @@
 	var_overrides = list(
 		"wlength" = WLENGTH_NORMAL
 	)
+
+/datum/alt_grip/greatsword/lowguard // low wdef stance for big damage on greatswords
+	two_handed = TRUE
+	name = "Tail Guard"
+	grip_intents = list(
+		/datum/intent/sword/cut/,
+		/datum/intent/sword/cut/zwei/cleave,
+		/datum/intent/sword/cut/zwei/sweep
+	)
+	onmobprop_overrides = list(
+		"altgrip" = list(
+			"shrink" = 0.6,
+			"sx" = 6,
+			"sy" = -7,
+			"nx" = -7,
+			"ny" = -2,
+			"wx" = -9,
+			"wy" = 2,
+			"ex" = 10,
+			"ey" = 2,
+			"northabove" = 0,
+			"southabove" = 1,
+			"eastabove" = 1,
+			"westabove" = 0,
+			"nturn" = -30,
+			"sturn" = -160,
+			"wturn" = -170,
+			"eturn" = -10,
+			"nflip" = 8,
+			"sflip" = 8,
+			"wflip" = 1,
+			"eflip" = 0,
+			
+
+		),
+	)
+	additive_var_overrides = list(
+		wdefense = -2 // weaker parrys 
+	)
+	
+/datum/alt_grip/greatsword/Nebenhut
+ //the zweihanders gimmick is it gets to use this stance without downside unlike other swords
+	name = "Nebenhut"
+	two_handed = TRUE
+	grip_intents = list(
+		/datum/intent/sword/cut/,
+		/datum/intent/sword/cut/zwei/cleave,
+		/datum/intent/sword/cut/zwei/sweep
+	)
+	onmobprop_overrides = list(
+		"altgrip" = list(
+			"shrink" = 0.6,
+			"sx" = 6,
+			"sy" = -7,
+			"nx" = -7,
+			"ny" = -2,
+			"wx" = -9,
+			"wy" = 2,
+			"ex" = 10,
+			"ey" = 2,
+			"northabove" = 0,
+			"southabove" = 1,
+			"eastabove" = 1,
+			"westabove" = 0,
+			"nturn" = -30,
+			"sturn" = -160,
+			"wturn" = -170,
+			"eturn" = -10,
+			"nflip" = 8,
+			"sflip" = 8,
+			"wflip" = 1,
+			"eflip" = 0,
+			
+
+		),
+	)

--- a/code/game/objects/items/rogueweapons/melee/swords/greatswords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/greatswords.dm
@@ -3,9 +3,9 @@
 	force = 12
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/sword/chop, /datum/intent/sword/strike) //bash is for nonlethal takedowns, only targets limbs
-	// Design Intent: I have a big fucking sword and I want to cut everything in sight.
-	gripped_intents = list(/datum/intent/sword/cut/zwei, /datum/intent/sword/thrust/zwei, /datum/intent/sword/cut/zwei/cleave, /datum/intent/sword/cut/zwei/sweep)
-	alt_grips = list(/datum/alt_grip/mordhau/greatsword, /datum/alt_grip/halfsword/greatsword)
+	// Design Intent: greatswords have two stances, the default is a low damage defensive stance, the alternate is a high damage offensive stance with cleave.
+	gripped_intents = list(/datum/intent/sword/cut/zwei, /datum/intent/sword/thrust/zwei, /datum/intent/sword/strike/bad)
+	alt_grips = list(/datum/alt_grip/greatsword/lowguard)
 	name = "greatsword"
 	desc = "Might be able to chop anything in half!"
 	icon_state = "gsw"
@@ -49,11 +49,12 @@
 			if("onback")
 				return list("shrink" = 0.6,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
-/obj/item/rogueweapon/greatsword/elfgsword
+/obj/item/rogueweapon/greatsword/elfgsword // this is now a defensive sword, +2 wdef over a greatsword at the cost of 5 force
 	name = "elven kriegsmesser"
 	desc = "An elegant greatsword, crested with a glistening blade that - in spite of its intimidating length - is mysteriously light. Unlike most elven masterworks, the grip is dressed in rosaleather; a foreboding symbol, christening it as a weapon of war against those who'd threaten elvekind."
 	icon_state = "elfkriegmesser"
 	item_state = "elfkriegmesser"
+	force_wielded = 25 
 	minstr = 10
 	wdefense = 7
 	sellprice = 120
@@ -103,34 +104,35 @@
 	icon_state = "ancient_gsw"
 	smeltresult = /obj/item/ingot/aaslag
 
-/obj/item/rogueweapon/greatsword/zwei
+/obj/item/rogueweapon/greatsword/zwei // an iron flamberge basically, 35 force but -1 wdef 
 	name = "claymore"
 	desc = "This is much longer than a common greatsword, and well balanced too!"
 	icon_state = "claymore"
 	smeltresult = /obj/item/ingot/iron
 	smelt_bar_num = 3
 	max_blade_int = 220
+	max_integrity = 200
 	wdefense = 4
 	force = 14
 	force_wielded = 35
 
-/obj/item/rogueweapon/greatsword/grenz
+/obj/item/rogueweapon/greatsword/grenz // unique merc weapon, exact stats of the greatsword but it's able to use the cleave stance without any downsides.
+	alt_grips = list(/datum/alt_grip/greatsword/Nebenhut)
 	name = "steel zweihander"
+	desc = "A steel greatsword of Grenzlehoft, it's steel Parierhaken allow the user to cleave large swaths of enemys and still be protected!"
 	icon_state = "steelzwei"
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 3
-	max_blade_int = 240
-	wdefense = 4
-	force = 14
-	force_wielded = 35
 
-/obj/item/rogueweapon/greatsword/grenz/flamberge
+
+
+/obj/item/rogueweapon/greatsword/grenz/flamberge // greatsword with +5 force but -1 wdef
+	alt_grips = list(/datum/alt_grip/greatsword/lowguard)
 	name = "steel flamberge"
 	desc = "A close relative of the Grenzelhoftian \"zweihander\", favored by Otavan nobility. The name comes from its unique, flame-shaped blade; a labor only surmountable by Psydonia's finest weaponsmiths."
 	icon_state = "steelflamberge"
-	max_blade_int = 180
-	max_integrity = 130
-	wdefense = 6
+	force_wielded = 35
+	wdefense = 4
 
 /obj/item/rogueweapon/greatsword/grenz/flamberge/getonmobprop(tag)
 	. = ..()
@@ -143,14 +145,16 @@
 			if("onback")
 				return list("shrink" = 0.6,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
-/obj/item/rogueweapon/greatsword/grenz/flamberge/malum
+/obj/item/rogueweapon/greatsword/grenz/flamberge/malum 
+	alt_grips = list(/datum/alt_grip/greatsword/lowguard)
 	name = "forgefiend flamberge"
 	desc = "This sword's creation took a riddle in its own making. A great sacrifice was made for a blade of perfect quality."
 	icon_state = "malumflamberge"
-	max_integrity = 200
-	max_blade_int = 200
+	max_integrity = 300
+	max_blade_int = 300
 
 /obj/item/rogueweapon/greatsword/grenz/flamberge/ravox
+	alt_grips = list(/datum/alt_grip/greatsword/lowguard)
 	name = "Censure"
 	desc = "A blade that invites imagery of hope. Of men clad in shattered plate and bearing blackened pauldrons, \
 	standing at His side. To correct Her wrongs, as they sought the censure of divine tyranny. \
@@ -160,7 +164,8 @@
 	max_blade_int = 240
 	wdefense = 7//You are truly unique, m'lord.
 
-/obj/item/rogueweapon/greatsword/grenz/flamberge/blacksteel
+/obj/item/rogueweapon/greatsword/grenz/flamberge/blacksteel // super weapon, has the best of both worlds and +5 force
+	alt_grips = list(/datum/alt_grip/greatsword/lowguard)
 	name = "blacksteel flamberge"
 	desc = "An uncommon kind of sword with a characteristically undulating style of blade, made with an equally rare metal. \
 	The wave in the blade is considered to contribute a flame-like quality to its appearance, turning it into a menacing sight. \

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -345,7 +345,7 @@
 	desc = "A cleave that cuts through a second target behind the first."
 	attack_verb = list("cleaves", "carves through")
 	clickcd = CLICK_CD_HEAVY
-	damfactor = 1.0
+	damfactor = 1.5
 	reach = 1 // No!!
 	cleave = /datum/cleave_pattern/forward_cleave
 
@@ -354,8 +354,9 @@
 	icon_state = "insweep"
 	desc = "A heavy sweep that cuts through targets to the front."
 	attack_verb = list("sweeps through", "cuts across")
+	damfactor = 1.5
 	reach = 1
-	clickcd = CLICK_CD_MASSIVE
+	clickcd = CLICK_CD_HEAVY
 	cleave = /datum/cleave_pattern/horizontal_sweep
 
 /datum/intent/sword/thrust/zwei

--- a/code/modules/mob/living/combat/cleave.dm
+++ b/code/modules/mob/living/combat/cleave.dm
@@ -170,9 +170,9 @@
 	desc = "Cleaves into an adjacent target."
 
 /datum/cleave_pattern/forward_cleave
-	tile_offsets = list(list(0, 1))
-	max_targets = 1
-	desc = "Cleaves forward into a second target."
+	tile_offsets = list(list(0,1), list(0,2))
+	max_targets = 2
+	desc = "Cleaves forward into two more targets."
 
 /datum/cleave_pattern/wide_sweep
 	tile_offsets = list(list(-1, 0), list(1, 0), list(0, -1), list(0, 1))


### PR DESCRIPTION
## About The Pull Request
TLDR: Greatswords lose their cleave intents on the main stance, and instead get a new stance that sacrifices Wdef for high damage cleaves.

default greatsword intents will now be
Cut
Stab
Strike
(there's no fourth one idk maybe i'll bring back rend but who cares)

<details>
<summary>Tailguard Details</summary>
Tail-guard is a new alt stance replacing mordhau and halfswording for greatswords only. It's named after that because you hold the sword like a tail. 

Tail guard lowers your weapons wdef by -2 while in the stance; however, you get access to very high damage cleaves. In order the intents are,

cut- 1 range, 1.1 force
cleave - 3x1 vertical intent, 1.5 force
sweep 3x1 horizontal intent, 1.5 force
strike .5 blunt damage


</details>

This also makes the 'vertical' cleave pattern hit 3 tiles in front of you instead of two. Very scary. 
<details>
<summary>scary cleave</summary>
<img width="363" height="355" alt="Screenshot 2026-04-15 200633" src="https://github.com/user-attachments/assets/1df1baf1-ee1d-466c-9ef4-f08777ff4661" />
you have to click where the red arrow is, this is not easy to hit people with consistantly.
</details>


Finally this also rebalanced most the greatswords very minorly. Here's a list. 
<details>
<summary>numberjaks</summary>

- elven kriegsmesser - this thing was evil, being a greatsword with +2 wdef and no downside. It now has +2 wdef but -5 force, a defensive powerhouse. 
- claymore - gave it actual iron integ instead of cheating to have steel integ made out of iron.
- steel zweihander- lost its extra force for losing 1 wdef gimmick, instead its new gimmick is being able to use the new stance without losing wdef, it even has a larpy german name for it. Has exactly the same stats as a steel greatsword otherwise
- steel flamberge - has taken the niche that the zweihander had, now being an acquirable upgrade to the iron claymore.  35 force for -1 wdef, also got its integ increased to the standard of a steel greatsword. 
-  malum/ravox swords - malum is now a flamberge with 50 extra integ, ravox is less integ but more wdef.

and that's it! If I didn't mention it here it's unchanged besides the global intent/stance changes. 
</details>


## Testing Evidence

works
## Why It's Good For The Game
ok so greatswords have been boring for a while, but I realize some players really enjoy the standardness of them. This is a compromise that keeps legacy greatswords have had of being 2 range tile weapons, while also expanding skill expression via giving them a new stance they can flick to / stay in to land big, dangerous cleaves and become aoe monsters at the cost of their own saftey (and their friends!)

This should give greatsword users a bit more to think about, while also allowing newer players or ones that don't care about this complexity to safely ignore it, as nothing has truly changed in the normal greatsword play pattern. 

## Changelog
