### PR TITLE
Attempts to fix Linux / Wine / Old Browser toArray Crash

### DIFF
--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -314,7 +314,10 @@ const encodedLengthBinarySearch = (haystack: string[], length: number) => {
 
 const chunkSplitter = {
   [Symbol.split]: (string: string) => {
-    const charSeq = string[Symbol.iterator]().toArray();
+    // Array.from over string[Symbol.iterator]().toArray() - the latter needs
+    // the Iterator Helpers proposal (Chrome 122 / Firefox 131 / Safari 18.4),
+    // which older CEF builds and Wine players don't have.
+    const charSeq = Array.from(string);
     const length = charSeq.length;
     const chunks: string[] = [];
     let startIndex = 0;


### PR DESCRIPTION
## About The Pull Request
Attempts to fix Linux / Wine / Old Browser toArray Crash on long text in TGUI input modal like flavortext / examine

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
(I can't replicate the crash on a modern system)
<img width="398" height="319" alt="c7CktLgyMu" src="https://github.com/user-attachments/assets/bacd8e9f-7638-4fb5-80f3-948db0f6b0c5" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fixes an annoying issue causing a few people's FT to crash

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Possibly fixed TGUI input modal crashing on long text above 2048 characters on older systems or older in built browser such as Wine / Linux emulator by using a feature introduced in 2015 instead of 2025.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
