### PR TITLE
Mantrap no longer smelt into anything

### DIFF
--- a/code/game/objects/items/beartraps.dm
+++ b/code/game/objects/items/beartraps.dm
@@ -236,4 +236,4 @@
 /obj/item/restraints/legcuffs/beartrap/crafted
 	rusty = FALSE
 	desc = "Curious is the trapmaker's art. Their efficacy unwitnessed by their own eyes."
-	smeltresult = /obj/item/ingot/iron
+	smeltresult = null

--- a/code/modules/roguetown/roguecrafting/trapmaking.dm
+++ b/code/modules/roguetown/roguecrafting/trapmaking.dm
@@ -5,10 +5,7 @@
 
 /datum/crafting_recipe/roguetown/trapmaking/mantrap
 	name = "mantrap"
-	result = list(
-		/obj/item/restraints/legcuffs/beartrap/crafted,
-		/obj/item/restraints/legcuffs/beartrap/crafted,
-		)
+	result = /obj/item/restraints/legcuffs/beartrap/crafted
 	reqs = list(
 		/obj/item/grown/log/tree/small = 1,
 		/obj/item/natural/fibers = 2,
@@ -20,10 +17,7 @@
 
 /datum/crafting_recipe/roguetown/trapmaking/mantrapscrap
 	name = "mantrap (scrap)"
-	result = list(
-		/obj/item/restraints/legcuffs/beartrap/crafted,
-		/obj/item/restraints/legcuffs/beartrap/crafted,
-		)
+	result = /obj/item/restraints/legcuffs/beartrap/crafted
 	reqs = list(
 		/obj/item/grown/log/tree/small = 1,
 		/obj/item/scrap = 4,


### PR DESCRIPTION
## About The Pull Request
Remove dupe exploit from mantrap by making them no longer smelt into anything

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Remove dupe exploit from mantrap

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Bear / Mantrap recipe no longer smelt into anything to avoid a dupe exploit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
