### PR TITLE
[Medical] - Makes medical EXP scale with wound severity & time spent sewing.

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -305,3 +305,5 @@
 	maxstring = 5
 
 #undef SEW_HP_EXP_NORMALIZER
+#undef SEW_EXP_PER_STEP
+#undef SEW_EXP_FINISH

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -247,7 +247,6 @@
 			var/exp_scale = target_wound.sew_threshold / SEW_HP_EXP_NORMALIZER
 			var/base_exp = doctor.STAINT * SEW_EXP_FINISH
 			doctor.mind.add_sleep_experience(/datum/skill/misc/medicine, base_exp * exp_scale)
-			to_chat(world, span_danger("ADDED [base_exp * exp_scale] EXP"))
 		use(1)
 		target_wound.sew_wound()
 		if(patient == doctor)

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -214,6 +214,8 @@
 				sewing_start_delay = 1 SECONDS
 		if(!do_after(doctor, sewing_start_delay, target = patient))
 			break
+		if(doctor.mind)
+			doctor.mind.add_sleep_experience(/datum/skill/misc/medicine, doctor.STAINT * 0.05)
 		playsound(loc, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
 		target_wound.sew_progress = min(target_wound.sew_progress + moveup, target_wound.sew_threshold)
 		var/bleedreduction = max((0.5 * medskill), 0.5)
@@ -238,7 +240,10 @@
 		if(target_wound.sew_progress < target_wound.sew_threshold)
 			continue
 		if(doctor.mind)
-			doctor.mind.add_sleep_experience(/datum/skill/misc/medicine, doctor.STAINT * 2.5)
+			var/exp_scale = target_wound.sew_threshold / 600
+			var/base_exp = doctor.STAINT * 2.5
+			doctor.mind.add_sleep_experience(/datum/skill/misc/medicine, base_exp * exp_scale)
+			to_chat(world, span_danger("ADDED [base_exp * exp_scale] EXP"))
 		use(1)
 		target_wound.sew_wound()
 		if(patient == doctor)

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -1,3 +1,7 @@
+#define SEW_HP_EXP_NORMALIZER 600
+#define SEW_EXP_PER_STEP 0.05
+#define SEW_EXP_FINISH 2.5
+
 /obj/item/needle
 	name = "needle"
 	icon_state = "needle"
@@ -215,7 +219,7 @@
 		if(!do_after(doctor, sewing_start_delay, target = patient))
 			break
 		if(doctor.mind)
-			doctor.mind.add_sleep_experience(/datum/skill/misc/medicine, doctor.STAINT * 0.05)
+			doctor.mind.add_sleep_experience(/datum/skill/misc/medicine, doctor.STAINT * SEW_EXP_PER_STEP)
 		playsound(loc, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
 		target_wound.sew_progress = min(target_wound.sew_progress + moveup, target_wound.sew_threshold)
 		var/bleedreduction = max((0.5 * medskill), 0.5)
@@ -240,8 +244,8 @@
 		if(target_wound.sew_progress < target_wound.sew_threshold)
 			continue
 		if(doctor.mind)
-			var/exp_scale = target_wound.sew_threshold / 600
-			var/base_exp = doctor.STAINT * 2.5
+			var/exp_scale = target_wound.sew_threshold / SEW_HP_EXP_NORMALIZER
+			var/base_exp = doctor.STAINT * SEW_EXP_FINISH
 			doctor.mind.add_sleep_experience(/datum/skill/misc/medicine, base_exp * exp_scale)
 			to_chat(world, span_danger("ADDED [base_exp * exp_scale] EXP"))
 		use(1)
@@ -299,3 +303,5 @@
 	desc = "This decrepit old needle doesn't seem helpful for much."
 	stringamt = 5
 	maxstring = 5
+
+#undef SEW_HP_EXP_NORMALIZER


### PR DESCRIPTION
## About The Pull Request
BEFORE :
I want to level medical EXP! I'm a powergamer!
=> cuts self with baby rock that gives a cut that takes like 2-3 sew actions.
=> Level up to expert in less than a minute.

BEFORE :
I'm a good player! I'm sewing my wounds as I get them in a dungeon. God this is a big wound...
=> Gets 5-10 wounds that take a cumulative 5-10 minutes to sew.
=> Level up to apprentice across half an hour.

AFTER :
=> get 40% of a huge wound that takes about 2 minutes to sew up from apprentice to jman skill with 10 int.

Overall you get MORE EXP for sewing up huge wounds now. EXP scales with sewHP & you get a little bit of exp per sew action. 0.5EXP

This makes it rewarding to sew wounds even if you don't finish sewing them wholly, but you still get the biggest chunk at the end.

## Testing Evidence
<img width="516" height="176" alt="image" src="https://github.com/user-attachments/assets/5028dec7-08d7-45d8-9a0e-d19de64f1c5a" />
<img width="280" height="26" alt="image" src="https://github.com/user-attachments/assets/5c2fd61f-0272-4f1b-a5fa-9fdc26c105f7" />

## Why It's Good For The Game
Makes medical EXP a bit more sensible.

## Changelog

:cl:
balance: Medical EXP scales with sew time & wound severity now.
/:cl:
