### PR TITLE
Goblin Outlaw Quest + Quest Spawner Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/mini_boss/large_goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/mini_boss/large_goblin.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(large_goblin_aggro, list(
 /mob/living/carbon/human/species/goblin/npc/large
 	name = "unusually large goblin"
 	gob_outfit = /datum/outfit/job/roguetown/npc/mini_boss/large_goblin
-	faction = list(FACTION_DUNDEAD)
+	faction = list(FACTION_DUNDEAD, FACTION_ORCS)
 	dodgetime = 20
 	d_intent = INTENT_PARRY
 

--- a/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
@@ -15,9 +15,9 @@
 	proximity_monitor = new(src, 7)
 
 /obj/effect/quest_spawn/Destroy(force)
-	. = ..()
 	QDEL_NULL(contained_atom)
 	proximity_monitor = null
+	. = ..()
 
 /obj/effect/quest_spawn/HasProximity(mob/nearby)
 	if(!contained_atom)
@@ -35,6 +35,14 @@
 		return
 
 	if(get_dist(get_turf(src), get_turf(quest.quest_scroll_ref?.resolve())) > 7)
+		return
+
+	// Pop every spawner this quest owns at once so the whole encounter materializes together.
+	quest.pop_all_spawners()
+
+/// Materializes the contained mob onto our turf with the warning flash + sound.
+/obj/effect/quest_spawn/proc/reveal_contained()
+	if(!contained_atom)
 		return
 
 	var/image/I = image(icon = 'icons/effects/effects.dmi', loc = get_turf(src), icon_state = "mobwarning", layer = 18)

--- a/code/modules/roguetown/roguemachine/questing/questing_landmarks.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_landmarks.dm
@@ -33,12 +33,16 @@
 	for(var/turf/open/floor/T in view(7, selected_landmark))
 		if(T.density || istransparentturf(T))
 			continue
-			
-		for(var/obj/O in get_turf(T))
-			if(O.density) //No more spawning in metal bars or trees...
-				continue
 
 		if(get_area(T) != get_area(selected_landmark)) //No more spawning in guild room...
+			continue
+
+		var/blocked = FALSE
+		for(var/obj/O in T)
+			if(O.density) //No more spawning in metal bars or trees...
+				blocked = TRUE
+				break
+		if(blocked)
 			continue
 
 		possible_turfs += T

--- a/code/modules/roguetown/roguemachine/questing/types/__quest.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/__quest.dm
@@ -34,6 +34,8 @@
 	var/datum/weakref/quest_scroll_ref
 	/// List of weakrefs to actual quest items/mobs for reducing overhead of compass.
 	var/list/datum/weakref/tracked_atoms = list()
+	/// Weakrefs to this quest's `/obj/effect/quest_spawn` pods — used to pop the whole encounter at once.
+	var/list/datum/weakref/spawners = list()
 
 /datum/quest/Destroy()
 	// Clean up mobs with quest components
@@ -70,6 +72,19 @@
 
 /datum/quest/proc/add_tracked_atom(atom/movable/to_track)
 	tracked_atoms += WEAKREF(to_track)
+
+/// Registers a quest_spawn pod so pop_all_spawners() can trigger the whole encounter at once.
+/datum/quest/proc/register_spawner(obj/effect/quest_spawn/spawner)
+	spawners += WEAKREF(spawner)
+
+/// Materializes every live spawner belonging to this quest. Called when any one of them triggers.
+/datum/quest/proc/pop_all_spawners()
+	for(var/datum/weakref/ref in spawners)
+		var/obj/effect/quest_spawn/spawner = ref.resolve()
+		if(QDELETED(spawner) || !spawner.contained_atom)
+			continue
+		spawner.reveal_contained()
+	spawners.Cut()
 
 /// Generate quest content - override in subtypes
 /datum/quest/proc/generate(obj/effect/landmark/quest_spawner/landmark)

--- a/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
@@ -25,6 +25,7 @@
 		addtimer(TRAIT_CALLBACK_REMOVE(new_mob, TRAIT_FRESHSPAWN, "[type]"), 60 SECONDS)
 		spawn_effect.contained_atom = new_mob
 		spawn_effect.AddComponent(/datum/component/quest_object/mob_spawner, src)
+		register_spawner(spawn_effect)
 		add_tracked_atom(new_mob)
 		landmark.add_quest_faction_to_nearby_mobs(spawn_turf)
 		sleep(1)

--- a/code/modules/roguetown/roguemachine/questing/types/kill/quest_outlaw.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/quest_outlaw.dm
@@ -63,3 +63,4 @@ GLOBAL_LIST_INIT(quest_outlaw_goblin_goons, list(
 		addtimer(TRAIT_CALLBACK_REMOVE(goon, TRAIT_FRESHSPAWN, "[type]"), 60 SECONDS)
 		spawn_effect.contained_atom = goon
 		spawn_effect.AddComponent(/datum/component/quest_object/mob_spawner, src)
+		register_spawner(spawn_effect)

--- a/code/modules/roguetown/roguemachine/questing/types/kill/quest_outlaw.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/quest_outlaw.dm
@@ -1,3 +1,13 @@
+/// Goblin minion pool used by the large-goblin boss variant.
+GLOBAL_LIST_INIT(quest_outlaw_goblin_goons, list(
+	/mob/living/carbon/human/species/goblin/npc,
+	/mob/living/carbon/human/species/goblin/npc,
+	/mob/living/carbon/human/species/goblin/npc,
+	/mob/living/carbon/human/species/goblin/npc/archer,
+	/mob/living/carbon/human/species/goblin/npc/slinger,
+	/mob/living/carbon/human/species/goblin/npc/bomber,
+))
+
 /datum/quest/kill/outlaw
 	quest_type = QUEST_OUTLAW
 	mob_types_to_spawn = list(
@@ -5,10 +15,16 @@
 		/mob/living/carbon/human/species/human/northern/outlaw_duelist,
 		/mob/living/carbon/human/species/human/northern/outlaw_ranger,
 		/mob/living/carbon/human/species/human/northern/outlaw_tank,
-		/mob/living/carbon/human/species/goblin/npc/large,
 	)
 	count_min = 1
 	count_max = 1
+	/// Typepath spawned by spawn_goons() as accompanying minions (human-outlaw default).
+	var/goon_type = /mob/living/carbon/human/species/human/northern/highwayman/dk_goon
+	/// Range of goons to spawn alongside the target.
+	var/goon_count_min = 2
+	var/goon_count_max = 5
+	/// Flipped during generate() when the large-goblin boss roll lands — swaps goon pool to goblins.
+	var/goblin_warlord_variant = FALSE
 
 /datum/quest/kill/outlaw/get_title()
 	if(title)
@@ -22,18 +38,25 @@
 	..()
 	if(!landmark)
 		return FALSE
+	// Roll the goblin-warlord variant before spawning — swaps target pool and beefs up the goon count.
+	if(prob(20))
+		goblin_warlord_variant = TRUE
+		mob_types_to_spawn = list(/mob/living/carbon/human/species/goblin/npc/large)
+		goon_count_min = 5
+		goon_count_max = 9
 	spawn_kill_mobs(landmark)
 	spawn_goons(landmark)
 	return TRUE
 
 /// Spawns proximity-gated goons near the quest landmark to accompany the outlaw target.
 /datum/quest/kill/outlaw/proc/spawn_goons(obj/effect/landmark/quest_spawner/landmark)
-	for(var/i in 1 to rand(2, 5))
+	for(var/i in 1 to rand(goon_count_min, goon_count_max))
 		var/turf/spawn_turf = landmark.get_safe_spawn_turf()
 		if(!spawn_turf)
 			continue
 		var/obj/effect/quest_spawn/spawn_effect = new /obj/effect/quest_spawn(spawn_turf)
-		var/mob/living/goon = new /mob/living/carbon/human/species/human/northern/highwayman/dk_goon(spawn_effect)
+		var/goon_path = goblin_warlord_variant ? pick(GLOB.quest_outlaw_goblin_goons) : goon_type
+		var/mob/living/goon = new goon_path(spawn_effect)
 		goon.faction |= "quest"
 		// Suppress AI scanning while dormant inside the spawn_effect — see __quest_kill_base.dm
 		ADD_TRAIT(goon, TRAIT_FRESHSPAWN, "[type]")


### PR DESCRIPTION
## About The Pull Request
- Fixes goblin quest by making goblin outlaw quest spawn goblin instead
- Quest spawner no longer spawn inside trees
- When one spawner is triggered, every single mob is spawned at once instead of one by one by proximity


<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yes

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This fixes the issue with unusually large goblin being beaten by their own goons and makes outlaw contract difficult and quest contract difficulty matches what is intended.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Outlaw Goblin's goons are now goblins, and should no longer deliberately beat the large goblin to death
add: Quest now spawns in every mob at once instead of based on which spawner is proximate to you or not. Expect higher difficulty. Bring friends and headhook.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
