### PR TITLE
Adds Fossilized Oysters that were previously unobtainable to the fishing loot table

### DIFF
--- a/code/__HELPERS/fishing_hunting.dm
+++ b/code/__HELPERS/fishing_hunting.dm
@@ -87,7 +87,6 @@
 		/obj/item/reagent_containers/food/snacks/fish/creepy_squid = 7*rareMod + 10*ceruleanMod,
 		/obj/item/reagent_containers/food/snacks/fish/creepy_shark = 2*rareMod + 10*ceruleanMod,
 		/obj/item/clothing/head/roguetown/octopus = 21*rareMod,
-		/obj/item/roguegem/oyster = 40*rareMod + 10*treasureMod,
 		/obj/item/reagent_containers/glass/bottle/rogue/wine = 1*treasureMod + 30*ceruleanMod,
 		/obj/item/clothing/ring/gold = 1*treasureMod + 30*ceruleanMod,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1*treasureMod + 75*ceruleanMod,
@@ -128,6 +127,7 @@
 			/obj/item/reagent_containers/food/snacks/fish/shrimp = 250*commonMod,
 			/obj/item/reagent_containers/food/snacks/fish/crab = 250*rareMod,
 			/obj/item/reagent_containers/food/snacks/fish/lobster = 250*commonMod,
+			/obj/item/roguegem/oyster = 190*rareMod,
 			/obj/item/reagent_containers/food/snacks/smallrat = 1 + 15*cheeseMod, //Oh for fucks sake!
 			/mob/living/simple_animal/hostile/retaliate/rogue/bigrat = 1*cheeseMod,
 			/obj/item/grown/log/tree/stick =  100*trashMod,

--- a/code/__HELPERS/fishing_hunting.dm
+++ b/code/__HELPERS/fishing_hunting.dm
@@ -87,6 +87,7 @@
 		/obj/item/reagent_containers/food/snacks/fish/creepy_squid = 7*rareMod + 10*ceruleanMod,
 		/obj/item/reagent_containers/food/snacks/fish/creepy_shark = 2*rareMod + 10*ceruleanMod,
 		/obj/item/clothing/head/roguetown/octopus = 21*rareMod,
+		/obj/item/roguegem/oyster = 40*rareMod + 10*treasureMod,
 		/obj/item/reagent_containers/glass/bottle/rogue/wine = 1*treasureMod + 30*ceruleanMod,
 		/obj/item/clothing/ring/gold = 1*treasureMod + 30*ceruleanMod,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1*treasureMod + 75*ceruleanMod,


### PR DESCRIPTION
## About The Pull Request

The gemcarving additions were supposed to include this as the way in which the player can obtain oyster shells and rosenstones to do gemcarving with. For whatever reason they were missing. This should count as a fix.

## Testing Evidence

One line change in a loot table, it should work pretty fine

## Why It's Good For The Game

Presumably if we have the fossilized oysters in the game, it's supposed to be obtainable.
It's also just really cool fishing loot.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fossilized Oysters are now obtainable

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
