### PR TITLE
Hammer now scales to the blacksmithing skill & Max integrity to 80 

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -11,7 +11,7 @@
 	wlength = WLENGTH_SHORT
 	slot_flags = ITEM_SLOT_HIP
 	w_class = WEIGHT_CLASS_NORMAL
-	associated_skill = /datum/skill/combat/maces
+	associated_skill = /datum/skill/craft/blacksmithing
 	smeltresult = /obj/item/ash
 	grid_width = 32
 	grid_height = 64

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -15,6 +15,7 @@
 	smeltresult = /obj/item/ash
 	grid_width = 32
 	grid_height = 64
+	max_integrity = 80
 	var/quality = 1
 
 /obj/item/rogueweapon/hammer/get_mechanics_examine(mob/user)


### PR DESCRIPTION
## About The Pull Request
- Hammer now scales to the blacksmithing skill instead of maces skill
- To (hopefully) prevent it from being more than a meme weapon for blacksmith occasionally, I have set max integrity to 80 so that if it get riposted / parried enough it would blow in a real fight.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This tries to give smith some self defense potential without me waking up tomorrow to see 4 MAA with Hammer and Shield fighting 3 Heretics with Hammer and Shield (legendary blacksmithing)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Hammer now scales to blacksmithing skills but has 80 instead of 250 max integrity to prevent it from becoming the hot new meta, hopefully.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
