### PR TITLE
Making chisling and sawing automatically do it on the items in the same turf

### DIFF
--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -337,21 +337,27 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			S.set_up(1, 1, front)
 			S.start()
 	if( user.used_intent.type == /datum/intent/chisel )
-		playsound(src.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
-		user.visible_message("<span class='info'>[user] chisels the stone into a block.</span>")
-		if(do_after(user, work_time))
-			new /obj/item/natural/stoneblock(get_turf(src.loc))
-			if(HAS_TRAIT(user, TRAIT_MASTER_MASON)) //double the amount for any in a stone worker role
+		var/stackcount = 0
+		for(var/obj/item/natural/stone in get_turf(src))
+			stackcount++
+		while(stackcount > 0)
+			user.visible_message("<span class='info'>[user] chisels the stone into a block.</span>")
+			if(do_after(user, work_time))
 				new /obj/item/natural/stoneblock(get_turf(src.loc))
-			new /obj/effect/decal/cleanable/debris/stony(get_turf(src))
-			playsound(src.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
-			qdel(src)
-			user.mind.add_sleep_experience(/datum/skill/craft/masonry, (user.STAINT*0.2))
+				if(HAS_TRAIT(user, TRAIT_MASTER_MASON)) //double the amount for any in a stone worker role
+					new /obj/item/natural/stoneblock(get_turf(src.loc))
+				new /obj/effect/decal/cleanable/debris/stony(get_turf(src))
+				playsound(src.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
+				var/obj/item/natural/stone/S = locate(/obj/item/natural/stone) in get_turf(src)
+				qdel(S)
+				user.mind.add_sleep_experience(/datum/skill/craft/masonry, (user.STAINT*0.2))
+				stackcount--
 		return
 	else if(istype(W, /obj/item/rogueweapon/chisel/assembly))
 		to_chat(user, span_warning("You most use both hands to chisel blocks."))
 	else
 		..()
+
 //rock munching
 /obj/item/natural/stone/attack(mob/living/M, mob/user)
 

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -337,21 +337,19 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			S.set_up(1, 1, front)
 			S.start()
 	if( user.used_intent.type == /datum/intent/chisel )
-		var/stackcount = 0
-		for(var/obj/item/natural/stone in get_turf(src))
-			stackcount++
-		while(stackcount > 0)
+		var/location = src.loc
+		for(var/obj/item/natural/stone/S in get_turf(src))
 			user.visible_message("<span class='info'>[user] chisels the stone into a block.</span>")
 			if(do_after(user, work_time))
-				new /obj/item/natural/stoneblock(get_turf(src.loc))
+				new /obj/item/natural/stoneblock(get_turf(location))
 				if(HAS_TRAIT(user, TRAIT_MASTER_MASON)) //double the amount for any in a stone worker role
-					new /obj/item/natural/stoneblock(get_turf(src.loc))
-				new /obj/effect/decal/cleanable/debris/stony(get_turf(src))
-				playsound(src.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
-				var/obj/item/natural/stone/S = locate(/obj/item/natural/stone) in get_turf(src)
+					new /obj/item/natural/stoneblock(get_turf(location))
+				new /obj/effect/decal/cleanable/debris/stony(get_turf(location))
+				playsound(location, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
 				qdel(S)
 				user.mind.add_sleep_experience(/datum/skill/craft/masonry, (user.STAINT*0.2))
-				stackcount--
+			else
+				return
 		return
 	else if(istype(W, /obj/item/rogueweapon/chisel/assembly))
 		to_chat(user, span_warning("You most use both hands to chisel blocks."))

--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -186,17 +186,21 @@
 	if(HAS_TRAIT(user, TRAIT_MASTER_CARPENTER)) //we give extra to those in the role
 		woodtotal += pick(1,2)
 	if(I.tool_behaviour == TOOL_SAW)
-		playsound(get_turf(src.loc), 'sound/foley/sawing.ogg', 100)
 		user.visible_message("<span class='notice'>[user] starts sawing planks from [src].</span>")
-		if(do_after(user, planking_time))
-			if(user.is_holding(src))
-				user.dropItemToGround(src)
-			for(var/i=1, i<=woodtotal, ++i)
-				new /obj/item/natural/wood/plank(get_turf(src.loc))
-			user.mind.add_sleep_experience(/datum/skill/craft/carpentry, (user.STAINT*0.5))
-			new /obj/effect/decal/cleanable/debris/woody(get_turf(src))
-			qdel(src)
-			return
+		var/location = src.loc
+		for(var/obj/item/grown/log/tree/small/S in get_turf(src))
+			playsound(get_turf(location), 'sound/foley/sawing.ogg', 100)
+			if(do_after(user, planking_time))
+				if(user.is_holding(src))
+					user.dropItemToGround(location)
+				for(var/i=1, i<=woodtotal, ++i)
+					new /obj/item/natural/wood/plank(get_turf(location))
+				user.mind.add_sleep_experience(/datum/skill/craft/carpentry, (user.STAINT*0.5))
+				new /obj/effect/decal/cleanable/debris/woody(get_turf(location))
+				qdel(S)
+			else
+				return
+		return
 	..()
 
 /obj/item/grown/log/tree/bowpartial


### PR DESCRIPTION
## About The Pull Request

Making chisling and sawing automated so you don't have to click repeatedly. 

## Testing Evidence

It complies. I've ran it and it works as intended.

## Why It's Good For The Game

Removes unnecessary tedium from the game.

## Changelog
:cl:
add: Chiseling and sawing now keeps going until the turf with the item you targetted runs out of the item.
/:cl: