### PR TITLE
[Hunting] - Hunting phantoms & boar balance

### DIFF
--- a/code/datums/ai/controllers/boar.dm
+++ b/code/datums/ai/controllers/boar.dm
@@ -47,11 +47,12 @@
 		finish_action(controller, FALSE)
 		return
 
-	controller.set_blackboard_key(BB_BOAR_CHARGE_COOLDOWN, world.time + 20 SECONDS)
-	boar.visible_message("<b>[boar]</b> lowers its head and charges!")
-	playsound(boar, 'sound/vo//mobs/boar/boar_charge.ogg', 75, TRUE)
-	var/charge_dir = get_dir(boar, target)
-	boar.throw_at(target, 7, 3, boar, callback = CALLBACK(src, .proc/on_charge_end, controller, charge_dir))
+	if(do_after(boar, 0.5 SECONDS))
+		controller.set_blackboard_key(BB_BOAR_CHARGE_COOLDOWN, world.time + 20 SECONDS)
+		boar.visible_message("<b>[boar]</b> lowers its head and charges!")
+		playsound(boar, 'sound/vo//mobs/boar/boar_charge.ogg', 75, TRUE)
+		var/charge_dir = get_dir(boar, target)
+		boar.throw_at(target, 7, 2.5, boar, callback = CALLBACK(src, .proc/on_charge_end, controller, charge_dir))
 	finish_action(controller, TRUE)
 
 /datum/ai_behavior/boar_charge/proc/on_charge_end(datum/ai_controller/controller, charge_dir)
@@ -96,7 +97,7 @@
 			var/obj/item/bodypart/chest = C.get_bodypart(BODY_ZONE_CHEST)
 			if(chest)
 				chest.add_wound(/datum/wound/slash/boar_gore)
-		victim.Stun(5 SECONDS)
+		victim.Stun(2 SECONDS)
 		victim.apply_status_effect(/datum/status_effect/debuff/exposed, 10 SECONDS)
 		boar.Stun(3 SECONDS)
 		victim.adjustBruteLoss(50)

--- a/code/game/objects/effects/animal_hunting/animal_phantom.dm
+++ b/code/game/objects/effects/animal_hunting/animal_phantom.dm
@@ -1,0 +1,47 @@
+/obj/effect/temp_visual/hunting_phantom
+	name = "approaching quarry"
+	desc = "Something is moving in the brush..."
+	icon_state = ""
+	layer = MOB_LAYER
+	plane = GAME_PLANE
+	alpha = 50
+	anchored = TRUE
+	var/mob_type_to_spawn
+	var/spawn_delay = 15 SECONDS
+	var/rot_path
+	var/list/target_factions
+	duration = 20 SECONDS
+	mouse_opacity = MOUSE_OPACITY_ICON
+
+/obj/effect/temp_visual/hunting_phantom/Initialize(mapload, target_mob_path, target_rot)
+	. = ..()
+	if(!ispath(target_mob_path))
+		return INITIALIZE_HINT_QDEL
+
+	mob_type_to_spawn = target_mob_path
+	rot_path = target_rot
+	var/mob/living/path_cast = target_mob_path
+	src.icon = initial(path_cast.icon)
+	src.icon_state = initial(path_cast.icon_state)
+	src.pixel_x = initial(path_cast.pixel_x)
+	src.pixel_y = initial(path_cast.pixel_y)
+	src.color = "#777777" 
+	appear_and_wait()
+
+/obj/effect/temp_visual/hunting_phantom/proc/appear_and_wait()
+	animate(src, alpha = 200, time = spawn_delay, easing = EASE_IN)
+	playsound(src, 'sound/misc/jumpscare (4).ogg', 50, TRUE)
+	addtimer(CALLBACK(src, .proc/finalize_spawn), spawn_delay)
+
+/obj/effect/temp_visual/hunting_phantom/proc/finalize_spawn()
+	var/turf/T = get_turf(src)
+	if(T)
+		var/mob/living/real_mob = new mob_type_to_spawn(T)
+		if(rot_path)
+			real_mob.rot_type = rot_path
+		if(target_factions)
+			real_mob.faction = target_factions
+
+		T.visible_message(span_boldwarning("The [real_mob.name] lunges out from the shadows!"))
+		playsound(T, 'sound/items/seedextract.ogg', 100, TRUE)
+	qdel(src)

--- a/code/game/objects/effects/animal_hunting/animal_phantom.dm
+++ b/code/game/objects/effects/animal_hunting/animal_phantom.dm
@@ -39,8 +39,7 @@
 		var/mob/living/real_mob = new mob_type_to_spawn(T)
 		if(rot_path)
 			real_mob.rot_type = rot_path
-		if(target_factions)
-			real_mob.faction = target_factions
+		real_mob.faction |= "hunting_ambush"
 
 		T.visible_message(span_boldwarning("The [real_mob.name] lunges out from the shadows!"))
 		playsound(T, 'sound/items/seedextract.ogg', 100, TRUE)

--- a/code/game/objects/effects/animal_hunting/animal_tracks.dm
+++ b/code/game/objects/effects/animal_hunting/animal_tracks.dm
@@ -231,10 +231,10 @@
 				if(trail_depth >= max_trail_depth)
 					to_chat(user, span_boldwarning("You see your quarry in the distance faintly!"))
 					distribute_party_exp(35)
-					var/mob/living/primary_target = new target_animal_type(T)
-					if(primary_target.rot_type)
-						primary_target.rot_type = /datum/component/rot/simple/hunt
-					if(spawn_group_bonus_animals(T, primary_target))
+					var/mob/living/L = target_animal_type
+					var/chosen_rot = initial(L.rot_type) ? /datum/component/rot/simple/hunt : null
+					new /obj/effect/temp_visual/hunting_phantom(T, target_animal_type, chosen_rot)
+					if(spawn_group_bonus_animals(T, target_animal_type))
 						visible_message(span_boldwarning("There seems to be a herd in the distance!"))
 					return TRUE
 
@@ -417,8 +417,8 @@
 	else
 		locked_track_icon = pick(track_types)
 
-/obj/effect/hunting_track/proc/spawn_group_bonus_animals(turf/T, mob/living/primary_target)
-	if(!hunt_category || !primary_target)
+/obj/effect/hunting_track/proc/spawn_group_bonus_animals(turf/T, target_path)
+	if(!hunt_category || !target_path)
 		return
 
 	var/mob/living/leader = hunter_ref?.resolve()
@@ -439,6 +439,10 @@
 		if(validate_turf(neighbor))
 			nearby_turfs += neighbor
 
+	// I hate doing this, but it's the only way to get the factions it seems.
+	var/mob/living/dummy = new target_path(T)
+	var/list/real_factions = islist(dummy.faction) ? dummy.faction.Copy() : null
+	qdel(dummy)
 	for(var/mob/living/hunter in valid_hunters)
 		if(spawned_count >= hunt_category.bonus_animal_amount)
 			break
@@ -447,11 +451,11 @@
 		if(prob(success_chance))
 			var/turf/spawn_turf = (nearby_turfs.len) ? pick(nearby_turfs) : T
 			var/bonus_type = pickweight(hunt_category.animals)
-			var/mob/living/bonus_mob = new bonus_type(spawn_turf)
-			if(bonus_mob.rot_type)
-				bonus_mob.rot_type = /datum/component/rot/simple/hunt
-			if(primary_target.faction?.len)
-				bonus_mob.faction = primary_target.faction.Copy()
+			var/mob/living/example_mob = bonus_type
+			var/chosen_rot = initial(example_mob.rot_type) ? /datum/component/rot/simple/hunt : null
+			var/obj/effect/temp_visual/hunting_phantom/P = new(spawn_turf, bonus_type, chosen_rot)
+			if(real_factions && real_factions.len)
+				P.target_factions = real_factions.Copy()
 			spawned_count++
 
 	return spawned_count

--- a/code/game/objects/effects/animal_hunting/animal_tracks.dm
+++ b/code/game/objects/effects/animal_hunting/animal_tracks.dm
@@ -439,10 +439,6 @@
 		if(validate_turf(neighbor))
 			nearby_turfs += neighbor
 
-	// I hate doing this, but it's the only way to get the factions it seems.
-	var/mob/living/dummy = new target_path(T)
-	var/list/real_factions = islist(dummy.faction) ? dummy.faction.Copy() : null
-	qdel(dummy)
 	for(var/mob/living/hunter in valid_hunters)
 		if(spawned_count >= hunt_category.bonus_animal_amount)
 			break
@@ -454,8 +450,6 @@
 			var/mob/living/example_mob = bonus_type
 			var/chosen_rot = initial(example_mob.rot_type) ? /datum/component/rot/simple/hunt : null
 			var/obj/effect/temp_visual/hunting_phantom/P = new(spawn_turf, bonus_type, chosen_rot)
-			if(real_factions && real_factions.len)
-				P.target_factions = real_factions.Copy()
 			spawned_count++
 
 	return spawned_count

--- a/code/game/objects/effects/animal_hunting/animal_tracks.dm
+++ b/code/game/objects/effects/animal_hunting/animal_tracks.dm
@@ -449,7 +449,7 @@
 			var/bonus_type = pickweight(hunt_category.animals)
 			var/mob/living/example_mob = bonus_type
 			var/chosen_rot = initial(example_mob.rot_type) ? /datum/component/rot/simple/hunt : null
-			var/obj/effect/temp_visual/hunting_phantom/P = new(spawn_turf, bonus_type, chosen_rot)
+			new /obj/effect/temp_visual/hunting_phantom(spawn_turf, bonus_type, chosen_rot)
 			spawned_count++
 
 	return spawned_count

--- a/code/modules/mob/living/simple_animal/rogue/creacher/white_stag.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/white_stag.dm
@@ -43,6 +43,8 @@
 	// We are not a normal wildshape.
 	untransform_on_death = FALSE
 	faction = list("White Stag")
+	icon = 'icons/mob/unique_shapeshifts/white_stag_shape.dmi'
+	icon_state = "stag"
 
 /mob/living/carbon/human/species/wildshape/white_stag/gain_inherent_skills()
 	return FALSE

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1163,6 +1163,7 @@
 #include "code\game\objects\effects\animal_hunting\animal_categories.dm"
 #include "code\game\objects\effects\animal_hunting\animal_hunt_blocker.dm"
 #include "code\game\objects\effects\animal_hunting\animal_maps.dm"
+#include "code\game\objects\effects\animal_hunting\animal_phantom.dm"
 #include "code\game\objects\effects\animal_hunting\animal_spawners.dm"
 #include "code\game\objects\effects\animal_hunting\animal_tracks.dm"
 #include "code\game\objects\effects\decals\cleanable.dm"


### PR DESCRIPTION
## About The Pull Request
- Spawned animals from hunting will now show a fuzzy phantom 15 seconds before spawning. The phantom slowly grows more visible until it spawns properly. Warns people with text/noise if they spawn near someone.
- Boars stun people less long upon goring them.
- Boars have a tiny windup before their charge now.
- Boars charge slightly slower.

## Testing Evidence
This was a pain to get working but I got it working woo.
<img width="310" height="92" alt="image" src="https://github.com/user-attachments/assets/3183e7ca-4d2b-45ee-9da2-f8a0baec114f" />

## Why It's Good For The Game
Avenges that one wretch trying to rob someone when a white stag showed up on his doorstep.
This should help people avoid getting gored by surprise boars. Keep in mind.. you are roleplaying in a wild forest, you may be interrupted by creatures! You just get an advance warning now.

Boars are supposed to be scary. But I found it was quite hard to get them to charge obstacles. The small windup should give people more time to maneuver and avoid being hit by the evil armor penetrating gore attack.

## Changelog

:cl:
balance: Boars charge slightly slower.
balance: Boars have a charge windup now.
balance: Boars don't stun victims they gored as long upon goring them.
qol: Hunting mechanic animals now preview their spawn before spawning in, at the end of trails.
/:cl:

