### PR TITLE
Create Hearth cantrip

### DIFF
--- a/code/modules/spells/spell_types/wizard/minor_aspects.dm
+++ b/code/modules/spells/spell_types/wizard/minor_aspects.dm
@@ -139,6 +139,7 @@
 		/datum/action/cooldown/spell/light,
 		/datum/action/cooldown/spell/mending,
 		/datum/action/cooldown/spell/create_campfire,
+		/datum/action/cooldown/spell/create_hearth,
 	)
 
 /datum/magic_aspect/illusion
@@ -176,6 +177,7 @@
 	fixed_spells = list(
 		/datum/action/cooldown/spell/great_shelter,
 		/datum/action/cooldown/spell/create_campfire,
+		/datum/action/cooldown/spell/create_hearth,
 	)
 
 /datum/magic_aspect/hex

--- a/code/modules/spells/spell_types/wizard/spell_list.dm
+++ b/code/modules/spells/spell_types/wizard/spell_list.dm
@@ -4,6 +4,7 @@ to all mage classes.
 GLOBAL_LIST_INIT(utility_spells, (list(
 		/datum/action/cooldown/spell/chill_food,
 		/datum/action/cooldown/spell/create_campfire,
+		/datum/action/cooldown/spell/create_hearth,
 		/datum/action/cooldown/spell/darkvision,
 		/datum/action/cooldown/spell/greater_cleaning,
 		/datum/action/cooldown/spell/lesser_knock,

--- a/code/modules/spells/spell_types/wizard/utility/create_campfire.dm
+++ b/code/modules/spells/spell_types/wizard/utility/create_campfire.dm
@@ -1,7 +1,7 @@
 /datum/action/cooldown/spell/create_campfire
 	button_icon = 'icons/mob/actions/roguespells.dmi'
 	name = "Create Campfire"
-	desc = "Creates a magical campfire to cook on. 3 tiles range. Lasts for 10 minutes."
+	desc = "Creates a magical campfire for warmth and respite. 3 tiles range. Lasts for 10 minutes."
 	button_icon_state = "create_campfire"
 	sound = 'sound/magic/whiteflame.ogg'
 	spell_color = GLOW_COLOR_FIRE
@@ -44,7 +44,7 @@
 	var/turf/target = get_turf(cast_on)
 
 	if(!target || !target.Enter(owner) || is_type_in_list(target, turf_blacklist))
-		to_chat(owner, span_warning("This turf can't be on fiyaaaah! (It's blocked sire.)"))
+		to_chat(owner, span_warning("The campfire cannot be conjured there."))
 		return FALSE
 	
 	new /obj/machinery/light/rogue/campfire/create_campfire(target)
@@ -70,6 +70,62 @@
 		QDEL_IN(src, lifespan) //delete after it runs out
 
 /obj/machinery/light/rogue/campfire/create_campfire/onkick(mob/user)
+	var/mob/living/L = user
+	L.visible_message(span_info("[L] kicks \the [src], the arcyne fire dissipating."))
+	burn_out()
+	qdel(src)
+
+/datum/action/cooldown/spell/create_hearth
+	name = "Create Hearth"
+	desc = "Creates a magical hearth for cooking. 3 tiles range. Lasts for 10 minutes."
+	button_icon = 'icons/mob/actions/roguespells.dmi'
+	button_icon_state = "create_campfire"
+	sound = 'sound/magic/whiteflame.ogg'
+	spell_color = "#6495ED"
+	glow_intensity = GLOW_INTENSITY_LOW
+
+	click_to_activate = TRUE
+	self_cast_possible = FALSE
+	cast_range = 3
+
+	primary_resource_type = SPELL_COST_STAMINA
+	primary_resource_cost = SPELLCOST_CANTRIP
+
+	invocations = list("Ignis Focus Magicae.")
+	invocation_type = INVOCATION_SHOUT
+
+	charge_required = TRUE
+	charge_time = 3 SECONDS
+	charge_drain = 1
+	charge_slowdown = CHARGING_SLOWDOWN_MEDIUM
+	charge_sound = 'sound/magic/charging.ogg'
+	cooldown_time = 60 SECONDS
+
+	associated_skill = /datum/skill/magic/arcane
+	spell_tier = 1
+	spell_impact_intensity = SPELL_IMPACT_NONE
+	point_cost = 1
+
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_NO_MOVE | SPELL_REQUIRES_SAME_Z
+	var/fire_type = /obj/machinery/light/rogue/hearth/conjured
+	var/static/list/turf_blacklist = list(
+		/turf/open/water,
+		/turf/open/transparent,
+		/turf/closed/transparent,
+		)
+
+/datum/action/cooldown/spell/create_hearth/cast(atom/cast_on)
+	. = ..()
+	var/turf/target = get_turf(cast_on)
+
+	if(!target || !target.Enter(owner) || is_type_in_list(target, turf_blacklist))
+		to_chat(owner, span_warning("The hearth cannot be conjured there."))
+		return FALSE
+	
+	new /obj/machinery/light/rogue/hearth/conjured(target)
+	return TRUE
+
+/obj/machinery/light/rogue/hearth/conjured/onkick(mob/user)
 	var/mob/living/L = user
 	L.visible_message(span_info("[L] kicks \the [src], the arcyne fire dissipating."))
 	burn_out()


### PR DESCRIPTION
## About The Pull Request

- Adds an alternative version of Create Campfire that makes a Hearth instead.

## Testing Evidence

<img width="797" height="257" alt="Screenshot_3" src="https://github.com/user-attachments/assets/92947675-29b2-460d-8342-8945896333a9" />
<img width="311" height="196" alt="Screenshot_2" src="https://github.com/user-attachments/assets/a58d1b17-a41a-4061-b4d3-a153de206b7f" />

## Why It's Good For The Game

A lot of cooler camping things are not something we can use with Create Campfire, so, Create Hearth's likely the most elegant solution here.

## Changelog

:cl:
add: Create Hearth cantrip spell (1 point)
/:cl: