### PR TITLE
Adds a crafting recipe for open eoran robes

### DIFF
--- a/code/modules/roguetown/roguecrafting/weaving.dm
+++ b/code/modules/roguetown/roguecrafting/weaving.dm
@@ -195,8 +195,16 @@
 	sellprice = 20
 
 /datum/crafting_recipe/roguetown/weaving/eorarobes
-	name = "eora robes"
+	name = "eoran robes"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/eora)
+	reqs = list(/obj/item/natural/cloth = 2,
+				/obj/item/natural/silk = 1)
+	craftdiff = 3
+	sellprice = 20
+
+/datum/crafting_recipe/roguetown/weaving/openeorarobes
+	name = "open eoran robes"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/robe/eora/alt)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/silk = 1)
 	craftdiff = 3


### PR DESCRIPTION
## About The Pull Request

All this does is add a crafting recipe to the pre-existing Open Eoran Robes. I should have done this in my other PR but I was tired and wanted to go to bed and stop testing. Also changes the "eora robes" crafting recipe to be called "eoran robes." The mask is _also_ noted as Eoran, so it felt right to standardize.

## Testing Evidence

Works.
<img width="254" height="35" alt="craft test" src="https://github.com/user-attachments/assets/5d81c041-12cc-4d83-bf1e-67ef57932093" />

## Why It's Good For The Game

It makes the Open Eoran Robes even more attainable. You can now get them if you're competent at sewing and a Baothan for example. There's something to be said about a Baothan in the radical Eoran outfit, I think.

## Changelog

:cl:
add: Added an Open Eoran Robes crafting recipe
spellcheck: Changed the grammar of the eoran robes entry in weaving, if anyone cares.
/:cl:
