### PR TITLE
touch(ing) up - turns all mentions of 'night' in the loading screen tips .txt to 'nite', finalizes 'lyndvhartia'

### DIFF
--- a/strings/rt/rp_prompt.txt
+++ b/strings/rt/rp_prompt.txt
@@ -344,20 +344,20 @@ Yet, not a millennium later, there came Zizo's ascension: a calamity so profound
 		<br>
 		<em>The Republic, Cultivators of the Weeping God's Order</em>
 		<br><br>
-		Valoria is a lesser kingdom that straddles the western coasts, just a stone's throw away from Zyndvhartia. They practice an optimistic variant of the Orthodoxy, and - though largely independent from Otava's influence - often helps out whenever the Archbishop calls for holy warfare. 
+		Valoria is a lesser kingdom that straddles the western coasts, just a stone's throw away from Lyndvhartia. They practice an optimistic variant of the Orthodoxy, and - though largely independent from Otava's influence - often helps out whenever the Archbishop calls for holy warfare. 
 <br><br>
 Residing within Valoria's walls is the Order of the Silver Psycross: a faith-militance that's renowned for its intoxicating mirth, adherence to chivalry, and remarkably delicious handpies. 
 		<br>
 	</details>
 
 	<details>
-		<summary><strong> ZYNDVHARTIA </strong></summary>
+		<summary><strong> LYNDVHARTIA </strong></summary>
 		<br>
 		<em>The Port, Receiver of Psydonia's Merchant-Fleets</em>
 		<br><br>
-		Zyndvhartia might be similar in size to Azuria, but has a far more vital presence in Psydonia's economic affairs. Due to their positioning on the western coast, they're considered the closest - and most neutral - port for nearly every major kingdom with a mercantile fleet. 
+		Lyndvhartia might be similar in size to Azuria, but has a far more vital presence in Psydonia's economic affairs. Due to their positioning on the western coast, they're considered the closest - and most neutral - port for nearly every major kingdom with a mercantile fleet. 
 <br><br>
-Fried salmoncakes, jellied eels, and pints of Fjall-iced liquor keep Zyndvhartia's dockworkers strong: both when laboring at the harbor, and when rioting against nobility after a particularly close game of lampternball.
+Fried salmoncakes, jellied eels, and pints of Fjall-iced liquor keep Lyndvhartia's dockworkers strong: both when laboring at the harbor, and when rioting against nobility after a particularly close game of lampternball.
 		<br>
 	</details>
 

--- a/strings/rt/timechangetips.txt
+++ b/strings/rt/timechangetips.txt
@@ -198,7 +198,7 @@ Aasimar cannot die of old age. Sometimes, however, they simply give up, and turn
 Everything these tips tell you is made up.
 Everything these tips tell you is completely true.
 You should move to Kingsfield. It's better there.
-Every yil, Heartfelt hosts a grand banquet for the nobility of Azuria, Rockhill, and Zyndvhartia to attend. The Holy Psydonic Inquisition is credited with thwarting an attempted bombing of its palace, during the previous yil's feast.
+Every yil, Heartfelt hosts a grand banquet for the nobility of Azuria, Rockhill, and Lyndvhartia to attend. The Holy Psydonic Inquisition is credited with thwarting an attempted bombing of its palace, during the previous yil's feast.
 They say that Heartfelt has fallen to a horde of the living dead, or-.. no, wait, wasn't that the Rudmarsch?
 Adonai, my God, why hath you forsaken me?!
 BEFORE THE FINAL BLOW WAS STRUCK, I TORE OPEN A PORTAL IN TYME AND FLUNG PSYDON INTO THE DAES-TO-COME; WHERE MY SIN IS LAW! NOW.. THE LOWLY FOOL SEEKS TO RETURN TO THE PAST, AND UNDO THE EVIL THAT IS VHESLYN!

--- a/strings/rt/timechangetips.txt
+++ b/strings/rt/timechangetips.txt
@@ -1,6 +1,6 @@
 The Holy Ecclesial is a splinter of the Holy See, formed during the great schism. They worship the Four Ascendants as true divinity.
 PSYDON yet lives. PSYDON yet ENDURES.
-Dae is far less dangerous than Night; Astrata’s gaze is far more searing to all forms of evils in a direct burn.
+Dae is far less dangerous than Nite; Astrata’s gaze is far more searing to all forms of evils in a direct burn.
 The Ten are less responsive to prayer than the Ascendant. The Holy See claims that this is a test of faith.
 I can jump further by getting a running start. Mind the overshoot.
 The world flooded for a thousand daes before Abyssor was finally put to rest. Some say he will one dae stir from his slumber; his sleep must endure.
@@ -114,7 +114,7 @@ The pauper never had much, but his worship for Abyssor led the faithful to mend 
 To trust an Abyssorite is to believe in Xylix. Since the first communion, his followers frequently fall to madness.
 The winds tell tales of Astratan devout turning flesh to flame and flame to blades. Beware her fury.
 Shal'ghur is a city only known by this name, denoted affectionately by creatures that dwell in Abyssor's dream. The shades of winding streets full of the damned reflected in his realm. A cautionary tale on the dangers of dream incursions.
-The mast buckles, as the ship is led through treacherous waters by Abyssorite under Astrata's gaze. Sleeping eyes giving way for the faithful of Noc, who continue their toil at night.
+The mast buckles, as the ship is led through treacherous waters by Abyssorite under Astrata's gaze. Sleeping eyes giving way for the faithful of Noc, who continue their toil at nite.
 To dream is to commune with Abyssor. Coffee is a sin, but a bit of Camomille tea never goes amiss.
 The righteous cult of Abyssor seeks to keep the old one asleep. His Sentinels and Acolytes often find employ within cities and the Holy See. it is immessurably expensive to scrawl down so many glimpses of dreams, yet the faithful do not care that most of it is gibberish.
 Heretical Abyssorites are despised by many, even their own ilk often think twice of associating with them. Whether it's fear of the destruction wrought by a waking Abyssor, or to condemn the time wasted by their attempts.
@@ -148,7 +148,7 @@ Bandages soak up a limited amount of blood. Get stitching quick, or die snow whi
 I SEE THE DREADED GEM-EATER. HIS METAL MITTS HOLD MY HIDDEN STASH OF SAFFIRA. ONE BY ONE, HE POPS THEM INTO HIS MOUTH...
 WHY IS IT WRITTEN SAIGA AND NOT PSYGA?
 YIELDING slows your bleeding and prevents your assailant from decapitating you, though you will struggle to attack in return.
-Crops can be dug up with spades. Hoes allow for instant removal of weeds. Compost, nightsoil, and bones can be combined by farmers into the legendary "fertilizer".
+Crops can be dug up with spades. Hoes allow for instant removal of weeds. Compost, nitesoil, and bones can be combined by farmers into the legendary "fertilizer".
 Sleeves can be torn for cloth. They can also be rolled up, if you care for the aesthetic.
 With enough STRENGTH, locked doors can be kicked open. You may not bust it down on the first go, keep trying!
 SAKURA LEAVES FALLING IS A SIGN OF EORA'S GROWING POWER. IF I SEE THEM, I SHOULD EXPECT PEACE...
@@ -176,7 +176,7 @@ The Necran symbol is a jawless skull. A smiling skull is used to represent ZIZO.
 Many Necrans seek to come closer to the threshhold between lyfe and death. Some emulate the silence of the grave, and take vows never to speak.
 In antiquity, it is said mortals could once travel to the Underworld to speak with the departed- since the ascension of ZIZO, it is now the dead who cross to menace the living.
 Undeath takes many forms. Wraiths and spectres haunt the steppes of Aavnr, will-o'-the-wisps feed on the unlucky travellers of Grenzelhoft, and in distant Naledi, ghuls and mummies drain blood with a touch.
-The people of Naledi believe that face coverings and bright colors ward off nightcreatures and bodystealers, like the fabled alghul and djinn. Gold, silk, and ceruleabaster decorate their robes and trinkets.
+The people of Naledi believe that face coverings and bright colors ward off nitecreechers and bodystealers, like the fabled alghul and djinn. Gold, silk, and ceruleabaster decorate their robes and trinkets.
 The divinatory astrologists of Naledi are unmatched throughout Psydonia. Naledi believe deeply in prophecies and fortune-telling in the stars, and a starless sky often inspires terror.
 The pomegranate is the sacred fruit of Eora.
 Zenitstadt is the second largest city in Grenzelhoft, and home to their famous fencing guilds. Most Grenzel mercenaries hail from here, and almost all of them have something unpleasant to say about it.
@@ -198,13 +198,13 @@ Aasimar cannot die of old age. Sometimes, however, they simply give up, and turn
 Everything these tips tell you is made up.
 Everything these tips tell you is completely true.
 You should move to Kingsfield. It's better there.
-Every yil, Heartfelt hosts a grand banquet for the nobility of Azuria, Rockhill, and Lyndvhar to attend. The Holy Psydonic Inquisition is credited with thwarting an attempted bombing of its palace, during the previous yil's feast.
+Every yil, Heartfelt hosts a grand banquet for the nobility of Azuria, Rockhill, and Zyndvhartia to attend. The Holy Psydonic Inquisition is credited with thwarting an attempted bombing of its palace, during the previous yil's feast.
 They say that Heartfelt has fallen to a horde of the living dead, or-.. no, wait, wasn't that the Rudmarsch?
 Adonai, my God, why hath you forsaken me?!
 BEFORE THE FINAL BLOW WAS STRUCK, I TORE OPEN A PORTAL IN TYME AND FLUNG PSYDON INTO THE DAES-TO-COME; WHERE MY SIN IS LAW! NOW.. THE LOWLY FOOL SEEKS TO RETURN TO THE PAST, AND UNDO THE EVIL THAT IS VHESLYN!
 Blastpowder was originally created by Hammerhold's wisest dwarve-alchemists to 'spice up' bubbleless ale. All it took was an errant spark - and the cellar's subsequent obliteration - to reveal an alternative use.
 Glimmering slag and gold have two things in common; they're both useless on their own, and they both thrumb with latent magicka. Perhaps alloying them together, two-to-two, could offer something new?
-What's the difference between a longsword, broadsword, and bastard sword? One's for a noble, another's for a knight, and the last one's for whatever they make after a night of drunken revelry.
+What's the difference between a longsword, broadsword, and bastard sword? One's for a noble, another's for a knight, and the last one's for whatever they make after a nite of drunken revelry.
 Bronze tools, weapons, and armor tend to be sharper and sturdier than their iron-wrought counterparts. The trickier part is forging the alloy; but, perhaps fashioning a smelter out of stone, charcoal, copper and tin could do the trick.
 Bronze is cherished by the worshippers of Ravox; the first alloy gifted to Psydonia, hewn into plate-and-blade by Man to bring justice unto the wicked. His most ardent paladins oft-forsake steel longswords, in favor of bronze flamberges.
 They'll tell you that the first alloy known to Psydonia was bronze, but they'd be lying.


### PR DESCRIPTION
## About The Pull Request

* Corrects all explicit mentions of 'night' to 'nite', as intended _(similarly to how we handle 'days' and 'daes'.)_
* Restores the 'L-' to Zyndhvartia, making it Lyndvhartia - a halfway point that should hopefully satiate both sides.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Corrects a minor incongruence with our particular type of vernacular.
* Avoids the self-made headache of having a nation mistaken for Zybantia, while still remaining tastefully adherent lore.

## Changelog

:cl:
fix: Mentions of 'night' in the loading screen tips have been changed to 'nite'.
fix: Zyndvhartia is partially restored as Lyndvhartia. No more chance for mistaking it with another 'Z-'-starting nation!
/:cl:
