### PR TITLE
Mystic clean up and qol, reduce the number of subclasses from 60 to 45

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -52,7 +52,6 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 		/datum/advclass/mystic,
 		/datum/advclass/mystic/resilientsoul,
 		/datum/advclass/mystic/holyblade,
-		/datum/advclass/mystic/theurgist,
 		/datum/advclass/mage,
 		/datum/advclass/mage/spellsinger,
 		/datum/advclass/mage/spellblade,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -3,6 +3,7 @@
 	tutorial = "I have spent my youth deepening my faith, only to be lured by the way of the magi, to the great regret of my family"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = list(/datum/patron/old_god,/datum/patron/divine/undivided,/datum/patron/divine/astrata,/datum/patron/divine/noc,/datum/patron/divine/dendor,/datum/patron/divine/abyssor,/datum/patron/divine/ravox,/datum/patron/divine/necra,/datum/patron/divine/xylix,/datum/patron/divine/pestra,/datum/patron/divine/malum,/datum/patron/divine/eora)
 	outfit = /datum/outfit/job/roguetown/adventurer/mystic
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
@@ -104,6 +105,7 @@
 	tutorial = "I have spent my youth studying both the Arcyne and Miraculous ways, and developed my mastery of shielding and preserving lyfe under my care."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = list(/datum/patron/old_god,/datum/patron/divine/undivided,/datum/patron/divine/astrata,/datum/patron/divine/noc,/datum/patron/divine/dendor,/datum/patron/divine/abyssor,/datum/patron/divine/ravox,/datum/patron/divine/necra,/datum/patron/divine/xylix,/datum/patron/divine/pestra,/datum/patron/divine/malum,/datum/patron/divine/eora)
 	outfit = /datum/outfit/job/roguetown/adventurer/resilient
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
@@ -236,6 +238,7 @@
 	tutorial = "I have spent my youth deepening my faith and one day an azurcaephan was under my care at the church, ever since their recovery i became the pupil of the noccite priests and templars"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
+	allowed_patrons = list(/datum/patron/old_god,/datum/patron/divine/undivided,/datum/patron/divine/astrata,/datum/patron/divine/noc,/datum/patron/divine/dendor,/datum/patron/divine/abyssor,/datum/patron/divine/ravox,/datum/patron/divine/necra,/datum/patron/divine/xylix,/datum/patron/divine/pestra,/datum/patron/divine/malum,/datum/patron/divine/eora)
 	outfit = /datum/outfit/job/roguetown/adventurer/holyblade
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -7,7 +7,7 @@
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
 	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT) //so they can produce red+ and blue+
-	subclass_stats = list( //only class with a 7 point spread since to compensate their offensive cantrip
+	subclass_stats = list( //only class with a 7 point spread to compensate their lack offensive cantrip
 			STATKEY_INT = 3,
 			STATKEY_CON = 2,
 			STATKEY_WIL = 2,
@@ -101,7 +101,7 @@
 
 /datum/advclass/mystic/resilientsoul
 	name = "Sage"
-	tutorial = "I have spent my youth studying both the Arcyne and Miraculous ways, and developed my mastery of shielding and preserving lyfe under my care. 2 statblocks of choice after picking your offensive cantrip: +3 INT +1 CON +2 WIL or +1 INT +3 CON +2 WIL."
+	tutorial = "I have spent my youth studying both the Arcyne and Miraculous ways, and developed my mastery of shielding and preserving lyfe under my care."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/resilient

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -184,7 +184,7 @@
 
 			
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_DEVOTEE, devotion_limit = CLERIC_REQ_1)
+	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)
 	if(H.mind)
 		H.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/blood_heal)
 	switch(H.patron?.type)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -37,13 +37,17 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-	backl = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/storage/backpack/rogue/backpack
 	r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
 	l_hand = /obj/item/rogueweapon/scabbard/gwstrap
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
 		/obj/item/recipe_book/survival = 1,
+		/obj/item/folding_alchcauldron_stored = 1,
+		/obj/item/reagent_containers/glass/bottle = 3,
+		/obj/item/reagent_containers/glass/bottle/alchemical = 3,
+		/obj/item/recipe_book/alchemy = 1,
 		/obj/item/book/spellbook = 1,
 		/obj/item/chalk = 1,
 		)
@@ -133,16 +137,12 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-	backl = /obj/item/storage/backpack/rogue/backpack
+	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogueweapon/woodstaff
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
 		/obj/item/recipe_book/survival = 1,
-		/obj/item/folding_alchcauldron_stored = 1,
-		/obj/item/reagent_containers/glass/bottle = 3,
-		/obj/item/reagent_containers/glass/bottle/alchemical = 3,
-		/obj/item/recipe_book/alchemy = 1,
 		/obj/item/book/spellbook = 1,
 		/obj/item/chalk = 1,
 		)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -6,7 +6,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/mystic
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
-	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE)
+	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT) //so they can produce red+ and blue+
 	subclass_stats = list( // stat spread of 6 points, lower than the 7 adventurer gets on average
 			STATKEY_INT = 2,
 			STATKEY_CON = 2,
@@ -18,7 +18,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN, //so they can produce red+ and blue+
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE, 
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -101,7 +101,7 @@
 
 /datum/advclass/mystic/resilientsoul
 	name = "Sage"
-	tutorial = "I have spent my youth studying both the Arcyne and Miraculous ways, and developed my mastery of shielding and preserving lyfe under my care."
+	tutorial = "I have spent my youth studying both the Arcyne and Miraculous ways, and developed my mastery of shielding and preserving lyfe under my care. 2 statblocks of choice after picking your offensive cantrip: +3 INT +1 CON +2 WIL or +1 INT +3 CON +2 WIL."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/resilient

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -49,8 +49,7 @@
 		)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)
-	if(H.mind)
-		H.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/blood_heal)
+
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
 			neck = /obj/item/clothing/neck/roguetown/psicross

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -7,8 +7,8 @@
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
 	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT) //so they can produce red+ and blue+
-	subclass_stats = list( // stat spread of 6 points, lower than the 7 adventurer gets on average
-			STATKEY_INT = 2,
+	subclass_stats = list( //only class with a 7 point spread since to compensate their offensive cantrip
+			STATKEY_INT = 3,
 			STATKEY_CON = 2,
 			STATKEY_WIL = 2,
 	)
@@ -109,9 +109,9 @@
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
 	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
-			STATKEY_INT = 0,
-			STATKEY_CON = 0,
-			STATKEY_WIL = 0,
+			STATKEY_INT = 2,
+			STATKEY_CON = 2,
+			STATKEY_WIL = 2,
 	)
 	age_mod = /datum/class_age_mod/mystic
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 2, "utilities" = 4, "locked_aspects" = list(/datum/magic_aspect/lesser_augmentation))
@@ -169,19 +169,6 @@
 			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arcyne_lance)
 		if("Lesser Gravel Blast")
 			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/gravel_blast/lesser)
-
-	var/stat_option = list("Great Intellect - +3 INT +1 CON +2 WIL", "Great Vitality - +1 INT +3 CON +2 WIL")
-	var/stat_choice = input(H, "What defines me", "Mind or Body.") as anything in stat_option
-	switch(stat_choice)
-		if("Great Intellect - +3 INT +1 CON +2 WIL")
-			H.change_stat(STATKEY_INT, 3)
-			H.change_stat(STATKEY_CON, 1)
-			H.change_stat(STATKEY_WIL, 2)
-		if("Great Vitality - +1 INT +3 CON +2 WIL")
-			H.change_stat(STATKEY_INT, 1)
-			H.change_stat(STATKEY_CON, 3)
-			H.change_stat(STATKEY_WIL, 2)
-
 			
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -17,6 +17,7 @@
 	subclass_skills = list(
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE, 
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
@@ -117,6 +118,7 @@
 	subclass_skills = list(
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE, //limited at apprentice, they have tools to reduce damage taken and slowing down bleeding
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
@@ -250,6 +252,7 @@
 	subclass_skills = list(
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -18,7 +18,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN, //so they can produce red+ and blue+
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
@@ -114,7 +114,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE, //limited at apprentice, they have tools to reduce damage taken and slowing down bleeding
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -170,7 +170,7 @@
 			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/gravel_blast/lesser)
 
 	var/stat_option = list("Great Intellect - +3 INT +1 CON +2 WIL", "Great Vitality - +1 INT +3 CON +2 WIL")
-	var/stat_choice = input(H, "What defines me", "Body or Soul.") as anything in stat_option
+	var/stat_choice = input(H, "What defines me", "Mind or Body.") as anything in stat_option
 	switch(stat_choice)
 		if("Great Intellect - +3 INT +1 CON +2 WIL")
 			H.change_stat(STATKEY_INT, 3)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -107,7 +107,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/resilient
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
-	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE)
+	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
 			STATKEY_INT = 0,
 			STATKEY_CON = 0,
@@ -239,7 +239,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/holyblade
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
-	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE)
+	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE, TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
 			STATKEY_STR = 1,
 			STATKEY_PER = 1,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -3,7 +3,6 @@
 	tutorial = "I have spent my youth deepening my faith, only to be lured by the way of the magi, to the great regret of my family"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	allowed_patrons = list(/datum/patron/old_god,/datum/patron/divine/undivided,/datum/patron/divine/astrata,/datum/patron/divine/noc,/datum/patron/divine/dendor,/datum/patron/divine/abyssor,/datum/patron/divine/ravox,/datum/patron/divine/necra,/datum/patron/divine/xylix,/datum/patron/divine/pestra,/datum/patron/divine/malum,/datum/patron/divine/eora)
 	outfit = /datum/outfit/job/roguetown/adventurer/mystic
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
@@ -105,7 +104,6 @@
 	tutorial = "I have spent my youth studying both the Arcyne and Miraculous ways, and developed my mastery of shielding and preserving lyfe under my care."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	allowed_patrons = list(/datum/patron/old_god,/datum/patron/divine/undivided,/datum/patron/divine/astrata,/datum/patron/divine/noc,/datum/patron/divine/dendor,/datum/patron/divine/abyssor,/datum/patron/divine/ravox,/datum/patron/divine/necra,/datum/patron/divine/xylix,/datum/patron/divine/pestra,/datum/patron/divine/malum,/datum/patron/divine/eora)
 	outfit = /datum/outfit/job/roguetown/adventurer/resilient
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
@@ -238,7 +236,6 @@
 	tutorial = "I have spent my youth deepening my faith and one day an azurcaephan was under my care at the church, ever since their recovery i became the pupil of the noccite priests and templars"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	allowed_patrons = list(/datum/patron/old_god,/datum/patron/divine/undivided,/datum/patron/divine/astrata,/datum/patron/divine/noc,/datum/patron/divine/dendor,/datum/patron/divine/abyssor,/datum/patron/divine/ravox,/datum/patron/divine/necra,/datum/patron/divine/xylix,/datum/patron/divine/pestra,/datum/patron/divine/malum,/datum/patron/divine/eora)
 	outfit = /datum/outfit/job/roguetown/adventurer/holyblade
 	class_select_category = CLASS_CAT_MYSTIC
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -105,9 +105,9 @@
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
 	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE)
 	subclass_stats = list(
-			STATKEY_INT = 1,
-			STATKEY_CON = 3,
-			STATKEY_WIL = 2,
+			STATKEY_INT = 0,
+			STATKEY_CON = 0,
+			STATKEY_WIL = 0,
 	)
 	age_mod = /datum/class_age_mod/mystic
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 2, "utilities" = 4, "locked_aspects" = list(/datum/magic_aspect/lesser_augmentation))
@@ -147,8 +147,10 @@
 		/obj/item/book/spellbook = 1,
 		/obj/item/chalk = 1,
 		)
+
 	H.mind.AddSpell(new /datum/action/cooldown/spell/stoneskin)
 	H.mind.AddSpell(new /datum/action/cooldown/spell/bestow_ward)
+
 	var/list/poke_options = list("Spitfire", "Frost Bolt", "Arc Bolt", "Greater Arcyne Bolt", "Stygian Efflorescence", "Arcyne Lance", "Lesser Gravel Blast")
 	var/poke_choice = input(H, "Choose your offensive cantrip.", "Arcyne Training") as anything in poke_options
 	switch(poke_choice)
@@ -166,6 +168,20 @@
 			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arcyne_lance)
 		if("Lesser Gravel Blast")
 			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/gravel_blast/lesser)
+
+	var/stat_option = list("Great Intellect - +3 INT +1 CON +2 WIL", "Great Vitality - +1 INT +3 CON +2 WIL")
+	var/stat_choice = input(H, "What defines me", "Body or Soul.") as anything in stat_option
+	switch(stat_choice)
+		if("Great Intellect - +3 INT +1 CON +2 WIL")
+			H.change_stat(STATKEY_INT, 3)
+			H.change_stat(STATKEY_CON, 1)
+			H.change_stat(STATKEY_WIL, 2)
+		if("Great Vitality - +1 INT +3 CON +2 WIL")
+			H.change_stat(STATKEY_INT, 1)
+			H.change_stat(STATKEY_CON, 3)
+			H.change_stat(STATKEY_WIL, 2)
+
+			
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_DEVOTEE, devotion_limit = CLERIC_REQ_1)
 	if(H.mind)
@@ -215,8 +231,8 @@
 			H.cmode_music = 'sound/music/combat_jester.ogg'
 
 /datum/advclass/mystic/holyblade
-	name = "Holyblade"
-	tutorial = "I have spent my youth deepening my faith and one day a spellblade was under my care at the church, ever since their recovery they accepted me as their pupil and taught me the way of the blade and arcyne"
+	name = "Luminary"
+	tutorial = "I have spent my youth deepening my faith and one day an azurcaephan was under my care at the church, ever since their recovery i became the pupil of the noccite priests and templars"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/holyblade
@@ -241,8 +257,6 @@
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN, // usual weapon proficiency, baseline apprentice is pretty coal to work with
-		/datum/skill/combat/shields = SKILL_LEVEL_NOVICE, // trainable on a target dummy/with other players/simple mobs, slight time sink
 	)
 
 /datum/outfit/job/roguetown/adventurer/holyblade/pre_equip(mob/living/carbon/human/H)
@@ -257,20 +271,32 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backr = /obj/item/rogueweapon/shield/wood
-	beltr = /obj/item/rogueweapon/scabbard/sword
 	neck = /obj/item/clothing/neck/roguetown/coif/padded
 
 	if(H.mind)
-		var/weapons = list("Arming Sword", "Shortsword", "Falchion") // you may want to upgrade for a better sword
+		var/weapons = list("Arming Sword", "Shortsword + shield", "Quarterstaff", "Mace + shield", "Spear") // you may want to upgrade for a better sword
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Arming Sword")
 				r_hand = /obj/item/rogueweapon/sword
-			if("Shortsword")
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
+			if("Shortsword + shield")
 				r_hand = /obj/item/rogueweapon/sword/short
-			if("Falchion")
-				r_hand = /obj/item/rogueweapon/sword/short/falchion
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
+			if("Quarterstaff")
+				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
+				H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE)
+			if("Mace + shield")
+				r_hand = /obj/item/rogueweapon/mace
+				backr = /obj/item/rogueweapon/shield/wood
+				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
+			if("Spear")
+				r_hand = /obj/item/rogueweapon/spear
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
 
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	backpack_contents = list(
@@ -344,118 +370,3 @@
 			id = /obj/item/clothing/neck/roguetown/luckcharm
 			H.cmode_music = 'sound/music/combat_jester.ogg'
 
-/datum/advclass/mystic/theurgist
-	name = "Theurgist"
-	tutorial = "I have spent my youth deepening my faith among Noccite acolytes, and was shown the wonders of the Arcyne. Ever since, I have studied the arcyne arts."
-	allowed_sexes = list(MALE, FEMALE)
-	allowed_races = RACES_ALL_KINDS
-	outfit = /datum/outfit/job/roguetown/adventurer/theurgist
-	class_select_category = CLASS_CAT_MYSTIC
-	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
-	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ARCYNE)
-	subclass_stats = list(
-			STATKEY_INT = 3,
-			STATKEY_CON = 1,
-			STATKEY_WIL = 2,
-	)
-	age_mod = /datum/class_age_mod/mystic
-	subclass_mage_aspects = list("mastery" = FALSE, "major" = 0, "minor" = 1, "utilities" = 3)
-	subclass_skills = list(
-		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
-		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE, // arcyne focused class, they ought to have better alchemy knowledge than their counterpart
-		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN, // what the bookworm gonna do? smash your head with their stick, they are better casting a spell
-	)
-
-/datum/outfit/job/roguetown/adventurer/theurgist/pre_equip(mob/living/carbon/human/H)
-	..()
-	to_chat(H, span_warning("I have spent my youth deepening my faith among Noccite acolytes, and was shown the wonders of the Arcyne. Ever since, I have studied the arcyne arts."))
-	head = /obj/item/clothing/head/roguetown/roguehood/mage
-	shoes = /obj/item/clothing/shoes/roguetown/boots
-	pants = /obj/item/clothing/under/roguetown/trou/leather
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-	armor = /obj/item/clothing/suit/roguetown/shirt/robe/mage
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	gloves = /obj/item/clothing/gloves/roguetown/angle
-	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-	backl = /obj/item/storage/backpack/rogue/satchel
-	backr = /obj/item/rogueweapon/woodstaff
-	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
-	backpack_contents = list(
-		/obj/item/flashlight/flare/torch = 1,
-		/obj/item/recipe_book/survival = 1,
-		/obj/item/book/spellbook = 1,
-		/obj/item/chalk = 1,
-		)
-
-	var/list/poke_options = list("Spitfire", "Frost Bolt", "Arc Bolt", "Greater Arcyne Bolt", "Stygian Efflorescence", "Arcyne Lance", "Lesser Gravel Blast")
-	var/poke_choice = input(H, "Choose your offensive cantrip.", "Arcyne Training") as anything in poke_options
-	switch(poke_choice)
-		if("Spitfire")
-			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/spitfire)
-		if("Frost Bolt")
-			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/frost_bolt)
-		if("Arc Bolt")
-			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arc_bolt)
-		if("Greater Arcyne Bolt")
-			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/greater_arcyne_bolt)
-		if("Stygian Efflorescence")
-			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/stygian_efflorescence)
-		if("Arcyne Lance")
-			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/arcyne_lance)
-		if("Lesser Gravel Blast")
-			H.mind.AddSpell(new /datum/action/cooldown/spell/projectile/gravel_blast/lesser)
-
-	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_WITCH, devotion_limit = CLERIC_REQ_1)
-	if(H.mind)
-		H.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/blood_heal)
-	switch(H.patron?.type)
-		if(/datum/patron/old_god)
-			neck = /obj/item/clothing/neck/roguetown/psicross
-		if(/datum/patron/divine/undivided)
-			neck = /obj/item/clothing/neck/roguetown/psicross/undivided
-		if(/datum/patron/divine/astrata)
-			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
-			H.cmode_music = 'sound/music/cmode/church/combat_astrata.ogg'
-		if(/datum/patron/divine/noc)
-			neck = /obj/item/clothing/neck/roguetown/psicross/noc
-		if(/datum/patron/divine/abyssor)
-			neck = /obj/item/clothing/neck/roguetown/psicross/abyssor
-			H.grant_language(/datum/language/abyssal)
-		if(/datum/patron/divine/dendor)
-			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
-			H.cmode_music = 'sound/music/cmode/garrison/combat_warden.ogg' // see: druid.dm
-		if(/datum/patron/divine/necra)
-			neck = /obj/item/clothing/neck/roguetown/psicross/necra
-			H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
-		if(/datum/patron/divine/pestra)
-			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
-		if(/datum/patron/divine/ravox)
-			neck = /obj/item/clothing/neck/roguetown/psicross/ravox
-		if(/datum/patron/divine/malum)
-			neck = /obj/item/clothing/neck/roguetown/psicross/malum
-		if(/datum/patron/divine/eora)
-			neck = /obj/item/clothing/neck/roguetown/psicross/eora
-			H.cmode_music = 'sound/music/cmode/church/combat_eora.ogg'
-		if(/datum/patron/inhumen/zizo)
-			H.cmode_music = 'sound/music/combat_heretic.ogg'
-			ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC)
-		if(/datum/patron/inhumen/matthios)
-			H.cmode_music = 'sound/music/combat_matthios.ogg'
-			ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC)
-		if(/datum/patron/inhumen/graggar)
-			H.cmode_music = 'sound/music/combat_graggar.ogg'
-			ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC)
-		if(/datum/patron/inhumen/baotha)
-			H.cmode_music = 'sound/music/combat_baotha.ogg'
-			ADD_TRAIT(H, TRAIT_HERESIARCH, TRAIT_GENERIC)
-		if(/datum/patron/divine/xylix)
-			neck = /obj/item/clothing/neck/roguetown/luckcharm
-			H.cmode_music = 'sound/music/combat_jester.ogg'


### PR DESCRIPTION
## About The Pull Request

QoL and re-adjusting each class identity, re-readjusting the total number of subclasses from 60 to 33.

Mystic is the Support focused class, they gain back the ability to cast the blood boon miracle, gain alchemist expert and lachemy skill is increased to apprentice, so they can produce strong potions and buff potions with some work and the alchemy loadout(backpack, 3 vials, 3 bottles, 1 folding cauldron)

Sage is the spellcaster focused class, having access to offence(1 cantrip), supportive spells(lesser miracle, fortitude, bestow ward and 4 utility points, the lesser augmentation minor forced and 1 minor school to pick), they lose on their alchemy loadout but keep apprentice in alchemy. their stat spread is slightly adjusted to match a mix of their old one and the Theurgist's - i roll the Theurgist stat spread there so people don't lose on their loved stat spread) so you can focuses on being able to take hits during fights before going down or casting your spell more frequently.

Holyblade have been renamed Luminary, they gained a greater weapon and weapon proficiency loadout selection.(sword, sword and board, mace and shield, spear)

Theurgist have been removed since it was a class that had less everywhere compared to Sage, less minors to bind, less utility points, no defining spells to manually add without ending up being oppressive

All classes gained novice wrestling so they can hope to get out of grappler fiend's grasp.


## Testing Evidence

<img width="625" height="800" alt="1" src="https://github.com/user-attachments/assets/a22c010a-71e0-4da4-967f-0421e0eb159d" />
<img width="1175" height="694" alt="2" src="https://github.com/user-attachments/assets/36761422-76ac-41f5-a1ae-6208abbfdfef" />
<img width="565" height="550" alt="3" src="https://github.com/user-attachments/assets/dbcbe6cc-128a-40d4-aea0-566f70066b6f" />
<img width="1052" height="284" alt="4" src="https://github.com/user-attachments/assets/85d6b6c7-2cef-401a-92e3-d679f6236101" />
<img width="1568" height="1008" alt="5" src="https://github.com/user-attachments/assets/a2600f33-c67e-4266-9095-d9f0b18c52e1" />
<img width="1314" height="478" alt="6" src="https://github.com/user-attachments/assets/a7ffb3ad-fe46-42c7-ade2-b8ce0bc1f5da" />



## Why It's Good For The Game

limping duplicate subclasses are bad, giving more choice than sword and board to diversify Luminaries without forcing the virtue tax is le good

## Changelog
Sage's stat spread is changed to match a mix of its old one and the theurgist's
Remove Theurgist
Rename Holyblade for Luminary
Mystic gain Blood Boon back, holy skill unchanged at apprentice(slightly inefficient)
Move Sage's alchemy loadout to Mystic's
Mystic gain alchemy expert so they can produce strong potion with a little work
Luminary now has greater weapon and skill selection.

:cl:
del: Deleted Theurgist
balance: mix THeurgist's stat spread in the Sage's own stat spread, they loose 1 con and gain 1 int
balance: raise Sage's Devotion regen to the same tier as Mystic's 
balance: Mystic now have apprentice alchemy and all mystic classes have alchemy expert trait so they can produce strong potions with some work, move the alchemy supplies and backpack from Sage's loadout to Mystic's, Sage stay at apprentice.
balance: all mystic classes now enjoy novice wrestling skill, fight back the bullies a little better!
qol: Mystic gain blood boon back, holy skill unchanged at apprentice.
qol: Holyblade, now named Luminary enjoy a  greater weapon loadout and proficiency diversity
/:cl:

