### PR TITLE
minor integrity check - brings visored + great barbute back in line with other steel helmets, integrity-wise

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -151,7 +151,7 @@
 	won't be long until they're almost here. Will you cry all your tears, or will you face your fears? </br>Mounted on the back is a unique couplet, fit for adopting feathered greatplumes."
 	icon_state = "barbute_visor"
 	item_state = "barbute_visor"
-	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL
+	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL - ARMOR_INT_HELMET_HEAVY_ADJUSTABLE_PENALTY
 	adjustable = CAN_CADJUST
 	emote_environment = 3
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
@@ -165,7 +165,7 @@
 	desc = "A steel greathelm of inordinate thickness, whose design seems to've been inspired by both a tournament's froggemund and a kingdom's sugarloaf. It is far from elegant, but it will \
 	thwart killing blows again-and-again without compromise. Never forget that a champion of Psydonia needn't nobility nor wealth to become eternal; they need only the courage to be free. \
 	</br>'In their legends, there were no gods - only heroes.'"
-	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL + 50
+	max_integrity = ARMOR_INT_HELMET_HEAVY_STEEL
 	icon_state = "barbutedunk"
 	item_state = "barbutedunk"
 	emote_environment = 3


### PR DESCRIPTION
## About The Pull Request

Very simple:
* Twiddles up the integrity values of the visored- and great barbute to match their more commonplace counterparts.
* In essence, this is a loss of about ~50 INT for both helmets. They should be on par with the standard helmet equivalents, now.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* These helmets are round-start obtainable by a fair amount of roles, and - by my mistake - probably shouldn't come with a higher-than-usual integrity value as a result. Again, my bad.

## Changelog

:cl:
balance: The visored- and great barbute now have slightly less integrity than before. Now, they're just as durable as your average visored helmet and great helmet.
/:cl:
