### PR TITLE
Revert "give view actors verb to admins"

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -41,7 +41,6 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/open_bounty_menu,
 	/client/proc/remove_bounty,
 	/client/proc/agevet_player,
-	/client/proc/view_actors_manifest,
 	// RATWOOD MODULAR START
 	/client/proc/bunker_bypass,
 	// RATWOOD MODULAR END

--- a/code/modules/client/roundendmanifest.dm
+++ b/code/modules/client/roundendmanifest.dm
@@ -9,10 +9,6 @@
 	popup.open(FALSE)
 
 /client/proc/view_actors_manifest()
-	set category = "OOC"
-	set name = "View Actors"
-	if(!holder)
-		return
 	var/list/actors_list = get_sorted_actors_list()
 	var/list/categories_used = list()
 


### PR DESCRIPTION
Reverts Azure-Peak/Azure-Peak#7139

people can't view the manifest anymore because of this.

https://github.com/user-attachments/assets/16f934fe-9a24-46e4-bc0f-6b3a816ee2cb

