### PR TITLE
ritual rune fixes pt1

### DIFF
--- a/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
+++ b/code/modules/roguetown/roguejobs/mages/ritualrunes.dm
@@ -758,7 +758,6 @@ GLOBAL_LIST(teleport_runes)
 	var/datum/map_template/template
 	var/fortress = /datum/map_template/arcyne_fortress
 	var/list/barriers = list()
-	rituals = list(/datum/runeritual/other/wall/t3::name = /datum/runeritual/other/wall/t3)
 
 /obj/effect/decal/cleanable/roguerune/arcyne/wallgreater/New()
 	. = ..()
@@ -766,7 +765,6 @@ GLOBAL_LIST(teleport_runes)
 
 /obj/effect/decal/cleanable/roguerune/arcyne/wallgreater/proc/get_template(/datum/map_template/arcyne_fortress/fortress)
 
-	to_chat(usr, span_hierophant_warning("template retrieving"))
 	var/datum/map_template/temporary = new fortress
 	template = SSmapping.map_templates[temporary.id]
 	if(!template)
@@ -783,7 +781,6 @@ GLOBAL_LIST(teleport_runes)
 	get_template(template)
 
 	template.load(deploy_location, centered = TRUE)
-	to_chat(usr, span_hierophant_warning("template.load complete"))
 	if(ritual_result)
 		pickritual.cleanup_atoms(selected_atoms)
 	invoke_cleanup()

--- a/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
+++ b/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
@@ -235,12 +235,16 @@
 	cleanspeed = initial(cleanspeed) * get_int_speed_mult(user)
 
 	if(istype(target, /obj/effect/decal/cleanable))
+		if(!should_clean_rune(target))
+			user.visible_message(span_notice("[user] gestures at \the [target.name]... but the active rune's arcyne power rebukes [user.p_them()]!"), span_notice("I attempt to scour \the [target.name] away with my arcyne power, but the active ritual prevents me!"))
+			return FALSE
 		user.visible_message(span_notice("[user] gestures at \the [target.name]. Arcyne power slowly scours it away..."), span_notice("I begin to scour \the [target.name] away with my arcyne power..."))
 		if(do_after(user, src.cleanspeed, target = target))
 			var/turf/T = get_turf(target)
 			new /obj/effect/temp_visual/cleaning_pulse(T)
 			for(var/obj/effect/decal/cleanable/C in T)
-				wash_atom(C, CLEAN_MEDIUM)
+				if(should_clean_rune(target))
+					wash_atom(C, CLEAN_MEDIUM)
 			wash_atom(T, CLEAN_MEDIUM)
 			to_chat(user, span_notice("I expunge \the [target.name] with my mana."))
 			return TRUE
@@ -251,12 +255,19 @@
 		if(do_after(user, src.cleanspeed, target = target))
 			var/turf/T = get_turf(target)
 			new /obj/effect/temp_visual/cleaning_pulse(T)
-			wash_atom(target, CLEAN_MEDIUM)
 			for(var/obj/effect/decal/cleanable/C in T)
-				wash_atom(C, CLEAN_MEDIUM)
+				if(should_clean_rune(C))
+					wash_atom(C, CLEAN_MEDIUM)
 			to_chat(user, span_notice("I render [clean_name] clean."))
 			return TRUE
 		return FALSE
+
+// we have to do this here because wash_turf just qdels cleanable decals instead of checking their wash_act
+/obj/item/melee/new_touch_attack/prestidigitation/proc/should_clean_rune(obj/effect/decal/cleanable/C)
+	var/obj/effect/decal/cleanable/roguerune/rune = C
+	if(istype(rune) && rune.active)
+		return FALSE
+	return TRUE
 
 /obj/effect/wisp/prestidigitation
 	name = "minor magelight mote"


### PR DESCRIPTION
## About The Pull Request
for a long time, prestidigitation has been able to just remotely erase active arcyne wall runes, making them useless as anyone with even arcpot-level arcyne skill can just take them down remotely. this fixes that, removes some old debug statements from the fortress rune, and uncovers the fact that the arcyne fortress rune is SO broken it has to be its own pr holy shit it's bad
also it removes a redundant function call from prestidigitation that was qdeling decals and then attempting to do so again 

## Testing Evidence
<img width="601" height="138" alt="image" src="https://github.com/user-attachments/assets/1aa3d451-a489-4da1-97a6-bf29fdc59c52" />
<img width="276" height="340" alt="image" src="https://github.com/user-attachments/assets/283c5869-2970-456c-81bc-011964d1c1ba" />
<img width="578" height="101" alt="image" src="https://github.com/user-attachments/assets/8b9f6208-81e0-4420-ae9b-0b6d0f161cc0" />

## Why It's Good For The Game
this was supposed to be fixed a while back and never was. now it is

## Changelog

:cl:
fix: arcyne wall runes can no longer be deleted by prestidigitation while active
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
