### PR TITLE
Fixes Open Eoran Robes (sorta)

### DIFF
--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -312,13 +312,13 @@
 	name = "open eoran robe"
 	desc = "Used by more radical followers of the Eoran Church"
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/armor.dmi'
-	body_parts_covered = null
+	body_parts_covered = null // Keyhole should show boob size and the outfit is too open to get in the way of sex
 	icon_state = "eorastraps"
 	item_state = "eorastraps"
-	flags_inv = HIDEBOOB
+	flags_inv = HIDEBOOB // This pretty much only prevents seeing underwear and or clipping if you have really big tits
 	fanatic_wear = TRUE
 
-/obj/item/clothing/suit/roguetown/shirt/robe/eora/attack_right(mob/user)
+/obj/item/clothing/suit/roguetown/shirt/robe/eora/attack_right(mob/user) // All this changes is the sprite which is okay
 	switch(fanatic_wear)
 		if(FALSE)
 			name = "open eoran robe"
@@ -327,7 +327,7 @@
 			icon_state = "eorastraps"
 			item_state = "eorastraps"
 			fanatic_wear = TRUE
-			flags_inv = HIDECROTCH
+			flags_inv = HIDEBOOB
 			to_chat(usr, span_warning("Now wearing radically!"))
 		if(TRUE)
 			name = "eoran robe"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -621,12 +621,18 @@
 			H.adjust_skillrank(/datum/skill/craft/weaponsmithing, SKILL_LEVEL_NOVICE, TRUE)
 			H.adjust_skillrank(/datum/skill/craft/smelting, SKILL_LEVEL_NOVICE, TRUE)
 		if (/datum/patron/divine/eora)
-			cloak = /obj/item/clothing/suit/roguetown/shirt/robe/eora
 			head = /obj/item/clothing/head/roguetown/eoramask
 			backpack_contents[/obj/item/reagent_containers/eoran_seed] = 1
 			r_hand = /obj/item/rogueweapon/huntingknife/scissors
 			H.adjust_skillrank(/datum/skill/craft/cooking, SKILL_LEVEL_APPRENTICE, TRUE)
 			ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
+			var/robes = list("Modest","Exposed")
+			var/robe_choice = input(H, "Choose your ROBES.", "TAKE UP ROBES.") as anything in robes
+			switch(robe_choice) // This feels wrong to do but I am unsure how else to do it
+				if("Modest")
+					cloak = /obj/item/clothing/suit/roguetown/shirt/robe/eora
+				if("Exposed")
+					cloak = /obj/item/clothing/suit/roguetown/shirt/robe/eora/alt
 		if (/datum/patron/divine/xylix)
 			cloak = /obj/item/clothing/cloak/tabard/devotee/xylix
 			H.adjust_skillrank(/datum/skill/misc/climbing, SKILL_LEVEL_NOVICE, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -129,10 +129,16 @@
 			head = /obj/item/clothing/head/roguetown/eoramask
 			neck = /obj/item/clothing/neck/roguetown/psicross/eora
 			shoes = /obj/item/clothing/shoes/roguetown/sandals
-			armor = /obj/item/clothing/suit/roguetown/shirt/robe/eora
 			cloak = /obj/item/clothing/cloak/templar/eoran
 			r_hand = /obj/item/rogueweapon/huntingknife/scissors
 			shirt = /obj/item/clothing/suit/roguetown/armor/vestments_padded
+			var/robes = list("Modest","Exposed")
+			var/robe_choice = input(H, "Choose your ROBES.", "TAKE UP ROBES.") as anything in robes
+			switch(robe_choice) // This feels wrong to do but I am unsure how else to do it
+				if("Modest")
+					armor = /obj/item/clothing/suit/roguetown/shirt/robe/eora
+				if("Exposed")
+					armor = /obj/item/clothing/suit/roguetown/shirt/robe/eora/alt
 		if(/datum/patron/divine/malum)
 			head = /obj/item/clothing/head/roguetown/roguehood
 			neck = /obj/item/clothing/neck/roguetown/psicross/malum


### PR DESCRIPTION
Fixes a weird number of issues, including some stuff in robes.dm and simply makes the open eoran robes (robe/eora/alt) no longer unobtainable

## About The Pull Request

I noticed a while back that the coverage does not properly update what genitalia is shown when it is changed by the right click alt wear of items. This exists for everything that uses this, including the new maid outfits and the like. I might, at a later date, also do this same thing for the maid outfits.
- Minor tweaks to robes.dm (mostly tweaking HIDECROTCH/HIDEBOOB and comments to explain my logic)
- Adds the previously unused robe/eora/alt to an option for Eoran Missionaries and Acolytes.
- Eoran Missionaries and Acolytes can now have clothed sex in their fancy open robes. People can see and interact with genitals if they have such enabled.
- Adds two sets of the open eoran robes to the church

This is basically a bandaid fix and should by no means need to be permanent. The right click code still exists and works fine for switching sprites, just not genitalia. 
This does NOT currently add a crafting recipe

## Testing Evidence
It opens the menu
<img width="551" height="459" alt="robetest1" src="https://github.com/user-attachments/assets/2dd8de40-9a74-4fb3-8541-7070b852d18a" />
It shows the straps of your panties (because SOVL, ignore the bra clipping issue I cannot fix that)
<img width="186" height="174" alt="robetest2" src="https://github.com/user-attachments/assets/f48534ea-1f65-4f78-bb63-98fb4b762792" />
Allows for interaction and sight of genitals
<img width="433" height="145" alt="robetest3" src="https://github.com/user-attachments/assets/119baa14-75ec-4fde-b7b2-bb920a5b0772" />
The robes are where they're supposed to be
<img width="351" height="190" alt="robetest4" src="https://github.com/user-attachments/assets/01f22afc-7c73-445d-93ed-15adfec31a89" />


## Why It's Good For The Game

The Open Eoran Robes altwear does not actually work for normal Eoran robes. After a frankly needless amount of testing and troubleshooting, I determined the issue was something to do with coverage not updating what genitals are visible/accessible. Open Eoran Robes appear to be intended to be a radical variant for clothed sex anyway, this just lets them actually do that. It also used to work this way.

Clothed sex is sovl

A number of other clothing items (such as the giltsilk belt) also cover relatively little skin or are quite open and are represented by not covering genitalia. The open eoran robes are about as much fabric, or oftentimes even LESS in the way,

## Changelog

:cl:
add: Eorans now get a pick between their normal robes and radical, open robes. This almost exists in the right click interaction but it didn't actually change what the outfit exposed.
add: There is a set of 2 open Eoran robes in the church. Just in case.
fix: Open Eoran Robes (the actual alt item, not the alt wear of the eoran robes) now allows you to have clothed sex and for your genitals to be visible (if you're wearing nothing under it)
/:cl:
