### PR TITLE
Rain Enlongening PR

### DIFF
--- a/code/datums/weather/weather_types/roguetown/rain.dm
+++ b/code/datums/weather/weather_types/roguetown/rain.dm
@@ -9,8 +9,8 @@
 
 	weather_message = ""
 	weather_overlay = "rain1"
-	weather_duration_lower = 5 MINUTES
-	weather_duration_upper = 12 MINUTES
+	weather_duration_lower = 8 MINUTES
+	weather_duration_upper = 18 MINUTES
 	weather_sound = 'sound/blank.ogg'
 	weather_alpha = 200
 


### PR DESCRIPTION
Raised the weather duration threshold.

## About The Pull Request

Simple PR that takes the original rain timer from 5-12 minutes, and extends it to 8-18 minutes.

## Testing Evidence

It didn't crash when I triggered the rain! 

## Why It's Good For The Game

There was a thread and people seemed down for the idea of rain lasting a bit longer for some atmosphere. OOooOOoOOOooOOOoo~
Not a major change, but I guess if anyone's feeling iffy about it, TM it and see how we feel about longer rain. I can't imagine it causes too many issues. 

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: Made weather longer. 
/:cl:

