### PR TITLE
Removes "triumph popping" (right clicking the Rogue Doakes)

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -1968,15 +1968,6 @@
 					to_chat(M, "[ddesc]")
 			already_printed = list()
 			to_chat(M, "*--------*")
-		if(modifiers["right"])
-			if(M.get_triumphs() <= 0)
-				to_chat(M, span_warning("I haven't TRIUMPHED."))
-				return
-			if(alert("Do you want to remember a TRIUMPH?", "", "Yes (-3 TRI)", "No") == "Yes (-3 TRI)")
-				if(!M.has_stress_event(/datum/stressevent/triumph))
-					M.add_stress(/datum/stressevent/triumph)
-					M.adjust_triumphs(-3)
-					M.playsound_local(M, 'sound/misc/notice (2).ogg', 100, FALSE)
 
 
 /atom/movable/screen/rmbintent


### PR DESCRIPTION
## About The Pull Request
Right clicking our Bald Hero will now do nothing.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
In a lot of ways this was a long time coming as the esoteric knowledge that you even *can* right click the guy wasn't easily known, and the effect itself could (and has been) used mid-combat to get rid of stress / FOR debuffs or to increase their chance of critting.

So you had a super esoteric feature that gave the user an advantage for what was (and is) negligible price. Not good, not what we're about in this Roguezure thing we have. It shouldn't be there, or it should do something else. I didn't have ideas for the latter so I finally opted for the former.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Removed Triumph consumption via the right clicking of the moodlet head.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
