### PR TITLE
The Crafter's Covenant: Maker's Marks and Named Items

### DIFF
--- a/code/datums/components/crafted_item.dm
+++ b/code/datums/components/crafted_item.dm
@@ -1,0 +1,7 @@
+/datum/component/crafted_item
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	var/crafter_name
+
+/datum/component/crafted_item/Initialize(realname)
+	. = ..()
+	crafter_name = realname

--- a/code/game/objects/items/rogueitems/natural/feather.dm
+++ b/code/game/objects/items/rogueitems/natural/feather.dm
@@ -42,7 +42,11 @@
 			if(oldname == input)
 				to_chat(user, span_notice("I changed \the [O.name] to... well... \the [O.name]."))
 			else
-				O.name = "[input] ([initial(O.name)])"
+				var/datum/component/crafted_item/crafted_component = O.GetComponent(/datum/component/crafted_item)
+				if(istype(crafted_component) && crafted_component.crafter_name == user.real_name)
+					O.name = "[input]"
+				else
+					O.name = "[input] ([initial(O.name)])"
 				to_chat(user, span_notice("\The [oldname] has been successfully been renamed to \the [input]."))
 				O.renamedByPlayer = TRUE
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -271,6 +271,10 @@
 	else
 		return ..()
 
+/obj/item/clothing/OnCrafted(dirin, mob/user)
+	. = ..()
+	if(user)
+		src.AddComponent(/datum/component/crafted_item, user.real_name)
 
 /*	if(damaged_clothes && istype(W, /obj/item/stack/sheet/cloth))
 		var/obj/item/stack/sheet/cloth/C = W

--- a/code/modules/farming/bin.dm
+++ b/code/modules/farming/bin.dm
@@ -208,6 +208,7 @@
 					editme.max_integrity = newmaxinteg
 					editme.obj_integrity = newinteg
 					editme.sellprice = newprice
+					editme.AddComponent(/datum/component/crafted_item, user.real_name)
 					if(istype(editme, /obj/item/lockpick))
 						editme.picklvl = newpicklvl
 					if(istype(editme, /obj/item/rogueweapon))
@@ -225,6 +226,7 @@
 			else // Just make one buddy
 				var/obj/item/IT = new crafteditem(used_turf)
 				R.handle_creation(IT)
+				IT.AddComponent(/datum/component/crafted_item, user.real_name)
 			playsound(src,pick('sound/items/quench_barrel1.ogg','sound/items/quench_barrel2.ogg'), 100, FALSE)
 			QDEL_NULL(T.hingot)
 			T.update_icon()

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -111,6 +111,9 @@
 			. += span_info("It's been thoroughly brushed.")
 		if(4)
 			. += span_green("It's been nicely polished.")
+	var/datum/component/crafted_item/crafted_component = GetComponent(/datum/component/crafted_item)
+	if(istype(crafted_component))
+		. += "It bears the maker's mark of [crafted_component.crafter_name]."
 
 /obj/item/polishing_cream
 	icon = 'icons/roguetown/items/misc.dmi'

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -730,6 +730,7 @@
 #include "code\datums\components\caltrop.dm"
 #include "code\datums\components\combat_vocalizer.dm"
 #include "code\datums\components\construction.dm"
+#include "code\datums\components\crafted_item.dm"
 #include "code\datums\components\creamed.dm"
 #include "code\datums\components\cursed_item.dm"
 #include "code\datums\components\deadchat_control.dm"


### PR DESCRIPTION
## About The Pull Request
A minor, but soulful, tweak to crafting gear: when you make an item (armor, clothing, or weapon only), your 'maker's mark' is added to it and others can see it on inspect. This component also allows you (and only you!) to rename it without the original name being appended. Make fancy aurafarming swords and custom-named blacksteel plate to your heart's content.

## Testing Evidence
<img width="594" height="568" alt="image" src="https://github.com/user-attachments/assets/14f76324-1464-4e7e-ba39-a3d86a14dbc3" />
<img width="591" height="288" alt="image" src="https://github.com/user-attachments/assets/faf7aa00-9fba-46d4-921c-edd98d531e38" />
<img width="593" height="291" alt="image" src="https://github.com/user-attachments/assets/a3f62b96-3268-4c80-9940-c39b0c67e7ee" />

(an example of a crafted item that is not a valid gear item, and therefore doesn't get maker's mark)
<img width="606" height="185" alt="image" src="https://github.com/user-attachments/assets/17a32678-7a34-4e3b-bc90-3524cb0f9124" />

## Why It's Good For The Game
Making a masterwork weapon and naming it only to have a stupid-looking addendum at the end sucks. This means smiths and tailors that make really cool things have an advantage in being able to reflavor them, as opposed to chumps that buy them from the silverface and have to suffer with the aura loss of having their sword be named Eviscerator (rapier) or something.

## Changelog

:cl:
add: Crafted/smithed equipment now gets a 'maker's mark' of the character that created it, which shows up on examine; that character can then rename it without the original name being appended.
/:cl:
