### PR TITLE
Skeleton Wretches & Storyteller Fixes Pack

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -660,6 +660,14 @@ SUBSYSTEM_DEF(gamemode)
 			to_chat(world, span_reallybig("[initialized_storyteller.name] is ascendant!"))
 			to_chat(world, "<br>")
 
+	// If an admin force-starts the round while the storyteller vote is still running,
+	// resolve it now so selected_storyteller reflects the votes cast so far.
+	if(SSvote.mode == "storyteller")
+		SSvote.result()
+		for(var/client/C in SSvote.voting)
+			C << browse(null, "window=vote;can_close=0;size=[SSvote.vote_width]x[SSvote.vote_height]")
+		SSvote.reset()
+
 	if(!current_storyteller || current_storyteller.type != selected_storyteller)
 		init_storyteller()
 	if(!ispath(roundstart_storyteller, /datum/storyteller))

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -661,15 +661,18 @@ SUBSYSTEM_DEF(gamemode)
 			to_chat(world, "<br>")
 
 	// If an admin force-starts the round while the storyteller vote is still running,
-	// resolve it now so selected_storyteller reflects the votes cast so far.
+	// resolve it now so selected_storyteller reflects votes cast so far (or falls back
+	// to Astrata via storyteller_vote_result() if no votes were cast).
 	if(SSvote.mode == "storyteller")
 		SSvote.result()
 		for(var/client/C in SSvote.voting)
 			C << browse(null, "window=vote;can_close=0;size=[SSvote.vote_width]x[SSvote.vote_height]")
 		SSvote.reset()
 
-	if(!current_storyteller || current_storyteller.type != selected_storyteller)
-		init_storyteller()
+	// Force set_storyteller() unconditionally — the lobby-fire pick_most_influential() may
+	// have seeded current_storyteller from zero-influence coin flips, and we want the
+	// vote result (or Astrata fallback) to win at round start regardless.
+	set_storyteller(selected_storyteller)
 	if(!ispath(roundstart_storyteller, /datum/storyteller))
 		roundstart_storyteller = selected_storyteller
 	calculate_ready_players()
@@ -918,8 +921,11 @@ SUBSYSTEM_DEF(gamemode)
 			matched_storyteller = TRUE
 			SSgnoll_scaling.get_gnoll_scaling() // Calling this here as to make sure scaling holds true as per the roundstart vote, not a latejoin hunted character joining.
 			break
+	// Inconclusive vote (no votes cast, or winner string didn't match any storyteller name)
+	// — fall back to Astrata instead of leaving whatever init-time pick_most_influential() seeded.
 	if(!matched_storyteller)
-		return
+		selected_storyteller = /datum/storyteller/astrata
+		SSgnoll_scaling.get_gnoll_scaling()
 
 	var/datum/storyteller/storytypecasted = selected_storyteller
 	to_chat(world, span_notice("<b>Storyteller is [initial(storytypecasted.name)]!</b>"))

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -348,6 +348,12 @@ SUBSYSTEM_DEF(vote)
 			if("storyteller")
 				save_storyteller_vote_log(., "completed")
 				SSgamemode.storyteller_vote_result(.)
+	else if(mode == "storyteller")
+		// No winner (inconclusive / no votes cast). Still run the result hook so
+		// selected_storyteller gets the Astrata fallback instead of whichever
+		// storyteller pick_most_influential() happened to seed at init.
+		save_storyteller_vote_log(null, "completed")
+		SSgamemode.storyteller_vote_result(null)
 
 	if(restart)
 		var/active_admins = 0

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -572,6 +572,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 			if(charflaws.len)
 				for(var/i = 1 to charflaws.len)
 					var/datum/charflaw/cf = charflaws[i]
+					if(!cf)
+						continue
 					var/warning = ""
 					if(cf.needs_extra_vice && charflaws.len < 2)
 						warning = "<font color = '#910505'>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -366,16 +366,30 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	charflaws = list()
 	var/list/charflaw_types
 	S["charflaws"] >> charflaw_types
+	var/needs_resave = FALSE
 	if(charflaw_types && length(charflaw_types))
 		for(var/flaw_type in charflaw_types)
-			if(flaw_type)
-				charflaws.Add(new flaw_type())
+			if(!ispath(flaw_type, /datum/charflaw))
+				needs_resave = TRUE
+				continue
+			var/datum/charflaw/cf = new flaw_type()
+			if(!cf)
+				needs_resave = TRUE
+				continue
+			charflaws.Add(cf)
 	// Backwards compatibility: load old single charflaw format
 	else
 		var/charflaw_type
 		S["charflaw"] >> charflaw_type
-		if(charflaw_type)
-			charflaws.Add(new charflaw_type())
+		if(ispath(charflaw_type, /datum/charflaw))
+			var/datum/charflaw/cf = new charflaw_type()
+			if(cf)
+				charflaws.Add(cf)
+	if(needs_resave)
+		var/list/cleaned_types = list()
+		for(var/datum/charflaw/cf in charflaws)
+			cleaned_types.Add(cf.type)
+		WRITE_FILE(S["charflaws"], cleaned_types)
 
 /datum/preferences/proc/_load_culinary_preferences(S)
 	var/list/loaded_culinary_preferences

--- a/code/modules/mob/living/carbon/human/skeletonize.dm
+++ b/code/modules/mob/living/carbon/human/skeletonize.dm
@@ -1,5 +1,19 @@
 /mob/living/carbon/human/proc/become_skeleton()
+	// Revenant's on_species_loss and on_head_destroyed both call death() — and the
+	// dullahan head's drop_limb assumes the owner is still dullahan, so it runtimes
+	// after a species swap. Replace the head with a vanilla one first under GODMODE,
+	// then swap species.
+	var/had_godmode = (status_flags & GODMODE)
+	status_flags |= GODMODE
+	if(isdullahan(src))
+		var/obj/item/bodypart/head/old_head = get_bodypart(BODY_ZONE_HEAD)
+		if(old_head)
+			var/obj/item/bodypart/head/new_head = new /obj/item/bodypart/head()
+			new_head.replace_limb(src, TRUE)
+			qdel(old_head)
 	set_species(/datum/species/human/northern)
+	if(!had_godmode)
+		status_flags &= ~GODMODE
 
 	for(var/datum/charflaw/cf in charflaws)
 		charflaws.Remove(cf)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
@@ -264,14 +264,15 @@
 	UnregisterSignal(user, COMSIG_MOB_SAY)
 	UnregisterSignal(user, COMSIG_MOB_SAY_POSTPROCESS)
 	//UnregisterSignal(user, COMSIG_ERP_LOCATION_ACCESSIBLE) // TODO SEXCON2
-	if(my_head.owner ~= user)
+	if(my_head && my_head.owner ~= user)
 		// Give their head back instead?
 		// In TG Dullahan heads are always off, thus they give back heads.
 		// Warn that they're going to die?
 		if(!(user.status_flags & GODMODE))
 			user.death()
 
-	UnregisterSignal(my_head, COMSIG_QDELETING)
+	if(my_head)
+		UnregisterSignal(my_head, COMSIG_QDELETING)
 	my_head = null
 	soul_light_off()
 	mob_light_obj = null


### PR DESCRIPTION
## About The Pull Request
- Fixes an issue where revenant who joins as wretch skeleton just dies. By setting them to Godmode, and then swap their species and head out for a normal head and then remove godmode. Yep. (Swapping the head is necessary to prevent runtimes from species swap)
- Possibly fix an issue where after you die as a wretch skeleton you get a character flaw needs extra vice related runtime that make you completely unable to play the game or rejoin the round
- When an admin click "Start Now", the storyteller vote automatically resolves
- When an admin click Start Now and there's no vote, the storyteller vote automatically resolves to Astrata. This means that on localhost I can save some time testing wretch classes and antagonists in general for the general use case, as Psydon is not a likely use case for most developers

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1190" height="582" alt="dreamseeker_gMhNfcbfDi" src="https://github.com/user-attachments/assets/0d64d0a9-ce96-40ab-9aaf-133460be40ee" />
<img width="797" height="201" alt="dreamseeker_b13gqHZDpZ" src="https://github.com/user-attachments/assets/37a9ed44-1690-4a76-a0a4-51a025a737fc" />
<img width="1185" height="525" alt="dreamseeker_FmBxKkgJsl" src="https://github.com/user-attachments/assets/5c3008cc-ec87-4e43-9985-88168a533b55" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugfix for Skele Wretches and improved developer experience.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixes an issue where revenant who joins as wretch skeleton just dies. By setting them to Godmode, and then swap their species and head out for a normal head and then remove godmode. Yep. (Swapping the head is necessary to prevent runtimes from species swap)
fix: Possibly fix an issue where after you die as a wretch skeleton you get a character flaw needs extra vice related runtime that make you completely unable to play the game or rejoin the round
fix: When an admin click "Start Now", the storyteller vote automatically resolves
fix: When an admin click Start Now and there's no vote, the storyteller vote automatically resolves to Astrata. This means that on localhost I can save some time testing wretch classes and antagonists in general for the general use case, as Psydon is not a likely use case for most developers

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
