### PR TITLE
[FIX] Prestidigitation can now clean again.

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
+++ b/code/modules/spells/spell_types/wizard/utility/prestidigitation.dm
@@ -243,8 +243,8 @@
 			var/turf/T = get_turf(target)
 			new /obj/effect/temp_visual/cleaning_pulse(T)
 			for(var/obj/effect/decal/cleanable/C in T)
-				if(should_clean_rune(target))
-					wash_atom(C, CLEAN_MEDIUM)
+				if(!should_clean_rune(target))
+					return FALSE
 			wash_atom(T, CLEAN_MEDIUM)
 			to_chat(user, span_notice("I expunge \the [target.name] with my mana."))
 			return TRUE
@@ -256,8 +256,9 @@
 			var/turf/T = get_turf(target)
 			new /obj/effect/temp_visual/cleaning_pulse(T)
 			for(var/obj/effect/decal/cleanable/C in T)
-				if(should_clean_rune(C))
-					wash_atom(C, CLEAN_MEDIUM)
+				if(!should_clean_rune(C))
+					return FALSE
+			wash_atom(target, CLEAN_MEDIUM)
 			to_chat(user, span_notice("I render [clean_name] clean."))
 			return TRUE
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Prestidigitation was unable to clean targets from a recent change, fixed c:
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I booted it up on my PC, ran. Was able to clean myself, the floor, and attempting to clean a active wall matrix glyph caused it not to be wiped away (Tested both clicking the tile under it and the glyph itself)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugs are bad
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixes Prestidigitation not being able to clean things/people. Wizards no longer need baths again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
