### PR TITLE
Add Servant Clothes to Loadout

### DIFF
--- a/code/datums/loadout/loadout_cloaks.dm
+++ b/code/datums/loadout/loadout_cloaks.dm
@@ -173,3 +173,8 @@
 	name = "Tabard, Sleeved"
 	path = /obj/item/clothing/cloak/tabard/sleevedtabard
 	sort_category = "Cloaks"
+
+/datum/loadout_item/fancymaidapron
+	name = "Fancy Maid Apron"
+	path = /obj/item/clothing/cloak/apron/waist/fancymaid
+	sort_category = "Cloaks"

--- a/code/datums/loadout/loadout_pants.dm
+++ b/code/datums/loadout/loadout_pants.dm
@@ -43,3 +43,8 @@
 	name = "Explorer Pants"
 	path = /obj/item/clothing/under/roguetown/tights/explorerpants
 	sort_category = "Pants"
+
+/datum/loadout_item/formaltrousers
+	name = "Formal Trousers"
+	path = /obj/item/clothing/under/roguetown/tights/formalfancy
+	sort_category = "Pants"	

--- a/code/datums/loadout/loadout_shirts.dm
+++ b/code/datums/loadout/loadout_shirts.dm
@@ -177,3 +177,11 @@
 	name = "Noble's Pinafore"
 	path = /obj/item/clothing/suit/roguetown/shirt/nobledress
 	sort_category = "Shirts"
+/datum/loadout_item/formalshirt
+	name = "formal shirt"
+	path = /obj/item/clothing/suit/roguetown/shirt/undershirt/formal
+	sort_category = "Shirts"
+/datum/loadout_item/fancymaiddress
+	name = "maid dress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/maidfancy
+	sort_category = "Shirts"

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -830,6 +830,7 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/maidfancy
 	name = "maid dress"
 	desc = "A dress befitting the housekeeper of a lord's staff. While not as intricate as a royal's, it is indicative of the house's status."
+	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 	body_parts_covered = CHEST|GROIN|ARMS|VITALS
 	sleeved = 'icons/roguetown/clothing/special/onmob/sleeves_maids.dmi'
 	r_sleeve_status = SLEEVE_NORMAL


### PR DESCRIPTION
## About The Pull Request

Special Request from Poots, added the Maid Dress + Butler Clothes to the Loadout.  Kith and kin, rejoice!

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

It's drip. The Maid Dress is legitimately one of the most flexible items to dye in-game. And it looks good with armor, too. Go forth and prosper, my friends.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added Fancy Servantry Clothing to the Loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
