### PR TITLE
Lich Consistancy - Another Deadite Examines

### DIFF
--- a/code/modules/antagonists/roguetown/roleobjs/skeleton.dm
+++ b/code/modules/antagonists/roguetown/roleobjs/skeleton.dm
@@ -14,6 +14,8 @@
 		return span_boldnotice("Another deadite.")
 	if(istype(examined_datum, /datum/antagonist/skeleton))
 		return span_boldnotice("Another deadite. My ally.")
+	if(istype(examined_datum, /datum/antagonist/lich))
+		return span_boldnotice("Another deadite. My ally")
 
 /datum/antagonist/skeleton/on_gain()
 //	if(!(locate(/datum/objective/escape) in objectives))

--- a/code/modules/antagonists/roguetown/villain/lich.dm
+++ b/code/modules/antagonists/roguetown/villain/lich.dm
@@ -175,6 +175,17 @@
 	eyes = new /obj/item/organ/eyes/night_vision/zombie
 	eyes.Insert(L)
 
+/datum/antagonist/lich/examine_friendorfoe(datum/antagonist/examined_datum,mob/examiner,mob/examined)
+	if(istype(examined_datum, /datum/antagonist/vampire))
+		if(!SEND_SIGNAL(examined_datum.owner, COMSIG_DISGUISE_STATUS))
+			return span_boldnotice("Another deadite.")
+	if(istype(examined_datum, /datum/antagonist/zombie))
+		return span_boldnotice("Another deadite.")
+	if(istype(examined_datum, /datum/antagonist/skeleton))
+		return span_boldnotice("Another deadite. My Ally.")
+	if(istype(examined_datum, /datum/antagonist/lich))
+		return span_boldnotice("Another Deadite.")
+
 /datum/outfit/job/roguetown/lich/post_equip(mob/living/carbon/human/H)
 	..()
 	var/datum/antagonist/lich/lichman = H.mind.has_antag_datum(/datum/antagonist/lich)

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -79,6 +79,8 @@
 		return span_boldnotice("Another deadite. [fellow_zombie.has_turned ? "My ally." : span_warning("Hasn't turned yet.")]")
 	if(istype(examined_datum, /datum/antagonist/skeleton))
 		return span_boldnotice("Another deadite.")
+	if(istype(examined_datum, /datum/antagonist/lich))
+		return span_boldnotice("Another deadite.")
 
 //Housekeeping/saving variables from pre-zombie
 

--- a/code/modules/vampire_neu/vampire.dm
+++ b/code/modules/vampire_neu/vampire.dm
@@ -80,6 +80,8 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 		return span_boldnotice("Another deadite.")
 	if(istype(examined_datum, /datum/antagonist/skeleton))
 		return span_boldnotice("Another deadite.")
+	if(istype(examined_datum, /datum/antagonist/lich))
+		return span_boldnotice("Another deadite.")
 
 /datum/antagonist/vampire/on_gain()
 	SSmapping.retainer.vampires |= owner


### PR DESCRIPTION
## About The Pull Request

So a fairly simple one, nothing as fancy as it sounds.
- Zombies/Skeletons/Vampires can examine lich to see they're a deadite.
- Lich can examine Vampires/Skeletons/Zombies to tell they're deadites.

Yes, the examines are intentionally vague about a lich, you will not get any more information than "**another deadite**" or "**my ally**" tacked onto it as a skeleton. This is so if the lich takes effort to disguise you won't be able to tell them from another skeleton.

Nuff said, really. You ARE undead as a lich, true undead. You get this blessing and curse as a proper antag.

Yes vampires and zombies **CAN** examine back to tell you're a true undead but that's intended. **You literally are.**
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="538" height="387" alt="Lich Examines" src="https://github.com/user-attachments/assets/9ec193f1-af13-47f3-a162-25941c67a85f" />

**this is an example of me examining a wretch skeleton but I assure you it works both ways**


Both Lich can examine deadites and deadites can examine the lich
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

- Consistant with other Undead antagonists in the game.
- Skeletons should probably be able to tell a Lich is a deadite through attire and an Ally.
- Zombies won't accidentally try to eat a Lich.
- You can tell who's actually a skeleton in a fight as a lich, or a fellow undead in a fight as a skeleton.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Lich can now be examined by deadites and examine them back.
fix: inconsistancy with lich compared to other deadite antagonists.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
