### PR TITLE
Bronze right limb discrepency fix.

### DIFF
--- a/code/modules/roguetown/roguejobs/engineer/prosthetic.dm
+++ b/code/modules/roguetown/roguejobs/engineer/prosthetic.dm
@@ -313,7 +313,7 @@
 	static_icon = TRUE			//returns icon to initial icon state after removal under get_limb_icon
 	brute_reduction = 0
 	burn_reduction = 0
-	max_damage = 220
+	max_damage = 110
 	w_class = WEIGHT_CLASS_NORMAL
 	max_integrity = 350
 	sellprice = 30


### PR DESCRIPTION
## About The Pull Request

Single line fix for bronze right arm that randomly had 2x the max damage stat of the left arm, which isn't the same on any other prosthetic.

## Testing Evidence

Just changed a number from 220 to 110 to match the left arm.

## Why It's Good For The Game

Puts it in line with all other prosthetics that have the same value on each limb, and now it doesn't have higher max_damage cap than the iron and steel prosthetics.

:cl:
balance: changed the bronze right limb to be equal to the left limb
/:cl: