### PR TITLE
munitionia - ports CockatriceXD's creation of projectile-induced special effects, allowing silver munitions to sunder

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -532,3 +532,5 @@
 #define  COMSIG_MOB_KICKED	"mob_kicked"	//from /datum/species/proc/kicked(mob/living/carbon/human/user, mob/living/carbon/human/target). This is for when the mob has BEEN kicked.
 #define COMSIG_STATUS_EFFECT_HAG_CURSE_CLEARED "status_effect_hag_curse_cleared" // Sent when a hag curse is cleared by the curse status effect
 #define COMSIG_SLEEPY_TIME "sleepy_time" // from /mob/living/carbon/human/update_tod(todd)
+#define COMSIG_PROJECTILE_ATTACK_EFFECT "projectile_attack_effect" //Handles the application of specific effects, like silver-based sundering, via ranged damage.
+#define COMSIG_PROJECTILE_ATTACK_EFFECT_SELF "projectile_attack_effect_self" //Ditto.

--- a/code/game/objects/items/rogueweapons/ranged/_ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/_ammo.dm
@@ -8,3 +8,19 @@
 	. = ..()
 	. += span_info("Projectiles have maximum and minimum falloff ranges, with particular falloff factors for damage.")
 	. += span_info("If the target is hit between the maximum and minimum tile range, then the full force is delivered.")
+
+//parent variable to projectiles
+/obj/projectile
+  var/is_silver_proj = FALSE //Self-explanatory.
+
+//handles the infliction of special effects upon projectile impact, such as silver-blighting
+/obj/projectile/proc/do_special_projectile_effect(firer, obj/item/bodypart/affecting, mob/living/victim, selzone)
+    SHOULD_CALL_PARENT(TRUE)
+    SEND_SIGNAL(victim, COMSIG_PROJECTILE_ATTACK_EFFECT, firer, affecting, selzone, src)
+    SEND_SIGNAL(src, COMSIG_PROJECTILE_ATTACK_EFFECT_SELF, firer, affecting, victim, selzone)
+
+    if(is_silver_proj && HAS_TRAIT(victim, TRAIT_SILVER_WEAK))
+        SEND_SIGNAL(victim, COMSIG_FORCE_UNDISGUISE)
+        to_chat(victim, span_danger("Silver rebukes my presence! My vitae smolders, and my powers wane!"))
+        victim.adjust_fire_stacks(1, /datum/status_effect/fire_handler/fire_stacks/sunder) // Ammunition can't be blessed.
+        victim.ignite_mob()

--- a/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
@@ -223,10 +223,8 @@
 	damage = 60 //The rarest, but most powerful arrow subtype. Intended to be incredibly scarce, in practice - a 'silver bullet', to the most literal extent.
 	armor_penetration = PEN_HEAVY
 	embedchance = 100
-	poisontype = /datum/reagent/water/blessed
-	poisonamount = 7
 	npc_simple_damage_mult = 7 //..or 420 damage against a mindless mob. Strike true; reduce if these become craftable or more easily acquirable, through any means.
-
+	is_silver_proj = TRUE 
 
 /obj/item/ammo_casing/caseless/rogue/arrow/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_arrows.dm
@@ -215,7 +215,8 @@
 	that has been fitted with a spearhead of silver. It is expensive, yet unrivaled \
 	in power - pray that you have the will to see its aim unfettered-and-true."
 	projectile_type = /obj/projectile/bullet/reusable/arrow/silver
-	is_silver = FALSE //Give these to the bad guys, if you want to be a little evil. Realistically wouldn't blight someone, unless they're touching the tip.
+	is_silver = TRUE
+	is_lesser_silver = TRUE //Still technically useable by cursed individuals, if they load it quickly enough. Would this be the Zizoid equivalent of using depleted uranium rounds?
 
 /obj/projectile/bullet/reusable/arrow/silver
 	name = "silver arrow"

--- a/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
@@ -62,7 +62,8 @@
 
 /obj/item/ammo_casing/caseless/rogue/bolt/holy
 	name = "sunderbolt"
-	desc = "A silver-tipped bolt, containing a small vial of holy water. Though it inflicts lesser wounds on living flesh, it exceeds when employed against the unholy; a snap and a crack, followed by a fiery surprise. </br>'One baptism for the remission of sins.'"
+	desc = "A silver-tipped bolt, containing a small vial of holy water. Though it inflicts lesser wounds on living flesh, it exceeds \
+	when employed against the unholy; a snap and a crack, followed by a fiery surprise. </br>'One baptism for the remission of sins.'"
 	projectile_type = /obj/projectile/bullet/reusable/bolt/holy
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust)
 	caliber = "regbolt"
@@ -280,12 +281,14 @@
 
 /obj/item/ammo_casing/caseless/rogue/bolt/silver
 	name = "silver bolt"
-	desc = "A masterworked bolt of silver, fitted to a winged rod of boswellia wood. Expensive, yet uncompromisingly lethal; the final adjucation of abberants, delivered from afar. </br>'Non timebo mala..' - '..I will fear no evil.'"
+	desc = "A masterworked bolt of silver, fitted to a winged rod of boswellia wood. Expensive, yet uncompromisingly lethal; the \
+	final adjucation of abberants, delivered from afar. </br>'Non timebo mala..' - '..I will fear no evil.'"
 	projectile_type = /obj/projectile/bullet/reusable/bolt/silver
 	possible_item_intents = list(/datum/intent/dagger/cut, /datum/intent/dagger/thrust)
 	caliber = "regbolt"
 	icon_state = "silvbolt"
-	is_silver = FALSE //Ditto.
+	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/projectile/bullet/reusable/bolt/silver
 	name = "silver bolt"
@@ -299,12 +302,14 @@
 
 /obj/item/ammo_casing/caseless/rogue/heavy_bolt/silver
 	name = "heavy silver bolt"
-	desc = "A silvered lance, poised to impale the unimaginable. You feel the hands of another guiding your own, as you prepare to load; may it be guidence from a higher power, or your wit upon the verge of breaking? </br>'God, please..'"
+	desc = "A silvered lance, poised to impale the unimaginable. You feel the hands of another guiding your own, as you prepare \
+	to load; may it be guidence from a higher power, or your wit upon the verge of breaking? </br>'God, please..'"
 	projectile_type = /obj/projectile/bullet/reusable/heavy_bolt/silver
 	icon_state = "silvheavybolt"
 	max_integrity = 30
 	force = 12
 	is_silver = TRUE
+	is_lesser_silver = TRUE
 
 /obj/projectile/bullet/reusable/heavy_bolt/silver
 	name = "heavy silver bolt"

--- a/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
@@ -135,6 +135,7 @@
 	embedchance = 100
 	poisontype = /datum/reagent/water/blessed
 	poisonamount = 5
+	is_silver_proj = TRUE //Uniquely deals a 'double whammy', in terms of both applying Sunder and some lingering post-impact damage.
 	npc_simple_damage_mult = 5 //175, compared to the regular bolt's 140. Slightly more damage, as to imitate its anti-unholy properties on mobs who aren't affected by any form of poison.
 
 /obj/projectile/bullet/reusable/bolt/blunt
@@ -294,8 +295,7 @@
 	ammo_type = /obj/item/ammo_casing/caseless/rogue/bolt/silver
 	embedchance = 100
 	npc_simple_damage_mult = 6 //..or 480 damage against a mindless mob. Only if you're desperate.
-	poisontype = /datum/reagent/water/blessed
-	poisonamount = 7
+	is_silver_proj = TRUE
 
 /obj/item/ammo_casing/caseless/rogue/heavy_bolt/silver
 	name = "heavy silver bolt"
@@ -314,8 +314,7 @@
 	icon_state = "silvheavybolt_proj"
 	hitsound = 'sound/combat/hits/hi_bolt (3).ogg'
 	speed = 0.8 //Same speed as a crossbow bolt. 
-	poisontype = /datum/reagent/water/blessed
-	poisonamount = 10
+	is_silver_proj = TRUE
 	npc_simple_damage_mult = 10 //..or 1000 damage against a mindless mob. If you're using this against one, you're either a fool or have no other choice left. Godspeed.
 
 // PYRO AMMO

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -222,6 +222,8 @@
 			if(P.embedchance && !check_projectile_embed(P, def_zone, armor))
 				P.handle_drop()
 
+			P.do_special_projectile_effect(P.firer, get_bodypart(check_zone(def_zone)), src, def_zone)
+
 		else
 			P.handle_drop()
 


### PR DESCRIPTION
## About The Pull Request

All credit to CockatriceXD, who - in this [pull request](https://github.com/Ochre-Valley/Ochre-Valley/pull/228) on a downstream fork - created this wonderful solution.
In short:
* Adds a new system that allows for projectiles to inflict special effects upon impact. In this case, we'll use Sundering.
* All silver-tipped munitions, including the _'sunderbolts'_, now induce a single holy firestack upon impact.
* Silver munitions now inherit the _'lesser silver'_ tag, as intended. To blighted handlers, it's basically using depleted uranium.
* To note, these munitions only apply the basic Sundering-type effects. They cannot induce Sunder-specific critical hits.
* _(That is to say, you don't need to worry about being instakilled at range - only skullcracked, like other silver weapons.)_

## Testing Evidence

<img width="293" height="107" alt="7a3e79823f768ae69ce7e24e5a5ef662" src="https://github.com/user-attachments/assets/8e499dd7-bf1d-4d03-830b-99f592233c5b" />

## Why It's Good For The Game

* Silver munitions now act _(mostly)_ the same as silver weapons, which helps for both performance and cohesion.
* Adds the necessary framework to let others make their own projectiles apply special effects upon impact.

## Changelog

:cl:
code: CockatriceXD's work on ammunition has been ported over - all credit to them, and all my thanks! Ammunition can now support the infliction of special effects upon impact.
add: Silver munitions are now counted as 'lesser silver' items, allowing for limited handling by blighted hands.
balance: Silver munitions now properly inflict Sundering-type debuffs upon impact. To note, this only applies one holy firestack (at the moment?) and cannot induce Sundering-exclusive (and lethal) critical hits.
/:cl:
