### PR TITLE
Absolver & Wounds

### DIFF
--- a/code/__DEFINES/medical.dm
+++ b/code/__DEFINES/medical.dm
@@ -138,3 +138,10 @@
 #define WOUND_SEVERITY_FATAL 5
 /// This wound has a zombie or werewolf infection
 #define WOUND_SEVERITY_BIOHAZARD 6
+
+/// Wound severity is determined by bleed rate (default)
+#define SEVERITY_TYPE_BLEED "bleed" 
+/// Wound severity is determined by pain value (alternative)
+#define SEVERITY_TYPE_PAIN "pain"
+/// Wound severity is determined by the wound's hp (alternative)
+#define SEVERITY_TYPE_WHP "whp"

--- a/code/__DEFINES/medical.dm
+++ b/code/__DEFINES/medical.dm
@@ -141,7 +141,5 @@
 
 /// Wound severity is determined by bleed rate (default)
 #define SEVERITY_TYPE_BLEED "bleed" 
-/// Wound severity is determined by pain value (alternative)
-#define SEVERITY_TYPE_PAIN "pain"
 /// Wound severity is determined by the wound's hp (alternative)
 #define SEVERITY_TYPE_WHP "whp"

--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 
 /datum/wound/New()
 	. = ..()
-	if(length(severity_names) && length(severity_names) < 5)
+	if(length(severity_stages) && length(severity_stages) < 5)
 		CRASH("[src] wound datum detected with severity stage list at less than 5. This will break severity scaling.")
 
 /// Description of this wound returned to the player when a bodypart is examined and such
@@ -115,6 +115,22 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 /// Description of this wound returned to the player when the bodypart is checked with check_for_injuries()
 /datum/wound/proc/get_check_name(mob/user)
 	return check_name
+
+/// 1:1 transfer from src to arg datum.
+/datum/wound/proc/copy_to(datum/wound/newwound, ratio = 1)
+	if(!newwound)
+		return FALSE
+	if(ratio < 0)
+		return FALSE
+	newwound.whp = whp
+	newwound.severity = severity
+	newwound.bleed_rate = bleed_rate
+	newwound.sew_threshold = sew_threshold
+	newwound.name = name
+	newwound.woundpain = woundpain
+	newwound.clotting_rate = clotting_rate
+	newwound.passive_healing = passive_healing
+	newwound.healable_by_miracles = healable_by_miracles
 
 /// Crit message that should be appended when this wound is applied in combat
 /datum/wound/proc/get_crit_message(mob/living/affected, obj/item/bodypart/affected_bodypart)
@@ -407,16 +423,27 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 	SHOULD_CALL_PARENT(TRUE)	//Don't skip this if you're making new dynamic wounds.
 	return
 
-/datum/wound/proc/update_name()
+/datum/wound/proc/update_stage()
 	var/newname
 	var/oldname = name
-	if(length(severity_names))
-		for(var/sevname in severity_names)
-			if(!bleed_rate) //if it's a hematoma, use whp for naming
-				if(severity_names[sevname] <= whp)
-					newname = sevname
-			else if(severity_names[sevname] <= bleed_rate)
+	if(length(severity_stages))
+		var/checkval
+		var/severityval
+		switch(severity_type)
+			if(SEVERITY_TYPE_BLEED)
+				checkval = bleed_rate
+			if(SEVERITY_TYPE_WHP)
+				checkval = whp
+		for(var/sevname in severity_stages)
+			if(severity_stages[sevname] <= checkval)
 				newname = sevname
+		for(var/i in 1 to length(severity_stages))
+			if(severity_stages[i] == newname)
+				severityval = i
+		severityval = clamp(severityval, 0, 5)
+		if(severityval)
+			severity = severityval
+		
 	name = "[newname  ? "[newname] " : ""][initial(name)]"	//[adjective] [name], aka, "gnarly slash" or "slash"
 	if(name != oldname)
 		owner.visible_message(span_red("The [oldname] on [owner]'s [lowertext(bodyzone2readablezone(bodypart_to_zone(bodypart_owner)))] gets worse!"))

--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -76,8 +76,10 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 	var/bypass_bloody_wound_check = FALSE
 	/// Some wounds make no sense on a dismembered limb and need to go
 	var/qdel_on_droplimb = FALSE
-	/// Severity names, assoc list.
-	var/list/severity_names = list()
+	/// Severity names, assoc list with severity stages. Make sure this list has at least !!5!! entries.
+	var/list/severity_stages = list()
+	/// What do we use for our severity type? Default is bleed rate (usually up to 20 -- artery equi.)
+	var/severity_type = SEVERITY_TYPE_BLEED
 	/// Whether miracles heal it.
 	var/healable_by_miracles = TRUE
 
@@ -93,6 +95,11 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 	owner = null
 	. = ..()
 	return QDEL_HINT_IWILLGC
+
+/datum/wound/New()
+	. = ..()
+	if(length(severity_names) && length(severity_names) < 5)
+		CRASH("[src] wound datum detected with severity stage list at less than 5. This will break severity scaling.")
 
 /// Description of this wound returned to the player when a bodypart is examined and such
 /datum/wound/proc/get_visible_name(mob/user)
@@ -433,6 +440,12 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 					playsound(owner, 'sound/combat/armored_wound.ogg', 100, TRUE)
 					owner.visible_message(span_crit("The wound tears open from [bodypart_owner.owner]'s <b>[bodyzone2readablezone(bodypart_to_zone(bodypart_owner))]</b>, the armor won't let it go any further!"))
 					is_armor_maxed = TRUE
+
+
+/datum/wound/dynamic/proc/update_severity()
+	if(bleed_rate)
+		switch(bleed_rate)
+
 
 #define CLOT_THRESHOLD_INCREASE_PER_HIT 0.1	//This raises the MINIMUM bleed the wound can clot to.
 #define CLOT_DECREASE_PER_HIT 0.05	//This reduces the amount of clotting the wound has.

--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -469,11 +469,6 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 					is_armor_maxed = TRUE
 
 
-/datum/wound/dynamic/proc/update_severity()
-	if(bleed_rate)
-		switch(bleed_rate)
-
-
 #define CLOT_THRESHOLD_INCREASE_PER_HIT 0.1	//This raises the MINIMUM bleed the wound can clot to.
 #define CLOT_DECREASE_PER_HIT 0.05	//This reduces the amount of clotting the wound has.
 #define CLOT_RATE_ARTERY 0	//Artery exceptions. Essentially overrides the clotting threshold.

--- a/code/datums/wounds/types/bites.dm
+++ b/code/datums/wounds/types/bites.dm
@@ -45,7 +45,7 @@
 	can_sew = TRUE
 	can_cauterize = TRUE
 	passive_healing = 0.5
-	severity_names = list(
+	severity_stages = list(
 		"shallow" = 3,
 		"deep" = 8,
 		"gnarly" = 12,
@@ -73,7 +73,7 @@
 	sew_threshold += (dam * BITE_UPG_SEWRATE)
 	woundpain += (dam * BITE_UPG_PAINRATE)
 	armor_check(armor, BITE_ARMORED_BLEED_CLAMP)
-	update_name()
+	update_stage()
 	..()
 
 #undef BITE_UPG_BLEEDRATE

--- a/code/datums/wounds/types/bruises.dm
+++ b/code/datums/wounds/types/bruises.dm
@@ -9,6 +9,7 @@
 	can_sew = FALSE
 	can_cauterize = FALSE
 	passive_healing = 0.5
+	severity_type = SEVERITY_TYPE_WHP
 
 	werewolf_infection_probability = 0
 

--- a/code/datums/wounds/types/bruises.dm
+++ b/code/datums/wounds/types/bruises.dm
@@ -49,7 +49,7 @@
 	can_sew = FALSE
 	can_cauterize = FALSE
 	passive_healing = 0.5
-	severity_names = list(
+	severity_stages = list(
 		"minor" = 20,
 		"moderate" = 60,
 		"big" = 100,
@@ -68,7 +68,7 @@
 	whp += (dam * BRUISE_UPG_WHPRATE)
 	woundpain += (dam * BRUISE_UPG_PAINRATE)
 	passive_healing += BRUISE_UPG_SELFHEAL
-	update_name()
+	update_stage()
 	..()
 
 #undef BRUISE_UPG_WHPRATE

--- a/code/datums/wounds/types/bruises.dm
+++ b/code/datums/wounds/types/bruises.dm
@@ -52,8 +52,9 @@
 	severity_names = list(
 		"minor" = 20,
 		"moderate" = 60,
-		"big" = 120,
-		"massive" = 180
+		"big" = 100,
+		"massive" = 140,
+		"immense" = 180,
 	)
 
 //Bruise Omniwounds

--- a/code/datums/wounds/types/punctures.dm
+++ b/code/datums/wounds/types/punctures.dm
@@ -51,7 +51,7 @@
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = TRUE
-	severity_names = list(
+	severity_stages = list(
 		"shallow" = 3,
 		"deep" = 6,
 		"gnarly" = 9,
@@ -85,7 +85,7 @@
 	sew_threshold += (dam * PUNC_UPG_SEWRATE)
 	woundpain += (dam * PUNC_UPG_PAINRATE)
 	armor_check(armor, PUNC_ARMORED_BLEED_CLAMP)
-	update_name()
+	update_stage()
 	..()
 
 #undef PUNC_UPG_WHPRATE
@@ -108,7 +108,7 @@
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = FALSE
-	severity_names = list(
+	severity_stages = list(
 		"shallow" = 2,
 		"deep" = 4,
 		"gnarly" = 8,
@@ -137,7 +137,7 @@
 	sew_threshold += (dam * GOUGE_UPG_SEWRATE)
 	woundpain += (dam * GOUGE_UPG_PAINRATE)
 	armor_check(armor, GOUGE_ARMORED_BLEED_CLAMP)
-	update_name()
+	update_stage()
 	..()
 
 #undef GOUGE_UPG_BLEEDRATE

--- a/code/datums/wounds/types/slashes.dm
+++ b/code/datums/wounds/types/slashes.dm
@@ -54,8 +54,9 @@
 	can_sew = TRUE
 	can_cauterize = TRUE
 	severity_names = list(
-		"light" = 5,
-		"deep" = 10,
+		"light" = 3,
+		"deep" = 6,
+		"severe" = 10,
 		"gnarly" = 15,
 		"lethal" = 20,
 	)
@@ -207,8 +208,9 @@
 	can_sew = TRUE
 	can_cauterize = FALSE	//Ouch owie oof
 	severity_names = list(
-		"light" = 5,
-		"deep" = 10,
+		"light" = 3,
+		"deep" = 6,
+		"severe" = 10,
 		"gnarly" = 15,
 		"lethal" = 20,
 	)
@@ -256,8 +258,9 @@
 	can_sew = TRUE
 	can_cauterize = FALSE	//Ouch owie oof
 	severity_names = list(
-		"light" = 5,
-		"deep" = 10,
+		"light" = 3,
+		"deep" = 6,
+		"severe" = 10,
 		"gnarly" = 15,
 		"lethal" = 20,
 	)

--- a/code/datums/wounds/types/slashes.dm
+++ b/code/datums/wounds/types/slashes.dm
@@ -53,7 +53,7 @@
 	
 	can_sew = TRUE
 	can_cauterize = TRUE
-	severity_names = list(
+	severity_stages = list(
 		"light" = 3,
 		"deep" = 6,
 		"severe" = 10,
@@ -89,7 +89,7 @@
 	sew_threshold += (dam * SLASH_UPG_SEWRATE)
 	woundpain += (dam * SLASH_UPG_PAINRATE)
 	armor_check(armor, SLASH_ARMORED_BLEED_CLAMP)
-	update_name()
+	update_stage()
 	..()
 
 #undef SLASH_UPG_BLEEDRATE
@@ -207,7 +207,7 @@
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = FALSE	//Ouch owie oof
-	severity_names = list(
+	severity_stages = list(
 		"light" = 3,
 		"deep" = 6,
 		"severe" = 10,
@@ -235,7 +235,7 @@
 	sew_threshold += (dam * LASHING_UPG_SEWRATE)
 	woundpain += (dam * LASHING_UPG_PAINRATE)
 	armor_check(armor, LASHING_ARMORED_BLEED_CLAMP)
-	update_name()
+	update_stage()
 	..()
 
 #undef LASHING_UPG_BLEEDRATE
@@ -257,7 +257,7 @@
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = FALSE	//Ouch owie oof
-	severity_names = list(
+	severity_stages = list(
 		"light" = 3,
 		"deep" = 6,
 		"severe" = 10,
@@ -284,7 +284,7 @@
 	woundpain += (dam * PUNISH_UPG_PAINRATE)
 	passive_healing += PUNISH_UPG_SELFHEAL
 	armor_check(armor, PUNISH_ARMORED_BLEED_CLAMP)
-	update_name()
+	update_stage()
 	..()
 
 #undef PUNISH_UPG_BLEEDRATE

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -646,7 +646,7 @@
 			var/stuntime = 0
 			for(var/obj/item/bodypart/c_BP in BPs_to_check)
 				if(c_BP.get_damage() >= c_BP.max_damage)	// We're some snowflake-ahh Absolver that does not accept regular wounds
-					if(!c_BP.dismember(skip_checks = TRUE) && !istype(c_BP, /obj/item/bodypart/head))	// Our limb can't fall off (or we don't want it to)
+					if(istype(c_BP, /obj/item/bodypart/head) || !c_BP.dismember(skip_checks = TRUE) )	// Our limb can't fall off (or we don't want it to)
 						stuntime += 5 SECONDS
 			if(stuntime)
 				C_caster.Knockdown(stuntime)

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -610,6 +610,8 @@
 			revert_cast()
 			return FALSE
 
+		var/list/BPs_to_check = list()
+
 		//Transfer wounds from each bodypart.
 		for(var/datum/wound/targetwound in tw_List)
 			if (istype(targetwound, /datum/wound/dismemberment))
@@ -623,9 +625,34 @@
 			if (istype(targetwound, /datum/wound/cbt/permanent))
 				continue			
 			var/obj/item/bodypart/c_BP = C_caster.get_bodypart(targetwound.bodypart_owner.body_zone)
-			c_BP.add_wound(targetwound.type)
-			var/obj/item/bodypart/t_BP = C_target.get_bodypart(targetwound.bodypart_owner.body_zone)
-			t_BP.remove_wound(targetwound.type)
+			if(c_BP)
+				var/datum/wound/newwound = c_BP.add_wound(targetwound.type)
+				if(newwound)	// We transferred it successfully.
+					targetwound.copy_to(newwound)
+				else
+					c_BP.receive_damage(targetwound.whp)
+					if(!(c_BP in BPs_to_check))
+						LAZYADD(BPs_to_check, c_BP)
+
+				if((HAS_TRAIT(C_caster, TRAIT_NOPAIN) || HAS_TRAIT(C_caster, TRAIT_NOPAINSTUN)) && HAS_TRAIT(C_caster, TRAIT_BLOODLOSS_IMMUNE))
+					if(!(c_BP in BPs_to_check))
+						c_BP.receive_damage(targetwound.whp)
+						LAZYADD(BPs_to_check, c_BP) // This, in essence, checks whether we're a quirky caster that does not bleed (IE constructs).
+				var/obj/item/bodypart/t_BP = C_target.get_bodypart(targetwound.bodypart_owner.body_zone)
+				if(t_BP)
+					t_BP.remove_wound(targetwound.type)
+
+		if(length(BPs_to_check))
+			var/stuntime = 0
+			for(var/obj/item/bodypart/c_BP in BPs_to_check)
+				if(c_BP.get_damage() >= c_BP.max_damage)	// We're some snowflake-ahh Absolver that does not accept regular wounds
+					if(!c_BP.dismember(skip_checks = TRUE) && !istype(c_BP, /obj/item/bodypart/head))	// Our limb can't fall off (or we don't want it to)
+						stuntime += 5 SECONDS
+			if(stuntime)
+				C_caster.Knockdown(stuntime)
+				C_caster.apply_status_effect(/datum/status_effect/debuff/exposed, stuntime)
+				C_caster.emote("pain")
+
 
 	// Transfer blood
 	var/blood_transfer = 0


### PR DESCRIPTION
## About The Pull Request
### WOUNDS
- Dynamic wounds now scale their severity (in sync with their names), from 1-5.
- This means an external source (like a miracle or diagnosis or examine) can determine the severity of a dynamic wound.
For context, dynamic wounds are the slashes, punctures, gouges, etc that everyone gets commonly.
- Consequently, psydonic miracles that checked for severity might not work on dynamic wounds past a certain stage.

### ABSOLVER
Absolver has been apparently broken this entire time. "WEEP" did not work as it should with dynamic wounds.
To elaborate:
A dynamic wound *starts* at near-0 values, stays on the bodypart and scales up as more damage is done to that bodypart.

Absolver would take that wound, delete it, and then make a new one (with the starting, near-0 values) and be done with it.
This has probably resulted in quite a few issues with Absolvers feeling 'oppressive' or 'too powerful'.

This PR fixes that. Dynamic wounds are now properly copied over to the Absolver, 1:1.

In addition, having fake limbs or being a character with bloodloss immunity (in this case only Constructs I believe?) will apply damage differently:
Because they can ignore both the pain (Absolver) and the bleed (character's trait acquired from wherever), they will instead take direct damage to the limb.

If that damage exceeds the maximum that the limb can take, the limb will, uh:
<img width="323" height="188" alt="dreamseeker_VMpfj10znj" src="https://github.com/user-attachments/assets/0956f4ec-d14b-4971-993e-b5481e6bea1c" />

If that damage is meant to go to a chest / head (as funny as it would be for an Absolver to self-decap by healing a head), they will be knocked down and Exposed for a duration.

Reminder, the above functionality ONLY applies to characters that would otherwise ignore normal wounds. So an organic normie Absolver will not lose their limbs like this.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
As per screenshot I did do some testing, but the miracle ended up having a lot more potential for runtimes / faults than expected so it needs more testing.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Weep now functions as intended (according to the designer / dev -- I didn't make it)
- Behaviour for Absolvers being absent the equivalent limb (Weep will simply not work on that limb).
- Behaviour for an Absolver who can ignore wounds (nopain + nobleed).
- Behaviour for an Absolver with fake / bronze limbs.

The alternative was removing Constructs from Absolver entirely so I'm pretty OK with this.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Absolver's WEEP now has more behaviours for caster or limbs that do not regularly take wounds or would otherwise ignore their effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
