### PR TITLE
smallens verb tabs

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -86,7 +86,7 @@ SUBSYSTEM_DEF(events)
 // REEEEEEEEE
 /client/proc/forceEvent()
 	set name = "Trigger Event"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	if(!holder ||!check_rights(R_FUN))
 		return
 	holder.forceEvent(usr)
@@ -96,7 +96,7 @@ SUBSYSTEM_DEF(events)
 
 /client/proc/forceGamemode()
 	set name = "Storyteller - Panel"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	if(!holder ||!check_rights(R_FUN))
 		return
 	holder.forceGamemode(usr)
@@ -109,7 +109,7 @@ SUBSYSTEM_DEF(events)
 	frequency_upper = initial(frequency_upper)
 
 /client/proc/view_storyteller_vote_log()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Storyteller - Log"
 
 	if(!check_rights(R_ADMIN))

--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -606,7 +606,7 @@ SUBSYSTEM_DEF(migrants)
 	return migrants
 
 /client/proc/admin_force_next_migrant_wave()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Force Migrant Wave"
 	if(!holder)
 		return

--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -146,7 +146,7 @@
 // Debug verb
 /mob/living/carbon/human/proc/devotionchange()
 	set name = "(DEBUG)Change Devotion"
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 
 	if(!devotion)
 		return FALSE

--- a/code/controllers/subsystem/rogue/scheduled_event_subsytem.dm
+++ b/code/controllers/subsystem/rogue/scheduled_event_subsytem.dm
@@ -228,7 +228,7 @@ SUBSYSTEM_DEF(event_scheduler)
 
 /client/proc/manage_fog_schedule()
 	set name = "Manage Fog Schedule"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	if(!holder)
 		return
 

--- a/code/controllers/subsystem/rogue/triumphs/triumphs_unsorted.dm
+++ b/code/controllers/subsystem/rogue/triumphs/triumphs_unsorted.dm
@@ -12,7 +12,7 @@
 	return SStriumphs.get_triumphs(ckey)
 
 /client/proc/adjusttriumph()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Adjust Own Triumphs"
 	var/input = input(src, "how much") as num
 	if(mob && input)

--- a/code/datums/particle_weathers/_base.dm
+++ b/code/datums/particle_weathers/_base.dm
@@ -334,7 +334,7 @@
 	return TRUE
 
 /client/proc/run_particle_weather()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Weather - Particle"
 	set desc = "Triggers a particle weather"
 
@@ -353,7 +353,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Run Particle Weather")
 
 /client/proc/run_custom_particle_weather()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Weather - Color Particle"
 	set desc = "Triggers a particle weather"
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -272,7 +272,7 @@
 /datum/admins/proc/admin_heal(mob/living/M in GLOB.mob_list)
 	set name = "Mob - Heal"
 	set desc = "Heal a mob to full health"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 
 	if(!check_rights())
 		return
@@ -282,7 +282,7 @@
 	log_admin("[key_name(usr)] healed [key_name(M)].")
 
 /datum/admins/proc/show_player_panel(mob/M in GLOB.mob_list)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Show Player Panel"
 	set desc="Edit player (respawn, ban, heal, etc)"
 
@@ -297,7 +297,7 @@
 /datum/admins/proc/admin_revive(mob/living/M in GLOB.mob_list)
 	set name = "Mob - Revive"
 	set desc = "Resuscitate a mob"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 
 	if(!check_rights())
 		return
@@ -323,7 +323,7 @@
 /datum/admins/proc/admin_sleep(mob/living/M in GLOB.mob_list)
 	set name = "Toggle Sleeping"
 	set desc = "Toggle a mob's sleeping state"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 
 	if(!check_rights())
 		return
@@ -341,7 +341,7 @@
 /datum/admins/proc/start_vote()
 	set name = "Start Vote"
 	set desc = "Start a vote"
-	set category = "-Server-"
+	set category = "Server"
 
 	if(!check_rights(R_POLL))
 		to_chat(usr, span_warning("You do not have the rights to start a vote."))
@@ -364,7 +364,7 @@
 /datum/admins/proc/adjustpq(mob/living/M in GLOB.mob_list)
 	set name = "Adjust PQ of Anything"
 	set desc = "Adjust a player's PQ"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set hidden = 1
 
 	if(!check_rights())
@@ -425,7 +425,7 @@
 
 
 /datum/admins/proc/restart()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Reboot World"
 	set desc="Restarts the world immediately"
 	if (!usr.client.holder)
@@ -460,7 +460,7 @@
 					world.TgsEndProcess()
 
 /datum/admins/proc/end_round()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "End Round"
 	set desc = ""
 
@@ -475,7 +475,7 @@
 
 
 /datum/admins/proc/announce()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Announce"
 	set desc="Announce your desires to the world"
 	if(!check_rights(0))
@@ -490,7 +490,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Announce") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/set_admin_notice()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Set Admin Notice"
 	set desc ="Set an announcement that appears to everyone who joins the server. Only lasts this round"
 	if(!check_rights(0))
@@ -513,7 +513,7 @@
 	return
 
 /datum/admins/proc/toggleooc()
-	set category = "-Server-"
+	set category = "Server"
 	set desc="Toggle dis bitch"
 	set name="Toggle OOC"
 	toggle_ooc()
@@ -522,7 +522,7 @@
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle OOC", "[GLOB.ooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleoocdead()
-	set category = "-Server-"
+	set category = "Server"
 	set desc="Toggle dis bitch"
 	set name="Toggle Dead OOC"
 	toggle_dooc()
@@ -532,7 +532,7 @@
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead OOC", "[GLOB.dooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/startnow()
-	set category = "-Server-"
+	set category = "Server"
 	set desc="Start the round RIGHT NOW"
 	set name="Start Now"
 	if(SSticker.current_state == GAME_STATE_PREGAME || SSticker.current_state == GAME_STATE_STARTUP)
@@ -552,7 +552,7 @@
 	return 0
 
 /datum/admins/proc/toggleenter()
-	set category = "-Server-"
+	set category = "Server"
 	set desc="People can't enter"
 	set name="Toggle Entering"
 	GLOB.enter_allowed = !( GLOB.enter_allowed )
@@ -566,7 +566,7 @@
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Entering", "[GLOB.enter_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleAI()
-	set category = "-Server-"
+	set category = "Server"
 	set desc="People can't be AI"
 	set name="Toggle AI"
 	set hidden = 1
@@ -581,7 +581,7 @@
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle AI", "[!alai ? "Disabled" : "Enabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleaban()
-	set category = "-Server-"
+	set category = "Server"
 	set desc="Respawn basically"
 	set name="Toggle Respawn"
 	set hidden = 1
@@ -597,7 +597,7 @@
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Respawn", "[!new_nores ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/delay()
-	set category = "-Server-"
+	set category = "Server"
 	set desc="Delay the game start"
 	set name="Delay pre-game"
 
@@ -617,7 +617,7 @@
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Delay Game Start") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/unprison(mob/M in GLOB.mob_list)
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Unprison"
 	if (is_centcom_level(M.z))
 		SSjob.SendToLateJoin(M)
@@ -630,7 +630,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////ADMIN HELPER PROCS
 
 /datum/admins/proc/spawn_atom(object as text)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set desc = ""
 	set name = "Spawn..."
 
@@ -702,7 +702,7 @@
 
 
 /datum/admins/proc/show_traitor_panel(mob/M in GLOB.mob_list)
-	set category = "-Admin-"
+	set category = "Admin"
 	set desc = ""
 	set name = "Show Traitor Panel"
 
@@ -731,7 +731,7 @@
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Tinted Welding Helmets", "[GLOB.tinted_weldhelh ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleguests()
-	set category = "-Server-"
+	set category = "Server"
 	set desc="Guests can't enter"
 	set name="Toggle guests"
 	set hidden = 1
@@ -861,7 +861,7 @@
 
 
 /client/proc/returntolobby()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Back to Lobby"
 
 	var/mob/living/carbon/human/H = mob
@@ -890,7 +890,7 @@
 
 /datum/admins/proc/sleep_view()
 	set name = "inview Sleep"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set hidden = FALSE
 
 	if(!check_rights(R_ADMIN))
@@ -905,7 +905,7 @@
 
 /datum/admins/proc/wake_view()
 	set name = "inview Wake"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set hidden = FALSE
 
 	if(!check_rights(R_ADMIN))
@@ -925,7 +925,7 @@
 GLOBAL_VAR_INIT(extend_round_timestamp, 0)
 /datum/admins/proc/extend_round()
 	set name = "Extend Round"
-	set category = "-Server-"
+	set category = "Server"
 	set hidden = FALSE
 
 	if(!check_rights(R_ADMIN))

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -6,7 +6,7 @@
 
 /client/proc/investigate_show()
 	set name = "Investigate"
-	set category = "-Admin-"
+	set category = "Admin"
 	if(!holder)
 		return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -388,7 +388,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	to_chat(src, show_popup_menus ? "Right click menus are now enabled" : "Right click menus are now disabled")
 
 /client/proc/open_bounty_menu()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "View Bounty List"
 	if(!holder)
 		return
@@ -415,7 +415,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	to_chat(src, aghost_toggle ? "Aghosting will now turn your mob invisible." : "Aghost will no longer turn your mob invisible.")
 
 /client/proc/admin_ghost()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Aghost"
 	if(!holder)
 		return
@@ -479,7 +479,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/check_antagonists()
 	set name = "Check Antags"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	if(holder)
 		holder.check_antagonists()
 		log_admin("[key_name(usr)] checked antagonists.")	//for tsar~
@@ -532,7 +532,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/ban_panel()
 	set name = "Banning Panel"
-	set category = "-Admin-"
+	set category = "Admin"
 	if(!check_rights(R_BAN))
 		return
 	holder.ban_panel()
@@ -540,7 +540,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/unban_panel()
 	set name = "Unbanning Panel"
-	set category = "-Admin-"
+	set category = "Admin"
 	if(!check_rights(R_BAN))
 		return
 	holder.unban_panel()
@@ -548,14 +548,14 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/game_panel()
 	set name = "Game Panel"
-	set category = "-Admin-"
+	set category = "Admin"
 	if(holder)
 		holder.Game()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Game Panel") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/secrets()
 	set name = "Secrets"
-	set category = "-Admin-"
+	set category = "Admin"
 	set hidden = 1
 	if (holder)
 		holder.Secrets()
@@ -563,7 +563,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/poll_panel()
 	set name = "Server Poll Management"
-	set category = "-Server-"
+	set category = "Server"
 	if(!check_rights(R_POLL))
 		return
 	holder.poll_list_panel()
@@ -617,7 +617,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Stealth Mode") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/drop_bomb()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Bomb..."
 	set desc = ""
 
@@ -659,7 +659,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Drop Bomb") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/drop_dynex_bomb()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Bomb - DynEx..."
 	set desc = ""
 
@@ -706,7 +706,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	message_admins("[key_name_admin(usr)] has  modified Dynamic Explosion Scale: [ex_scale]")
 
 /client/proc/give_spell(mob/T in GLOB.mob_list)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Give Spell"
 	set desc = ""
 
@@ -730,7 +730,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		message_admins(span_danger("Spells given to mindless mobs will not be transferred in mindswap or cloning!"))
 
 /client/proc/remove_spell(mob/T in GLOB.mob_list)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Remove Spell"
 	set desc = ""
 
@@ -743,7 +743,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 			SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Spell") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/object_say(obj/O in world)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "OSay"
 	set desc = ""
 	var/message = input(usr, "What do you want the message to be?", "Make Sound") as text | null
@@ -755,7 +755,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Object Say") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/force_say(mob/living/L in GLOB.mob_list)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Force Speech"
 	set desc = ""
 	
@@ -782,7 +782,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/togglebuildmodeself()
 	set name = "Toggle Build Mode"
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	if (!(holder.rank.rights & R_BUILD))
 		return
 	if(src.mob)
@@ -812,7 +812,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/readmin()
 	set name = "Readmin"
-	set category = "-Admin-"
+	set category = "Admin"
 	set desc = ""
 
 	var/datum/admins/A = GLOB.deadmins[ckey]
@@ -839,7 +839,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 /client/proc/toggle_AI_interact()
 	set name = "Toggle Admin AI Interact"
-	set category = "-Admin-"
+	set category = "Admin"
 	set desc = ""
 	set hidden = 1
 
@@ -860,7 +860,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	to_chat(src, span_interface("Lobby OOC visibility is now [show_lobby_ooc ? "ON" : "OFF"]."))
 
 /client/proc/end_party()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "EndPlaytest"
 	set hidden = 1
 	if(!holder)
@@ -914,7 +914,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 		to_chat(src, span_notice("Either the book file doesn't exist or you have failed to type something in properly (you can look up the file name by the verb 'database book file names'"))
 
 /client/proc/remove_bounty()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Remove Bounty"
 	if(!holder)
 		return

--- a/code/modules/admin/adminmenu.dm
+++ b/code/modules/admin/adminmenu.dm
@@ -6,7 +6,7 @@
 /datum/verbs/menu/Admin/verb/playerpanel()
 	set name = "Player Panel New"
 	set desc = ""
-	set category = "-Admin-"
+	set category = "Admin"
 	if(usr.client.holder)
 		usr.client.holder.player_panel_new()
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Player Panel New") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/agevetting.dm
+++ b/code/modules/admin/agevetting.dm
@@ -19,7 +19,7 @@ GLOBAL_PROTECT(agevetted_list)
 	return FALSE
 
 /client/proc/agevet_player()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "BC - Add Age Vetted"
 
 	if(!check_rights())

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -1,5 +1,5 @@
 /client/proc/edit_admin_permissions()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Permissions Panel"
 	set desc = "Edit admin permissions"
 	if(!check_rights(R_PERMISSIONS))

--- a/code/modules/admin/playerquality.dm
+++ b/code/modules/admin/playerquality.dm
@@ -91,7 +91,7 @@
 		log_admin("[admin] adjusted [key]'s PQ by [amt] for reason: [reason]")
 
 /client/proc/check_pq()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "PQ - Check"
 	if(!holder)
 		return
@@ -151,7 +151,7 @@
 	popup.open()
 
 /client/proc/adjust_pq()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "PQ - Adjust"
 	if(!holder)
 		return

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -485,7 +485,7 @@
 
 /client/proc/stickybanpanel()
 	set name = "Sticky Ban Panel"
-	set category = "-Admin-"
+	set category = "Admin"
 	set hidden = 1
 	if (!holder)
 		return

--- a/code/modules/admin/verbs/admin_spread_effect.dm
+++ b/code/modules/admin/verbs/admin_spread_effect.dm
@@ -1,6 +1,6 @@
 /client/proc/admin_spread_effect()
 	set name = "Spread Effect"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 
 	if(!check_rights(R_ADMIN))
 		return

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -506,7 +506,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	adminhelp(msg)
 
 /client/verb/adminhelp(msg as message)
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Adminhelp"
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -1,7 +1,7 @@
 /client/proc/jumptoarea(area/A in GLOB.sortedAreas)
 	set name = "Jump to Area"
 	set desc = ""
-	set category = "-Admin-"
+	set category = "Admin"
 	if(!src.holder)
 //		//to_chat(src, "Only administrators may use this command.")
 		return
@@ -26,7 +26,7 @@
 
 /client/proc/jumptoturf(turf/T in world)
 	set name = "Jump to Turf"
-	set category = "-Admin-"
+	set category = "Admin"
 	if(!src.holder)
 //		//to_chat(src, "Only administrators may use this command.")
 		return
@@ -38,7 +38,7 @@
 	return
 
 /client/proc/jumptomob(mob/M in GLOB.mob_list)
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Jump to Mob"
 
 	if(!src.holder)
@@ -57,7 +57,7 @@
 			to_chat(A, "This mob is not located in the game world.")
 
 /client/proc/jumptocoord(tx as num, ty as num, tz as num)
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Jump to Coordinate"
 
 	if (!holder)
@@ -72,7 +72,7 @@
 	message_admins("[key_name_admin(usr)] jumped to coordinates [tx], [ty], [tz]")
 
 /client/proc/jumptokey()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Jump to Key"
 
 	if(!src.holder)
@@ -95,7 +95,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Jump To Key") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/Getmob(mob/M in GLOB.mob_list - GLOB.dummy_mob_list)
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Get Mob"
 	set desc = ""
 	if(!src.holder)
@@ -111,7 +111,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Get Mob") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/Getkey()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Get Key"
 	set desc = ""
 
@@ -139,7 +139,7 @@
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Get Key") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/sendmob(mob/M in sortmobs())
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Send Mob"
 	if(!src.holder)
 		//to_chat(src, "Only administrators may use this command.")

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -15,7 +15,7 @@
 
 //shows a list of clients we could send PMs to, then forwards our choice to cmd_admin_pm
 /client/proc/cmd_admin_pm_panel()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Admin PM"
 	if(!holder)
 		to_chat(src, span_danger("Error: Admin-PM-Panel: Only administrators may use this command."))

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -1,5 +1,5 @@
 /client/proc/cmd_admin_say(msg as text)
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 0
 	if(!check_rights(0))

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -36,7 +36,7 @@
 	return container
 
 /datum/admins/proc/beaker_panel()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Spawn reagent container"
 	if(!check_rights())
 		return

--- a/code/modules/admin/verbs/cinematic.dm
+++ b/code/modules/admin/verbs/cinematic.dm
@@ -1,6 +1,6 @@
 /client/proc/cinematic()
 	set name = "cinematic"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set desc = ""	// Intended for testing but I thought it might be nice for events on the rare occasion Feel free to comment it out if it's not wanted.
 	set hidden = 1
 	if(!SSticker)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -26,7 +26,7 @@ Because if you select a player mob as owner it tries to do the proc for
 But you can call procs that are of type /mob/living/carbon/human/proc/ for that player.
 */
 /client/proc/cmd_admin_animalize(mob/M in GLOB.mob_list)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Make Simple Animal"
 
 	if(!SSticker.HasRoundStarted())
@@ -69,7 +69,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Delete All") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_assume_direct_control(mob/M in GLOB.mob_list)
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Direct control..."
 	set desc = ""
 
@@ -211,7 +211,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	cmd_admin_areatest(FALSE)
 
 /client/proc/cmd_admin_dress(mob/M in GLOB.mob_list)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Select Loadout"
 	if(!(ishuman(M) || isobserver(M)))
 		alert("Invalid mob")

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -58,7 +58,7 @@
 
 /client/proc/reload_admins()
 	set name = "Reload Admins"
-	set category = "-Server-"
+	set category = "Server"
 
 	if(!src.holder)
 		return
@@ -73,7 +73,7 @@
 
 /client/proc/reload_whitelist()
 	set name = "Reload Whitelist"
-	set category = "-Server-"
+	set category = "Server"
 
 	if(!src.holder)
 		return

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -2,14 +2,14 @@
 /client/proc/getserverlogs()
 	set name = "Get Server Logs"
 	set desc = ""
-	set category = "-Server-"
+	set category = "Server"
 
 	browseserverlogs()
 
 /client/proc/getcurrentlogs()
 	set name = "Get Current Logs"
 	set desc = ""
-	set category = "-Server-"
+	set category = "Server"
 
 	browseserverlogs("[GLOB.log_directory]/")
 

--- a/code/modules/admin/verbs/heal_panel.dm
+++ b/code/modules/admin/verbs/heal_panel.dm
@@ -1,6 +1,6 @@
 /datum/admins/proc/admin_show_heal_panel(mob/living/M in GLOB.mob_list)
 	set name = "Show Health Panel"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 
 	if(!check_rights(R_ADMIN))
 		return

--- a/code/modules/admin/verbs/inventory_panel.dm
+++ b/code/modules/admin/verbs/inventory_panel.dm
@@ -316,7 +316,7 @@
 
 /datum/admins/proc/admin_show_inventory(mob/living/M in GLOB.mob_list)
 	set name = "Show Inventory Panel"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 
 	if(!check_rights(R_ADMIN))
 		return

--- a/code/modules/admin/verbs/local_lightsout.dm
+++ b/code/modules/admin/verbs/local_lightsout.dm
@@ -1,5 +1,5 @@
 /client/proc/local_lightsout()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Local Lightsout"
 
 	if(!check_rights(R_ADMIN))

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -1,5 +1,5 @@
 /client/proc/map_template_load()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Map template - Place"
 
 	var/datum/map_template/template
@@ -27,7 +27,7 @@
 	images -= preview
 
 /client/proc/map_template_upload()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Map Template - Upload"
 
 	var/map = input(src, "Choose a Map Template to upload to template storage","Upload Map Template") as null|file

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -1,5 +1,5 @@
 /client/proc/forcerandomrotate()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Trigger Random Map Rotation"
 	set hidden = 1 // Only one map
 	var/rotate = alert("Force a random map rotation to trigger?", "Rotate map?", "Yes", "Cancel")
@@ -11,7 +11,7 @@
 	SSmapping.maprotate()
 
 /client/proc/adminchangemap()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Change Map"
 	var/list/maprotatechoices = list()
 	for (var/map in config.maplist)

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -1,5 +1,5 @@
 /client/proc/panicbunker()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Toggle Panic Bunker"
 	if (!CONFIG_GET(flag/sql_enabled))
 		to_chat(usr, span_adminnotice("The Database is not enabled!"))

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -1,5 +1,5 @@
 /client/proc/play_sound(S as sound)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Sound - Global"
 	if(!check_rights(R_SOUND))
 		return
@@ -138,7 +138,7 @@
 */
 
 /client/proc/play_local_sound(S as sound)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Sound - Local"
 	if(!check_rights(R_SOUND))
 		return
@@ -149,7 +149,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Local Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/play_local_sound_variable(S as sound)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Sound - Variable Dist"
 	if(!check_rights(R_SOUND))
 		return
@@ -165,7 +165,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Local Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/play_web_sound()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Sound - Internet"
 	if(!check_rights(R_SOUND))
 		return
@@ -250,7 +250,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Internet Sound")
 
 /client/proc/set_round_end_sound(S as sound)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Sound - Round End"
 	if(!check_rights(R_SOUND))
 		return
@@ -262,7 +262,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Set Round End Sound") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/stop_sounds()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Sound - Stop All Playing"
 	if(!src.holder)
 		return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -20,7 +20,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Drop Everything") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_subtle_message(mob/M in GLOB.mob_list)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Subtle Message"
 
 	if(!ismob(M))
@@ -46,7 +46,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Subtle Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_mod_antag_rep(client/C in GLOB.clients, operation)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Modify Antagonist Reputation"
 
 	if(!check_rights(R_ADMIN))
@@ -92,7 +92,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Modify Antagonist Reputation") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_mod_triumphs(mob/M in GLOB.mob_list, operation)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Adjust Triumphs..."
 
 	if(!check_rights(R_ADMIN))
@@ -117,7 +117,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Modify Triumphs") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_mod_pq(mob/M in GLOB.mob_list, operation)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Adjust PQ"
 	set hidden = 1
 
@@ -144,7 +144,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Modify Player Quality") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_world_narrate()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Narrate - Global"
 
 	if(!check_rights(R_ADMIN))
@@ -160,7 +160,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Global Narrate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_direct_narrate(mob/M)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Narrate - Direct"
 
 	if(!check_rights(R_ADMIN))
@@ -185,7 +185,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Direct Narrate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_local_narrate(atom/A)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Narrate - Local"
 
 	if(!check_rights(R_ADMIN))
@@ -206,7 +206,7 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Local Narrate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_godmode(mob/M in GLOB.mob_list)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Godmode"
 	if(!check_rights(R_ADMIN))
 		return
@@ -404,7 +404,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	return new_character
 
 /client/proc/cmd_admin_rejuvenate(mob/living/M in GLOB.mob_list)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Rejuvenate"
 
 	if(!check_rights(R_ADMIN))
@@ -424,7 +424,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Rejuvinate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_create_centcom_report()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Create Command Report"
 
 	if(!check_rights(R_ADMIN))
@@ -446,7 +446,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Create Command Report") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_change_command_name()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Change Command Name"
 	set hidden = 1 // May have uses?
 
@@ -461,7 +461,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	log_admin("[key_name(src)] has changed the Central Command name to: [input]")
 
 /client/proc/cmd_admin_delete(atom/A as obj|mob|turf in world)
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Delete..."
 
 	if(!check_rights(R_SPAWN|R_DEBUG))
@@ -470,7 +470,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	admin_delete(A)
 
 /client/proc/cmd_admin_list_open_jobs()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Manage Job Slots"
 
 	if(!check_rights(R_DEBUG))
@@ -479,7 +479,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Manage Job Slots") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_explosion(atom/O as obj|mob|turf in world)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Explosion"
 
 	if(!check_rights(R_ADMIN))
@@ -515,7 +515,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 /client/proc/cmd_admin_emp(atom/O as obj|mob|turf in world)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "EM Pulse"
 
 	if(!check_rights(R_ADMIN))
@@ -540,7 +540,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 /client/proc/cmd_admin_gib(mob/M in GLOB.mob_list)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Gib..."
 
 	if(!check_rights(R_ADMIN))
@@ -567,7 +567,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 /client/proc/cmd_admin_gib_self()
 	set name = "Gibself"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 
 	var/confirm = alert(src, "You sure?", "Confirm", "Yes", "No")
 	if(confirm == "Yes")
@@ -577,7 +577,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		mob.gib(1, 1, 1)
 
 /client/proc/cmd_admin_check_contents(mob/living/M in GLOB.mob_list)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Check Contents"
 
 	var/list/L = M.get_contents()
@@ -586,7 +586,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Check Contents") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/toggle_view_range()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Change View Range"
 	set desc = ""
 
@@ -603,7 +603,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 
 /client/proc/toggle_random_events()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Toggle random events on/off"
 	set desc = ""
 	var/new_are = !CONFIG_GET(flag/allow_random_events)
@@ -618,7 +618,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 
 /client/proc/toggle_combo_hud()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Toggle Combo HUD"
 	set desc = ""
 	set hidden = 1 // If somebody loves this, I'm sorry, you can unhide it
@@ -651,7 +651,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 
 /client/proc/run_weather()
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set name = "Run Weather"
 	set desc = ""
 	set hidden = 1 //Replaced by particle weather
@@ -675,7 +675,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Run Weather")
 
 /client/proc/show_tip()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Show Tip"
 	set desc = "Sends a tip (that you specify) to all players. After all \
 		you're the experienced player here."
@@ -697,7 +697,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Show Tip")
 
 /client/proc/toggle_hub()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Toggle Hub"
 
 	world.update_hub_visibility(!GLOB.hub_visibility)
@@ -711,7 +711,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 /client/proc/smite(mob/living/target as mob)
 	set name = "Smite"
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	if(!check_rights(R_ADMIN) || !check_rights(R_FUN))
 		return
 	var/static/list/punishment_list = list(
@@ -868,7 +868,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	log_admin("[key_name(usr)] punished [key_name(whom)] with [punishment].")
 
 /client/proc/cmd_admin_check_player_exp()	//Allows admins to determine who the newer players are.
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Player Playtime"
 	if(!check_rights(R_ADMIN))
 		return

--- a/code/modules/admin/verbs/reestablish_db_connection.dm
+++ b/code/modules/admin/verbs/reestablish_db_connection.dm
@@ -1,5 +1,5 @@
 /client/proc/reestablish_db_connection()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Reestablish DB Connection"
 	if (!CONFIG_GET(flag/sql_enabled))
 		to_chat(usr, span_adminnotice("The Database is not enabled!"))

--- a/code/modules/admin/verbs/set_date.dm
+++ b/code/modules/admin/verbs/set_date.dm
@@ -1,5 +1,5 @@
 /client/proc/cmd_admin_set_ic_date()
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "Set IC Date"
 
 	if(!check_rights(R_ADMIN))

--- a/code/modules/admin/view_variables/mark_datum.dm
+++ b/code/modules/admin/view_variables/mark_datum.dm
@@ -7,6 +7,6 @@
 	vv_update_display(D, "marked", VV_MSG_MARKED)
 
 /client/proc/mark_datum_mapview(datum/D as mob|obj|turf|area in view(view))
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Mark Object"
 	mark_datum(D)

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -1,5 +1,5 @@
 /client/proc/debug_variables(datum/D in world)
-	set category = "-Special Verbs-"
+	set category = "Special Verbs"
 	set name = "View Variables"
 	//set src in world
 	var/static/cookieoffset = rand(1, 9999) //to force cookies to reset after the round.

--- a/code/modules/client/border_control.dm
+++ b/code/modules/client/border_control.dm
@@ -53,7 +53,7 @@ GLOBAL_VAR_INIT(whitelistLoaded, 0)
 /datum/admins/proc/BC_WhitelistKeyVerb()
 
 	set name = "BC - Whitelist Key"
-	set category = "-Server-"
+	set category = "Server"
 
 	var/key = input("CKey to Whitelist", "Whitelist Key") as null|text
 
@@ -95,7 +95,7 @@ GLOBAL_VAR_INIT(whitelistLoaded, 0)
 ///client/proc/BC_RemoveKeyVerb()
 /datum/admins/proc/BC_RemoveKeyVerb()
 	set name = "BC - Remove Whitelist Key"
-	set category = "-Server-"
+	set category = "Server"
 
 	var/keyToRemove = input("CKey to Remove", "Remove Key") as null|anything in GLOB.whitelistedCkeys
 
@@ -132,7 +132,7 @@ GLOBAL_VAR_INIT(whitelistLoaded, 0)
 /datum/admins/proc/BC_ToggleState()
 
 	set name = "BC - Toggle Mode"
-	set category = "-Server-"
+	set category = "Server"
 	set desc= "Enables or disables border control"
 
 	var/borderControlMode = CONFIG_GET(number/border_control)

--- a/code/modules/client/manual_donator.dm
+++ b/code/modules/client/manual_donator.dm
@@ -63,7 +63,7 @@ GLOBAL_VAR_INIT(donatorLoaded, 0)
 // Procs goes here
 /datum/admins/proc/admin_add_donator_verb()
 	set name = "BC - Add Donator Ckey"
-	set category = "-Server-"
+	set category = "Server"
 
 	var/key = input("CKey to Add", "Add Donator CKey") as null|text
 
@@ -78,7 +78,7 @@ GLOBAL_VAR_INIT(donatorLoaded, 0)
 
 /datum/admins/proc/admin_remove_donator_verb()
 	set name = "BC - Remove Donator Ckey"
-	set category = "-Server-"
+	set category = "Server"
 
 	var/key = input("CKey to Remove", "Remove Donator CKey") as null|anything in GLOB.donatorCkeys
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -249,7 +249,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 /client/proc/set_ooc(newColor as color)
 	set name = "Set Player OOC Color"
 	set desc = ""
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set hidden = 1
 	if(!holder)
 		return
@@ -260,7 +260,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 /client/proc/reset_ooc()
 	set name = "Reset Player OOC Color"
 	set desc = ""
-	set category = "-GameMaster-"
+	set category = "GameMaster"
 	set hidden = 1
 	if(!holder)
 		return
@@ -320,7 +320,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 //Checks admin notice
 /client/verb/admin_notice()
 	set name = "Adminnotice"
-	set category = "-Admin-"
+	set category = "Admin"
 	set desc ="Check the admin notice if it has been set"
 	set hidden = 1
 	if(!holder)

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -96,7 +96,7 @@
 	to_chat(src, msg)
 
 /client/verb/adminwho()
-	set category = "-Admin-"
+	set category = "Admin"
 	set name = "Adminwho"
 	set desc = "Lists all admins currently online."
 

--- a/code/modules/discord/manipulation.dm
+++ b/code/modules/discord/manipulation.dm
@@ -1,7 +1,7 @@
 // Verb to manipulate IDs and ckeys
 /client/proc/discord_id_manipulation()
 	set name = "Discord Manipulation"
-	set category = "-Admin-"
+	set category = "Admin"
 	set hidden = 1
 
 	if(!check_rights(R_ADMIN))

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -59,7 +59,7 @@
 /client/verb/mentorhelp()
 	set name = "Mentorhelp"
 	set desc = ""
-	set category = "-Admin-"
+	set category = "Admin"
 	if(mob)
 		var/msg = input("Submit your question to the Voices:", "Mentorhelp Input") as text|null
 		if(msg)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -220,7 +220,7 @@ window "statwindow"
 		tab-text-color = #d6dbd5
 		tab-background-color = #000000
 		tab-font-family = "Blackmoor LET"
-		tab-font-size = 20
+		tab-font-size = 15
 		prefix-color = #f9bb00
 		suffix-color = #d6dbd5
 

--- a/modular/code/modules/admin/bunker_bypass.dm
+++ b/modular/code/modules/admin/bunker_bypass.dm
@@ -8,7 +8,7 @@ GLOBAL_LIST_INIT(bunker_bypasses, load_bypasses_from_file())
 	return FALSE
 
 /client/proc/bunker_bypass()
-	set category = "-Server-"
+	set category = "Server"
 	set name = "Add Bunker Bypass"
 
 	var/selection = input("Who would you like to let in?", "CKEY", "") as text|null


### PR DESCRIPTION
## About The Pull Request

verb tabs are now small. they no longer jump around when you select one and take up less space. this one is way less heavy handed and keeps the DMF style rendering

this is mutually exclusive to #6883 do not do both together.

## Testing Evidence

<img width="588" height="188" alt="dreamseeker_4HI1EBr0WD" src="https://github.com/user-attachments/assets/626e244e-11b2-46fa-9331-c8329b64379f" />


## Why It's Good For The Game

i feel we can do something bettera nd more permanant but for now this is ok. ideally we'd go over all the verbs n combine/resegregate them.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: makes verb tabs smaller
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
