### PR TITLE
[TM] Riposte, Swingdelays and Tempo & Misc

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -124,6 +124,7 @@
 #define SWINGDELAY_NORMAL 1	//No penalties, we just swing.
 #define SWINGDELAY_PENALTY 2 //We suffer a defensive penalty if struck during it. Otherwise, normal.
 #define SWINGDELAY_CANCEL 3 //We have -no- defense during it, and it can be interrupted if we are hit.
+#define SWINGDELAY_CANCELSLOW 4	//Same as cancel but our speed is also hardset to 10 for the delay.
 
 //Grab levels
 #define GRAB_PASSIVE				0

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -397,12 +397,15 @@
 		if(SWINGDELAY_PENALTY)
 			apply_status_effect(/datum/status_effect/swingdelay/penalty, delay)
 			return TRUE
-		if(SWINGDELAY_CANCEL)
-			apply_status_effect(/datum/status_effect/swingdelay/disrupt, delay)
+		if(SWINGDELAY_CANCEL, SWINGDELAY_CANCELSLOW)
+			apply_status_effect(/datum/status_effect/swingdelay/disrupt, delay, (used_intent.swingdelay_type == SWINGDELAY_CANCELSLOW ? TRUE : FALSE))
 			return TRUE
 
-/mob/living/proc/is_swinging()
-	return (has_status_effect(/datum/status_effect/swingdelay) || has_status_effect(/datum/status_effect/swingdelay/disrupt))
+/mob/living/proc/is_swinging(disrupt_only = FALSE)
+	if(!disrupt_only)
+		return (has_status_effect(/datum/status_effect/swingdelay) || has_status_effect(/datum/status_effect/swingdelay/disrupt))
+	else
+		return (has_status_effect(/datum/status_effect/swingdelay/disrupt))
 
 //Branching path for Adjacent clicks with or without items
 //DOES NOT ACTUALLY KNOW IF YOU'RE ADJACENT, DO NOT CALL ON IT'S OWN

--- a/code/datums/status_effects/rogue/roguestatus.dm
+++ b/code/datums/status_effects/rogue/roguestatus.dm
@@ -83,6 +83,12 @@
 	mob_effect_icon_state = "eff_swingdelay_cancel"
 	var/is_disrupted = FALSE
 
+/datum/status_effect/swingdelay/disrupt/on_creation(mob/living/new_owner, newdur, apply_slow = FALSE)
+	. = ..()
+	if(apply_slow)
+		var/spd_mod = 10 - owner.get_true_stat(STATKEY_SPD)
+		effectedstats = list(STATKEY_SPD = spd_mod)
+
 /datum/status_effect/swingdelay/disrupt/proc/attacked()
 	owner.swing_state = FALSE
 	is_disrupted = TRUE

--- a/code/datums/status_effects/rogue/roguestatus.dm
+++ b/code/datums/status_effects/rogue/roguestatus.dm
@@ -84,10 +84,10 @@
 	var/is_disrupted = FALSE
 
 /datum/status_effect/swingdelay/disrupt/on_creation(mob/living/new_owner, newdur, apply_slow = FALSE)
-	. = ..()
 	if(apply_slow)
-		var/spd_mod = 10 - owner.get_true_stat(STATKEY_SPD)
+		var/spd_mod = 10 - new_owner.get_true_stat(STATKEY_SPD)
 		effectedstats = list(STATKEY_SPD = spd_mod)
+	. = ..()
 
 /datum/status_effect/swingdelay/disrupt/proc/attacked()
 	owner.swing_state = FALSE

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -222,7 +222,7 @@
 				inspec += SPAN_TOOLTIP("The swing will be without any unusual effects.", "<font color='#e6e6e6'><u>Normal</u></font>")
 			if(SWINGDELAY_PENALTY)
 				inspec += SPAN_TOOLTIP("The swing will reduce my defense by a significant amount.", "<font color='#dab141'><u>Difficult</u></font>")
-			if(SWINGDELAY_CANCEL)
+			if(SWINGDELAY_CANCEL, SWINGDELAY_CANCELSLOW)
 				inspec += SPAN_TOOLTIP("I will have no chance to defend while swinging, and a strike against me will interrupt it.", "<font color='#a70d0d'><u>Rigid</u></font>")
 		
 	if(cleave)

--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -289,13 +289,18 @@
 
 /datum/intent/axe/cut/long
 	reach = 2
-	swingdelay = 0.4 SECONDS
+	damfactor = 1
+	demolition_mod = 1
 
-/datum/intent/axe/chop/long
+/datum/intent/axe/cut/long/bronze
+	damfactor = 0.8
+	demolition_mod = 1.3
+
+/datum/intent/axe/chop/long/bronze
 	reach = 2
-	damfactor = 1.2
-	demolition_mod = 2
-	swingdelay = 1.2 SECONDS
+	damfactor = 1
+	demolition_mod = 1.5
+	swingdelay = 0.5 SECONDS
 
 /obj/item/rogueweapon/stoneaxe/woodcut/steel/woodcutter
 	name = "woodcutter's axe"
@@ -459,7 +464,7 @@
 	force = 15
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/axe/sweep)
+	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
 	name = "greataxe"
 	desc = "A large axe, requiring both hands to properly swing. It carves, chops, and cleaves from afar."
 	icon_state = "igreataxe"
@@ -477,7 +482,7 @@
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/iron
 	associated_skill = /datum/skill/combat/axes
-	wdefense = 6
+	wdefense = 4
 
 /obj/item/rogueweapon/greataxe/getonmobprop(tag)
 	. = ..()
@@ -493,8 +498,6 @@
 /obj/item/rogueweapon/greataxe/steel
 	force = 15
 	force_wielded = 30
-	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/axe/sweep)
 	name = "steel greataxe"
 	desc = "A large axe with a sharpened steel edge, requiring both hands to properly swing. It carves, chops, and cleaves from afar."
 	icon_state = "sgreataxe"
@@ -506,7 +509,7 @@
 	force = 15
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
+	gripped_intents = list(/datum/intent/axe/cut/long/bronze, /datum/intent/axe/chop/long/bronze, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
 	name = "bronze greataxe"
 	desc = "A massive staff with a bronze axhead mantled onto the wood. It splits and carves from afar with lethal force; be it lumber or limbs."
 	icon_state = "bronzegreataxe"
@@ -514,7 +517,6 @@
 	wdefense = 7
 	max_blade_int = 400
 	smeltresult = /obj/item/ingot/bronze
-	armor_penetration = PEN_NONE
 	throwforce = 32
 	throw_speed = 3
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 33, "embedded_fall_chance" = 2)
@@ -602,6 +604,7 @@
 	afar. </br>'Crush your enemies, see them driven before you, and hear the lamentations of the women..'"
 	icon_state = "doublegreataxe"
 	max_blade_int = 230
+	wdefense = 3
 	minstr = 13
 
 /obj/item/rogueweapon/greataxe/steel/doublehead/graggar

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1340,7 +1340,7 @@
 	damfactor = 1.3
 	penfactor = PEN_BSTEEL
 
-	swingdelay_type = SWINGDELAY_CANCEL
+	swingdelay_type = SWINGDELAY_CANCELSLOW
 	canparry = FALSE
 	candodge = FALSE
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1231,7 +1231,7 @@
 	inhand_y_dimension = 64
 	dropshrink = 0.75
 	max_blade_int = 230
-	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/thrust/rapier/lunge, /datum/intent/sword/cut/rapier)
+	possible_item_intents = list(/datum/intent/sword/thrust/rapier, /datum/intent/sword/cut/rapier, /datum/intent/sword/thrust/rapier/lunge)
 	gripped_intents = null
 	special = /datum/special_intent/piercing_lunge
 	parrysound = list(
@@ -1345,6 +1345,7 @@
 	candodge = FALSE
 
 	swingdelay = 0.8 SECONDS
+	clickcd = 1.5 SECONDS
 
 /obj/item/rogueweapon/sword/rapier/dec
 	name = "decorated rapier"

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -223,7 +223,7 @@
 		newcd = 5 SECONDS
 		special_msg = span_warning("They need to see me for me to feint them!")
 
-	perc = CLAMP(perc, 0, 90)
+	perc = CLAMP(perc, 10, 90)
 
 	if(!prob(perc)) //feint intent increases the immobilize duration significantly
 		playsound(user, 'sound/combat/feint.ogg', 100, TRUE)

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -194,6 +194,13 @@
 	if(istype(active_spell) && (active_spell.currently_charging || active_spell.charged))
 		to_chat(src, span_warning("I can't guard while channeling a spell!"))
 		return FALSE
+
+	if(is_swinging(disrupt_only = TRUE))
+		return FALSE
+
+	if(has_status_effect(/datum/status_effect/debuff/exposed))
+		return FALSE
+
 	apply_status_effect(/datum/status_effect/buff/clash)
 	return TRUE
 
@@ -296,7 +303,7 @@
 	return highest_ac
 
 /mob/living/carbon/human/proc/process_tempo_attack(mob/living/carbon/attacker)
-	if(iscarbon(attacker) && attacker.mind && attacker != src)
+	if(iscarbon(attacker) && attacker != src) //! && attacker.mind
 		if(length(tempo_attackers) <= TEMPO_CAP || (attacker in tempo_attackers))	//This list auto-culls so we don't need to flood it. If you're fighting 7 dudes at the same time you've got other problems.
 			var/newtime
 			var/att_count = length(tempo_attackers)

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -303,8 +303,8 @@
 	return highest_ac
 
 /mob/living/carbon/human/proc/process_tempo_attack(mob/living/carbon/attacker)
-	if(iscarbon(attacker) && attacker != src) //! && attacker.mind
-		if(length(tempo_attackers) <= TEMPO_CAP || (attacker in tempo_attackers))	//This list auto-culls so we don't need to flood it. If you're fighting 7 dudes at the same time you've got other problems.
+	if(iscarbon(attacker) && attacker != src && attacker.mind)
+		if(length(tempo_attackers) <= TEMPO_CAP || (REF(attacker) in tempo_attackers))	//This list auto-culls so we don't need to flood it. If you're fighting 7 dudes at the same time you've got other problems.
 			var/newtime
 			var/att_count = length(tempo_attackers)
 			switch(att_count)
@@ -314,7 +314,7 @@
 					newtime = world.time + TEMPO_DELAY_TWO
 				if(TEMPO_MAX to TEMPO_CAP)
 					newtime = world.time + TEMPO_DELAY_MAX
-			tempo_attackers[attacker] = newtime
+			tempo_attackers[REF(attacker)] = newtime
 			next_tempo_cull = world.time + TEMPO_CULL_DELAY	//We reset the autocull timer on a hit from a valid person.
 		manage_tempo()
 


### PR DESCRIPTION
## About The Pull Request
- Fixed a severe bug (how many more do we have I wonder) that counted every "Unknown" attacker as the same one for the purposes of Tempo.
- Added a way for red ("Rigid" in-game) swingdelays to apply a slow, hard-setting the SPD of the attacker to 10 for the duration.
   - Applied this type to the Rapier lunge. This means it will also pen less (the attack connects before the status ends) without extra speed boosts.
- Riposte is no longer usable while under the effects of a red ("Rigid") swingdelay.
- Riposte is no longer usable while Exposed (red shield). Works fine while made Vulnerable (white shield), though.

- Greataxes were reviewed and their intents no longer have a swingdelay, but deal less damage (have less damfactor & demolition factor)
- Greataxes had their wdef lowered to no longer have more than shorter weapons.
- Minimum feint% is now 10%.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Most footage here would be very subtle (a slowdown with a rapier) or stuff working / not working without any real indication that it's any different.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The swing delays are new and if the moggers are to be believed the Rapier one is the most overtly problematic. I'm not particularly keen to nerf every red delay because of it or make it significantly harder to use for everyone (by increasing its duration), so this is more of a surgical vasectomy. 

As for Riposte -- it's just following my own design intentions. The hotkey changes + exposed / vuln separation didn't cleanly account for Riposte usage. An Exposed is the more severe effect that happens due to a mistake -- something a user shouldn't just riposte out of. Vulns are often imposed far more easily (via a rclick with feint, quicker specials or even projectiles), so they're a lot cheaper, and are fine to riposte through.

This goes doubly so for Red swingdelays.

And for Tempo, uh. I honestly have no idea how long it's been broken like this, I assume from its conception, so this will likely result in even more Tempo tweaks as *suddenly* it will be triggering so much more often. Mostly due to this bugfix it's gonna be TM only for this PR for a while.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed a bug that prevented Tempo from counting "Unknown" attackers properly.
balance: Some Red ("Rigid") swingdelays now apply a slow down to X SPD for their duration. This was applied to Rapier's Lunge.
balance: Greataxes had their swingdelays from base intents removed. Instead they had their wdef lowered relative to their non-reach counterparts.
balance: Riposte no longer works while under the effects of a Red ("Rigid") swingdelay.
balance: Riposte no longer works while Exposed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
