### PR TITLE
add a mob cull subsystem

### DIFF
--- a/code/controllers/subsystem/rogue/spawned_mobs.dm
+++ b/code/controllers/subsystem/rogue/spawned_mobs.dm
@@ -1,0 +1,124 @@
+#define SPAWNED_MOBS_DEFAULT_LIFESPAN 10 MINUTES
+
+GLOBAL_LIST_INIT(spawnmob_lifespan, list(
+	"Necromancer" = 15 MINUTES,
+	"Lich" = 60 MINUTES
+))
+
+GLOBAL_LIST_INIT(spawnmob_lifespan_override, list())
+
+SUBSYSTEM_DEF(spawned_mobs)
+	name = "Spawned Mob Cull"
+	wait = 30 SECONDS
+	flags = SS_BACKGROUND | SS_NO_INIT
+	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	var/list/tracked_mobs = list()
+	var/list/currentrun = list()
+
+/datum/controller/subsystem/spawned_mobs/stat_entry()
+	..("T:[length(tracked_mobs)]")
+
+/datum/controller/subsystem/spawned_mobs/fire(resumed = FALSE)
+	if(!resumed)
+		currentrun = list()
+		for(var/datum/weakref/mobref as anything in tracked_mobs)
+			currentrun += mobref
+
+	while(currentrun.len)
+		var/datum/weakref/mobref = currentrun[currentrun.len]
+		currentrun.len--
+
+		var/expires = tracked_mobs[mobref]
+		if(!expires)
+			if(MC_TICK_CHECK)
+				return
+			continue
+
+		var/mob/living/target = mobref.resolve()
+		if(!target || QDELETED(target) || target.stat == DEAD || target.client)
+			unregister_mob(mobref, target)
+			if(MC_TICK_CHECK)
+				return
+			continue
+
+		if(expires <= world.time)
+			unregister_mob(mobref, target)
+			target.visible_message(span_warning("[target] unravels as the power binding it expires!"))
+			target.death(FALSE)
+
+		if(MC_TICK_CHECK)
+			return
+
+/datum/controller/subsystem/spawned_mobs/proc/get_role_lifespan(role)
+	if(role && GLOB.spawnmob_lifespan[role])
+		return GLOB.spawnmob_lifespan[role]
+
+/datum/controller/subsystem/spawned_mobs/proc/get_type_lifespan(mob/living/target)
+	var/current_type = target?.type
+	while(current_type)
+		if(GLOB.spawnmob_lifespan_override[current_type])
+			return GLOB.spawnmob_lifespan_override[current_type]
+		current_type = type2parent(current_type)
+
+/datum/controller/subsystem/spawned_mobs/proc/get_lifespan(mob/living/target, mob/living/summoner, lifespan)
+	if(isnum(lifespan))
+		return lifespan
+
+	var/type_lifespan = get_type_lifespan(target)
+	if(type_lifespan)
+		return type_lifespan
+
+	var/role_lifespan = get_role_lifespan(summoner?.advjob)
+	if(role_lifespan)
+		return role_lifespan
+
+	role_lifespan = get_role_lifespan(summoner?.job)
+	if(role_lifespan)
+		return role_lifespan
+
+	role_lifespan = get_role_lifespan(summoner?.mind?.assigned_role)
+	if(role_lifespan)
+		return role_lifespan
+
+	return SPAWNED_MOBS_DEFAULT_LIFESPAN
+
+/datum/controller/subsystem/spawned_mobs/proc/register_mob(mob/living/target, mob/living/summoner, lifespan)
+	if(!target || target.client)
+		return FALSE
+
+	var/timer = get_lifespan(target, summoner, lifespan)
+	if(!isnum(timer) || timer <= 0 || timer == INFINITY)
+		return FALSE
+
+	var/datum/weakref/mobref = WEAKREF(target)
+	if(!tracked_mobs[mobref])
+		RegisterSignal(target, COMSIG_PARENT_EXAMINE, PROC_REF(on_mob_examine))
+	tracked_mobs[mobref] = world.time + timer
+	return TRUE
+
+/datum/controller/subsystem/spawned_mobs/proc/unregister_mob(datum/weakref/mobref, mob/living/target)
+	tracked_mobs -= mobref
+	if(target)
+		UnregisterSignal(target, COMSIG_PARENT_EXAMINE)
+
+/datum/controller/subsystem/spawned_mobs/proc/get_remaining_lifespan(mob/living/target)
+	if(!target || target.client || target.stat == DEAD)
+		return 0
+
+	var/expires = tracked_mobs[WEAKREF(target)]
+	if(!expires)
+		return 0
+
+	return max(0, expires - world.time)
+
+/datum/controller/subsystem/spawned_mobs/proc/on_mob_examine(mob/living/source, mob/user, list/examine_list)
+	var/remaining_lifespan = get_remaining_lifespan(source)
+	if(!remaining_lifespan)
+		return
+
+	examine_list += span_notice("A fading force binds [source] together. It will last for [DisplayTimeText(remaining_lifespan)].")
+
+/proc/apply_mob_lifespan(mob/living/target, mob/living/summoner, lifespan)
+	return SSspawned_mobs.register_mob(target, summoner, lifespan)
+
+#undef SPAWNED_MOBS_DEFAULT_LIFESPAN

--- a/code/datums/components/summoning.dm
+++ b/code/datums/components/summoning.dm
@@ -6,11 +6,12 @@
 	var/spawn_text
 	var/spawn_sound
 	var/list/faction
+	var/spawn_lifespan
 
 	var/last_spawned_time = 0
 	var/list/spawned_mobs = list()
 
-/datum/component/summoning/Initialize(mob_types, spawn_chance=100, max_mobs=3, spawn_delay=100, spawn_text="appears out of nowhere", spawn_sound='sound/blank.ogg', faction)
+/datum/component/summoning/Initialize(mob_types, spawn_chance=100, max_mobs=3, spawn_delay=100, spawn_text="appears out of nowhere", spawn_sound='sound/blank.ogg', faction, spawn_lifespan)
 	if(!isitem(parent) && !ishostile(parent) && !isgun(parent) && !ismachinery(parent) && !isstructure(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -21,6 +22,7 @@
 	src.spawn_text = spawn_text
 	src.spawn_sound = spawn_sound
 	src.faction = faction
+	src.spawn_lifespan = spawn_lifespan
 
 /datum/component/summoning/RegisterWithParent()
 	if(ismachinery(parent) || isstructure(parent) || isgun(parent)) // turrets, etc
@@ -60,6 +62,8 @@
 	spawned_mobs += L
 	if(faction != null)
 		L.faction = faction
+	if(spawn_lifespan)
+		apply_mob_lifespan(L, summoner, spawn_lifespan)
 	RegisterSignal(L, COMSIG_MOB_DEATH, PROC_REF(on_spawned_death)) // so we can remove them from the list, etc (for mobs with corpses)
 	playsound(spawn_location,spawn_sound, 50, TRUE)
 	spawn_location.visible_message("<span class='danger'>[L] [spawn_text].</span>")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -65,7 +65,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_undead_formation/necromancer)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_undead_guard)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_undead_guard/necromancer)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tame_undead)
 		H.mind.AddSpell(new /datum/action/cooldown/spell/raise_deadite)

--- a/code/modules/spells/roguetown/necromancer/raise_undead_formation.dm
+++ b/code/modules/spells/roguetown/necromancer/raise_undead_formation.dm
@@ -19,6 +19,7 @@
 	var/cabal_affine = FALSE
 	var/is_summoned = FALSE
 	var/to_spawn = 4
+	var/spawn_lifespan
 	hide_charge_effect = TRUE
 
 /obj/effect/proc_holder/spell/invoked/raise_undead_formation/cast(list/targets, mob/living/user)
@@ -57,17 +58,19 @@
 
 		new /obj/effect/temp_visual/bluespace_fissure(T)
 		skeleton_roll = rand(1,100)
+		var/mob/living/skeletonnew
 		switch(skeleton_roll)
 			if(1 to 20)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T, user, cabal_affine)
+				skeletonnew = new /mob/living/simple_animal/hostile/rogue/skeleton/axe(T, user, cabal_affine)
 			if(21 to 40)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T, user, cabal_affine)
+				skeletonnew = new /mob/living/simple_animal/hostile/rogue/skeleton/spear(T, user, cabal_affine)
 			if(41 to 60)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T, user, cabal_affine)
+				skeletonnew = new /mob/living/simple_animal/hostile/rogue/skeleton/guard(T, user, cabal_affine)
 			if(61 to 80)
-				new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T, user, cabal_affine)
+				skeletonnew = new /mob/living/simple_animal/hostile/rogue/skeleton/bow(T, user, cabal_affine)
 			if(81 to 100)
-				new /mob/living/simple_animal/hostile/rogue/skeleton(T, user, cabal_affine)
+				skeletonnew = new /mob/living/simple_animal/hostile/rogue/skeleton(T, user, cabal_affine)
+		apply_mob_lifespan(skeletonnew, user, spawn_lifespan)
 	return TRUE
 
 /obj/effect/proc_holder/spell/invoked/raise_undead_formation/necromancer

--- a/code/modules/spells/roguetown/necromancer/raise_undead_guard.dm
+++ b/code/modules/spells/roguetown/necromancer/raise_undead_guard.dm
@@ -16,6 +16,7 @@
 	gesture_required = TRUE // Summon spell
 	associated_skill = /datum/skill/magic/arcane
 	recharge_time = 30 SECONDS
+	var/spawn_lifespan
 	hide_charge_effect = TRUE
 
 /obj/effect/proc_holder/spell/invoked/raise_undead_guard/cast(list/targets, mob/living/user)
@@ -33,6 +34,10 @@
 
 	new /obj/effect/temp_visual/gib_animation(T, "gibbed-h")
 	var/mob/living/skeleton_new = new /mob/living/carbon/human/species/skeleton/npc/bogguard(T, user)
+	apply_mob_lifespan(skeleton_new, user, spawn_lifespan)
 	spawn(11) //Ashamed of this but I hate how after_creation() uses spawn too and I'm not making a timer for this. Proc needs a look-over. - Ryan
 		skeleton_new.faction |= list("cabal", "[user.mind.current.real_name]_faction")
 	return TRUE
+
+/obj/effect/proc_holder/spell/invoked/raise_undead_guard/necromancer
+	spawn_lifespan = 30 MINUTES

--- a/code/modules/spells/spell_types/undead/summon/raise_undead.dm
+++ b/code/modules/spells/spell_types/undead/summon/raise_undead.dm
@@ -36,7 +36,7 @@
 		var/message = "The depths are hollow."
 		if(user.cmode)
 			message += " A decrepit skeleton rises instead."
-			backup_summon(T)
+			backup_summon(T, user)
 		to_chat(user, span_warning(message))
 		return TRUE
 
@@ -59,12 +59,14 @@
 	target.mind.AddSpell(new /obj/effect/proc_holder/spell/self/suicidebomb/lesser)
 	return TRUE
 
-/obj/effect/proc_holder/spell/invoked/raise_undead/proc/backup_summon(var/turf/T)
+/obj/effect/proc_holder/spell/invoked/raise_undead/proc/backup_summon(var/turf/T, mob/living/user)
 	var/skeleton_roll = rand(1, 3)
+	var/mob/living/skeletonnew
 	// 66% chance of medium 33% of heavy
 	switch(skeleton_roll)
 		if(1 to 2) // 66% chance
-			new /mob/living/carbon/human/species/skeleton/npc/medium(T)
+			skeletonnew = new /mob/living/carbon/human/species/skeleton/npc/medium(T)
 		if(3) // 33% chance
-			new /mob/living/carbon/human/species/skeleton/npc/hard(T)
+			skeletonnew = new /mob/living/carbon/human/species/skeleton/npc/hard(T)
+	apply_mob_lifespan(skeletonnew, user)
 	return TRUE

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -462,6 +462,7 @@
 #include "code\controllers\subsystem\rogue\heart_tech_subsystem.dm"
 #include "code\controllers\subsystem\rogue\hunting_subsystem.dm"
 #include "code\controllers\subsystem\rogue\miscprocs.dm"
+#include "code\controllers\subsystem\rogue\spawned_mobs.dm"
 #include "code\controllers\subsystem\rogue\city_assembly\_subsystem.dm"
 #include "code\controllers\subsystem\rogue\city_assembly\motions.dm"
 #include "code\controllers\subsystem\rogue\city_assembly\session.dm"


### PR DESCRIPTION
## About The Pull Request

for certain spawned mobs (lich/necro skeles for now) the mobs are put into a cull list handled by a subsystem that goes thru the list every 30s and checks the lifespan of the mobs and kills them if it exceeds.

this makes necromancers mobspamming nearly impossible. maybe they can be buffed beyond this. this can be done for any sort of simple_animal or carbon mob. Mobs themselves can have lifespans that overrides the job lifespan.

Necromancers get 15mins of mobs, Liches get 60mins.

## Testing Evidence

it works. performance wise i just wonder how bad it would be on a proper round.

## Why It's Good For The Game

i hate mobspam. we can buff necromancer/lich after this

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: add a mob cull subsystem.
balance: liches get 60mins of mobs. necromancers get 15mins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
