### PR TITLE
lonely fixes

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -266,7 +266,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 /datum/charflaw/lonely/flaw_on_life(mob/user)
 	if(!user)
 		return
-	if(is_active)
+	if(is_active && user.stat == CONSCIOUS)
 		if(world.time > next_check)
 			next_check = world.time + interval
 			var/cnt = 0
@@ -307,7 +307,7 @@ GLOBAL_LIST_INIT(averse_factions, list(
 	if(stacks >= 2)
 		to_chat(L, span_info("Oh thank [L.patron?.name]! A person!"))
 	if(stacks > 1)
-		L.remove_stress_list(/datum/stressevent/lonely_one, /datum/stressevent/lonely_two, /datum/stressevent/lonely_three, /datum/stressevent/lonely_max)
+		L.remove_stress_list(list(/datum/stressevent/lonely_one, /datum/stressevent/lonely_two, /datum/stressevent/lonely_three, /datum/stressevent/lonely_max))
 	stacks = 0
 
 /datum/charflaw/clingy


### PR DESCRIPTION
## About The Pull Request
- Lonely now accounts for the user being conscious. Being dead should really not result in extra loneliness, Necra's got you.
- Fixed an issue with the stress debuffs being removed incorrectly once fully stacked
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed Lonely Vice working while unconscious / dead.
fix: Fixed Lonely Vice stress debuffs not being removed correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
