### PR TITLE
Matthios balancefix speedmerge

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -459,7 +459,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_AZURENATIVE = span_info("I've grown up and lived all my lyfe in these lands. I can only trigger ambushes if I sprint through them."),
 	TRAIT_SLEUTH = span_info("I can spot my tracked Mark's trail without needing to approach it, and can spot them at a distance. I can track more frequently, and the act is not impaired by movement. I can examine tracks right away."),
 	TRAIT_HARDSHELL = span_info("The bulk of this armor prevents me from parrying effectively, but I can still move out of the way."),
-	TRAIT_MATTHIOS_EYES = span_notice("I have a sense for what the most valuable item someone has is. I can also estimate how much mammon they have."),
+	TRAIT_MATTHIOS_EYES = span_notice("I have a sense for what the most valuable item someone has is. I can also tell if someone is hoarding mammons, and with blessed gilded spectacles, I can even see how much they have in their bank."),
 	TRAIT_WOODWALKER = span_notice("I can climb trees quicker, and gain climbing experience twice as quickly. I can step on thorns and branches safely in the woods. I can get twice as many things from searching bushes, and I can stand on leaves in trees safely."),
 	TRAIT_ARCYNE = span_notice("I am trained in the Arcyne arts, allowing me to wield magyck."),
 	TRAIT_INFINITE_ENERGY = span_notice ("I don't need rest; I won't ever feel fatigue."),

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -362,7 +362,10 @@
 				break
 			if(prob(pickchance))
 				lockprogress += moveup
-				playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 5, TRUE)
+				if(silentpick)
+					playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 2, TRUE)
+				else
+					playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 5, TRUE)
 				to_chat(user, "<span class='warning'>Click...</span>")
 				if(L.mind)
 					add_sleep_experience(L, /datum/skill/misc/lockpicking, L.STAINT/2)
@@ -376,7 +379,7 @@
 					continue
 			else
 				if(silentpick)
-					playsound(loc, 'sound/items/pickbad.ogg', 5, TRUE)
+					playsound(loc, 'sound/items/pickbad.ogg', 2, TRUE)
 				else
 					playsound(loc, 'sound/items/pickbad.ogg', 40, TRUE)
 				I.take_damage(1, BRUTE, "blunt")
@@ -526,7 +529,10 @@
 	if(locked)
 		user.visible_message(span_warning("[user] unlocks [src]."), \
 			span_notice("I unlock [src]."))
-		playsound(src, 'sound/foley/doors/lock.ogg', 100)
+		if(HAS_TRAIT(user, TRAIT_SILENT_LOCKPICK))
+			playsound(src, 'sound/foley/doors/lock.ogg', 25)
+		else
+			playsound(src, 'sound/foley/doors/lock.ogg', 100)
 		locked = 0
 	else
 		user.visible_message(span_warning("[user] locks [src]."), \

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -601,7 +601,10 @@
 				break
 			if(prob(pickchance))
 				lockprogress += moveup
-				playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 5, TRUE)
+				if(silentpick)
+					playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 2, TRUE)
+				else
+					playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 5, TRUE)
 				to_chat(user, "<span class='warning'>Click...</span>")
 				if(L.mind)
 					add_sleep_experience(L, /datum/skill/misc/lockpicking, L.STAINT/2)
@@ -621,7 +624,7 @@
 					continue
 			else
 				if(silentpick)
-					playsound(loc, 'sound/items/pickbad.ogg', 5, TRUE)
+					playsound(loc, 'sound/items/pickbad.ogg', 2, TRUE)
 				else
 					playsound(loc, 'sound/items/pickbad.ogg', 40, TRUE)
 				I.take_damage(1, BRUTE, "blunt")
@@ -636,7 +639,10 @@
 	if(locked)
 		user?.visible_message(span_warning("[user] unlocks [src]."), \
 			span_notice("I unlock [src]."))
-		playsound(src, unlocksound, 100)
+		if(HAS_TRAIT(user, TRAIT_SILENT_LOCKPICK))
+			playsound(src, unlocksound, 25)
+		else
+			playsound(src, unlocksound, 100)
 		locked = 0
 	else
 		user?.visible_message(span_warning("[user] locks [src]."), \

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -328,9 +328,10 @@
 		if(isnull(mammonsinbank))
 			mammonsinbank = 0
 		var/totalvalue = mammonsonperson + mammonsinbank
-		if(totalvalue)
+		if(totalvalue && HAS_TRAIT(user, TRAIT_GILDED_SIGHT))
 			. += span_notice("They carry [mammonsonperson] mammons, with [mammonsinbank] stored away, totaling [totalvalue].")
-
+		else if(mammonsonperson && mammonsonperson >= 200)
+			. += span_notice("They carry about [mammonsonperson] mammons with them.")
 	var/obscured = check_obscured_slots()
 	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 	if(HAS_TRAIT(user, TRAIT_ROYALSERVANT))

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -119,14 +119,6 @@
 			var/mob/living/carbon/human/H = user
 			if(H in SStreasury.bank_accounts)
 
-				if(istype(P, /obj/item/roguecoin/gold/matthios))
-					if(prob(30))
-						say("Matthios be praised! You are FREE of taxes!")
-					say("Your deposit was taxed 0 mammon.")
-					playsound(src, 'sound/misc/coininsert.ogg', 100, FALSE, -1)
-					qdel(P)
-					return
-
 				var/list/deposit_results = SStreasury.generate_money_account(P.get_real_price(), H)
 				if(islist(deposit_results))
 					record_round_statistic(STATS_MAMMONS_DEPOSITED, deposit_results[1] - deposit_results[2])

--- a/code/modules/spells/pantheon/inhumen/_inhumen_spell_items.dm
+++ b/code/modules/spells/pantheon/inhumen/_inhumen_spell_items.dm
@@ -515,7 +515,6 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 					/obj/item/roguegem/yellow,
 					/obj/item/roguegem/green,
 					/obj/item/roguegem/violet,
-					/obj/item/roguegem/diamond
 				)
 				var/typepath = pick(ores)
 				var/bonus = get_stone_value(new typepath)
@@ -806,7 +805,13 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		return TRUE
 
 	if(do_after(user, 1.5 SECONDS))
-		inserted_ingredients += I.type
+
+		if(istype(I, /obj/item/natural/bundle/fibers))
+			var/obj/item/natural/bundle/fibers/B = I
+			for(var/i = 1 to B.amount)
+				inserted_ingredients += /obj/item/natural/fibers
+		else
+			inserted_ingredients += I.type
 
 		var/color_to_use = null
 		for(var/T in ingredient_colors)
@@ -911,6 +916,8 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		/obj/item/alch/mentha,
 		/obj/item/alch/manabloompowder,
 		/obj/item/reagent_containers/powder,
+		/obj/item/natural/bone,
+		/obj/item/natural/bundle/bone,
 	)
 
 	ingredient_colors = list(
@@ -918,6 +925,8 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 		/obj/item/alch/mentha = "#3aff7a",
 		/obj/item/alch/manabloompowder = "#66ccff",
 		/obj/item/reagent_containers/powder = "#ff00b3",
+		/obj/item/natural/bone = "#e8e2cf",
+		/obj/item/natural/bundle/bone = "#e8e2cf",
 	)
 
 /obj/item/matthios_canister/goodnite/freeman_truth()
@@ -1779,12 +1788,14 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 	icon_state = "matthios"
 	resistance_flags = FIRE_PROOF
 	slot_flags = ITEM_SLOT_NECK
-	smeltresult = /obj/item/roguecoin/gold/matthios/pile
+	smeltresult = /obj/item/ash
 	var/grant_chant = FALSE
 	aura_color = "#ffe761"
 
 /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios/gilded/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
+	if(obj_broken)
+		return
 	if(slot == (SLOT_NECK||SLOT_RING) && HAS_TRAIT(user, TRAIT_FREEMAN))
 		if(!user.has_language(/datum/language/thievescant))
 			to_chat(user, span_info("You gain insight on Thieves' Cant.<br><br><i>Keep in mind these are 'words' that come out as gestures, so blend it between normal speech to make it not so obvious.</i>"))
@@ -1811,6 +1822,8 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 
 /obj/item/clothing/gloves/roguetown/fingerless_leather/muffle_matthios/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
+	if(obj_broken)
+		return
 	if(slot == SLOT_GLOVES && HAS_TRAIT(user, TRAIT_FREEMAN))
 		to_chat(user, span_info("Like Him, my hands ready to grasp the impossible."))
 		ADD_TRAIT(user, TRAIT_SILENT_LOCKPICK, "matthiosboon")
@@ -2143,42 +2156,31 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 
 //MISC
 
-/obj/item/roguecoin/gold/matthios
-	name = "zenar"
-	desc = "A gold coin bearing the symbol of the Taurus and the pre-kingdom psycross. These were in the best condition of the provincial gold mints, the rest were melted down."
-	sellprice = 0 // honk, though knowing these powergamers, the meme won't last forever, worst case this skill's worth is to create free pouches :'(
+/datum/component/storage/concrete/roguetown/pouch/matthios
+	screen_max_rows = 4
+	screen_max_columns = 2
 
-/obj/item/roguecoin/gold/matthios/examine(mob/user)
+/obj/item/storage/belt/rogue/pouch/matthios
+	aura_color = "#fff385"
+	desc = "A small sack with a drawstring that allows it to be worn around the neck. Or at the hips, provided you have a belt. It has a strange, gilded glow to it."
+	component_type = /datum/component/storage/concrete/roguetown/pouch/matthios
+
+/obj/item/storage/belt/rogue/pouch/matthios/Initialize()
 	. = ..()
-	if(prob(20)) // this may be remove based on how much people troll with it, but for now
-		if(HAS_TRAIT(user, TRAIT_SEEPRICES))
-			. += span_warning("Is this true...?")
-		else if(HAS_TRAIT(user, TRAIT_SEEPRICES_SHITTY))
-			. += span_warning("Is this TRVE??")
+	AddComponent(/datum/component/cursed_item, (TRAIT_FREEMAN||TRAIT_XYLIX), "BLESSED POUCH")
 
-/obj/item/roguecoin/gold/matthios/pile/Initialize()
+/obj/item/storage/backpack/rogue/backpack/matthios
+	name = "smuggling bag"
+	desc = "A sack tied with some 'blessed' rope. There is a carving of a grinning symbol within the side of it. It has a strange, gilded glow to it."
+	aura_color = "#fff385"
+	icon_state = "rucksack_untied"
+	item_state = "rucksack"
+	component_type = /datum/component/storage/concrete/roguetown/backpack
+	max_integrity = 100
+
+/obj/item/storage/backpack/rogue/backpack/matthios/Initialize()
 	. = ..()
-	set_quantity(rand(4,19))
-
-/obj/item/storage/belt/rogue/pouch/coins/matthios
-	name = "pouch"
-	desc = "A small sack with a drawstring that allows it to be worn around the neck. Or at the hips, provided you have a belt."
-	preload = TRUE
-
-/obj/item/storage/belt/rogue/pouch/coins/matthios/get_types_to_preload()
-	var/list/to_preload = list()
-	to_preload += /obj/item/roguecoin/gold/matthios/pile
-	return to_preload
-
-/obj/item/storage/belt/rogue/pouch/coins/matthios/PopulateContents()
-	. = ..()
-	for(var/i in 1 to 4)
-		var/obj/item/roguecoin/gold/matthios/pile/H = SSwardrobe.provide_type(/obj/item/roguecoin/gold/matthios/pile, loc)
-		if(istype(H))
-			H.set_quantity(20) // full stacks
-			if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_INSERT, H, null, TRUE, TRUE))
-				SSwardrobe.recycle_object(H)
-				break
+	AddComponent(/datum/component/cursed_item, (TRAIT_FREEMAN||TRAIT_XYLIX), "BLESSED RUCKSACK")
 
 /obj/item/rope/chain/matthios
 	name = "gilded chain"
@@ -2186,7 +2188,7 @@ var/global/list/da_bubbles = list('sound/foley/bubb (1).ogg','sound/foley/bubb (
 	color = "#fdff86"
 	aura_color = "#fff385"
 	matthios_chains = TRUE
-	smeltresult = /obj/item/roguecoin/gold/matthios/pile
+	smeltresult = /obj/item/ash
 
 /obj/item/melee/touch_attack/lesserknock/matthios
 	name = "Gilded Lockpick"

--- a/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -41,13 +41,21 @@
 			category = "Gilded Tools",
 			lines = list("#By thine hands...", "#No locks shall bar the free!", "#Thine tool shall bring liberation!", "#Matthios, shatter my locks!")
 		),
-		//freely spawns 400 mammon!!! no wae! is this trve?!!?!??
-		"Pouch of Bribery" = list(
-			path = /obj/item/storage/belt/rogue/pouch/coins/matthios,
-			m_cooldown = 5 MINUTES,
-			m_rank = SKILL_LEVEL_EXPERT,
+		//rip the bag of bribery, say hello to pouch of smuggling
+		"Pouch of Smuggling" = list(
+			path = /obj/item/storage/belt/rogue/pouch/matthios,
+			m_cooldown = 10 MINUTES,
+			m_rank = SKILL_LEVEL_NOVICE,
 			category = "Rogue Arts",
-			lines = list("#Coin begets coin!", "#Matthios, grant me a sliver of thy wealth!", "#Wealth through will, as He demands!", "#Matthios, see to my poverty!")
+			lines = list("#Let me begin your work!", "#Matthios, protect my well-deserved goods!", "#Grant me protection against those tyrant knaves!", "#Matthios, ordain me your blessed storage!")
+		),
+		//like a pouch of smuggling, but smugglier
+		"Bag of Smuggling" = list(
+			path = /obj/item/storage/backpack/rogue/backpack/matthios,
+			m_cooldown = -1,
+			m_rank = SKILL_LEVEL_APPRENTICE,
+			category = "Rogue Arts",
+			lines = list("#Let me begin your work!", "#Matthios, protect my well-deserved goods!", "#Grant me protection against those tyrant knaves!", "#Matthios, ordain me your blessed storage!")
 		),
 		//makes failed lockpicking attempts muffled
 		"Gilded Dexterous Gloves" = list(
@@ -85,7 +93,7 @@
 		"Gilded Amulet of Matthios" = list(
 			path = /obj/item/clothing/neck/roguetown/psicross/inhumen/matthios/gilded,
 			m_cooldown = 30 MINUTES,
-			m_rank = SKILL_LEVEL_NOVICE,
+			m_rank = SKILL_LEVEL_NONE,
 			category = "Gilded Tools",
 			lines = list("#Matthios, let thine will be done.", "#Lord of Exchange, my soul is yours.", "#God of the Stolen Fyre, thou will be done.")
 		),


### PR DESCRIPTION
## About The Pull Request

The radioactive waste of my thingy is finally on my doorstep, but here is the fix to about everything I could see from playing it myself and seeing others be cringe with.

- Gilded Amulet is now a proper T0 gilded tool.
- Lockpicking Gloves are no longer worthless, they'll muffle more sounds from doors.
- Matthioses will no longer 'luckily' score hundreds worth of mammon by converting a boulder into dorpel with firstlaw.
- Matthioses will no longer troll merchants, instead, they'll get a cool pouch (and higher tiers, bag) that only Matthioses (and someone else) can hold.
- Matthios's Blessing will no longer tell every nickel someone has, unless they're hoarding. Or if you are wearing Gilded Specs (in which it'll have the current interaction with full detail of their mammon).

## Testing Evidence

Spent the whole day working on this, works. Most of this is code maint and jakking of what's already functional. I couldn't make counterfeit work so I scrapped it completely in exchange of something else.

## Why It's Good For The Game

What we got right now is an absurd in a lot of parts, do I have to say more? FREE SAVE MY SOVLLLLLLL! 

## Changelog

:cl:
balance: Problematic/buggy/unhealthy Matthios miracle interactions have been addressed
fix: Fiber bundles were not counting properly for kingsfeast
/:cl: