### PR TITLE
[Black rot & malpractioner] Misc changes, requires rotfang to actually use a parry-able attack to inflict rot.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/plaguebearer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/plaguebearer.dm
@@ -37,7 +37,7 @@
 
 /datum/outfit/job/roguetown/wretch/plaguebearer/pre_equip(mob/living/carbon/human/H)
 	head = /obj/item/clothing/head/roguetown/physician
-	mask = /obj/item/clothing/mask/rogue/physician
+	mask = /obj/item/clothing/mask/rogue/physician/plaguebearer
 	neck = /obj/item/clothing/neck/roguetown/chaincoif 
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	cloak = /obj/item/clothing/suit/roguetown/shirt/robe/physician
@@ -75,3 +75,11 @@
 		H.mind.teach_crafting_recipe(/datum/crafting_recipe/roguetown/alchemy/unique/ichor)
 		H.mind.teach_crafting_recipe(/datum/crafting_recipe/roguetown/alchemy/unique/ichor_big)
 		wretch_select_bounty(H)
+
+/obj/item/clothing/mask/rogue/physician/plaguebearer
+	desc = "What better laboratory than the blood-soaked battlefield? This one seems to be uniquely armored."
+	armor = ARMOR_PLATE
+	// Less than an actual steel mask.
+	max_integrity = 160
+	// Consistency with other masks.
+	body_parts_covered = FACE

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/plaguebearer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/plaguebearer.dm
@@ -83,3 +83,4 @@
 	max_integrity = 160
 	// Consistency with other masks.
 	body_parts_covered = FACE
+	blocksound = PLATEHIT

--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_black_rot.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_black_rot.dm
@@ -46,22 +46,22 @@
 	switch(tier)
 		if(1)
 			linked_alert.name = "Black Rot (Creeping)"
-			linked_alert.desc = "A faint darkness spreads beneath my skin."
+			linked_alert.desc = "A faint darkness spreads beneath my skin. I should seek out a calyx or heartblood vials before it is too late."
 			linked_alert.icon_state = "blackrot1"
 			examine_text = "SUBJECTPRONOUN seems to be rotting alive! (Creeping)"
 		if(2)
 			linked_alert.name = "Black Rot (Festering)"
-			linked_alert.desc = "My veins run black with corruption. I will surely die if this persists."
+			linked_alert.desc = "My veins run black with corruption. I will surely die if this persists. I should seek out a calyx or heartblood vials before it is too late."
 			linked_alert.icon_state = "blackrot2"
 			examine_text = "SUBJECTPRONOUN seems to be rotting alive! (Festering)"
 		if(3)
 			linked_alert.name = "Black Rot (Boiling)"
-			linked_alert.desc = "My flesh decays and my bones ache. It feels like my skin is boiling."
+			linked_alert.desc = "My flesh decays and my bones ache. It feels like my skin is boiling. I should seek out a calyx or heartblood vials before it is too late."
 			linked_alert.icon_state = "blackrot3"
 			examine_text = "SUBJECTPRONOUN seems to be rotting alive! (Boiling)"
 		if(4)
 			linked_alert.name = "Black Rot (Necrosis)"
-			linked_alert.desc = "I am being consumed by the void. I can feel my bones creaking."
+			linked_alert.desc = "I am being consumed by the void. I can feel my bones creaking. I should seek out a calyx or heartblood vials now!!"
 			linked_alert.icon_state = "blackrot4"
 			examine_text = "SUBJECTPRONOUN seems to be rotting alive! (Necrosis)"
 
@@ -181,8 +181,8 @@
 	return ..()
 
 /atom/movable/screen/alert/status_effect/black_rot
-	name = "Black Rot"
-	desc = "A corrupting darkness spreads through my body."
+	name = "Black Rot (Creeping)"
+	desc = "A faint darkness spreads beneath my skin. I should seek out a calyx or heartblood vials before it is too late."
 	icon_state = "blackrot1"
 
 // Puke when advancing stages, woo

--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
@@ -44,13 +44,14 @@
 				var/intent_name = initial(I_path:name)
 				var/intent_cd = initial(I_path:clickcd)
 				var/intent_delay = initial(I_path:swingdelay)
-				var/intent_blade_class = initial(I_path:blade_class)
+				var/intent_can_dodge = initial(I_path:candodge)
+				var/intent_can_parry = initial(I_path:canparry)
 				var/predicted_rot = 5
 				if(intent_cd > CLICK_CD_QUICK)
 					predicted_rot += 3
 				if(intent_delay > 5)
 					predicted_rot += 3
-				if(intent_blade_class == BCLASS_BLUNT)
+				if(!intent_can_dodge || !intent_can_parry)
 					predicted_rot = 0
 				examine_list += span_info(" - <b>[uppertext(intent_name)]</b>: [predicted_rot] stacks")
 
@@ -94,7 +95,7 @@
 		if(I.swingdelay > 5) 
 			rot_to_apply += 3
 
-		if(I.blade_class == BCLASS_BLUNT)
+		if(!I.canparry || !I.candodge)
 			rot_to_apply = 0
 
 	if(rot_to_apply)

--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
@@ -47,7 +47,7 @@
 				var/intent_can_dodge = initial(I_path:candodge)
 				var/intent_can_parry = initial(I_path:canparry)
 				var/predicted_rot = 5
-				if(intent_cd > CLICK_CD_QUICK)
+				if(intent_cd > CLICK_CD_FAST)
 					predicted_rot += 3
 				if(intent_delay > 5)
 					predicted_rot += 3
@@ -88,7 +88,7 @@
 
 	if(I)
 		// If the intent is slower/heavier than the standard quick stab
-		if(I.clickcd > CLICK_CD_QUICK)
+		if(I.clickcd > CLICK_CD_FAST)
 			rot_to_apply += 3
 
 		// If the swing delay is significant (0.5s or 5 deciseconds)

--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
@@ -47,7 +47,7 @@
 				var/intent_can_dodge = initial(I_path:candodge)
 				var/intent_can_parry = initial(I_path:canparry)
 				var/predicted_rot = 5
-				if(intent_cd > CLICK_CD_FAST)
+				if(intent_cd > CLICK_CD_QUICK)
 					predicted_rot += 3
 				if(intent_delay > 5)
 					predicted_rot += 3
@@ -88,7 +88,7 @@
 
 	if(I)
 		// If the intent is slower/heavier than the standard quick stab
-		if(I.clickcd > CLICK_CD_FAST)
+		if(I.clickcd > CLICK_CD_QUICK)
 			rot_to_apply += 3
 
 		// If the swing delay is significant (0.5s or 5 deciseconds)

--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
@@ -6,6 +6,8 @@
 	max_integrity = 220
 	wdefense = 5
 	special = /datum/special_intent/rot_ring
+	// Identical to dagger except it uses the heavier cut to help build rot.
+	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/cut/heavy, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch)
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/rotfang/Initialize()
 	. = ..()
@@ -21,7 +23,8 @@
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 	var/obj/item/parent_weapon
 	var/charges = 0
-	var/max_charges = 100
+	var/max_charges = 200
+	var/charges_to_restore = 110
 
 /datum/component/ichor_stained/Initialize()
 	if(!isitem(parent))
@@ -34,7 +37,7 @@
 
 /datum/component/ichor_stained/proc/on_examine(datum/source, mob/user, list/examine_list)
 	if(charges > 0)
-		examine_list += span_notice("It is coated in [charges] layers of thick, viscous ichor.")
+		examine_list += span_notice("It is coated in [charges]/[max_charges] layers of thick, viscous ichor.")
 		examine_list += span_notice("Black rot scales up to 100 stacks.")
 		if(parent_weapon.possible_item_intents && length(parent_weapon.possible_item_intents))
 			examine_list += span_notice("Careful strikes will apply the following rot stacks:")
@@ -48,9 +51,9 @@
 				var/intent_can_parry = initial(I_path:canparry)
 				var/predicted_rot = 5
 				if(intent_cd > CLICK_CD_QUICK)
-					predicted_rot += 3
+					predicted_rot += 2
 				if(intent_delay > 5)
-					predicted_rot += 3
+					predicted_rot += 4
 				if(!intent_can_dodge || !intent_can_parry)
 					predicted_rot = 0
 				examine_list += span_info(" - <b>[uppertext(intent_name)]</b>: [predicted_rot] stacks")
@@ -72,7 +75,7 @@
 
 /datum/component/ichor_stained/proc/start_dipping(obj/item/_target, mob/living/attacker, params)
 	if(do_after(attacker, 0.4 SECONDS, target = _target))
-		charges = max_charges
+		charges = min(max_charges, charges + charges_to_restore)
 		update_visuals(attacker)
 		to_chat(attacker, span_nicegreen("You coat the blade in a fresh layer of ichor."))
 		qdel(_target)
@@ -89,11 +92,11 @@
 	if(I)
 		// If the intent is slower/heavier than the standard quick stab
 		if(I.clickcd > CLICK_CD_QUICK)
-			rot_to_apply += 3
+			rot_to_apply += 2
 
 		// If the swing delay is significant (0.5s or 5 deciseconds)
 		if(I.swingdelay > 5) 
-			rot_to_apply += 3
+			rot_to_apply += 4
 
 		if(!I.canparry || !I.candodge)
 			rot_to_apply = 0

--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_weapons.dm
@@ -44,11 +44,14 @@
 				var/intent_name = initial(I_path:name)
 				var/intent_cd = initial(I_path:clickcd)
 				var/intent_delay = initial(I_path:swingdelay)
+				var/intent_blade_class = initial(I_path:blade_class)
 				var/predicted_rot = 5
 				if(intent_cd > CLICK_CD_QUICK)
 					predicted_rot += 3
 				if(intent_delay > 5)
 					predicted_rot += 3
+				if(intent_blade_class == BCLASS_BLUNT)
+					predicted_rot = 0
 				examine_list += span_info(" - <b>[uppertext(intent_name)]</b>: [predicted_rot] stacks")
 
 /datum/component/ichor_stained/proc/check_dip(obj/item/source, atom/_target, mob/living/attacker, params)
@@ -91,10 +94,14 @@
 		if(I.swingdelay > 5) 
 			rot_to_apply += 3
 
-	apply_black_rot(target, rot_to_apply)
+		if(I.blade_class == BCLASS_BLUNT)
+			rot_to_apply = 0
 
-	charges -= rot_to_apply
-	to_chat(user, span_warning("you apply black ichor to [target]!"))
+	if(rot_to_apply)
+		apply_black_rot(target, rot_to_apply)
+		charges -= rot_to_apply
+		to_chat(user, span_warning("you apply black ichor to [target]!"))
+
 	if(charges <= 0)
 		remove_visuals(user)
 		to_chat(user, span_warning("The last of the ichor rubs off onto [target]!"))


### PR DESCRIPTION
## About The Pull Request
- My fuzzy brain didn't let it sink in that punch intent is unavoidable. (Rotfang is supposed to be balanced around parries/dodges)
- Black rot status effects now have it in their tooltip that you should seek out calyxes or drink heartblood to cure it, as this should be common knowledge.
- Malpractioner plague mask is now equivalent to a steel mask with 20% less integrity.
- Changes rotfang to have heavy dagger cut instead of regular cut since chop was pruned off daggers.
- Upped the amount of ichor it can hold from 100 stacks of rot to 200, since wretches aren't expected to always fight 1 on 1.

## Testing Evidence
Tested, didn't transfer any rot using punch intent and the desc updated correctly.
<img width="575" height="269" alt="image" src="https://github.com/user-attachments/assets/ed955a12-3c3f-4af2-acf6-e31140bad453" />

## Why It's Good For The Game
Bypassing parries to max out rot is indeed, not intended. 
Antags should spawn with at least basic coverage.
Makes the dagger more consistent. The aim is to have to land 11 good hits in a fight to max out rot. 15 if the special misses. 

## Changelog

:cl:
add: Gave the Malpractioner a slightly armored variant of their plague doctor mask.
qol: Made black rot more obvious in the tooltip in how to cure it.
qol: Made rotfang tooltip more descriptive.
balance: Rotfang (malpractitioner) now doesn't apply black rot when using punch intent.
balance: Rotfang can hold more ichor.
balance: Rotfang now has heavy cut instead of regular cut.
/:cl:
