### PR TITLE
Procifies the gear getting flung off on breakage

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -359,6 +359,27 @@
 		. += how_cool_are_your_threads.Join()
 */
 
+/obj/item/clothing/proc/get_flung_off()
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		if(!H.get_tempo_bonus(TEMPO_TAG_EQUIPTOSS))
+			return
+		var/max_range = (H.mind ? 2 : 3)
+		var/throwprob = (H.mind ? 8 : 80) + ((10 - H.STALUC))	// More FOR we have the less likely it is to happen.
+		if(!prob(throwprob))
+			return
+		if(H.dropItemToGround(src, silent = TRUE))
+			H.update_fov_angles()
+			if(material_category == ARMOR_MAT_PLATE || material_category == ARMOR_MAT_CHAINMAIL)
+				do_sparks(2, TRUE, get_turf(H))
+			var/turnangle = (prob(10) ? 180 : prob(50) ? 270 : 90)
+			var/turndir = turn(H.dir, turnangle)
+			var/dist = rand(1, max_range)
+			var/current_turf = get_turf(H)
+			var/target_turf = get_ranged_target_turf(current_turf, turndir, dist)
+			playsound(get_turf(H), 'sound/misc/obj_toss.ogg', 100, TRUE)
+			throw_at(target_turf, dist, 6, H, FALSE)
+
 /obj/item/clothing/obj_break(damage_flag)
 	original_armor = armor
 	var/list/armorlist = armor.getList()
@@ -367,25 +388,7 @@
 			armorlist[x] = 0
 	..()
 	if(throw_on_break && !HAS_TRAIT(src, TRAIT_NODROP))
-		if(ishuman(loc))
-			var/mob/living/carbon/human/H = loc
-			if(!H.get_tempo_bonus(TEMPO_TAG_EQUIPTOSS))
-				return
-			var/max_range = (H.mind ? 2 : 3)
-			var/throwprob = (H.mind ? 8 : 80) + ((10 - H.STALUC))	// More FOR we have the less likely it is to happen.
-			if(!prob(throwprob))
-				return
-			if(H.dropItemToGround(src, silent = TRUE))
-				H.update_fov_angles()
-				if(material_category == ARMOR_MAT_PLATE || material_category == ARMOR_MAT_CHAINMAIL)
-					do_sparks(2, TRUE, get_turf(H))
-				var/turnangle = (prob(10) ? 180 : prob(50) ? 270 : 90)
-				var/turndir = turn(H.dir, turnangle)
-				var/dist = rand(1, max_range)
-				var/current_turf = get_turf(H)
-				var/target_turf = get_ranged_target_turf(current_turf, turndir, dist)
-				playsound(get_turf(H), 'sound/misc/obj_toss.ogg', 100, TRUE)
-				throw_at(target_turf, dist, 6, H, FALSE)
+		get_flung_off()
 
 /obj/item/clothing/obj_fix(mob/user, full_repair = TRUE)
 	..()


### PR DESCRIPTION
## About The Pull Request
No user facing changes.

Devs / Admins / Event Managers can now call `get_flung_off` on a worn piece of armor (any, in this case) for it to be dropped and flung off of them.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
By request.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
