### PR TITLE
Fixes red swingdelays not getting disrupted properly

### DIFF
--- a/code/modules/mob/living/combat/checkdefense.dm
+++ b/code/modules/mob/living/combat/checkdefense.dm
@@ -1,5 +1,13 @@
 /mob/living/proc/checkdefense(datum/intent/intenty, mob/living/user)
 
+	// We check for a disruptable swingdelay first.
+	var/datum/status_effect/swingdelay/disrupt/SW = has_status_effect(/datum/status_effect/swingdelay/disrupt)
+	if(SW)
+		if(!SW.is_disrupted())
+			SW.attacked()
+			swing_state = FALSE
+			return FALSE
+
 	if(!cmode)
 		return FALSE
 	if(stat)
@@ -10,13 +18,7 @@
 		return FALSE
 	if(!(mobility_flags & MOBILITY_MOVE))
 		return FALSE
-		
-	var/datum/status_effect/swingdelay/disrupt/SW = has_status_effect(/datum/status_effect/swingdelay/disrupt)
-	if(SW)
-		if(!SW.is_disrupted())
-			SW.attacked()
-			swing_state = FALSE
-			return FALSE
+
 
 	if(client && used_intent)
 		if(client.charging && used_intent.tranged && !used_intent.tshield)


### PR DESCRIPTION
## About The Pull Request
Certain (a bit far-fetched or silly) circumstances allowed red swingdelays to go through even after being hit. Most of the circumstances involved not having a defense anyway so they took a free hit, but now it will be disrupted properly as well.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed red swingdelays not getting disrupted under some niche circumstances.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
