### PR TITLE
GJFHJARTUUUUUUURGH - fixes minor typo in crusader tabard filepath

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
@@ -125,7 +125,7 @@
 	desc = "A regal surcoat, inlined with golden threading. The stitchwork tethers it to the Golden Orders; a catch-all term for the various faith-militances that \
 	ward Psydonia from heathens, cultists, and the ever-looming threat of another calamity. This variant bares the unicruciform sigil of the Undivided and Erranteer \
 	orders."
-	icon_state = "uacrusader_surcoat"
+	icon_state = "ucrusader_surcoat"
 
 /obj/item/clothing/cloak/tabard/stabard/crusader/t/undivided
 	name = "surcoat of the silver order"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/special/crusader.dm
@@ -7,10 +7,10 @@
 
 	maximum_possible_slots = 1 // Disabled Role
 
-	tutorial = "The crusaders... Knights who have pledged \
+	tutorial = "The Crusaders; knights who have pledged \
 	their wealth and lands to the church, taking up the banner \
 	of one of the rival Orders dedicated to retaking the holy land. \
-	The 451st crusade is sure to be the last."
+	The 451st Crusade is sure to be the last."
 
 	category_tags = list(CTAG_DISABLED)
 	subclass_stats = list(


### PR DESCRIPTION
## About The Pull Request

* Corrects the filepath of the Undivided Gold Order tabard.

## Testing Evidence

NOW it's good to go.

## Why It's Good For The Game

* No more invisible cloaks.

## Changelog

:cl:
fix: Undivided Golden Order tabards should now properly render.
/:cl: