### PR TITLE
Allow tongue bathing of clothed partners.

### DIFF
--- a/code/datums/sexcon2/actions/miscellaneous/tongue_bath.dm
+++ b/code/datums/sexcon2/actions/miscellaneous/tongue_bath.dm
@@ -36,17 +36,24 @@
 /datum/sex_action/miscellaneous/tonguebath/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/arousal_amt = 0.1
+	var/body_desc = "body"
+
 	if(check_location_accessible(user, target, BODY_ZONE_PRECISE_EARS))
 		arousal_amt += 0.08
 	if(check_location_accessible(user, target, BODY_ZONE_PRECISE_NECK))
 		arousal_amt += 0.08
-	if(check_location_accessible(user, target, BODY_ZONE_CHEST, TRUE) && target.getorganslot(ORGAN_SLOT_BREASTS) && check_sex_lock(target, ORGAN_SLOT_BREASTS)) // do they have breasts and are they accessible?
-		arousal_amt += 0.1
+	if(check_location_accessible(user, target, BODY_ZONE_CHEST, TRUE))
+		body_desc = "exposed body"
+		if(target.getorganslot(ORGAN_SLOT_BREASTS) && check_sex_lock(target, ORGAN_SLOT_BREASTS))
+			arousal_amt += 0.1
 	if(check_location_accessible(user, target, BODY_ZONE_PRECISE_STOMACH))
 		arousal_amt += 0.08
+		body_desc = "exposed body"
 	if(check_location_accessible(user, target, BODY_ZONE_PRECISE_GROIN))
 		arousal_amt += 0.16
-	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] bathes [target]'s body with [user.p_their()] tongue..."))
+		body_desc = "exposed body"
+	
+	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] bathes [target]'s [body_desc] with [user.p_their()] tongue..."))
 	user.make_sucking_noise()
 
 	sex_session.perform_sex_action(target, arousal_amt, 0, TRUE)

--- a/code/datums/sexcon2/actions/miscellaneous/tongue_bath.dm
+++ b/code/datums/sexcon2/actions/miscellaneous/tongue_bath.dm
@@ -6,8 +6,6 @@
 /datum/sex_action/miscellaneous/tonguebath/shows_on_menu(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user == target)
 		return FALSE
-	if(!check_location_accessible(user, target, BODY_ZONE_PRECISE_GROIN))
-		return FALSE
 	if(!check_location_accessible(user, user, BODY_ZONE_PRECISE_MOUTH))
 		return FALSE
 	return TRUE
@@ -17,8 +15,6 @@
 	if(!.)
 		return FALSE
 	if(user == target)
-		return FALSE
-	if(!check_location_accessible(user, target, BODY_ZONE_PRECISE_GROIN))
 		return FALSE
 	if(!check_location_accessible(user, user, BODY_ZONE_PRECISE_MOUTH))
 		return FALSE
@@ -39,8 +35,19 @@
 
 /datum/sex_action/miscellaneous/tonguebath/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
+	var/arousal_amt = 0.1
+	if(check_location_accessible(user, target, BODY_ZONE_PRECISE_EARS))
+		arousal_amt += 0.08
+	if(check_location_accessible(user, target, BODY_ZONE_PRECISE_NECK))
+		arousal_amt += 0.08
+	if(check_location_accessible(user, target, BODY_ZONE_CHEST, TRUE) && target.getorganslot(ORGAN_SLOT_BREASTS) && check_sex_lock(target, ORGAN_SLOT_BREASTS)) // do they have breasts and are they accessible?
+		arousal_amt += 0.1
+	if(check_location_accessible(user, target, BODY_ZONE_PRECISE_STOMACH))
+		arousal_amt += 0.08
+	if(check_location_accessible(user, target, BODY_ZONE_PRECISE_GROIN))
+		arousal_amt += 0.16
 	user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] bathes [target]'s body with [user.p_their()] tongue..."))
 	user.make_sucking_noise()
 
-	sex_session.perform_sex_action(target, 0.5, 0, TRUE)
+	sex_session.perform_sex_action(target, arousal_amt, 0, TRUE)
 	sex_session.handle_passive_ejaculation(target)


### PR DESCRIPTION
## About The Pull Request

Allows tongue bathing of fully-clothed partners. Instead of a covered groin preventing tongue bathing entirely, the amount of arousal caused now increases based on how many exposed areas the recipient has.

## Testing Evidence

Tested on local instance. Tried every variation of clothedness/gender I could think of to make sure the various checks work correctly.

## Why It's Good For The Game

Tongue bathing isn't the same as fellatio, nor explicitly directed at the exposed groin. Now you can thank your adventuring partners for a job well done in a properly beastvolkish way!

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: can now tongue bathe clothed partners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
