### PR TITLE
[Bugfix] - Makes guaranteed dream effects bypass the math

### DIFF
--- a/code/game/objects/effects/gods/unassuming_fluff.dm
+++ b/code/game/objects/effects/gods/unassuming_fluff.dm
@@ -24,18 +24,19 @@ GLOBAL_LIST_EMPTY(players_in_dream)
 	stressadd = 20
 	desc = span_userdanger("WHAT IS THAT THING?!")
 
-/proc/teleport_to_dream(mob/living/carbon/human/user, base_probability = 10000, probability = 10, weapons = TRUE, duration = 2 MINUTES)
+/proc/teleport_to_dream(mob/living/carbon/human/user, base_probability = 10000, probability = 10, weapons = TRUE, duration = 2 MINUTES, force = FALSE)
 	if(!ishuman(user))
 		return
 
-	var/effective_probability = probability
-	if(user.patron.type == /datum/patron/divine/abyssor)
-		effective_probability *= 5
+	if(!force)
+		var/effective_probability = probability
+		if(user.patron.type == /datum/patron/divine/abyssor)
+			effective_probability *= 5
 
-	// Look kids, if you want accurate probability, don't use fractional numbers. Pickweight is safer and more accurate than prob() here.
-	var/list/options = list("teleport" = effective_probability, "no_teleport" = base_probability - effective_probability)
-	if(pickweight(options) == "no_teleport")
-		return
+		// Look kids, if you want accurate probability, don't use fractional numbers. Pickweight is safer and more accurate than prob() here.
+		var/list/options = list("teleport" = effective_probability, "no_teleport" = max(0, base_probability - effective_probability))
+		if(pickweight(options) == "no_teleport")
+			return
 
 	var/area/dream_area = GLOB.areas_by_type[/area/rogue/underworld/dream]
 	if(!dream_area)

--- a/code/game/objects/effects/gods/unassuming_fluff.dm
+++ b/code/game/objects/effects/gods/unassuming_fluff.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_EMPTY(players_in_dream)
 			effective_probability *= 5
 
 		// Look kids, if you want accurate probability, don't use fractional numbers. Pickweight is safer and more accurate than prob() here.
-		var/list/options = list("teleport" = effective_probability, "no_teleport" = max(0, base_probability - effective_probability))
+		var/list/options = list("teleport" = effective_probability, "no_teleport" = max(1, base_probability - effective_probability))
 		if(pickweight(options) == "no_teleport")
 			return
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_spells.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_spells.dm
@@ -228,6 +228,6 @@
 	target.visible_message(span_userdanger("[user] banishes [target] into a dark rift!"))
 	to_chat(target, span_userdanger("The world dissolves into mist as you are dragged into a dream!"))
 
-	teleport_to_dream(target, 1, 1, FALSE, 2 MINUTES)
+	teleport_to_dream(target, 1, 1, FALSE, 2 MINUTES, force = TRUE)
 
 	return TRUE

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_curses/hag_curses_effects.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_curses/hag_curses_effects.dm
@@ -114,7 +114,7 @@
 
 	H.Knockdown(10)
 	H.blur_eyes(20)
-	teleport_to_dream(H, 1, 1, FALSE, 40 SECONDS)
+	teleport_to_dream(H, 1, 1, FALSE, 40 SECONDS, force = TRUE)
 
 /datum/status_effect/curse/hag_slumber/on_remove()
 	UnregisterSignal(owner, COMSIG_SLEEPY_TIME)

--- a/modular/Neu_Food/code/raw/raw_fish.dm
+++ b/modular/Neu_Food/code/raw/raw_fish.dm
@@ -198,7 +198,7 @@
 
 /obj/item/reagent_containers/food/snacks/fish/creepy_eel/pickup(mob/living/user)
 	if(!was_i_picked_up && ishuman(user))
-		teleport_to_dream(user, 1, 1)
+		teleport_to_dream(user, force = TRUE)
 		was_i_picked_up = TRUE
 		desc = "A slimy eel, you feel a strange mundanity looking at it... You're assured there's nothing weird about it whatsoever. It might as well be the most average thing in the realm."
 	..()


### PR DESCRIPTION
## About The Pull Request
Fixes a long standing bug where guaranteed dream effects are actually a 50/50
Turns out that zero values and especially negative values in pickweight lists are weird, and not considered to actually be non items for the math.

Instead, it now bypasses the math if you ask the proc to.

## Testing Evidence
picked up like 15 eels, teleported each time.

## Why It's Good For The Game
Bugfeex.
Reckon this one wasn't really discovered earlier due to the insane rarity of these effects.

## Changelog

:cl:
fix: Abyssor dream isn't shy when it isn't supposed to be now.
/:cl:
