### PR TITLE
Boots cannot be stripped off someone mid-combat.

### DIFF
--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -22,7 +22,6 @@
 
 	grid_width = 32
 	grid_height = 64
-	throw_on_break = TRUE
 
 /obj/item/clothing/shoes/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION


## About The Pull Request

You can no longer knock someone's shoes off when boots are destroyed. Keep your pants on.

## Testing Evidence

No.

## Why It's Good For The Game

It's a lil goofy. How you gonna knock off my shoes when I'm standing in 'em.

The way I see it, I win regardless of what happens. If Free merges this, I no longer have to suffer stepping on a glass shard with my toes out. If Free doesn't merge this, I can continue to accuse them of having a foot fetish.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Boots no longer get knocked off your feet when destroyed. This changelog being in game is proof Free does not have a thing for feet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
