### PR TITLE
Time for NPC corpses to dust to 20 / 15 minutes, no longer drop items

### DIFF
--- a/code/controllers/subsystem/rogue/roguerot.dm
+++ b/code/controllers/subsystem/rogue/roguerot.dm
@@ -1,6 +1,6 @@
 
 PROCESSING_SUBSYSTEM_DEF(roguerot)
 	name = "roguerot"
-	wait = 20
+	wait = 30 SECONDS
 	flags = SS_NO_INIT
 	priority = 10

--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -3,7 +3,7 @@
 
 #define CORPSE_ROT_START_TIME 5 MINUTES
 #define CORPSE_SKELETONIZE_TIME 12 MINUTES
-#define CORPSE_DUST_TIME 15 MINUTES
+#define CORPSE_DUST_TIME 20 MINUTES
 
 #define SIMPLE_CORPSE_ROT_START 8 MINUTES
 #define SIMPLE_CORPSE_DUST_TIME 15 MINUTES
@@ -120,7 +120,7 @@
 
 	if(dustme)
 		qdel(src)
-		return C.dust(drop_items=TRUE)
+		return C.dust(drop_items=FALSE)
 
 	if(findonerotten)
 		var/turf/open/T = C.loc

--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -1,5 +1,12 @@
-#define DEAD_TO_ZOMBIE_TIME 7 MINUTES	//Time before death -> raised as zombie (when outside of the city)	
+#define DEAD_TO_ZOMBIE_TIME 7 MINUTES	//Time before death -> raised as zombie (when outside of the city)
 										//(This isn't exact time. Extended 5 -> 7 because only takes 2-3 min in testing at 5.)
+
+#define CORPSE_ROT_START_TIME 5 MINUTES
+#define CORPSE_SKELETONIZE_TIME 12 MINUTES
+#define CORPSE_DUST_TIME 15 MINUTES
+
+#define SIMPLE_CORPSE_ROT_START 8 MINUTES
+#define SIMPLE_CORPSE_DUST_TIME 15 MINUTES
 
 /datum/component/rot
 	var/amount = 0
@@ -63,6 +70,11 @@
 			qdel(src)
 			return
 
+	// Bodies that ever belonged to a player are exempt from auto-decay/dusting.
+	var/was_player = C.mind || C.last_mind || C.ckey
+	if(was_player && !is_zombie)
+		return
+
 	var/area/A = get_area(C)
 	if (istype(A, /area/rogue/indoors/town))	//Stops rotting inside town buildings; will stop your zombification such as at church or appothocary.
 		return
@@ -86,13 +98,13 @@
 	for(var/obj/item/bodypart/B in C.bodyparts)
 		if(!B.skeletonized && B.is_organic_limb())
 			if(!B.rotted)
-				if(amount > 20 MINUTES)
+				if(amount > CORPSE_ROT_START_TIME)
 					B.rotted = TRUE
 					findonerotten = TRUE
 					shouldupdate = TRUE
 					C.apply_status_effect(/datum/status_effect/debuff/rotted_zombie)	//-8 con to rotting zombie corpse.
 			else
-				if(amount > 40 MINUTES)
+				if(amount > CORPSE_SKELETONIZE_TIME)
 					if(!is_zombie)
 						B.skeletonize()
 						if(C.dna && C.dna.species)
@@ -101,11 +113,10 @@
 						shouldupdate = TRUE
 				else
 					findonerotten = TRUE
-		if(amount > 35 MINUTES)  // Code to delete a corpse after 35 minutes if it's not a zombie and not skeletonized. Possible failsafe.
+		if(amount > CORPSE_DUST_TIME)
 			if(!is_zombie)
-				if(!C.client)	// We want to dust NPC bodies, not player bodies.
-					if(B.skeletonized)
-						dustme = TRUE
+				if(B.skeletonized)
+					dustme = TRUE
 
 	if(dustme)
 		qdel(src)
@@ -144,13 +155,16 @@
 	if(L.stat != DEAD)
 		qdel(src)
 		return
-	if(amount > 15 MINUTES)
+	// Player-controlled (or formerly player-controlled) creatures don't auto-decay.
+	if(L.mind || L.ckey)
+		return
+	if(amount > SIMPLE_CORPSE_ROT_START)
 		if(soundloop && soundloop.stopped)
 			soundloop.start()
 		var/turf/open/T = get_turf(L)
 		if(istype(T))
 			T.pollute_turf(/datum/pollutant/rot, 5)
-	if(amount > 25 MINUTES)
+	if(amount > SIMPLE_CORPSE_DUST_TIME)
 		qdel(src)
 		return L.dust(drop_items=TRUE)
 
@@ -164,3 +178,8 @@
 	extra_range = 0
 
 #undef DEAD_TO_ZOMBIE_TIME
+#undef CORPSE_ROT_START_TIME
+#undef CORPSE_SKELETONIZE_TIME
+#undef CORPSE_DUST_TIME
+#undef SIMPLE_CORPSE_ROT_START
+#undef SIMPLE_CORPSE_DUST_TIME

--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -8,6 +8,9 @@
 #define SIMPLE_CORPSE_ROT_START 8 MINUTES
 #define SIMPLE_CORPSE_DUST_TIME 15 MINUTES
 
+#define HUNT_CORPSE_ROT_START 20 MINUTES
+#define HUNT_CORPSE_DUST_TIME 35 MINUTES
+
 /datum/component/rot
 	var/amount = 0
 	var/last_process = 0
@@ -149,6 +152,10 @@
 		if(H.buried)
 			soundloop.stop()
 
+/datum/component/rot/simple
+	var/rot_start = SIMPLE_CORPSE_ROT_START
+	var/dust_time = SIMPLE_CORPSE_DUST_TIME
+
 /datum/component/rot/simple/process()
 	..()
 	var/mob/living/L = parent
@@ -158,15 +165,19 @@
 	// Player-controlled (or formerly player-controlled) creatures don't auto-decay.
 	if(L.mind || L.ckey)
 		return
-	if(amount > SIMPLE_CORPSE_ROT_START)
+	if(amount > rot_start)
 		if(soundloop && soundloop.stopped)
 			soundloop.start()
 		var/turf/open/T = get_turf(L)
 		if(istype(T))
 			T.pollute_turf(/datum/pollutant/rot, 5)
-	if(amount > SIMPLE_CORPSE_DUST_TIME)
+	if(amount > dust_time)
 		qdel(src)
 		return L.dust(drop_items=TRUE)
+
+/datum/component/rot/simple/hunt
+	rot_start = HUNT_CORPSE_ROT_START
+	dust_time = HUNT_CORPSE_DUST_TIME
 
 /datum/component/rot/gibs
 	amount = MIASMA_GIBS_MOLES
@@ -183,3 +194,5 @@
 #undef CORPSE_DUST_TIME
 #undef SIMPLE_CORPSE_ROT_START
 #undef SIMPLE_CORPSE_DUST_TIME
+#undef HUNT_CORPSE_ROT_START
+#undef HUNT_CORPSE_DUST_TIME

--- a/code/game/objects/effects/animal_hunting/animal_tracks.dm
+++ b/code/game/objects/effects/animal_hunting/animal_tracks.dm
@@ -232,6 +232,7 @@
 					to_chat(user, span_boldwarning("You see your quarry in the distance faintly!"))
 					distribute_party_exp(35)
 					var/mob/living/primary_target = new target_animal_type(T)
+					primary_target.rot_type = /datum/component/rot/simple/hunt
 					if(spawn_group_bonus_animals(T, primary_target))
 						visible_message(span_boldwarning("There seems to be a herd in the distance!"))
 					return TRUE
@@ -446,6 +447,7 @@
 			var/turf/spawn_turf = (nearby_turfs.len) ? pick(nearby_turfs) : T
 			var/bonus_type = pickweight(hunt_category.animals)
 			var/mob/living/bonus_mob = new bonus_type(spawn_turf)
+			bonus_mob.rot_type = /datum/component/rot/simple/hunt
 			if(primary_target.faction?.len)
 				bonus_mob.faction = primary_target.faction.Copy()
 			spawned_count++


### PR DESCRIPTION
## About The Pull Request
This PR aggressively lower the time needed for corpses to rot / skeletonize / dust to 5 - 12 - 15 instead of the previous 40 minutes, for the sake of some sanity and trash cleanup with the much bigger increased amount of mobs slain / killed

Also makes roguerot process every 30 seconds instead of 2.

For **HUNT** spawned animals, the rot timer is far less aggressive and remains at previous level (20 minutes - 35 minutes rot - dust)

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It compiled

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Better cleanup and performance, less stinky

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Greatly lowered the frequency of the rotting process (should not meaningfully affect rotting time), made non-player corpses rot at 5 minutes, skeletonize at 12 and dust in 20. Simple corspe rot in 8, dust in 15 minutes.
add: For **HUNT** spawned animals, the rot timer is far less aggressive and remains at previous level (20 minutes - 35 minutes rot - dust)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
