### PR TITLE
mechanical yaoi - ports the ability to aggressively shove people against walls

### DIFF
--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -32,8 +32,13 @@
 		if(L.mobility_flags & MOBILITY_MOVE)
 			wallpress(L)
 			return
+	else if(user != O && ishuman(user) && ishuman(O)) // check to see if user is dragging another mob onto the wall
+		var/mob/living/carbon/human/us = user
+		var/mob/living/carbon/human/them = O
+		if((us.mobility_flags & MOBILITY_MOVE) && (them.mobility_flags & MOBILITY_MOVE) && us.get_highest_grab_state_on(them) > GRAB_PASSIVE)
+			wallpress(them, us)
 
-/turf/closed/proc/wallpress(mob/living/user)
+/turf/closed/proc/wallpress(mob/living/user, mob/living/pressing_mob = null)
 	if(user.wallpressed)
 		return
 	if(user.is_shifted)
@@ -41,6 +46,10 @@
 	if(!(user.mobility_flags & MOBILITY_STAND))
 		return
 	var/dir2wall = get_dir(user,src)
+	if(pressing_mob) // step up to the wall
+		user.Move(get_step(pressing_mob, user))
+		user.setDir(turn(get_dir(pressing_mob, src),180))
+		dir2wall = get_dir(user,src)
 	if(!(dir2wall in GLOB.cardinals))
 		return
 	user.wallpressed = dir2wall
@@ -48,7 +57,7 @@
 	if(user.m_intent == MOVE_INTENT_SNEAK)
 		to_chat(user, span_info("You press yourself against [src]."))
 	else
-		user.visible_message(span_info("[user] leans against [src]."))
+		user.visible_message(pressing_mob ? span_info("[user] is pushed against [src] by [pressing_mob].") : span_info("[user] leans against [src]."))
 	switch(dir2wall)
 		if(NORTH)
 			user.setDir(SOUTH)


### PR DESCRIPTION
## About The Pull Request

Port of [this](https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1364) particular pull request. In short:
* When aggressively grabbing someone's chest, you can click-drag them in order to forcefully 'push' them against a wall.
* You can only do this from the sides for right now - at least, until someone disables one-tile-wide collisions on the grapplee.

## Testing Evidence

<img width="491" height="109" alt="0154e266a9774f8c552462305f7d8358 (1)" src="https://github.com/user-attachments/assets/b2a7ea78-9fdf-4583-a0ef-94f55744fca5" />

## Why It's Good For The Game

* Offers another way to non-lethally push people out of your way, alongside shoving and toppling.
* Adds further mechanical means of intimidating others.

## Changelog

:cl:
add: Aggressively grabbing someone's torso will now let you forcefully push them against a wall, by click-dragging them onto-said wall.
/:cl:
