### PR TITLE
turn rapier lunge to 3/4 pen

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1394,7 +1394,7 @@
 	name = "deep lunge"
 	icon_state = "inlunge"
 	damfactor = 1.3
-	penfactor = PEN_BSTEEL
+	penfactor = PEN_HEAVY
 
 	swingdelay_type = SWINGDELAY_CANCELSLOW
 	canparry = FALSE


### PR DESCRIPTION
## About The Pull Request

as it says on the tin

## Testing Evidence

shouldn't need a test

## Why It's Good For The Game

4/4 bsteel pen noparry isn't really healthy. 3/4 equates it to the saber heavy cut.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Rapier lunge is now 3/4 pen and not 4/4.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
