### PR TITLE
dun_world Housekeeping

### DIFF
--- a/_maps/dungeon_generator/room/TheatherOfSadism.dmm
+++ b/_maps/dungeon_generator/room/TheatherOfSadism.dmm
@@ -271,7 +271,7 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/under/tomb)
 "qv" = (
-/obj/structure/fluff/sellsign{
+/obj/structure/fluff/sign{
 	name = "INEDIBLE PARTS"
 	},
 /turf/open/floor/rogue/blocks/stonered,

--- a/_maps/dungeon_generator/room/lavafort.dmm
+++ b/_maps/dungeon_generator/room/lavafort.dmm
@@ -626,7 +626,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/cave/lava)
 "Pq" = (
-/obj/structure/fluff/buysign{
+/obj/structure/fluff/sign{
 	name = "If you are reading this, the Ten says you are a nerd."
 	},
 /turf/open/floor/rogue/grassred,

--- a/_maps/shuttles/cargo_rogue.dmm
+++ b/_maps/shuttles/cargo_rogue.dmm
@@ -21,7 +21,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "c" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -33,7 +33,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "d" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -46,7 +46,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "e" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -66,7 +66,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "f" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -83,7 +83,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "g" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -92,7 +92,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "h" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -102,21 +102,21 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "i" = (
 /turf/closed/wall/mineral/rogue/wooddark{
 	above_floor = null
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "j" = (
 /turf/open/floor/rogue/ruinedwood,
-/area/shuttle/supply/buy)
+/area/template_noop)
 "k" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "l" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -126,12 +126,12 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "m" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/shuttle/supply/sell)
+/area/template_noop)
 "n" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -149,7 +149,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "o" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -163,21 +163,14 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "p" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
 	dir = 8
 	},
 /turf/open/floor/rogue/ruinedwood,
-/area/shuttle/supply/buy)
-"q" = (
-/obj/machinery/light/rogue/firebowl/blue,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
-	},
-/area/shuttle/supply)
+/area/template_noop)
 "r" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -187,7 +180,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "s" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -201,13 +194,13 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "t" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "u" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -217,7 +210,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "v" = (
 /obj/structure/boatbell{
 	pixel_y = 20
@@ -226,7 +219,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "w" = (
 /obj/structure/fluff/railing/border{
 	icon_state = "border";
@@ -236,7 +229,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "x" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -251,7 +244,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "y" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -269,7 +262,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "z" = (
 /obj/structure/fluff/railing/border,
 /obj/effect/decal/cobbleedge{
@@ -279,7 +272,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "A" = (
 /obj/structure/fluff/railing/border,
 /obj/effect/decal/cobbleedge{
@@ -290,7 +283,7 @@
 	icon_state = "vertw";
 	dir = 1
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "B" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -308,7 +301,7 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "horzw"
 	},
-/area/shuttle/supply)
+/area/template_noop)
 "C" = (
 /obj/machinery/light/rogue/torchholder{
 	icon_state = "torchwall1";
@@ -317,26 +310,11 @@
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},
-/area/shuttle/supply/sell)
-"D" = (
-/obj/docking_port/mobile/supply{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "vertw";
-	dir = 1
-	},
-/area/shuttle/supply)
+/area/template_noop)
 "E" = (
-/obj/structure/fluff/buysign,
+/obj/structure/fluff/sign,
 /turf/open/floor/rogue/ruinedwood,
-/area/shuttle/supply/buy)
-"F" = (
-/obj/structure/fluff/sellsign,
-/turf/open/floor/rogue/ruinedwood{
-	icon_state = "weird1"
-	},
-/area/shuttle/supply/sell)
+/area/template_noop)
 
 (1,1,1) = {"
 a
@@ -406,7 +384,7 @@ k
 k
 i
 v
-D
+k
 "}
 (11,1,1) = {"
 k
@@ -417,7 +395,7 @@ k
 "}
 (12,1,1) = {"
 d
-F
+E
 m
 m
 A
@@ -446,7 +424,7 @@ z
 (16,1,1) = {"
 e
 l
-q
+k
 w
 B
 "}

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -693,7 +693,7 @@
 
 /obj/structure/fluff/signage
 	name = "sign"
-	desc = ""
+	desc = "It's a sign! It seems to be pointing somewhere."
 	icon = 'icons/roguetown/misc/structure.dmi'
 	icon_state = "shitsign"
 	density = TRUE
@@ -705,41 +705,16 @@
 	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
 	attacked_sound = list('sound/combat/hits/onwood/woodimpact (1).ogg','sound/combat/hits/onwood/woodimpact (2).ogg')
 
-/obj/structure/fluff/signage/examine(mob/user)
-	. = ..()
-	if(!user.is_literate())
-		. += "I have no idea what it says."
-	else
-		. += "It says \"AZURE PEAK\""
-
-/obj/structure/fluff/buysign
+/obj/structure/fluff/sign
 	icon_state = "signwrote"
 	name = "sign"
-	desc = ""
+	desc = "It's a sign! These usually have words carved into them."
 	icon = 'icons/roguetown/misc/structure.dmi'
-/obj/structure/fluff/buysign/examine(mob/user)
-	. = ..()
-	if(!user.is_literate())
-		. += "I have no idea what it says."
-	else
-		. += "It says \"IMPORTS\""
-
-/obj/structure/fluff/sellsign
-	icon_state = "signwrote"
-	name = "sign"
-	desc = ""
-	icon = 'icons/roguetown/misc/structure.dmi'
-/obj/structure/fluff/sellsign/examine(mob/user)
-	. = ..()
-	if(!user.is_literate())
-		. += "I have no idea what it says."
-	else
-		. += "It says \"EXPORTS\""
-
 
 /obj/structure/fluff/customsign
 	name = "sign"
-	desc = ""
+	desc = "It's a sign! It looks like it'd be quite easy to carve your \
+	own message into this one, were you so inclined."
 	icon_state = "sign"
 	var/wrotesign
 	max_integrity = 500
@@ -753,6 +728,10 @@
 			. += "I have no idea what it says."
 		else
 			. += "It says \"[wrotesign]\"."
+
+/obj/structure/fluff/customsign/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("Left clicking on the sign with a dagger on STAB intent allows you to carve a message into it!")
 
 /obj/structure/fluff/customsign/attackby(obj/item/W, mob/user, params)
 	if(!user.cmode)

--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -1251,6 +1251,9 @@
 /turf/open/floor/rogue/cobblerock/cardinal_smooth(adjacencies)
 	roguesmooth(adjacencies)
 
+/turf/open/floor/rogue/cobblerock/no_smooth
+	smooth = SMOOTH_FALSE
+
 /obj/effect/decal/cobbleedge
 	name = "old cobble path"
 	desc = "Erosion and time have worn this path to half-scattered rocks slowly sinking back into the earth."


### PR DESCRIPTION
## About The Pull Request

Implements many small mapping changes which have been overdue for a while, or which I just think are an improvement.

1. Removes /buysign and /sellsign, replaces all sign objects on every map with a new basic /sign type. Preserves /signage and /customsign, but removes all pre-mapped /customsign objects, as they can't be used that way without lacking writing on their sprite. No user-facing changes, besides the odd 'IMPORTS' and 'EXPORTS' thing on examine is gone.
2. Removes misplaced RCOMs in wardens' outpost, adds one public SCOM to the outpost to hopefully make it less of a liminal space, adds one EXCIDUM to the outpost so the quickest way for wardens to check bounties isn't to go to the abandoned inn.
3. Simplifies the mapping in the nave of the cathedral a little, as it became a bit of an eyesore combined with runes.
4. Removes the ~secret basement~ in the south of the map.
5. Touches up the turfs of the underground arena to be less frenetic.

For anything else, see the changelog!

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="446" height="213" alt="image" src="https://github.com/user-attachments/assets/b37d5434-c57e-401c-a251-e42a63f268a8" />

<img width="544" height="608" alt="image" src="https://github.com/user-attachments/assets/482daf54-7c06-4635-9829-0da2b1945ffb" />

<img width="672" height="256" alt="image" src="https://github.com/user-attachments/assets/55a7ddbd-f212-4f59-b39f-69bacc113438" />

<img width="1030" height="1029" alt="image" src="https://github.com/user-attachments/assets/22424f00-4a04-4c02-b8c7-2211fdb135d2" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

This is mostly fixing oversights and brushing up noisy mapping. If any element might be controversial it'd certainly be the public SCOM in the outpost, which I can nix if requested.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
map: Added a public SCOM and EXCIDUM to the outpost.
map: Minorly touches up the mapping of the underground arena and the cathedral nave, hopefully to be easier on the eyes.
map: Moved the anti-littering bins to more immanent positions, touched up name and description.
map: The southern entrance to the bog is no longer blocked by palisades.
map: Removed several instances of borders and weepvines being placed on water turfs, causing them to be nearly invisible as they layer underneath the water.
del: Removed the secret basement which was previously accidentally left under the southern tip of the map, connected to no building above it.
refactor: Collated both sign subtypes into a basic /sign object, shifted all pre-mapped signs to this object bar /signage objects. Remember to use the new sign rather than /customsign in future mapping, otherwise the sprite will appear blank!
fix: Signs no longer read 'IMPORTS' or 'EXPORTS' on examine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
