### PR TITLE
Visually separate stacking balloon alert

### DIFF
--- a/code/__DEFINES/balloon_alert.dm
+++ b/code/__DEFINES/balloon_alert.dm
@@ -11,6 +11,10 @@
 #define BALLOON_Y_OFFSET_TIER1 5
 #define BALLOON_Y_OFFSET_TIER2 15
 #define BALLOON_Y_OFFSET_TIER3 25
+/// Vertical pixels between stacked concurrent balloons shown to the same client.
+#define BALLOON_STACK_SPACING 12
+/// Max concurrent balloons per client before new ones are dropped to avoid towers.
+#define BALLOON_STACK_MAX 5
 
 #define WXH_TO_HEIGHT(measurement, return_var) \
 	do { \

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -540,6 +540,13 @@
 /proc/remove_image_from_client(image/image_to_remove, client/remove_from)
 	remove_from?.images -= image_to_remove
 
+/// Removes a balloon alert image and decrements the client's active balloon counter.
+/proc/remove_balloon_from_client(image/image_to_remove, client/remove_from)
+	if(!remove_from)
+		return
+	remove_from.images -= image_to_remove
+	remove_from.active_balloon_count = max(0, remove_from.active_balloon_count - 1)
+
 /// Returns this user's display ckey, used in OOC contexts.
 /proc/get_display_ckey(key)
 	var/ckey = ckey(key)

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -34,9 +34,15 @@
 	var/client/viewer_client = viewer?.client
 	if (isnull(viewer_client))
 		return
-	
+
 	if(!(viewer_client.prefs.combat_toggles & FLOATING_TEXT))
 		return
+
+	if(viewer_client.active_balloon_count >= BALLOON_STACK_MAX)
+		return
+
+	var/stack_offset = viewer_client.active_balloon_count * BALLOON_STACK_SPACING
+	viewer_client.active_balloon_count++
 
 	var/image/balloon_alert = image(loc = isturf(src) ? src : get_atom_on_turf(src), layer = ABOVE_MOB_LAYER)
 	balloon_alert.plane = BALLOON_CHAT_PLANE
@@ -51,17 +57,18 @@
 	var/length_mult = 1 + max(0, length(strip_html_simple(text)) - BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN) * BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT
 
 	if(!y_offset)
+		balloon_alert.pixel_y = stack_offset
 		animate(
 			balloon_alert,
-			pixel_y = ICON_SIZE_Y * 1.2,
+			pixel_y = stack_offset + ICON_SIZE_Y * 1.2,
 			time = BALLOON_TEXT_TOTAL_LIFETIME(length_mult),
 			easing = SINE_EASING | EASE_OUT,
 		)
 	else
-		balloon_alert.pixel_y = y_offset
+		balloon_alert.pixel_y = y_offset + stack_offset
 		animate(
 			balloon_alert,
-			pixel_y = y_offset + 5,
+			pixel_y = y_offset + stack_offset + 5,
 			time = BALLOON_TEXT_TOTAL_LIFETIME(length_mult),
 			easing = SINE_EASING | EASE_OUT,
 		)
@@ -83,7 +90,7 @@
 	// These two timers are not the same
 	// One manages the relation to the atom that spawned us, the other to the client we're displaying to
 	// We could lose our loc, and still need to talk to our client, so they are done seperately
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_image_from_client), balloon_alert, viewer_client), BALLOON_TEXT_TOTAL_LIFETIME(length_mult))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_balloon_from_client), balloon_alert, viewer_client), BALLOON_TEXT_TOTAL_LIFETIME(length_mult))
 
 ///Proc for creating a balloon alert that only someone with a specific trait would see.
 /atom/proc/filtered_balloon_alert(trait, text, x_offset, y_offset, show_self = TRUE)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -42,6 +42,8 @@
 		///////////////
 		//SOUND STUFF//
 		///////////////
+	///Active balloon alert count, used to vertically stack concurrent balloons so they don't overlap.
+	var/active_balloon_count = 0
 	///Currently playing ambience sound
 	var/ambience_playing = null
 	///Whether an ambience sound has been played and one shouldn't be played again, unset by a callback


### PR DESCRIPTION
## About The Pull Request
This implement a feature to visually separate stacking balloon alert that are simultaneous by 12px which should makes them not visually overlap (as much)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="258" height="242" alt="dreamseeker_h9VHw4vETt" src="https://github.com/user-attachments/assets/7b3aa1bf-5493-4684-959e-f780dae8dff3" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Better visual clarity for the player

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Balloon alerts that appears at the same time should appear vertically stacked on top instead of overlapping eachother most of the time, making it visually clearer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
