### PR TITLE
Adds tempo teams

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -402,6 +402,10 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 	#define TEMPO_DODGE_LOSS_NONE 2
 #define TEMPO_TAG_BINDABLE "defbindable"
 
+#define TEMPO_FACTION_KEEP (1 << 0)
+#define TEMPO_FACTION_WRETCH (1 << 1)
+#define TEMPO_FACTION_CHURCH (1 << 2)
+
 /*
 Medical defines
 */

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -69,6 +69,8 @@
 
 	var/datum/class_age_mod/age_mod = null
 
+	var/class_tempo_faction = null
+
 /datum/advclass/New()
 	if(ispath(age_mod) && !istype(age_mod))
 		var/datum/class_age_mod/newmod = new age_mod()
@@ -152,6 +154,8 @@
 	addtimer(CALLBACK(H,TYPE_PROC_REF(/mob/living/carbon/human, add_credit), TRUE), 20)
 	if(cmode_music)
 		H.cmode_music = cmode_music
+	if(class_tempo_faction)
+		H.tempo_faction_flag = class_tempo_faction
 
 /*
 	Whoa! we are checking requirements here!

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -580,9 +580,6 @@
 		return 0
 	return ..()
 
-/mob/living/carbon
-	var/nausea = 0
-	var/bleeding_tier = 0
 
 /mob/living/carbon/proc/add_nausea(amt)
 	nausea = clamp(nausea + amt, 0, 300)
@@ -783,10 +780,6 @@
 	else
 		remove_movespeed_modifier(MOVESPEED_ID_CARBON_SOFTCRIT, TRUE)
 	SEND_SIGNAL(src, COMSIG_LIVING_HEALTH_UPDATE)
-
-/mob/living/carbon
-	var/lightning_flashing = FALSE
-	var/burn_warning_shown = FALSE
 
 /mob/living/carbon/update_sight()
 	if(!client)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -90,3 +90,10 @@
 	var/stam_paralyzed = FALSE
 
 	var/next_smell = 0
+
+	var/lightning_flashing = FALSE
+	var/burn_warning_shown = FALSE
+	var/nausea = 0
+	var/bleeding_tier = 0
+
+	var/tempo_faction_flag = null

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -305,6 +305,8 @@
 
 /mob/living/carbon/human/proc/process_tempo_attack(mob/living/carbon/attacker)
 	if(iscarbon(attacker) && attacker != src && attacker.mind)
+		if(tempo_faction_flag && tempo_faction_flag == attacker.tempo_faction_flag)
+			return
 		if(length(tempo_attackers) <= TEMPO_CAP || (REF(attacker) in tempo_attackers))	//This list auto-culls so we don't need to flood it. If you're fighting 7 dudes at the same time you've got other problems.
 			var/newtime
 			var/att_count = length(tempo_attackers)

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -305,7 +305,7 @@
 
 /mob/living/carbon/human/proc/process_tempo_attack(mob/living/carbon/attacker)
 	if(iscarbon(attacker) && attacker != src && attacker.mind)
-		if(tempo_faction_flag && tempo_faction_flag == attacker.tempo_faction_flag)
+		if(tempo_faction_flag && (tempo_faction_flag & attacker.tempo_faction_flag))
 			return
 		if(length(tempo_attackers) <= TEMPO_CAP || (REF(attacker) in tempo_attackers))	//This list auto-culls so we don't need to flood it. If you're fighting 7 dudes at the same time you've got other problems.
 			var/newtime


### PR DESCRIPTION
## About The Pull Request
This is backend only. Adds functionality for tempo "teams" such that hitting someone from the same team won't cause Tempo interactions. 

Currently I added three teams -- Wretch, Church and Keep. No roles get these, atm. They're distributed via a matching `class_tempo_faction` on the advclass datum, AKA on every subclass. Could be job-specific, but we have a bit of a mess of distinguished jobs vs subjobs.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Hard to show!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Better to have it than not should issues come up. Our downstreams / servers that port from us might definitely need this. The implementation's very barebones but like it's a flag what else would we need y'know.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
