### PR TITLE
Adds ambient music toggle

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -141,6 +141,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/lobbymusicvol = 50
 	var/ambiencevol = 50
 	var/mastervol = 50
+	var/stopdroning = FALSE
 
 	var/anonymize = TRUE
 	var/masked_examine = FALSE

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -161,6 +161,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["lobbymusicvol"]		>> lobbymusicvol
 	S["ambiencevol"]		>> ambiencevol
 	S["anonymize"]			>> anonymize
+	S["stopdroning"]		>> stopdroning
 	S["masked_examine"]		>> masked_examine
 	S["full_examine"]		>> full_examine
 	S["mute_animal_emotes"]	>> mute_animal_emotes
@@ -282,6 +283,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["lobbymusicvol"], lobbymusicvol)
 	WRITE_FILE(S["ambiencevol"], ambiencevol)
 	WRITE_FILE(S["anonymize"], anonymize)
+	WRITE_FILE(S["stopdroning"], stopdroning)
 	WRITE_FILE(S["masked_examine"], masked_examine)
 	WRITE_FILE(S["full_examine"], full_examine)
 	WRITE_FILE(S["mute_animal_emotes"], mute_animal_emotes)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -206,6 +206,20 @@
 	if(mob)
 		SEND_SOUND(mob, sound(null))
 
+/client/verb/toggle_area_music()
+	set category = "Options"
+	set name = "Toggle Area Music"
+	if(prefs)
+		prefs.stopdroning = !prefs.stopdroning
+		prefs.save_preferences()
+
+		if(prefs.stopdroning)
+			to_chat(src, "You will no longer hear looping area music.")
+			SSdroning.kill_droning(src)
+			SSdroning.kill_loop(src)
+		else
+			to_chat(src, "You will now hear looping area music.")
+
 /client/verb/cmode_strip()
 	set name = "Combat Mode Stripping"
 	set category = "Options"

--- a/code/modules/droning/droning.dm
+++ b/code/modules/droning/droning.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(droning)
 /datum/controller/subsystem/droning/proc/area_entered(area/area_entered, client/entering)
 	if(!area_entered || !entering)
 		return
-	if(listener && listener.prefs && listener.prefs.stopdroning)
+	if(entering && entering.prefs && entering.prefs.stopdroning)
 		return
 /*
 	if(HAS_TRAIT(entering.mob, TRAIT_LEAN) && !area_entered.droning_sound)

--- a/code/modules/droning/droning.dm
+++ b/code/modules/droning/droning.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(droning)
 /datum/controller/subsystem/droning/proc/area_entered(area/area_entered, client/entering)
 	if(!area_entered || !entering)
 		return
-	if(listener?.prefs?.stopdroning)
+	if(listener && listener.prefs && listener.prefs.stopdroning)
 		return
 /*
 	if(HAS_TRAIT(entering.mob, TRAIT_LEAN) && !area_entered.droning_sound)
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(droning)
 	if(!area_player || !listener)
 		return
 	
-	if(listener?.prefs?.stopdroning)
+	if(listener && listener.prefs && listener.prefs.stopdroning)
 		return
 	
 	if(SSticker.current_state >= GAME_STATE_FINISHED) //stop drones in round end
@@ -112,7 +112,7 @@ SUBSYSTEM_DEF(droning)
 /datum/controller/subsystem/droning/proc/last_phase(area/area_player, client/listener, shouldskip = FALSE)
 	if(!area_player || !listener)
 		return
-	if(listener?.prefs?.stopdroning)
+	if(listener && listener.prefs && listener.prefs.stopdroning)
 		return
 	if(!listener?.droning_sound)
 		shouldskip = TRUE

--- a/code/modules/droning/droning.dm
+++ b/code/modules/droning/droning.dm
@@ -6,6 +6,8 @@ SUBSYSTEM_DEF(droning)
 /datum/controller/subsystem/droning/proc/area_entered(area/area_entered, client/entering)
 	if(!area_entered || !entering)
 		return
+	if(listener?.prefs?.stopdroning)
+		return
 /*
 	if(HAS_TRAIT(entering.mob, TRAIT_LEAN) && !area_entered.droning_sound)
 		//just kill the previous droning sound
@@ -31,6 +33,9 @@ SUBSYSTEM_DEF(droning)
 
 /datum/controller/subsystem/droning/proc/play_area_sound(area/area_player, client/listener)
 	if(!area_player || !listener)
+		return
+	
+	if(listener?.prefs?.stopdroning)
 		return
 	
 	if(SSticker.current_state >= GAME_STATE_FINISHED) //stop drones in round end
@@ -106,6 +111,8 @@ SUBSYSTEM_DEF(droning)
 
 /datum/controller/subsystem/droning/proc/last_phase(area/area_player, client/listener, shouldskip = FALSE)
 	if(!area_player || !listener)
+		return
+	if(listener?.prefs?.stopdroning)
 		return
 	if(!listener?.droning_sound)
 		shouldskip = TRUE


### PR DESCRIPTION
## About The Pull Request

Ever get annoyed that you had to mute the game because the bathhouse music kept looping for the 1000th time? Can't hear Abyssor's blessed rain over that damned shop music?
Me too.

Adds a toggle to turn off looping area music.

Due to the way droning sounds work, the toggle temporarily also cuts off ambience (rain/wind/etc) if some is playing, but simply retrigger it (walk indoors/outdoors) and it's fine. Those still play even with the toggle on, as intended.

## Testing Evidence

I tested it.

## Why It's Good For The Game

I had a musician play some music in the bathhouse the other day and I could barely hear it over the bathhouse loop. So I made this PR. Also when testing this I noticed just how much more immersive the game is with just the ambience sounds.

## Changelog

:cl:
qol: Added a toggle for looping area music. Bathhouse/bandit/etc music loop BEGONE.
/:cl: