### PR TITLE
Revert "Blood Boon fix"

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -284,10 +284,6 @@
 	if(ishuman(targets[1]))
 		var/mob/living/carbon/human/target = targets[1]
 		var/mob/living/carbon/human/UH = user
-		if(target == UH)
-			to_chat(UH, span_warning("Foolishness."))
-			revert_cast()
-			return FALSE
 		if(NOBLOOD in UH.dna?.species?.species_traits)
 			to_chat(UH, span_warning("I have no blood to provide."))
 			revert_cast()


### PR DESCRIPTION
It's intended for the miracle to be self-castable, at least at the moment. It was merged by mistake.