### PR TITLE
Tries to fix arcyne ward issues

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -911,6 +911,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 			if(active_ward && !QDELETED(active_ward))
 				new_ward_spell.conjured_ward = active_ward
 				active_ward.linked_spell = new_ward_spell
+				new_ward_spell.regen_action?.build_all_button_icons()
 		else
 			AddSpell(new /datum/action/cooldown/spell/conjure_arcyne_ward)
 	else

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_arcyne_ward.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_arcyne_ward.dm
@@ -49,7 +49,8 @@
 	var/ward_type = /obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward
 	var/dismiss_invocation = "Aegis Dissipo!"
 	var/regen_invocation = "Aegis Restauro!"
-	/// Regen action granted alongside a live ward and removed on ward destruction — see grant_regen_action().
+	/// Paired regen action - granted alongside the conjure spell itself and lives as long as it does.
+	/// IsAvailable() on the regen gates by ward existence, so it sits inert (red) when no ward is active.
 	var/datum/action/cooldown/spell/regenerate_arcyne_ward/regen_action
 	/// Regen spell path paired with this conjure variant. Children override to their matching regen subtype.
 	var/regen_spell_type = /datum/action/cooldown/spell/regenerate_arcyne_ward
@@ -81,20 +82,19 @@
 		if(adjusted > 0)
 			L.stamina_add(adjusted)
 
-/// Adds the paired regen action to the owner. Called when a ward is conjured.
-/datum/action/cooldown/spell/conjure_arcyne_ward/proc/grant_regen_action()
-	if(regen_action || !owner)
+/datum/action/cooldown/spell/conjure_arcyne_ward/Grant(mob/grant_to)
+	. = ..()
+	if(!owner)
 		return
-	regen_action = new regen_spell_type(owner)
-	regen_action.parent_spell = src
+	if(!regen_action)
+		regen_action = new regen_spell_type(owner)
+		regen_action.parent_spell = src
 	regen_action.Grant(owner)
 
-/// Removes the paired regen action from the owner. Called when a ward is destroyed or dismissed.
-/datum/action/cooldown/spell/conjure_arcyne_ward/proc/revoke_regen_action()
-	if(!regen_action)
-		return
-	regen_action.Remove(owner)
-	QDEL_NULL(regen_action)
+/datum/action/cooldown/spell/conjure_arcyne_ward/Remove(mob/living/remove_from)
+	if(regen_action)
+		regen_action.Remove(remove_from)
+	return ..()
 
 /datum/action/cooldown/spell/conjure_arcyne_ward/cast(atom/cast_on)
 	. = ..()
@@ -130,13 +130,15 @@
 	conjured_ward.setup_ward(H)
 	conjured_ward.linked_spell = src
 	reset_spell_cooldown()
-	grant_regen_action()
+	// Wake the paired regen button up now that there's a live ward to mend
+	regen_action?.build_all_button_icons()
 	return TRUE
 
 /datum/action/cooldown/spell/conjure_arcyne_ward/Destroy()
 	if(conjured_ward && !QDELETED(conjured_ward))
 		conjured_ward.visible_message(span_warning("The arcyne ward flickers and fades!"))
 		qdel(conjured_ward)
+	QDEL_NULL(regen_action)
 	return ..()
 
 /datum/action/cooldown/spell/conjure_arcyne_ward/dragonhide
@@ -236,12 +238,30 @@
 		return FALSE
 	return ..()
 
+/// Fraction of the ward's max integrity that's missing. 0 at full HP, 1 at zero HP.
+/// Drives the proportional resource cost for both check_cost (button state) and before_cast (actual spend).
+/datum/action/cooldown/spell/regenerate_arcyne_ward/proc/get_damage_ratio()
+	var/obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/ward = parent_spell?.conjured_ward
+	if(!ward || QDELETED(ward) || !ward.max_integrity)
+		return 0
+	return 1 - (ward.obj_integrity / ward.max_integrity)
+
+/datum/action/cooldown/spell/regenerate_arcyne_ward/check_cost(feedback = TRUE)
+	// IsAvailable, and therefore the button's red state, calls into check_cost. Scale the
+	// primary cost the same way before_cast does so the button reflects the real cost, not
+	// the unscaled max - otherwise a half-damaged ward shows red whenever you're below full energy.
+	var/damage_ratio = get_damage_ratio()
+	var/saved_primary = primary_resource_cost
+	primary_resource_cost = round(primary_resource_cost * damage_ratio)
+	. = ..()
+	primary_resource_cost = saved_primary
+
 /datum/action/cooldown/spell/regenerate_arcyne_ward/before_cast(atom/cast_on)
 	var/obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/ward = parent_spell?.conjured_ward
 	if(!ward || QDELETED(ward))
 		return ..() | SPELL_CANCEL_CAST
 
-	var/damage_ratio = 1 - (ward.obj_integrity / ward.max_integrity)
+	var/damage_ratio = get_damage_ratio()
 	var/saved_upfront = upfront_stamina_cost
 	var/saved_drain = charge_drain
 	var/saved_primary = primary_resource_cost
@@ -400,7 +420,8 @@
 		if(!QDELETED(linked_spell) && !dismissed)
 			linked_spell.StartCooldown(linked_spell.get_adjusted_cooldown())
 		linked_spell.conjured_ward = null
-		linked_spell.revoke_regen_action()
+		// Refresh the paired regen's button state so it goes red now that the ward is gone
+		linked_spell.regen_action?.build_all_button_icons()
 		linked_spell = null
 
 // --- Dragonhide Ward Item ---


### PR DESCRIPTION
## About The Pull Request
Tries to fix arcyne ward issues with redundant ward, by rearchitecturing it so that you always gain the regen spell in a pair and it doesn't disappear.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="593" height="597" alt="dreamseeker_aIHhDigwfO" src="https://github.com/user-attachments/assets/188e65d2-62b4-464b-931a-a6739ad9d117" />
<img width="556" height="624" alt="dreamseeker_qr79SNyNqb" src="https://github.com/user-attachments/assets/c142628e-cfc1-4ec5-a23f-7a4b218cc264" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Less jank with the new arcyne ward

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: You always gain the arcyne ward paired regeneration spell with gain of any arcyne ward, which should hopefully fixes issues with gaining infinite regen spell and most cases of jankiness
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
