### PR TITLE
Peasant Cap in loadout menu & Peasant Cap can be worn on mask slot, similarly to it's armoured version

### DIFF
--- a/code/datums/loadout/loadout_hats.dm
+++ b/code/datums/loadout/loadout_hats.dm
@@ -19,6 +19,11 @@
 	path = /obj/item/clothing/head/roguetown/archercap
 	sort_category = "Hats"
 
+/datum/loadout_item/cap
+	name = "Cap"
+	path = /obj/item/clothing/head/roguetown/cap
+	sort_category = "Hats"
+
 /datum/loadout_item/tiyon
 	name = "Tiyon"
 	path = /obj/item/clothing/head/roguetown/tiyon

--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -200,6 +200,9 @@
 /obj/item/clothing/head/roguetown/cap
 	name = "cap"
 	desc = "A light cap made of cloth, usually worn under a helmet."
+	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HEAD //Meant to be worn under helmets pmuch
+	icon = 'icons/roguetown/clothing/head.dmi'
+	mob_overlay_icon = 'icons/roguetown/clothing/onmob/head.dmi' //Overrides slot icon behavior
 	icon_state = "armingcap"
 	item_state = "armingcap"
 	flags_inv = HIDEEARS


### PR DESCRIPTION
## About The Pull Request

title

## Testing Evidence

Yeh

## Why It's Good For The Game

I wanted it there

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:SpartanBobby
add: Added Peasant cap to loadout menu
add: Peasant cap can now be worn on mask, similarly to its armoured versions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
