### PR TITLE
removes the dead check on surgical healing scaling

### DIFF
--- a/code/modules/surgery/surgeries/healing.dm
+++ b/code/modules/surgery/surgeries/healing.dm
@@ -79,9 +79,8 @@
 	var/urhealedamt_brute = brutehealing * healing_multiplier
 	var/urhealedamt_burn = burnhealing * healing_multiplier
 	if(missinghpbonus)
-		if(target.stat != DEAD)
-			urhealedamt_brute += round((target.getBruteLoss()/ missinghpbonus),0.1)
-			urhealedamt_burn += round((target.getFireLoss()/ missinghpbonus),0.1)
+		urhealedamt_brute += round((target.getBruteLoss()/ missinghpbonus),0.1)
+		urhealedamt_burn += round((target.getFireLoss()/ missinghpbonus),0.1)
 	if(!get_location_accessible(target, target_zone))
 		urhealedamt_brute *= 0.55
 		urhealedamt_burn *= 0.55
@@ -103,7 +102,6 @@
 	if(missinghpbonus)
 		urdamageamt_brute += round((target.getBruteLoss()/(missinghpbonus*2)),0.1)
 		urdamageamt_burn += round((target.getFireLoss()/(missinghpbonus*2)),0.1)
-
 	target.take_bodypart_damage(urdamageamt_brute, urdamageamt_burn)
 	target.update_damage_hud()
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

There is currently a system in place that makes surgical damage tending heal more of a damage type, the more of that damage there is. However, this only applies to **living** patients ; this PR simply makes it so that scaling works on dead patients as well.

## Testing Evidence

Single line change. Tested before vs after, values work as expected, no crash.

## Why It's Good For The Game

Frankly, I'm confused why that check is there in the first place. I think it contributes nothing to the game to have someone come in horribly mauled, and either have to spend 15 minutes patching them up, or outright declare them round removed solely because a bog troll hit their deadite's chest 1546363 times. By definition, corpses need this feature more than living patients do.
Also some church revival miracles can basically instaheal someone so why would the apothecary not be able to keep up ?

## Changelog

:cl:
balance: trauma surgery now scales its healing based on total damage for dead patients, like it did for living ones
/:cl: