### PR TITLE
Reverts Pull 6679: Layering fixes so sleeves appear on armor once more

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -38,12 +38,12 @@
 #define SHOES_LAYER				35
 #define SHOESLEEVE_LAYER		34
 #define SHIRT_LAYER				33
-#define HANDS_PART_LAYER		32
-#define WRISTS_LAYER			31
-#define ARMOR_LAYER				30
-#define TABARD_LAYER			29		//only when looking south
-#define BELT_LAYER				28
-#define UNDER_CLOAK_LAYER		27
+#define WRISTS_LAYER			32
+#define ARMOR_LAYER				31
+#define TABARD_LAYER			30
+#define BELT_LAYER				29		//only when looking south
+#define UNDER_CLOAK_LAYER		28
+#define HANDS_PART_LAYER		27
 #define GLOVES_LAYER			26
 #define ARM_DAMAGE_LAYER		25
 #define SHIRTSLEEVE_LAYER		24
@@ -61,7 +61,7 @@
 #define MOUTH_LAYER				12
 #define HEAD_LAYER				11
 #define BACK_LAYER				10		//only when looking north
-#define HANDS_LAYER				9		//the item in hand, not the actual hands.
+#define HANDS_LAYER				9
 #define HANDCUFF_LAYER			8
 #define LEGCUFF_LAYER			7
 #define BODY_FRONT_LAYER		6

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -121,8 +121,6 @@
 	var/list/appearance_list = list()
 //	var/specific_layer = aux ? aux_layer : BODYPARTS_LAYER
 	var/specific_layer = aux_layer ? aux_layer : BODYPARTS_LAYER
-	if((specific_layer == HANDS_PART_LAYER) && (human_owner.wear_shirt)) // Arms snowflake check
-		return appearance_list
 	var/specific_render_zone = aux ? aux_zone : body_zone
 	for(var/key in specific_markings)
 		var/color = specific_markings[key]


### PR DESCRIPTION
## About The Pull Request
Reverts: https://github.com/Azure-Peak/Azure-Peak/pull/6679

I have bad news, this breaks sleeves for armor, and wearing armor breaks markings. We're gonna have to find another solution for the markings appearing through sleeves issue.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Revert booted successfully, sleeves reappeared for everything missing them. (Gambesons, tabards, armor, etc)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Reverts an issue.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Reverts changes made to sleeves that made them not appear for armor/cloaks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
