### PR TITLE
Giving some love to utlity spells such as mending and orison's miraculous light, and fixing orison

### DIFF
--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -22,7 +22,7 @@
 	ignore_armor_penalty = TRUE
 
 	primary_resource_type = SPELL_COST_DEVOTION
-	primary_resource_cost = SPELLCOST_MIRACLE_ORISON
+	primary_resource_cost = 0 // the cost is spent when spawning the hand miracle and canceling it
 
 	secondary_resource_type = SPELL_COST_STAMINA
 	secondary_resource_cost = SPELLCOST_CANTRIP

--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -104,7 +104,7 @@
 /datum/status_effect/light_buff
 	id = "orison_light_buff"
 	alert_type = /atom/movable/screen/alert/status_effect/light_buff
-	duration = 5 MINUTES
+	duration = 10 MINUTES
 	status_type = STATUS_EFFECT_REFRESH
 	examine_text = "SUBJECTPRONOUN is surrounded by an aura of gentle light."
 	var/outline_colour = "#ffffff"

--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -28,7 +28,7 @@
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
-	var/repair_percent = 0.40
+	var/repair_percent = 0.35
 	var/int_bonus = 0.00
 
 /datum/action/cooldown/spell/mending/is_valid_target(atom/cast_on)

--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -28,7 +28,7 @@
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
-	var/repair_percent = 0.25
+	var/repair_percent = 0.27
 	var/int_bonus = 0.00
 
 /datum/action/cooldown/spell/mending/is_valid_target(atom/cast_on)

--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -18,7 +18,7 @@
 	invocations = list("Reficio")
 	invocation_type = INVOCATION_SHOUT
 
-	cooldown_time = 20 SECONDS
+	cooldown_time = 15 SECONDS
 
 	associated_skill = /datum/skill/magic/arcane
 	spell_tier = 1
@@ -28,7 +28,7 @@
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
-	var/repair_percent = 0.35
+	var/repair_percent = 0.25
 	var/int_bonus = 0.00
 
 /datum/action/cooldown/spell/mending/is_valid_target(atom/cast_on)

--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -28,7 +28,7 @@
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
-	var/repair_percent = 0.20
+	var/repair_percent = 0.40
 	var/int_bonus = 0.00
 
 /datum/action/cooldown/spell/mending/is_valid_target(atom/cast_on)
@@ -86,6 +86,6 @@
 
 /datum/action/cooldown/spell/mending/lesser
 	name = "Lesser Mending"
-	repair_percent = 0.10
+	repair_percent = 0.15
 	cooldown_time = 30 SECONDS
 	point_cost = 1


### PR DESCRIPTION
## About The Pull Request

Mending and Orison light are better

## Testing Evidence
it compiles

## Why It's Good For The Game

Mending always was a good spells but keeping taking breaks every 20 seconds to sit 4 seconds gets very annoying on the long run, orison is a cost-dependant creation of water and light, it should perform better than Light spell. this doesn't make it perform better but it make it less annoying by asking the player to stop half as often to use it.(light is a 1 cost 1 cast infinite duration light source costing 6 stamina/energy, to keep the light on yourself for the entire round you would need to cast miraculous light 60 times spending a total of 1200 devotion 360 stamina/energy, this PR cut both cost in half by doubling the duration)

## Changelog
Mending's base repair increased from 20% to 27% and reduces the cooldown by 5 seconds this effectively reduces the minimal numbers of sittings down the 3(so a total of 12 seconds at MOST for broken items, and 2 sittings at 15 INT in most cases. still takes 4 seconds per repair but this cuts down waiting town from maximum 24 seconds to 19 seconds between each repairs.)
Lesser Mending base repair's increased from 10% to 15%
Miraculous light's duration increased from 5 minutes to 10 minutes

:cl:
balance: mending repairs 27% baseline with a 15 seconds cooldown, lesser mending repairs 15%
balance: Miraculous light's duration has been doubled, from 5 minutes to 10 minutes.
fix: orison now no longer cost devotion on invokation and revokation, all the cost comes from using miraculous light, thaumaturgical voice and create blessed water
/:cl:

