### PR TITLE
Xylix acolyte gets Expert music skill

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -234,4 +234,4 @@
 	if(H.patron?.type == /datum/patron/divine/xylix)  // Trickery and Inspiration - muxic and rogueish skills
 		H.adjust_skillrank(/datum/skill/misc/climbing, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/lockpicking, SKILL_LEVEL_NOVICE, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/music, SKILL_LEVEL_APPRENTICE, TRUE)
+		H.adjust_skillrank(/datum/skill/misc/music, SKILL_LEVEL_EXPERT, TRUE)

--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -234,4 +234,4 @@
 	if(H.patron?.type == /datum/patron/divine/xylix)  // Trickery and Inspiration - muxic and rogueish skills
 		H.adjust_skillrank(/datum/skill/misc/climbing, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		H.adjust_skillrank(/datum/skill/misc/lockpicking, SKILL_LEVEL_NOVICE, TRUE)
-		H.adjust_skillrank(/datum/skill/misc/music, SKILL_LEVEL_EXPERT, TRUE)
+		H.adjust_skillrank_up_to(/datum/skill/misc/music, SKILL_LEVEL_EXPERT, TRUE)


### PR DESCRIPTION


## About The Pull Request

Xylix Acolyte gets Expert in music for equivalency to other bards.

## Testing Evidence

<img width="366" height="40" alt="image" src="https://github.com/user-attachments/assets/1539fd4f-f4fe-4178-995f-809d6f0d063b" />

## Why It's Good For The Game

Every other guy with bardic inspiration gets Expert music. Lets the acolyte play their bad .ogg files without grinding out default dance music.

P.S. we should have a changelog tag for "tweaks" because it feels weird to call this balance.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Xylix acolyte gets Expert music like other bards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
