### PR TITLE
Intents Swap for the Shamshir

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1617,7 +1617,7 @@
 	desc = "The mariner's special: A short, broad sabre with a slightly curved blade optimized for slashing."
 	icon_state = "cutlass"
 	force = 23
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/chop)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/chop)
 	gripped_intents = null
 	wdefense = 6
 	wbalance = WBALANCE_SWIFT

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -1302,12 +1302,12 @@
 
 /obj/item/rogueweapon/sword/sabre/shamshir
 	name = "shamshir"
-	desc = "A curved one-handed longsword. This type of scimitar is the quintessential armament of Ranesheni horsemen, its name derived from Sama'glos for \"Tiger's claw\"."
+	desc = "A curved one-handed sword. This type of scimitar is the quintessential armament of Ranesheni horsemen, its name derived from Sama'glos for \"Tiger's claw\"."
 	force = 24
-	wdefense = 6	//Has chop mode, so slightly less defense. Slightly.
+	wdefense = 6	//Loses 1 wdef for that extra 2 force
 	icon_state = "tabi"
 	icon = 'icons/roguetown/weapons/swords64.dmi'
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/sword/chop)
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/chop, /datum/intent/sword/cut/sabre/heavy, /datum/intent/sword/strike)
 	bigboy = TRUE
 	pixel_y = -16
 	pixel_x = -16


### PR DESCRIPTION
## About The Pull Request

After the removal of peel and the introduction of the cool "yellow/red" intents by Free, the shamshir was somewhat left behind, even losing its alt-grip intents. This shuffles things about, removing the thrust intent from the dedicated slashing sword, and adding both the "precise cut" or "hack" intent which is a high risk/reward "red" intent, and also reintroducing the pommel strike to it.

A last-second change also changes the cutlass cut from the regular sword cut to the sabre cut.

## Testing Evidence

<img width="278" height="519" alt="Screenshot 2026-05-06 191912" src="https://github.com/user-attachments/assets/63d9ba92-d985-4cc0-abf2-beef7139ba08" />

The list of new intents.

## Why It's Good For The Game

It might not be, but one of the main users of the shamshir requested something along these lines, and I think having more intents for a weapon an entire mercenary class is expected to almost exclusively use when they take it is interesting, so long as the intents are thematic (and I believe they are for this particular sword).

Also gives the cutlass back the sabre cut instead of the regular sword cut.

## Changelog

:cl:
change: shamshir intents from sabre cut/sword thrust/sword chop to sabre cut/sword chop/sabre chop heavy/sword strike
/:cl:
