### PR TITLE
Adds mounts to Dukes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -164,7 +164,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/virtue/utility/riding
 	)
 	
-	subclass_stashed_items = list("Ducal Caparison" = /obj/item/caparison/azure)
+	subclass_stashed_items = list(
+		"Ducal Caparison (Saiga)" = /obj/item/caparison/azure,
+		"Fogbeast Caparison" = /obj/item/caparison/fogbeast)
 
 /datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -211,7 +213,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/virtue/utility/riding
 	)
 
-	subclass_stashed_items = list("Ducal Caparison" = /obj/item/caparison/azure)
+	subclass_stashed_items = list(
+		"Ducal Caparison (Saiga)" = /obj/item/caparison/azure,
+		"Fogbeast Caparison" = /obj/item/caparison/fogbeast)
 
 /datum/outfit/job/roguetown/lord/merchant/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -258,7 +262,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/virtue/utility/riding
 	)
 
-	subclass_stashed_items = list("Ducal Caparison" = /obj/item/caparison/azure)
+	subclass_stashed_items = list(
+		"Ducal Caparison (Saiga)" = /obj/item/caparison/azure,
+		"Fogbeast Caparison" = /obj/item/caparison/fogbeast)
 
 /datum/outfit/job/roguetown/lord/mage/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -299,7 +305,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/virtue/utility/riding
 	)
 
-	subclass_stashed_items = list("Ducal Caparison" = /obj/item/caparison/azure)
+	subclass_stashed_items = list(
+		"Ducal Caparison (Saiga)" = /obj/item/caparison/azure,
+		"Fogbeast Caparison" = /obj/item/caparison/fogbeast)
 
 /datum/outfit/job/roguetown/lord/inbred/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -160,6 +160,12 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/skill/misc/hunting = SKILL_LEVEL_APPRENTICE,
 	)
 
+	subclass_virtues = list(
+		/datum/virtue/utility/riding
+	)
+	
+	subclass_stashed_items = list("Ducal Caparison" = /obj/item/caparison/azure)
+
 /datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
@@ -200,6 +206,12 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
 	)
+
+	subclass_virtues = list(
+		/datum/virtue/utility/riding
+	)
+
+	subclass_stashed_items = list("Ducal Caparison" = /obj/item/caparison/azure)
 
 /datum/outfit/job/roguetown/lord/merchant/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -242,6 +254,12 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 	)
 
+	subclass_virtues = list(
+		/datum/virtue/utility/riding
+	)
+
+	subclass_stashed_items = list("Ducal Caparison" = /obj/item/caparison/azure)
+
 /datum/outfit/job/roguetown/lord/mage/pre_equip(mob/living/carbon/human/H)
 	..()
 	backr = /obj/item/storage/backpack/rogue/satchel
@@ -276,6 +294,12 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
 	)
+
+	subclass_virtues = list(
+		/datum/virtue/utility/riding
+	)
+
+	subclass_stashed_items = list("Ducal Caparison" = /obj/item/caparison/azure)
 
 /datum/outfit/job/roguetown/lord/inbred/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. Dukes now have the Saddleborn virtue added by default, and get their own mounts, like knights, without needing a separate virtue.

Also adds caparisons to Dukes' loadouts, for obvious reasons.

## Testing Evidence

<img width="254" height="238" alt="image" src="https://github.com/user-attachments/assets/e0c73959-6391-4c3c-bc27-1f8d9dcc0de4" />

## Why It's Good For The Game

Bit odd for the Duke to not have a steed of their own when everyone around them does, innit mate?

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added the ability for Dukes to have their own mounts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
