### PR TITLE
[Ham] - Nerfs Thanos and the infinity hams.

### DIFF
--- a/modular/Neu_Food/code/cooked/cooked_meat.dm
+++ b/modular/Neu_Food/code/cooked/cooked_meat.dm
@@ -451,6 +451,8 @@
 	slice_sound = TRUE
 	eat_effect = null
 	tastes = list("hog" = 1)
+	cooked_type = null
+	fried_type = null
 
 /obj/item/reagent_containers/food/snacks/rogue/meat/ham/steamed/update_icon()
 	if(slices_num)


### PR DESCRIPTION
## About The Pull Request
- Stops you from slicing ham and cooking sliced ham or ham slices into more full steamed hams

## Testing Evidence
simple fix

## Why It's Good For The Game
I'm sorry but we can't let ham be infinite, the economy! think of the economy!
It was a hard fight, I really wanted ham to be infinite.. sigh.
Like imagine, never having to.. run out of ham.
you can just. eat ham. every dae. all dae. Never run out of ham. Reject non-ham. Never not eat ham.

## Changelog

:cl:
fix: Fixed the infinity ham, hams are no longer infinite.
/:cl:

