### PR TITLE
Blood Boon fix

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -284,6 +284,10 @@
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/target = targets[1]
 		var/mob/living/carbon/human/UH = user
+		if(target == UH)
+			to_chat(UH, span_warning("Foolishness."))
+			revert_cast()
+			return FALSE
 		if(NOBLOOD in UH.dna?.species?.species_traits)
 			to_chat(UH, span_warning("I have no blood to provide."))
 			revert_cast()


### PR DESCRIPTION
## About The Pull Request

- Blood Boon could be used on yourself. Wat. It can no longer be used on yourself.

## Testing Evidence

Compiles. 1 line changed with a 'return FALSE' if you use it on yourself.

## Why It's Good For The Game

Literally makes no sense you'd trade your current blood to restore your missing blood, and in higher cases, be used openly to restore your blood from blood that you're sacrificing to restore your... blood.

'It's magic, I ain't gotta explain shit.'

Well, it defeats the point of sacrificing your blood for another, if you can sacrifice your blood for your own blood.

## Changelog
:cl:
fix: Blood Boon no longer targets yourself.
/:cl: