### PR TITLE
rituos (3/3) - finishes staging all avantyne-threaded content, adds fragments to ascendant equipment, and repaths summoned variants (/avantyne to /zizo)

### DIFF
--- a/code/game/objects/items/ritualcircles.dm
+++ b/code/game/objects/items/ritualcircles.dm
@@ -1674,32 +1674,32 @@
 	for(var/I in items)
 		H.dropItemToGround(I, TRUE)
 	H.drop_all_held_items()
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/full/avantyne
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/avantyne/heavy
-	pants = /obj/item/clothing/under/roguetown/platelegs/avantyne/heavy
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/avantyne/heavy
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/avantyne/heavy
-	gloves = /obj/item/clothing/gloves/roguetown/plate/avantyne/heavy
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/full/zizo
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/zizo/heavy
+	pants = /obj/item/clothing/under/roguetown/platelegs/zizo/heavy
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/zizo/heavy
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/zizo/heavy
+	gloves = /obj/item/clothing/gloves/roguetown/plate/zizo/heavy
 	head = selected_helm_path
-	neck = /obj/item/clothing/neck/roguetown/bevor/avantyne/heavy
+	neck = /obj/item/clothing/neck/roguetown/bevor/zizo/heavy
 	switch(selected_weapon_choice)
 		if("Avantyne Arming Sword and Darkshield")
-			r_hand = /obj/item/rogueweapon/sword/avantyne
-			l_hand = /obj/item/rogueweapon/shield/tower/metal/avantyne
+			r_hand = /obj/item/rogueweapon/sword/zizo
+			l_hand = /obj/item/rogueweapon/shield/tower/metal/zizo
 		else
-			r_hand = /obj/item/rogueweapon/sword/long/avantyne
+			r_hand = /obj/item/rogueweapon/sword/long/zizo
 
 	H.mind.AddSpell(new /datum/action/cooldown/spell/mending/lesser)
 
 /datum/outfit/job/roguetown/darksteelrite/medium/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/fluted/avantyne
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/avantyne
-	pants = /obj/item/clothing/under/roguetown/platelegs/avantyne
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/avantyne
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/avantyne
-	gloves = /obj/item/clothing/gloves/roguetown/plate/avantyne
-	neck = /obj/item/clothing/neck/roguetown/bevor/avantyne
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/fluted/zizo
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/zizo
+	pants = /obj/item/clothing/under/roguetown/platelegs/zizo
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/zizo
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/zizo
+	gloves = /obj/item/clothing/gloves/roguetown/plate/zizo
+	neck = /obj/item/clothing/neck/roguetown/bevor/zizo
 	H.mind.RemoveSpell(new /datum/action/cooldown/spell/mending/lesser)
 
 
@@ -1925,7 +1925,7 @@
 
 			var/list/weapon_options = list(
 				"Vicious Greataxe" = image(icon = 'icons/roguetown/weapons/axes64.dmi', icon_state = "graggargaxe"),
-				"Vicious Hand-axe and Shield" = image(icon = 'icons/roguetown/weapons/shields32.dmi', icon_state = "gheretic_shield"),
+				"Vicious Tomahawk and Shield" = image(icon = 'icons/roguetown/weapons/shields32.dmi', icon_state = "gheretic_shield"),
 			)
 			var/weapon_choice = show_radial_menu(user, src, weapon_options, require_near = TRUE, tooltips = TRUE)
 			if(!weapon_choice)
@@ -1974,7 +1974,7 @@
 		if("Vicious Helmet")
 			helm_path = /obj/item/clothing/head/roguetown/helmet/heavy/graggar
 		if("Vicious Skullhelm")
-			helm_path = /obj/item/clothing/head/roguetown/helmet/heavy/graggar/alt
+			helm_path = /obj/item/clothing/head/roguetown/helmet/heavy/graggar/skull
 	switch(armor_choice)
 		if("Vicious Half-Plate")
 			outfit_path = /datum/outfit/job/roguetown/viciousrite
@@ -2074,7 +2074,7 @@
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel/graggar
 	cloak = /obj/item/clothing/cloak/graggar
 	switch(selected_weapon_choice)
-		if("Vicious Hand-axe and Shield")
+		if("Vicious Tomahawk and Shield")
 			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut/steel/graggar
 			l_hand = /obj/item/rogueweapon/shield/iron/graggar
 		else
@@ -2088,14 +2088,14 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/graggar
 	pants = /obj/item/clothing/under/roguetown/platelegs/graggar
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/graggar
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/graggar/alt
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/graggar/heavy
 	gloves = /obj/item/clothing/gloves/roguetown/plate/graggar/heavy
 	head = selected_helm_path
 	mask = /obj/item/clothing/mask/rogue/facemask/steel/graggar
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel/graggar
 	cloak = /obj/item/clothing/cloak/graggar/heavy
 	switch(selected_weapon_choice)
-		if("Vicious Hand-axe and Shield")
+		if("Vicious Tomahawk and Shield")
 			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut/steel/graggar
 			l_hand = /obj/item/rogueweapon/shield/iron/graggar
 		else

--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -272,9 +272,10 @@
 	wdefense = 3
 
 /obj/item/rogueweapon/stoneaxe/woodcut/steel/graggar
-	name = "vicious hand-axe"
+	name = "vicious tomahawk"
 	icon_state = "gheretic_axe"
-	desc = "A reinforced steel-axe. The edges crave for flesh."
+	desc = "A handaxe of greater stature, intricately decorated with the Sinistar's heraldry. Worshippers wield it to strengthen their soul's connection \
+	to the force of violence; a blessing, before they pursue the most dangerous game of all."
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash, /datum/intent/axe/thrust)
 	force = 30
 	wdefense = 5

--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -279,6 +279,7 @@
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash, /datum/intent/axe/thrust)
 	force = 30
 	wdefense = 5
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/rogueweapon/stoneaxe/woodcut/steel/graggar/Initialize()
 	. = ..()
@@ -631,6 +632,7 @@
 	force_wielded = 40
 	max_blade_int = 270
 	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/rogueweapon/greataxe/steel/doublehead/graggar/Initialize()
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -329,7 +329,7 @@
 	associated_skill = /datum/skill/combat/whipsflails
 	slot_flags = ITEM_SLOT_BACK
 	anvilrepair = /datum/skill/craft/weaponsmithing
-
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/rogueweapon/flail/peasantwarflail/matthios/Initialize()
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -565,7 +565,7 @@
 	embedding = list("embedded_pain_multiplier" = 1.2, "embed_chance" = 20, "embedded_fall_chance" = 0) 
 	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/rogueweapon/huntingknife/idagger/steel/avantyne
+/obj/item/rogueweapon/huntingknife/idagger/avantyne
 	name = "avantyne-threaded dagger"
 	desc = "An otherworldly misericorde, defying rhyme-and-reason in favor of unholy lethality. The jagged edge continuously remorphs itself, \
 	yearning to disembowel the divine filament once more; though for now, it will settle with the bellies of blunderous bastards."

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -553,15 +553,29 @@
 	smeltresult = /obj/item/ingot/drow
 	smelt_bar_num = 1
 
-/obj/item/rogueweapon/huntingknife/idagger/steel/avantyne
+/obj/item/rogueweapon/huntingknife/idagger/steel/zizo
 	name = "avantyne dagger"
-	desc = "Made of bleeding avantyne. An unholy jab at the world."
+	desc = "The very moment of sacrifice; that imperceptable difference between a dagger's edge and a heart's chamber, crystallized into \
+	a scalpel of bleeding darksteel. In the hands of Her trusted disciples, it serves as an unholy countermandate against order and sanity."
 	icon_state = "zeretic_dagger"
-	sheathe_icon = "sdagger"
+	sheathe_icon = "zizodagger"
 	force = 25
 	max_integrity = 250
 	max_blade_int = 300
 	embedding = list("embedded_pain_multiplier" = 1.2, "embed_chance" = 20, "embedded_fall_chance" = 0) 
+	smeltresult = /obj/item/ingot/component/zizo
+
+/obj/item/rogueweapon/huntingknife/idagger/steel/avantyne
+	name = "avantyne-threaded dagger"
+	desc = "An otherworldly misericorde, defying rhyme-and-reason in favor of unholy lethality. The jagged edge continuously remorphs itself, \
+	yearning to disembowel the divine filament once more; though for now, it will settle with the bellies of blunderous bastards."
+	icon_state = "zeretic_dagger"
+	sheathe_icon = "zizodagger"
+	force = 25
+	max_integrity = 250
+	max_blade_int = 300
+	embedding = list("embedded_pain_multiplier" = 1.2, "embed_chance" = 50, "embedded_fall_chance" = 0) 
+	smeltresult = /obj/item/ingot/avantyne
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/holysee
 	name = "eclipsum dagger"

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -439,6 +439,43 @@
 		added_def = 2,\
 	)
 
+/obj/item/rogueweapon/handclaw/steel/graggaredged
+	name = "vicious sickleclaw"
+	desc = "A tainted mimicry of Ravox's falx, forever stained with the blood of the one they both cherished above all else. The fury of God, for \
+	just a moment, wilted before the sorrow of Man; before the wounded champion lept forth and drove His blade straight into the Sinistar's eye."
+	icon_state = "gheretic_patasickle"
+	icon = 'icons/roguetown/weapons/unarmed32.dmi'
+	wdefense = 3
+	force = 35
+	possible_item_intents = list(/datum/intent/claw/cut/steel, /datum/intent/claw/lunge/steel, /datum/intent/claw/rend/steel)
+	wbalance = WBALANCE_HEAVY
+	max_blade_int = 333
+	max_integrity = 333
+	sharpness_mod = 2
+	smeltresult = /obj/item/ingot/component/graggar
+
+/obj/item/rogueweapon/handclaw/steel/graggaredged/Initialize()
+	. = ..()
+	AddComponent(/datum/component/cursed_item, TRAIT_HORDE, "GAUNTLET", "RENDERED ASUNDER")
+
+/obj/item/rogueweapon/handclaw/steel/graggarblunt
+	name = "vicious mantlebreaker"
+	desc = "A tainted mimicry of Astrata's staff, studded with the remains of divine bone and gristle. By His command, the Apotheosis rose; and with His \
+	final heartbeat, the Sinistar fell. How little He could've known, that it would ultimately be a tragedy without purpose - a war without reason."
+	icon_state = "gheretic_pataclub"
+	icon = 'icons/roguetown/weapons/unarmed32.dmi'
+	wdefense = 3
+	force = 35
+	possible_item_intents = list(/datum/intent/mace/strike, /datum/intent/mace/smash)
+	wbalance = WBALANCE_HEAVY
+	max_blade_int = 333
+	max_integrity = 333
+	smeltresult = /obj/item/ingot/component/graggar
+
+/obj/item/rogueweapon/handclaw/steel/graggarblunt/Initialize()
+	. = ..()
+	AddComponent(/datum/component/cursed_item, TRAIT_HORDE, "GAUNTLET", "RENDERED ASUNDER")
+
 ///Peasantry / Militia Weapon Pack///
 
 /obj/item/rogueweapon/woodstaff/militia

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -133,16 +133,34 @@
 	wdefense = 4
 	sellprice = 10
 
-/obj/item/rogueweapon/sword/avantyne
+/obj/item/rogueweapon/sword/zizo
 	name = "avantyne arming sword"
-	desc = "Blade cut straight from earnest avantyne. Imperfections are absent."
+	desc = "The cardinal sin, coalesced into a crystalline crucifix. In Her name, your will shall be projected unto the worshippers of lesser gods; and by your \
+	hand, they shall bend the knee to progress."
 	icon_state = "zeretic_arming"
+	sheathe_icon = "zeretic_arming"
 	force = 25
 	force_wielded = 30
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/rogueweapon/sword/avantyne/Initialize()
+/obj/item/rogueweapon/sword/zizo/Initialize()
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "SWORD")
+
+/obj/item/rogueweapon/sword/avantyne
+	name = "avantyne-threaded arming sword"
+	desc = "Anger and spite, channeled into a blade that defies both wisdom and purity. Seldom does such power come without a price, however; are you ready to pay it?"
+	icon_state = "zeretic_arming"
+	sheathe_icon = "zeretic_arming"
+	possible_item_intents = list(/datum/intent/sword/cut/arming, /datum/intent/sword/thrust/short, /datum/intent/sword/strike)
+	gripped_intents = list(/datum/intent/sword/cut/arming, /datum/intent/sword/thrust/arming, /datum/intent/sword/strike)
+	force = 25
+	force_wielded = 30
+	max_blade_int = 300
+	max_integrity = 300
+	equip_delay_self = 0
+	unequip_delay_self = 0
+	smeltresult = /obj/item/ingot/avantyne
 
 /obj/item/rogueweapon/sword/long
 	name = "longsword"
@@ -360,7 +378,7 @@
 	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/sword/thrust/long/halfsword/lesser, /datum/intent/sword/chop)
 	wlength = WLENGTH_NORMAL
 
-/obj/item/rogueweapon/sword/long/avantyne
+/obj/item/rogueweapon/sword/long/zizo
 	name = "avantyne longsword"
 	desc = "A wicked, unconventional, and otherwordly blade that was created by no swordsmith - a manifestation of hate for the state of this world that follows no design principles but spite and anger."
 	icon_state = "zizosword"
@@ -372,10 +390,26 @@
 	equip_delay_self = 0
 	unequip_delay_self = 0
 	wdefense_wbonus = 7
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/rogueweapon/sword/long/avantyne/Initialize()
+/obj/item/rogueweapon/sword/long/zizo/Initialize()
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "SWORD")
+
+/obj/item/rogueweapon/sword/long/avantyne
+	name = "avantyne-threaded longsword"
+	desc = "A parasitic mandate to progress, borne through the cultivation of crystalline metastasis. This otherworldly blade is stronger and sharper than any \
+	mortal-made masterwork, yet comes at a cost that has yet to be realized."
+	icon_state = "zizolongsword"
+	sheathe_icon = "zizolongsword"
+	force = 30
+	force_wielded = 35
+	max_blade_int = 400
+	max_integrity = 400
+	equip_delay_self = 0
+	unequip_delay_self = 0
+	wdefense_wbonus = 5
+	smeltresult = /obj/item/ingot/avantyne
 
 /obj/item/rogueweapon/sword/long/heirloom
 	name = "old longsword"

--- a/code/game/objects/items/rogueweapons/melee/swords/greatswords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/greatswords.dm
@@ -174,7 +174,9 @@
 
 /obj/item/rogueweapon/greatsword/silver
 	name = "silver greatsword"
-	desc = "A greatsword with a massive blade of pure silver. Such is favored amongst the Order of Syonica's paladins: a faith-militance that seeks to safeguard those who've taken pilgrimage towards Azuria. </br>'There is no fate, but what we make for ourselves. It is not the will of gods that will determine Psydonia's fate.. but instead, the hope of its children.'"
+	desc = "A greatsword with a massive blade of pure silver. Such is favored amongst the Order of Syonica's paladins: a faith-militance that \
+	seeks to safeguard those who've taken pilgrimage towards Azuria. </br>'There is no fate, but what we make for ourselves. It is not the will of \
+	gods that will determine Psydonia's fate.. but instead, the hope of its children.'"
 	icon_state = "silverexealt"
 	force = 8
 	force_wielded = 25
@@ -196,7 +198,8 @@
 
 /obj/item/rogueweapon/greatsword/psygsword
 	name = "psydonic greatsword"
-	desc = "It is said that a Psydonian smith was guided by Saint Malum himself to forge such a formidable blade, and given the task to slay a daemon preying on the Otavan farmlands. The design was retrieved, studied, and only a few replicas made - for they believe it dulls its edge."
+	desc = "It is said that a Psydonian smith was guided by Saint Malum himself to forge such a formidable blade, and given the task to slay a \
+	daemon preying on the Otavan farmlands. The design was retrieved, studied, and only a few replicas made - for they believe it dulls its edge."
 	icon_state = "silverexealt"
 	force = 8
 	force_wielded = 25
@@ -218,7 +221,9 @@
 
 /obj/item/rogueweapon/greatsword/psygsword/relic
 	name = "Apocrypha"
-	desc = "In the Otavan mosaics, Saint Ravox - bare in all but a beaked helmet and loincloth - is often depicted wielding such an imposing greatweapon against the Sinistar, Graggar. Regardless of whether this relic was actually wielded by divinity-or-not, its unparallel strength will nevertheless command even the greatest foes to fall."
+	desc = "In Otava's grandest mosaics, Saint Ravox - bare in all but a beaked helmet and loincloth - is depicted wielding such an imposing \
+	greatweapon against the Sinistar, Graggar. Regardless of whether this relic was actually wielded by divinity-or-not, its unparallel strength \
+	will nevertheless command even the greatest foes to fall. Stand fast, childe o' God, and drive the unforgivable back to Hell."
 	force = 25
 	force_wielded = 30
 	icon_state = "psygsword"
@@ -255,9 +260,10 @@
 
 /obj/item/rogueweapon/greatsword/bsword/psy
 	name = "forgotten blade"
-	desc = "'Let His name be naught but forgot'n.'"
+	desc = "'Let His name be naught but forgot'n.' </br>The remnants of a legendary champion, who's name has been lost to the annals of tyme. Even so, the tarnished \
+	silver still glimmers with otherworldly strength; to exorcise, to eradicate, and to endure."
 	icon_state = "oldpsybroadsword"
-	force = 20
+	force = 20 
 	force_wielded = 25
 	minstr = 11
 	wdefense = 6
@@ -280,7 +286,8 @@
 
 /obj/item/rogueweapon/greatsword/bsword/psy/relic
 	name = "Creed"
-	desc = "Psydonian prayers and Tennite smiths, working as one to craft a weapon to slay the Four. A heavy and large blade, favored by Saint Ravox, to lay waste to those who threaten His flock. The crossguard's psycross reflects even the faintest of Noc's light. You're the light - show them the way."
+	desc = "Psydonian prayers and Tennite smiths, working as one to craft a weapon to slay the Four. A heavy and large blade, favored by Saint Ravox, to lay \
+	waste to those who threaten His flock. The crossguard's psycross reflects even the faintest of Noc's light. You're the light - show them the way."
 	icon_state = "psybroadsword"
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
@@ -307,7 +314,9 @@
 
 /obj/item/rogueweapon/greatsword/bsword/psy/unforgotten
 	name = "unforgotten blade"
-	desc = "High Inquisitor Archibald once recorded an expedition of seven brave Adjudicators into Gronnian snow-felled wastes to root out evil. Its leader, Holy Ordinator Guillemin, was said to have held on for seven daes and seven nights against darksteel-clad heretics before Psydon acknowledged his endurance. Nothing but his blade remained - his psycross wrapped around its hilt in rememberance."
+	desc = "'Let His name be naught but forgot'n.' </br>High Inquisitor Archibald once recorded an expedition of seven brave Adjudicators into Gronnian snow-felled wastes to \
+	root out evil. Its leader, Holy Ordinator Guillemin, was said to have held on for seven daes and seven nights against darksteel-clad heretics before Psydon acknowledged his \
+	endurance. Nothing but his blade remained - his psycross wrapped around its hilt in rememberance."
 	icon_state = "forgottenblade"
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
@@ -322,6 +331,18 @@
 		added_int = 50,\
 		added_def = 2,\
 	)
+
+/obj/item/rogueweapon/greatsword/avantyne
+	name = "avantyne-threaded greatsword"
+	desc = "Malediction made manifest; the greatweapon of an otherworldly champion, unphased by the thickest plates nor the toughest flesh. Let no one stop the \
+	march of Her disciples, towards the filament's sputtering wound. Take thine birthright and ascend to the heavens beyond, or die trying."
+	gripped_intents = list(/datum/intent/sword/cut/zwei, /datum/intent/sword/thrust/estoc, /datum/intent/sword/cut/zwei/cleave, /datum/intent/sword/cut/zwei/sweep)
+	icon_state = "zizogsw"
+	force = 20
+	force_wielded = 40
+	max_blade_int = 500
+	max_integrity = 500
+	smeltresult = /obj/item/ingot/avantyne
 
 /obj/item/rogueweapon/estoc
 	name = "estoc"

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -427,18 +427,33 @@
 				return list("shrink" = 0.6,"sx" = 1,"sy" = 4,"nx" = 1,"ny" = 2,"wx" = 3,"wy" = 3,"ex" = -3,"ey" = 3,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 8,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 	return ..()
 
-/obj/item/rogueweapon/shield/tower/metal/avantyne
+/obj/item/rogueweapon/shield/tower/metal/zizo
 	name = "avantyne darkshield"
-	desc = "A kite-shield, avantyne and darksteel intermingled. The softness on the surface tends to catch hits very well."
+	desc = "A threaded purportance, summoned from the interminglance of both avantyne and darksteel. The surface is uncharacteristically soft, not unlike silk \
+	or skin; uncomforting to the unexpecting touch, but more-than-excellent for catching blows."
 	icon_state = "zeretic_shield"
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/rogueweapon/shield/tower/metal/avantyne/Initialize()
+/obj/item/rogueweapon/shield/tower/metal/zizo/Initialize()
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "SHIELD")
 
+/obj/item/rogueweapon/shield/tower/metal/avantyne
+	name = "avantyne-threaded pavise"
+	desc = "An interloper in causality's ever-so-fragile stream, woven from wafers to ward against those who're not yet ready to comprehend \
+	the gospel of Her disciples. Zizo sought to ward Her children from extinction, but failed; and in the throes of divine mania, She had come \
+	to realize that this world was no longer worth saving."
+	max_integrity = 400
+	force = 25
+	throwforce = 20
+	coverage = 75
+	icon_state = "zeretic_shield"
+	smeltresult = /obj/item/ingot/avantyne
+
 /obj/item/rogueweapon/shield/tower/metal/gold
 	name = "golden shield"
-	desc = "A resplendant kite shield, assembled from six golden plates that've been hooked together by a glimmering holy sigil. Nobility may be fragile, but - so long as its grip remains steadfast - none could ever hope to sever its weakest link."
+	desc = "A resplendant kite shield, assembled from six golden plates that've been hooked together by a glimmering holy sigil. Nobility may be fragile, \
+	but - so long as its grip remains steadfast - none could ever hope to sever its weakest link."
 	icon_state = "goldshield"
 	force = 25
 	throwforce = 35
@@ -458,7 +473,8 @@
 
 /obj/item/rogueweapon/shield/tower/metal/psy
 	name = "Covenant"
-	desc = "A Psydonian endures. A Psydonian preserves themselves. A Psydonian preserves His flock."
+	desc = "'A Psydonian endures. A Psydonian preserves themselves. A Psydonian preserves His flock.' </br>A blessed silver pavise, capable of thwarting the deadliness of \
+	even the hottest balefires. The one who wields it shall never falter; and the ones behind them shall never suffer."
 	icon_state = "psyshield"
 	force = 15
 	throwforce = 5
@@ -489,7 +505,8 @@
 
 /obj/item/rogueweapon/shield/tower/metal/alloy
 	name = "decrepit shield"
-	desc = "A hefty tower shield, wrought from frayed bronze. Looped with dried kelp and reeking of saltwater, you'd assume that this had been fished out from the remains of a long-sunken warship.. alongside its former legionnaire."
+	desc = "A hefty tower shield, wrought from frayed bronze. Looped with dried kelp and reeking of saltwater, you'd assume that this had been fished \
+	out from the remains of a long-sunken warship.. alongside its former legionnaire."
 	max_integrity = 120
 	wdefense = 9
 	icon_state = "ancientsh"
@@ -500,7 +517,8 @@
 
 /obj/item/rogueweapon/shield/tower/metal/palloy
 	name = "ancient shield"
-	desc = "A venerable scutum, plated with polished gilbranze. An undying legionnaire's closest friend; that which rebukes arrow-and-bolt alike with unphasing prejudice. It is a reminder - one of many - that Her progress cannot be stopped."
+	desc = "A venerable scutum, plated with polished gilbranze. An undying legionnaire's closest friend; that which rebukes arrow-and-bolt alike with \
+	unphasing prejudice. It is a reminder - one of many - that Her progress cannot be stopped."
 	icon_state = "ancientsh"
 	smeltresult = /obj/item/ingot/purifiedaalloy
 
@@ -660,8 +678,10 @@
 	smeltresult = null 
 
 /obj/item/rogueweapon/shield/iron/graggar
-	name = "vicious metal shield"
-	desc = "A viscous, vicious composite of metal, dried blood strengthened with an unknown substance, and bone. It will stand."
+	name = "vicious targe"
+	desc = "A decorated targe, splattered and sanctified with the trophies of Psydonia's most dangerous hunters. No matter the icy rains, \
+	no matter the scorching heat – no matter the wrath of their enemies, Graggar never faltered in His arms. When Ravox broke their oath and \
+	rescinded their claim to Godhood, grief could not describe what He had felt."
 	icon_state = "gheretic_shield"
 	max_integrity = 300
 
@@ -699,7 +719,8 @@
 
 /obj/item/rogueweapon/shield/bronze/great
 	name = "hoplon greatshield"
-	desc = "A heavy shield, taller and thicker than most of their contemporaries. It has survived the Calamity, endured the Apotheosis, and blunted the Sundering; and for one final time, it shall ward this dying world from a crueler fate."
+	desc = "A heavy shield, taller and thicker than most of their contemporaries. It has survived the Calamity, endured the Apotheosis, and blunted the Sundering; \
+	and for one final time, it shall ward this dying world from a crueler fate."
 	icon_state = "bronzegreatshield"
 	item_state = "bronzegreatshield"
 	max_integrity = 360 //Highest integrity and passive projectile-blocking chance of most non-unique shields.

--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -222,6 +222,7 @@
 	name = "gilded hauberk"
 	desc = "All that glimmers is gold; yet only shining stars shalt break the mold.."
 	color = "#ffc960"
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/matthios/Initialize()
 	. = ..()
@@ -229,25 +230,26 @@
 
 //
 
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/avantyne
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/zizo
 	name = "avantyne hauberk"
 	desc = "The rings crackle softly with avantynic power, yet this lighter weave can still be taken off without being lost to the rite."
 	color = "#c1b18d"
 	chunkcolor = "#363030"
 	material_category = ARMOR_MAT_CHAINMAIL
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/avantyne/Initialize()
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/zizo/Initialize()
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "ARMOR")
 
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/avantyne/heavy
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/zizo/heavy
 	name = "fused avantyne hauberk"
 
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/avantyne/heavy/Initialize(mapload)
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/zizo/heavy/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/avantyne/heavy/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/zizo/heavy/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return
@@ -259,6 +261,7 @@
 	name = "vicious hauberk"
 	desc = "The blessing of a Martyr is nothing, when put before the Sinistar's rage."
 	color = "#ddc0a7"
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/graggar/Initialize()
 	. = ..()

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -299,6 +299,7 @@
 	max_integrity = ARMOR_INT_CHEST_PLATE_STEEL // We are probably one of the best medium armor sets. At higher integ than most(heavy armor levels, pretty much. But worse resistances, we get the bonus over the other sets of being medium and being unequippable.)
 	icon_state = "graggarplate"
 	armor = ARMOR_PLATE
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/suit/roguetown/armor/plate/fluted/graggar/Initialize()
 	. = ..()
@@ -306,11 +307,12 @@
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/graggar
 	name = "vicious full-plate"
-	desc = "Shorn together plate, curated from hand-crafted bones and ligaments - combined under an unholy spirit of violence. It bleeds."
+	desc = "Shorn together plate, curated from hand-crafted bones and ligaments - combined under an unholy spirit of violence. It drools with the distilled essence of worldlux; the afterbirth of ascensionism."
 	icon_state = "graggarplate_heavy"
 	max_integrity = ARMOR_INT_CHEST_PLATE_ANTAG
 	chunkcolor = "#363030"
 	material_category = ARMOR_MAT_PLATE
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/graggar/Initialize()
 	. = ..()
@@ -448,6 +450,7 @@
 	desc = "Often, you have heard that told,"
 	icon_state = "matthiosarmor"
 	max_integrity = ARMOR_INT_CHEST_PLATE_ANTAG
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/matthios/Initialize()
 	. = ..()
@@ -459,39 +462,50 @@
 		return
 	qdel(src)
 
-/obj/item/clothing/suit/roguetown/armor/plate/fluted/avantyne
+/obj/item/clothing/suit/roguetown/armor/plate/fluted/zizo
 	name = "avantyne half-plate"
-	desc = "Pauldrons lyke that of fire. The metal curves and curdles with insidious energies."
+	desc = "Pauldrons lyke that of fire. The metal curves and curdles with insidious energies, attempting to reform into an angularities not meant for the layman's eyes to withstand."
 	armor_class = ARMOR_CLASS_MEDIUM
 	max_integrity = ARMOR_INT_CHEST_PLATE_STEEL
 	icon_state = "zizoplatechest_med"
 	armor = ARMOR_PLATE
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/clothing/suit/roguetown/armor/plate/fluted/avantyne/Initialize()
+/obj/item/clothing/suit/roguetown/armor/plate/fluted/zizo/Initialize()
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "ARMOR")
 
-/obj/item/clothing/suit/roguetown/armor/plate/fluted/avantyne/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/suit/roguetown/armor/plate/fluted/zizo/dropped(mob/living/carbon/human/user)
 	return ..()
 
-/obj/item/clothing/suit/roguetown/armor/plate/full/avantyne
+/obj/item/clothing/suit/roguetown/armor/plate/full/zizo
 	name = "avantyne fullplate"
 	desc = "Impossible angularities, molded into a form more comprehensible to the layman's eyes. It has been called forth from the edge of what should be known, in Her name."
 	icon_state = "zizoplate"
 	max_integrity = ARMOR_INT_CHEST_PLATE_ANTAG
 	chunkcolor = "#363030"
 	material_category = ARMOR_MAT_PLATE
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/clothing/suit/roguetown/armor/plate/full/avantyne/Initialize()
+/obj/item/clothing/suit/roguetown/armor/plate/full/zizo/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "ARMOR")
 
-/obj/item/clothing/suit/roguetown/armor/plate/full/avantyne/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/suit/roguetown/armor/plate/full/zizo/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return
 	qdel(src)
+
+/obj/item/clothing/suit/roguetown/armor/plate/fluted/avantyne
+	name = "avantyne maille"
+	desc = "Pauldrons lyke that of fire, crested atop a veil of otherworldly maille - impossibly tough, warm to the touch, and crackling with insidious energies."
+	armor_class = ARMOR_CLASS_MEDIUM
+	max_integrity = ARMOR_INT_CHEST_PLATE_STEEL
+	icon_state = "zizoplatechest_med"
+	armor = ARMOR_PLATE_BSTEEL
+	smeltresult = /obj/item/ingot/avantyne //Made from 'inert avantyne wafers', meaning that anyone can feasibly wear it.
 
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini
 	name = "full-plate corset"
@@ -529,7 +543,6 @@
 	body_parts_covered = COVERAGE_ALL_BUT_HANDFEET
 	icon_state = "heartfelt_hand"
 	item_state = "heartfelt_hand"
-
 
 /obj/item/clothing/suit/roguetown/armor/plate/otavan
 	name = "otavan half-plate"

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -499,7 +499,7 @@
 	qdel(src)
 
 /obj/item/clothing/suit/roguetown/armor/plate/fluted/avantyne
-	name = "avantyne maille"
+	name = "avantyne-threaded maille"
 	desc = "Pauldrons lyke that of fire, crested atop a veil of otherworldly maille - impossibly tough, warm to the touch, and crackling with insidious energies."
 	armor_class = ARMOR_CLASS_MEDIUM
 	max_integrity = ARMOR_INT_CHEST_PLATE_STEEL

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -348,6 +348,7 @@
 	max_integrity = ARMOR_INT_SIDE_ANTAG
 	armor = ARMOR_PLATE_BSTEEL
 	icon_state = "graggarplateboots"
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/shoes/roguetown/boots/armor/graggar/Initialize()
 	. = ..()
@@ -360,6 +361,7 @@
 	desc = "Gilded tombs do worm enfold."
 	icon_state = "matthiosboots"
 	armor = ARMOR_PLATE_BSTEEL
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/clothing/shoes/roguetown/boots/armor/matthios/Initialize()
 	. = ..()
@@ -371,7 +373,7 @@
 		return
 	qdel(src)
 
-/obj/item/clothing/shoes/roguetown/boots/armor/avantyne
+/obj/item/clothing/shoes/roguetown/boots/armor/zizo
 	name = "avantyne boots"
 	desc = "Bolstered by threads of avantyne, these lighter sabatons remain practical enough to be removed once the rite is done."
 	icon_state = "zizoboots"
@@ -380,23 +382,36 @@
 	material_category = ARMOR_MAT_PLATE
 	armor = ARMOR_PLATE_BSTEEL
 	armor_class = ARMOR_CLASS_MEDIUM
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/clothing/shoes/roguetown/boots/armor/avantyne/heavy
+/obj/item/clothing/shoes/roguetown/boots/armor/zizo/heavy
 	name = "fused avantyne boots"
 
-/obj/item/clothing/shoes/roguetown/boots/armor/avantyne/Initialize(mapload)
+/obj/item/clothing/shoes/roguetown/boots/armor/zizo/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "ARMOR")
 
-/obj/item/clothing/shoes/roguetown/boots/armor/avantyne/heavy/Initialize()
+/obj/item/clothing/shoes/roguetown/boots/armor/zizo/heavy/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/shoes/roguetown/boots/armor/avantyne/heavy/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/shoes/roguetown/boots/armor/zizo/heavy/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return
 	qdel(src)
+
+/obj/item/clothing/shoes/roguetown/boots/armor/avantyne
+	name = "avantyne-threaded sabatons"
+	desc = "Marrow, flesh, ash; the bedrock of a new reality, fated to suffer until the final breath. It is this prognosis that commands Her disciples to \
+	work towards ascensionism - for no sacrifice is too great, in the pursuit of bringing lyfe back to this dying world."
+	icon_state = "zizoboots"
+	max_integrity = ARMOR_INT_SIDE_STEEL
+	chunkcolor = "#363030"
+	material_category = ARMOR_MAT_PLATE
+	armor = ARMOR_PLATE_BSTEEL
+	armor_class = ARMOR_CLASS_MEDIUM
+	smeltresult = /obj/item/ingot/avantyne
 
 /obj/item/clothing/shoes/roguetown/boots/armor/iron
 	name = "light plated boots"

--- a/code/modules/clothing/rogueclothes/gloves/plate.dm
+++ b/code/modules/clothing/rogueclothes/gloves/plate.dm
@@ -60,11 +60,13 @@
 	desc = "Fluted gauntlets, razor-tipped and fluidic in motion. Most are led to believe that 'might makes right', yet Graggar's truth is far more succinct - 'might makes'. Murder is the ultimate force; the only difference between you and them is that they're too afraid to admit it."
 	max_integrity = ARMOR_INT_SIDE_ANTAG
 	icon_state = "graggarplategloves"
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/gloves/roguetown/plate/graggar/heavy
 	name = "vicious bone-gauntlets"
-	desc = "Steel plated gauntlets overlaid by an ornamental imagery of fractured bone and entrails."
+	desc = "Steel plated gauntlets overlaid by an ornamental imagery of fractured bone and entrails. The violet smears; a tether to the lyfe that once was - and now, a stinging reminder of what could've been."
 	icon_state = "graggarplategloves_heavy"
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/gloves/roguetown/plate/graggar/heavy/Initialize()
 	. = ..()
@@ -85,6 +87,7 @@
 	desc = "Many a man his life hath sold,"
 	icon_state = "matthiosgloves"
 	max_integrity = ARMOR_INT_SIDE_ANTAG
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/clothing/gloves/roguetown/plate/matthios/Initialize()
 	. = ..()
@@ -97,37 +100,47 @@
 	qdel(src)
 
 
-/obj/item/clothing/gloves/roguetown/plate/avantyne
+/obj/item/clothing/gloves/roguetown/plate/zizo
 	name = "avantyne gauntlets"
-	desc = "Gauntlets with full range of motion. The fore-arm guards do hurt, if used."
+	desc = "A razor-tipped finger was all it took to splay the divine fillament; now, it is time to bring down the wrath of God's hand in full. </br> Do mind the forearm's guards, however - they \
+	tend to leave a stinging bruise, whenever used to parry an incoming strike."
 	icon_state = "zizogauntlets_med"
 	max_integrity = ARMOR_INT_SIDE_STEEL
 	chunkcolor = "#363030"
 	material_category = ARMOR_MAT_PLATE
 	armor_class = ARMOR_CLASS_MEDIUM
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/clothing/gloves/roguetown/plate/avantyne/heavy
+/obj/item/clothing/gloves/roguetown/plate/zizo/heavy
 	name = "heavy avantyne gauntlets"
 	desc = "Unknowing truths, veiling the hands that prayed. Called forth from the edge of what should be known, in Her name."
 	icon_state = "zizogauntlets"
 	max_integrity = ARMOR_INT_SIDE_ANTAG
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/clothing/gloves/roguetown/plate/avantyne/Initialize()
+/obj/item/clothing/gloves/roguetown/plate/zizo/Initialize()
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "ARMOR")
 
-/obj/item/clothing/gloves/roguetown/plate/avantyne/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/gloves/roguetown/plate/zizo/dropped(mob/living/carbon/human/user)
 	return ..()
 
-/obj/item/clothing/gloves/roguetown/plate/avantyne/heavy/Initialize()
+/obj/item/clothing/gloves/roguetown/plate/zizo/heavy/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/gloves/roguetown/plate/avantyne/heavy/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/gloves/roguetown/plate/zizo/heavy/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return
 	qdel(src)
+
+/obj/item/clothing/gloves/roguetown/plate/avantyne
+	name = "avantyne-threaded gloves"
+	desc = "Incongruent silks from a tymeline-most-doomed, woven to cradle the palms of God's successor. Softer than silk, yet unfettered by the blows from those who know no better."
+	icon_state = "zizoplategauntlets_med"
+	smeltresult = /obj/item/ingot/avantyne
+	armor = ARMOR_PLATE_BSTEEL
 
 /obj/item/clothing/gloves/roguetown/plate/shadowgauntlets
 	name = "darkplate gauntlets"

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -1205,6 +1205,7 @@
 	bloody_icon = 'icons/effects/blood64.dmi'
 	experimental_inhand = FALSE
 	experimental_onhip = FALSE
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/clothing/head/roguetown/helmet/heavy/matthios/Initialize()
 	. = ..()
@@ -1217,6 +1218,7 @@
 	max_integrity = ARMOR_INT_HELMET_ANTAG
 	flags_inv = HIDEEARS|HIDEFACE|HIDESNOUT|HIDEHAIR|HIDEFACIALHAIR
 	var/active_item = FALSE
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/head/roguetown/helmet/heavy/graggar/Initialize()
 	. = ..()
@@ -1237,10 +1239,11 @@
 	active_item = FALSE
 	REMOVE_TRAIT(user, TRAIT_BITERHELM, TRAIT_GENERIC)
 
-/obj/item/clothing/head/roguetown/helmet/heavy/graggar/alt
+/obj/item/clothing/head/roguetown/helmet/heavy/graggar/skull
 	name = "vicious skullhelm"
-	desc = "Nigh lyke a crushed skull worn with pride; as sturdy as one that has seen fractures - and survived them, too."
+	desc = "Nigh lyke a crushed skull worn with pride; as sturdy as one that has seen fractures.. and survived them, too. Godliness was never meant to be tainted with minds so fragile and passionate."
 	icon_state = "graggarplatehelm_heavy"
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/head/roguetown/helmet/heavy/matthios/Initialize()
 	. = ..()
@@ -1255,6 +1258,7 @@
 	chunkcolor = "#363030"
 	material_category = ARMOR_MAT_PLATE
 	toggle_icon_state = TRUE
+	smeltresult = /obj/item/ingot/component/zizo
 
 /obj/item/clothing/head/roguetown/helmet/heavy/zizo/frogge
 	icon_state = "zizofrogmouth"
@@ -1263,12 +1267,14 @@
 	flags_inv = HIDEFACE|HIDESNOUT|HIDEEARS|HIDEHAIR
 	body_parts_covered = HEAD|EARS|HAIR
 	adjustable = CANT_CADJUST
+	smeltresult = /obj/item/ingot/component/zizo
 
 /obj/item/clothing/head/roguetown/helmet/heavy/zizo/volfhelm
 	name = "avantyne volf-face bascinet"
-	desc = "An unholy combination of a bastardised volf-face bascinet, along with avantyne reinforcements. Progress is an agonising process."
+	desc = "A terminal prognosis, a lethal parasite; unholy strands of avantyne, worming their way through the steel to make something greater. Progress is an agonising process, both unto flesh and metal."
 	icon_state = "volfplate_avantyne"
 	item_state = "volfplate_avantyne"
+	smeltresult = /obj/item/ingot/component/zizo
 
 /obj/item/clothing/head/roguetown/helmet/heavy/zizo/bascinet
 	name = "avantyne full-face bascinet"
@@ -1278,6 +1284,7 @@
 	flags_inv = HIDEFACE|HIDESNOUT|HIDEEARS|HIDEHAIR
 	body_parts_covered = HEAD|EARS|HAIR
 	adjustable = CANT_CADJUST
+	smeltresult = /obj/item/ingot/component/zizo
 
 /obj/item/clothing/head/roguetown/helmet/heavy/zizo/Initialize()
 	. = ..()
@@ -1286,6 +1293,18 @@
 /obj/item/clothing/head/roguetown/helmet/heavy/zizo/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/adjustable_clothing, (HEAD|EARS|HAIR), (HIDEEARS|HIDEHAIR), null, 'sound/items/visor.ogg', null, UPD_HEAD)	//Standard helmet
+
+/obj/item/clothing/head/roguetown/helmet/heavy/avantyne
+	name = "avantyne veil"
+	desc = "A veil threaded from an otherworldly alloy, perpetually backlit with an eerie crimson haze. Glimpse into the abyss for too long.. </br>‎  <font color='FF0000'>..and something will look back.</font>."
+	icon_state = "zizoplatehelm_med"
+	item_state = "zizoplatehelm_med"
+	flags_inv = HIDEFACE|HIDESNOUT|HIDEEARS
+	body_parts_covered = HEAD|EARS|HAIR
+	adjustable = CANT_CADJUST
+	smeltresult = /obj/item/ingot/avantyne
+	armor = ARMOR_PLATE_BSTEEL
+	armor_class = ARMOR_CLASS_LIGHT
 
 /obj/item/clothing/head/roguetown/helmet/heavy/bucket/iron
 	name = "iron bucket helm"

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -1034,6 +1034,7 @@
 	name = "gilded chain mantle"
 	desc = "The world is yours, as they say - yet, why doth the Gods still led us astray?"
 	color = "#ffc960"
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/clothing/neck/roguetown/chaincoif/chainmantle/matthios/Initialize()
 	. = ..()
@@ -1041,26 +1042,27 @@
 
 //
 
-/obj/item/clothing/neck/roguetown/bevor/avantyne
+/obj/item/clothing/neck/roguetown/bevor/zizo
 	name = "avantyne bevor"
 	desc = "An avantyne neckguard cut for the medium rite, still protective without becoming impossible to remove."
 	color = "#c1b18d"
 	chunkcolor = "#363030"
 	material_category = ARMOR_MAT_PLATE
 	armor_class = ARMOR_CLASS_MEDIUM
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/clothing/neck/roguetown/bevor/avantyne/Initialize()
+/obj/item/clothing/neck/roguetown/bevor/zizo/Initialize()
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "ARMOR")
 
-/obj/item/clothing/neck/roguetown/bevor/avantyne/heavy
+/obj/item/clothing/neck/roguetown/bevor/zizo/heavy
 	name = "fused avantyne bevor"
 
-/obj/item/clothing/neck/roguetown/bevor/avantyne/heavy/Initialize()
+/obj/item/clothing/neck/roguetown/bevor/zizo/heavy/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/neck/roguetown/bevor/avantyne/heavy/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/neck/roguetown/bevor/zizo/heavy/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return
@@ -1072,6 +1074,7 @@
 	name = "vicious gorget"
 	desc = "Curled plate, cradling the neck. Once, they were chains - now, they've allowed you to break free."
 	color = "#ddc0a7"
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/neck/roguetown/gorget/graggar/Initialize()
 	. = ..()

--- a/code/modules/clothing/rogueclothes/pants/plate.dm
+++ b/code/modules/clothing/rogueclothes/pants/plate.dm
@@ -47,17 +47,20 @@
 
 /obj/item/clothing/under/roguetown/platelegs/paalloy
 	name = "ancient plate chausses"
-	desc = "Polished gilbranze plates, layered atop silken chausses. Only the few who had embraced undeath were spared from Zizo's ascension; now, they command the undying legionnaires who march forth to sunder creation in Her name."
+	desc = "Polished gilbranze plates, layered atop silken chausses. Only the few who had embraced undeath were spared from Zizo's ascension; now, they command the undying \
+	legionnaires who march forth to sunder creation in Her name."
 	icon_state = "ancientpants"
 	smeltresult = /obj/item/ingot/aaslag
 
 /obj/item/clothing/under/roguetown/platelegs/graggar
 	name = "vicious leggings"
-	desc = "Fluted chausses, marinated in the afterbirth of disemboweled tyrants. Never kneel, again - never fall, again; cripple the ones who sought to keep you a slave, and force them to see the monster they've made of you."
+	desc = "Fluted chausses, marinated in the afterbirth of disemboweled tyrants. Never kneel, again - never fall, again; cripple the ones who sought to keep you a slave, \
+	and force them to see the monster they've made of you."
 	icon_state = "graggarplatelegs"
 	armor = ARMOR_PLATE_BSTEEL
 	max_integrity = ARMOR_INT_LEG_STEEL_PLATE // Good good resistances, but less crit resist than the other ascendant armors. In trade, we can take off our pants to repair, and they are medium rather than heavy.
 	armor_class = ARMOR_CLASS_MEDIUM
+	smeltresult = /obj/item/ingot/component/graggar
 
 /obj/item/clothing/under/roguetown/platelegs/graggar/Initialize(mapload)
 	. = ..()
@@ -69,6 +72,7 @@
 	desc = "But my outside to behold:"
 	icon_state = "matthioslegs"
 	armor = ARMOR_PLATE_BSTEEL
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/clothing/under/roguetown/platelegs/matthios/Initialize()
 	. = ..()
@@ -81,14 +85,14 @@
 		return
 	qdel(src)
 
-
-/obj/item/clothing/under/roguetown/platelegs/avantyne
+/obj/item/clothing/under/roguetown/platelegs/zizo
 	name = "avantyne garments"
 	desc = "Bolstered by threads of avantyne, padded by darksteel. It covers and protects - thought to be impossibly made."
 	icon_state = "zizoplatelegs_med"
 	max_integrity = ARMOR_INT_LEG_STEEL_PLATE
 	armor = ARMOR_PLATE_BSTEEL
 	armor_class = ARMOR_CLASS_MEDIUM
+	smeltresult = /obj/item/ingot/component/zizo
 
 /obj/item/clothing/under/roguetown/platelegs/avantyne/heavy
 	name = "fused avantyne garments"
@@ -96,23 +100,34 @@
 	icon_state = "zizocloth"
 	max_integrity = ARMOR_INT_LEG_ANTAG
 
-/obj/item/clothing/under/roguetown/platelegs/avantyne/Initialize(mapload)
+/obj/item/clothing/under/roguetown/platelegs/zizo/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "ARMOR")
 	AddComponent(/datum/component/item_equipped_movement_rustle, SFX_PLATE_STEP, 8)
 
-/obj/item/clothing/under/roguetown/platelegs/avantyne/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/under/roguetown/platelegs/zizo/dropped(mob/living/carbon/human/user)
 	return ..()
 
-/obj/item/clothing/under/roguetown/platelegs/avantyne/heavy/Initialize(mapload)
+/obj/item/clothing/under/roguetown/platelegs/zizo/heavy/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/under/roguetown/platelegs/avantyne/heavy/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/under/roguetown/platelegs/zizo/heavy/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return
 	qdel(src)
+
+/obj/item/clothing/under/roguetown/platelegs/avantyne
+	name = "avantyne fauldcoat"
+	desc = "The fossilization of a memory, damned to be forgotten by all but the divine - Her lux, crystallized into a veil impenetratable by all but the sharpest \
+	blades. If the legends are to be believed, She had worn these very garments long ago during Psydonia's darkest hour; when the Ascendants were but-two, when the \
+	Sinistar blotted out Astrata's glare, and when the ashes of Her empire were still smoldering. </br>..and to think, it was all a war without reason."
+	icon_state = "zizoplatelegs_med"
+	max_integrity = ARMOR_INT_LEG_STEEL_PLATE
+	armor_class = ARMOR_CLASS_MEDIUM
+	smeltresult = /obj/item/ingot/avantyne
+	armor = ARMOR_PLATE_BSTEEL
 
 /obj/item/clothing/under/roguetown/platelegs/skirt
 	name = "steel plate tassets"

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -396,6 +396,7 @@
 	name = "gilded bracers"
 	desc = "Away with you, vile beggar!"
 	color = "#ffc960"
+	smeltresult = /obj/item/ingot/component/matthios
 
 /obj/item/clothing/wrists/roguetown/bracers/matthios/Initialize()
 	. = ..()
@@ -403,7 +404,7 @@
 
 //
 
-/obj/item/clothing/wrists/roguetown/bracers/avantyne
+/obj/item/clothing/wrists/roguetown/bracers/zizo
 	name = "avantyne bracers"
 	desc = "Clasped yet practical, these avantyne wristguards are reinforced for the rite without binding themselves to the wearer forever."
 	color = "#c1b18d"
@@ -411,19 +412,20 @@
 	material_category = ARMOR_MAT_PLATE
 	max_integrity = ARMOR_INT_SIDE_STEEL
 	armor_class = ARMOR_CLASS_MEDIUM
+	smeltresult = /obj/item/ingot/component/zizo
 
-/obj/item/clothing/wrists/roguetown/bracers/avantyne/Initialize()
+/obj/item/clothing/wrists/roguetown/bracers/zizo/Initialize()
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_CABAL, "ARMOR")
 
-/obj/item/clothing/wrists/roguetown/bracers/avantyne/heavy
+/obj/item/clothing/wrists/roguetown/bracers/zizo/heavy
 	name = "fused avantyne bracers"
 
-/obj/item/clothing/wrists/roguetown/bracers/avantyne/heavy/Initialize()
+/obj/item/clothing/wrists/roguetown/bracers/zizo/heavy/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/wrists/roguetown/bracers/avantyne/heavy/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/wrists/roguetown/bracers/zizo/heavy/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return
@@ -434,19 +436,24 @@
 	name = "vicious bracers"
 	desc = "Oh, to plunge hands into cold water; to play a melody upon an ivory-keyed piano; to watch steam rise from boiling, twisting entrails.."
 	color = "#ddc0a7"
+	smeltresult = /obj/item/ingot/component/graggar
 
-/obj/item/clothing/wrists/roguetown/bracers/graggar/alt
+/obj/item/clothing/wrists/roguetown/bracers/graggar/heavy
 	name = "vicious wristguards"
-	desc = "Padded with a mixture of twine, leather and entrails. Steel and bone on the outside. It won't survive the onslaught - but it's not meant to."
+	desc = "Swaying chains, padded with a mixture of twine, leather and entrails. Steel and bone on the outside. It won't survive the onslaught - but it's \
+	not meant to. </br>Everything He did, He did for Ravox. To see them squander such power in favor of mortality's chains - it broke Him. Yils of resentment, \
+	of jealousy and frustration; released all at once. Through flowing tears, He disemboweled the divine filament and shattered His chains once and for all.. \
+	for if He would not be loved, then He would settle for hatred instead."
 	icon_state = "graggarplatebracer_heavy"
 	max_integrity = ARMOR_INT_SIDE_ANTAG
 	color = null
+	smeltresult = /obj/item/ingot/component/graggar
 
-/obj/item/clothing/wrists/roguetown/bracers/graggar/alt/Initialize()
+/obj/item/clothing/wrists/roguetown/bracers/graggar/heavy/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
-/obj/item/clothing/wrists/roguetown/bracers/graggar/alt/dropped(mob/living/carbon/human/user)
+/obj/item/clothing/wrists/roguetown/bracers/graggar/heavy/dropped(mob/living/carbon/human/user)
 	. = ..()
 	if(QDELETED(src))
 		return

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -365,7 +365,7 @@
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger
 				else if(istype(H.patron, /datum/patron/inhumen/zizo))
-					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/avantyne
+					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/zizo
 				else
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
 			if("Crossbow")
@@ -377,7 +377,7 @@
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger
 				else if(istype(H.patron, /datum/patron/inhumen/zizo))
-					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/avantyne
+					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/zizo
 				else
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
 			if("Slurbow")
@@ -389,7 +389,7 @@
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger/silver/psydagger
 				else if(istype(H.patron, /datum/patron/inhumen/zizo))
-					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/avantyne
+					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel/zizo
 				else
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger/steel
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)

--- a/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
+++ b/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
@@ -187,14 +187,14 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 /datum/outfit/job/roguetown/quest_miniboss/zizo/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/full/avantyne
-	pants = /obj/item/clothing/under/roguetown/platelegs/avantyne/heavy
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/avantyne/heavy
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/full/zizo
+	pants = /obj/item/clothing/under/roguetown/platelegs/zizo/heavy
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/zizo/heavy
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
-	gloves = /obj/item/clothing/gloves/roguetown/plate/avantyne/heavy
+	gloves = /obj/item/clothing/gloves/roguetown/plate/zizo/heavy
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/zizo
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel
-	r_hand = /obj/item/rogueweapon/sword/long/avantyne
+	r_hand = /obj/item/rogueweapon/sword/long/zizo
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
 
 /datum/outfit/job/roguetown/quest_miniboss/graggar/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -48,6 +48,10 @@
 	abstract_type = /datum/anvil_recipe/armor/blacksteel
 	craftdiff = SKILL_LEVEL_MASTER
 
+/datum/anvil_recipe/armor/avantyne
+	abstract_type = /datum/anvil_recipe/weapons/avantyne
+	craftdiff = SKILL_LEVEL_MASTER
+
 /datum/anvil_recipe/armor/gold
 	abstract_type = /datum/anvil_recipe/armor/gold
 	craftdiff = SKILL_LEVEL_LEGENDARY
@@ -1335,6 +1339,36 @@
 	name = "Ancient Blacksteel Plate Boots"
 	req_bar = /obj/item/ingot/blacksteel
 	created_item = /obj/item/clothing/shoes/roguetown/boots/armor/blacksteel
+
+// AVANTYNE
+
+/datum/anvil_recipe/armor/avantyne/helmet
+	name = "Veil, Avantyne (+1 A. Wafer)"
+	req_bar = /obj/item/ingot/avantyne
+	additional_items = list(/obj/item/ingot/avantyne)
+	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/avantyne
+
+/datum/anvil_recipe/armor/avantyne/maille
+	name = "Maille, Avantyne (+3 A. Wafer, +1 Cured Leather)"
+	req_bar = /obj/item/ingot/avantyne
+	additional_items = list(/obj/item/ingot/avantyne, /obj/item/ingot/avantyne, /obj/item/ingot/avantyne, /obj/item/natural/hide/cured)
+	created_item = /obj/item/clothing/suit/roguetown/armor/plate/fluted/avantyne
+
+/datum/anvil_recipe/armor/avantyne/faulds
+	name = "Fauldcoat, Avantyne (+1 A. Wafer)"
+	req_bar = /obj/item/ingot/avantyne
+	additional_items = list(/obj/item/ingot/avantyne)
+	created_item = /obj/item/clothing/under/roguetown/platelegs/avantyne
+
+/datum/anvil_recipe/armor/avantyne/gloves
+	name = "Gloves, Avantyne"
+	req_bar = /obj/item/ingot/avantyne
+	created_item = /obj/item/clothing/gloves/roguetown/plate/avantyne
+
+/datum/anvil_recipe/armor/avantyne/boots
+	name = "Sabatons, Avantyne"
+	req_bar = /obj/item/ingot/avantyne
+	created_item = /obj/item/clothing/shoes/roguetown/boots/armor/avantyne
 
 // GOLD
 

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -47,6 +47,10 @@
 	abstract_type = /datum/anvil_recipe/weapons/blacksteel
 	craftdiff = SKILL_LEVEL_MASTER
 
+/datum/anvil_recipe/weapons/avantyne
+	abstract_type = /datum/anvil_recipe/weapons/avantyne
+	craftdiff = SKILL_LEVEL_MASTER
+
 /datum/anvil_recipe/weapons/gold
 	abstract_type = /datum/anvil_recipe/weapons/gold
 	craftdiff = SKILL_LEVEL_LEGENDARY
@@ -1626,6 +1630,36 @@
 	req_bar = /obj/item/ingot/blacksteel
 	additional_items = list(/obj/item/ingot/blacksteel, /obj/item/roguegem/ruby, /obj/item/natural/silk)
 	created_item = /obj/item/rogueweapon/greatsword/grenz/flamberge/blacksteel
+
+// AVANTYNE
+
+/datum/anvil_recipe/weapons/avantyne/dagger
+	name = "Dagger, Avantyne"
+	req_bar = /obj/item/ingot/avantyne
+	created_item = /obj/item/rogueweapon/huntingknife/idagger/avantyne
+
+/datum/anvil_recipe/weapons/avantyne/sword
+	name = "Arming Sword, Avantyne"
+	req_bar = /obj/item/ingot/avantyne
+	created_item = /obj/item/rogueweapon/sword/avantyne
+
+/datum/anvil_recipe/weapons/avantyne/longsword
+	name = "Longsword, Avantyne (+1 A. Wafer)"
+	req_bar = /obj/item/ingot/avantyne
+	additional_items = list(/obj/item/ingot/avantyne)
+	created_item = /obj/item/rogueweapon/sword/long/avantyne
+
+/datum/anvil_recipe/weapons/avantyne/greatsword
+	name = "Greatsword, Avantyne (+2 A. Wafer)"
+	req_bar = /obj/item/ingot/avantyne
+	additional_items = list(/obj/item/ingot/avantyne, /obj/item/ingot/avantyne)
+	created_item = /obj/item/rogueweapon/greatsword/avantyne
+
+/datum/anvil_recipe/weapons/avantyne/shield
+	name = "Shield, Avantyne (+1 A. Wafer, +1 Cured Leather)"
+	req_bar = /obj/item/ingot/avantyne
+	additional_items = list(/obj/item/ingot/avantyne, /obj/item/natural/hide/cured)
+	created_item = /obj/item/rogueweapon/shield/tower/metal/avantyne
 
 // GOLD
 


### PR DESCRIPTION
## About The Pull Request

I'd like to apologize to Quinalion, as I have only _just_ noticed that they actually made a [pull request](https://github.com/Azure-Peak/Azure-Peak/pull/6959) to implement a lot of [PR #6666](https://github.com/Azure-Peak/Azure-Peak/pull/6664)'s delayed features while I was finishing this up. Check their PR out as well: they have a _lot_ of cool stuff coming down the pipeline!

Besides that, the summary:
* Finishes implementing the fragment code. Ascendant equipment, when destroyed, now drops _(currently cosmetic)_ fragments.
* Adds the Avantyne tier to smithing, between Blacksteel and Gold. Currently inaccesable, without administrative intervention.
* Adds the Avantyne-Threaded Dagger, Arming Sword, Longsword, Greatsword, Pavise, and Armorset. Blacksteel-tiered.
* Repaths all variants of _summoned_ Avantyne to use '/zizo', similar to how all other Ascendent-unique items are pathed.
* Likewise, _crafted_ Avantyne is now distinguished with the '/avantyne' filepath and '-threaded' suffix.
* Adds some supplemental descriptions to Ryan's, Dakken's, and Ruediger's contributions.

To note; almost all of this is _not_ player-facing. Avantyne wafers - and to that extent, all Avantyne-Threaded items - are **currently inaccessible** through non-administrative means. This'll allow for Dakken and his developers to do some last-minute tweaks to the aforementioned items, if desired, before making them publicly available.

Similarly, the repathing of summoned Avantyne equipment should have no player-facing effect. This just tidies up how everything's presented, code-wise. I made sure to also apply this change to the ritual circles and minibosses, where needed.

## Testing Evidence

Previously done in PR #6666, linked above. All good to go. I'll be on standby to deliver day one hotfixes, just in case.

## Why It's Good For The Game

* Brings all Ascendant-related equipment up to parity, in terms of code, which helps to make a neater and cleaner codebase.
* Adds some supplemental mirth to the new items, which is always(?) a boon.
* Finishes staging all wafer-related, making it much easier for Dakken to handle the final steps of fully implementing Avantyne.

## Changelog

:cl:
add: Destroying Ascendant-related equipment now drops fragments; remnants of their otherworldly alloys. Collectable as a trophy, or for some yet-unseen purpose.
add: The 'Avantyne' alloy tier. Equivalent to Blacksteel, handleable by all, but borne of unholy circumstance. Distinguished as being 'Avantyne-Threaded', these items are currently inaccessible through normal means.
add: Adds the Avantyne-Threaded Dagger, Arming Sword, Longsword, Greatsword, Pavise, Helmet, Maille, Gloves, Fauldcoat, and Sabatons. Light yet impossibly strong. Likewise, inaccessable through normal means.. for now.
add: Adds additional descriptions to Ascendant- and Psydonic-related equipment.
code: Adds more \-ings to long descriptions, in order to tidy things up.
code: Distinguishes summoned Avantyne from crafted Avantyne. All summoned variants of Avantyne have been repathed to '/zizo',  similar to how other Ascendant-related items are pathed. Ritual circles and minibosses have been accordingly changed to accomadate this; if you notice anything strange or off, contact @Dongwaiver on the 'cord for a hotfix.
/:cl: