### PR TITLE
Noble Virtue Heirloom Choices

### DIFF
--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -2,13 +2,39 @@
 	name = "Nobility"
 	desc = "By birth, blade or brain, I am noble known to the royalty of these lands, and have all the benefits associated with it. I've cleverly stashed away a healthy amount of coinage, alongside a familial heirloom."
 	restricted = TRUE
+	max_choices = 1
 	races = list(/datum/species/construct, /datum/species/dullahan)
 	added_traits = list(TRAIT_NOBLE, TRAIT_EXPERT_HUNTER)
 	added_skills = list(list(/datum/skill/misc/reading, 1, 6))
-	added_stashed_items = list("Heirloom Amulet" = /obj/item/clothing/neck/roguetown/ornateamulet/noble,
-								"Hefty Coinpurse" = /obj/item/storage/belt/rogue/pouch/coins/virtuepouch)
+	added_stashed_items = list("Hefty Coinpurse" = /obj/item/storage/belt/rogue/pouch/coins/virtuepouch)
+	choice_costs = list(0)
+	extra_choices = list(
+		"Gold Ring" = /obj/item/clothing/ring/gold/triumph,                                        //Golden Ring, Ornate
+		"Golden Circlet" = /obj/item/clothing/head/roguetown/circlet/triumph,                      //Golden Circlet, Ornate
+		"Heirloom Amulet" = /obj/item/clothing/neck/roguetown/ornateamulet/noble,                  //Golden Amulet
+		"Silver Scabbard" = /obj/item/rogueweapon/scabbard/sword/noble,                            //Decorated Scabbard, Silver
+		"Silver Sheath" = /obj/item/rogueweapon/scabbard/sheath/noble,                             //Decorated Sheath, Silver
+		"Golden Psycross" = /obj/item/clothing/neck/roguetown/psicross/g/triumph,                  //Golden Psycross, Ornate
+		"Golden Astratan Psycross" = /obj/item/clothing/neck/roguetown/psicross/astrata/g/triumph, //Golden Astratan Amulet, Ornate
+		"Golden Signet Ring" = /obj/item/clothing/ring/signet/triumph,                             //Golden Signet Ring, Ornate
+		"Gilded Dress Shirt" = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince,         //Gilded Dress Shirt
+		"Pristine Dress" = /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess,           //Pristine Dress
+		"Royal Sleeves" = /obj/item/clothing/wrists/roguetown/royalsleeves,                        //Royal Sleeves
+		"Golden Halfmask" = /obj/item/clothing/mask/rogue/lordmask/triumph,                        //Golden Halfmask, Ornate
+		"Golden Mask" = /obj/item/clothing/mask/rogue/facemask/goldmask/triumph,                   //Golden Mask, Ornate
+		"Crestless Golden Mask" = /obj/item/clothing/mask/rogue/facemask/goldmaskc/triumph,        //Crestless Golden Mask, Ornate
+		"Lordly Cloak" = /obj/item/clothing/cloak/lordcloak,                                       //Lordly Cloak
+		"Ladylike Cloak" = /obj/item/clothing/cloak/lordcloak/ladycloak,                           //Ladylike Cloak
+		"Golden Scabbard" = /obj/item/rogueweapon/scabbard/sword/royal,                            //Decorated Scabbard, Golden
+		"Golden Sheath" = /obj/item/rogueweapon/scabbard/sheath/royal,                             //Decorated Sheath, Golden
+		"Golden Dorpel Ring" = /obj/item/clothing/ring/diamond/triumph                             //Golden Dorpel Ring, Ornate
+	)
+
 
 /datum/virtue/utility/noble/apply_to_human(mob/living/carbon/human/recipient)
+	for(var/choice in picked_choices)
+		if(ispath(extra_choices[choice], /obj/item))
+			recipient.mind?.special_items[choice] = extra_choices[choice]
 	if(HAS_TRAIT(recipient, TRAIT_OUTLAW))
 		return
 	var/already_has_income = !isnull(SStreasury.noble_incomes[recipient])


### PR DESCRIPTION
## About The Pull Request

Adds in the ability to pick your heirloom instead of the amulet. Select from a long list of items, all items taken from the triumph loadout list. Scroll down for the full list of items, and to reiterate all options are solely from the triumph menu, no gold sneakin or silver sneakin allowed.

## Testing Evidence

Tested locally, works flawlessly.
Screenshot of the selection list, you can only pick 1.
<img width="461" height="734" alt="ingame selection for nobles" src="https://github.com/user-attachments/assets/16f4255e-1d9b-4e24-b454-72bb2ec959d0" />


## Why It's Good For The Game

Allows for more customization of characters, its been a long requested feature to be able to choose what your heirloom is, and now you can. If I knew how, I'd also let you customize the description and name of it but sadly I don't have the skills to do that.


## Changelog

:cl:
add: Adds the ability to choose your heirloom for the Noble Virtue
/:cl:
