### PR TITLE
Update Order Minion desc, fix, proper player faction

### DIFF
--- a/code/datums/ai/controllers/mossback.dm
+++ b/code/datums/ai/controllers/mossback.dm
@@ -10,7 +10,7 @@
 
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/being_a_minion,
-		/datum/ai_planning_subtree/aggro_find_target,
+		/datum/ai_planning_subtree/simple_find_target/closest,
 		/datum/ai_planning_subtree/attack_obstacle_in_path,
 		/datum/ai_planning_subtree/basic_melee_attack_subtree,
 		/datum/ai_planning_subtree/find_food,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -423,8 +423,8 @@
 	extra_context = "This subclass has higher-tier miracles, but regenerates Devotion far slower."
 
 /datum/outfit/job/roguetown/adventurer/cantor/pre_equip(mob/living/carbon/human/H)
+	..()
 	to_chat(H, span_warning("You were a bard once - but you've found a new calling. Your eyes have been opened to the divine, now you wander from city to city singing songs and telling tales of your patron's greatness."))
-	H.mind?.current.faction += "[H.name]_faction"
 	head = /obj/item/clothing/head/roguetown/bardhat
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
 	backl = /obj/item/storage/backpack/rogue/satchel
@@ -577,8 +577,8 @@
 	extra_context = "This subclass regenerates Devotion far quicker, but only has access to lesser miracles."
 
 /datum/outfit/job/roguetown/adventurer/missionary/pre_equip(mob/living/carbon/human/H)
+	..()
 	to_chat(H, span_warning("You are a devout worshipper of the divine with a strong connection to your patron god. You've spent years studying scriptures and serving your deity - now you wander into foreign lands, spreading the word of your faith."))
-	H.mind?.current.faction += "[H.name]_faction"
 	backl = /obj/item/storage/backpack/rogue/satchel
 	shirt = /obj/item/clothing/suit/roguetown/armor/vestments_padded
 	pants = /obj/item/clothing/under/roguetown/trou/leather

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
@@ -43,7 +43,6 @@
 
 /datum/outfit/job/roguetown/adventurer/crusader/pre_equip(mob/living/carbon/human/H)
 	..()
-	H.mind?.current.faction += "[H.name]_faction"
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold
 	pants = /obj/item/clothing/under/roguetown/chainlegs
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -44,7 +44,6 @@
 	to_chat(H, span_warning("You father your unholy cause through the most time-tested of ways: hard, heavy steel in both arms and armor."))
 	H.set_blindness(0)
 	if(H.mind)
-		H.mind?.current.faction += "[H.name]_faction"
 		var/weapons = list("Longsword", "Mace", "Flail", "Axe", "Billhook")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
@@ -92,7 +91,6 @@
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
 			H.verbs |= /mob/living/carbon/human/proc/revelations
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
-			H.mind?.current.faction += "[H.name]_faction"
 		ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
 	neck = /obj/item/clothing/neck/roguetown/gorget
@@ -336,7 +334,6 @@
 		)
 	H.cmode_music = 'sound/music/cmode/antag/combat_cutpurse.ogg'
 	if(H.mind)
-		H.mind?.current.faction += "[H.name]_faction"
 		var/weapons = list("Rapier", "Sabre", "Bow", "Crossbow", "Slurbow")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
@@ -396,7 +393,6 @@
 		if(H.mind)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
-			H.mind?.current.faction += "[H.name]_faction"
 		ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
 	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
 	H.mind?.AddSpell(new /datum/action/cooldown/spell/miracle/intervention)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/munitioneer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/munitioneer.dm
@@ -68,7 +68,6 @@
 /datum/outfit/job/roguetown/wretch/munitioneer/choose_loadout(mob/living/carbon/human/H)
 	. = ..()
 	if(H.mind)
-		H.mind?.current.faction += "[H.name]_faction"
 		H.set_patron(/datum/patron/divine/malum)
 		H.AddComponent(/datum/component/ore_sight) // controversial, and powerful, but it means you're spending less Wretch Time just mining.
 	var/weapons = list("Path of the Hammer - Steel Warhammer", "Path of the Crossbow - Crossbow and Bolts", "Path of the Pick - Pulaski Axe")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -58,7 +58,6 @@
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	if(H.mind)
 		backr = choose_implement(H, "greater")
-		H.mind?.current.faction += "[H.name]_faction"
 		H.set_patron(/datum/patron/inhumen/zizo)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/eyebite)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/bonechill)

--- a/code/modules/jobs/job_types/roguetown/roguetown.dm
+++ b/code/modules/jobs/job_types/roguetown/roguetown.dm
@@ -52,6 +52,8 @@
 
 /datum/outfit/job/roguetown/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
+	if(!visualsOnly && H.real_name)
+		H.faction |= "[H.real_name]_faction"
 	var/datum/patron/old_patron = H.patron
 	if(length(allowed_patrons) && (!old_patron || !(old_patron.type in allowed_patrons)))
 		var/list/datum/patron/possiblegods = list()

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
@@ -40,7 +40,6 @@
 /datum/outfit/job/roguetown/mercenary/atgervi/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("You are a Varangian of the Gronn Highlands. Warrior-Traders whose exploits into the Raneshen Empire will be forever remembered by historians."))
-	H.mind?.current.faction += "[H.name]_faction"
 	head = /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi
 	gloves = /obj/item/clothing/gloves/roguetown/angle/atgervi
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/atgervi
@@ -118,7 +117,6 @@
 	..()
 	H.set_blindness(0)
 	to_chat(H, span_warning("You are a Shaman of the Fjall, The Northern Empty. Shamans are savage combatants who commune with the Ecclesical Beast gods through ritualistic violence, rather than idle prayer."))
-	H.mind?.current.faction += "[H.name]_faction"
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 
 	head = /obj/item/clothing/head/roguetown/helmet/leather/shaman_hood

--- a/code/modules/jobs/job_types/roguetown/sidefolk/vagabond/excommunicado.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/vagabond/excommunicado.dm
@@ -19,7 +19,6 @@
 
 /datum/outfit/job/roguetown/vagabond/excommunicated/pre_equip(mob/living/carbon/human/H)
 	..()
-	H.mind?.current.faction += "[H.name]_faction"
 	if(should_wear_femme_clothes(H))
 		armor = /obj/item/clothing/suit/roguetown/shirt/rags
 	else if(should_wear_masc_clothes(H))

--- a/code/modules/spells/minion_order.dm
+++ b/code/modules/spells/minion_order.dm
@@ -1,7 +1,10 @@
 /obj/effect/proc_holder/spell/invoked/minion_order
 	name = "Order Minions"
-	desc = "Cast on turf to head in that direction ignoring all else. \
-	Cast on a minion to set to aggressive, cast on self to passive and follow, cast on target to focus them. \
+	desc = "Issues commands to your summoned minions within 12 tiles. \
+	Cast on a turf to send them marching there, ignoring all else along the way. \
+	Cast on yourself to recall them - they will turn passive and follow you. \
+	Cast on an enemy to focus them; minions will pursue and attack that target. \
+	Cast on one of your own minions to toggle its stance: a passive minion becomes hostile and will hunt strangers on its own; a hostile minion calms down and reverts to follow-and-defend. \
 	Does not work on greater skeletons."
 	range = 12
 	associated_skill = /datum/skill/misc/athletics
@@ -83,9 +86,11 @@
 						if(minion == target) // single minion clicked
 							if("neutral" in minion.faction) // currently passive → switch to aggressive
 								minion.faction -= "neutral"
+								minion.pet_passive = FALSE
 								msg = "[minion.name] becomes hostile to nearby strangers."
 							else
 								minion.faction += "neutral"
+								minion.pet_passive = TRUE
 								msg = "[minion.name] calms down."
 	if(count>0)
 		to_chat(caster, "Ordered [count] minions to " + msg)
@@ -94,8 +99,11 @@
 
 /obj/effect/proc_holder/spell/invoked/minion_order/carbon //Specialized for carbon-based minions.
 	name = "Order Minions"
-	desc = "Cast on turf to head in that direction ignoring all else. \
-	Cast on a minion to set to aggressive, cast on self to passive and follow, cast on target to focus them."
+	desc = "Issues commands to your summoned minions within 12 tiles. \
+	Cast on a turf to send them marching there, ignoring all else along the way. \
+	Cast on yourself to recall them - they will turn passive and follow you. \
+	Cast on an enemy to focus them; minions will pursue and attack that target. \
+	Cast on one of your own minions to toggle its stance: a passive minion becomes hostile and will hunt strangers on its own; a hostile minion calms down and reverts to follow-and-defend."
 
 /obj/effect/proc_holder/spell/invoked/minion_order/carbon/cast(list/targets, mob/user)
 	var/mob/caster = user
@@ -170,9 +178,11 @@
 						if(minion == target) // single minion clicked
 							if("neutral" in minion.faction) // currently passive → switch to aggressive
 								minion.faction -= "neutral"
+								minion.pet_passive = FALSE
 								msg = "[minion.name] becomes hostile to nearby strangers."
 							else
 								minion.faction += "neutral"
+								minion.pet_passive = TRUE
 								msg = "[minion.name] calms down."
 	if(count>0)
 		to_chat(caster, "Ordered [count] minions to " + msg)


### PR DESCRIPTION
## About The Pull Request
- Fixes the "Mossback fluoride staring" issue reported by Ketrai, by making Order Minion toggle OFF the passive mode
- All people on spawn now gain realname_faction as part of their faction. This means mobs that relied on realname_faction (several of them) actually can match their summoner faction and NOT gank the summoner - particularly important for toggling Mossback to aggro mode because they start hitting you right away
- Removed snowflake real name faction set in favor of just setting it on spawn, on every class (that I can catch)
- Updated Order Minion description to be more detailed and better

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1734" height="754" alt="dreamseeker_o91mSPT9ay" src="https://github.com/user-attachments/assets/c13a3ad2-821a-47b8-ab90-a198f330055a" />
<img width="475" height="650" alt="dreamseeker_g2lZFTpUSl" src="https://github.com/user-attachments/assets/9d5fc82c-dafa-440d-ab54-a5c388b37134" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fixes some issues with summon being less aggressive and responsive. Possibly fix the issues with Necro summon ganking them on spawn.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Order Minions spell now have better description on how it actually works
add: When a pet is ordered to go on aggressive mode, it will now attack strangers properly. It will also no longer attack its summoner (in most case)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
