### PR TITLE
au - undivided cloaks were unavailable for HOW long?

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
@@ -125,14 +125,14 @@
 	desc = "A regal surcoat, inlined with golden threading. The stitchwork tethers it to the Golden Orders; a catch-all term for the various faith-militances that \
 	ward Psydonia from heathens, cultists, and the ever-looming threat of another calamity. This variant bares the unicruciform sigil of the Undivided and Erranteer \
 	orders."
-	icon_state = "acrusader_surcoat"
+	icon_state = "uacrusader_surcoat"
 
 /obj/item/clothing/cloak/tabard/stabard/crusader/t/undivided
 	name = "surcoat of the silver order"
 	desc = "A noble surcoat, inlined with silver threading. The stitchwork tethers it to the Silver Orders; a catch-all term for the various faith-militances that \
 	ward Psydonia from monsters, deadites, and the ever-looming threat of another calamity. This variant bares the unicruciform sigil of the Undivided and Erranteer \
 	orders."
-	icon_state = "acrusader_surcoatt2"
+	icon_state = "ucrusader_surcoatt2"
 
 /obj/item/clothing/cloak/tabard/stabard/crusader/bsteel
 	name = "surcoat of the blacksteel order"


### PR DESCRIPTION
## About The Pull Request

* Undivided Cloaks are now properly obtainable.

## Testing Evidence

Good to go; turns out it was a single letter.

## Why It's Good For The Game

* Restores intended function.

## Changelog

:cl:
fix: Undivided Order Surcoats now properly render.
/:cl:
