### PR TITLE
[TM ONLY] Experimental Storyteller Changes

### DIFF
--- a/code/__DEFINES/gnoll.dm
+++ b/code/__DEFINES/gnoll.dm
@@ -2,3 +2,4 @@
 #define GNOLL_SCALING_DYNAMIC 1 // Mode 1: Guaranteed increase until 3 slots, diminishing chances until 10 slots
 #define GNOLL_SCALING_FLAT    2 // Mode 2: 15% chance, capped at 2 slots
 #define GNOLL_SCALING_SINGLE  3 // Mode 3: Single gnoll. We do nothing in code because this is the default.
+#define GNOLL_SCALING_NONE    4 // Mode 4: No gnolls at all. Pantheon thematically excludes them.

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -880,8 +880,6 @@ SUBSYSTEM_DEF(gamemode)
 		misc += "Masquerade can roll with 2 roundstart slots"
 	if(storyteller_type == /datum/storyteller/graggar)
 		misc += "Gnolls and assassins open at 3 slots"
-	if(storyteller_type == /datum/storyteller/abyssor)
-		misc += "Adds 2 roundstart dreamwalkers"
 	if(story_hardequal(storyteller_type))
 		misc += "Hard antags roll at equal chance"
 	if(story_hardonly(storyteller_type))
@@ -1008,7 +1006,7 @@ SUBSYSTEM_DEF(gamemode)
 	switch(storyteller_type)
 		if(/datum/storyteller/psydon)
 			return STORYTELLER_ANTAG_VILLAIN | STORYTELLER_ANTAG_ROUNDSTART | STORYTELLER_ANTAG_SOFT
-		if(/datum/storyteller/eora)
+		if(/datum/storyteller/eora, /datum/storyteller/astrata, /datum/storyteller/ravox)
 			return STORYTELLER_ANTAG_VILLAIN | STORYTELLER_ANTAG_ROUNDSTART
 	return STORYTELLER_ANTAG_NONE
 
@@ -1029,27 +1027,9 @@ SUBSYSTEM_DEF(gamemode)
 	return STORYTELLER_FAVOR_NONE
 
 /datum/controller/subsystem/gamemode/proc/story_guarantee_flags(storyteller_type)
-	if(!ispath(storyteller_type, /datum/storyteller))
-		return STORYTELLER_FAVOR_NONE
-	var/flags = STORYTELLER_FAVOR_NONE
-	switch(storyteller_type)
-		if(/datum/storyteller/psydon)
-			return STORYTELLER_FAVOR_NONE
-		if(/datum/storyteller/graggar)
-			flags |= STORYTELLER_FAVOR_GNOLL | STORYTELLER_FAVOR_ASSASSIN
-		if(/datum/storyteller/matthios)
-			flags |= STORYTELLER_FAVOR_BANDIT
-		if(/datum/storyteller/astrata)
-			flags |= STORYTELLER_FAVOR_MASQUERADE
-		if(/datum/storyteller/zizo)
-			flags |= STORYTELLER_FAVOR_LICH
-		if(/datum/storyteller/baotha)
-			flags |= STORYTELLER_FAVOR_VAMPIRE_LORD
-		if(/datum/storyteller/abyssor)
-			flags |= STORYTELLER_FAVOR_DREAMWALKER
-		if(/datum/storyteller/dendor)
-			flags |= STORYTELLER_FAVOR_WEREWOLF
-	return flags
+	// Guarantees are intentionally empty - every god is now thematic-favored only.
+	// Kept as a proc so callers in storyteller_guaranteed_events() and elsewhere don't break.
+	return STORYTELLER_FAVOR_NONE
 
 /datum/controller/subsystem/gamemode/proc/story_favor_flags(storyteller_type)
 	if(!ispath(storyteller_type, /datum/storyteller))
@@ -1063,6 +1043,20 @@ SUBSYSTEM_DEF(gamemode)
 			return STORYTELLER_FAVOR_LICH
 		if(/datum/storyteller/xylix)
 			return STORYTELLER_FAVOR_HARD_ANTAGS
+		if(/datum/storyteller/astrata)
+			return STORYTELLER_FAVOR_MASQUERADE
+		if(/datum/storyteller/abyssor)
+			return STORYTELLER_FAVOR_DREAMWALKER
+		if(/datum/storyteller/dendor)
+			return STORYTELLER_FAVOR_WEREWOLF
+		if(/datum/storyteller/zizo)
+			return STORYTELLER_FAVOR_LICH
+		if(/datum/storyteller/baotha)
+			return STORYTELLER_FAVOR_VAMPIRE_LORD
+		if(/datum/storyteller/graggar)
+			return STORYTELLER_FAVOR_GNOLL | STORYTELLER_FAVOR_ASSASSIN
+		if(/datum/storyteller/matthios)
+			return STORYTELLER_FAVOR_BANDIT
 	return STORYTELLER_FAVOR_NONE
 
 /datum/controller/subsystem/gamemode/proc/story_hardonly(storyteller_type)
@@ -1083,11 +1077,6 @@ SUBSYSTEM_DEF(gamemode)
 	return storyteller_type in list(/datum/storyteller/pestra, /datum/storyteller/malum)
 
 /datum/controller/subsystem/gamemode/proc/story_bonus_flags(storyteller_type)
-	if(!ispath(storyteller_type, /datum/storyteller))
-		return STORYTELLER_FAVOR_NONE
-	switch(storyteller_type)
-		if(/datum/storyteller/abyssor)
-			return STORYTELLER_FAVOR_DREAMWALKER
 	return STORYTELLER_FAVOR_NONE
 
 /datum/controller/subsystem/gamemode/proc/story_policy_type(roundstart = FALSE, storyteller_type = null)
@@ -1201,7 +1190,8 @@ SUBSYSTEM_DEF(gamemode)
 		return 0
 	var/is_hard_roundstart = event.roundstart && (event.storyteller_antag_flags & STORYTELLER_ANTAG_VILLAIN)
 	if(is_hard_roundstart && story_hardonly(storyteller_type))
-		if(!event.storyteller_guarantee_flags || !storyteller_guarantees_antag(event.storyteller_guarantee_flags, storyteller_type, TRUE))
+		// Themed gods only spawn their favored hard antag at roundstart (legacy guarantee gate, now driven by favor flags).
+		if(!event.storyteller_guarantee_flags || !storyteller_favors_antag(event.storyteller_guarantee_flags, storyteller_type, TRUE))
 			return 0
 	if(is_hard_roundstart && story_hardequal(storyteller_type))
 		return 10
@@ -1224,8 +1214,8 @@ SUBSYSTEM_DEF(gamemode)
 		return "blocked by storyteller hard-antag policy"
 	var/is_hard_roundstart = event.roundstart && (event.storyteller_antag_flags & STORYTELLER_ANTAG_VILLAIN)
 	if(is_hard_roundstart && story_hardonly(storyteller_type))
-		if(!event.storyteller_guarantee_flags || !storyteller_guarantees_antag(event.storyteller_guarantee_flags, storyteller_type, TRUE))
-			return "not storyteller-guaranteed hard antag"
+		if(!event.storyteller_guarantee_flags || !storyteller_favors_antag(event.storyteller_guarantee_flags, storyteller_type, TRUE))
+			return "not storyteller-favored hard antag"
 	return "effective weight 0"
 
 /datum/controller/subsystem/gamemode/proc/story_combat_pop()
@@ -1479,31 +1469,7 @@ SUBSYSTEM_DEF(gamemode)
 		send_to_playing_players(span_notice("[current_storyteller.welcome_text]"))
 
 /datum/controller/subsystem/gamemode/proc/apply_storyteller_bonus_roundstart_antags()
-	var/storyteller_type = story_policy_type(TRUE)
-	if(storyteller_type != /datum/storyteller/abyssor)
-		return
-	var/datum/round_event_control/antagonist/solo/dreamwalker/source_event
-	for(var/datum/round_event_control/antagonist/solo/dreamwalker/event as anything in event_pools?[EVENT_TRACK_CHARACTER_INJECTION])
-		source_event = event
-		break
-	if(!source_event)
-		return
-	var/list/candidates = source_event.get_candidates()
-	if(!length(candidates))
-		return
-	var/picks = min(2, length(candidates))
-	var/applied = 0
-	for(var/i in 1 to picks)
-		var/mob/living/carbon/human/picked = pick_n_take(candidates)
-		if(!picked?.mind || picked.mind.has_antag_datum(/datum/antagonist/dreamwalker))
-			continue
-		picked.mind.add_antag_datum(/datum/antagonist/dreamwalker)
-		applied++
-	if(!applied)
-		return
-	var/message = "STORYTELLER: Applied Abyssor bonus dreamwalker roundstart picks ([applied])."
-	message_admins(message)
-	log_storyteller(message)
+	return
 
 /// Panel containing information, variables and controls about the gamemode and scheduled event
 /datum/controller/subsystem/gamemode/proc/admin_panel(mob/user)
@@ -1548,8 +1514,9 @@ SUBSYSTEM_DEF(gamemode)
 	dat += "<BR><b>--- Job Scaling ---</b>"
 	var/list/wretch_scaling = calculate_wretch_scaling()
 	var/datum/job/wretch_job = SSjob.GetJob("Wretch")
-	dat += "<BR>Wretch Slots: [wretch_job?.current_positions]/[wretch_job?.total_positions] — T1: [wretch_scaling["tier1_slots"]]/10, T2: +[wretch_scaling["tier2_extra"]] / 5 = [wretch_scaling["final_slots"]] final"
-	dat += "<BR>&nbsp;&nbsp;Garrison: [wretch_scaling["garrison"]], Holy Warriors: [wretch_scaling["holy_warrior"]], Acolytes: [wretch_scaling["acolyte"]] (half weight), Combat Total: [wretch_scaling["combat_total"]] (need > 10 for T2)"
+	var/wretch_cap = wretch_scaling["cap"] || 10
+	dat += "<BR>Wretch Slots: [wretch_job?.current_positions]/[wretch_job?.total_positions] - T1: [wretch_scaling["tier1_slots"]]/[wretch_cap], T2: +[wretch_scaling["tier2_extra"]] / 5 = [wretch_scaling["final_slots"]] final (cap [wretch_cap])"
+	dat += "<BR>&nbsp;&nbsp;Garrison: [wretch_scaling["garrison"]], Holy Warriors: [wretch_scaling["holy_warrior"]], Acolytes: [wretch_scaling["acolyte"]] (half weight), Combat Total: [wretch_scaling["combat_total"]] (T2 inactive while cap <= 10)"
 	if(wretch_scaling["major_antag_active"])
 		dat += "<BR>&nbsp;&nbsp;<font color='red'>MAJOR ANTAG ACTIVE (VL/LICH) — Tier 2 locked, max 10</font>"
 

--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -1027,8 +1027,17 @@ SUBSYSTEM_DEF(gamemode)
 	return STORYTELLER_FAVOR_NONE
 
 /datum/controller/subsystem/gamemode/proc/story_guarantee_flags(storyteller_type)
-	// Guarantees are intentionally empty - every god is now thematic-favored only.
-	// Kept as a proc so callers in storyteller_guaranteed_events() and elsewhere don't break.
+	if(!ispath(storyteller_type, /datum/storyteller))
+		return STORYTELLER_FAVOR_NONE
+	switch(storyteller_type)
+		if(/datum/storyteller/zizo)
+			return STORYTELLER_FAVOR_LICH
+		if(/datum/storyteller/baotha)
+			return STORYTELLER_FAVOR_VAMPIRE_LORD
+		if(/datum/storyteller/graggar)
+			return STORYTELLER_FAVOR_GNOLL | STORYTELLER_FAVOR_ASSASSIN
+		if(/datum/storyteller/matthios)
+			return STORYTELLER_FAVOR_BANDIT
 	return STORYTELLER_FAVOR_NONE
 
 /datum/controller/subsystem/gamemode/proc/story_favor_flags(storyteller_type)

--- a/code/datums/storytellers/_base.dm
+++ b/code/datums/storytellers/_base.dm
@@ -88,6 +88,8 @@
 	var/ascendant = FALSE
 	/// Which kind of gnoll scaling this storyteller prefers, default is 1 gnoll spawn.
 	var/preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	/// Hard cap on wretch job slots this storyteller will ever open. Defualt 10 = T1 max - lower = clamps T1 ad skips T2
+	var/wretch_slot_cap = 10
 
 /datum/storyteller/New()
 	. = ..()

--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -29,12 +29,12 @@
 /datum/storyteller/psydon
 	name = "Psydon"
 	vote_desc = "Peace reigns. No villains will be present. His children can rest easy, for they have earned their respite"
-	desc = "Psydon will do little, events will be common as he takes a hands-off approach to the world. Consider this the 'extended' experience."
+	desc = "Mundane and moderate events fire 1.2x more often. No antagonists, no divine intervention. Gnolls absent."
 	welcome_text = "A temperate breeze rolls through the quiet streets.."
 	weight = 6
 	always_votable = TRUE
 	color_theme = "#80ced8"
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
 	guarantees_roundstart_roleset = FALSE
 	roundstart_prob = 0
 
@@ -49,14 +49,24 @@
 
 /datum/storyteller/astrata
 	name = "Astrata"
-	vote_desc = "Order reigns. All occurrences are perfectly balanced out, without bias. Her favor shines upon nobility and their decrees."
-	desc = "Astrata will provide a balanced and varied experience. Consider this the default experience."
+	vote_desc = "Order reigns. No great villains will rise, and gnolls do not stalk her daelight. Her favor shines upon nobility and their decrees."
+	desc = "Bandits, liches, werewolves, and vampire lords cannot roll. Masquerade is the only roundstart hard antag and gets a 1.5x weight bump. Gnolls absent. Wretches scale normally."
 	welcome_text = "The warmth of daelight rouses you from your slumber.."
 	weight = 6
 	always_votable = TRUE
 	follower_modifier = LOWER_FOLLOWER_MODIFIER
 	color_theme = "#FFD700"
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
+	guarantees_roundstart_roleset = FALSE
+	roundstart_prob = 0
+
+	starting_point_multipliers = list(
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
+	)
+
+	point_gains_multipliers = list(
+		EVENT_TRACK_CHARACTER_INJECTION = 0,	//No antagonist spawns under Her order.
+	)
 
 	influence_sets = list(
 	"Set 1" = list(
@@ -80,7 +90,7 @@
 /datum/storyteller/noc
 	name = "Noc"
 	vote_desc = "Knowledge reigns. Occurrences are tame, but remain suspectable to arcyne intervention. His favor shines upon those who dream for greater ambitions."
-	desc = "Noc will try to send more magical events."
+	desc = "Magical events fire 1.2x more often, haunted 1.1x. Higher event cost variance. No antag pool changes. Single gnoll possible."
 	welcome_text = "The air crackles with arcyne energy.."
 	weight = 4
 	always_votable = TRUE
@@ -113,16 +123,22 @@
 
 /datum/storyteller/ravox
 	name = "Ravox"
-	vote_desc = "Glory reigns. Raids, villains, and omens are more likely to occur. His favor shines upon clashing steel and the cries of war."
-	desc = "Ravox will cause raids to happen naturally instead of only when people are dying a lot."
+	vote_desc = "Glory reigns. Raids and omens are more likely to occur. His favor shines upon clashing steel and the cries of war - though no villains nor gnolls answer His call."
+	desc = "Raids fire 2x more often (track gain) and raid events get a 1.3x weight bump. No antagonists at all. Mundane and personal events suppressed. Gnolls absent."
 	welcome_text = "\"The trumpets of Zericho are echoing in the distance..\""
 	weight = 4
 	always_votable = TRUE
 	color_theme = "#228822"
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
+	guarantees_roundstart_roleset = FALSE
+	roundstart_prob = 0
 
 	tag_multipliers = list(
 		TAG_RAID = 1.3,
+	)
+
+	starting_point_multipliers = list(
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
 	)
 
 	point_gains_multipliers = list(
@@ -130,7 +146,7 @@
 		EVENT_TRACK_PERSONAL = 0.9,
 		EVENT_TRACK_MODERATE = 1,
 		EVENT_TRACK_INTERVENTION = 1,
-		EVENT_TRACK_CHARACTER_INJECTION = 1,	//Gaurenteed antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 0,	//No antagonist spawns - raids and omens carry the conflict.
 		EVENT_TRACK_OMENS = 1,
 		EVENT_TRACK_RAIDS = 2,
 	)
@@ -155,13 +171,13 @@
 
 /datum/storyteller/abyssor
 	name = "Abyssor"
-	vote_desc = "Water reigns. Occurrences are tame, though their temperance oft-sways with the tide's flow. His favor shines upon the fished, leeched, and drowned."
-	desc = "Abyssor likes to send water and trade-related events."
+	vote_desc = "Water reigns. Occurrences are tame, though their temperance oft-sways with the tide's flow. His favor shines upon the fished, leeched, and drowned - dreamwalkers ride the deep, but no gnolls dare His shores."
+	desc = "Water events get a 1.3x weight bump, trade 1.2x. Dreamwalker gets a 1.5x weight bump in the antag pool. Gnolls absent."
 	welcome_text = "The horizon grows dark, as its clouds gather for a coming storm.."
 	weight = 4
 	always_votable = TRUE
 	color_theme = "#3366CC"
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
 
 	tag_multipliers = list(
 		TAG_WATER = 1.3,
@@ -191,7 +207,7 @@
 /datum/storyteller/xylix
 	name = "Xylix"
 	vote_desc = "Unpredictability reigns. Nothing is set in stone, yet everything is possible. His favor shines upon acts of chance and whimsy."
-	desc = "Xylix is a wildcard, spinning the wheels of fate."
+	desc = "Forced events bypass population prerequisites and any event that's already fired this round drops to its full repetition penalty immediately. Intervention 1.75x; omens and raids suppressed to 0. All hard antags get a 1.5x weight bump. Gnoll mode randomized."
 	welcome_text = "\"..well, that's what happens out of too much spice and wine!\""
 	weight = 4
 	always_votable = TRUE
@@ -205,7 +221,7 @@
 		EVENT_TRACK_PERSONAL = 1.1,
 		EVENT_TRACK_MODERATE = 1,
 		EVENT_TRACK_INTERVENTION = 1.75,
-		EVENT_TRACK_CHARACTER_INJECTION = 0,
+		EVENT_TRACK_CHARACTER_INJECTION = 1,
 		EVENT_TRACK_OMENS = 0,
 		EVENT_TRACK_RAIDS = 0,
 	)
@@ -229,7 +245,7 @@
 /datum/storyteller/necra
 	name = "Necra"
 	vote_desc = "Death reigns. Occurrences happen less often, and villains are less likely. Her favor shines upon those who put the deathless back into their graves."
-	desc = "Necra takes things very slow, rarely bringing in newcomers."
+	desc = "Haunted events get a 1.3x weight bump. Antag track and raid track gain points half as fast; personal events also slowed. Mundane and moderate events fire 1.25x more often. Single gnoll possible."
 	welcome_text = "\"In the fief of Zenmarke, there was the odor of decay..\""
 	weight = 4
 	always_votable = TRUE
@@ -245,7 +261,7 @@
 		EVENT_TRACK_PERSONAL = 0.7,
 		EVENT_TRACK_MODERATE = 1.25,
 		EVENT_TRACK_INTERVENTION = 1.25,
-		EVENT_TRACK_CHARACTER_INJECTION = 0.5,	//High-chance antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 0.5,
 		EVENT_TRACK_OMENS = 1.25,
 		EVENT_TRACK_RAIDS = 0.5,
 	)
@@ -274,7 +290,7 @@
 /datum/storyteller/pestra
 	name = "Pestra"
 	vote_desc = "Health reigns. Occurrences are tame, yet swayable with practiced hands. Her favor shines upon stitches and alchemists"
-	desc = "Pestra keeps things simple, with a slight bias towards alchemy."
+	desc = "Alchemy and medical events get a 1.2x weight bump, nature 1.1x. All hard antags roll at flat equal weight - no preference between bandits, liches, werewolves, or vampire lords. Single gnoll possible."
 	welcome_text = "The clattering of instruments, and the churning of alchemical wonders.."
 	color_theme = "#AADDAA"
 	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
@@ -309,7 +325,7 @@
 /datum/storyteller/malum
 	name = "Malum"
 	vote_desc = "Effort reigns. Divine intervention occurs more often. His favor shines upon masterworks and mineshafts."
-	desc = "Malum believes in hard work, intervening more often than others."
+	desc = "Work-tagged events get a 1.5x weight bump. Divine intervention fires 2x more often, personal events 1.2x. All hard antags roll at flat equal weight. Single gnoll possible."
 	welcome_text = "The pounding of red-hot steel, and the laboring of a hundred calloused hands.."
 	color_theme = "#D4A56C"
 	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
@@ -323,7 +339,7 @@
 		EVENT_TRACK_PERSONAL = 1.2,
 		EVENT_TRACK_MODERATE = 1,
 		EVENT_TRACK_INTERVENTION = 2,
-		EVENT_TRACK_CHARACTER_INJECTION = 1,	//Gaurenteed antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 1,
 		EVENT_TRACK_OMENS = 1,
 		EVENT_TRACK_RAIDS = 1,
 	)
@@ -349,11 +365,12 @@
 
 /datum/storyteller/eora
 	name = "Eora"
-	vote_desc = " Love reigns. Positive affairs occur more often, and She wills for none to be ill. Her favor shines upon romance."
-	desc = "Eora hates death and promotes love. There is no possibility for ill-will from external forces. Though deaths will anger."
+	vote_desc = " Love reigns. Positive affairs occur more often, and She wills for none to be ill. No villains, no gnolls; only a small handful of wretches lurk at the fringe. Her favor shines upon romance."
+	desc = "Widespread events get a 1.5x weight bump, boons 1.2x. No antagonists, no raids. Divine intervention fires 2x more often, personal events 1.4x. Wretches hard-capped at 5 slots. Gnolls absent."
 	welcome_text = "\"Love is in the air? Nay; tis the smell of freshly-baked pies upon the windowsills!\""
 	color_theme = "#9966CC"
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
+	wretch_slot_cap = 5
 	guarantees_roundstart_roleset = FALSE
 	roundstart_prob = 0
 
@@ -402,13 +419,13 @@
 
 /datum/storyteller/dendor
 	name = "Dendor"
-	vote_desc = " Nature reigns. Overgrowth and Verevolves are more likely to occur. His favor shines upon harvests and lycanthropes."
-	desc = "Dendor likes to send nature-themed events."
+	vote_desc = " Nature reigns. Overgrowth and Verevolves are more likely to occur. His favor shines upon harvests and lycanthropes - gnolls keep their distance from His wilds."
+	desc = "Nature events get a 1.5x weight bump. Werewolf is the only roundstart hard antag and gets a 1.5x weight bump - bandits, liches, and vampire lords cannot roll. Intervention fires 2x more often. Gnolls absent."
 	welcome_text = "The cackling of perched zads, and the glimmer of morning dew.."
 	weight = 4
 	always_votable = TRUE
 	color_theme = "#664422"
-	preferred_gnoll_mode = GNOLL_SCALING_SINGLE
+	preferred_gnoll_mode = GNOLL_SCALING_NONE
 
 	tag_multipliers = list(
 		TAG_NATURE = 1.5,
@@ -419,7 +436,7 @@
 		EVENT_TRACK_PERSONAL = 0.8,
 		EVENT_TRACK_MODERATE = 1,
 		EVENT_TRACK_INTERVENTION = 2,
-		EVENT_TRACK_CHARACTER_INJECTION = 1,	//Gaurenteed antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 1,
 		EVENT_TRACK_OMENS = 1,
 		EVENT_TRACK_RAIDS = 1,
 	)
@@ -446,8 +463,8 @@
 
 /datum/storyteller/zizo
 	name = "Zizo"
-	vote_desc = "Chaos reigns. Villains are assured, and Deadites are far more vicious. Her favor shines upon corpses; be they holy, noble, or reanimated."
-	desc = "Zizo thrives on risk and reward, favoring the daring and unpredictable."
+	vote_desc = "Chaos reigns. Liches stir more readily than under any other god, and Deadites are far more vicious. Her favor shines upon corpses; be they holy, noble, or reanimated."
+	desc = "Magical, gamble, trickery, and unexpected events get weight bumps (1.2x to 1.5x). Lich is the only roundstart hard antag and gets a 1.5x weight bump - bandits, werewolves, and vampire lords cannot roll. High event cost variance. Flat gnoll spawn (15% chance, 2 cap)."
 	welcome_text = "A breeze of morbid air, ferrying the howls of the damned.."
 	weight = 4
 	always_votable = TRUE
@@ -466,7 +483,7 @@
 		EVENT_TRACK_PERSONAL = 1.2,
 		EVENT_TRACK_MODERATE = 1.1,
 		EVENT_TRACK_INTERVENTION = 1.5,
-		EVENT_TRACK_CHARACTER_INJECTION = 1,	//Gaurenteed antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 1,
 		EVENT_TRACK_OMENS = 1.3,
 		EVENT_TRACK_RAIDS = 0.8,
 	)
@@ -498,7 +515,7 @@
 /datum/storyteller/baotha
 	name = "Baotha"
 	vote_desc = "Spice reigns. Occurrences are more erratic and negative. Her favor shines upon drunkards and addicts."
-	desc = "Baotha revels in chaos, making events and reality unpredictable."
+	desc = "Insanity, magic, and disaster events get weight bumps (1.1x to 1.4x). Vampire Lord is the only roundstart hard antag and gets a 1.5x weight bump - bandits, liches, and werewolves cannot roll. All event tracks accelerated. Gnoll mode randomized."
 	welcome_text = "The sickly sweet aromas of liqour and spice fills the air.."
 	weight = 4
 	always_votable = TRUE
@@ -516,7 +533,7 @@
 		EVENT_TRACK_PERSONAL = 1.2,
 		EVENT_TRACK_MODERATE = 1.3,
 		EVENT_TRACK_INTERVENTION = 2,
-		EVENT_TRACK_CHARACTER_INJECTION = 0.7,	//High chance antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 0.7,
 		EVENT_TRACK_OMENS = 1.5,
 		EVENT_TRACK_RAIDS = 1.2,
 	)
@@ -546,8 +563,8 @@
 
 /datum/storyteller/graggar
 	name = "Graggar"
-	vote_desc = " Inhumenity reigns. Villains are assured, and raids occur far more often. His favor shines upon bloodshed and cannibalism."
-	desc = "Graggar encourages war and conquest, making combat the solution to all."
+	vote_desc = " Inhumenity reigns. Gnolls and assassins prowl more eagerly than under any other god, and raids occur far more often. His favor shines upon bloodshed and cannibalism."
+	desc = "Battle, blood, and war events get weight bumps (1.2x to 1.6x). Gnoll and Assassin are the only roundstart hard antags and get a 1.5x weight bump. Raid track gains 2.5x faster. Dynamic gnoll scaling - packs grow with population."
 	welcome_text = "Plumes of smoke are blown through the streets, reeking of ash and blood.."
 	weight = 4
 	always_votable = TRUE
@@ -565,7 +582,7 @@
 		EVENT_TRACK_PERSONAL = 0.7,
 		EVENT_TRACK_MODERATE = 1.2,
 		EVENT_TRACK_INTERVENTION = 1.5,
-		EVENT_TRACK_CHARACTER_INJECTION = 1,	//Gaurenteed antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 1,
 		EVENT_TRACK_OMENS = 0.9,
 		EVENT_TRACK_RAIDS = 2.5,
 	)
@@ -592,8 +609,8 @@
 
 /datum/storyteller/matthios
 	name = "Matthios"
-	vote_desc = "Thievery reigns. Banditry runs rampant. His favor shines upon thefts and offerings to a certain shrine."
-	desc = "Matthios manipulates wealth and corruption, rewarding those who make deals."
+	vote_desc = "Thievery reigns. Bandit incursions are far more common than under other gods. His favor shines upon thefts and offerings to a certain shrine."
+	desc = "Trade, corruption, and loot events get weight bumps (1.2x to 1.4x). Bandit is the only roundstart hard antag and gets a 1.5x weight bump - liches, werewolves, and vampire lords cannot roll. Antag track gains 1.5x faster. Gnoll mode randomized."
 	welcome_text = "The jingling of mammons, and the dripping of ink from freshly-signed bounties.."
 	weight = 4
 	always_votable = TRUE
@@ -611,7 +628,7 @@
 		EVENT_TRACK_PERSONAL = 1.1,
 		EVENT_TRACK_MODERATE = 1.2,
 		EVENT_TRACK_INTERVENTION = 1.3,
-		EVENT_TRACK_CHARACTER_INJECTION = 1.5,	//Gaurenteed antagonist spawn
+		EVENT_TRACK_CHARACTER_INJECTION = 1.5,
 		EVENT_TRACK_OMENS = 1.1,
 		EVENT_TRACK_RAIDS = 0.6,
 	)

--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -35,6 +35,7 @@
 	always_votable = TRUE
 	color_theme = "#80ced8"
 	preferred_gnoll_mode = GNOLL_SCALING_NONE
+	wretch_slot_cap = 0
 	guarantees_roundstart_roleset = FALSE
 	roundstart_prob = 0
 
@@ -464,12 +465,13 @@
 /datum/storyteller/zizo
 	name = "Zizo"
 	vote_desc = "Chaos reigns. Liches stir more readily than under any other god, and Deadites are far more vicious. Her favor shines upon corpses; be they holy, noble, or reanimated."
-	desc = "Magical, gamble, trickery, and unexpected events get weight bumps (1.2x to 1.5x). Lich is the only roundstart hard antag and gets a 1.5x weight bump - bandits, werewolves, and vampire lords cannot roll. High event cost variance. Flat gnoll spawn (15% chance, 2 cap)."
+	desc = "Magical, gamble, trickery, and unexpected events get weight bumps (1.2x to 1.5x). Lich is guaranteed roundstart - bandits, werewolves, and vampire lords cannot roll. High event cost variance. Flat gnoll spawn (15% chance, 2 cap). Wretch T2 garrison expansion can fire."
 	welcome_text = "A breeze of morbid air, ferrying the howls of the damned.."
 	weight = 4
 	always_votable = TRUE
 	color_theme = "#CC4444"
 	preferred_gnoll_mode = GNOLL_SCALING_FLAT
+	wretch_slot_cap = 15
 
 	tag_multipliers = list(
 		TAG_MAGICAL = 1.2,
@@ -515,12 +517,13 @@
 /datum/storyteller/baotha
 	name = "Baotha"
 	vote_desc = "Spice reigns. Occurrences are more erratic and negative. Her favor shines upon drunkards and addicts."
-	desc = "Insanity, magic, and disaster events get weight bumps (1.1x to 1.4x). Vampire Lord is the only roundstart hard antag and gets a 1.5x weight bump - bandits, liches, and werewolves cannot roll. All event tracks accelerated. Gnoll mode randomized."
+	desc = "Insanity, magic, and disaster events get weight bumps (1.1x to 1.4x). Vampire Lord is guaranteed roundstart - bandits, liches, and werewolves cannot roll. All event tracks accelerated. Gnoll mode randomized. Wretch T2 garrison expansion can fire."
 	welcome_text = "The sickly sweet aromas of liqour and spice fills the air.."
 	weight = 4
 	always_votable = TRUE
 	color_theme = "#9933FF"
 	preferred_gnoll_mode = GNOLL_SCALING_RANDOM
+	wretch_slot_cap = 15
 
 	tag_multipliers = list(
 		TAG_INSANITY = 1.4,
@@ -564,12 +567,13 @@
 /datum/storyteller/graggar
 	name = "Graggar"
 	vote_desc = " Inhumenity reigns. Gnolls and assassins prowl more eagerly than under any other god, and raids occur far more often. His favor shines upon bloodshed and cannibalism."
-	desc = "Battle, blood, and war events get weight bumps (1.2x to 1.6x). Gnoll and Assassin are the only roundstart hard antags and get a 1.5x weight bump. Raid track gains 2.5x faster. Dynamic gnoll scaling - packs grow with population."
+	desc = "Battle, blood, and war events get weight bumps (1.2x to 1.6x). Gnolls and Assassins are guaranteed roundstart. Raid track gains 2.5x faster. Dynamic gnoll scaling - packs grow with population. Wretch T2 garrison expansion can fire."
 	welcome_text = "Plumes of smoke are blown through the streets, reeking of ash and blood.."
 	weight = 4
 	always_votable = TRUE
 	color_theme = "#8B3A3A"
 	preferred_gnoll_mode = GNOLL_SCALING_DYNAMIC
+	wretch_slot_cap = 15
 
 	tag_multipliers = list(
 		TAG_BATTLE = 1.6,
@@ -610,12 +614,13 @@
 /datum/storyteller/matthios
 	name = "Matthios"
 	vote_desc = "Thievery reigns. Bandit incursions are far more common than under other gods. His favor shines upon thefts and offerings to a certain shrine."
-	desc = "Trade, corruption, and loot events get weight bumps (1.2x to 1.4x). Bandit is the only roundstart hard antag and gets a 1.5x weight bump - liches, werewolves, and vampire lords cannot roll. Antag track gains 1.5x faster. Gnoll mode randomized."
+	desc = "Trade, corruption, and loot events get weight bumps (1.2x to 1.4x). Bandits are guaranteed roundstart - liches, werewolves, and vampire lords cannot roll. Antag track gains 1.5x faster. Gnoll mode randomized. Wretch T2 garrison expansion can fire."
 	welcome_text = "The jingling of mammons, and the dripping of ink from freshly-signed bounties.."
 	weight = 4
 	always_votable = TRUE
 	color_theme = "#8B4513"
 	preferred_gnoll_mode = GNOLL_SCALING_RANDOM
+	wretch_slot_cap = 15
 
 	tag_multipliers = list(
 		TAG_TRADE = 1.4,

--- a/code/datums/storytellers/gods.dm
+++ b/code/datums/storytellers/gods.dm
@@ -208,7 +208,7 @@
 /datum/storyteller/xylix
 	name = "Xylix"
 	vote_desc = "Unpredictability reigns. Nothing is set in stone, yet everything is possible. His favor shines upon acts of chance and whimsy."
-	desc = "Forced events bypass population prerequisites and any event that's already fired this round drops to its full repetition penalty immediately. Intervention 1.75x; omens and raids suppressed to 0. All hard antags get a 1.5x weight bump. Gnoll mode randomized."
+	desc = "Forced events bypass population prerequisites and any event that's already fired this round drops to its full repetition penalty immediately. Intervention 1.75x; character injection, omens and raids suppressed to 0. All roundstart hard antags get a 1.5x weight bump. Gnoll mode randomized."
 	welcome_text = "\"..well, that's what happens out of too much spice and wine!\""
 	weight = 4
 	always_votable = TRUE
@@ -222,7 +222,7 @@
 		EVENT_TRACK_PERSONAL = 1.1,
 		EVENT_TRACK_MODERATE = 1,
 		EVENT_TRACK_INTERVENTION = 1.75,
-		EVENT_TRACK_CHARACTER_INJECTION = 1,
+		EVENT_TRACK_CHARACTER_INJECTION = 0,
 		EVENT_TRACK_OMENS = 0,
 		EVENT_TRACK_RAIDS = 0,
 	)

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -20,7 +20,14 @@
 	return ..()
 
 /datum/round_event/migrant_wave/banditsorgnolls/start()
-	var/evilmode = is_storyteller_villain_blocked() ? "gnolls" : pick("gnolls", "bandits")
+	var/gnolls_disabled = (SSgamemode.current_storyteller?.preferred_gnoll_mode == GNOLL_SCALING_NONE)
+	var/evilmode
+	if(gnolls_disabled)
+		evilmode = "bandits"
+	else if(is_storyteller_villain_blocked())
+		evilmode = "gnolls"
+	else
+		evilmode = pick("gnolls", "bandits")
 	if(evilmode == "bandits")
 		var/datum/job/bandit_job = SSjob.GetJob("Bandit")
 		var/bandit_maxcap = max(SSgamemode.story_antag_slot_cap(/datum/antagonist/bandit), bandit_job.total_positions)

--- a/code/modules/events/antagonist/migrant_waves/gnolls.dm
+++ b/code/modules/events/antagonist/migrant_waves/gnolls.dm
@@ -15,6 +15,8 @@
 /datum/round_event_control/antagonist/migrant_wave/gnolls/preRunEvent()
 	if(is_storyteller_soft_antag_blocked())
 		return EVENT_CANT_RUN
+	if(SSgamemode.current_storyteller?.preferred_gnoll_mode == GNOLL_SCALING_NONE)
+		return EVENT_CANT_RUN
 	return ..()
 
 /datum/round_event/migrant_wave/gnolls/start()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -111,6 +111,9 @@
 	if(is_storyteller_soft_antag_blocked())
 		result["final_slots"] = 0
 		return result
+	if(SSgamemode.current_storyteller?.preferred_gnoll_mode == GNOLL_SCALING_NONE)
+		result["final_slots"] = 0
+		return result
 	var/slots = 1
 	if(SSgnoll_scaling)
 		switch(SSgnoll_scaling.get_gnoll_scaling())

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -147,6 +147,8 @@
 	var/list/result = list()
 	var/player_count = override_player_count || length(GLOB.joined_player_list)
 	result["player_count"] = player_count
+	var/cap = SSgamemode.current_storyteller?.wretch_slot_cap || 10
+	result["cap"] = cap
 	if(is_storyteller_soft_antag_blocked())
 		result["tier1_slots"] = 0
 		result["major_antag_active"] = FALSE
@@ -158,11 +160,11 @@
 		result["final_slots"] = 0
 		return result
 
-	// Tier 1: Population scaling, +1 per 10 players above 40, max 10
+	// Tier 1: Population scaling, +1 per 10 players above 40, capped per pantheon
 	var/slots = 5
 	if(player_count > 40)
 		slots += floor((player_count - 40) / 10)
-	slots = min(slots, 10)
+	slots = min(slots, cap)
 	result["tier1_slots"] = slots
 
 	// Check for major round antagonists (lich, vampire lord, any bandits) — hard cap at tier 1
@@ -175,7 +177,7 @@
 			break
 	result["major_antag_active"] = major_antag_active
 
-	// Tier 2: Garrison-gated expansion from 10 to 15
+	// Tier 2: Garrison-gated expansion above 10, bounded by per-pantheon cap.
 	var/garrison_count = SSgamemode.garrison
 	var/holy_count = SSgamemode.holy_warrior
 	var/acolyte_count = SSgamemode.half_combatant
@@ -186,11 +188,11 @@
 	result["combat_total"] = combat_count
 
 	var/tier2_max = 0
-	if(slots >= 10 && !major_antag_active)
-		tier2_max = min(max(0, combat_count - 10), 5)
+	if(slots >= 10 && cap > 10 && !major_antag_active)
+		tier2_max = min(max(0, combat_count - 10), 5, cap - slots)
 		slots += tier2_max
 	result["tier2_extra"] = tier2_max
-	result["final_slots"] = max(0, slots)
+	result["final_slots"] = max(0, min(slots, cap))
 
 	return result
 
@@ -228,10 +230,15 @@
 	var/player_count = override_player_count || length(GLOB.joined_player_list)
 	result["player_count"] = player_count
 
-	var/slots = 20
+	// Adventurer slots absorb whatever wretch headroom the pantheon gives up below the default cap of 10.
+	var/cap = SSgamemode.current_storyteller?.wretch_slot_cap || 10
+	var/wretch_offset = max(0, 10 - cap) * 2
+	result["wretch_offset"] = wretch_offset
+
+	var/slots = 20 + wretch_offset
 	if(player_count > 70)
 		slots += floor((player_count - 70) / 10) * 2
-	slots = min(slots, 40)
+	slots = min(slots, 40 + wretch_offset)
 	result["final_slots"] = slots
 
 	return result

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -230,9 +230,9 @@
 	var/player_count = override_player_count || length(GLOB.joined_player_list)
 	result["player_count"] = player_count
 
-	// Adventurer slots absorb whatever wretch headroom the pantheon gives up below the default cap of 10.
+	// Adventurer slots absorb the wretch headroom each pantheon forfeits below the original 15-slot ceiling (T2 garrison expansion + Eora's lower T1 cap).
 	var/cap = SSgamemode.current_storyteller?.wretch_slot_cap || 10
-	var/wretch_offset = max(0, 10 - cap) * 2
+	var/wretch_offset = max(0, 15 - cap)
 	result["wretch_offset"] = wretch_offset
 
 	var/slots = 20 + wretch_offset

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -147,7 +147,9 @@
 	var/list/result = list()
 	var/player_count = override_player_count || length(GLOB.joined_player_list)
 	result["player_count"] = player_count
-	var/cap = SSgamemode.current_storyteller?.wretch_slot_cap || 10
+	var/cap = SSgamemode.current_storyteller?.wretch_slot_cap
+	if(isnull(cap))
+		cap = 10
 	result["cap"] = cap
 	if(is_storyteller_soft_antag_blocked())
 		result["tier1_slots"] = 0
@@ -230,8 +232,10 @@
 	var/player_count = override_player_count || length(GLOB.joined_player_list)
 	result["player_count"] = player_count
 
-	// Adventurer slots absorb the wretch headroom each pantheon forfeits below the original 15-slot ceiling (T2 garrison expansion + Eora's lower T1 cap).
-	var/cap = SSgamemode.current_storyteller?.wretch_slot_cap || 10
+	// Adventurer slots absorb the wretch headroom each pantheon forfeits below the original 15-slot ceiling.
+	var/cap = SSgamemode.current_storyteller?.wretch_slot_cap
+	if(isnull(cap))
+		cap = 10
 	var/wretch_offset = max(0, 15 - cap)
 	result["wretch_offset"] = wretch_offset
 


### PR DESCRIPTION
## About The Pull Request
Experimental changes for storyteller proposed by Witty so that we don't roll guaranteed antagonist back to back and there's quieter rounds in between

**Guaranteed Antag:**
- Removed from **ALL** Divine Pantheon Storytellers, now weigh for them heavily but not guarantee it. 

**Gnolls:**
- Disabled on Eora, Astrata, Ravox, Dendor, Abyssor

**Adventurer / Wretch Slots Scaling:**
- On all **Divine** Pantheon storyteller: Wretch limited to 10, Adv +5
- Eora: Wretch Limited to 5, Adv +10 
- Psydon: 0 Wretch, so +15 Adv Slots

**Antagonists:**
- Forbidden for Eora, Astrata and Ravox

**Ascendants:**
- Unchanged

**Other stuffs:**
- Rewrote description to be more mechanical

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Yae

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This is experimental and may not land well, but maybe it will help with giving some quieter rounds.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
tweak: Guaranteed antag are removed from **ALL** Divine Pantheon Storytellers, now weigh for them heavily but not guarantee it. 
tweak: Gnolls are disabled on Eora, Astrata, Ravox, Dendor, Abyssor
tweak: Wretches are limited to 10 slots on Divine storyteller, all of them gain +5 adventurer slots base
tweak: Antagonists no longer spawn on Astrata and Ravox.
tweak: Eora have no antagonists and have 5 Wretch Slots, 10 more adventurer slots
tweak: Psydon gains +15 Adv Slots to compensate for losses of wretch slots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
