### PR TITLE
[Virtue & Hag] - Second voice allows changing descriptor. Hags get better mirror magic.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -272,6 +272,7 @@
 #define TRAIT_WEATHER_PROTECTED "Weather Protected"
 #define TRAIT_VAMPIRE_SPAWN_PROTECTION "Vampire Spawn Protection"
 #define TRAIT_WHITE_STAG "Stag Protection"
+#define TRAIT_EDIT_DESCRIPTORS "Edit Descriptors"
 
 // Economic Roles Traits
 // Most of these should NOT be given to any true combat roles (I.E. anything with Dexpert or Miracle / Good Magic) with very few exceptions
@@ -542,6 +543,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_FEYTOUCHED = span_info("I've been influenced or created by fey, after offering lux to a heartroot, I can use it to travel."),
 	TRAIT_ROOT_WALKER = span_info("After offering lux, I can now travel along heartroot trees."),
 	TRAIT_WHITE_STAG = span_info("The power of the white stag lives on inside of me!"),
+	TRAIT_EDIT_DESCRIPTORS = span_info("I can change my appearance at a magic mirror in a thorough manner."),
 ))
 
 // trait accessor defines

--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -196,29 +196,35 @@
 	set name = "Change Second Voice (Can only use Once!)"
 	set category = "Virtue"
 
+	var/datum/component/voice_handler/V = GetComponent(/datum/component/voice_handler)
+	if(!V)
+		V = AddComponent(/datum/component/voice_handler)
+
 	var/newcolor = input(src, "Choose your character's SECOND voice color:", "VIRTUE","#a0a0a0") as color|null
-	if(newcolor)
-		second_voice = sanitize_hexcolor(newcolor)
-		src.verbs -= /mob/living/carbon/human/proc/changevoice
-		return TRUE
-	else
+	if(!newcolor)
 		return FALSE
+	var/datum/descriptor_choice/VC = DESCRIPTOR_CHOICE(/datum/descriptor_choice/voice)
+	var/list/voice_options = list()
+	for(var/desc_type in VC.descriptors)
+		var/datum/mob_descriptor/D = MOB_DESCRIPTOR(desc_type)
+		if(D)
+			voice_options[D.name] = desc_type
+
+	var/picked_name = input(src, "Choose how your SECOND voice is described:", "VIRTUE") as null|anything in voice_options
+	if(!picked_name)
+		return FALSE
+	V.second_color = sanitize_hexcolor(newcolor)
+	V.second_desc_path = voice_options[picked_name]
+	to_chat(src, span_notice("Second voice configured: Color [V.second_color] with the '[picked_name]' description."))
+	src.verbs -= /mob/living/carbon/human/proc/changevoice
+	return TRUE
 
 /mob/living/carbon/human/proc/swapvoice()
 	set name = "Swap Voice"
 	set category = "Virtue"
 
-	if(!second_voice)
-		to_chat(src, span_info("I haven't decided on my second voice yet."))
-		return FALSE
-	if(voice_color != second_voice)
-		original_voice = voice_color
-		voice_color = second_voice
-		to_chat(src, span_info("I've changed my voice to the second one."))
-	else
-		voice_color = original_voice
-		to_chat(src, span_info("I've returned to my natural voice."))
-	return TRUE
+	var/datum/component/voice_handler/V = GetComponent(/datum/component/voice_handler)
+	V.toggle_voice()
 
 /mob/living/carbon/human/proc/toggleblindness()
 	set name = "Toggle Colorblindness"

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -33,7 +33,7 @@
 	if(obj_broken || !Adjacent(user))
 		return
 
-	if(!HAS_TRAIT(H, TRAIT_MIRROR_MAGIC))
+	if(!HAS_TRAIT(H, TRAIT_MIRROR_MAGIC) && !HAS_TRAIT(H, TRAIT_EDIT_DESCRIPTORS))
 		to_chat(H, span_warning("You look into the mirror but see only your normal reflection."))
 		if(HAS_TRAIT(user, TRAIT_BEAUTIFUL))
 			H.add_stress(/datum/stressevent/beautiful)
@@ -286,7 +286,7 @@
 
 	var/mob/living/carbon/human/H = user
 
-	if(HAS_TRAIT(H, TRAIT_MIRROR_MAGIC))
+	if(HAS_TRAIT(H, TRAIT_MIRROR_MAGIC) || HAS_TRAIT(H, TRAIT_EDIT_DESCRIPTORS))
 		to_chat(H, span_info("You tilt your jaw from side to side, concentrating on the glamoring magicks limning your form..."))
 		if(do_after(H, 3 SECONDS))
 			perform_mirror_transform(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_traits.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_traits.dm
@@ -212,3 +212,8 @@
 	name = "Wyrd Labourer"
 	trait_to_apply = TRAIT_WYRD_LABOURER
 	points = 20
+
+/datum/hag_boon/trait/mirror_magic
+	name = "Wyrd Mirror Magic"
+	trait_to_apply = TRAIT_EDIT_DESCRIPTORS
+	points = 40

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_class.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_class.dm
@@ -5,7 +5,7 @@
 	tutorial = "You are ancient, malevolent evil. None of the known gods claim to have brought you into this world. All you know is hatred, how to sift through the grains of this land with your calloused hands, picking those who prove themselves useful."
 	outfit = /datum/outfit/job/roguetown/hag
 	traits_applied = list(TRAIT_RITUALIST, TRAIT_ALCHEMY_EXPERT,
-	 					  TRAIT_ANCIENT_HAG, TRAIT_MIRROR_MAGIC,
+	 					  TRAIT_ANCIENT_HAG, TRAIT_EDIT_DESCRIPTORS,
 						  TRAIT_HOMESTEAD_EXPERT, TRAIT_SEWING_EXPERT,
 						  TRAIT_LEECHIMMUNE, TRAIT_ZOMBIE_IMMUNE,
 						  TRAIT_NOMOOD, TRAIT_UNLYCKERABLE,

--- a/code/modules/spells/spell_types/wizard/utility/mirror_transform.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mirror_transform.dm
@@ -49,6 +49,8 @@
 		return
 	var/should_update = FALSE
 	var/list/choices = list("Accessory", "Breast Quantity", "Breast Size", "Ears", "Ear Color One", "Ear Color Two", "Eye Color", "Facial Hairstyle", "Facial Hair Color", "Face Detail", "Hairstyle", "Hair Primary Color", "Hair Secondary Gradient", "Hair Secondary Natural Color", "Hair Third Gradient", "Hair Third Dye Color", "Horns", "Horn Color", "Penis", "Penis Size", "Tail", "Tail Color One", "Tail Color Two", "Testicles", "Testicle Size", "Vagina", "Wings", "Wing Color")
+	if(HAS_TRAIT(H, TRAIT_EDIT_DESCRIPTORS))
+		choices += "Descriptors"
 	var/chosen = input(H, "Change what?", "Appearance") as null|anything in choices
 
 	if(!chosen)
@@ -768,6 +770,31 @@
 					should_update = TRUE
 			else
 				to_chat(H, span_warning("You don't have wings!"))
+		if("Descriptors")
+			var/list/species_choices = H.dna.species.descriptor_choices
+			if(!length(species_choices))
+				to_chat(H, span_warning("Your species has no standard descriptors to modify."))
+				return
+			var/list/choice_map = list()
+			for(var/path in species_choices)
+				var/datum/descriptor_choice/C = DESCRIPTOR_CHOICE(path)
+				choice_map[C.name] = path
+			var/choice_name = input(H, "Which feature do you want to describe?", "Standard Descriptors") as null|anything in choice_map
+			if(!choice_name)
+				return
+			var/choice_type = choice_map[choice_name]
+			var/datum/descriptor_choice/chosen_datum = DESCRIPTOR_CHOICE(choice_type)
+			var/list/picklist = list()
+			for(var/desc_type in chosen_datum.descriptors)
+				var/datum/mob_descriptor/descriptor = MOB_DESCRIPTOR(desc_type)
+				if(descriptor)
+					picklist[descriptor.name] = desc_type
+			var/picked_name = input(H, "Choose a new description for [choice_name]:", "Describe Myself") as null|anything in picklist
+			if(picked_name)
+				for(var/old_path in picklist)
+					H.remove_mob_descriptor(picklist[old_path])
+				H.add_mob_descriptor(picklist[picked_name])
+				should_update = TRUE
 
 	if(should_update)
 		H.update_hair()

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -210,6 +210,7 @@
 			else if(choice == "Second Voice")
 				recipient.verbs += /mob/living/carbon/human/proc/changevoice
 				recipient.verbs += /mob/living/carbon/human/proc/swapvoice
+				recipient.AddComponent(/datum/component/voice_handler)
 
 /datum/virtue/utility/performer
 	name = "Performer"

--- a/code/modules/virtues/virtue_helpers/virtue_components.dm
+++ b/code/modules/virtues/virtue_helpers/virtue_components.dm
@@ -1,0 +1,42 @@
+/datum/component/voice_handler
+	var/original_color
+	var/second_color
+	var/natural_desc_path
+	var/second_desc_path
+	var/active_state = FALSE // FALSE = Natural, TRUE = Second
+	var/virtue_setup = FALSE
+
+/datum/component/voice_handler/proc/setup(mob/living/carbon/human/H)
+	src.original_color = H.voice_color
+	var/datum/descriptor_choice/VC = DESCRIPTOR_CHOICE(/datum/descriptor_choice/voice)
+	var/list/current_descs = H.get_mob_descriptors()
+	for(var/path in current_descs)
+		if(path in VC.descriptors)
+			src.natural_desc_path = path
+			break
+	virtue_setup = TRUE
+
+/datum/component/voice_handler/proc/toggle_voice()
+	var/mob/living/carbon/human/H = parent
+	if(!virtue_setup)
+		setup(H)
+	if(!second_color)
+		to_chat(H, span_info("I haven't decided on my second voice yet."))
+		return
+
+	active_state = !active_state
+
+	if(active_state)
+		// Switch to Second
+		H.voice_color = second_color
+		if(natural_desc_path) H.remove_mob_descriptor(natural_desc_path)
+		if(second_desc_path) H.add_mob_descriptor(second_desc_path)
+		to_chat(H, span_info("I've changed my voice to the second one."))
+	else
+		// Switch to Natural
+		H.voice_color = original_color
+		if(second_desc_path) H.remove_mob_descriptor(second_desc_path)
+		if(natural_desc_path) H.add_mob_descriptor(natural_desc_path)
+		to_chat(H, span_info("I've returned to my natural voice."))
+
+	//parent.update_appearance()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3196,6 +3196,7 @@
 #include "code\modules\virtues\size.dm"
 #include "code\modules\virtues\thief.dm"
 #include "code\modules\virtues\utility.dm"
+#include "code\modules\virtues\virtue_helpers\virtue_components.dm"
 #include "interface\interface.dm"
 #include "interface\LOOC.dm"
 #include "interface\menu.dm"


### PR DESCRIPTION
## About The Pull Request
- Hags get advanced mirror magic, and can give it out as a 40pt boon.
(The only difference is that advanced mirror magic lets you change descriptors too)
- Second voice lets you pick a second voice descriptor too.
- Comm for noire hh

## Testing Evidence
<img width="1225" height="734" alt="image" src="https://github.com/user-attachments/assets/d954f87c-10a8-4223-8bab-21affdb61c29" />

## Why It's Good For The Game
More unique hag powers good.
Second voice didn't make much sense without this.
Refactored second voice into a component to avoid needlessly polluting the human datum with more variable for a single freaking virtue oh my god.

I really need men

## Changelog

:cl:
add: Second voice now lets you pick a voice descriptor for the second voice
add: Advanced mirror magic hag boon & hag feature
/:cl:
