### PR TITLE
Ghost hiding spot fix

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -232,7 +232,7 @@
 /obj/structure/examine(mob/user)
 	. = ..()
 
-	if(in_range(user, src))
+	if(in_range(user, src) && istype(user, /mob/living))
 		if(occupied)
 			var/mob/living/M = locate() in src
 			if(M)


### PR DESCRIPTION
## About The Pull Request

Ghosts can no longer yoink your ass from hiding spots.

## Testing Evidence

Tested.

## Why It's Good For The Game

Ghosts need to stay in their lane.

## Changelog

:cl:
fix: Ghosts can no longer pull people from hiding spots.
/:cl:
