### PR TITLE
[TM ONLY] Removes SCOMstones from most roles. THE SCOM SYSTEM IS STILL INTACT. 

### DIFF
--- a/code/modules/jobs/job_types/roguetown/burghers/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/burghers/guildmaster.dm
@@ -82,7 +82,6 @@
 		shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/artificer
 		backl = /obj/item/storage/backpack/rogue/backpack
-		id = /obj/item/scomstone
 		backpack_contents = list(
 			/obj/item/rogueweapon/hammer/iron = 1,
 			/obj/item/rogueweapon/tongs = 1,

--- a/code/modules/jobs/job_types/roguetown/courtier/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/archivist.dm
@@ -97,7 +97,6 @@
 	beltl = /obj/item/storage/keyring/archivist
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
 	mask = /obj/item/clothing/mask/rogue/spectacles
-	id = /obj/item/scomstone/bad
 	backpack_contents = list(
 		/obj/item/recipe_book/alchemy,
 		/obj/item/skillbook/unfinished, //give the book man a starter book, enough paper for 3 pages, and a writing instrument to get him started

--- a/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manatarms.dm
@@ -56,7 +56,6 @@
 	beltl = /obj/item/rogueweapon/mace/cudgel
 	belt = /obj/item/storage/belt/rogue/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
-	id = /obj/item/scomstone/bad/garrison
 
 // Melee goon
 /datum/advclass/manorguard/footsman

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -39,7 +39,6 @@
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	saiga_shoes = /obj/item/clothing/shoes/roguetown/horseshoes
-	id = /obj/item/scomstone/bad/garrison
 	job_bitflag = BITFLAG_GARRISON //Counts towards overall combat roles
 
 /datum/advclass/warden/warden

--- a/code/modules/jobs/job_types/roguetown/retinue/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/knight.dm
@@ -71,7 +71,6 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	belt = /obj/item/storage/belt/rogue/leather/steel
 	backr = /obj/item/storage/backpack/rogue/satchel
-	id = /obj/item/scomstone/bad/garrison
 	backpack_contents = list(
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot = 1,
 		/obj/item/storage/keyring/knight = 1,

--- a/code/modules/jobs/job_types/roguetown/retinue/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/retinue/squire.dm
@@ -35,7 +35,6 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/keyring/squire
 	cloak = /obj/item/clothing/cloak/tabard/stabard/surcoat/guard
-	id = /obj/item/scomstone/bad/garrison
 	job_bitflag = BITFLAG_GARRISON
 
 /datum/job/roguetown/squire/after_spawn(mob/living/L, mob/M, latejoin = TRUE)


### PR DESCRIPTION
## About The Pull Request
Title.


**THIS ONLY REMOVES SCOM STONES. YOU STILL HAVE THE SCOMS. I AM NOT TOUCHING THAT. THIS IS JUST A TEST**
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Another test to see what adjustments can be made to lower TDM!

Now the garrision actually has to run out their orders

I'd add forest warden to one slot and then bump the other wardens to three and call them forest garrision so they still keep their radio but that's too big of a change. Too radical for now.

The map has serious design issues as is. This is an attempt to make something that makes it much more dangerous for the garrision to operate outside of town, and restrict the flow of information. Only the head roles of the garrision and keep have radios to radio information to and fro.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:

balance: Experimental removal of scomstones from most of the garrision. Give feedback in the discord! This is not going to be full merged.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
