### PR TITLE
Aesthetic Storage Toggle & Masks

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -52,3 +52,4 @@
 #define ANTI_TINFOIL_MANEUVER   (1<<12) //Hats with negative effects when worn (i.e the tinfoil hat).
 #define CANT_SLEEP_IN			(1<<13) //Makes you unable to sleep with this on
 #define TAUR_COMPATIBLE			(1<<14) // Clothing that can be worn by taurs
+#define NOT_SHOW_IN_STORAGE	(1<<15)	// Whether we'll show up if we're held in aesthetic storage.

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -16,6 +16,8 @@
 	var/list/icon/current = list() //the current hud icons
 	var/vision_correction = 0 //does wearing these glasses correct some of our vision defects?
 	var/glass_colour_type //colors your vision when worn
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/glasses/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is stabbing \the [src] into [user.p_their()] eyes! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -84,7 +84,8 @@
 /obj/item/clothing/head/get_mechanics_examine(mob/user)
 	. = ..()
 	if(attachment_component)
-		. += span_info("Shift-right-click to open the headwear's storage. This can be used to wear cosmetics over it or store smaller items.")
+		. += span_info("Shift + RMB will open aesthetic storage, allowing the user to layer extra decorations over \the [src].")
+		. += span_info("Alt + RMB allows the user to toggle aesthetic storage (Shift + RMB) items on or off.")
 
 /obj/item/clothing/head/ShiftRightClick(mob/user)
 	if(attachment_component)

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -94,6 +94,31 @@
 			return TRUE
 	return ..()
 
+/obj/item/clothing/head/AltRightClick(mob/user)
+	if(attachment_component)
+		var/datum/component/storage/concrete/roguetown/storage_component = GetComponent(attachment_component)
+		if(storage_component && length(storage_component.item_to_grid_coordinates))
+			var/list/options = list()
+			for(var/obj/item/clothing/C in storage_component.item_to_grid_coordinates)
+				if(!C || !isclothing(C))
+					continue
+				if(C.item_flags & NOT_SHOW_IN_STORAGE)
+					options["[C.name] (Hidden)"] = C
+				else
+					options["[C.name] (Shown)"] = C
+			var/choice = input(user, "Choose clothing to layer:","Layering") as null|anything in options
+			if(choice)
+				var/clothes_to_change = options[choice]
+				if(isclothing(clothes_to_change))
+					var/obj/item/clothing/C = clothes_to_change
+					if(C.item_flags & NOT_SHOW_IN_STORAGE)
+						C.item_flags &= ~NOT_SHOW_IN_STORAGE
+					else
+						C.item_flags |= NOT_SHOW_IN_STORAGE
+					to_chat(user, span_info("[C] will be [(C.item_flags & NOT_SHOW_IN_STORAGE) ? "hidden" : "visible"] \the [src]"))
+				user.update_inv_head()
+	
+
 ///Special throw_impact for hats to frisbee hats at people to place them on their heads/attempt to de-hat them.
 /obj/item/clothing/head/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
 	. = ..()
@@ -148,6 +173,8 @@
 		var/datum/component/storage/concrete/roguetown/our_component = GetComponent(attachment_component)
 		if(our_component && length(our_component.item_to_grid_coordinates))
 			for(var/obj/item/thing as anything in our_component.item_to_grid_coordinates)
+				if(thing.item_flags & NOT_SHOW_IN_STORAGE)
+					continue
 				var/mutable_appearance/thing_appearance = thing.build_worn_icon(default_layer, default_icon_file, isinhands, femaleuniform, override_state, female, customi, sleeveindex, boobed_overlay, clip_mask)
 				thing_appearance.appearance_flags = RESET_COLOR
 				thing_appearance.pixel_x = -standing.pixel_x

--- a/code/modules/clothing/rogueclothes/armor/_armor.dm
+++ b/code/modules/clothing/rogueclothes/armor/_armor.dm
@@ -98,7 +98,8 @@
 /obj/item/clothing/suit/roguetown/armor/get_mechanics_examine(mob/user)
 	. = ..()
 	if(attachment_component)
-		. += span_info("Shift-right-click to open the armors's storage. This can be used to wear cosmetics over it")
+		. += span_info("Shift + RMB will open aesthetic storage, allowing the user to layer extra decorations over \the [src].")
+		. += span_info("Alt + RMB allows the user to toggle aesthetic storage (Shift + RMB) items on or off.")
 
 /obj/item/clothing/suit/roguetown/armor/ShiftRightClick(mob/user)
 	if(attachment_component)
@@ -108,6 +109,31 @@
 			return TRUE
 	return ..()
 
+/obj/item/clothing/suit/roguetown/armor/AltRightClick(mob/user)
+	if(attachment_component)
+		var/datum/component/storage/concrete/roguetown/storage_component = GetComponent(attachment_component)
+		if(storage_component && length(storage_component.item_to_grid_coordinates))
+			var/list/options = list()
+			for(var/obj/item/clothing/C in storage_component.item_to_grid_coordinates)
+				if(!C || !isclothing(C))
+					continue
+				if(C.item_flags & NOT_SHOW_IN_STORAGE)
+					options["[C.name] (Hidden)"] = C
+				else
+					options["[C.name] (Shown)"] = C
+			var/choice = input(user, "Choose clothing to layer:","Layering") as null|anything in options
+			if(choice)
+				var/clothes_to_change = options[choice]
+				if(isclothing(clothes_to_change))
+					var/obj/item/clothing/C = clothes_to_change
+					if(C.item_flags & NOT_SHOW_IN_STORAGE)
+						C.item_flags &= ~NOT_SHOW_IN_STORAGE
+					else
+						C.item_flags |= NOT_SHOW_IN_STORAGE
+					to_chat(user, span_info("[C] will be [(C.item_flags & NOT_SHOW_IN_STORAGE) ? "hidden" : "visible"] \the [src]"))
+				user.update_inv_head()
+
+
 /obj/item/clothing/suit/roguetown/armor/build_worn_icon(default_layer = 0, default_icon_file = null, isinhands = FALSE, femaleuniform = NO_FEMALE_UNIFORM, override_state = null, female = FALSE, customi = null, sleeveindex, boobed_overlay = FALSE, var/icon/clip_mask = null)
 	var/mutable_appearance/standing = ..()
 	// get attachment component and check if there's anything inside
@@ -115,6 +141,8 @@
 		var/datum/component/storage/concrete/roguetown/our_component = GetComponent(attachment_component)
 		if(our_component && length(our_component.item_to_grid_coordinates))
 			for(var/obj/item/thing as anything in our_component.item_to_grid_coordinates)
+				if(thing.item_flags & NOT_SHOW_IN_STORAGE)
+					continue
 				var/mutable_appearance/thing_appearance = thing.build_worn_icon(default_layer, default_icon_file, isinhands, femaleuniform, override_state, female, customi, sleeveindex, boobed_overlay, clip_mask)
 				thing_appearance.appearance_flags = RESET_COLOR
 				thing_appearance.pixel_x += standing.pixel_x

--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -51,6 +51,9 @@
 	. = ..()
 	. += span_info("Visored helmets can be articulated by right-clicking them. Lifted visors offer a wider field of view, but expose your face to precise strikes.")
 	. += span_info("Certain helmets can be further decorated by left-clicking them with a feather, cloth, or both.")
+	. += span_info("MMB will reveal my character's hair from underneath \the [src].")
+	. += span_info("Shift + RMB will open aesthetic storage, allowing the user to layer extra decorations over \the [src].")
+	. += span_info("Alt + RMB allows the user to toggle aesthetic storage (Shift + RMB) items on or off.")
 
 /obj/item/clothing/head/roguetown/helmet/skullcap
 	name = "skull cap"

--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -52,8 +52,6 @@
 	. += span_info("Visored helmets can be articulated by right-clicking them. Lifted visors offer a wider field of view, but expose your face to precise strikes.")
 	. += span_info("Certain helmets can be further decorated by left-clicking them with a feather, cloth, or both.")
 	. += span_info("MMB will reveal my character's hair from underneath \the [src].")
-	. += span_info("Shift + RMB will open aesthetic storage, allowing the user to layer extra decorations over \the [src].")
-	. += span_info("Alt + RMB allows the user to toggle aesthetic storage (Shift + RMB) items on or off.")
 
 /obj/item/clothing/head/roguetown/helmet/skullcap
 	name = "skull cap"

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -44,16 +44,6 @@
 			update_icon()
 			return
 
-/obj/item/clothing/mask/rogue/MiddleClick(mob/user)
-	if(!ishuman(user))
-		return
-	to_chat(user, span_info("I [overarmor ? "wear \the [src] under my hair" : "wear \the [src] over my hair"]."))
-	if(flags_inv & HIDE_HEADTOP)
-		flags_inv &= ~HIDE_HEADTOP
-	else
-		flags_inv |= HIDE_HEADTOP
-	user.update_inv_head()
-
 /obj/item/clothing/mask/rogue/get_mechanics_examine()
 	. = ..()
 

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -44,10 +44,21 @@
 			update_icon()
 			return
 
-/obj/item/clothing/mask/rogue/examine()
+/obj/item/clothing/mask/rogue/MiddleClick(mob/user)
+	if(!ishuman(user))
+		return
+	to_chat(user, span_info("I [overarmor ? "wear \the [src] under my hair" : "wear \the [src] over my hair"]."))
+	if(flags_inv & HIDE_HEADTOP)
+		flags_inv &= ~HIDE_HEADTOP
+	else
+		flags_inv |= HIDE_HEADTOP
+	user.update_inv_head()
+
+/obj/item/clothing/mask/rogue/get_mechanics_examine()
 	. = ..()
 
-	. += "[span_notice("Alt+RMB while on face to swap sprites between snout and standard variant, if it exists.")]"
+	. += span_notice("Alt+RMB while on face to swap sprites between snout and standard variant, if it exists.")
+	. += span_info("MMB will reveal my character's hair from underneath \the [src].")
 
 /obj/item/clothing/mask/rogue/spectacles
 	name = "spectacles"
@@ -61,11 +72,16 @@
 	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HEAD
 	anvilrepair = /datum/skill/craft/armorsmithing
 //	block2add = FOV_BEHIND
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/faceveil
 	name = "simple veil"
 	icon_state = "faceveil"
 	desc = "A remarkably plain veil meant to conceal ones face... if you wore this, a gust of wind would be all it takes to reveal your identity."
+	grid_width = 32
+	grid_height = 32
+
 /obj/item/clothing/mask/rogue/spectacles/inq
 	name = "otavan nocshade lens-pair"
 	icon_state = "bglasses"
@@ -78,6 +94,8 @@
 	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HEAD
 	anvilrepair = /datum/skill/craft/armorsmithing
 	var/lensmoved = FALSE
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/spectacles/inq/spawnpair
 	lensmoved = TRUE
@@ -192,6 +210,8 @@
 	block2add = FOV_RIGHT
 	body_parts_covered = EYES
 	sewrepair = TRUE
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/eyepatch/left
 	desc = "An eyepatch, fitted for the left eye."
@@ -491,6 +511,8 @@
 	toggle_icon_state = TRUE
 	experimental_onhip = TRUE
 	sewrepair = TRUE
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/shepherd/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, 'sound/foley/equip/rummaging-03.ogg', null, (UPD_HEAD|UPD_MASK))	//Standard mask
@@ -513,6 +535,8 @@
 	sewrepair = TRUE
 	salvage_result = /obj/item/natural/hide/cured
 	salvage_amount = 1
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/physician/feld
 	name = "feldsher's mask"
@@ -557,6 +581,8 @@
 	toggle_icon_state = TRUE
 	experimental_onhip = TRUE
 	sewrepair = TRUE
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/ragmask/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, 'sound/foley/equip/rummaging-03.ogg', null, (UPD_HEAD|UPD_MASK))	//Standard mask
@@ -602,6 +628,8 @@
 	toggle_icon_state = FALSE
 	salvage_result = /obj/item/natural/silk
 	salvage_amount = 2
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/silkmask/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, 'sound/foley/equip/rummaging-03.ogg', null, (UPD_HEAD|UPD_MASK))	//Standard mask
@@ -616,6 +644,8 @@
 	tint = 3
 	mob_overlay_icon = 'icons/mob/clothing/eyes.dmi'
 	icon = 'icons/obj/clothing/glasses.dmi'
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/blindfold/fake
 	desc = "A strip of cloth tied around the eyes. It's too transparent to block vision."
@@ -632,6 +662,8 @@
 	detail_tag = "_detail"
 	detail_color = COLOR_SILVER
 	sewrepair = TRUE
+	grid_width = 32
+	grid_height = 32
 
 /obj/item/clothing/mask/rogue/courtphysician
 	name = "head physician's mask"


### PR DESCRIPTION
## About The Pull Request
- Masks (and spectacles) that are unarmored now occupy 1x1 inventory grid space
   - <img width="141" height="135" alt="dreamseeker_Ueei4tyhbB" src="https://github.com/user-attachments/assets/3e5e5c09-7426-466a-a237-e05fa0067c43" />


- Alt + RMB on a helmet can now toggle aesthetic storage items on / off from being shown. This will stay applied to the item even if it's taken out of storage. (It'll still be visible if equipped normally)
   - <img width="268" height="236" alt="dreamseeker_gnCPkVOGRN" src="https://github.com/user-attachments/assets/0b8f8db0-895f-43c5-8bd8-ee495a1726aa" />

- Cleaned up a few mechanics examines for helmets and armor to reflect this new mechanic.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
By request! I mostly was trying to get them to layer *under* the parent storage obj, but it seems overlays struggle to cull themselves like that or skill issue.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
