### PR TITLE
call of the storm - fleshes out the Warden's loadout, organizes the Warden's inventory, and touches up various aspects of the Warden's backend stuff

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -151,7 +151,7 @@
 	won't be long until they're almost here. Will you cry all your tears, or will you face your fears? </br>Mounted on the back is a unique couplet, fit for adopting feathered greatplumes."
 	icon_state = "barbute_visor"
 	item_state = "barbute_visor"
-	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL
+	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL - ARMOR_INT_HELMET_HEAVY_ADJUSTABLE_PENALTY
 	adjustable = CAN_CADJUST
 	emote_environment = 3
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
@@ -165,7 +165,7 @@
 	desc = "A steel greathelm of inordinate thickness, whose design seems to've been inspired by both a tournament's froggemund and a kingdom's sugarloaf. It is far from elegant, but it will \
 	thwart killing blows again-and-again without compromise. Never forget that a champion of Psydonia needn't nobility nor wealth to become eternal; they need only the courage to be free. \
 	</br>'In their legends, there were no gods - only heroes.'"
-	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL + 50
+	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL
 	icon_state = "barbutedunk"
 	item_state = "barbutedunk"
 	emote_environment = 3

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -151,7 +151,7 @@
 	won't be long until they're almost here. Will you cry all your tears, or will you face your fears? </br>Mounted on the back is a unique couplet, fit for adopting feathered greatplumes."
 	icon_state = "barbute_visor"
 	item_state = "barbute_visor"
-	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL - ARMOR_INT_HELMET_HEAVY_ADJUSTABLE_PENALTY
+	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL
 	adjustable = CAN_CADJUST
 	emote_environment = 3
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
@@ -165,7 +165,7 @@
 	desc = "A steel greathelm of inordinate thickness, whose design seems to've been inspired by both a tournament's froggemund and a kingdom's sugarloaf. It is far from elegant, but it will \
 	thwart killing blows again-and-again without compromise. Never forget that a champion of Psydonia needn't nobility nor wealth to become eternal; they need only the courage to be free. \
 	</br>'In their legends, there were no gods - only heroes.'"
-	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL
+	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL + 50
 	icon_state = "barbutedunk"
 	item_state = "barbutedunk"
 	emote_environment = 3

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -94,20 +94,20 @@
 	H.set_blindness(0)
 
 	if(H.mind)
-		var/armor_options = list("Ranger - Dodge Expert, Padded Gambeson + Bracers", "Sentinel - Maille Training, Iron Hauberk + Jackchains")
-		var/armor_choice = input(H, "Choose your ARMOR.", "EVADE OR ENDURE.") as anything in armor_options
+		var/armor_options = list("Light - Dodge Expert, Padded Gambeson", "Medium - Maille Training, Iron Hauberk")
+		var/armor_choice = input(H, "Choose your ARMOR.", "PREPARE FOR THE HUNT-TO-COME.") as anything in armor_options
 		switch(armor_choice) //Like Skirmisher, you are not getting both. Choose wisely.
-			if("Ranger - Dodge Expert, Padded Gambeson + Bracers")
+			if("Light - Dodge Expert, Padded Gambeson")
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-			if("Sentinel - Maille Training, Iron Hauberk + Jackchains")
+			if("Medium - Maille Training, Iron Hauberk")
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain
 				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 		var/weapon_options = list("Bowhunter - Warden's Longbow + 20 Broadheads", "Spearhunter - Spear + Sling, +I STR / -I SPD")
-		var/weapon_choice = input(H, "Choose your SPECIALITY.", "PREPARE FOR THE HUNT.") as anything in weapon_options
+		var/weapon_choice = input(H, "Choose your SPECIALITY.", "JACK OF MANY TRADES, MASTER OF NONE.") as anything in weapon_options
 		switch(weapon_choice)
 			if("Bowhunter - Warden's Longbow + 20 Broadheads")
 				beltr = /obj/item/quiver/arrows
@@ -128,7 +128,7 @@
 			"Path of the Rous"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/rat,
 			"None"
 		)
-		var/helmchoice = input(H, "Choose your HELMET.", "FOLLOW THE PATH.") as anything in helmets
+		var/helmchoice = input(H, "Choose your HELMET.", "FOLLOW THE PATH OF YOUR ANCESTORS.") as anything in helmets
 		if(helmchoice != "None")
 			head = helmets[helmchoice]
 
@@ -137,7 +137,7 @@
 			"Antlered Shroud"		= /obj/item/clothing/head/roguetown/roguehood/warden/antler,
 			"None"
 		)
-		var/hoodchoice = input(H, "Choose your SHROUD.", "LEST THEY SEE YOUR EYES.") as anything in hoods
+		var/hoodchoice = input(H, "Choose your SHROUD.", "LEST THEY SEE THE WHITES OF YOUR EYES.") as anything in hoods
 		if(hoodchoice != "None")
 			mask = hoods[hoodchoice]
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -117,6 +117,8 @@ extra_context = "Wardens receive a boost to Perception, Willpower, and Speed whe
 				r_hand = /obj/item/rogueweapon/spear
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
+				H.change_stat(STATKEY_SPD, -1)
+				H.change_stat(STATKEY_STR, 1)
 
 		var/helmets = list(
 			"Path of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -9,8 +9,8 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
-	tutorial = "Typically a denizen of the sparsely populated Azurian woods, you are a volunteer with the Wardens; a fraternity of rangers who keep a vigil over the untamed wilderness. \
-				While you may not be a professional soldier of the Watch, you nevertheless serve as the first line of defense against outside threats and an early warning of problems to come. \
+	tutorial = "You are a volunteer with the Wardens; a fraternity of rangers who keep a vigil over Azuria's untamed wilderness. \
+				While you may not be a professional soldier, you nevertheless serve as the first line of defense against outside threats and an early warning of problems to come. \
 				Obey your Sergeant-at-Arms, the Marshal, and the Crown. Serve their will, and you will receive that which a Warden covets most - freedom and safety."
 
 	display_order = JDO_WARDEN
@@ -33,7 +33,6 @@
 	cloak = /obj/item/clothing/cloak/wardencloak
 	backr = /obj/item/storage/backpack/rogue/satchel
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
@@ -95,20 +94,22 @@
 	H.set_blindness(0)
 
 	if(H.mind)
-		var/armor_options = list("Ranger - Dodge Expert, Padded Gambeson", "Sentinel - Maille Training, Iron Hauberk")
-		var/armor_choice = input(H, "Choose your ARMOR.", "EVADE OR ENDURE, LEST THE FORESTS DRAG YOU DOWN.") as anything in armor_options
-		switch(armor_choice)//Like skirmisher, you are not getting both
-			if("Ranger - Dodge Expert, Padded Gambeson")
+		var/armor_options = list("Ranger - Dodge Expert, Padded Gambeson + Bracers", "Sentinel - Maille Training, Iron Hauberk + Jackchains")
+		var/armor_choice = input(H, "Choose your ARMOR.", "EVADE OR ENDURE.") as anything in armor_options
+		switch(armor_choice) //Like Skirmisher, you are not getting both. Choose wisely.
+			if("Ranger - Dodge Expert, Padded Gambeson + Bracers")
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-			if("Sentinel - Maille Training, Iron Hauberk")
+ 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+			if("Sentinel - Maille Training, Iron Hauberk + Jackchains")
 				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
-		var/weapon_options = list("Warden's Longbow + 20 Broadhead Arrows", "Spearhunter - Spear + Sling, +I STR / -I SPD")
-		var/weapon_choice = input(H, "Choose your SPECIALITY.", "ADOPT YOUR FORM FOR THE HUNT-TO-COME.") as anything in weapon_options
+		var/weapon_options = list("Bowhunter - Warden's Longbow + 20 Broadheads", "Spearhunter - Spear + Sling, +I STR / -I SPD")
+		var/weapon_choice = input(H, "Choose your SPECIALITY.", "PROFESS YOUR FOOTWORK.") as anything in weapon_options
 		switch(weapon_choice)
-			if("Bowhunter - Warden's Longbow + 20 Broadhead Arrows")
+			if("Bowhunter - Warden's Longbow + 20 Broadheads")
 				beltr = /obj/item/quiver/arrows
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/warden
 			if("Spearhunter - Spear + Sling, +I STR / -I SPD")
@@ -127,7 +128,7 @@
 			"Path of the Rous"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/rat,
 			"None"
 		)
-		var/helmchoice = input(H, "Choose your HELMET.", "FOLLOW THE PATH OF YOUR SPIRITBEASTE.") as anything in helmets
+		var/helmchoice = input(H, "Choose your HELMET.", "FOLLOW THE PATH.") as anything in helmets
 		if(helmchoice != "None")
 			head = helmets[helmchoice]
 
@@ -136,7 +137,7 @@
 			"Antlered Shroud"		= /obj/item/clothing/head/roguetown/roguehood/warden/antler,
 			"None"
 		)
-		var/hoodchoice = input(H, "Choose your SHROUD.", "DO NOT GIFT THEM THE GLIMMER OF YOUR EYE.") as anything in hoods
+		var/hoodchoice = input(H, "Choose your SHROUD.", "LEST THEY SEE YOUR EYES.") as anything in hoods
 		if(hoodchoice != "None")
 			mask = hoods[hoodchoice]
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -99,15 +99,15 @@
 		switch(armor_choice) //Like Skirmisher, you are not getting both. Choose wisely.
 			if("Ranger - Dodge Expert, Padded Gambeson + Bracers")
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
- 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 			if("Sentinel - Maille Training, Iron Hauberk + Jackchains")
-				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 		var/weapon_options = list("Bowhunter - Warden's Longbow + 20 Broadheads", "Spearhunter - Spear + Sling, +I STR / -I SPD")
-		var/weapon_choice = input(H, "Choose your SPECIALITY.", "PROFESS YOUR FOOTWORK.") as anything in weapon_options
+		var/weapon_choice = input(H, "Choose your SPECIALITY.", "PREPARE FOR THE HUNT.") as anything in weapon_options
 		switch(weapon_choice)
 			if("Bowhunter - Warden's Longbow + 20 Broadheads")
 				beltr = /obj/item/quiver/arrows

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -56,8 +56,8 @@
 		STATKEY_SPD = 1 //(2 with buff)
 	)//8 points weighted, look at their buff to understand as to why.
 	subclass_skills = list(
-		/datum/skill/combat/bows = SKILL_LEVEL_MASTER,
-		/datum/skill/combat/slings = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/bows = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/slings = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
@@ -106,17 +106,19 @@
 				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
-		var/weapon_options = list("Bowhunter - Warden's Longbow + 20 Broadheads", "Spearhunter - Spear + Sling, +I STR / -I SPD")
+		var/weapon_options = list("Bowhunter - Blackhorn Bow + 20 Broadheads", "Spearhunter - Spear + Sling, +I STR / -I SPD")
 		var/weapon_choice = input(H, "Choose your SPECIALITY.", "JACK OF MANY TRADES, MASTER OF NONE.") as anything in weapon_options
 		switch(weapon_choice)
-			if("Bowhunter - Warden's Longbow + 20 Broadheads")
+			if("Bowhunter - Blackhorn Bow + 20 Broadheads")
 				beltr = /obj/item/quiver/arrows
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/warden
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_MASTER, TRUE)
 			if("Spearhunter - Spear + Sling, +I STR / -I SPD")
 				beltr = /obj/item/quiver/sling/iron
 				r_hand = /obj/item/rogueweapon/spear
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
+				H.adjust_skillrank_up_to(/datum/skill/combat/slings, SKILL_LEVEL_EXPERT, TRUE)
 				H.change_stat(STATKEY_SPD, -1)
 				H.change_stat(STATKEY_STR, 1)
 

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -45,7 +45,8 @@
 
 /datum/advclass/warden/warden
 	name = "Warden"
-	tutorial = "You are a Warden; a guerilla beneath the Crown's command, a ranger of Azuria's sparsely populated woods, and the first line of defense against whatever"
+	tutorial = "You are a Warden; a guerilla beneath the Crown's command, a ranger of Azuria's sparsely populated woods, and the first line of defense against whatever foulness befalls this fief."
+	extra_context = "Wardens receive a boost to Perception, Willpower, and Speed when traveling within the 'Azurian Grove' biome. When outside this biome, their statblock - compared to the Man-at-Arms - is slightly reduced."
 	outfit = /datum/outfit/job/roguetown/warden/warden
 	category_tags = list(CTAG_WARDEN)
 	subclass_stats = list(
@@ -79,8 +80,6 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 	)
-
-extra_context = "Wardens receive a boost to Perception, Willpower, and Speed when traveling within the 'Azurian Grove' biome. When outside this biome, their statblock - compared to the Man-at-Arms - is slightly reduced."
 
 /datum/outfit/job/roguetown/warden/warden/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -9,9 +9,9 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
-	tutorial = "Typically a denizen of the sparsely populated Azurian woods, a volunteer with the Wardens - a group of ranger types who keep a vigil over the untamed wilderness. \
-				While you may not be a professional soldier of the Watch, you serve as the first line of defense against outside threats and an early warning of problems to come. \
-				Obey your Sergeant-at-Arms, the Marshal, and the Crown. Show noblemen respect as a commoner should."
+	tutorial = "Typically a denizen of the sparsely populated Azurian woods, you are a volunteer with the Wardens; a fraternity of rangers who keep a vigil over the untamed wilderness. \
+				While you may not be a professional soldier of the Watch, you nevertheless serve as the first line of defense against outside threats and an early warning of problems to come. \
+				Obey your Sergeant-at-Arms, the Marshal, and the Crown. Serve their will, and you will receive that which a Warden covets most - freedom and safety."
 
 	display_order = JDO_WARDEN
 	whitelist_req = TRUE
@@ -32,12 +32,10 @@
 	neck = /obj/item/clothing/neck/roguetown/coif/padded
 	cloak = /obj/item/clothing/cloak/wardencloak
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/warden
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 	belt = /obj/item/storage/belt/rogue/leather
-	beltr = /obj/item/quiver/arrows
 	beltl = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
@@ -47,7 +45,7 @@
 
 /datum/advclass/warden/warden
 	name = "Warden"
-	tutorial = "You are a ranger, a hunter who volunteered to become a part of the wardens. You have experience using bows and daggers."
+	tutorial = "You are a Warden; a guerilla beneath the Crown's command, a ranger of Azuria's sparsely populated woods, and the first line of defense against whatever"
 	outfit = /datum/outfit/job/roguetown/warden/warden
 	category_tags = list(CTAG_WARDEN)
 	subclass_stats = list(
@@ -82,6 +80,8 @@
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 	)
 
+extra_context = "Wardens receive a boost to Perception, Willpower, and Speed when traveling within the 'Azurian Grove' biome. When outside this biome, their statblock - compared to the Man-at-Arms - is slightly reduced."
+
 /datum/outfit/job/roguetown/warden/warden/pre_equip(mob/living/carbon/human/H)
 	..()
 	r_hand = /obj/item/rogueweapon/huntingknife/idagger/warden_machete
@@ -96,15 +96,27 @@
 	H.set_blindness(0)
 
 	if(H.mind)
-		var/armor_options = list("Dodge Expert", "Maille Training")
-		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMS") as anything in armor_options
+		var/armor_options = list("Ranger - Dodge Expert, Padded Gambeson", "Sentinel - Maille Training, Iron Hauberk")
+		var/armor_choice = input(H, "Choose your ARMOR.", "EVADE OR ENDURE, LEST THE FORESTS DRAG YOU DOWN.") as anything in armor_options
 		switch(armor_choice)//Like skirmisher, you are not getting both
-			if("Dodge Expert")
+			if("Ranger - Dodge Expert, Padded Gambeson")
 				ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
-			if("Maille Training")
+			if("Sentinel - Maille Training, Iron Hauberk")
 				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+
+		var/weapon_options = list("Warden's Longbow + 20 Broadhead Arrows", "Spearhunter - Spear + Sling, +I STR / -I SPD")
+		var/weapon_choice = input(H, "Choose your SPECIALITY.", "ADOPT YOUR FORM FOR THE HUNT-TO-COME.") as anything in weapon_options
+		switch(weapon_choice)
+			if("Bowhunter - Warden's Longbow + 20 Broadhead Arrows")
+				beltr = /obj/item/quiver/arrows
+				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve/warden
+			if("Spearhunter - Spear + Sling, +I STR / -I SPD")
+				beltr = /obj/item/quiver/sling/iron
+				r_hand = /obj/item/rogueweapon/spear
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
 
 		var/helmets = list(
 			"Path of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,
@@ -114,7 +126,7 @@
 			"Path of the Rous"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/rat,
 			"None"
 		)
-		var/helmchoice = input(H, "Choose your path.", "HELMET SELECTION") as anything in helmets
+		var/helmchoice = input(H, "Choose your HELMET.", "FOLLOW THE PATH OF YOUR SPIRITBEASTE.") as anything in helmets
 		if(helmchoice != "None")
 			head = helmets[helmchoice]
 
@@ -123,7 +135,7 @@
 			"Antlered Shroud"		= /obj/item/clothing/head/roguetown/roguehood/warden/antler,
 			"None"
 		)
-		var/hoodchoice = input(H, "Choose your shroud.", "HOOD SELECTION") as anything in hoods
+		var/hoodchoice = input(H, "Choose your SHROUD.", "DO NOT GIFT THEM THE GLIMMER OF YOUR EYE.") as anything in hoods
 		if(hoodchoice != "None")
 			mask = hoods[hoodchoice]
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -82,8 +82,8 @@
 
 /datum/outfit/job/roguetown/warden/warden/pre_equip(mob/living/carbon/human/H)
 	..()
-	r_hand = /obj/item/rogueweapon/huntingknife/idagger/warden_machete
 	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/warden_machete = 1,
 		/obj/item/storage/keyring/warden = 1,
 		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -10,7 +10,7 @@
 	allowed_races = ACCEPTED_RACES
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	tutorial = "You are a volunteer with the Wardens; a fraternity of rangers who keep a vigil over Azuria's untamed wilderness. \
-				While you may not be a professional soldier, you nevertheless serve as the first line of defense against outside threats and an early warning of problems to come. \
+				While you may not be a professional soldier, you nevertheless serve the Duchy as the first line of defense against outside threats. \
 				Obey your Sergeant-at-Arms, the Marshal, and the Crown. Serve their will, and you will receive that which a Warden covets most - freedom and safety."
 
 	display_order = JDO_WARDEN


### PR DESCRIPTION
## About The Pull Request

_(Named as such, since I'm currently in the middle of a heavy thunderstorm. Let's ride the lightning, baby!)_
In short:
* Most descriptory facets - namely the description, tutorial, and prompts - have been updated to provide more clarity.
* The Warden's satchel now houses the unique knife they spawn with, instead of it spawning in their hand.
* Selecting the 'Light Armor' option now provides leather bracers, while the 'Medium Armor' option retains the jackchains.
* Adds a new Hunter-themed weapon prompt. The first option is essentially the same as before, giving the unique longbow..
* ..while the second option, being more melee-focused, gives an iron spear and sling with a +I STR / -I SPD statblock mod.
* Tweaked upon suggestion: each option gives you the original ranged skill, and Journeyman-tier skills in the other.

## Testing Evidence

<img width="800" height="600" alt="gaaga" src="https://github.com/user-attachments/assets/d33fd91a-d26c-4214-a174-a15deb7b7849" />

## Why It's Good For The Game

* Expands upon Lamasmaster's plan for Wardens, which wasn't able to be realized _(in their preceding pull request)_ due to technical issues. In short, the vision was to let them pick between primary weapons, similar to the Towner's Hunter class - a feature that is also _very_ much desired by a lot of Warden players.
* Lets us have our cake and eat it, too. Wardens have a little more fidelity with customizing themselves , _without_ having to reimplement subclasses or going against the _"jack-of-all-trades"_ design that they ended up with.
* Gives slings a little more love. Who doesn't love a proper David and Goliath-type loadout, after all?
* Ensures everything's all nice and clean.

## Changelog

:cl:
balance: Wardens can now pick between their unique bow, or a spear and sling. Choosing the latter slightly alters the statblock as well, giving +I STR at the cost of -I SPD.
balance: Wardens now have Journeyman-level skills in both ranged weapon types, by default. Picking the Bow gives Master-tier bow skills (like before), while picking the Sling gives Expert-tier sling skills (like before.)
balance: Wardens now get leather bracers, like before, if selecting the 'light armored' option. Picking the alternative supplies them with a pair of jackchains, like before.
code: Touches up a lot of the prompts, descriptors, and tutorials for the Warden role's .dm file.
code: Adds an 'extra_content' line to the Warden, explaining the nature of how their region-based statboosts work.
/:cl: