### PR TITLE
Adding smithing skills and mining to Homesteader

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
@@ -9,7 +9,7 @@
 		TRAIT_SMITHING_EXPERT,
 		TRAIT_SEWING_EXPERT,
 		TRAIT_SURVIVAL_EXPERT,
-		TRAIT_HOMESTEAD_EXPERT // No medicine but they get the full package
+		TRAIT_HOMESTEAD_EXPERT, // No medicine but they get the full package
 		// No hunting, as it's a specialty skill.
 	)
 	category_tags = list(CTAG_PILGRIM, CTAG_TOWNER)
@@ -51,10 +51,15 @@
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/tanning = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/cooking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/blacksmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/armorsmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,
 
 		/datum/skill/labor/lumberjacking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/fishing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/butchering = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/mining = SKILL_LEVEL_APPRENTICE
 	)
 	maximum_possible_slots = 20 // Should not fill, just a hack to make it shows what types of towners are in round
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
@@ -51,15 +51,15 @@
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/tanning = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/cooking = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/blacksmithing = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/armorsmithing = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/blacksmithing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/armorsmithing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/smelting = SKILL_LEVEL_NOVICE,
 
 		/datum/skill/labor/lumberjacking = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/fishing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/butchering = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/labor/mining = SKILL_LEVEL_APPRENTICE
+		/datum/skill/labor/mining = SKILL_LEVEL_NOVICE
 	)
 	maximum_possible_slots = 20 // Should not fill, just a hack to make it shows what types of towners are in round
 


### PR DESCRIPTION
## About The Pull Request

Really simple. Homesteader is supposed to be able to fill any role but not be great at it from round start, but they really suck at mining and smithing, the latter taking an especially long time to level up without prior skill.

## Testing Evidence

It compiles, runs and gives me the skills. They're very simple changes.

## Why It's Good For The Game

Homesteaders should be looked at to fix all kinds of problems, and being able to repair and make some small items on the fly is going to make them even more valuable. Now adventurers can ask Homesteaders to repair their stuff if they meet them and hopefully give them some pay.

## Changelog
:cl:
balance: Gave Homesteaders Novice Smelting, Mining, Blacksmithing, Armorsmithing and Weaponsmithing.
/:cl: