### PR TITLE
[Puzzlebox] - Rejigs the jigsaw that is the royal puzzlebox (rebalance)

### DIFF
--- a/code/game/objects/effects/spawners/clutter_spawner.dm
+++ b/code/game/objects/effects/spawners/clutter_spawner.dm
@@ -167,3 +167,15 @@
 		/obj/item/clothing/neck/roguetown/psicross/malum/secret = 1,
 		/obj/item/clothing/neck/roguetown/psicross/weeping = 1,
 	) //'Stat_' and 'Psicross_' rings at '2' or below provide statbuffs, and should be kept rare. Move to a seperate drop table if they become too common. Likeliest find is from high-end dungeons and mimics.
+
+/obj/effect/spawner/lootdrop/puzzlebox_rings
+    name = "royal puzzlebox ring spawner"
+    lootcount = 2
+    loot = list(
+        /obj/item/clothing/ring/statgemerald = 20,   // Swiftness
+        /obj/item/clothing/ring/statonyx = 20,      // Vitality
+        /obj/item/clothing/ring/statamythortz = 20, // Wisdom
+        /obj/item/clothing/ring/statrontz = 20,     // Courage
+        /obj/item/clothing/ring/dragon_ring = 10,   // Dragonstone
+        /obj/item/clothing/ring/statdorpel = 5      // Omnipotence
+    )

--- a/code/game/objects/items/mundanities.dm
+++ b/code/game/objects/items/mundanities.dm
@@ -99,7 +99,6 @@
 	icon_state = "grimace_box"
 	var/fluff_desc = null
 	var/list/finished_ckeys = list()
-	var/dice_roll = null
 	sellprice = 150
 
 	grid_width = 32
@@ -107,7 +106,6 @@
 
 /obj/item/mundane/puzzlebox/impossible/Initialize()
 	. = ..()
-	dice_roll = rand(11,20)
 	fluff_desc = pick("It, frankly, looks nearly impossible.","Its centerpiece is that of Astrata banishing a heretic from this world.","Without doubt, this is rather befuddling.","It looks arcane and nearly-impossible.","Why do I feel like I could try for hours and not succeed at this?","Even a bored archivist would probably have trouble with this one.","It looks nearly impossible.")
 	desc += "[fluff_desc]"
 
@@ -121,17 +119,14 @@
 	if (alert(user, "My fingers trace the outside of this box. It looks nearly impossible. Do I try to solve it?", "ROGUETOWN", "Yes", "No") != "Yes")
 		return
 	if(do_after(user,100, target = src))
-		if((dice_roll) + 4 <= user.STAINT)
+		var/success_chance = clamp(10 + user.STAINT, 10, 30)
+		if(prob(success_chance))
 			to_chat(user, span_notice("After much deliberation, I solve \the [src]!"))
 			user.add_stress(/datum/stressevent/puzzle_impossible)
 			finished_ckeys += ckey
 			playsound(src.loc, 'sound/foley/doors/lockrattle.ogg', 75, TRUE)
-			to_chat(user, span_notice("As I pop open \the [src], I feel a tingling wave run from my head to my feet. A piece of an azure crystal tumbles out. When I grab it, it's gone- and I suddenly feel invigorated."))
-			user.STAINT += rand(1,5)
-			user.STASTR += rand(1,5)
-			user.STASPD += rand(1,5)
-			user.STACON += rand(1,5)
-			user.STAWIL += rand(1,5)
+			to_chat(user, span_notice("As I pop open \the [src], I feel a tingling wave run from my head to my feet. Excitement bubbling in my core as two particularly rare rings tumble forth!"))
+			new /obj/effect/spawner/lootdrop/puzzlebox_rings(get_turf(src))
 			finished_ckeys += ckey
 			playsound(src.loc, 'sound/foley/doors/lock.ogg', 75, TRUE)
 			playsound(src.loc, 'sound/items/visor.ogg', 75, TRUE)


### PR DESCRIPTION
## About The Pull Request
- Royal puzzlebox is now no longer 10-60% chance to solve from 14-20 int
- Formula is now 10-30% from 0-20 int.
- Instead of 5-25 stats rewarded at random, the puzzlebox now rewards 2 stat rings.
- Stat rings are weighted, with the powerful dorpel & dragonrings being far rarer.
- Puzzlebox can only yield rewards once instead of rewarding every different person who completes the same box.

## Testing Evidence
<img width="1490" height="734" alt="image" src="https://github.com/user-attachments/assets/8ff9550d-e75a-4d70-950b-654f0286e64c" />

## Why It's Good For The Game
<img width="124" height="224" alt="image" src="https://github.com/user-attachments/assets/3fe65b1d-7e1e-4bab-a54e-24af9cf94a2e" />

These stacked, 25 allstats potentially is frankly- silly... And almost everyone would do int potion & other buffs to max out their chances anyways. This is just sort of powergaming central.

Besides, rings can be stolen or traded, allowing for more roleplay opportunity.

## Changelog

:cl:
balance: Royal puzzlebox scales less hard with intelligence to solve, now drops stat rings instead.
balance: Royal puzzleboxes can only yield rewards once, instead of per person.
/:cl:

