### PR TITLE
Give Blacksmith Apprentice a Hammer and Tongs

### DIFF
--- a/code/modules/virtues/crafter.dm
+++ b/code/modules/virtues/crafter.dm
@@ -23,7 +23,7 @@
 		SKILLED_ARTIF,
 	)
 	choice_tooltips = list(
-		SKILLED_BSMITH	= "Grants Expert Forgehand. Weaponsmithing, Armorsmithing, Blacksmithing and Smelting raised to Apprentice.",
+		SKILLED_BSMITH	= "Grants Expert Forgehand. Weaponsmithing, Armorsmithing, Blacksmithing and Smelting raised to Apprentice. Stashed Hammer and Tongs.",
 		SKILLED_TAILOR	= "Grants Expert Clothier. Butchering, Tanning raised to Apprentice. Sewing raised to Journeyman. Stashed Needle & Scissors.",
 		SKILLED_HUNTER	= "Grants Expert Survivalist. Trapping, Tracking, Butchering, Sewing and Tanning raised to Apprentice.",
 		SKILLED_PHYS	= "Grants Expert Physicker and Alchemist. Alchemy and Medicine raised to Apprentice. Grants secular diagnose and a stashed medicine pouch.",
@@ -50,6 +50,8 @@
 				added_skills.Add(list(list(/datum/skill/craft/blacksmithing, 2, 2)))
 				added_skills.Add(list(list(/datum/skill/craft/smelting, 2, 2)))
 				added_traits.Add(TRAIT_SMITHING_EXPERT)
+				recipient.mind?.special_items["Hammer"] = /obj/item/rogueweapon/hammer/iron
+				recipient.mind?.special_items["Tongs"] = /obj/item/rogueweapon/tongs
 			if(SKILLED_TAILOR)
 				added_skills.Add(list(list(/datum/skill/labor/butchering, 2, 2)))
 				added_skills.Add(list(list(/datum/skill/craft/sewing, 3, 3)))


### PR DESCRIPTION
## About The Pull Request

Currently, Blacksmith Apprentice is the only Skilled Apprentice sub-virtue to not get any equipment added to stash to get it started a little. This changes that, by giving it a hammer and tongs.

## Testing Evidence

<img width="526" height="75" alt="image" src="https://github.com/user-attachments/assets/4b0d41da-8d85-4feb-896b-a1b746902ae2" />
<img width="454" height="282" alt="image" src="https://github.com/user-attachments/assets/f1b35d04-a21e-417a-b550-01711be93567" />
<img width="91" height="106" alt="image" src="https://github.com/user-attachments/assets/ffc36ca0-9b16-476c-a334-2b37b5839114" />

## Why It's Good For The Game

It fixes the odd outlier in this virtue, and is not intrusive as getting a hammer and tongs is not hard anyway ; it merely reduces tedium, so players can get up to more interesting things faster.

...plus, people using this will probably want to find/set up a forge, so they have bigger things to worry about. 🤭

## Changelog

:cl:
add: Gives Blacksmith Apprentice a hammer and tongs to their stash
/:cl: