### PR TITLE
Fixes spell charge camera

### DIFF
--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -948,6 +948,9 @@
 /datum/action/cooldown/spell/proc/on_start_charge()
 	currently_charging = TRUE
 	if(owner)
+		owner.tempfixeye = TRUE
+		if(!owner.fixedeye)
+			owner.nodirchange = TRUE
 		owner.channeling_spell = src
 	START_PROCESSING(SSfastprocess, src)
 	build_all_button_icons(UPDATE_BUTTON_STATUS|UPDATE_BUTTON_BACKGROUND)
@@ -988,6 +991,10 @@
 /// When finish charging the spell called from set_click_ability or try_casting
 /// This does not mean we succeeded in charging the spell just that we did mouseUp/ended the do_after
 /datum/action/cooldown/spell/proc/on_end_charge(success)
+	if(owner)
+		owner.tempfixeye = FALSE
+		if(!owner.fixedeye)
+			owner.nodirchange = FALSE
 	end_charging()
 	. = success
 	if(success)


### PR DESCRIPTION
## About The Pull Request

- Seamlessly transposes the camera lock we had on proc_holder to action/cooldown

## Testing Evidence

- Compiles, just 7 lines of code.
- Tried on local, held down mmb, no longer shuffling my camera back and forth. It works!

## Why It's Good For The Game

This functionality was lost with the port from proc_holder to spell/cooldown and only my OCD headass could tell the difference after what's been month(?)s ever since the transition due to Mage 2. 

Now it's not the case, behold, mages won't be blind-tossing spells over their shoulder anymore. The past is now, old man.

## Changelog

:cl:
fix: Restored a missing functionality to spellcasting.
/:cl: