### PR TITLE
Reduce the maximum amount of sex bots by 1

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -5,8 +5,8 @@
 	department_flag = PEASANTS
 	selection_color = JCOLOR_PEASANT
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 4
+	spawn_positions = 4
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES


### PR DESCRIPTION
## About The Pull Request

*earcrushing keyboard noises heavy typing that emphasizes how important this is*

- Removes 1 (one), ((the first unit of any mathematical base)) from the Bathhouse Attendant (also known as bathmaid.dm) purely for balance reasons and balance only

## Testing Evidence

Using vendored Bun 1.2.16
:: Juke Build version 0.8.1
=> Starting 'bun'
=> Starting 'dm'
:: Using defines: CBT, LOCALTEST
bun install v1.2.16 (631e6748)
DM compiler version 516.1667
loading roguetown.dme

Checked 728 installs across 732 packages (no changes) [11.20s]
=> Finished 'bun' in 11.295s
:: Skipping 'tgui' (up to date)
loading interface/skin.dmf
loading _maps/map_files/generic/CentCom.dmm
saving roguetown.dmb (DEBUG mode)
roguetown.dmb - 0 errors, 0 warnings (4/26/26 11:34 am)
Total time: 0:39
=> Finished 'dm' in 39.524s
=> Done in 59.13s
 *  Terminal will be reused by tasks, press any key to close it. 
 
 Exception has occurred: list index out of bounds

## Why It's Good For The Game

the less maids the better i hate bath house they are taking full custody of all erp i nthis game like what the fuck they have a tile that literally says im not supple enough to pass through like HELLO? HOW DARE YOU?? this is the most non-inclusive towner job in the game and quite honestly this nerf was warranted they had it coming long ago

## Changelog
:cl:
refactor: consequences will never be the same and they done goofed
/:cl:

(this is a 10 in the morning joke while i wait for my coffee to brew)