### PR TITLE
Fixes sleeved tabards sleeve layering

### DIFF
--- a/code/datums/loadout/loadout_cloaks.dm
+++ b/code/datums/loadout/loadout_cloaks.dm
@@ -171,5 +171,5 @@
 
 /datum/loadout_item/sleevedtabard
 	name = "Tabard, Sleeved"
-	path = /obj/item/clothing/cloak/tabard/sleevedtabard
+	path = /obj/item/clothing/cloak/sleevedtabard
 	sort_category = "Cloaks"

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -157,7 +157,7 @@
 			pic.color = get_detail_color()
 		add_overlay(pic)
 
-/obj/item/clothing/cloak/tabard/sleevedtabard
+/obj/item/clothing/cloak/sleevedtabard
 	name = "Sleeved Tabard"
 	desc = " A tabard with a light sleeve and pauldron sewn on, it lacks the explicit detailing of other tabards in exchange."
 	color = null 


### PR DESCRIPTION
## About The Pull Request

should fix sleeved tabards weird layering issue with arm armour, i just turned it into a cloak subtype instead of a tabard subtype. Shouldnt affect anything else 

## Testing Evidence

nothing exploded when i booted up the testserver

## Why It's Good For The Game

IT IS SUPPOSED TO HAVE A SLEEVE THAT GO OVER THA ARM AMOUR BUT FOR SOME REASON IT DO NOT!!! AAAA

## Changelog

:cl:

fix: Fixed sleeved tabards weird sleeve layering issue

/:cl:

