### PR TITLE
minor triumph touchups - restores original high-end price cap of 7TRI per item, moves most noble garb up to that price

### DIFF
--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -140,6 +140,24 @@
 	triumph_cost = 5
 	sort_category = "Triumphs"
 
+/datum/loadout_item/triumph_gildedshirt
+	name = "Gilded Dress Shirt"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince
+	triumph_cost = 5
+	sort_category = "Triumphs"
+
+/datum/loadout_item/triumph_pristinedress
+	name = "Pristine Dress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess
+	triumph_cost = 5
+	sort_category = "Triumphs"
+
+/datum/loadout_item/triumph_royalsleeves
+	name = "Royal Sleeves"
+	path = /obj/item/clothing/wrists/roguetown/royalsleeves
+	triumph_cost = 5
+	sort_category = "Triumphs"
+
 // -7 TRI
 /datum/loadout_item/triumph_buttpack
 	name = "Belted Satchel"
@@ -162,24 +180,6 @@
 /datum/loadout_item/triumph_ladycloak
 	name = "Ladylike Cloak"
 	path = /obj/item/clothing/cloak/lordcloak/ladycloak
-	triumph_cost = 7
-	sort_category = "Triumphs"
-
-/datum/loadout_item/triumph_gildedshirt
-	name = "Gilded Dress Shirt"
-	path = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince
-	triumph_cost = 7
-	sort_category = "Triumphs"
-
-/datum/loadout_item/triumph_pristinedress
-	name = "Pristine Dress"
-	path = /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess
-	triumph_cost = 7
-	sort_category = "Triumphs"
-
-/datum/loadout_item/triumph_royalsleeves
-	name = "Royal Sleeves"
-	path = /obj/item/clothing/wrists/roguetown/royalsleeves
 	triumph_cost = 7
 	sort_category = "Triumphs"
 

--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -116,24 +116,6 @@
 	triumph_cost = 5
 	sort_category = "Triumphs"
 
-/datum/loadout_item/triumph_gildedshirt
-	name = "Gilded Dress Shirt"
-	path = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince
-	triumph_cost = 5
-	sort_category = "Triumphs"
-
-/datum/loadout_item/triumph_pristinedress
-	name = "Pristine Dress"
-	path = /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess
-	triumph_cost = 5
-	sort_category = "Triumphs"
-
-/datum/loadout_item/triumph_royalsleeves
-	name = "Royal Sleeves"
-	path = /obj/item/clothing/wrists/roguetown/royalsleeves
-	triumph_cost = 5
-	sort_category = "Triumphs"
-
 /datum/loadout_item/triumph_goldhalfmask
 	name = "Golden Halfmask, Ornate"
 	path = /obj/item/clothing/mask/rogue/lordmask/triumph
@@ -158,23 +140,23 @@
 	triumph_cost = 5
 	sort_category = "Triumphs"
 
-// -9 TRI
+// -7 TRI
 /datum/loadout_item/triumph_buttpack
 	name = "Belted Satchel"
 	path = /obj/item/storage/backpack/rogue/satchel/beltpack
-	triumph_cost = 9
+	triumph_cost = 7
 	sort_category = "Triumphs"
 
 /datum/loadout_item/triumph_lunchpouch
 	name = "Pouch of Luncheons"
 	path = /obj/item/storage/belt/rogue/pouch/triumphlunch
-	triumph_cost = 9
+	triumph_cost = 7
 	sort_category = "Triumphs"
 
 /datum/loadout_item/triumph_lordcloak
 	name = "Lordly Cloak"
 	path = /obj/item/clothing/cloak/lordcloak
-	triumph_cost = 9
+	triumph_cost = 7
 	sort_category = "Triumphs"
 
 /datum/loadout_item/triumph_ladycloak
@@ -183,22 +165,40 @@
 	triumph_cost = 7
 	sort_category = "Triumphs"
 
+/datum/loadout_item/triumph_gildedshirt
+	name = "Gilded Dress Shirt"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince
+	triumph_cost = 7
+	sort_category = "Triumphs"
+
+/datum/loadout_item/triumph_pristinedress
+	name = "Pristine Dress"
+	path = /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess
+	triumph_cost = 7
+	sort_category = "Triumphs"
+
+/datum/loadout_item/triumph_royalsleeves
+	name = "Royal Sleeves"
+	path = /obj/item/clothing/wrists/roguetown/royalsleeves
+	triumph_cost = 7
+	sort_category = "Triumphs"
+
 /datum/loadout_item/triumph_scabbardroyal
 	name = "Decorated Scabbard, Golden"
 	path = /obj/item/rogueweapon/scabbard/sword/royal
-	triumph_cost = 9
+	triumph_cost = 7
 	sort_category = "Triumphs"
 
 /datum/loadout_item/triumph_sheathroyal
 	name = "Decorated Sheath, Golden"
 	path = /obj/item/rogueweapon/scabbard/sheath/royal
-	triumph_cost = 9
+	triumph_cost = 7
 	sort_category = "Triumphs"
 
 /datum/loadout_item/triumph_gdorpelring
 	name = "Golden Dorpel Ring, Ornate"
 	path = /obj/item/clothing/ring/diamond/triumph
-	triumph_cost = 9
+	triumph_cost = 7
 	sort_category = "Triumphs"
 
 //////////////////


### PR DESCRIPTION
## About The Pull Request

* Restored the original price cap of 3-5-7 _(instead of 3-5-9_) for TRI-related items.
* Moves most items previously priced at 9 TRI down to 7 TRI.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Restores the original pricing system, where one item's price doesn't exceed how much TRI a week'll naturally provide.
* Should hopefully encourage people to use more TRI on more items, without feeling too daunted.

## Changelog

:cl:
fix: Equalizes the TRI-LOADOUT prices to be 3-5-7, instead of 3-5-9. Likewise, most noble garbs have received a minor price bump from 5 to 7.
/:cl: