### PR TITLE
Kazengun Silverface additions, some rebalance, plus some other housekeeping

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
@@ -1,4 +1,5 @@
-// Special Mercenary Weapons, at exorbitant prices
+// Special Mercenary Weapons, at exorbitant prices.
+// I just wish someone explained how to price these.
 /datum/supply_pack/rogue/merc_weapons
 	group = "Weapons (Foreign)"
 	crate_name = "merchant guild's crate"
@@ -15,7 +16,7 @@
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/steel/parrying/vaquero)
 
 /datum/supply_pack/rogue/merc_weapons/erapier
-	name = "Etruscan Cup-Hilt Rapier"
+	name = "Cup-Hilt Rapier"
 	cost = 120
 	contains = list(/obj/item/rogueweapon/sword/rapier/vaquero)
 
@@ -59,30 +60,42 @@
 	cost = 140
 	contains = list(/obj/item/rogueweapon/spear/naginata)
 
-/datum/supply_pack/rogue/merc_weapons/katana
-	name = "Kazengun Hwando"
-	cost = 120
-	contains = list(/obj/item/rogueweapon/sword/sabre/mulyeog)
-
-/datum/supply_pack/rogue/merc_weapons/kazengunhookblade
-	name = "Kazengun Hook Sword"
+/datum/supply_pack/rogue/merc_weapons/hookblade
+	name = "Hook Sword"
 	cost = 150
 	contains = list(/obj/item/rogueweapon/sword/sabre/hook)
 
-/datum/supply_pack/rogue/merc_weapons/kazengunkodachi
-	name = "Kazengun Kodachi"
-	cost = 120
-	contains = list(/obj/item/rogueweapon/sword/short/kazengun)
-
-/datum/supply_pack/rogue/merc_weapons/kazenguntanto
-	name = "Kazengun Tanto"
-	cost = 80
-	contains = list(/obj/item/rogueweapon/huntingknife/idagger/steel/kazengun)
-
-/datum/supply_pack/rogue/merc_weapons/kazengunscabbard
-	name = "Kazengun Scabbard"
+/datum/supply_pack/rogue/merc_weapons/hwando
+	name = "Hwando and custom scabbard"
 	cost = 250
-	contains = list(/obj/item/rogueweapon/scabbard/sword/kazengun)
+	contains = list(
+		/obj/item/rogueweapon/sword/sabre/mulyeog,
+		/obj/item/rogueweapon/scabbard/sword/kazengun
+	)
+
+/datum/supply_pack/rogue/merc_weapons/ssangsudo
+	name = "Ssangsudo and custom scabbard"
+	cost = 250
+	contains = list(
+		/obj/item/rogueweapon/sword/long/kriegmesser/ssangsudo,
+		/obj/item/rogueweapon/scabbard/sword/kazengun/noparry // Freebie for the drip.
+	)
+
+/datum/supply_pack/rogue/merc_weapons/kodachi
+	name = "Kodachi and custom scabbard"
+	cost = 150
+	contains = list(
+		/obj/item/rogueweapon/sword/short/kazengun,
+		/obj/item/rogueweapon/scabbard/sword/kazengun/kodachi
+	)
+
+/datum/supply_pack/rogue/merc_weapons/tanto
+	name = "Tanto and custom sheathe"
+	cost = 120 // This is just a reskinned sail dagger, but this one comes with a sheathe.
+	contains = list(
+		/obj/item/rogueweapon/huntingknife/idagger/steel/kazengun,
+		/obj/item/rogueweapon/scabbard/sheath/kazengun
+	)
 
 /datum/supply_pack/rogue/merc_weapons/beardedaxe
 	name = "Bearded Axe"
@@ -90,11 +103,11 @@
 	contains = list(/obj/item/rogueweapon/stoneaxe/woodcut/steel/atgervi)
 
 /datum/supply_pack/rogue/merc_weapons/handclaw_iron
-	name = "Gronnic Iron Claw"
+	name = "Iron Claw"
 	cost = 150
 	contains = list(/obj/item/rogueweapon/handclaw)
 
 /datum/supply_pack/rogue/merc_weapons/handclaw_steel
-	name = "Gronnic Steel Claw"
+	name = "Steel Claw"
 	cost = 200
 	contains = list(/obj/item/rogueweapon/handclaw/steel)

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_foreign.dm
@@ -78,7 +78,7 @@
 	cost = 250
 	contains = list(
 		/obj/item/rogueweapon/sword/long/kriegmesser/ssangsudo,
-		/obj/item/rogueweapon/scabbard/sword/kazengun/noparry // Freebie for the drip.
+		/obj/item/rogueweapon/scabbard/sword/kazengun/noparry
 	)
 
 /datum/supply_pack/rogue/merc_weapons/kodachi

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
@@ -8,264 +8,189 @@
 /datum/supply_pack/rogue/steel_weapons/dagger
 	name = "Dagger"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/huntingknife/idagger/steel,
-				)
+	contains = list(/obj/item/rogueweapon/huntingknife/idagger/steel)
 
 /datum/supply_pack/rogue/steel_weapons/chefknife
 	name = "Chef's Knife"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/huntingknife/chefknife,
-				)
+	contains = list(/obj/item/rogueweapon/huntingknife/idagger/steel)
 
 /datum/supply_pack/rogue/steel_weapons/chefcleaver
 	name = "Chef's Cleaver"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/huntingknife/chefknife/cleaver,
-				)
+	contains = list(/obj/item/rogueweapon/huntingknife/chefknife/cleaver)
 
 /datum/supply_pack/rogue/steel_weapons/rondeldagger
 	name = "Rondel Dagger"
 	cost = 70 // 2 Steel Ingots
-	contains = list(
-					/obj/item/rogueweapon/huntingknife/idagger/steel/rondel,
-				)
+	contains = list(/obj/item/rogueweapon/huntingknife/idagger/steel/rondel)
 
 /datum/supply_pack/rogue/steel_weapons/katar
 	name = "Katar"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/katar
-				)
+	contains = list(/obj/item/rogueweapon/katar)
 
 /datum/supply_pack/rogue/steel_weapons/steelknuckle
 	name = "Steel Knuckle"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/clothing/gloves/roguetown/knuckles
-				)
+	contains = list(/obj/item/clothing/gloves/roguetown/knuckles)
 
 /datum/supply_pack/rogue/steel_weapons/rapier
 	name = "Rapier"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/rapier,
-				)
-				
+	contains = list(/obj/item/rogueweapon/sword/rapier)
+
 /datum/supply_pack/rogue/steel_weapons/cutlass
 	name = "Cutlass"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/cutlass,
-				)
+	contains = list(/obj/item/rogueweapon/sword/cutlass)
 
 /datum/supply_pack/rogue/steel_weapons/sword
 	name = "Arming Sword"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword,
-				)
+	contains = list(/obj/item/rogueweapon/sword)
 
 /datum/supply_pack/rogue/steel_weapons/shortsword
 	name = "Shortsword"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/short,
-				)
+	contains = list(/obj/item/rogueweapon/sword/short)
 
 /datum/supply_pack/rogue/steel_weapons/falchion
 	name = "Falchion"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/short/falchion,
-				)
+	contains = list(/obj/item/rogueweapon/sword/short/falchion)
 
 /datum/supply_pack/rogue/steel_weapons/messer
 	name = "Messer"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/short/messer,
-				)
+	contains = list(/obj/item/rogueweapon/sword/short/messer)
 
 /datum/supply_pack/rogue/steel_weapons/messeralt
 	name = "Hunting Sword"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/short/messer/alt,
-				)
+	contains = list(/obj/item/rogueweapon/sword/short/messer/alt)
 
 /datum/supply_pack/rogue/steel_weapons/sabre
 	name = "Sabre"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/sabre,
-				)
+	contains = list(/obj/item/rogueweapon/sword/sabre)
 
 /datum/supply_pack/rogue/steel_weapons/flail
 	name = "Flail"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/flail/sflail,
-				)
+	contains = list(/obj/item/rogueweapon/flail/sflail)
 
 /datum/supply_pack/rogue/steel_weapons/warhammer
 	name = "Warhammer"
 	cost = 70 // 2 Steel Ingots
-	contains = list(
-					/obj/item/rogueweapon/mace/warhammer/steel,
-				)
+	contains = list(/obj/item/rogueweapon/mace/warhammer/steel)
 
 /datum/supply_pack/rogue/steel_weapons/sflangedmace
 	name = "Flanged Mace"
 	cost = 70 // 2 Steel Ingots
-	contains = list(
-					/obj/item/rogueweapon/mace/cudgel/flanged,
-				)
+	contains = list(/obj/item/rogueweapon/mace/cudgel/flanged)
 
 /datum/supply_pack/rogue/steel_weapons/longsword
 	name = "Longsword"
 	cost = 70 // 2 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/long,
-				)
+	contains = list(/obj/item/rogueweapon/sword/long)
 
 /datum/supply_pack/rogue/steel_weapons/kriegmesser
 	name = "Kriegsmesser"
 	cost = 70 // 2 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/long/kriegmesser,
-				)
+	contains = list(/obj/item/rogueweapon/sword/long/kriegmesser)
 
 /datum/supply_pack/rogue/steel_weapons/broadsword
 	name = "Broadsword"
 	cost = 75 // 2 Steel Ingot + 1 Small Log
-	contains = list(
-					/obj/item/rogueweapon/sword/long/broadsword/steel,
-				)
+	contains = list(/obj/item/rogueweapon/sword/long/broadsword/steel)
 
 /datum/supply_pack/rogue/steel_weapons/battleaxe
 	name = "Battle Axe"
 	cost = 70 // 2 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/stoneaxe/battle,
-				)
+	contains = list(/obj/item/rogueweapon/stoneaxe/battle)
 
 /datum/supply_pack/rogue/steel_weapons/mace
 	name = "Mace"
 	cost = 70 // 2 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/mace/steel,
-				)
+	contains = list(/obj/item/rogueweapon/mace/steel)
 
 /datum/supply_pack/rogue/steel_weapons/greatsword
 	name = "Greatsword"
 	cost = 105 // 3 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/greatsword,
-				)
+	contains = list(/obj/item/rogueweapon/greatsword)
 
 /datum/supply_pack/rogue/steel_weapons/estoc
 	name = "Estoc"
 	cost = 70 // 2 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/estoc,
-				)
+	contains = list(/obj/item/rogueweapon/estoc)
 
 /datum/supply_pack/rogue/steel_weapons/aplongsword
 	name = "Stecher"
 	cost = 75 // 2 Steel Ingot, 1 Small Log
-	contains = list(
-					/obj/item/rogueweapon/sword/long/ap,
-				)
+	contains = list(/obj/item/rogueweapon/sword/long/ap)
 
 /datum/supply_pack/rogue/steel_weapons/greataxe
 	name = "Greataxe"
 	cost = 75 // 2 Steel Ingot, 1 Small Log
-	contains = list(
-					/obj/item/rogueweapon/greataxe/steel,
-				)
+	contains = list(/obj/item/rogueweapon/greataxe/steel)
 
 /datum/supply_pack/rogue/steel_weapons/greataxeknight
 	name = "Steel Poleaxe"
 	cost = 85 // 2 Steel Ingot, 1 Small Log
-	contains = list(
-					/obj/item/rogueweapon/greataxe/steel/knight,
-				)
+	contains = list(/obj/item/rogueweapon/greataxe/steel/knight)
 
 /datum/supply_pack/rogue/steel_weapons/greataxedoublehead
 	name = "Greataxe, Double-Headed"
 	cost = 110 // 3 Steel Ingot, 1 Small Log
-	contains = list(
-					/obj/item/rogueweapon/greataxe/steel/doublehead,
-				)
+	contains = list(/obj/item/rogueweapon/greataxe/steel/doublehead)
 
 /datum/supply_pack/rogue/steel_weapons/billhook
 	name = "Billhook"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/spear/billhook,
-				)
+	contains = list(/obj/item/rogueweapon/spear/billhook)
 
 /datum/supply_pack/rogue/steel_weapons/halberd
 	name = "Halberd"
 	cost = 75 // 2 Steel Ingot, 1 Small Log
-	contains = list(
-					/obj/item/rogueweapon/halberd,
-				)
+	contains = list(/obj/item/rogueweapon/halberd)
 
 /datum/supply_pack/rogue/steel_weapons/eaglebeak
 	name = "Eagle's Beak"
 	cost = 75 // 2 Steel Ingot, 1 Small Log
-	contains = list(
-					/obj/item/rogueweapon/eaglebeak,
-				)
+	contains = list(/obj/item/rogueweapon/eaglebeak)
 
 /datum/supply_pack/rogue/steel_weapons/grandmace
 	name = "Grand Mace"
 	cost = 75 // 2 Steel Ingot, 1 Small Log
-	contains = list(
-					/obj/item/rogueweapon/mace/goden/steel,
-				)
+	contains = list(/obj/item/rogueweapon/mace/goden/steel)
 
 /datum/supply_pack/rogue/steel_weapons/partizan
 	name = "Partizan"
 	cost = 80 // 2 Steel Ingot, 1 Small Log. Slight increase cuz gated behind skill 4
-	contains = list(
-					/obj/item/rogueweapon/spear/partizan,
-				)
+	contains = list(/obj/item/rogueweapon/spear/partizan)
 
 /datum/supply_pack/rogue/steel_weapons/boarspear
 	name = "Boar Spear"
 	cost = 80 // 2 Steel Ingot, 1 Small Log. Slight increase cuz gated behind skill 4
-	contains = list(
-					/obj/item/rogueweapon/spear/boar,
-				)
+	contains = list(/obj/item/rogueweapon/spear/boar)
 
 /datum/supply_pack/rogue/steel_weapons/lance
 	name = "Lance"
 	cost = 80 // 2 Steel Ingot, 1 Small Log. Slight increase cuz gated behind skill 4
-	contains = list(
-					/obj/item/rogueweapon/spear/lance,
-				)
+	contains = list(/obj/item/rogueweapon/spear/lance)
 
 /datum/supply_pack/rogue/steel_weapons/fishingspear
 	name = "Fishing Spear"
-	cost = 75 // 2 Steel Ingot, 1 Small Log. 
-	contains = list(
-					/obj/item/rogueweapon/fishspear,
-				)
+	cost = 75 // 2 Steel Ingot, 1 Small Log.
+	contains = list(/obj/item/rogueweapon/fishspear)
+
 /datum/supply_pack/rogue/steel_weapons/rhomphaia
 	name = "Rhomphaia"
 	cost = 70 // 2 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/long/rhomphaia,
-				)
+	contains = list(/obj/item/rogueweapon/sword/long/rhomphaia)
 
 /datum/supply_pack/rogue/steel_weapons/falx
 	name = "Falx"
 	cost = 40 // 1 Steel Ingot
-	contains = list(
-					/obj/item/rogueweapon/sword/falx,
-				)
+	contains = list(/obj/item/rogueweapon/sword/falx)

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_ranged.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_ranged.dm
@@ -25,85 +25,63 @@
 
 /datum/supply_pack/rogue/ranged_weapons/hurlbat
 	name = "Hurlbat"
-	cost = 50 // 1 Steel Ingot, but a pretty strong weapon. 
+	cost = 50 // 1 Steel Ingot, but a pretty strong weapon.
 	contains = list(/obj/item/rogueweapon/stoneaxe/hurlbat)
 
 /datum/supply_pack/rogue/ranged_weapons/crossbow
 	name = "Crossbow"
 	cost = 30
-	contains = list(
-					/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-				)
+	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow)
 
 /datum/supply_pack/rogue/ranged_weapons/crossbow/slurbow
 	name = "Slurbow"
 	cost = 30
-	contains = list(
-					/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow,
-				)
+	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow)
 
 /datum/supply_pack/rogue/ranged_weapons/recurvebow
 	name = "Bow, Recurve"
 	cost = 20
-	contains = list(
-					/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve,
-				)
+	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve)
 
 /datum/supply_pack/rogue/ranged_weapons/longbow
 	name = "Bow, Longbow"
 	cost = 45
-	contains = list(
-					/obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow,
-				)
+	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow)
 
 /datum/supply_pack/rogue/ranged_weapons/quiver
 	name = "Quiver"
 	cost = 5
-	contains = list(
-					/obj/item/quiver,
-				)
+	contains = list(/obj/item/quiver)
 
 /datum/supply_pack/rogue/ranged_weapons/quivers/arrows
 	name = "Quiver of Arrows"
 	cost = 35 // 2 Iron Ingots
-	contains = list(
-					/obj/item/quiver/arrows,
-				)
+	contains = list(/obj/item/quiver/arrows)
 
 /datum/supply_pack/rogue/ranged_weapons/quivers/barrows
 	name = "Quiver of Bodkin Arrows"
 	cost = 100 // 2 Steel Ingots + Sticks
-	contains = list(
-					/obj/item/quiver/bodkin,
-				)
+	contains = list(/obj/item/quiver/bodkin)
 
 /datum/supply_pack/rogue/ranged_weapons/quivers/poisonarrows
 	name = "Quiver of Poison Arrows"
-	cost = 100 
-	contains = list(
-					/obj/item/quiver/poisonarrows,
-				)
+	cost = 100
+	contains = list(/obj/item/quiver/poisonarrows)
 
 /datum/supply_pack/rogue/ranged_weapons/quivers/bolts
 	name = "Quiver of Bolts"
 	cost = 35 // 2 Iron Ingots
-	contains = list(
-					/obj/item/quiver/bolt/standard
-				)
+	contains = list(/obj/item/quiver/bolt/standard)
 
 /datum/supply_pack/rogue/ranged_weapons/quivers/lightbolts
 	name = "Quiver of Light Bolts"
 	cost = 30
-	contains = list(
-					/obj/item/quiver/bolt/light
-				)
+	contains = list(/obj/item/quiver/bolt/light)
 
 /datum/supply_pack/rogue/ranged_weapons/quivers/pyrobolts
 	name = "Quiver of Pyroclastic Bolts"
 	cost = 100
-	contains = list(
-					/obj/item/quiver/bolt/pyro,
-				)
+	contains = list(/obj/item/quiver/bolt/pyro)
 
 /datum/supply_pack/rogue/ranged_weapons/slingandpouch
 	name = "Sling and Pouch"
@@ -117,13 +95,9 @@
 /datum/supply_pack/rogue/ranged_weapons/slingiron
 	name = "Sling Bullets Pouch, Iron"
 	cost = 35 // 2 Iron Ingots
-	contains = list(
-					/obj/item/quiver/sling/iron,
-				)
+	contains = list(/obj/item/quiver/sling/iron)
 
 /datum/supply_pack/rogue/ranged_weapons/net
 	name = "Net"
 	cost = 20
-	contains = list(
-					/obj/item/net,
-				)
+	contains = list(/obj/item/net)


### PR DESCRIPTION
## About The Pull Request

Added some more Kazengun weapons to the Silverface since they otherwise are impossible to obtain if lost or stolen. They're stll pretty expensive. I also cleaned up some annoying whitespace in silverface weapons pages since MOST purchases are just one item.

Honestly I haven't the foggiest fucking idea how to assign cost to these.

**PLEASE GIVE ME SOME FEEDBACK ON PRICES!! I AM GOING ON VIBES!!**
- I was extremely unsure of what to do with the hwando scabbard. On the one hand, that 250 mammon pricetag for _just the fucking sheathe_ was supposedly added during a time where 1) the ability to parry could also block projectiles, 2) the scabbard could accept any sword you shoved in it, and 3) the scabbard was invulnerable and had no integrity loss if hit. It otherwise has the same wdefense as the cup hilted rapier which is also on this list. The sword is just a slightly buffed attack shortsword that pays for it by losing its parry stats, because you're _supposed_ to use it with the neat scabbard. However, I don't know for sure if any of that is true because the dumbass who told me this has been incorrect or straight up lied about balance problems in the past because he's exaggerating how broken or OP something is in hopes that I'll nerf it. It _appears to me_ like their hype about this weapon was entirely overblown and it's already been nerfed, or it's based on knowledge from over a year ago. Point being, I'm hoping this can be less expensive now.
- I also had no fucking idea how to price the other stuff. If you have a system for this, tell me what it is. There wasn't many good 1:1 comparisons in the foreign weapons.

## Testing Evidence

I'm sure it's fine.

## Why It's Good For The Game

All the Kazengun items are now possible to purchase, whereas before, they weren't, and it's not like these are the super exclusive Ruma clan variants. These are just the normal variants.

Previously, if a Kazengun person wanted to use their traditional weapons and either didn't spawn with one or lost it, they could never get another.

I also think the hwando scabbard was overpriced for what it was and you'll now _absolutely never buy it_ unless you're also buying the hwando, so I made them a package deal. Then I thought, why not do that for all the bespoke scabbards and swords? So I did.

## Changelog

:cl:
add: Added more Kazengun items to Silverface/Goldface.
qol: Kazengun swords are bought with their corresponding scabbard.
balance: Hwando and scabbard are now cheaper as a package deal.
refactor: Removed unnecessary whitespace and commas on weapon listings that were only one item for sale.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
