### PR TITLE
that smelly smell.. most.. smelly.. - baking certain foods no longer gives a default smell message

### DIFF
--- a/code/datums/pollutants/foods.dm
+++ b/code/datums/pollutants/foods.dm
@@ -38,19 +38,19 @@
 
 /datum/pollutant/food/cookies_chocolate
 	name = "freshly baked chocolate cookies"
-	name = "freshly baked chocolate cookies"
+	scent = "freshly baked chocolate cookies"
 
 /datum/pollutant/food/cookies_caramel
 	name = "freshly baked caramelized cookies"
-	name = "freshly baked caramelized cookies"
+	scent = "freshly baked caramelized cookies"
 
 /datum/pollutant/food/cookies_dragee
 	name = "freshly baked herbal cookies"
-	name = "freshly baked herbal cookies"
+	scent = "freshly baked herbal cookies"
 
 /datum/pollutant/food/cookies_raisins
 	name = "freshly baked raisined cookies"
-	name = "freshly baked raisined cookies"
+	scent = "freshly baked raisined cookies"
 
 /datum/pollutant/food/bread
 	name = "fresh baked bread"


### PR DESCRIPTION
## About The Pull Request

* Originally discovered by Shadowlarkins on Orche. Thanks. Fixes a duplicate 'name =' entry with 'scent ='.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Smelling 'smell' is funny, but is unintended behavior. Let people smell delicious cookies, instead.

## Changelog

:cl:
fix: Baking certain pastries should now print the proper smells. Courtesy to Shadowlarkins for discovering the original fix.
/:cl:

