### PR TITLE
[TM only] Familiar 2 Maintenence PR

### DIFF
--- a/code/__DEFINES/familiars.dm
+++ b/code/__DEFINES/familiars.dm
@@ -95,3 +95,5 @@ GLOBAL_LIST_INIT(planar_lists, list(
 	"elemental" = GLOB.elemental_familiars,
 	"void" = null
 ))
+
+GLOBAL_LIST_INIT(familiar_advertised, list())

--- a/code/game/objects/items/rogueitems/magic/magic_resources.dm
+++ b/code/game/objects/items/rogueitems/magic/magic_resources.dm
@@ -27,13 +27,18 @@
 
 /obj/item/magic/familiar
 	resistance_flags = INDESTRUCTIBLE
+	var/mob/living/simple_animal/pet/familiar/stored_familiar
+
+/obj/item/magic/familiar/dropped(mob/user, silent)
+	. = ..()
+	if(stored_familiar)
+		stored_familiar.reset_perspective()
 
 // vestige - needed to revive a familiar. sort of like a carbon's head, but magic-style
 /obj/item/magic/familiar/familiar_vestige
 	name = "Planar Vestige"
 	icon_state = "abberant"
 	desc = "The vestige of a planar creature, departed from this plane. Likely worth a lot to the magos that summoned them!"
-	var/mob/living/simple_animal/pet/familiar/stored_familiar
 
 // familiar (item form): familiars can transform into this for portability and sovl
 /obj/item/magic/familiar/familiar_spirit

--- a/code/game/objects/items/rogueitems/magic/magic_resources.dm
+++ b/code/game/objects/items/rogueitems/magic/magic_resources.dm
@@ -25,21 +25,21 @@
 	grid_height = 32
 	var/tier = 0 //used for determining potency for mob healing
 
+/obj/item/magic/familiar
+	resistance_flags = INDESTRUCTIBLE
+
 // vestige - needed to revive a familiar. sort of like a carbon's head, but magic-style
-/obj/item/magic/familiar_vestige
+/obj/item/magic/familiar/familiar_vestige
 	name = "Planar Vestige"
 	icon_state = "abberant"
-	var/mob/living/simple_animal/pet/familiar/stored_familiar
-	resistance_flags = INDESTRUCTIBLE // don't even want to know what would happen if you broke this while a familiar was stored inside
 	desc = "The vestige of a planar creature, departed from this plane. Likely worth a lot to the magos that summoned them!"
+	var/mob/living/simple_animal/pet/familiar/stored_familiar
 
 // familiar (item form): familiars can transform into this for portability and sovl
-/obj/item/magic/familiar_spirit
+/obj/item/magic/familiar/familiar_spirit
 	name = "Familiar Spirit"
 	icon = 'icons/roguetown/mob/familiars.dmi'
-	resistance_flags = INDESTRUCTIBLE
 	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK|ITEM_SLOT_RING // little pendant-esque thing
-	desc = "You should not be seeing this!"
 
 // MELD
 /obj/item/magic/melded

--- a/code/modules/client/familiar_prefs.dm
+++ b/code/modules/client/familiar_prefs.dm
@@ -81,7 +81,7 @@
 			if (lore_blurb)
 				dat += "<br><i><b>Lore inspiration:</b> [lore_blurb]</i>"
 		dat += "<br><b>Examine settings:</b> <a href='?_src_=familiar_prefs;preference=familiar_examine;task=select;planar_origin=[planar_origin]'>Open</a>"
-	dat += "<br><br><i>Press this button to send a hint to all arcyne users, once per round, that you are available and wish to be summoned:</i> <a href='?_src_=familiar_prefs;preference=pulse'>Pulse</a>"
+	dat += "<br><br><i>Press this button to send a hint to all arcyne users that you are available and wish to be summoned:</i> <a href='?_src_=familiar_prefs;preference=pulse'>Pulse</a>"
 	var/datum/browser/popup = new(client?.mob, "Familiar Preferences", "<center>Familiar Preferences</center>", 900, 900)
 	popup.set_window_options("can_close=1")
 	popup.set_content(dat.Join())
@@ -236,17 +236,23 @@
 
 		if("pulse")
 			if(user.ckey in GLOB.familiar_advertised)
-				to_chat(user, span_info("You have already advertised your presence this week; no more."))
+				to_chat(user, span_info("You have already advertised your presence recently; have patience."))
 				return
 			for(var/mob/living/carbon/human/advertisee in GLOB.alive_mob_list)
 				if(!advertisee.client)
 					continue
 				if(HAS_TRAIT(advertisee, TRAIT_ARCYNE))
 					to_chat(advertisee, span_info("The leylines pulse beneath your feet... a new familiar strains against the veil, seeking to be summoned!"))
+			to_chat(user, span_notice("All alive arcyne users have been notified; you may send out another pulse in 10 minutes."))
 			GLOB.familiar_advertised += user.ckey
+			addtimer(CALLBACK(src, PROC_REF(remove_ckey), user.ckey), 10 MINUTES)
 
 	if(user.client)
 		fam_show_ui()
+
+// because you can't add a callback to list.operator--, apparently. woe
+/datum/familiar_prefs/proc/remove_ckey(ckey)
+	GLOB.familiar_advertised -= ckey
 
 // used for updating old objects without wiping the rest of the prefs
 /datum/familiar_prefs/proc/instantiate_examine_prefs()

--- a/code/modules/client/familiar_prefs.dm
+++ b/code/modules/client/familiar_prefs.dm
@@ -81,7 +81,7 @@
 			if (lore_blurb)
 				dat += "<br><i><b>Lore inspiration:</b> [lore_blurb]</i>"
 		dat += "<br><b>Examine settings:</b> <a href='?_src_=familiar_prefs;preference=familiar_examine;task=select;planar_origin=[planar_origin]'>Open</a>"
-
+	dat += "<br><br><i>Press this button to send a hint to all arcyne users, once per round, that you are available and wish to be summoned.</i> <a href='?_src_=familiar_prefs;preference=pulse'>Pulse</a>"
 	var/datum/browser/popup = new(client?.mob, "Familiar Preferences", "<center>Familiar Preferences</center>", 900, 900)
 	popup.set_window_options("can_close=1")
 	popup.set_content(dat.Join())
@@ -233,6 +233,17 @@
 			log_game("[user] has set their Familiar OOC Extra to '[link]'.")
 			setup_examine_window(user,planar_origin)
 			return
+
+		if("pulse")
+			if(user.ckey in GLOB.familiar_advertised)
+				to_chat(user, span_info("You have already advertised your presence this week; no more."))
+				return
+			for(var/mob/living/carbon/human/advertisee in GLOB.alive_mob_list)
+				if(!advertisee.client)
+					continue
+				if(HAS_TRAIT(advertisee, TRAIT_ARCYNE))
+					to_chat(advertisee, span_info("The leylines pulse beneath your feet... a new familiar strains against the veil, seeking to be summoned!"))
+			GLOB.familiar_advertised += user.ckey
 
 	if(user.client)
 		fam_show_ui()

--- a/code/modules/client/familiar_prefs.dm
+++ b/code/modules/client/familiar_prefs.dm
@@ -81,7 +81,7 @@
 			if (lore_blurb)
 				dat += "<br><i><b>Lore inspiration:</b> [lore_blurb]</i>"
 		dat += "<br><b>Examine settings:</b> <a href='?_src_=familiar_prefs;preference=familiar_examine;task=select;planar_origin=[planar_origin]'>Open</a>"
-	dat += "<br><br><i>Press this button to send a hint to all arcyne users, once per round, that you are available and wish to be summoned.</i> <a href='?_src_=familiar_prefs;preference=pulse'>Pulse</a>"
+	dat += "<br><br><i>Press this button to send a hint to all arcyne users, once per round, that you are available and wish to be summoned:</i> <a href='?_src_=familiar_prefs;preference=pulse'>Pulse</a>"
 	var/datum/browser/popup = new(client?.mob, "Familiar Preferences", "<center>Familiar Preferences</center>", 900, 900)
 	popup.set_window_options("can_close=1")
 	popup.set_content(dat.Join())

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -64,6 +64,7 @@
 	var/summoning_emote = null
 	var/list/valid_healing_items = list() // what planar materials can heal you?
 	var/planar_origin = "void" // what plane are we from? avoids a bunch of istype checks
+	rot_type = null // no rotting inside vestiges please
 	
 //As far as I am aware, you cannot pat out fire as a familiar at least not in time for it to not kill you, this seems fair.
 /mob/living/simple_animal/pet/familiar/fire_act(added, maxstacks)

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -70,6 +70,10 @@
 	. = ..()
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living, extinguish_mob)), 1 SECONDS)
 
+// if they are within the orb, they should not be able to commit recursion
+/mob/living/simple_animal/pet/familiar/restrained(ignore_grab)
+	return !isturf(src.loc)
+
 /mob/living/simple_animal/pet/familiar/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NOFALLDAMAGE1, TRAIT_GENERIC)

--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -82,9 +82,9 @@
 
 /mob/living/simple_animal/pet/familiar/death(gibbed)
 	. = ..(gibbed)
-	var/obj/item/magic/familiar_vestige/vestige = new /obj/item/magic/familiar_vestige(loc)
+	var/obj/item/magic/familiar/familiar_vestige/vestige = new /obj/item/magic/familiar/familiar_vestige(loc)
 	vestige.stored_familiar = src
-	src.loc = vestige
+	src.forceMove(vestige)
 	vestige.desc = "The vestige of [src.name], a fallen [GLOB.familiar_display_names[src.type]]. Likely worth a lot to the magos that summoned [src.p_them()]!"
 
 /mob/living/simple_animal/pet/familiar/proc/TryAddFlight()

--- a/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
@@ -199,6 +199,7 @@
 	to_chat(fam, span_warning("You feel your link with [user.name] break, you are free."))
 
 	fam.familiar_summoner = null
+	GLOB.character_ckey_list -= fam.real_name
 
 	user.mind?.RemoveSpell(/datum/action/cooldown/spell/message_familiar)
 	fam.mind?.RemoveSpell(/datum/action/cooldown/spell/message_summoner)

--- a/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
@@ -157,13 +157,13 @@
 /datum/runeritual/binding/revive_familiar
 	name = "Revive Familiar"
 	desc = "Return a departed familiar to lyfe, so long as they have not yet fully returned to their home plane. Requires the vestige dropped upon their death."
-	required_atoms = list(/obj/item/magic/melded/t1 = 1, /obj/item/magic/familiar_vestige = 1)
+	required_atoms = list(/obj/item/magic/melded/t1 = 1, /obj/item/magic/familiar/familiar_vestige = 1)
 	blacklisted = FALSE
 	invocation = "Redeo, spiritus fidus!" // "return, loyal spirit"
 
 /datum/runeritual/binding/revive_familiar/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = FALSE
-	for(var/obj/item/magic/familiar_vestige/vestige in selected_atoms)
+	for(var/obj/item/magic/familiar/familiar_vestige/vestige in selected_atoms)
 		if(vestige.stored_familiar)
 			if(!vestige.stored_familiar.client)
 				to_chat(user, span_warning("[vestige.stored_familiar.name] has fully departed for their home plane... they cannot be revived!"))

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -298,6 +298,8 @@
 		"Spoon" = /obj/item/kitchen/spoon/iron,
 		"Needle" = /obj/item/needle/thorn
 	)
+	cooldown_time = 30 SECONDS
+	charge_required = FALSE
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/cast(atom/cast_on)
 	. = ..()
@@ -307,9 +309,10 @@
 
 	// We're an item. Stop being an item.
 	if(conjured_item && !QDELETED(conjured_item))
-		H.loc = get_turf(H)
-		QDEL_NULL(conjured_item)
+		revert()
 		return FALSE // we don't want to add a cooldown for this case
+	else if (!isturf(H.loc))
+		return FALSE // no casting this from the orb
 
 	var/choice = tgui_input_list(H, "Choose what to conjure", "Earthen Forge", conjure_options)
 	if(!choice)
@@ -330,9 +333,13 @@
 	// Conjured glow
 	R.AddComponent(/datum/component/conjured_item, GLOW_COLOR_EARTHEN)
 	RegisterSignal(R, COMSIG_ITEM_BROKEN, PROC_REF(revert))
+	RegisterSignal(R, COMSIG_ITEM_DROPPED, PROC_REF(revert_perspective))
 	H.forceMove(R)
 	conjured_item = R
 	return TRUE
+
+/datum/action/cooldown/spell/arcyne_forge/elemental/proc/revert_perspective()
+	owner.reset_perspective()
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/proc/revert()
 	if(conjured_item)
@@ -343,7 +350,8 @@
 	name = "Greater Earthen Shaping"
 	desc = "Shape a weapon or tool of your choice out of raw earth. Conjured items have halved durability.\n\
 	Only one conjured item can exist at a time - conjuring a new one destroys the old."
-
+	cooldown_time = 5 MINUTES
+	charge_required = TRUE
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/t2/cast(atom/cast_on)
 	. = ..()

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -43,7 +43,7 @@
 		return FALSE
 
 	var/user_z = user.z
-	var/obj/item/magic/familiar_vestige/vestige = fam.loc
+	var/obj/item/magic/familiar/familiar_vestige/vestige = fam.loc
 	if(!istype(vestige))
 		to_chat(user, span_warning("The familiar is not within their vestige. This should not happen!"))
 	var/dist = get_dist(user, vestige)
@@ -123,20 +123,20 @@
 		return FALSE
 	if(isturf(user.loc))
 		// we're on the ground somewhere, so we should become orb
-		var/obj/item/magic/familiar_spirit/spirit = new /obj/item/magic/familiar_spirit(user.loc)
+		var/obj/item/magic/familiar/familiar_spirit/spirit = new /obj/item/magic/familiar/familiar_spirit(user.loc)
 		spirit.icon = user.icon
 		spirit.icon_state = user.icon_living
 		spirit.name = user.name
 		spirit.desc = "A small orb, containing the spirit of [user.name]."
-		user.loc = spirit
+		user.forceMove(spirit)
 		return TRUE
 	else
 		if(user.health<=0) // you shouldn't be able to cast this while dead, but just in case
 			return FALSE
-		var/obj/item/magic/familiar_spirit/spirit = user.loc
+		var/obj/item/magic/familiar/familiar_spirit/spirit = user.loc
 		if(!istype(spirit)) // we might be inside another item like warden tools
 			return FALSE
-		user.loc = get_turf(user)
+		user.forceMove(get_turf(user))
 		qdel(spirit)
 		return TRUE
 
@@ -330,13 +330,13 @@
 	// Conjured glow
 	R.AddComponent(/datum/component/conjured_item, GLOW_COLOR_EARTHEN)
 	RegisterSignal(R, COMSIG_ITEM_BROKEN, PROC_REF(revert))
-	H.loc = R
+	H.forceMove(R)
 	conjured_item = R
 	return TRUE
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/proc/revert()
 	if(conjured_item)
-		owner.loc = get_turf(owner)
+		owner.forceMove(get_turf(owner))
 		QDEL_NULL(conjured_item)
 
 /datum/action/cooldown/spell/arcyne_forge/elemental/t2


### PR DESCRIPTION
## About The Pull Request
since familiar 2 was fullmerged while there were still outstanding feature requests and bugs to fix, this is where those are going

## Testing Evidence
can't repro the hearing bug on local, so the bugfix needs to be tested on live
<img width="784" height="80" alt="image" src="https://github.com/user-attachments/assets/1dd01b0c-b27c-479f-80ea-2c5b68ae603d" />
<img width="573" height="46" alt="image" src="https://github.com/user-attachments/assets/5a777395-adef-4406-8830-27b1f6f2df6c" />
<img width="451" height="35" alt="image" src="https://github.com/user-attachments/assets/d5de20b8-91f3-4c64-9e1b-3126a252ddc5" />

## Why It's Good For The Game
popularly requested tweaks like familiars being able to advertise their presence (limited to once per player per ten minutes to prevent spam); and bugfixes are always nice 

## Changelog

:cl:
add: Familiars can now advertise their presence to arcyne users like they could in my old PR
fix: Familiars no longer rot, delete themselves by committing recursion, lose hearing when carried in item form, or permanently delete name slots when freed.
qol: Familiar revival now needs to be near a leyline, but costs no materials other than the vestige
fix: Reagent bite can now be cancelled by the target moving (which was always intended to be the case)
fix: Updated encyclopedia to reflect binding changes
fix: Familiars can now read parchments and noticeboards
/:cl:
