### PR TITLE
Aggressive Guarded Buffs

### DIFF
--- a/code/_onclick/hud/mouseover.dm
+++ b/code/_onclick/hud/mouseover.dm
@@ -199,7 +199,7 @@
 		var/mousecolor = "#c1aaaa"
 		if(ishuman(src))
 			var/mob/living/carbon/human/H = src
-			if(H.voice_color)
+			if(H.voice_color && H.show_descriptors)
 				if(H.name == H.real_name)
 					mousecolor = "#[H.voice_color]"
 		p.client.mouseovertext.maptext = {"<span style='font-size:8pt;font-family:"Pterra";color:[mousecolor];text-shadow:0 0 10px #fff, 0 0 20px #fff, 0 0 30px #e60073, 0 0 40px #e60073, 0 0 50px #e60073, 0 0 60px #e60073, 0 0 70px #e60073;' class='center maptext '>[name]"}

--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -238,3 +238,15 @@
 	else
 		ADD_TRAIT(src, TRAIT_COMBAT_AWARE, TRAIT_VIRTUE)
 	to_chat(src, "I will see [HAS_TRAIT(src, TRAIT_COMBAT_AWARE) ? "more" : "less"] combat information now.")
+
+
+/mob/living/carbon/human/proc/toggle_descriptors()
+	set name = "Toggle Anonimity"
+	set category = "Virtue"
+
+	show_descriptors = !show_descriptors
+	to_chat(src, "My identifying features are [show_descriptors ? "no longer " : ""]obscured.")
+	if(show_descriptors)
+		voicecolor_override = null
+	else
+		voicecolor_override = "#A0A0A0"

--- a/code/game/objects/examine.dm
+++ b/code/game/objects/examine.dm
@@ -50,9 +50,12 @@
 			result = span_warning("It's a little damaged.")
 	return result
 
-/obj/item/clothing/integrity_check(elaborate = FALSE)
+/obj/item/clothing/integrity_check(elaborate = FALSE, guarded = FALSE)
 	if(obj_broken)
 		return span_warning("It's broken.")
+
+	if(guarded)
+		return ""
 
 	var/eff_maxint = max_integrity - (max_integrity * integrity_failure)
 	var/eff_currint = max(obj_integrity - (max_integrity * integrity_failure), 0)

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -228,7 +228,7 @@
 	if(!prob(perc)) //feint intent increases the immobilize duration significantly
 		playsound(user, 'sound/combat/feint.ogg', 100, TRUE)
 		if(user.client?.prefs.showrolls)
-			to_chat(user, span_warning("[L.p_they(TRUE)] did not fall for my feint... [perc]%"))
+			to_chat(user, span_warning("[L.p_they(TRUE)] did not fall for my feint... [HAS_TRAIT(L, TRAIT_DECEIVING_MEEKNESS) ? "???" : perc]%"))
 		user.apply_status_effect(/datum/status_effect/debuff/feintcd, newcd)
 		if(special_msg)
 			to_chat(user, special_msg)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -360,6 +360,7 @@
 	var/is_stupid = FALSE
 	var/is_smart = FALSE
 	var/is_normal = FALSE
+	var/guarded = FALSE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 
@@ -369,6 +370,10 @@
 			is_stupid = TRUE
 		if(((H?.STAINT - 10) + (H?.STAPER - 10) + H.get_skill_level(/datum/skill/misc/reading)) >= 5)
 			is_normal = TRUE
+
+		if(user != src)
+			if(HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS))
+				guarded = TRUE
 
 	if(user != src)
 		var/datum/mind/Umind = user.mind
@@ -383,7 +388,7 @@
 
 	if(wear_shirt && !(SLOT_SHIRT in obscured))
 		var/str = "[m3] [wear_shirt.generate_tooltip(wear_shirt.get_examine_string(user))]. "
-		str += "[wear_shirt.integrity_check(is_smart)]"
+		str += "[wear_shirt.integrity_check(is_smart, guarded)]"
 		if(is_stupid)
 			str = "[m3] some kind of shirt!"
 		. += str
@@ -398,7 +403,7 @@
 				accessory_msg += " with [icon2html(U.attached_accessory, user)] \a [U.attached_accessory]"
 		var/str = "[m3] [wear_pants.generate_tooltip(wear_pants.get_examine_string(user))][accessory_msg]. "
 		if(!wear_armor)
-			str += wear_pants.integrity_check(is_smart)
+			str += wear_pants.integrity_check(is_smart, guarded)
 		if(is_stupid)
 			str = "[m3] a pair of some pants! "
 		. += str
@@ -419,7 +424,7 @@
 	if(wear_armor && !(SLOT_ARMOR in obscured))
 		var/str = "[m3] [wear_armor.generate_tooltip(wear_armor.get_examine_string(user))]. "
 		if(is_smart || is_normal)
-			str += wear_armor.integrity_check(is_smart)
+			str += wear_armor.integrity_check(is_smart, guarded)
 		else if (is_stupid)
 			if(istype(wear_armor, /obj/item/clothing/suit/roguetown/armor))
 				var/obj/item/clothing/suit/roguetown/armor/examined_armor = wear_armor
@@ -450,7 +455,7 @@
 			str = "[m3] [CL.generate_tooltip(CL.get_examine_string(user))] on [m2] shoulders. "
 		else
 			str = "[m3] [cloak.get_examine_string(user)] on [m2] shoulders. "
-		str += cloak.integrity_check(is_smart)
+		str += cloak.integrity_check(is_smart, guarded)
 		if (is_stupid)					//So they can tell the named RG tabards. If they can read them, anyway.
 			if(!istype(cloak, /obj/item/clothing/cloak/tabard/stabard) && user.get_skill_level(/datum/skill/misc/reading) == 0)
 				str = "[m3] some kinda clothy thing on [m2] shoulders!"
@@ -459,27 +464,27 @@
 	//right back
 	if(backr && !(SLOT_BACK_R in obscured))
 		var/str = "[m3] [backr.get_examine_string(user)] on [m2] back. "
-		str += backr.integrity_check(is_smart)
+		str += backr.integrity_check(is_smart, guarded)
 		. += str
 
 	//left back
 	if(backl && !(SLOT_BACK_L in obscured))
 		var/str = "[m3] [backl.get_examine_string(user)] on [m2] back. "
-		str += backl.integrity_check(is_smart)
+		str += backl.integrity_check(is_smart, guarded)
 		. += str
 
 	//Hands
 	for(var/obj/item/I in held_items)
 		if(!(I.item_flags & ABSTRACT))
 			var/str = "[m1] holding [I.get_examine_string(user)] in [m2] [get_held_index_name(get_held_index_of_item(I))]. "
-			str += I.integrity_check(is_smart)
+			str += I.integrity_check(is_smart, guarded)
 			. += str
 
 	var/datum/component/forensics/FR = GetComponent(/datum/component/forensics)
 	//gloves
 	if(gloves && !(SLOT_GLOVES in obscured))
 		var/str = "[m3] [gloves.generate_tooltip(gloves.get_examine_string(user))] on [m2] hands. "
-		str += gloves.integrity_check(is_smart)
+		str += gloves.integrity_check(is_smart, guarded)
 		if(is_stupid)
 			str = "[m3] a pair of gloves of some kind!"
 		. += str
@@ -494,13 +499,13 @@
 	//belt
 	if(belt && !(SLOT_BELT in obscured))
 		var/str = "[m3] [belt.get_examine_string(user)] about [m2] waist. "
-		str += belt.integrity_check(is_smart)
+		str += belt.integrity_check(is_smart, guarded)
 		. += str
 
 	//right belt
 	if(beltr && !(SLOT_BELT_R in obscured))
 		var/str = "[m3] [beltr.get_examine_string(user)] on [m2] belt. "
-		str += beltr.integrity_check(is_smart)
+		str += beltr.integrity_check(is_smart, guarded)
 		. += str
 
 	//left belt
@@ -512,7 +517,7 @@
 	//shoes
 	if(shoes && !(SLOT_SHOES in obscured))
 		var/str = "[m3] [shoes.generate_tooltip(shoes.get_examine_string(user))] on [m2] feet. "
-		str += shoes.integrity_check(is_smart)
+		str += shoes.integrity_check(is_smart, guarded)
 		if(is_stupid)
 			str = "[m3] some shoes on [m2] feet!"
 		. += str
@@ -520,7 +525,7 @@
 	//mask
 	if(wear_mask && !(SLOT_WEAR_MASK in obscured))
 		var/str = "[m3] [wear_mask.generate_tooltip(wear_mask.get_examine_string(user))] on [m2] face. "
-		str += wear_mask.integrity_check(is_smart)
+		str += wear_mask.integrity_check(is_smart, guarded)
 		if(is_stupid)
 			str = "[m3] some kinda thing on [m2] face!"
 		. += str
@@ -533,7 +538,7 @@
 			str = "[m3] [CM.generate_tooltip(CM.get_examine_string(user))] in [m2] mouth. "
 		else
 			"[m3] [mouth.get_examine_string(user)] in [m2] mouth. "
-		str += mouth.integrity_check(is_smart)
+		str += mouth.integrity_check(is_smart, guarded)
 		if(is_stupid)
 			str = "[m3] some kinda thing on [m2] mouth!"
 		. += str
@@ -541,7 +546,7 @@
 	//neck
 	if(wear_neck && !(SLOT_NECK in obscured))
 		var/str = "[m3] [wear_neck.generate_tooltip(wear_neck.get_examine_string(user))] around [m2] neck. "
-		str += wear_neck.integrity_check(is_smart)
+		str += wear_neck.integrity_check(is_smart, guarded)
 		if (is_stupid)
 			str = "[m3] something on [m2] neck!"
 		. += str
@@ -574,7 +579,7 @@
 	//wrists
 	if(wear_wrists && !(SLOT_WRISTS in obscured))
 		var/str = "[m3] [wear_wrists.generate_tooltip(wear_wrists.get_examine_string(user))] on [m2] wrists."
-		str += wear_wrists.integrity_check(is_smart)
+		str += wear_wrists.integrity_check(is_smart, guarded)
 		if (is_stupid)
 			str = "[m3] something on [m2] wrists!"
 		. += str
@@ -583,7 +588,7 @@
 	if(istype(skin_armor, /obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward))
 		var/obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/ward = skin_armor
 		var/str = "[m3] <font color='[ward.ward_color]'>[ward.generate_tooltip(ward.get_examine_string(user))] shimmering around [user == src ? "me" : p_them()].</font>"
-		str += ward.integrity_check(is_smart)
+		str += ward.integrity_check(is_smart, guarded)
 		if (is_stupid)
 			str = "[m3] some weird shiny thing!"
 		. += str
@@ -993,24 +998,25 @@
 				. += "<span class='info' style='color: #313131ff'>[m1] wearing black lipstick.</span>"
 
 
-	var/list/lines
-	if((get_face_name() != real_name) && !observer_privilege)
-		lines = build_cool_description_unknown(get_mob_descriptors_unknown(obscure_name, user), src)
-	else
-		lines = build_cool_description(get_mob_descriptors(obscure_name, user), src)
+	if(show_descriptors)
+		var/list/lines
+		if((get_face_name() != real_name) && !observer_privilege)
+			lines = build_cool_description_unknown(get_mob_descriptors_unknown(obscure_name, user), src)
+		else
+			lines = build_cool_description(get_mob_descriptors(obscure_name, user), src)
 
-	var/app_str
-	if(!(user.client?.prefs?.full_examine))
-		app_str = "<details><summary>[span_info("Details")]</summary>"
+		var/app_str
+		if(!(user.client?.prefs?.full_examine))
+			app_str = "<details><summary>[span_info("Details")]</summary>"
 
-	for(var/line in lines)
-		app_str += span_info(line)
-		app_str += "<br>"
-	if(!(user.client?.prefs?.full_examine))
-		if(length(lines))
-			app_str += "</details>"
+		for(var/line in lines)
+			app_str += span_info(line)
+			app_str += "<br>"
+		if(!(user.client?.prefs?.full_examine))
+			if(length(lines))
+				app_str += "</details>"
 
-	. += app_str
+		. += app_str
 
 	// Characters with the hunted flaw will freak out if they can't see someone's face.
 	if(!appears_dead)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -208,3 +208,6 @@
 	var/can_do_sex = TRUE
 
 	fovangle = FOV_DEFAULT
+
+	/// Guarded Virtue (TRAIT_DECEIVING_MEEKNESS) exclusive variable for filtering out our descriptors from examine.
+	var/show_descriptors = TRUE

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -44,6 +44,8 @@
 		return face_name
 	if(id_name)
 		return id_name
+	if(HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS) && !show_descriptors)
+		return "Unknown"
 	var/list/d_list = get_mob_descriptors()
 	var/trait_desc = "[capitalize(build_coalesce_description_nofluff(d_list, src, list(MOB_DESCRIPTOR_SLOT_TRAIT), "%DESC1%"))]"
 	var/stature_desc = "[capitalize(build_coalesce_description_nofluff(d_list, src, list(MOB_DESCRIPTOR_SLOT_STATURE), "%DESC1%"))]"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -56,7 +56,7 @@
 /mob/living/carbon/human/get_alt_name(var/force = FALSE)
 	if(force || name != GetVoice())
 		var/datum/mob_descriptor/voice/voice_descriptor = get_descriptor_type(/datum/mob_descriptor/voice)
-		if(!voice_descriptor)
+		if(!voice_descriptor || (HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS) && !show_descriptors))
 			return "Unknown Person"
 
 		var/voice_gender = "Person"

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -257,7 +257,7 @@
 
 		var/attacker_feedback 
 
-		if(src.client?.prefs.showrolls)
+		if(src.client?.prefs.showrolls && !HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
 			var/text = "Roll to dodge... [prob2defend]%"
 			if((defender_dualw || attacker_dualw))
 				if(defender_dualw && attacker_dualw)

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -263,7 +263,7 @@
 				if(defender_dualw && attacker_dualw)
 					text += " Our dual wielding cancels out!"
 				else//If we're defending against or as a dual wielder, we roll disadv. But if we're both dual wielding it cancels out.
-					text += " Twice! Disadvantage! [!HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS) ? "([(prob2defend / 100) * (prob2defend / 100) * 100]%)" : ""]
+					text += " Twice! Disadvantage! [!HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS) ? "([(prob2defend / 100) * (prob2defend / 100) * 100]%)" : ""]"
 			to_chat(src, span_info("[text]"))
 
 		if(user.client?.prefs.showrolls && !HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS) && has_trait && client)

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -257,13 +257,13 @@
 
 		var/attacker_feedback 
 
-		if(src.client?.prefs.showrolls && !HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
-			var/text = "Roll to dodge... [prob2defend]%"
+		if(src.client?.prefs.showrolls)
+			var/text = "Roll to dodge... [HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS) ? "???" : prob2defend]%"
 			if((defender_dualw || attacker_dualw))
 				if(defender_dualw && attacker_dualw)
 					text += " Our dual wielding cancels out!"
 				else//If we're defending against or as a dual wielder, we roll disadv. But if we're both dual wielding it cancels out.
-					text += " Twice! Disadvantage! ([(prob2defend / 100) * (prob2defend / 100) * 100]%)"
+					text += " Twice! Disadvantage! [!HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS) ? "([(prob2defend / 100) * (prob2defend / 100) * 100]%)" : ""]
 			to_chat(src, span_info("[text]"))
 
 		if(user.client?.prefs.showrolls && !HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS) && has_trait && client)

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -230,7 +230,7 @@
 		extradefroll = prob(prob2defend)
 		defender_dualw = TRUE
 
-	if(src.client?.prefs.showrolls)
+	if(src.client?.prefs.showrolls && !HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
 		var/text = "Roll to parry... [prob2defend]%"
 		if(defender_dualw)
 			text += " Twice! Disadvantage! ([(prob2defend / 100) * (prob2defend / 100) * 100]%)"

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -230,10 +230,10 @@
 		extradefroll = prob(prob2defend)
 		defender_dualw = TRUE
 
-	if(src.client?.prefs.showrolls && !HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
-		var/text = "Roll to parry... [prob2defend]%"
+	if(src.client?.prefs.showrolls)
+		var/text = "Roll to parry... [HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS) ? "???" : prob2defend]%"
 		if(defender_dualw)
-			text += " Twice! Disadvantage! ([(prob2defend / 100) * (prob2defend / 100) * 100]%)"
+			text += " Twice! Disadvantage! [!HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS) ? "([(prob2defend / 100) * (prob2defend / 100) * 100]%)" : ""]"
 		to_chat(src, span_info("[text]"))
 
 	if(has_status_effect(/datum/status_effect/swingdelay/penalty))

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -1488,7 +1488,7 @@
 
 /datum/emote/living/fsalute/run_emote(mob/living/user, params, type_override, intentional, targetted, animal)
 	. = ..()
-	if(. && !isnull(user.patron) && !HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))	//Guarded doesn't show an icon to anyone.
+	if(. && !isnull(user.patron))
 		user.play_overhead_indicator('icons/mob/overhead_effects.dmi', "stress", 15, MUTATIONS_LAYER, private = user.patron.type, soundin = 'sound/magic/holyshield.ogg', y_offset = 32)
 
 /mob/living/carbon/human/verb/emote_fsalute()

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -109,6 +109,8 @@
 	// Edit - Overwriting the outgoing message here to prevent metagaming faith via message.
 	// Not getting rid of the messages in the code, we might want them for something else later.
 	message_out = span_info("Healing energies envelop [target]!")
+	if(HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
+		message_self = "Healing energies envelop me!"
 	target.visible_message(message_out, message_self)
 
 	return TRUE

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -163,6 +163,7 @@
 /datum/virtue/combat/guarded/apply_to_human(mob/living/carbon/human/recipient)
 	. = ..()
 	recipient.verbs += /mob/living/carbon/human/proc/toggle_descriptors
+	recipient.verbs += /mob/living/carbon/human/proc/emote_ffsalute
 
 
 /datum/virtue/combat/rotcured

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -160,6 +160,11 @@
 	custom_text = "Obfuscates information about you from all sorts of effects, including patron abilities & passives, Assess and other virtues."
 	added_traits = list(TRAIT_DECEIVING_MEEKNESS)
 
+/datum/virtue/combat/guarded/apply_to_human(mob/living/carbon/human/recipient)
+	. = ..()
+	recipient.verbs += /mob/living/carbon/human/proc/toggle_descriptors
+
+
 /datum/virtue/combat/rotcured
 	name = "Rotcured"
 	desc = "I was once afflicted with the accursed rot, and was cured. It has left me changed: my limbs are weaker, but I feel no pain and have no need to breathe..."

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -164,7 +164,7 @@ h1.alert, h2.alert	{color: #c9c1ba;font-family: Pterra, TrueType;}
 .redtext				{color: #FF0000;}
 .clown					{color: #FF69Bf;	font-size: 3;	font-family: "Comic Sans MS", cursive, sans-serif;	font-weight: bold;}
 .his_grace				{color: #15D512;	font-family: "Courier New", cursive, sans-serif;	font-style: italic;}
-.hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500ms infinite;}
+.hypnophrase			{color: #3bb5d3;	font-weight: bold;	animation: hypnocolor 1500 ms infinite;}
 
 .phobia					{color: #dd0000;	font-weight: bold;}
 


### PR DESCRIPTION
## About The Pull Request
Guarded Virtue now grants a new verb in the Virtue tab:
<img width="166" height="45" alt="dreamseeker_ucxGzFjp6y" src="https://github.com/user-attachments/assets/66471770-deff-4582-a0e7-91230f302ca1" />

This verb will do several things:
- It will remove all descriptors entirely from the examine block:
<img width="319" height="77" alt="dreamseeker_NBF7VHopxr" src="https://github.com/user-attachments/assets/d9bc4f43-562f-41e6-949e-fcb97ea49ea0" />

- It will obscure your masked identity to that of a genderless "Unknown"
<img width="142" height="125" alt="dreamseeker_LRXaHbR9OV" src="https://github.com/user-attachments/assets/317bcc69-027b-49c6-aeb4-c3e244b7de9b" />

- It will do the same to your voice while also overriding the user's voice color:
<img width="484" height="31" alt="dreamseeker_9SMyJ3FuSE" src="https://github.com/user-attachments/assets/9907bc54-ec07-4a2e-bd06-938716054847" />


In addition:
- Guarded will no longer show any identifiable lesser miracle text.
- Guarded now gets the fake faith salute emote that Xylixians get ("Fake Faith Salute" emote). Guarded people's faith salute now works like everyone else's.
- Having Guarded will now prevent dodge and parry% from being shown to the defender.
- Guarded targets will no longer show a feint% on failure.
- Guarded now prevents any examine armor integrity from being shown, even to Intellectuals. Only broken armor states show up on examine of Guarded people.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I realised after reviewing the general power of Intellectual and Combat Aware that Guarded was entirely deserving of being a total nullification of all of those virtues rather than holding myself back because it "didn't make sense" that Guarded would interact with some of this stuff (IE armor integ on examine or masked descriptors)

Now it's a true, total informational black hole of a Virtue that might find more uses.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Guarded virtue can now toggle their own anonimity with a button in the Virtue tab, appearing with fewer identifying features.
refactor: Guarded virtue no longer has a forcefully blank faith salute, it works like normal now. Instead, Guarded gets a Fake Faith Salute emote.
balance: Guarded virtue now obscures worn armor integrity values unless broken.
balance: Guarded virtue now obscures dodge / feint / parry values for the defender.
balance: Guarded virtue now prevents showing any identifiable healing miracle text to the target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
