### PR TITLE
Removes Construct from Absolver

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1 // THE ONE.
 	spawn_positions = 1
-	
+	forbidden_races = list(RACES_CONSTRUCT)
 	allowed_patrons = list(/datum/patron/old_god) //Requires the character to be a practicing Psydonite.
 	tutorial = "Once, you were alone in this monastery; a chapel of stone, protecting a shard of Psydon's divinity. Now, you've a whole sect to shepherd - and their propensity for violence oft-clashes with your own vows of pacifism. Temper the floch with your wisdom, siphon away their wounds with your blessings, and guide the wayard towards absolution."
 	selection_color = JCOLOR_INQUISITION


### PR DESCRIPTION
## About The Pull Request
Issues:
- The solutions in https://github.com/Azure-Peak/Azure-Peak/pull/7056 proved not enough.
   - Constructs are able to instantly (and absurdly) pop their limbs right back in after delimbing. This seems to be an intentional part of their design. (IE, making "stump" wounds that prevent it and require surgery or w/e would nerf every construct probably unjustifiably, all over this role)
- They can, apparently, still self-tank a ton by using other abilities due to the combined Absolver miracles

Thus I can:
- Nerf every construct specifically because of this one role 
- Come up with something awfully niche and specific and contrived for how this one role handles wounds only for constructs (IE, deleting limbs instead of delimbing them from WEEP, adjusting what / how RESPITE works)

Or I can disable them and not worry about this again. 
Give me feasible ideas or it's going, basically.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Constructs can no longer be Absolvers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
