### PR TITLE
Ruma Underling Welfare

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1803,15 +1803,19 @@
 	name = "ruma hwando"
 	desc = "A foreign steel single-edged sword with cloud patterns on the groove. The Ruma Clan's insignia is engraved on the blade."
 	icon_state = "eastsword2"
+	force = 27
+	max_integrity = 200
+	sharpness_mod = 2
+	sellprice = 50
 
 /obj/item/rogueweapon/sword/sabre/mulyeog/rumacaptain
-	force = 30
 	name = "samjeongdo"
 	desc = "A gold-stained sword with cloud patterns on the groove. One of a kind. It is a symbol of status within the Ruma clan."
 	icon_state = "eastsword3"
-	max_integrity = 180
+	force = 27
+	max_integrity = 200
 	sharpness_mod = 2
-	wdefense = 4
+	sellprice = 150
 
 /obj/item/rogueweapon/sword/sabre/hook
 	force = 20

--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -552,7 +552,7 @@
 	force = 20
 	valid_blade = /obj/item/rogueweapon/sword/sabre/mulyeog
 	associated_skill = /datum/skill/combat/swords
-	possible_item_intents = list(SHIELD_BASH, SHIELD_BLOCK)
+	possible_item_intents = list(SHIELD_BASH, SHIELD_SMASH)
 	can_parry = TRUE
 	sewrepair = FALSE
 	wdefense = 8
@@ -586,7 +586,8 @@
 	icon_state = "kazscab_gold"
 	item_state = "kazscab_gold"
 	valid_blade = /obj/item/rogueweapon/sword/sabre/mulyeog/rumacaptain
-	sellprice = 10
+	max_integrity = 220
+	sellprice = 50
 
 /obj/item/rogueweapon/scabbard/sword/kazengun/kodachi
 	name = "plain lacquer scabbard"

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
@@ -1,13 +1,13 @@
 /datum/advclass/mercenary/rumaclan
 	name = "Ruma Clan Gun-in"
-	tutorial = "You are well versed and experienced in swordfighting, you have no problem in taking up most jobs so long as the coin is good, for either yourself or the clan and the seonjang."
+	tutorial = "A swordfighter from a band of Kazengite foreigners. The Ruma Clan were outcasts from the Xinyi Dynasty, believed to be associated with the rebels at the time. The clan departed to avoid repercussion. It is no organized group of soldiers, but rather a loose collection of experienced fighters."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = NON_DWARVEN_RACE_TYPES //no dwarf sprites
 	outfit = /datum/outfit/job/roguetown/mercenary/rumaclan
 	subclass_languages = list(/datum/language/kazengunese)
 	class_select_category = CLASS_CAT_KAZENGUN
 	category_tags = list(CTAG_MERCENARY)
-	traits_applied = list(TRAIT_BLOOD_RESISTANCE, TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_HONORBOUND)
+	traits_applied = list(TRAIT_BLOOD_RESISTANCE, TRAIT_NOPAINSTUN, TRAIT_HONORBOUND)
 	cmode_music = 'sound/music/combat_Kazengun_Runaway_Chariot.ogg'
 	subclass_stats = list(
 		STATKEY_CON = 3,
@@ -31,7 +31,7 @@
 
 /datum/outfit/job/roguetown/mercenary/rumaclan/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning("You are well versed and experienced in swordfighting, you have no problem in taking up most jobs so long as the coin is good, for either yourself or the clan and the seonjang."))
+	to_chat(H, span_warning("You are a swordfighter of the Clan, peerless with a blade. So long as the coin is good, you have no problem taking up most jobs on behalf of either yourself, your leading Seonjang, or the Clan as a whole."))
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/rogueweapon/scabbard/sword/kazengun/steel
 	beltl = /obj/item/rogueweapon/sword/sabre/mulyeog/rumahench
@@ -43,22 +43,22 @@
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
-		/obj/item/roguekey/mercenary,
-		/obj/item/flashlight/flare/torch/lantern,
-		/obj/item/storage/belt/rogue/pouch/coins/poor,
+		/obj/item/roguekey/mercenary = 1,
+		/obj/item/flashlight/flare/torch/lantern = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		)
 	H.merctype = 9
 
 /datum/advclass/mercenary/rumaclan_sasu
 	name = "Ruma Clan Sasu"
-	tutorial = "A band of foreign outcast Kazengunites. The Ruma Clan were outcasts from the Xinyi Dynasty, believed to be associated with the rebels at the time. The clan departed lest they risked being executed for such suspicions, or worse. It is no organized group of soldiers, but rather a loose collection of experienced fighters."
+	tutorial = "An archer from a band of Kazengite foreigners. The Ruma Clan were outcasts from the Xinyi Dynasty, believed to be associated with the rebels at the time. The clan departed to avoid repercussion. It is no organized group of soldiers, but rather a loose collection of experienced fighters."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = NON_DWARVEN_RACE_TYPES //no dwarf sprites
 	outfit = /datum/outfit/job/roguetown/mercenary/rumaclan_sasu
 	subclass_languages = list(/datum/language/kazengunese)
 	class_select_category = CLASS_CAT_KAZENGUN
 	category_tags = list(CTAG_MERCENARY)
-	traits_applied = list(TRAIT_BLOOD_RESISTANCE, TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_HONORBOUND)
+	traits_applied = list(TRAIT_BLOOD_RESISTANCE, TRAIT_NOPAINSTUN, TRAIT_HONORBOUND)
 	subclass_stats = list(
 		STATKEY_SPD = 4,
 		STATKEY_PER = 2,
@@ -83,7 +83,7 @@
 /datum/outfit/job/roguetown/mercenary/rumaclan_sasu/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.set_blindness(0)
-	to_chat(H, span_warning("You are an archer of the clan, many have called you an true marksman for your skills with the bow. You have no problem in taking up most jobs so long as the coin is good, for either yourself or the clan and the seonjang."))
+	to_chat(H, span_warning("You are an archer of the Clan, matchless with a bow. So long as the coin is good, you have no problem taking up most jobs on behalf of either yourself, your leading Seonjang, or the Clan as a whole."))
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/quiver/arrows
 	beltl = /obj/item/flashlight/flare/torch/lantern
@@ -96,9 +96,9 @@
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
-		/obj/item/roguekey/mercenary,
-		/obj/item/storage/belt/rogue/pouch/coins/poor,
-		/obj/item/rogueweapon/huntingknife/idagger,
-		/obj/item/rogueweapon/scabbard/sheath = 1,
+		/obj/item/roguekey/mercenary = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/steel/kazengun = 1,
+		/obj/item/rogueweapon/scabbard/sheath/kazengun = 1,
 		)
 	H.merctype = 9

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/seonjang.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/seonjang.dm
@@ -1,6 +1,6 @@
-/datum/advclass/mercenary/seonjang //shitcode approved by free
-	name = "Seonjang"
-	tutorial = "The respected leader and singular representative of the Ruma clan, you're an experienced swordsman. It matters not where the coin comes from, so long as you can make enough to support the clan in its survival from the Xinyi Dynasty and its conflicts, now in strange lands."
+/datum/advclass/mercenary/seonjang
+	name = "Ruma Seonjang"
+	tutorial = "A Captain from a band of Kazengite foreigners. The Ruma Clan were outcasts from the Xinyi Dynasty, believed to be associated with the rebels at the time. The clan departed to avoid repercussion. It is no organized group of soldiers, but rather a loose collection of experienced fighters."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = NON_DWARVEN_RACE_TYPES
 	outfit = /datum/outfit/job/roguetown/mercenary/seonjang
@@ -31,6 +31,7 @@
 
 /datum/outfit/job/roguetown/mercenary/seonjang/pre_equip(mob/living/carbon/human/H)
 	..()
+	to_chat(H, span_warning("You are a Captain of the Clan, second to none. The blades and bows of the Ruma look to you for guidance - rally your warriors and lead by example!"))
 	armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
 	gloves = /obj/item/clothing/gloves/roguetown/eastgloves2
@@ -40,9 +41,9 @@
 	beltl = /obj/item/rogueweapon/scabbard/sword/kazengun/gold
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
-		/obj/item/roguekey/mercenary,
-		/obj/item/flashlight/flare/torch/lantern,
-		/obj/item/storage/belt/rogue/pouch/coins/rich,
+		/obj/item/roguekey/mercenary = 1,
+		/obj/item/flashlight/flare/torch/lantern = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
 		)
 	H.adjust_blindness(-3)
 


### PR DESCRIPTION
## About The Pull Request

Ruma Seonjang sword from 30 force to 27. 150 sellprice. Ruma Gun-in sword from 25 force to 27. 50 sellprice. Both swords share the higher integrity value and the doubled sharpness decay now.
Both types of scabbard now share 220 integrity, instead of just the one. Seonjang's has 50 sellprice.
Kazengun scabbards get smash instead of block intent, since it only worked with shields (and blocking arrows with swords is too anime anyway)
Both standard ruma get Seonjang's painres, Sasu gets a tanto (steel dagger up from iron), minor text changes.
Seonjang is now Ruma Seonjang to make it immediately more obvious as belonging to the faction.

## Testing Evidence

<img width="267" height="121" alt="image" src="https://github.com/user-attachments/assets/b9948352-e26c-49e9-bb37-ec13112c3ef0" />
<img width="443" height="148" alt="image" src="https://github.com/user-attachments/assets/b46a9b62-677b-412f-a1d6-23c9342114e3" />
<img width="380" height="467" alt="image" src="https://github.com/user-attachments/assets/e9ea47a8-7423-4543-8a12-cec936e89cda" />
<img width="224" height="234" alt="image" src="https://github.com/user-attachments/assets/4c7721fc-451c-4cdf-b242-85f6d18d1ca7" />



## Why It's Good For The Game

For one, anytime discussion on Ruma comes up, it's almost exclusively centered around the Seonjang and their pocket greatsword. This has somewhat left the others in the dust, especially with their loss of pain resistance. Now all they get over their goons is the allowance to distribute.

For two, Seonjang's one-slot "Gun-in but better" loadout sort of discourages from actually trying them if the slot's actually taken. Hopefully this encourages the Rumains to gang up instead of existing as separate Seonjangs.

Now both are functionally just reskins on a middle-ground. Low staying power fighters with slightly more hard-hitting swords at the cost of oppressive sharpness decay, and the painres needed to try and get away when it starts kicking in.
The most interesting of the bunch is still the Sasu as one of the few (if not the only?) painres ranged classes, but I've never seen them pull off any plays even before the critical resistance removal either.

tl;dr seonjang power level donation. weaker captains, stronger goons.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Ruma Seonjang and Gun-in weapons nerfed and buffed respectively into a middle-ground. They can now be sold.
balance: Ruma Sasu's iron dagger replaced with a steel tanto.
balance: All Ruma now share pain resistance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
