### PR TITLE
Adds silver unarmed options to exorcist, and related fixes

### DIFF
--- a/code/game/objects/effects/spawners/equipment_spawners.dm
+++ b/code/game/objects/effects/spawners/equipment_spawners.dm
@@ -276,6 +276,7 @@
 		/obj/item/rogueweapon/sword/long/exe/silver = 1,
 		/obj/item/rogueweapon/greatsword/silver = 1,
 		/obj/item/rogueweapon/handclaw/gronn/silver = 1,
+		/obj/item/rogueweapon/katar/silver = 1,
 	)
 
 /obj/effect/spawner/lootdrop/decrepit_equipment_spawner

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_classagemods.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_classagemods.dm
@@ -264,13 +264,16 @@
 		STATKEY_CON = -2,
 	)
 	skill_mods = list(
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/maces = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/staves = SKILL_LEVEL_EXPERT
+		/datum/skill/combat/staves = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
 	)
+	//It says in warrior.dm that exorcist should get Expert only in knives and their selected weapon, but it actually gives it to EVERY weapon skill..? Not sure if it needs fixing.
 
 /datum/class_age_mod/barber_surgeon
 	target_age = AGE_OLD

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -486,7 +486,7 @@
 	H.verbs |= /mob/living/carbon/human/proc/faith_test //Allows the Exorcist to interrogate others for their faith. Trait's agnostically worded, to allow more flexiable usage by Pantheoneers and Ascendants in this role.
 	H.verbs |= /mob/living/carbon/human/proc/torture_victim //Not as scary as it sounds. Mostly. Okay, just a little bit.
 	if(H.mind)
-		var/silver = list("Silver Dagger","Silver Shortsword","Silver Arming Sword","Silver Rapier","Silver Longsword","Silver Broadsword","Silver Mace","Silver Warhammer","Silver Morningstar","Silver Whip","Silver War Axe","Silver Poleaxe","Silver Spear","Silver Quarterstaff","Broadsword - Steel")
+		var/silver = list("Silver Dagger","Silver Shortsword","Silver Arming Sword","Silver Rapier","Silver Longsword","Silver Broadsword","Silver Mace","Silver Warhammer","Silver Morningstar","Silver Whip","Silver War Axe","Silver Poleaxe","Silver Spear","Silver Quarterstaff","Silver Katar (+1 Athletics)","Silver Claws (+1 Athletics)","Broadsword - Steel")
 		var/silver_choice = input(H, "Choose your WEAPON.", "PREPARE YOUR ARMS.") as anything in silver //Trim down to five or six choices, later? See what's the most popular, first. Gives people a chance to experiment with all of the new silver weapons.
 		switch(silver_choice)
 			if("Silver Dagger")
@@ -540,6 +540,14 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/staves, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/silver
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Silver Katar (+1 Athletics)")  //For these 2 unarmed weapon options, get a level of athletics as a consolation prize, since this class gets jman unarmed already, and expert would be OP.
+				if(H.age != AGE_OLD)  //BUT ONLY IF THE CHARACTER IS NOT OLD, because old exorcists get expert EVERYTHING anyway, no need for compensation.
+					H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_EXPERT, TRUE)  
+				r_hand = /obj/item/rogueweapon/katar/silver
+			if("Silver Claws (+1 Athletics)")
+				if(H.age != AGE_OLD)
+					H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/rogueweapon/handclaw/gronn/silver
 			if("Broadsword - Steel")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				r_hand = /obj/item/rogueweapon/sword/long/broadsword/steel


### PR DESCRIPTION
## About The Pull Request

Recently, silver unarmed weapons were added to the game, which surprised me because they were not an option in the exorcist loadout options. This mod changes that, adding Silver Gronnic Claws and a Silver Katar as primary weapon options. A silver knuckle was also added, but then removed in the knuckle rework, so I'll tackle that one after a re-implementation (assuming this PR goes through).

Since exorcist gets jman unarmed by default, picking an unarmed weapon gives you no weapon skill, but a level of athletics (jman --> expert) as a consolation prize. I think it's still a worse trade-off, but this is very much a soul PR. Note : old exorcist already gets expert in EVERY loadout weapon skill (which is maybe an oversight lol, but not within this's PR's scope), so I've made sure to not give the athletics bonus on that, since there's no sacrifice made for picking an unarmed weapon then.

And while I was in there, I fixed old exorcist missing knifefighting, and readded the silver katar to the silver weapon loot table, both of which seemed to be oversights. Let me know if not and I'll revert it.

## Testing Evidence

<img width="1441" height="528" alt="awesomesauce" src="https://github.com/user-attachments/assets/39ee00ab-add9-41c1-bfe2-23b36814a1f7" />


## Why It's Good For The Game

Gives exorcist more soul by giving them peak weapon options, which you would never see otherwise because making/looting silver weapons is a pain. Does this in a non-oppressive way in regards to balance.

## Changelog

:cl:
add: Exorcist can now spawn with a silver katar or silver gronnic claws, sacrificing a specialised weapon skill for +1 athletics (bonus does not apply to old characters)
balance: old exorcist now gets missing expert knifefighting and unarmed skills, in line with their other weapon skills
fix: fixed silver katar (not the psydonic one) missing from the silver weapon loot table

/:cl:
