### PR TITLE
[Bugfix] Permanent Rot skin color

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -6,6 +6,9 @@
 	var/last_process = 0
 	var/datum/looping_sound/fliesloop/soundloop
 
+/mob/living/carbon/human // i have FURY.
+	var/tmp/original_skin_tone
+
 /datum/component/rot/Initialize(new_amount)
 	..()
 	if(!isatom(parent))
@@ -126,7 +129,11 @@
 	if(shouldupdate)
 		if(findonerotten)
 			if(ishuman(C))
-				var/mob/living/carbon/human/H = C
+				var/mob/living/carbon/human/H = C			
+						
+				if(!H.original_skin_tone) // patchwork slop, the real fix is looking into generate_icon_render_key(), cause like 90% of this code, we have two different versions of it, one for mobliving other for moblivinghuman
+					H.original_skin_tone = H.skin_tone
+
 				H.skin_tone = "878f79" //elf ears
 			if(soundloop && soundloop.stopped && !is_zombie)
 				soundloop.start()

--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -6,9 +6,6 @@
 	var/last_process = 0
 	var/datum/looping_sound/fliesloop/soundloop
 
-/mob/living/carbon/human // i have FURY.
-	var/tmp/original_skin_tone
-
 /datum/component/rot/Initialize(new_amount)
 	..()
 	if(!isatom(parent))
@@ -130,11 +127,7 @@
 		if(findonerotten)
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C			
-						
-				if(!H.original_skin_tone) // patchwork slop, the real fix is looking into generate_icon_render_key(), cause like 90% of this code, we have two different versions of it, one for mobliving other for moblivinghuman
-					H.original_skin_tone = H.skin_tone
-
-				H.skin_tone = "878f79" //elf ears
+				H.skin_tone = SKIN_COLOR_ROT // "878f79"
 			if(soundloop && soundloop.stopped && !is_zombie)
 				soundloop.start()
 		C.update_body()

--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -82,5 +82,7 @@
 		bodypart.update_limb()
 		bodypart.update_disabled()
 
-	target.skin_tone = da_skin
+	if(ishuman(target)) // did you know drunk driving is safer if you do it in a car rather than a bike?
+		var/mob/living/carbon/human/H = target			
+		H.skin_tone = da_skin 
 	target.update_body()

--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -81,4 +81,10 @@
 		bodypart.update_limb()
 		bodypart.update_disabled()
 
+		if(ishuman(target)) // more patchwork slop
+			var/mob/living/carbon/human/H = target
+			if(H.original_skin_tone)
+				H.skin_tone = H.original_skin_tone
+				H.original_skin_tone = null
+
 	target.update_body()

--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -75,16 +75,12 @@
 
 ///Cure bodyparts
 /proc/clean_body_parts(mob/living/carbon/target)
+	var/da_skin = getblock(target.dna.uni_identity, DNA_SKIN_TONE_BLOCK) // copied from mirror transform, think this is where we store skin data(???)
 	for (var/obj/item/bodypart/bodypart in target.bodyparts)
 		bodypart.rotted = FALSE
 		bodypart.skeletonized = FALSE
 		bodypart.update_limb()
 		bodypart.update_disabled()
 
-		if(ishuman(target)) // more patchwork slop
-			var/mob/living/carbon/human/H = target
-			if(H.original_skin_tone)
-				H.skin_tone = H.original_skin_tone
-				H.original_skin_tone = null
-
+	target.skin_tone = da_skin
 	target.update_body()


### PR DESCRIPTION
## About The Pull Request

- "Fixes" an annoying problem on live right now that makes your skin color not revert to its base color when you are cured of rot. I made it so the procs store your original skin color before rotting, and recall said skin color on cure.

#### !!! _NOTE FOR MAINT GANG_ !!!
This is a patchwork fix to the issue, the real problem might be in another proc.

## Testing Evidence

This is unfortunately, quite difficult to test on local unless someone gives me a good suggestion on how to tackle it. But all I did was slap a bandaid on it that.

Visual representation of my bugfix:
<img width="427" height="256" alt="mashallah" src="https://github.com/user-attachments/assets/7efee7e3-746f-4012-bf6d-3ad4ab56568a" />


## Why It's Good For The Game

I am not into necrophilia.

## Changelog
:cl:
fix: Fixed the greenskin bug (patchwork slop, though!)
/:cl: