### PR TITLE
Give pockets to all non-armoured robes

### DIFF
--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -3,6 +3,7 @@
 	name = "robe"
 	desc = ""
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|VITALS
+	armor = ARMOR_CLOTHING
 	icon_state = "white_robe"
 	icon = 'icons/roguetown/clothing/armor.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/armor.dmi'
@@ -13,6 +14,23 @@
 	r_sleeve_status = SLEEVE_NORMAL
 	l_sleeve_status = SLEEVE_NORMAL
 	experimental_inhand = TRUE
+	var/storage = TRUE
+
+	grid_width = 64
+	grid_height = 64
+
+/obj/item/clothing/suit/roguetown/shirt/robe/ComponentInitialize()
+	. = ..()
+	if(storage)
+		AddComponent(/datum/component/storage/concrete/roguetown/cloak)
+
+/obj/item/clothing/suit/roguetown/shirt/robe/dropped(mob/living/carbon/human/user)
+	..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	if(STR)
+		var/list/things = STR.contents()
+		for(var/obj/item/I in things)
+			STR.remove_from_storage(I, get_turf(src))
 
 /obj/item/clothing/suit/roguetown/shirt/robe/unholy
 	name = "foreboding robes"
@@ -24,6 +42,7 @@
 	boobed = null
 	item_state = "warlock"
 	icon_state = "warlock"
+	storage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/unholy/lich
 	name = "ominous robes"
@@ -37,6 +56,7 @@
 	allowed_race = ALL_RACES_TYPES
 	item_state = "ewarlock"
 	icon_state = "ewarlock"
+	storage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/astrata
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT|ITEM_SLOT_CLOAK
@@ -167,6 +187,7 @@
 	resistance_flags = FIRE_PROOF // astratan
 	armor = ARMOR_PADDED	//Equal to gamby
 	color = null
+	storage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/priest/Initialize()
 	. = ..()
@@ -199,6 +220,7 @@
 	armor = ARMOR_PADDED	//Equal to a padded gambeson, like before.
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
+	storage = FALSE
 
 //This is for templars/psydonites. Gives a boon for wearing it to counter-act giving up plate and such.
 /obj/item/clothing/suit/roguetown/shirt/robe/monk/holy
@@ -352,6 +374,7 @@
 	icon_state = "desertgown"
 	item_state = "desertgown"
 	color = null
+	storage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/pointfex
 	name = "pointfex's qaba"
@@ -362,6 +385,7 @@
 	color = null
 	r_sleeve_status = SLEEVE_NOMOD
 	l_sleeve_status = SLEEVE_NOMOD
+	storage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/feld
 	name = "feldsher's robe"


### PR DESCRIPTION
## About The Pull Request

Originally intended for the plague coat, this gives all robes with no armour values the cloak-styled 2x2 inventory slots.
I couldn't think of any edge case that specifically should NOT get pockets, but if there are any I can easily blacklist them, let me know.

## Testing Evidence

<img width="362" height="365" alt="image" src="https://github.com/user-attachments/assets/293fe9d4-24a5-4458-b9d8-4d09b9fa9256" />
Look at it. It works ! Not depicted, but I made such the various unholy, priest and monk robes do not get pockets, to avoid that powercreep.
For reference, this is based on the code defining cloaks.

## Why It's Good For The Game

Clothing items that gives you pockets and go to the cape/armour/shirt slots do not disrupt balance, since we already have a lot of loadout-available items that do that, like the many tabards. Might as well give you more options to achieve the same end if it's not disruptive. Gives one less reason for malpractitioners to get rid of their drip, too.
Again, if there any that turn out disruptive, I'm ready to blacklist them anyway.

## Changelog
:cl:
add: Non-armoured cloaks get pockets
/:cl:
