### PR TITLE
Malum adjustment

### DIFF
--- a/code/datums/gods/patrons/divine/malum.dm
+++ b/code/datums/gods/patrons/divine/malum.dm
@@ -15,7 +15,7 @@
 					/obj/effect/proc_holder/spell/invoked/hammerfall			= CLERIC_T3,
 					/obj/effect/proc_holder/spell/self/repair                   = CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/craftercovenant		= CLERIC_T4,
-					/obj/effect/proc_holder/spell/invoked/resurrect/malum		= CLERIC_T4,
+					/obj/effect/proc_holder/spell/invoked/resurrect/malum		= CLERIC_T3, // changed only the tier so it doesn't mess up with Acolyte's spell lineup, pls don't move this thank u <3
 	)
 	confess_lines = list(
 		"MALUM IS MY MUSE!",


### PR DESCRIPTION
## About The Pull Request

- Malum can now resurrect people on Expert miracle tier (i.e Missionary). No other changes.

## Testing Evidence

Nothing to test here, just changed T4 to T3.

## Why It's Good For The Game

It's may, we can ask for balance changes again. >:(

(Discussion was had here: https://discord.com/channels/1264916899653746808/1398387250433233038/1501574104648777790 )

Basically, we only have two gods capable of resurrecting people at T3, being Matthios and Astrata. In low-pop scenarios this can be quite rough, because it's a 2 in 15 chance you'll have a missionary (a class that's already barely played) around for it, with no Acolytes.

After a bit of musing, and on the spirit of expanding the god's domains, Malum came as a good idea to also be a god capable of performing ressurections, given their domain is also of 'Rebirth'.

After this, and with Zizo being adjusted too, we'll have 2 tennites, 2 ascendants and 0 psydonites capable of reviving on adventurer-level, and helping accidental PvE deaths not sour the mood and ruin a dungeon dive. Yippie.

## Changelog

:cl:
balance: Malum's Anastasis is now T3.
/:cl: