### PR TITLE
Renames Mailled Hauberk to Mailled Cuirass.

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -114,7 +114,7 @@
 //HEAVY ARMOR//
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/heavy
-	name = "mailled hauberk"
+	name = "mailled cuirass"
 	desc = "A maille-aketon of steel, comfortably fitted beneath a matching cuirass. Best paired with a padded arming jacket and a lovely goblet of wine, sourced straight from the Duke's private reserves."
 	slot_flags = ITEM_SLOT_ARMOR
 	icon_state = "cuirasshauberk"
@@ -123,7 +123,7 @@
 	max_integrity = ARMOR_INT_CHEST_PLATE_STEELLIGHT // To note, this is about 450 INT, or +150 over regular hauberk and -50 under regular plate.
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron/heavy
-	name = "iron mailled hauberk"
+	name = "iron mailled cuirass"
 	desc = "A maille-aketon of iron, snuggly fitted beneath a matching cuirass. Best paired with a gambeson and a mug of chilled ale, or - as is the case with most levymen and adventurers - last nite's rags."
 	slot_flags = ITEM_SLOT_ARMOR
 	icon_state = "icuirasshauberk"
@@ -132,14 +132,14 @@
 	max_integrity = ARMOR_INT_CHEST_PLATE_IRONLIGHT // Roughly 325 INT. +150 over regular hauberk, and -50 under regular plate.
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/aalloy/heavy
-	name = "decrepit hauberk"
+	name = "decrepit mailled cuirass"
 	desc = "Frayed bronze rings and rotting leather, woven together to form a sleeved maille-atekon; one that's been uncomfortably tucked beneath a matching cuirass. Such are the last remains of those who've dared to march against the undying legions, be it yils or centuries prior."
 	icon_state = "ancientcuirasshauberk"
 	item_state = "ancientcuirasshauberk"
 	max_integrity = ARMOR_INT_CHEST_PLATE_DECREPITLIGHT // 200 INT.
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy/heavy
-	name = "ancient hauberk"
+	name = "ancient mailled cuirass"
 	desc = "Polished gilbranze rings and silk, woven together to form a sleeved maille-atekon; one that's been uncomfortably tucked beneath a matching cuirass. It eminates an unfamiliar sensation, rarely seen amongst rot-and-undeath - elegance. In the worlds to come, do you suppose Her death knights would bare such a mantle?"
 	icon_state = "ancientcuirasshauberk"
 	item_state = "ancientcuirasshauberk"
@@ -149,7 +149,7 @@
 	slot_flags = ITEM_SLOT_ARMOR
 	armor_class = ARMOR_CLASS_HEAVY
 	armor = ARMOR_PLATE
-	name = "psydonic hauberk"
+	name = "psydonic mailled cuirass"
 	desc = "A beautiful steel cuirass, decorated with blessed silver fluting and worn atop thick chainmaille. While it falters against arrows and bolts, these interlinked layers are superb at warding off the blows of inhumen claws and axes. </br>‎  </br>'..the knowledge of evil, and the burden of carrying Psydonia's hope upon thine shoulders..'"
 	icon_state = "ornatehauberk"
 	item_state = "ornatehauberk"


### PR DESCRIPTION
## About The Pull Request

Title. Why is it called mailled hauberk when the hauberk IS the maille... and the cuirass is what's ADDED.... RAAAH.
Also some stuff that's described and listed under the same area as the mailled cuirasses/hauberks is just called x hauberk when there's also normal hauberks of it and the descriptions imply it's Also a mailled cuirass, so changes the name there too.
## Testing Evidence

it compile and its just me renaming stuff.
also spawned the separate parts and it crafts still. forgot screenshots before I closed localhost, sorgy.
## Why It's Good For The Game

More logical naming of thing is gooder. Probably.
## Changelog
:cl:
fix: Previously named 'mailled hauberks' have been renamed to 'mailled cuirass' to better reflect what they are. The hauberk IS the maille.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
