### PR TITLE
some patron related fixes/tweaks

### DIFF
--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -175,7 +175,7 @@
 		return FALSE
 
 	var/prayersesh = 0
-	visible_message("[src] kneels their head in prayer to the Gods.", "I kneel my head in prayer to [devotion.patron.name].")
+	visible_message("[src] kneels their head in prayer to the Gods.", "I kneel my head in prayer to [istype(devotion.patron, /datum/patron/divine/undivided) ? "the Ten" : devotion.patron.name].")
 	for(var/i in 1 to 50)
 		if(devotion.devotion >= devotion.max_devotion)
 			to_chat(src, span_warning("I have reached the limit of my devotion..."))

--- a/code/datums/gods/_patron.dm
+++ b/code/datums/gods/_patron.dm
@@ -9,6 +9,8 @@ GLOBAL_LIST_EMPTY(prayers)
 /datum/patron
 	/// Name of the god
 	var/name
+	/// Common titles of the god - used for prayers
+	var/list/titles = list()
 	/// Domain of the god, such as earth, fire, water, murder etc
 	var/domain = "Bad coding practices"
 	/// Description of the god
@@ -109,8 +111,10 @@ GLOBAL_LIST_EMPTY(prayers)
     GLOB.prayers |= prayer
     record_round_statistic(STATS_PRAYERS_MADE)
 
-    if(findtext(prayer, name))
-        reward_prayer(follower)
+    for(var/title in (follower.patron.titles + patron_name))
+        if(findtext(prayer, title))
+            reward_prayer(follower)
+            return . 
 
 /// The follower has somehow offended the patron and is now being punished.
 /datum/patron/proc/punish_prayer(mob/living/follower)

--- a/code/datums/gods/patrons/divine/abyssor.dm
+++ b/code/datums/gods/patrons/divine/abyssor.dm
@@ -22,6 +22,9 @@
 		"THE OCEAN'S FURY IS ABYSSOR'S WILL!",
 		"I AM DRAWN BY THE PULL OF THE TIDE!",
 	)
+	titles = list(
+		"Dreamer"
+	)
 
 	storyteller = /datum/storyteller/abyssor
 

--- a/code/datums/gods/patrons/divine/abyssor.dm
+++ b/code/datums/gods/patrons/divine/abyssor.dm
@@ -23,7 +23,8 @@
 		"I AM DRAWN BY THE PULL OF THE TIDE!",
 	)
 	titles = list(
-		"Dreamer"
+		"Dreamer",
+		"Forgotten One"
 	)
 
 	storyteller = /datum/storyteller/abyssor

--- a/code/datums/gods/patrons/divine/astrata.dm
+++ b/code/datums/gods/patrons/divine/astrata.dm
@@ -23,6 +23,11 @@
 		"I SERVE THE GLORY OF THE SUN!",
 	)
 	storyteller = /datum/storyteller/astrata
+	titles = list(
+		"Tyrant",
+		"Overtyrant",
+		"Sun", // should match any sort of Sun(x) title
+	)
 
 // In daylight, church, cross, or ritual chalk.
 /datum/patron/divine/astrata/can_pray(mob/living/follower)

--- a/code/datums/gods/patrons/divine/dendor.dm
+++ b/code/datums/gods/patrons/divine/dendor.dm
@@ -22,6 +22,10 @@
 		"I ANSWER THE CALL OF THE WILD!",
 	)
 	storyteller = /datum/storyteller/dendor
+	titles = list(
+		"Treefather",
+		"Tree-Father"
+	)
 
 // In grove, bog, cross, or ritual chalk 
 // Yes, he is NOT calling the master cus he's unique. Whole bog is his prayer zone. Druids exist for a reason instead of in the church.

--- a/code/datums/gods/patrons/divine/eora.dm
+++ b/code/datums/gods/patrons/divine/eora.dm
@@ -23,6 +23,9 @@
 	)
 	traits_tier = list(TRAIT_EORAN_CALM = CLERIC_T0, TRAIT_EORAN_SERENE = CLERIC_T2)
 	storyteller = /datum/storyteller/eora
+	titles = list(
+		"Mother" // have seen people call her this, or variants like 'Great Mother', ic. she doesn't really get titles though
+	)
 
 // Near a psycross, by an eoran sacred tree, inside the church, at the eoran shrine, holding poppy flowers, or has pacifism trait
 /datum/patron/divine/eora/can_pray(mob/living/follower)

--- a/code/datums/gods/patrons/divine/malum.dm
+++ b/code/datums/gods/patrons/divine/malum.dm
@@ -25,6 +25,8 @@
 
 	storyteller = /datum/storyteller/malum
 
+	titles = list() // people just kinda call him malum
+
 // Near a smelter, hearth, cross, within the smithy, or within the church
 /datum/patron/divine/malum/can_pray(mob/living/follower)
 	. = ..()

--- a/code/datums/gods/patrons/divine/necra.dm
+++ b/code/datums/gods/patrons/divine/necra.dm
@@ -25,7 +25,8 @@
 
 	titles = list(
 		"Veiled Lady",
-		"Corpse Mother"
+		"Corpse Mother",
+		"Undermaiden"
 	)
 
 // Near a grave, cross, or within the church

--- a/code/datums/gods/patrons/divine/necra.dm
+++ b/code/datums/gods/patrons/divine/necra.dm
@@ -23,6 +23,10 @@
 	)
 	storyteller = /datum/storyteller/necra
 
+	titles = list(
+		"Veiled Lady"
+	)
+
 // Near a grave, cross, or within the church
 /datum/patron/divine/necra/can_pray(mob/living/follower)
 	. = ..()

--- a/code/datums/gods/patrons/divine/necra.dm
+++ b/code/datums/gods/patrons/divine/necra.dm
@@ -24,7 +24,8 @@
 	storyteller = /datum/storyteller/necra
 
 	titles = list(
-		"Veiled Lady"
+		"Veiled Lady",
+		"Corpse Mother"
 	)
 
 // Near a grave, cross, or within the church

--- a/code/datums/gods/patrons/divine/noc.dm
+++ b/code/datums/gods/patrons/divine/noc.dm
@@ -26,6 +26,11 @@
 	traits_tier = list(TRAIT_DARKVISION = CLERIC_T1)
 	storyteller = /datum/storyteller/noc
 
+	titles = list(
+		"Nite-Scholar",
+		"Moon" // should match a bunch of variant titles like Brother Moon
+	)
+
 // In moonlight, church, cross, or ritual chalk
 /datum/patron/divine/noc/can_pray(mob/living/follower)
 	. = ..()

--- a/code/datums/gods/patrons/divine/pestra.dm
+++ b/code/datums/gods/patrons/divine/pestra.dm
@@ -24,6 +24,10 @@
 	)
 	storyteller = /datum/storyteller/pestra
 
+	titles = list(
+		"Lady of Pestilence" // yeah, i have no idea. what do people even call Pestra?
+	)
+
 // Near a well, cross, within the physicians, within the heartbeast's sanctum, or within the church
 /datum/patron/divine/pesta/can_pray(mob/living/follower)
 	. = ..()

--- a/code/datums/gods/patrons/divine/pestra.dm
+++ b/code/datums/gods/patrons/divine/pestra.dm
@@ -25,7 +25,8 @@
 	storyteller = /datum/storyteller/pestra
 
 	titles = list(
-		"Lady of Pestilence" // yeah, i have no idea. what do people even call Pestra?
+		"Lady of Pestilence", // yeah, i have no idea. what do people even call Pestra?
+		"Rot Mother"
 	)
 
 // Near a well, cross, within the physicians, within the heartbeast's sanctum, or within the church

--- a/code/datums/gods/patrons/divine/ravox.dm
+++ b/code/datums/gods/patrons/divine/ravox.dm
@@ -26,6 +26,11 @@
 	storyteller = /datum/storyteller/ravox
 	COOLDOWN_DECLARE(lesser_heal_buff_cooldown)
 
+	titles = list(
+		"Justiciar",
+		"Justicar" // it is misspelled ingame enough that we should probably accept this too 
+	)
+
 // Near a knight statue, cross, or within the church
 /datum/patron/divine/ravox/can_pray(mob/living/follower)
 	. = ..()

--- a/code/datums/gods/patrons/divine/undivided.dm
+++ b/code/datums/gods/patrons/divine/undivided.dm
@@ -25,6 +25,10 @@
 	)
 	storyteller = /datum/storyteller/astrata // no unique storyteller for this one, since its so broad. No real reason to have a unique storyteller - Undivided contributes to ecah of the Ten's follower count.
 
+	titles = list(
+		"Ten" // having to put the actual word "Undivided" in your prayers is counterintuitive. they're the ten that's what people call them.
+	)
+
 /datum/patron/divine/undivided/can_pray(mob/living/follower)
 	. = ..()
 	// Undivided - More restricted, needs to be within range of a pantheon cross or the church itself.

--- a/code/datums/gods/patrons/divine/xylix.dm
+++ b/code/datums/gods/patrons/divine/xylix.dm
@@ -38,6 +38,10 @@
 	)
 	storyteller = /datum/storyteller/xylix
 
+	titles = list(
+		"Tragedian"
+	)
+
 // Near a gambling machine, cross, or within the church
 /datum/patron/divine/xylix/can_pray(mob/living/follower)
 	. = ..()

--- a/code/datums/gods/patrons/inhumen/baotha.dm
+++ b/code/datums/gods/patrons/inhumen/baotha.dm
@@ -28,7 +28,8 @@
 	crafting_recipes = list(/datum/crafting_recipe/roguetown/structure/baotha_cross_stone, /datum/crafting_recipe/roguetown/structure/baotha_cross_meat)
 
 	titles = list(
-		"Lady of Heartbreak"
+		"Lady of Heartbreak",
+		"Scarlet Lady"
 	)
 
 /datum/patron/inhumen/baotha/can_pray(mob/living/follower)

--- a/code/datums/gods/patrons/inhumen/baotha.dm
+++ b/code/datums/gods/patrons/inhumen/baotha.dm
@@ -27,6 +27,10 @@
 	traits_tier = list(TRAIT_CRACKHEAD = CLERIC_T1)
 	crafting_recipes = list(/datum/crafting_recipe/roguetown/structure/baotha_cross_stone, /datum/crafting_recipe/roguetown/structure/baotha_cross_meat)
 
+	titles = list(
+		"Lady of Heartbreak"
+	)
+
 /datum/patron/inhumen/baotha/can_pray(mob/living/follower)
 	. = ..()
 	// Allows prayer in the Zzzzzzzurch(!)

--- a/code/datums/gods/patrons/inhumen/graggar.dm
+++ b/code/datums/gods/patrons/inhumen/graggar.dm
@@ -24,6 +24,11 @@
 	storyteller = /datum/storyteller/graggar
 	crafting_recipes = list(/datum/crafting_recipe/roguetown/structure/graggar_cross_stone, /datum/crafting_recipe/roguetown/structure/graggar_cross_meat)
 
+	titles = list(
+		"Sinistar",
+		"Dark Star"
+	)
+
 /datum/patron/inhumen/graggar/on_lesser_heal(
     mob/living/user,
     mob/living/target,

--- a/code/datums/gods/patrons/inhumen/matthios.dm
+++ b/code/datums/gods/patrons/inhumen/matthios.dm
@@ -25,6 +25,14 @@
 	)
 	storyteller = /datum/storyteller/matthios
 
+	titles = list(
+		"Fyre-Thief",
+		"Fire-Thief",
+		"Thief-of-Fyre",
+		"Thief-of-Fire", // aaaaaaaa
+		"Lord" // catchall for various titles of his
+	)
+
 // When near coin of at least 100 mammon, zchurch, bad-cross, or ritual talk
 /datum/patron/inhumen/matthios/can_pray(mob/living/follower)
 	. = ..()

--- a/code/datums/gods/patrons/inhumen/zizo.dm
+++ b/code/datums/gods/patrons/inhumen/zizo.dm
@@ -25,7 +25,11 @@
 	storyteller = /datum/storyteller/zizo
 
 	titles = list(
-		"Dame of Progress"
+		"Dame of Progress",
+		"Lady of Progress",
+		"Lady of Secrets",
+		"Dame of Secrets",
+		"Arch Lych"
 	)
 
 /datum/patron/inhumen/zizo/post_equip(mob/living/pious)

--- a/code/datums/gods/patrons/inhumen/zizo.dm
+++ b/code/datums/gods/patrons/inhumen/zizo.dm
@@ -24,6 +24,10 @@
 	)
 	storyteller = /datum/storyteller/zizo
 
+	titles = list(
+		"Dame of Progress"
+	)
+
 /datum/patron/inhumen/zizo/post_equip(mob/living/pious)
 	. = ..()
 	if(ishuman(pious))

--- a/code/datums/gods/patrons/mossmother.dm
+++ b/code/datums/gods/patrons/mossmother.dm
@@ -14,12 +14,12 @@
 		"I AM THE LAND. YOU SHOULD BE THANKING ME FOR THREADING IT.",
 	)
 
-/datum/patron/godless/can_pray(mob/living/follower)
+/datum/patron/mossmother/can_pray(mob/living/follower)
 	. = ..()
 	to_chat(follower, span_danger("I do not need to pray to the Mossmother, she is with me always."))
 	return FALSE	//heathen
 
-/datum/patron/godless/on_lesser_heal(
+/datum/patron/mossmother/on_lesser_heal(
     mob/living/user,
     mob/living/target,
     message_out,

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -22,6 +22,9 @@
 		"WITNESS ME, PSYDON; THE SACRIFICE MADE MANIFEST!",
 	)
 
+	titles = list(
+		"God" // people call him this for. some reason. he has a name, y'all
+	)
 
 /////////////////////////////////
 // Does God Hear Your Prayer ? //

--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -155,10 +155,12 @@
 		to_chat(caster, span_notice("Only living creachers can bear the blessing of [caster.patron.name]'s light."))
 		return
 
+	var/god_title = istype(caster.patron, /datum/patron/divine/undivided) ? "Ten Undivided" : "Blessed [caster.patron.name]"
+
 	if(victim != caster)
-		caster.visible_message(span_notice("[caster] reaches gently towards [victim], beads of light glimmering at [caster.p_their()] fingertips..."), span_notice("Blessed [caster.patron.name], I ask but for a light to guide the way..."))
+		caster.visible_message(span_notice("[caster] reaches gently towards [victim], beads of light glimmering at [caster.p_their()] fingertips..."), span_notice("[god_title], I ask but for a light to guide the way..."))
 	else
-		caster.visible_message(span_notice("[caster] closes [caster.p_their()] eyes and places a glowing hand upon [caster.p_their()] chest..."), span_notice("Blessed [caster.patron.name], I ask but for a light to guide the way..."))
+		caster.visible_message(span_notice("[caster] closes [caster.p_their()] eyes and places a glowing hand upon [caster.p_their()] chest..."), span_notice("[god_title], I ask but for a light to guide the way..."))
 
 	if(!do_after(caster, cast_time, target = victim))
 		return

--- a/code/modules/spells/pantheon/divine/undivided.dm
+++ b/code/modules/spells/pantheon/divine/undivided.dm
@@ -63,7 +63,7 @@
 
 	secondary_resource_cost = SPELLCOST_UTILITY_BUFF
 
-	invocations = list("Zwillingslichter, leitet meinen Blick..")//(Twin lights, guide my gaze)
+	invocations = list("Zwillingslichter, leitet meinen Blick.")//(Twin lights, guide my gaze)
 	invocation_type = INVOCATION_WHISPER
 
 	charge_required = FALSE
@@ -547,7 +547,7 @@
 			target.apply_status_effect(/datum/status_effect/buff/ten_united)
 			continue
 		if(istype(target.patron, /datum/patron/old_god) || istype(target.patron, /datum/patron/inhumen)) 
-			to_chat(target, span_undivided("The divine light leaves me as abruptly as it came.."))
+			to_chat(target, span_undivided("The divine light leaves me as abruptly as it came."))
 			continue
 		if(!owner.faction_check_mob(target))
 			continue


### PR DESCRIPTION
## About The Pull Request
have you ever tried to pray to your god, but didn't include their name because you used a title, or because you were an Undivided follower and called them the Ten? yeah? it's annoying. this fixes that.
it also fixes orison calling the ten "Blessed Undivided", cleric prayers saying you "kneel your head in prayer to Undivided", and a few typos in the undivided miracles
it _also_ fixes some procs in the mossmother patron that had the wrong path from a sloppy copy-paste from the science patron file
it does not touch balance or miracles because i would like to keep my sanity

## Testing Evidence
<img width="566" height="148" alt="image" src="https://github.com/user-attachments/assets/5a1d0a87-8013-4147-9f1e-ad7d2b0f7662" />

## Why It's Good For The Game
already answered in the top section

## Changelog

:cl:
add: You can now pray to gods by common titles, in addition to their name
fix: Fixed some weirdness with Undivided patron name, and some typos
/:cl: