### PR TITLE
Deprived display

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -46,6 +46,7 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 		/datum/advclass/sfighter/mhunter,
 		/datum/advclass/sfighter/barbarian,
 		/datum/advclass/sfighter/ironclad,
+		/datum/advclass/sfighter/deprived,
 		/datum/advclass/rogue,
 		/datum/advclass/rogue/thief,
 		/datum/advclass/rogue/bard,


### PR DESCRIPTION
## About The Pull Request

Deprived adventurer class is now displayed in class list since it was already possible to play.

## Testing Evidence

<img width="456" height="442" alt="image" src="https://github.com/user-attachments/assets/93295e45-4259-4dc6-974f-83b724369f95" />

## Why It's Good For The Game

Critical bugfix

## Changelog

:cl:
fix: Deprived is now displayed properly.
/:cl:
