### PR TITLE
swap around some yellow swingdelay intents

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -631,7 +631,8 @@
 		"wlength" = WLENGTH_SHORT
 	)
 	additive_var_overrides = list(
-		"wdefense" = 2
+		"wdefense" = 2,
+		"force_wielded" = 5
 	)
 
 /datum/alt_grip/halfsword/frei

--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -297,7 +297,7 @@
 	damfactor = 0.8
 	demolition_mod = 1.3
 
-/datum/intent/axe/chop/long/bronze
+/datum/intent/axe/chop/long
 	reach = 2
 	damfactor = 1
 	demolition_mod = 1.5
@@ -510,7 +510,7 @@
 	force = 15
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, SPEAR_BASH) //bash is for nonlethal takedowns, only targets limbs
-	gripped_intents = list(/datum/intent/axe/cut/long/bronze, /datum/intent/axe/chop/long/bronze, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
+	gripped_intents = list(/datum/intent/axe/cut/long/bronze, /datum/intent/axe/chop/long, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
 	name = "bronze greataxe"
 	desc = "A massive staff with a bronze axhead mantled onto the wood. It splits and carves from afar with lethal force; be it lumber or limbs."
 	icon_state = "bronzegreataxe"

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -82,13 +82,13 @@
 	name = "halfsword thrust"
 	icon_state = "inimpale"
 	clickcd = CLICK_CD_CHARGED
-	penfactor = PEN_HEAVY
+	penfactor = PEN_MEDIUM
 	damfactor = 0.8
-	swingdelay_type = SWINGDELAY_PENALTY
-	swingdelay = 0.7 SECONDS
+	swingdelay = 0.5 SECONDS
 
 /datum/intent/sword/thrust/long/halfsword/jab
 	name = "jab"
+	icon_state = "instab"
 	attack_verb = list("jabs")
 	penfactor = PEN_LIGHT
 	damfactor = 0.8


### PR DESCRIPTION
## About The Pull Request

- Halfswording now gives: +5 force (on top of +2 wdef)
- Halfsword thrust is now 0.5s swingdelay and loses the difficulty penalty. Back down to medium penetration.
- Greataxe chops are now back to being 2-tile at 1s delay.

## Testing Evidence

will need ingame balance testing

## Why It's Good For The Game

swingdelay penalties are good but after consideration, may have made a few of the affected intents a bit useless. this is to bring them back to usability.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: halfsword thrust is 0.5s delay without penalty. medium pen.
balance: halfswording gives you +5 force alongside the +2 wdef
balance: greataxe chop is now 2-tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
