### PR TITLE
(Speedmerge) Broom Fixes & More Loadout Options

### DIFF
--- a/code/datums/loadout/loadout_accessories.dm
+++ b/code/datums/loadout/loadout_accessories.dm
@@ -151,6 +151,11 @@
 	path = /obj/item/storage/belt/rogue/leather/double
 	sort_category = "Accessories"
 
+/datum/loadout_item/knifebelt // comes empty
+	name = "Tossblade Belt"
+	path = /obj/item/storage/belt/rogue/leather/knifebelt/black
+	sort_category = "Accessories"
+
 /datum/loadout_item/psicross
 	name = "Psydonian Cross"
 	path = /obj/item/clothing/neck/roguetown/psicross

--- a/code/datums/loadout/loadout_tools.dm
+++ b/code/datums/loadout/loadout_tools.dm
@@ -34,11 +34,6 @@
 	path = /obj/item/natural/whetstone
 	sort_category = "Tools"
 
-/datum/loadout_item/scissors
-	name = "Scissors"
-	path = /obj/item/rogueweapon/huntingknife/scissors
-	sort_category = "Tools"
-
 /datum/loadout_item/hammer
 	name = "Wood Mallet"
 	path = /obj/item/rogueweapon/hammer/wood

--- a/code/datums/loadout/loadout_tools.dm
+++ b/code/datums/loadout/loadout_tools.dm
@@ -8,3 +8,58 @@
 	name = "Fine Parasol"
 	path = /obj/item/rogueweapon/mace/parasol/noble
 	sort_category = "Tools"
+
+/datum/loadout_item/cloth
+	name = "Cloth"
+	path = /obj/item/natural/cloth
+	sort_category = "Tools"
+
+/datum/loadout_item/broom
+	name = "Broom"
+	path = /obj/item/broom
+	sort_category = "Tools"
+
+/datum/loadout_item/bucket
+	name = "Bucket"
+	path = /obj/item/reagent_containers/glass/bucket
+	sort_category = "Tools"
+
+/datum/loadout_item/needle
+	name = "Sewing Needle"
+	path = /obj/item/needle/thorn
+	sort_category = "Tools"
+
+/datum/loadout_item/whetstone
+	name = "Whetstone"
+	path = /obj/item/natural/whetstone
+	sort_category = "Tools"
+
+/datum/loadout_item/scissors
+	name = "Scissors"
+	path = /obj/item/rogueweapon/huntingknife/scissors
+	sort_category = "Tools"
+
+/datum/loadout_item/hammer
+	name = "Wood Mallet"
+	path = /obj/item/rogueweapon/hammer/wood
+	sort_category = "Tools"
+
+/datum/loadout_item/axe 
+	name = "Stone Axe"
+	path = /obj/item/rogueweapon/stoneaxe
+	sort_category = "Tools"
+
+/datum/loadout_item/knife 
+	name = "Stone Knife"
+	path = /obj/item/rogueweapon/huntingknife/stoneknife
+	sort_category = "Tools"
+
+/datum/loadout_item/hoe 
+	name = "Stone Hoe"
+	path = /obj/item/rogueweapon/hoe/stone
+	sort_category = "Tools"
+
+/datum/loadout_item/hoe 
+	name = "Wood Spade"
+	path = /obj/item/rogueweapon/shovel/small
+	sort_category = "Tools"

--- a/code/datums/loadout/loadout_tools.dm
+++ b/code/datums/loadout/loadout_tools.dm
@@ -58,3 +58,9 @@
 	name = "Wood Spade"
 	path = /obj/item/rogueweapon/shovel/small
 	sort_category = "Tools"
+
+/datum/loadout_item/mirror 
+	name = "Hand Mirror"
+	path = /obj/item/handmirror
+	sort_category = "Tools"
+

--- a/code/game/objects/items/rogueitems/broom.dm
+++ b/code/game/objects/items/rogueitems/broom.dm
@@ -50,20 +50,17 @@
 /obj/item/broom/proc/broom_fu(atom/A, mob/living/user)
 	if(!A)
 		return
-	for(var/obj/effect/decal/cleanable/dirt/C in A)
-		qdel(C)
-	for(var/obj/item/paper/crumpled/C in A)
-		qdel(C)
-	for(var/obj/item/ash/C in A)
-		qdel(C)
-	for(var/obj/item/natural/glass_shard/C in A)
-		qdel(C)
-	for(var/obj/effect/decal/cleanable/debris/woody/C in A)
-		qdel(C)
-	for(var/obj/effect/decal/cleanable/debris/stony/C in A)
-		qdel(C)
-	for(var/obj/effect/decal/cleanable/debris/glassy/C in A)
-		qdel(C)
+
+	var/turf/T = get_turf(A)
+	if(!T)
+		return
+
+	if(istype(A, /obj/effect/decal/cleanable/dirt) || istype(A, /obj/item/paper/crumpled) || istype(A, /obj/item/ash) || istype(A, /obj/item/natural/glass_shard) || istype(A, /obj/effect/decal/cleanable/debris) || istype(A, /obj/effect/decal/remains/human))
+		qdel(A)
+
+	for(var/obj/O in T.contents)
+		if(istype(O, /obj/effect/decal/cleanable/dirt) || istype(O, /obj/item/paper/crumpled) || istype(O, /obj/item/ash) || istype(O, /obj/item/natural/glass_shard) || istype(O, /obj/effect/decal/cleanable/debris) || istype(O, /obj/effect/decal/remains/human))
+			qdel(O)
 
 /obj/item/broom/proc/gather_clutter(turf/T, mob/living/user)
 	if(!T)

--- a/code/game/objects/items/rogueitems/broom.dm
+++ b/code/game/objects/items/rogueitems/broom.dm
@@ -3,15 +3,20 @@
 	desc = "A robust-looking broom, made from a bundle of twigs. Sweep away debris, glass, blood, dirt, and time without a care in the world."
 	icon = 'icons/roguetown/weapons/tools.dmi'
 	icon_state = "broom"
-	possible_item_intents = list(/datum/intent/use)
+	possible_item_intents = list(/datum/intent/use, /datum/intent/mace/strike/wood)
 	gripped_intents = list(/datum/intent/use, /datum/intent/mace/strike/wood)
-	force = 2
-	force_wielded = 4
+	force = 10
+	force_wielded = 14
 	throwforce = 1
 	firefuel = 10 MINUTES
+	wlength = WLENGTH_LONG
+	sharpness = IS_BLUNT
 	resistance_flags = FLAMMABLE
-	slot_flags = ITEM_SLOT_BACK
+	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
+	can_parry = TRUE
+	wdefense = 4
 	walking_stick = TRUE
+	anvilrepair = /datum/skill/craft/carpentry
 	smeltresult = /obj/item/ash
 
 /obj/item/broom/getonmobprop(tag)
@@ -46,6 +51,30 @@
 		broom_fu(T, user)
 		gather_clutter(T, user)
 
+
+/obj/item/broom/attack_obj(obj/O, mob/living/user)
+	if(istype(O, /obj/structure/spider/stickyweb)) // perish, spiders
+		O.take_damage(200, BRUTE, "blunt", FALSE)
+		playsound(loc,"smashlimb", 50, FALSE)
+		return
+
+	if(do_after(user, 15, target = O))
+		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [O.name].</span>", "<span class='notice'>I dutifully sweep \the [O.name].</span>")
+		playsound(user, "clothwipe", 100, TRUE)		
+		broom_fu(O, user)
+
+// Even if there's nothing mechanically dirty about the floor, you can still sweep it! Anything to look busy. // added a few more to it cause why not
+/obj/item/broom/attack_turf(turf/T, mob/living/user)
+	if(istype(T, /turf/open/lava)) // lol
+		return
+	if(istype(T, /turf/open/water))
+		return
+	if(do_after(user, 20, target = T))
+		user.visible_message("<span class='notice'>[user] dutifully sweeps \the [T.name].</span>", "<span class='notice'>I dutifully sweep \the [T.name].</span>")
+		playsound(user, 'sound/items/broom_sweep.ogg', 150, TRUE)
+		broom_fu(T, user)
+		gather_clutter(T, user)
+
 // i should make this delete squires who try to steal your butter too it'll probably be funny
 /obj/item/broom/proc/broom_fu(atom/A, mob/living/user)
 	if(!A)
@@ -55,11 +84,16 @@
 	if(!T)
 		return
 
-	if(istype(A, /obj/effect/decal/cleanable/dirt) || istype(A, /obj/item/paper/crumpled) || istype(A, /obj/item/ash) || istype(A, /obj/item/natural/glass_shard) || istype(A, /obj/effect/decal/cleanable/debris) || istype(A, /obj/effect/decal/remains/human))
-		qdel(A)
-
 	for(var/obj/O in T.contents)
-		if(istype(O, /obj/effect/decal/cleanable/dirt) || istype(O, /obj/item/paper/crumpled) || istype(O, /obj/item/ash) || istype(O, /obj/item/natural/glass_shard) || istype(O, /obj/effect/decal/cleanable/debris) || istype(O, /obj/effect/decal/remains/human))
+		if(O.loc != T) // think this might stop it from deleting clutter from bags? oughh...
+			continue
+
+		if(istype(O, /obj/effect/decal/cleanable/dirt) || \
+		   istype(O, /obj/item/paper/crumpled) || \
+		   istype(O, /obj/item/ash) || \
+		   istype(O, /obj/item/natural/glass_shard) || \
+		   istype(O, /obj/effect/decal/cleanable/debris) || \
+		   istype(O, /obj/effect/decal/remains/human))
 			qdel(O)
 
 /obj/item/broom/proc/gather_clutter(turf/T, mob/living/user)


### PR DESCRIPTION
## About The Pull Request

Speedmerge this one.

- Made it so brooms can also target objects for cleaning, it'll force scan the turf. For those very common dyslexical moments when you can't afford to click a tile properly.
- Added most survival-tier tools to Tools tab in our Loadout menu.
- Added an empty tossblade belt to Accessories tab in our Loadout menu.

Unatomized:
- Gave brooms 10 base force so I can whack those pesky butter-stealing squires, along a few more flags that can be useful, such as letting carpentry repair it.

## Testing Evidence

Compiles. Just code maint and adding a few more options for the Loadout menu.

## Why It's Good For The Game

More customization is good, more larp is good.

## Changelog
:cl:
add: Tossblade Belt (empty) and most Survival-tier Tools to Loadout menu.
qol: Brooms are more dyslexia-friendly and gain bonus accuracy against garbage.
/:cl: