### PR TITLE
Mage Staple Spell Adjustments

### DIFF
--- a/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
@@ -37,7 +37,7 @@
 /obj/projectile/magic/frostbolt
 	name = "frost bolt"
 	icon_state = "ice_2"
-	damage = 28
+	damage = 33
 	npc_simple_damage_mult = 2
 	damage_type = BURN
 	woundclass = BCLASS_BURN
@@ -49,7 +49,7 @@
 
 /obj/projectile/magic/frostbolt/arc
 	name = "arced frost bolt"
-	damage = 21
+	damage = 25
 	arcshot = TRUE
 
 /obj/projectile/magic/frostbolt/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
@@ -39,7 +39,7 @@
 	icon = 'icons/obj/magic_projectiles.dmi'
 	icon_state = "air_blade_stab"
 	guard_deflectable = TRUE
-	damage = 55
+	damage = 66
 	damage_type = BRUTE
 	woundclass = BCLASS_STAB
 	npc_simple_damage_mult = 1.5
@@ -57,7 +57,7 @@
 
 /obj/projectile/magic/arcyne_lance/arc
 	name = "arced arcyne lance"
-	damage = 41
+	damage = 50
 	arcshot = TRUE
 	max_hits = 1 // Arced version does not pierce
 

--- a/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
@@ -61,7 +61,7 @@
 	range = 5
 	icon = 'icons/obj/magic_projectiles.dmi'
 	icon_state = "stygian"
-	damage = 35
+	damage = 42
 	damage_type = BRUTE
 	woundclass = BCLASS_STAB
 	armor_penetration = PEN_LIGHT
@@ -74,7 +74,7 @@
 
 /obj/projectile/energy/stygian/arc
 	name = "arced stygian harpe"
-	damage = 26
+	damage = 32
 	arcshot = TRUE
 
 /obj/projectile/energy/stygian/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
@@ -70,7 +70,7 @@
 	accuracy = 65
 	flag = "piercing"
 	hitsound = 'sound/combat/hits/bladed/genstab (1).ogg'
-	var/reduced_damage = 19
+	var/reduced_damage = 23
 
 /obj/projectile/energy/stygian/arc
 	name = "arced stygian harpe"

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/arc_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/arc_bolt.dm
@@ -39,7 +39,7 @@
 	hitscan = TRUE
 	movement_type = UNSTOPPABLE
 	light_color = LIGHT_COLOR_WHITE
-	damage = 35
+	damage = 42
 	npc_simple_damage_mult = 2
 	damage_type = BURN
 	woundclass = BCLASS_BURN
@@ -52,7 +52,7 @@
 
 /obj/projectile/magic/arc_bolt/arc
 	name = "arced arc bolt"
-	damage = 26
+	damage = 32
 	arcshot = TRUE
 
 /obj/projectile/magic/arc_bolt/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
@@ -51,7 +51,7 @@
 	name = "gravel shot"
 	icon = 'icons/obj/magic_projectiles.dmi'
 	icon_state = "stone"
-	damage = 22
+	damage = 26
 	nodamage = FALSE
 	damage_type = BRUTE
 	woundclass = BCLASS_BLUNT
@@ -75,7 +75,7 @@
 
 /obj/projectile/magic/gravel_blast/arc
 	name = "arced gravel shot"
-	damage = 17
+	damage = 20
 	arcshot = TRUE
 
 /obj/projectile/magic/gravel_blast/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
@@ -71,7 +71,7 @@
 	ricochet_incidence_leeway = 40
 	ricochet_decay_chance = 1
 	ricochet_decay_damage = 1
-	var/reduced_damage = 9
+	var/reduced_damage = 11
 
 /obj/projectile/magic/gravel_blast/arc
 	name = "arced gravel shot"

--- a/code/modules/spells/spell_types/wizard/kinesis/soulshot.dm
+++ b/code/modules/spells/spell_types/wizard/kinesis/soulshot.dm
@@ -41,7 +41,7 @@
 	hitscan = TRUE
 	movement_type = UNSTOPPABLE
 	guard_deflectable = TRUE
-	damage = 80
+	damage = 95
 	damage_type = BRUTE
 	woundclass = BCLASS_STAB
 	npc_simple_damage_mult = 1.5

--- a/code/modules/spells/spell_types/wizard/projectiles_single/greater_arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/greater_arcyne_bolt.dm
@@ -39,7 +39,7 @@
 	icon = 'icons/obj/magic_projectiles.dmi'
 	icon_state = "arcyne_bolt"
 	guard_deflectable = TRUE
-	damage = 45
+	damage = 54
 	damage_type = BRUTE
 	flag = "blunt"
 	woundclass = BCLASS_BLUNT
@@ -52,7 +52,7 @@
 
 /obj/projectile/magic/greater_arcyne_bolt/arc
 	name = "arced greater arcyne bolt"
-	damage = 34
+	damage = 41
 	arcshot = TRUE
 
 /obj/projectile/magic/greater_arcyne_bolt/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/pyromancy/fireball_artillery.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/fireball_artillery.dm
@@ -14,7 +14,7 @@
 
 	charge_time = CHARGETIME_HEAVY
 	charge_slowdown = CHARGING_SLOWDOWN_HEAVY
-	cooldown_time = 18 SECONDS
+	cooldown_time = 16 SECONDS
 
 	spell_tier = 4
 	point_cost = 9
@@ -28,7 +28,7 @@
 	exp_fire = 1
 	damage = 70
 	damage_type = BURN
-	npc_simple_damage_mult = 2.4
+	npc_simple_damage_mult = 3
 	accuracy = 40
 	nodamage = FALSE
 	flag = "fire"

--- a/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
@@ -37,7 +37,7 @@
 	light_color = "#f8af07"
 	light_outer_range = 2
 	speed = MAGE_PROJ_MEDIUM
-	damage = 30
+	damage = 35
 	npc_simple_damage_mult = 2
 	accuracy = 40
 	damage_type = BURN
@@ -48,7 +48,7 @@
 
 /obj/projectile/magic/spitfire/arc
 	name = "arced spitfire"
-	damage = 23
+	damage = 26
 	arcshot = TRUE
 
 /obj/projectile/magic/spitfire/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
@@ -37,7 +37,7 @@
 	light_color = "#f8af07"
 	light_outer_range = 2
 	speed = MAGE_PROJ_MEDIUM
-	damage = 35
+	damage = 36
 	npc_simple_damage_mult = 2
 	accuracy = 40
 	damage_type = BURN
@@ -48,7 +48,7 @@
 
 /obj/projectile/magic/spitfire/arc
 	name = "arced spitfire"
-	damage = 26
+	damage = 27
 	arcshot = TRUE
 
 /obj/projectile/magic/spitfire/on_hit(target)


### PR DESCRIPTION
## About The Pull Request

Mage implements previously provided a damage buff to a single staple spell of a school that ranged between 20% and 25%. Staves were recently changed to instead provide a "mana rebate" where you get back up to a third of a spell mana cost over 20s. Magic damage was already very well balanced around the concept of rotations and it requiring a cycle to bring down most targets, and the balance was already in a good spot for that. The loss of the staple spell enhancement may have been an unnecessary nerf and impacted some Majors more than others.

For example, Battlewardry and Augmentation only have Soulshot or Greater Arcyne Bolt as their main direct damaging spell, so a 20%+ nerf to their output is quite harsh. These tweaks opt for the lowest 20% mark to be baked into only the staple spells, so in effect damage is unchanged for the majority of mage roles and it remains a miniscule nerf at the higher end.

I've also proposed a bugfix/tweak for artillery fireball, because it has the incorrect npc simplemob modifier and cooldown time. Artillery fireball is nominally designed to be a sidegrade to Fireball, which has an NPC multiplier of 3x and a cooldown of 16 seconds. Note that artillery fireball _does_ retain its longer cast time and greater slowdown while channeling however, to account for its other strengths.

## Testing Evidence

Compiled and ran locally. Every change here is a line edit. 

## Why It's Good For The Game

Mage damage was already tuned and balanced for a very particular "flow", and the removal of the damage increase provided by staves has negatively impacted that to varying degrees depending on major. It's important to stress this is not a buff as much as a reversion to how things already were before staves were moved to their utility function.

## Changelog
First draft, tweaked the damage and arc damage values of every staple spell by 1.20 and then adjusted by 0.75x for the arced value. 

:cl:
balance: adjusted the damage and arced damage values of every staple Mage spell.
balance/tweak: adjusted the cooldown and simplemob multiplier of Artillery Fireball to match its baseline counterpart.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
