### PR TITLE
TRAIT_NOMOOD interactions (Deadened virtue buff)

### DIFF
--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -367,8 +367,11 @@ Inquisitorial armory down here
 				M.update_inv_hands()
 			START_PROCESSING(SSobj, src)
 	else if(fuel <= 0 && user.used_intent.type == /datum/intent/weep)
-		to_chat(user, span_info("It is gone. You weep."))
-		user.emote("cry")
+		if(!HAS_TRAIT(user, TRAIT_NOMOOD))
+			to_chat(user, span_info("It is gone. You weep."))
+			user.emote("cry")
+		else
+			to_chat(user, span_info("It is gone. You feel nothing."))
 
 /obj/item/flashlight/flare/torch/lantern/psycenser/process()
 	if(on && next_smoke < world.time)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1287,5 +1287,5 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	victim.energy_add(-2)
 
 	qdel(src)
- 
+
 #undef HAL_LINES_FILE

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -231,14 +231,13 @@
 /mob/living/proc/freak_out()
 	return
 
-/mob/proc/do_freakout_scream()
-	emote("scream", forced=TRUE)
-
 /mob/living/carbon/freak_out() // currently solely used for vampire snowflake stuff
 	if(mob_timers["freakout"])
 		if(world.time < mob_timers["freakout"] + 10 SECONDS)
 			flash_fullscreen("stressflash")
 			return
+	if(HAS_TRAIT(src, TRAIT_NOMOOD))
+		return
 	mob_timers["freakout"] = world.time
 	shake_camera(src, 1, 3)
 	flash_fullscreen("stressflash")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -292,6 +292,9 @@
 			if(HAS_TRAIT(user, TRAIT_EMPATH) && HAS_TRAIT(src, TRAIT_PERMAMUTE))
 				. += span_notice("[m1] lacks a voice. [m1] is a mute!")
 
+			if(HAS_TRAIT(user, TRAIT_EMPATH) && HAS_TRAIT(src, TRAIT_NOMOOD))
+				. += span_biginfo("[m1] completely hollow inside, radiating a deep, tragic silence.")
+
 		var/villain_text = get_villain_text(user)
 		if(villain_text)
 			. += villain_text

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -292,9 +292,6 @@
 			if(HAS_TRAIT(user, TRAIT_EMPATH) && HAS_TRAIT(src, TRAIT_PERMAMUTE))
 				. += span_notice("[m1] lacks a voice. [m1] is a mute!")
 
-			if(HAS_TRAIT(user, TRAIT_EMPATH) && HAS_TRAIT(src, TRAIT_NOMOOD))
-				. += span_biginfo("[m1] completely hollow inside, radiating a deep, tragic silence.")
-
 		var/villain_text = get_villain_text(user)
 		if(villain_text)
 			. += villain_text
@@ -809,6 +806,10 @@
 					msg += "[m1] looking like a drunken mess."
 				if(91.01 to INFINITY)
 					msg += "[m1] a shitfaced, slobbering wreck."
+
+			//Deadened
+			if(HAS_TRAIT(user, TRAIT_EMPATH) && HAS_TRAIT(src, TRAIT_NOMOOD))
+				msg += "[m1] completely hollow inside, radiating a deep, tragic silence."
 
 			//Stress
 			var/stress = get_stress_amount()

--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -216,6 +216,8 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 	stress_freakout()
 
 /mob/living/carbon/proc/stress_freakout()
+	if(HAS_TRAIT(src, TRAIT_NOMOOD))
+		return
 	to_chat(src, span_boldred("I PANIC!!!"))
 	Stun(2 SECONDS)
 	blur_eyes(2)

--- a/code/modules/vampire_neu/covens/coven_powers/presence.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/presence.dm
@@ -32,6 +32,9 @@
 	if((theirpower >= mypower))
 		to_chat(owner, span_warning("[target]'s mind is too powerful to sway!"))
 		return FALSE
+	if(HAS_TRAIT(target, TRAIT_NOMOOD))
+		to_chat(owner, span_warning("[target]'s mind is a hollow void, offering no emotions for your presence to seize."))
+		return FALSE
 	return TRUE
 
 /datum/coven_power/presence/awe/activate(mob/living/carbon/human/target)
@@ -117,6 +120,12 @@
 
 	multi_activate = TRUE
 	cooldown_length = 60 SECONDS
+
+/datum/coven_power/presence/dread_gaze/pre_activation_checks(mob/living/target)
+	if(HAS_TRAIT(target, TRAIT_NOMOOD))
+		to_chat(owner, span_warning("[target]'s mind is a hollow void, offering no emotions for your presence to seize."))
+		return FALSE
+	return TRUE
 
 /datum/coven_power/presence/dread_gaze/activate(mob/living/carbon/human/target)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Adds broader interactions for `TRAIT_NOMOOD`.
- Some presence discipline abilities (Ave and Dread Gaze) no longer affect targets that have `TRAIT_NOMOOD`.
- When examining a target with `TRAIT_EMPATH`, a note now appears informing you that the target is emotionless.
- Characters with `TRAIT_NOMOOD` no longer freaking out.
- Removed dead/unused code in `energy_stamina.dm` and trimmed an unnecessary whitespace.
- Exploded Golgatha no longer causes Psydonites with `TRAIT_NOMOOD` to cry.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="421" height="46" alt="изображение" src="https://github.com/user-attachments/assets/4d7a6ecb-a7af-498e-8857-dc2c4e693f91" />
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Mechanics clarity. In VTM lore, the Presence discipline functions by supernaturally amplifying or manipulating the target's emotions. Since trait implies a complete lack of emotional state or an inability to be affected by mood-altering shifts, these characters should logically be "numb" to such influences.
- Nomood characters are immune to panic or cry as intended, avoiding confusing edge-cases.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Inspecting a TRAIT_EMPATH target now shows a message indicating they are emotionless.
add: Exploded Golgatha no longer makes Psydonites with TRAIT_NOMOOD cry.
balance: Presence discipline abilities (Ave, Dread Gaze) no longer affect TRAIT_NOMOOD targets.
fix: Characters with TRAIT_NOMOOD no longer panic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
