### PR TITLE
Ashes can now be scattered

### DIFF
--- a/code/game/objects/items/rogueitems/natural/ash.dm
+++ b/code/game/objects/items/rogueitems/natural/ash.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "ash"
 	w_class = WEIGHT_CLASS_TINY
+	var/being_deleted = FALSE
 
 /obj/item/ash/get_mechanics_examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/rogueitems/natural/ash.dm
+++ b/code/game/objects/items/rogueitems/natural/ash.dm
@@ -30,3 +30,14 @@
 			prob2break = 100
 		if(prob(prob2break))
 			qdel(src)
+
+/obj/item/ash/attack_self(mob/living/user)
+	user.visible_message(span_warning("[user] scatters [src]."))
+	if(being_deleted || QDELETED(src))
+		return
+	being_deleted = TRUE
+	qdel(src)
+
+/obj/item/ash/Destroy()
+	being_deleted = TRUE
+	return ..()


### PR DESCRIPTION
## About The Pull Request

Lazily copypasted code from dirt clods.

## Testing Evidence

uhh

## Why It's Good For The Game

People downstream are requesting the ability to scatter and thus clean up ashes using the same method they would get rid of twigs, thorns, clods of dirt, etc. Feels intuitive.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Ashes can now be scattered by using them in hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
