### PR TITLE
readds homelessness to revenants - fixes oversight that undid the ability for revenants to be vagabonds

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/vagabond.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/vagabond.dm
@@ -8,7 +8,7 @@
 	townie_contract_gate_exempt = TRUE
 
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
-	allowed_races = ACCEPTED_RACES
+	allowed_races = RACES_ALL_KINDS
 
 	outfit = null
 	outfit_female = null


### PR DESCRIPTION
## About The Pull Request

* Fixes an oversight that unintentionally resulted in Revenants no longer being able to homelessmaxx as Vagabonds.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Restores an intended feature.
* Allows for Revenants to continue being homeless vagrants, once more.

## Changelog

:cl:
fix: Readds homelessness to the Revenant species; rejoice, for they can be Vagabonds once more!
/:cl: