### PR TITLE
Fulgurmancy Jak

### DIFF
--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -96,12 +96,14 @@
 /datum/status_effect/buff/lightningstruck/on_apply()
 	. = ..()
 	var/mob/living/target = owner
+	ADD_TRAIT(target, TRAIT_SPELLCOCKBLOCK, TRAIT_STATUS_EFFECT)
 	target.update_vision_cone()
 	target.add_movespeed_modifier(MOVESPEED_ID_LIGHTNINGSTRUCK, update=TRUE, priority=100, multiplicative_slowdown=4, movetypes=GROUND)
 
 /datum/status_effect/buff/lightningstruck/on_remove()
 	. = ..()
 	var/mob/living/target = owner
+	REMOVE_TRAIT(target, TRAIT_SPELLCOCKBLOCK, TRAIT_STATUS_EFFECT)
 	target.update_vision_cone()
 	target.remove_movespeed_modifier(MOVESPEED_ID_LIGHTNINGSTRUCK, TRUE)
 


### PR DESCRIPTION
## About The Pull Request

One-line change to lightning bolt's status effect to bring parity between the spell's effects against martials vs mages.

## Testing Evidence

One line change, sire.
~~Also my local hosting is fucky with the new UIs and I haven't fixed it yet. Worth a TM first, but there shouldn't be any major issues.~~

## Why It's Good For The Game

Lightning bolt's functionality (slowdown + forced inaction) should be roughly equivalent whether you're fighting a martial character or a magician character. Previously, it was not.

## Changelog

:cl:
balance: Added TRAIT_SPELLCOCKBLOCK to Lightning Bolt's status debuff
/:cl: