### PR TITLE
[Storyteller] - Attempts to reimplement polling for injection.

### DIFF
--- a/code/modules/events/antagonist/solo/_base.dm
+++ b/code/modules/events/antagonist/solo/_base.dm
@@ -109,55 +109,72 @@
 /datum/round_event/antagonist/solo/setup()
 	var/datum/round_event_control/antagonist/solo/cast_control = control
 	var/requested_antag_count = cast_control.get_antag_amount()
-
+	antag_count = requested_antag_count
 	antag_flag = cast_control.antag_flag
 	antag_datum = cast_control.antag_datum
 	restricted_roles = cast_control.restricted_roles
 	prompted_picking = cast_control.prompted_picking
-	
 	var/list/possible_candidates = cast_control.get_candidates()
-	var/list/picked_mobs = list()
-
+	var/list/candidates = list()
+	if(cast_control == SSgamemode.current_roundstart_event && length(SSgamemode.roundstart_antag_minds))
+		log_storyteller("Running roundstart antagonist assignment, event: [src], roundstart_antag_minds: [english_list(SSgamemode.roundstart_antag_minds)]")
+		for(var/datum/mind/antag_mind in SSgamemode.roundstart_antag_minds)
+			if(!antag_mind.current)
+				log_storyteller("Roundstart antagonist setup error: antag_mind([antag_mind]) in roundstart_antag_minds without a set mob")
+				continue
+			candidates += antag_mind.current
+			SSgamemode.roundstart_antag_minds -= antag_mind
+			log_storyteller("Roundstart antag_mind, [antag_mind]")
+	
 	if(prompted_picking)
-		while(length(possible_candidates) && length(picked_mobs) < requested_antag_count)
-			var/mob/M = pick_n_take(possible_candidates)
+		// Trying a callback here to avoid hanging the event logic.
+		INVOKE_ASYNC(src, PROC_REF(poll_and_assign), possible_candidates)
+		setup = TRUE // We tell the controller we started successfully
+		return
 
-			if(!M || !M.client || QDELETED(M))
-				continue
+	//guh
+	var/list/cliented_list = list()
+	for(var/mob/living/mob as anything in possible_candidates)
+		cliented_list += mob.client
 
-			var/ask_choice = tgui_alert(M, "Would you like to become a [cast_control.name]?", "Antagonist Offer", list("Yes", "No"), 20 SECONDS)
+	while(length(possible_candidates) && length(candidates) < antag_count) //both of these pick_n_take from weighted_candidates so this should be fine
+		var/mob/picked_ckey = pick_n_take(possible_candidates)
+		var/client/picked_client = picked_ckey.client
+		if(QDELETED(picked_client))
+			continue
+		var/mob/picked_mob = picked_client.mob
+		picked_mob?.mind?.picking = TRUE
+		log_storyteller("Picked antag event mob: [picked_mob], special role: [picked_mob.mind?.special_role ? picked_mob.mind.special_role : "none"]")
+		candidates |= picked_mob
 
-			if(ask_choice == "Yes")
-				picked_mobs += M
-				message_admins("STORYTELLER: [key_name_admin(M)] accepted the [cast_control.name] offer.")
-			else
-				log_storyteller("[key_name(M)] declined the [cast_control.name] offer.")
-				continue
-
-	// instant pick
+	antag_count = min(antag_count, length(candidates))
+	if(antag_count <= 0)
+		message_admins("STORYTELLER:[cast_control.name] failed to spawn because it had no valid candidates at setup.")
+		log_storyteller("STORYTELLER:[cast_control.name] failed to spawn because it had no valid candidates at setup.")
+		return
+	if(antag_count < requested_antag_count)
+		message_admins("STORYTELLER:[cast_control.name] partially filled from [requested_antag_count] to [antag_count] due to limited valid candidates.")
+		log_storyteller("STORYTELLER:[cast_control.name] partially filled from [requested_antag_count] to [antag_count] due to limited valid candidates.")
 	else
-		while(length(possible_candidates) && length(picked_mobs) < requested_antag_count)
-			var/mob/M = pick_n_take(possible_candidates)
-			if(M)
-				picked_mobs += M
+		message_admins("STORYTELLER:[cast_control.name] spawning [antag_count].")
 
-	if(!length(picked_mobs))
-		return // Event fails gracefully
+	var/list/picked_mobs = list()
+	for(var/i in 1 to antag_count)
+		if(!length(candidates))
+			message_admins("A roleset event got fewer antags then its antag_count and may not function correctly.")
+			break
 
-	for(var/mob/candidate in picked_mobs)
+		var/mob/candidate = pick_n_take(candidates)
+		log_storyteller("Antag event spawned mob: [candidate], special role: [candidate.mind?.special_role ? candidate.mind.special_role : "none"]")
+
 		if(!candidate.mind)
 			candidate.mind = new /datum/mind(candidate.key)
 
-		var/mob/final_mob = candidate
-		if(isobserver(candidate))
-			final_mob = make_body(candidate)
+		setup_minds += candidate.mind
+		candidate.mind.special_role = antag_flag
+		candidate.mind.restricted_roles = restricted_roles
+		picked_mobs += WEAKREF(candidate.client)
 
-		if(final_mob)
-			final_mob.mind.special_role = antag_flag
-			final_mob.mind.restricted_roles = restricted_roles
-			setup_minds += final_mob.mind
-
-	antag_count = length(setup_minds)
 	setup = TRUE
 	if(LAZYLEN(extra_spawned_events))
 		var/event_type = pickweight(extra_spawned_events)
@@ -259,3 +276,44 @@
 	new_character.key = ghost_player.key
 
 	return new_character
+
+/// POLLING LOGIC BELOW.
+
+/datum/round_event/antagonist/solo/proc/poll_and_assign(list/mob/living/possible_candidates)
+	var/datum/round_event_control/antagonist/solo/cast_control = control
+	var/list/willing_candidates = list()
+	var/poll_time = 20 SECONDS
+
+	for(var/mob/living/L in possible_candidates)
+		if(!L.client)
+			continue
+		INVOKE_ASYNC(src, PROC_REF(ask_candidate), L, willing_candidates, poll_time)
+
+	sleep(poll_time)
+
+	for(var/mob/M in willing_candidates)
+		if(QDELETED(M) || !M.client || (M.stat == DEAD && !istype(M, /mob/dead/observer)))
+			willing_candidates -= M
+
+	if(!length(willing_candidates))
+		message_admins("STORYTELLER: [cast_control.name] failed - poll returned no willing candidates.")
+		return
+
+	var/requested_count = cast_control.get_antag_amount()
+	while(length(willing_candidates) && setup_minds.len < requested_count)
+		var/mob/chosen = pick_n_take(willing_candidates)
+
+		if(!chosen.mind)
+			chosen.mind = new /datum/mind(chosen.key)
+
+		setup_minds += chosen.mind
+		chosen.mind.special_role = antag_flag
+		add_datum_to_mind(chosen.mind) 
+	message_admins("STORYTELLER: [cast_control.name] poll finished. [setup_minds.len] antags spawned.")
+
+/datum/round_event/antagonist/solo/proc/ask_candidate(mob/M, list/willing_list, poll_time)
+	var/ask_text = "The storyteller is requesting a [antag_flag]. Would you like to play this role?"
+	var/choice = tgui_alert(M, ask_text, "Antagonist Request", list("Yes", "No"), poll_time)
+	
+	if(choice == "Yes")
+		willing_list += M

--- a/code/modules/events/antagonist/solo/_base.dm
+++ b/code/modules/events/antagonist/solo/_base.dm
@@ -109,66 +109,55 @@
 /datum/round_event/antagonist/solo/setup()
 	var/datum/round_event_control/antagonist/solo/cast_control = control
 	var/requested_antag_count = cast_control.get_antag_amount()
-	antag_count = requested_antag_count
+
 	antag_flag = cast_control.antag_flag
 	antag_datum = cast_control.antag_datum
 	restricted_roles = cast_control.restricted_roles
 	prompted_picking = cast_control.prompted_picking
+	
 	var/list/possible_candidates = cast_control.get_candidates()
-	var/list/candidates = list()
-	if(cast_control == SSgamemode.current_roundstart_event && length(SSgamemode.roundstart_antag_minds))
-		log_storyteller("Running roundstart antagonist assignment, event: [src], roundstart_antag_minds: [english_list(SSgamemode.roundstart_antag_minds)]")
-		for(var/datum/mind/antag_mind in SSgamemode.roundstart_antag_minds)
-			if(!antag_mind.current)
-				log_storyteller("Roundstart antagonist setup error: antag_mind([antag_mind]) in roundstart_antag_minds without a set mob")
-				continue
-			candidates += antag_mind.current
-			SSgamemode.roundstart_antag_minds -= antag_mind
-			log_storyteller("Roundstart antag_mind, [antag_mind]")
-
-	//guh
-	var/list/cliented_list = list()
-	for(var/mob/living/mob as anything in possible_candidates)
-		cliented_list += mob.client
-
-	while(length(possible_candidates) && length(candidates) < antag_count) //both of these pick_n_take from weighted_candidates so this should be fine
-		var/mob/picked_ckey = pick_n_take(possible_candidates)
-		var/client/picked_client = picked_ckey.client
-		if(QDELETED(picked_client))
-			continue
-		var/mob/picked_mob = picked_client.mob
-		picked_mob?.mind?.picking = TRUE
-		log_storyteller("Picked antag event mob: [picked_mob], special role: [picked_mob.mind?.special_role ? picked_mob.mind.special_role : "none"]")
-		candidates |= picked_mob
-
-	antag_count = min(antag_count, length(candidates))
-	if(antag_count <= 0)
-		message_admins("STORYTELLER:[cast_control.name] failed to spawn because it had no valid candidates at setup.")
-		log_storyteller("STORYTELLER:[cast_control.name] failed to spawn because it had no valid candidates at setup.")
-		return
-	if(antag_count < requested_antag_count)
-		message_admins("STORYTELLER:[cast_control.name] partially filled from [requested_antag_count] to [antag_count] due to limited valid candidates.")
-		log_storyteller("STORYTELLER:[cast_control.name] partially filled from [requested_antag_count] to [antag_count] due to limited valid candidates.")
-	else
-		message_admins("STORYTELLER:[cast_control.name] spawning [antag_count].")
-
 	var/list/picked_mobs = list()
-	for(var/i in 1 to antag_count)
-		if(!length(candidates))
-			message_admins("A roleset event got fewer antags then its antag_count and may not function correctly.")
-			break
 
-		var/mob/candidate = pick_n_take(candidates)
-		log_storyteller("Antag event spawned mob: [candidate], special role: [candidate.mind?.special_role ? candidate.mind.special_role : "none"]")
+	if(prompted_picking)
+		while(length(possible_candidates) && length(picked_mobs) < requested_antag_count)
+			var/mob/M = pick_n_take(possible_candidates)
 
+			if(!M || !M.client || QDELETED(M))
+				continue
+
+			var/ask_choice = tgui_alert(M, "Would you like to become a [cast_control.name]?", "Antagonist Offer", list("Yes", "No"), 20 SECONDS)
+
+			if(ask_choice == "Yes")
+				picked_mobs += M
+				message_admins("STORYTELLER: [key_name_admin(M)] accepted the [cast_control.name] offer.")
+			else
+				log_storyteller("[key_name(M)] declined the [cast_control.name] offer.")
+				continue
+
+	// instant pick
+	else
+		while(length(possible_candidates) && length(picked_mobs) < requested_antag_count)
+			var/mob/M = pick_n_take(possible_candidates)
+			if(M)
+				picked_mobs += M
+
+	if(!length(picked_mobs))
+		return // Event fails gracefully
+
+	for(var/mob/candidate in picked_mobs)
 		if(!candidate.mind)
 			candidate.mind = new /datum/mind(candidate.key)
 
-		setup_minds += candidate.mind
-		candidate.mind.special_role = antag_flag
-		candidate.mind.restricted_roles = restricted_roles
-		picked_mobs += WEAKREF(candidate.client)
+		var/mob/final_mob = candidate
+		if(isobserver(candidate))
+			final_mob = make_body(candidate)
 
+		if(final_mob)
+			final_mob.mind.special_role = antag_flag
+			final_mob.mind.restricted_roles = restricted_roles
+			setup_minds += final_mob.mind
+
+	antag_count = length(setup_minds)
 	setup = TRUE
 	if(LAZYLEN(extra_spawned_events))
 		var/event_type = pickweight(extra_spawned_events)

--- a/code/modules/events/antagonist/solo/dreamwalker.dm
+++ b/code/modules/events/antagonist/solo/dreamwalker.dm
@@ -26,6 +26,7 @@
 	antag_datum = /datum/antagonist/dreamwalker
 
 	restricted_roles = DEFAULT_ANTAG_BLACKLISTED_ROLES
+	prompted_picking = TRUE
 
 /datum/round_event/antagonist/solo/dreamwalker
 
@@ -36,4 +37,5 @@
 	base_antags = 2
 	maximum_antags = 2
 	max_occurrences = 1
+	prompted_picking = FALSE
 	allowed_storytellers = list(/datum/storyteller/abyssor)


### PR DESCRIPTION
## About The Pull Request
I'm not that familiar with storyteller code. Apparently there was supposed to be polling support but it was commented out?
**TM first pls**

This attempts to fix that, enabled for mid-round dreamwalkers.

By default, will assume the event is successful to skirt around some other bugs that require a deeper refactor I can't seem to figure out right now.

When enabled, prompts every possible candidate at the same time. Everyone who answered yes is then used for the antag roll. At the end of the polling period, pick a winner at random.

**Only enabled for dreamwalker now as to not accidentally mess up anyone else.**

## Testing Evidence
Triggered dreamwalkers. got polled. Y/N seems to work just fine. Can't test multiple clients but that's what TM is for.

## Why It's Good For The Game
Sometimes you're just not in a good position to become a certain antag (Like ongoing roleplay, being in a public place). Or not in the mood, and you haven't updated your preferences.

## Changelog
:cl:
fix: Antag polling is now functional & enabled for dreamwalkers.
/:cl:

