### PR TITLE
fix ascendent examines (?)

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1108,16 +1108,22 @@
 			heretic_text += "A member of Zizo's cabal."
 			if(HAS_TRAIT(examiner, TRAIT_CABAL))
 				heretic_text += " May their ambitions not interfere with mine."
+		else if(HAS_TRAIT(examiner, TRAIT_CABAL))
+			heretic_text += "Another of the Cabal."
 	else if((HAS_TRAIT(src, TRAIT_HORDE)))
 		if(seer)
 			heretic_text += "Hardened by Graggar's Rituals."
 			if(HAS_TRAIT(examiner, TRAIT_HORDE))
 				heretic_text += " Mine were a glorious memory."
+		else if(HAS_TRAIT(examiner, TRAIT_HORDE))
+			heretic_text += "BLOOD-SIBLING!"
 	else if((HAS_TRAIT(src, TRAIT_DEPRAVED)))
 		if(seer)
 			heretic_text += "Baotha's Touched."
 			if(HAS_TRAIT(examiner, TRAIT_DEPRAVED))
 				heretic_text += " She leads us to the greatest ends."
+		else if(HAS_TRAIT(examiner, TRAIT_DEPRAVED))
+			heretic_text += "Another Broken-Hearted..."
 
 	return heretic_text
 


### PR DESCRIPTION
## About The Pull Request
the code for the ascendent-patron traits claim they make you able to recognize other followers:
<img width="898" height="101" alt="image" src="https://github.com/user-attachments/assets/de31525d-d6f9-4792-b12e-4abadc58009f" />
this is not, in fact, the case... _except_ for matthios for some reason? which seems like a bug. this PR just copies over the code that makes the matthios examine work to the other 3 cases, which will now work the same way

before & after (this one cannot imagine this was intentional)
<img width="729" height="474" alt="image" src="https://github.com/user-attachments/assets/bb2711e5-26d6-46cf-ad3d-7ef3a3ea890f" />
<img width="908" height="565" alt="image" src="https://github.com/user-attachments/assets/71637861-c78f-406b-a6cc-d873d962b173" />

## Testing Evidence
compiles. it's the same code as the matthios examine. don't really feel like spinning up two test instances and messing with traits in VV to get a comprehensive screenshot battery here

## Why It's Good For The Game
matthiosans really have no reason to be the only heretics that can see who each other are. if it's intended to be a thing, everyone should get it, if not, it should be removed entirely. being able to see who is a fellow four-worshipper without needing to do the very suspicious faith salute is probably good for intrigue?

## Changelog

:cl:
fix: All ascendent-followers can now see fellow worshippers of their patron, not just Matthiosians
/:cl:

