### PR TITLE
Buckle bugfix for chairs

### DIFF
--- a/code/game/objects/structures/beds_chairs/roguechair.dm
+++ b/code/game/objects/structures/beds_chairs/roguechair.dm
@@ -45,6 +45,7 @@
 		if(user.m_intent == MOVE_INTENT_SNEAK)
 			hideinside(user)
 			return
+		return ..()
 
 /obj/structure/chair/bench/proc/hideinside(mob/living/user)
 	var/sneak_level = user.get_skill_level(/datum/skill/misc/sneaking) || 0


### PR DESCRIPTION
## About The Pull Request
I recently fixed the bug for bed buckling and it didn't occur to me that chairs also are buckleable. So chairs also get a parent call to prevent weird buckle states.

## Testing Evidence

Yeah.

## Why It's Good For The Game

Bug bad.