### PR TITLE
addendum - silver order surcoats now vary depending on faith

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -27,7 +27,7 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
 	)
-	// One of you is gonna look at me and act like I am stupid. It is a form of disguise
+	// One of you is gonna look at me and act like I am stupid. It is a form of disguise.
 	// Also because the alternative is not very clean codewise.
 	subclass_stashed_items = list(
 		"The Verses and Acts of the Ten" = /obj/item/book/rogue/bibble,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -340,15 +340,15 @@
 				l_hand = /obj/item/needle/thorn/cleric //Unique to the Cleric. Far worse than a traditional iron needle, but better than a regular thorn needle - with 10 uses, instead of 5 (or 20, in the former's case).
 				beltl = /obj/item/reagent_containers/glass/bottle/rogue/healthpot //No cloth, but a basic potion of lifeblood - similar to the Sorcerer's manna potion. Take the 'Physician's Apprentice' virtue for that, uncapped skills, and more.
 			if("Crusader - Silver Longsword + Surcoat")
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE) //Essentially turns it into the old Monster Hunter, balance-wise.
 				beltl = /obj/item/rogueweapon/sword/long/silver //Functionally, inflicts silverbane at the cost of -5 damage. Likely won't be a balancing issue, unless we start seeing +5-10 Clerics overnight.
 				switch(H.patron?.type)
 					if(/datum/patron/old_god)
-						H.equip_to_slot_or_del(new /obj/item/clothing/cloak/tabard/stabard/crusader/t, SLOT_BELT_CLOAK, TRUE)
+						l_hand = /obj/item/clothing/cloak/tabard/stabard/crusader/t
 					if(/datum/patron/divine/astrata)
-						H.equip_to_slot_or_del(new /obj/item/clothing/cloak/tabard/stabard/crusader/t/astrata, SLOT_BELT_CLOAK, TRUE)
+						l_hand = /obj/item/clothing/cloak/tabard/stabard/crusader/t/astrata
 					else
-						H.equip_to_slot_or_del(new /obj/item/clothing/cloak/tabard/stabard/crusader/t/undivided, SLOT_BELT_CLOAK, TRUE)
+						l_hand = /obj/item/clothing/cloak/tabard/stabard/crusader/t/undivided
 			if("None")
 				id = /obj/item/clothing/ring/silver/cleric //Minor restoration of the old silver ring that Clerics could get. Worth less than the other two alternatives, but offers a choice for those who want to remain unspecialized.
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -341,8 +341,14 @@
 				beltl = /obj/item/reagent_containers/glass/bottle/rogue/healthpot //No cloth, but a basic potion of lifeblood - similar to the Sorcerer's manna potion. Take the 'Physician's Apprentice' virtue for that, uncapped skills, and more.
 			if("Crusader - Silver Longsword + Surcoat")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				l_hand = /obj/item/clothing/cloak/tabard/stabard/crusader/t //Turns the Paladin into a pre-Exorcist version of the Monster Hunter. Differences are +1 CON / -1 INT, access to minor miracles, and more limb coverage.
 				beltl = /obj/item/rogueweapon/sword/long/silver //Functionally, inflicts silverbane at the cost of -5 damage. Likely won't be a balancing issue, unless we start seeing +5-10 Clerics overnight.
+				switch(H.patron?.type)
+					if(/datum/patron/old_god)
+						H.equip_to_slot_or_del(new /obj/item/clothing/cloak/tabard/stabard/crusader/t, SLOT_BELT_CLOAK, TRUE)
+					if(/datum/patron/divine/astrata)
+						H.equip_to_slot_or_del(new /obj/item/clothing/cloak/tabard/stabard/crusader/t/astrata, SLOT_BELT_CLOAK, TRUE)
+					else
+						H.equip_to_slot_or_del(new /obj/item/clothing/cloak/tabard/stabard/crusader/t/undivided, SLOT_BELT_CLOAK, TRUE)
 			if("None")
 				id = /obj/item/clothing/ring/silver/cleric //Minor restoration of the old silver ring that Clerics could get. Worth less than the other two alternatives, but offers a choice for those who want to remain unspecialized.
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -340,7 +340,7 @@
 				l_hand = /obj/item/needle/thorn/cleric //Unique to the Cleric. Far worse than a traditional iron needle, but better than a regular thorn needle - with 10 uses, instead of 5 (or 20, in the former's case).
 				beltl = /obj/item/reagent_containers/glass/bottle/rogue/healthpot //No cloth, but a basic potion of lifeblood - similar to the Sorcerer's manna potion. Take the 'Physician's Apprentice' virtue for that, uncapped skills, and more.
 			if("Crusader - Silver Longsword + Surcoat")
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE) //Essentially turns it into the old Monster Hunter, balance-wise.
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE) //Essentially turns it into the old Monster Hunter, in terms of balance.
 				beltl = /obj/item/rogueweapon/sword/long/silver //Functionally, inflicts silverbane at the cost of -5 damage. Likely won't be a balancing issue, unless we start seeing +5-10 Clerics overnight.
 				switch(H.patron?.type)
 					if(/datum/patron/old_god)


### PR DESCRIPTION
## About The Pull Request

* Silver Order surcoats achieved by the Cleric's 'Crusader' oath now change depending on their faith.
* Psydonians get the Psycrossed version, Astratans get the Astratan version, and the rest get the Undivided version.

## Testing Evidence

<img width="282" height="488" alt="21f3963892967fc7eb44f8e6800c8264" src="https://github.com/user-attachments/assets/c60ee687-f99b-45e2-9eca-0b5e37a2f589" />


## Why It's Good For The Game

* More continuity, more divorcing of Psydonism from other faiths.

## Changelog

:cl:
add: Clerics who take the 'Crusader' oath now receive a surcoat based on their faith.
/:cl: