### PR TITLE
Fixes offering candelabrum to Matthios statue damaging it.

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1100,15 +1100,15 @@
 			if(W.flags_1 & HOARDMASTER_SPAWNED_1)
 				to_chat(user, span_warning("This item is from the Hoard!"))
 				return
-			if(W.sellprice <= 0)
-				to_chat(user, span_warning("This item is worthless."))
-				return
 			var/proceed_with_offer = FALSE
 			for(var/TT in treasuretypes)
 				if(istype(W, TT))
 					proceed_with_offer = TRUE
 					break
 			if(proceed_with_offer)
+				if(W.sellprice <= 0)
+					to_chat(user, span_warning("This item is worthless."))
+					return
 				playsound(loc,'sound/items/carvty.ogg', 50, TRUE)
 				log_admin("[user] ([user?.ckey]) submitted [W] ([W.type]) to the Idol, worth [W.get_real_price()]")
 				qdel(W)
@@ -1120,10 +1120,10 @@
 							bandit_players.favor += donatedamnt
 							bandit_players.totaldonated += donatedamnt
 							to_chat(player, ("<font color='yellow'>[user.name] donates [donatedamnt] to the shrine! You now have [bandit_players.favor] favor.</font>"))
+				return //Do not call base - if item sold/given off then stop attacks/hits/other events from using that item on the statue.
 
 			else
 				to_chat(user, span_warning("This item isn't a good offering."))
-				return
 	..()
 
 /obj/structure/fluff/psycross


### PR DESCRIPTION
## About The Pull Request

Fixes the Matthios statue so that offering it a candelabrum or other worthy items won't also make you bash it with them.
Otherwise allows you to normally attack it.

## Testing Evidence

Tried offering it candelabrum, did not damage the statue. Swung a sword at it, able to damage the statue normally.

## Why It's Good For The Game

Minor bugfix.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl: Kelshark
fix: Offering candelabrums to Matthios statue won't also make you hit the statue.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
