### PR TITLE
Missing Gear & Maid Stuff

### DIFF
--- a/code/datums/loadout/loadout_cloaks.dm
+++ b/code/datums/loadout/loadout_cloaks.dm
@@ -174,7 +174,7 @@
 	path = /obj/item/clothing/cloak/sleevedtabard
 	sort_category = "Cloaks"
 
-/datum/loadout_item/fancymaidapron
-	name = "Fancy Maid Apron"
+/datum/loadout_item/maidapron
+	name = "Maid Apron"
 	path = /obj/item/clothing/cloak/apron/waist/fancymaid
 	sort_category = "Cloaks"

--- a/code/datums/loadout/loadout_hats.dm
+++ b/code/datums/loadout/loadout_hats.dm
@@ -205,11 +205,11 @@
 	sort_category = "Hats"
 
 /datum/loadout_item/maidband
-	name = "maid headdress"
-	path = /obj/item/clothing/suit/roguetown/shirt/dress/maid
+	name = "Maid Headdress"
+	path = /obj/item/clothing/head/roguetown/maidhead
 	sort_category = "Hats"
 
 /datum/loadout_item/maidbandfancy
-	name = "valorian maid headdress"
-	path = /obj/item/clothing/suit/roguetown/shirt/dress/fancymaid
+	name = "Valorian Maid Headband"
+	path = /obj/item/clothing/head/roguetown/maidband
 	sort_category = "Hats"

--- a/code/datums/loadout/loadout_hats.dm
+++ b/code/datums/loadout/loadout_hats.dm
@@ -204,3 +204,12 @@
 	path = /obj/item/clothing/head/roguetown/jester
 	sort_category = "Hats"
 
+/datum/loadout_item/maidband
+	name = "maid headdress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/maid
+	sort_category = "Hats"
+
+/datum/loadout_item/maidbandfancy
+	name = "valorian maid headdress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/fancymaid
+	sort_category = "Hats"

--- a/code/datums/loadout/loadout_shirts.dm
+++ b/code/datums/loadout/loadout_shirts.dm
@@ -169,19 +169,28 @@
 	name = "Bared Robe"
 	path = /obj/item/clothing/suit/roguetown/shirt/robe/bared
 	sort_category = "Shirts"
+
 /datum/loadout_item/velvetdress
 	name = "Velvet Dress"
 	path = /obj/item/clothing/suit/roguetown/shirt/velvetdress
 	sort_category = "Shirts"
+
 /datum/loadout_item/nobledress
 	name = "Noble's Pinafore"
 	path = /obj/item/clothing/suit/roguetown/shirt/nobledress
 	sort_category = "Shirts"
+
 /datum/loadout_item/formalshirt
-	name = "formal shirt"
+	name = "Formal Shirt"
 	path = /obj/item/clothing/suit/roguetown/shirt/undershirt/formal
 	sort_category = "Shirts"
+
 /datum/loadout_item/fancymaiddress
-	name = "maid dress"
-	path = /obj/item/clothing/suit/roguetown/shirt/dress/maidfancy
+	name = "Valorian Maid dress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/fancymaid
+	sort_category = "Shirts"
+
+/datum/loadout_item/maiddress
+	name = "Maid Dress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/maid
 	sort_category = "Shirts"

--- a/code/datums/loadout/loadout_shirts.dm
+++ b/code/datums/loadout/loadout_shirts.dm
@@ -186,8 +186,8 @@
 	sort_category = "Shirts"
 
 /datum/loadout_item/fancymaiddress
-	name = "Valorian Maid dress"
-	path = /obj/item/clothing/suit/roguetown/shirt/dress/fancymaid
+	name = "Valorian Maid Dress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/maidfancy
 	sort_category = "Shirts"
 
 /datum/loadout_item/maiddress

--- a/code/datums/migrants/migrant_waves/ranesheni_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/ranesheni_noble_roles.dm
@@ -200,6 +200,7 @@
 			if("Spear")
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 				r_hand = /obj/item/rogueweapon/spear/boar
+				l_hand = /obj/item/rogueweapon/scabbard/gwstrap
 
 /datum/migrant_role/ranesheni/advisor
 	name = "Advisor"

--- a/code/game/objects/items/rogueitems/broom.dm
+++ b/code/game/objects/items/rogueitems/broom.dm
@@ -1,6 +1,6 @@
 /obj/item/broom
 	name = "broom"
-	desc = "A broom, made from a bundle of twigs. Sweep away blood, dirt, and tyme without a care in the world."
+	desc = "A robust-looking broom, made from a bundle of twigs. Sweep away debris, glass, blood, dirt, and time without a care in the world."
 	icon = 'icons/roguetown/weapons/tools.dmi'
 	icon_state = "broom"
 	possible_item_intents = list(/datum/intent/use)
@@ -26,26 +26,48 @@
 				return list("shrink" = 0.5,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
 /obj/item/broom/attack_obj(obj/O, mob/living/user)
+	if(do_after(user, 15, target = O))
+		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [O.name].</span>", "<span class='notice'>I dutifully sweep \the [O.name].</span>")
+		
+		playsound(user, "clothwipe", 100, TRUE)
+		
+		broom_fu(O, user)
 
-	if(do_after(user, 30, target = O))
-		if(istype(O, /obj/effect/decal/cleanable/dirt))
-			user.visible_message("<span class='notice'>[user] dutifully sweeps \the [O.name].</span>", "<span class='notice'>I dutifully sweep \the [O.name].</span>")
-			playsound(user, "clothwipe", 100, TRUE)
-			qdel(O)
-		if(istype(O, /obj/effect/decal/cleanable/blood))
-			add_blood_DNA(O.return_blood_DNA())
-			return
-
-// Even if there's nothing mechanically dirty about the floor, you can still sweep it! Anything to look busy.
+// Even if there's nothing mechanically dirty about the floor, you can still sweep it! Anything to look busy. // added a few more to it cause why not
 /obj/item/broom/attack_turf(turf/T, mob/living/user)
-	if(do_after(user, 30, target = T))
+	if(istype(T, /turf/open/lava)) // lol
+		return
+	if(istype(T, /turf/open/water))
+		return
+
+	if(do_after(user, 25, target = T))
 		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [T.name].</span>", "<span class='notice'>I dutifully sweep \the [T.name].</span>")
 		playsound(user, 'sound/items/broom_sweep.ogg', 150, TRUE)
 
-		if(istype(T, /turf/open/water))
-			..()
-		for(var/obj/effect/decal/cleanable/dirt/C in T)
-			qdel(C)
-		for(var/obj/effect/decal/cleanable/blood/O in T)
-			add_blood_DNA(O.return_blood_DNA())
-			return
+		broom_fu(T, user)
+
+// i should make this delete squires who try to steal your butter too it'll probably be funny
+/obj/item/broom/proc/broom_fu(atom/A, mob/living/user)
+	if(!A)
+		return
+	for(var/obj/effect/decal/cleanable/dirt/C in A)
+		qdel(C)
+	for(var/obj/item/scrap/C in A)
+		qdel(C)
+	for(var/obj/item/paper/crumpled/C in A)
+		qdel(C)
+	for(var/obj/item/grown/log/tree/stick/C in A)
+		qdel(C)
+	for(var/obj/item/ash/C in A)
+		qdel(C)
+	for(var/obj/item/natural/glass_shard/C in A)
+		qdel(C)
+	for(var/obj/effect/decal/cleanable/debris/woody/C in A)
+		qdel(C)
+	for(var/obj/effect/decal/cleanable/debris/stony/C in A)
+		qdel(C)
+	for(var/obj/effect/decal/cleanable/debris/glassy/C in A)
+		qdel(C)
+	for(var/obj/effect/decal/cleanable/blood/O in A)
+		add_blood_DNA(O.return_blood_DNA())
+		return

--- a/code/game/objects/items/rogueitems/broom.dm
+++ b/code/game/objects/items/rogueitems/broom.dm
@@ -28,9 +28,7 @@
 /obj/item/broom/attack_obj(obj/O, mob/living/user)
 	if(do_after(user, 15, target = O))
 		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [O.name].</span>", "<span class='notice'>I dutifully sweep \the [O.name].</span>")
-		
-		playsound(user, "clothwipe", 100, TRUE)
-		
+		playsound(user, "clothwipe", 100, TRUE)		
 		broom_fu(O, user)
 
 // Even if there's nothing mechanically dirty about the floor, you can still sweep it! Anything to look busy. // added a few more to it cause why not
@@ -43,8 +41,8 @@
 	if(do_after(user, 25, target = T))
 		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [T.name].</span>", "<span class='notice'>I dutifully sweep \the [T.name].</span>")
 		playsound(user, 'sound/items/broom_sweep.ogg', 150, TRUE)
-
 		broom_fu(T, user)
+		gather_clutter(T, user)
 
 // i should make this delete squires who try to steal your butter too it'll probably be funny
 /obj/item/broom/proc/broom_fu(atom/A, mob/living/user)
@@ -52,11 +50,7 @@
 		return
 	for(var/obj/effect/decal/cleanable/dirt/C in A)
 		qdel(C)
-	for(var/obj/item/scrap/C in A)
-		qdel(C)
 	for(var/obj/item/paper/crumpled/C in A)
-		qdel(C)
-	for(var/obj/item/grown/log/tree/stick/C in A)
 		qdel(C)
 	for(var/obj/item/ash/C in A)
 		qdel(C)
@@ -68,6 +62,27 @@
 		qdel(C)
 	for(var/obj/effect/decal/cleanable/debris/glassy/C in A)
 		qdel(C)
-	for(var/obj/effect/decal/cleanable/blood/O in A)
-		add_blood_DNA(O.return_blood_DNA())
+
+/obj/item/broom/proc/gather_clutter(turf/T, mob/living/user)
+	if(!T)
 		return
+
+	var/count = 0
+	var/flufftext = FALSE
+
+	for(var/atom/A in range(1, T))
+		if(count >= 10)
+			break
+		if(A.loc == T) 
+			continue
+		if(istype(A, /obj/item/natural/stone) || istype(A, /obj/item/scrap) || istype(A, /obj/item/paper/crumpled) || istype(A, /obj/item/grown/log/tree/stick) || istype(A, /obj/item/ash) || istype(A, /obj/item/natural/glass_shard) || istype(A, /obj/item/ammo_casing))
+			if(A.loc != T && !QDELETED(A))
+				A.forceMove(T)
+				count++
+				flufftext = TRUE
+
+	if(flufftext)
+		user.visible_message(
+			"<span class='notice'>[user] gathers the clutter into \the [T.name].</span>",
+			"<span class='notice'>I gather the clutter into \the [T.name].</span>"
+		)

--- a/code/game/objects/items/rogueitems/broom.dm
+++ b/code/game/objects/items/rogueitems/broom.dm
@@ -26,6 +26,9 @@
 				return list("shrink" = 0.5,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
 /obj/item/broom/attack_obj(obj/O, mob/living/user)
+	if(istype(T, /obj/structure/spider/stickyweb))
+		//where tf is the damage structure code aaa 1 sec
+
 	if(do_after(user, 15, target = O))
 		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [O.name].</span>", "<span class='notice'>I dutifully sweep \the [O.name].</span>")
 		playsound(user, "clothwipe", 100, TRUE)		
@@ -37,8 +40,7 @@
 		return
 	if(istype(T, /turf/open/water))
 		return
-
-	if(do_after(user, 25, target = T))
+	if(do_after(user, 20, target = T))
 		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [T.name].</span>", "<span class='notice'>I dutifully sweep \the [T.name].</span>")
 		playsound(user, 'sound/items/broom_sweep.ogg', 150, TRUE)
 		broom_fu(T, user)
@@ -70,19 +72,16 @@
 	var/count = 0
 	var/flufftext = FALSE
 
-	for(var/atom/A in range(1, T))
+	for(var/atom/movable/A in range(1, T))
 		if(count >= 10)
 			break
 		if(A.loc == T) 
 			continue
-		if(istype(A, /obj/item/natural/stone) || istype(A, /obj/item/scrap) || istype(A, /obj/item/paper/crumpled) || istype(A, /obj/item/grown/log/tree/stick) || istype(A, /obj/item/ash) || istype(A, /obj/item/natural/glass_shard) || istype(A, /obj/item/ammo_casing))
+		if(istype(A, /obj/item/natural/stone) || istype(A, /obj/item/scrap) || istype(A, /obj/item/paper/crumpled) || istype(A, /obj/item/grown/log/tree/stick) || istype(A, /obj/item/ash) || istype(A, /obj/item/natural/glass_shard) || istype(A, /obj/item/natural/cloth) || istype(A, /obj/item/natural/fibers) || istype(A, /obj/item/natural/silk) || istype(A, /obj/item/ammo_casing) || istype(A, /obj/item/rogueweapon/huntingknife/throwingknife))
 			if(A.loc != T && !QDELETED(A))
 				A.forceMove(T)
 				count++
 				flufftext = TRUE
 
 	if(flufftext)
-		user.visible_message(
-			"<span class='notice'>[user] gathers the clutter into \the [T.name].</span>",
-			"<span class='notice'>I gather the clutter into \the [T.name].</span>"
-		)
+		user.visible_message("<span class='notice'>[user] gathers the clutter into \the [T.name].</span>", "<span class='notice'>I gather the clutter into \the [T.name].</span>")

--- a/code/game/objects/items/rogueitems/broom.dm
+++ b/code/game/objects/items/rogueitems/broom.dm
@@ -26,8 +26,8 @@
 				return list("shrink" = 0.5,"sx" = -1,"sy" = 2,"nx" = 0,"ny" = 2,"wx" = 2,"wy" = 1,"ex" = 0,"ey" = 1,"nturn" = 0,"sturn" = 0,"wturn" = 70,"eturn" = 15,"nflip" = 1,"sflip" = 1,"wflip" = 1,"eflip" = 1,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
 /obj/item/broom/attack_obj(obj/O, mob/living/user)
-	if(istype(T, /obj/structure/spider/stickyweb))
-		//where tf is the damage structure code aaa 1 sec
+	if(istype(O, /obj/structure/spider/stickyweb)) // perish, spiders
+		O.take_damage(50, BRUTE, "blunt", FALSE)
 
 	if(do_after(user, 15, target = O))
 		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [O.name].</span>", "<span class='notice'>I dutifully sweep \the [O.name].</span>")

--- a/code/modules/antagonists/roguetown/villain/unbound_spellblade.dm
+++ b/code/modules/antagonists/roguetown/villain/unbound_spellblade.dm
@@ -226,6 +226,7 @@
 			switch(weapon_choice)
 				if("Spear")
 					r_hand = /obj/item/rogueweapon/spear
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
 				if("Bardiche")
 					r_hand = /obj/item/rogueweapon/halberd/bardiche
 					backr = /obj/item/rogueweapon/scabbard/gwstrap

--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -628,7 +628,7 @@
 		add_overlay(pic)
 
 /obj/item/clothing/head/roguetown/maidband
-	name = "maid headband"
+	name = "valorian maid headband"
 	desc = "A pleated cloth headband. It has gained widespread popularity from Valorian nobles travelling with their servants."
 	icon_state = "maidband"
 	body_parts_covered = NONE

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -743,7 +743,7 @@
 
 /obj/item/clothing/suit/roguetown/shirt/dress/maid
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
-	name = "servant dress"
+	name = "maid dress"
 	desc = "A distinctive black dress that should be kept clean and tidy - unless you want to be disciplined."
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|VITALS
 	boobed = TRUE
@@ -757,13 +757,13 @@
 /obj/item/clothing/suit/roguetown/shirt/dress/maid/attack_right(mob/user)
 	switch(open_wear)
 		if(FALSE)
-			name = "open servant dress"
+			name = "open maid dress"
 			body_parts_covered = null
 			open_wear = TRUE
 			flags_inv = HIDEBOOB
 			to_chat(usr, span_warning("Now wearing radically!"))
 		if(TRUE)
-			name = "servant dress"
+			name = "maid dress"
 			body_parts_covered = CHEST|GROIN|ARMS|LEGS|VITALS
 			open_wear = FALSE
 			flags_inv = HIDEBOOB|HIDECROTCH
@@ -828,7 +828,7 @@
 		add_overlay(pic)
 
 /obj/item/clothing/suit/roguetown/shirt/dress/maidfancy
-	name = "maid dress"
+	name = "valorian maid dress"
 	desc = "A dress befitting the housekeeper of a lord's staff. While not as intricate as a royal's, it is indicative of the house's status."
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
 	body_parts_covered = CHEST|GROIN|ARMS|VITALS
@@ -842,7 +842,7 @@
 	detail_color = CLOTHING_DARK_GREY
 
 /obj/item/clothing/suit/roguetown/shirt/dress/maidservant
-	name = "servant gown"
+	name = "maid gown"
 	sleeved = 'icons/roguetown/clothing/special/onmob/sleeves_maids.dmi'
 	desc = "A dress worn by those of manors and noble staff. Commonly black, though some estates dye them to their house colors."
 	icon_state = "maidgown"
@@ -855,12 +855,14 @@
 	icon_state = "butlershirt"
 	item_state = "butlershirt"
 	sleeved = 'icons/roguetown/clothing/special/onmob/sleeves_maids.dmi'
+
 /obj/item/clothing/suit/roguetown/shirt/velvetdress
 	name = "velvet dress"
 	desc = "A garment made with embroidered velvet, both elegant and warm. Poetry made manifest in swaying fabric."
 	icon_state = "velvetdress"
 	item_state = "velvetdress"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
+
 /obj/item/clothing/suit/roguetown/shirt/nobledress
 	name = "noble's pinafore"
 	desc = "A comfortable dress adapted from simpler garments often worn by working-class women."

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -287,6 +287,7 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
 			if("Spear")
 				r_hand = /obj/item/rogueweapon/spear
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
 
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -1803,7 +1803,7 @@
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/sewing/maiddress
-	name = "servant dress"
+	name = "maid dress"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/maid)
 	reqs = list(/obj/item/natural/cloth = 3,
 				/obj/item/natural/fibers = 1)
@@ -1811,7 +1811,7 @@
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/sewing/maidhead
-	name = "maid headdress (1 fibers, 1 cloth)"
+	name = "maid headband"
 	result = list(/obj/item/clothing/head/roguetown/maidhead)
 	reqs = list(/obj/item/natural/cloth = 1,
 				/obj/item/natural/fibers = 1)
@@ -1819,7 +1819,7 @@
 	craftdiff = 2
 
 /datum/crafting_recipe/roguetown/sewing/maidapron
-	name = "servant apron"
+	name = "maid apron"
 	result = list(/obj/item/clothing/cloak/apron/waist/maid)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)
@@ -2110,7 +2110,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/maidband
-	name = "maid headband"
+	name = "valorian maid headband"
 	result = list(/obj/item/clothing/head/roguetown/maidband)
 	reqs = list(
 		/obj/item/natural/cloth = 1,
@@ -2119,7 +2119,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/maiddress
-	name = "maid dress"
+	name = "valorian maid dress"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/dress/maidfancy)
 	reqs = list(
 		/obj/item/natural/cloth = 3,
@@ -2128,7 +2128,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/maidapron
-	name = "maid apron"
+	name = "valorian maid apron"
 	result = list(/obj/item/clothing/cloak/apron/waist/fancymaid)
 	reqs = list(
 		/obj/item/natural/cloth = 1,

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -108,7 +108,7 @@
 		"Stashed Messer & Parrying Dagger" = list(/obj/item/rogueweapon/sword/short/messer/iron/virtue, /obj/item/rogueweapon/huntingknife/idagger/virtue),
 		"Stashed Shield & Arming Sword" = list(/obj/item/rogueweapon/shield/wood, /obj/item/rogueweapon/sword/iron),
 		"Stashed Quarterstaff & Sling" = list(/obj/item/rogueweapon/woodstaff/quarterstaff/iron, /obj/item/gun/ballistic/revolver/grenadelauncher/sling, /obj/item/quiver/sling/iron),
-		"Stashed Spear & Mace" = list(/obj/item/rogueweapon/spear, /obj/item/rogueweapon/mace),
+		"Stashed Spear & Mace" = list(/obj/item/rogueweapon/spear, /obj/item/rogueweapon/mace, /obj/item/rogueweapon/scabbard/gwstrap),
 		"Stashed Katar & Knuckles" = list(/obj/item/rogueweapon/katar/bronze, /obj/item/clothing/gloves/roguetown/knuckles/bronze),
 		"Stashed Axe & Whip" = list(/obj/item/rogueweapon/stoneaxe/woodcut, /obj/item/rogueweapon/whip)
 	)


### PR DESCRIPTION
## About The Pull Request

- Adds a Greatweapon Strap to a lot of Spear instances that lack it.
- Maid Dress and the fancier version of it are now distinctive by name. (Maid Dress & Valorian Maid Dress)
- Added the missing maid headdress from a recent PR to item loadout, I got you fam.
- As a little extra, also made brooms clean more stuff that they logically should be able to. (They can also be used to vacuum clutter to one spot and make Keep hyperwar clean-ups a little less soul-draining. And also be used to clean all decals but blood. Blood requires a wet cloth or soap.)

## Testing Evidence

<img width="644" height="299" alt="Screenshot_3" src="https://github.com/user-attachments/assets/558f5460-aac0-4330-9745-85e28ec68f37" />
<img width="847" height="417" alt="Screenshot_4" src="https://github.com/user-attachments/assets/f8f162b9-0b17-498a-904d-590b1e7fa0c0" />
<img width="810" height="381" alt="Screenshot_5" src="https://github.com/user-attachments/assets/81e0dee2-5376-4cb4-8e30-489fd8a9170e" />
<img width="1294" height="548" alt="Screenshot_6" src="https://github.com/user-attachments/assets/db3f85ca-e247-4c1c-9cbb-bddc703d4d4b" />


## Why It's Good For The Game

Just patching what the other two PRs that are related to this have forgotten to add. And going a little back to my roots as the battlemaid main. 

## Changelog

:cl:
add: Brooms are now more useful for cleaning garbage.
fix: Added some missing gear to where they should be, notably,  greatweapon straps for spears.
spellcheck: Fixed a few naming disparities between the new and old and eldest maid dresses we have.
/:cl: