### PR TITLE
Change all mindlink description

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_spells.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_spells.dm
@@ -290,7 +290,7 @@
 
 /obj/effect/proc_holder/spell/invoked/mindlink/hag
 	name = "Coven Link"
-	desc = "Weave the minds of up to three others into a shared coven with yourself. All participants communicate via ,y."
+	desc = "Weave the minds of up to three others into a shared coven with yourself. All participants communicate via ,Y."
 	invocation_type = "none"
 	recharge_time = 4 MINUTES
 	cost = 12

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -313,12 +313,12 @@
 	///////TYPING INDICATORS///////
 	/// Set to true if we want to show typing indicators.
 	var/typing_indicator_enabled = FALSE
-	/// Default icon_state of our typing indicator. Currently only supports paths (because anything else is, as of time of typing this, unnecesary.
-	var/typing_indicator_state = /obj/effect/overlay/typing_indicator
 	/// The timer that will remove our indicator for early aborts (like when an user finishes their message)
 	var/typing_indicator_timerid
-	/// Current state of our typing indicator. Used for cut overlay, DO NOT RUNTIME ASSIGN OTHER THAN FROM SHOW/CLEAR. Used to absolutely ensure we do not get stuck overlays.
-	var/mutable_appearance/typing_indicator_current
+	/// The shared typing indicator currently attached to our vis_contents, or null if not typing. DO NOT RUNTIME ASSIGN OTHER THAN FROM SHOW/CLEAR.
+	var/obj/effect/overlay/typing_indicator/typing_indicator_current
+	/// TRUE if we set KEEP_TOGETHER on the mob to make the indicator follow our transform (and need to clear it on stop).
+	var/typing_indicator_added_keep_together = FALSE
 
 	// The last tick where we manually moved, or clicked on something in-world. Useful for preventing abuse of mobs with AFK players.
 	var/last_client_interact = 0

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,53 +1,32 @@
-/// state = overlay/image/object/type/whatever add_overlay will accept
-GLOBAL_LIST_EMPTY(typing_indicator_overlays)
-
-/// Fetches the typing indicator we'll use from GLOB.typing_indicator_overlays
-/mob/proc/get_indicator_overlay(state)
-	. = GLOB.typing_indicator_overlays[state]
-	if(.)
-		return
-	// doesn't exist, make it and cache it
-	if(ispath(state))
-		. = GLOB.typing_indicator_overlays[state] = state
-	// We only support paths for now because anything else isn't necessary yet.
-
-
-/// Gets the state we will use for typing indicators. Defaults to src.typing_indicator_state
-/mob/proc/get_typing_indicator_icon_state()
-	return typing_indicator_state
-
-/// Generates the mutable appearance for typing indicator. Should prevent stuck overlays.
-/mob/proc/generate_typing_indicator()
-	var/state = get_typing_indicator_icon_state()
-	if(ispath(state))
-		var/atom/thing = new state(null)
-		var/mutable_appearance/generated = new(thing)
-		generated.plane = FULLSCREEN_PLANE
-		return generated
-	else
-		CRASH("Unsupported typing indicator state: [state]")
+GLOBAL_DATUM_INIT(shared_typing_indicator, /obj/effect/overlay/typing_indicator, new(null))
 
 /**
   * Displays typing indicator.
-  * @param timeout_override - Sets how long until this will disappear on its own without the user finishing their message or logging out. Defaults to src.typing_indicator_timeout
-  * @param state_override - Sets the state that we will fetch. Defaults to src.get_typing_indicator_icon_state()
-  * @param force - shows even if src.typing_indcator_enabled is FALSE.
+  * @param timeout_override - Sets how long until this will disappear on its own without the user finishing their message or logging out. Defaults to TYPING_INDICATOR_TIMEOUT
+  * @param force - shows even if src.typing_indicator_enabled is FALSE.
   */
-/mob/proc/display_typing_indicator(timeout_override = TYPING_INDICATOR_TIMEOUT, state_override = generate_typing_indicator(), force = FALSE)
+/mob/proc/display_typing_indicator(timeout_override = TYPING_INDICATOR_TIMEOUT, force = FALSE)
 	if(((!typing_indicator_enabled || (stat != CONSCIOUS)) && !force) || typing_indicator_current)
 		return
-	typing_indicator_current = state_override
+	typing_indicator_current = GLOB.shared_typing_indicator
 	log_message("started typing", LOG_ATTACK)
-	add_overlay(state_override)
-	update_vision_cone()
+	// KEEP_TOGETHER on the mob so vis_contents children inherit our transform (giant virtue, etc).
+	if(!(appearance_flags & KEEP_TOGETHER))
+		appearance_flags |= KEEP_TOGETHER
+		typing_indicator_added_keep_together = TRUE
+	vis_contents += typing_indicator_current
 	typing_indicator_timerid = addtimer(CALLBACK(src, PROC_REF(clear_typing_indicator)), timeout_override, TIMER_STOPPABLE)
 
 /**
   * Removes typing indicator.
   */
 /mob/proc/clear_typing_indicator()
-	cut_overlay(typing_indicator_current)
-	update_vision_cone()
+	if(!typing_indicator_current)
+		return
+	vis_contents -= typing_indicator_current
+	if(typing_indicator_added_keep_together)
+		appearance_flags &= ~KEEP_TOGETHER
+		typing_indicator_added_keep_together = FALSE
 	typing_indicator_current = null
 	if(typing_indicator_timerid)
 		deltimer(typing_indicator_timerid)
@@ -62,3 +41,4 @@ GLOBAL_LIST_EMPTY(typing_indicator_overlays)
 	layer = HUD_LAYER
 	plane = FULLSCREEN_PLANE
 	alpha = 175
+	vis_flags = NONE

--- a/code/modules/spells/spell_types/wizard/utility/mindlink.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mindlink.dm
@@ -88,8 +88,8 @@
 	var/datum/mindlink/link = new(first_target, second_target)
 	GLOB.mindlinks += link
 
-	to_chat(first_target, span_notice("A mindlink has been established with [second_target]! Use ,y before a message to communicate telepathically. Use ,mst to break the link."))
-	to_chat(second_target, span_notice("A mindlink has been established with [first_target]! Use ,y before a message to communicate telepathically. Use ,mst to break the link."))
+	to_chat(first_target, span_notice("A mindlink has been established with [second_target]! Use ,Y before a message to communicate telepathically. Use ,mst to break the link."))
+	to_chat(second_target, span_notice("A mindlink has been established with [first_target]! Use ,Y before a message to communicate telepathically. Use ,mst to break the link."))
 
 	addtimer(CALLBACK(src, PROC_REF(break_link), link), 3 MINUTES)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Change all mindlink description to use ,Y instead of ,y

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
No

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Yes

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: All mindlinks tell you to use ,Y 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
