### PR TITLE
disable gnoll and dreamwalker

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1188,10 +1188,19 @@ SUBSYSTEM_DEF(gamemode)
 		return 1
 	return storyteller_favors_antag(storyteller_favor_flags, storyteller_type, roundstart) ? STORYTELLER_STANDARD_FAVOR_MULTIPLIER : 1
 
+/datum/controller/subsystem/gamemode/proc/antag_can_roll(antag_datum)
+	if(!ispath(antag_datum, /datum/antagonist))
+		return TRUE
+	return initial(antag_datum:can_roll)
+
 /datum/controller/subsystem/gamemode/proc/storyteller_event_weight(datum/round_event_control/event, base_weight, storyteller_type = null)
 	if(!event)
 		return 0
 	base_weight = max(0, round(base_weight))
+	if(istype(event, /datum/round_event_control/antagonist/solo))
+		var/datum/round_event_control/antagonist/solo/antag_event = event
+		if(!antag_can_roll(antag_event.antag_datum))
+			return 0
 	storyteller_type = story_policy_type(event.roundstart, storyteller_type)
 	if(!storyteller_type)
 		return base_weight
@@ -1218,6 +1227,8 @@ SUBSYSTEM_DEF(gamemode)
 	var/failure_reason = event.return_failure_string(player_count)
 	if(length(failure_reason))
 		return failure_reason
+	if(!antag_can_roll(event.antag_datum))
+		return "disabled by antagonist roll settings"
 	if(storyteller_blocks_antag(event.storyteller_antag_flags, event.roundstart, storyteller_type))
 		return "blocked by storyteller antag flags"
 	if(storyteller_blocks_type(event.storyteller_guarantee_flags, storyteller_type, event.roundstart))
@@ -1240,10 +1251,14 @@ SUBSYSTEM_DEF(gamemode)
 /datum/controller/subsystem/gamemode/proc/storyteller_picked_roundstart_antag(antag_datum)
 	if(!ispath(antag_datum, /datum/antagonist))
 		return FALSE
+	if(!antag_can_roll(antag_datum))
+		return FALSE
 	var/datum/round_event_control/antagonist/solo/roundstart_event = current_roundstart_event
 	if(!roundstart_event)
 		return FALSE
 	if(!ispath(roundstart_event.antag_datum, /datum/antagonist))
+		return FALSE
+	if(!antag_can_roll(roundstart_event.antag_datum))
 		return FALSE
 	return ispath(roundstart_event.antag_datum, antag_datum) || ispath(antag_datum, roundstart_event.antag_datum)
 
@@ -1256,6 +1271,8 @@ SUBSYSTEM_DEF(gamemode)
 	return story_antag_open_slots(roundstart_event.antag_datum, get_correct_popcount())
 
 /datum/controller/subsystem/gamemode/proc/storyteller_unlocks_scaled_antag_slots(antag_datum, storyteller_favor_flags = null)
+	if(!antag_can_roll(antag_datum))
+		return FALSE
 	if(storyteller_picked_roundstart_antag(antag_datum))
 		return TRUE
 	if(isnull(storyteller_favor_flags) && ispath(antag_datum, /datum/antagonist))
@@ -1272,10 +1289,14 @@ SUBSYSTEM_DEF(gamemode)
 /datum/controller/subsystem/gamemode/proc/story_antag_min_players(antag_datum)
 	if(!ispath(antag_datum, /datum/antagonist))
 		return 0
+	if(!antag_can_roll(antag_datum))
+		return 0
 	return max(0, initial(antag_datum:storyteller_min_players))
 
 /datum/controller/subsystem/gamemode/proc/story_antag_open_slots(antag_datum, player_count = null)
 	if(!ispath(antag_datum, /datum/antagonist))
+		return FALSE
+	if(!antag_can_roll(antag_datum))
 		return FALSE
 	if(!initial(antag_datum:override_candidatereq))
 		return FALSE
@@ -1302,6 +1323,8 @@ SUBSYSTEM_DEF(gamemode)
 /datum/controller/subsystem/gamemode/proc/story_antag_slot_cap(antag_datum, roundstart = FALSE, storyteller_type = null)
 	if(!ispath(antag_datum, /datum/antagonist))
 		return 0
+	if(!antag_can_roll(antag_datum))
+		return 0
 	storyteller_type = story_policy_type(roundstart, storyteller_type)
 	var/storyteller_antag_flags = initial(antag_datum:storyteller_antag_flags)
 	if(storyteller_blocks_antag(storyteller_antag_flags, roundstart, storyteller_type))
@@ -1316,6 +1339,8 @@ SUBSYSTEM_DEF(gamemode)
 	return default_cap
 /datum/controller/subsystem/gamemode/proc/story_antag_slots(slot_count, antag_datum, player_count = null)
 	if(slot_count <= 0)
+		return 0
+	if(!antag_can_roll(antag_datum))
 		return 0
 	if(isnull(player_count))
 		player_count = get_correct_popcount()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/list/storyteller_maxcaps
 	var/storyteller_min_players = 0
 	var/override_candidatereq = FALSE
+	var/can_roll = TRUE
 
 /datum/antagonist/New()
 	GLOB.antagonists += src

--- a/code/modules/antagonists/roguetown/villain/dreamwalker.dm
+++ b/code/modules/antagonists/roguetown/villain/dreamwalker.dm
@@ -11,6 +11,7 @@
 	job_rank = ROLE_DREAMWALKER
 	storyteller_antag_flags = STORYTELLER_ANTAG_SOFT
 	storyteller_favor_flags = STORYTELLER_FAVOR_DREAMWALKER
+	can_roll = FALSE
 	confess_lines = list(
 		"MY VISION ABOVE ALL!",
 		"I'LL TAKE YOU TO MY REALM!",

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
@@ -29,6 +29,7 @@
 	job_rank = ROLE_GNOLL
 	storyteller_antag_flags = STORYTELLER_ANTAG_SOFT
 	storyteller_favor_flags = STORYTELLER_FAVOR_GNOLL
+	can_roll = FALSE
 
 /datum/antagonist/gnoll/on_gain()
 	greet()

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -17,10 +17,19 @@
 /datum/round_event_control/antagonist/migrant_wave/banditsorgnolls/preRunEvent()
 	if(is_storyteller_soft_antag_blocked())
 		return EVENT_CANT_RUN
+	if(is_storyteller_villain_blocked() && !SSgamemode.antag_can_roll(/datum/antagonist/gnoll))
+		return EVENT_CANT_RUN
 	return ..()
 
 /datum/round_event/migrant_wave/banditsorgnolls/start()
-	var/evilmode = is_storyteller_villain_blocked() ? "gnolls" : pick("gnolls", "bandits")
+	var/list/evil_modes = list()
+	if(!is_storyteller_villain_blocked())
+		evil_modes += "bandits"
+	if(SSgamemode.antag_can_roll(/datum/antagonist/gnoll))
+		evil_modes += "gnolls"
+	if(!length(evil_modes))
+		return
+	var/evilmode = pick(evil_modes)
 	if(evilmode == "bandits")
 		var/datum/job/bandit_job = SSjob.GetJob("Bandit")
 		var/bandit_maxcap = max(SSgamemode.story_antag_slot_cap(/datum/antagonist/bandit), bandit_job.total_positions)

--- a/code/modules/events/antagonist/solo/_base.dm
+++ b/code/modules/events/antagonist/solo/_base.dm
@@ -30,6 +30,8 @@
 	. = ..()
 	if(!.)
 		return
+	if(!SSgamemode.antag_can_roll(antag_datum))
+		return FALSE
 	var/is_hard_roundstart = roundstart && (storyteller_antag_flags & STORYTELLER_ANTAG_VILLAIN)
 	if(is_hard_roundstart && players_amt < HARD_ANTAG_MIN_POP)
 		return FALSE
@@ -41,6 +43,8 @@
 		return FALSE
 
 /datum/round_event_control/antagonist/solo/proc/get_antag_amount()
+	if(!SSgamemode.antag_can_roll(antag_datum))
+		return 0
 	var/people = SSgamemode.get_correct_popcount()
 	var/storyteller_cap = SSgamemode.story_antag_slot_cap(antag_datum, roundstart = roundstart)
 	if(storyteller_cap > 0)
@@ -62,6 +66,11 @@
 
 /datum/round_event_control/antagonist/solo/return_failure_string(players_amt)
 	. =..()
+	if(!SSgamemode.antag_can_roll(antag_datum))
+		if(.)
+			. += ", "
+		. += "Antagonist roll disabled"
+		return .
 	var/is_hard_roundstart = roundstart && (storyteller_antag_flags & STORYTELLER_ANTAG_VILLAIN)
 	if(is_hard_roundstart && players_amt < HARD_ANTAG_MIN_POP)
 		if(.)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -47,11 +47,15 @@
 	)
 
 /datum/job/roguetown/gnoll/special_job_check(mob/dead/new_player/player)
+	if(!SSgamemode.antag_can_roll(/datum/antagonist/gnoll))
+		return FALSE
 	if(is_storyteller_soft_antag_blocked())
 		return FALSE
 	return ..()
 
 /datum/job/roguetown/gnoll/special_check_latejoin(client/C)
+	if(!SSgamemode.antag_can_roll(/datum/antagonist/gnoll))
+		return FALSE
 	if(is_storyteller_soft_antag_blocked())
 		return FALSE
 	return ..()
@@ -108,6 +112,9 @@
 
 /proc/gnollslot_calc()
 	var/list/result = list()
+	if(!SSgamemode.antag_can_roll(/datum/antagonist/gnoll))
+		result["final_slots"] = 0
+		return result
 	if(is_storyteller_soft_antag_blocked())
 		result["final_slots"] = 0
 		return result


### PR DESCRIPTION
## About The Pull Request

1. adds `can_roll` to easily disable roles.
2. disables gnoll and dreamwalker spawns.

## Testing Evidence

tested

## Why It's Good For The Game

1. ease of use in future
2. gnoll and dreamwalker are currently points of big contention balance-wise and there's no view of them improving in the near future. disabling them minimises the damage that they do to a player's round until they can actually be fixed.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
code: disable dreamwalker and gnolls from spawn.
code: add `can_roll` to block roundstart/midround antag spawns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
