### PR TITLE
Chopping trees will now throw off anyone on them

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axe/axe_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axe_intents.dm
@@ -23,7 +23,7 @@
 	hitsound = list('sound/combat/hits/bladed/genchop (1).ogg', 'sound/combat/hits/bladed/genchop (2).ogg', 'sound/combat/hits/bladed/genchop (3).ogg')
 	penfactor = PEN_MEDIUM
 	damfactor = 1.5
-	demolition_mod = 5
+	demolition_mod = 2.5
 	swingdelay = 0.8 SECONDS
 	swingdelay_type = SWINGDELAY_PENALTY
 	clickcd = CLICK_CD_CHARGED // Effective Shield DPS: 25 / 2.4 = 10.4

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -226,13 +226,20 @@
 				for(var/mob/living/carbon/human/H in goobers)
 					var/worn_ac = H.highest_ac_worn(FALSE, FALSE)
 					if(HAS_TRAIT(H, TRAIT_WOODWALKER) && worn_ac > 0)
-						toss_a_guy(H)
-						to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))
-						continue
+						var/turf/T = get_turf(H)
+						var/tossed = FALSE
+						for(var/leaf in T.contents)
+							if(istype(leaf, /obj/structure/flora/newleaf))
+								toss_a_guy(H)
+								tossed = TRUE
+								to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))
+								break
+						if(tossed)
+							continue
 					if(HAS_TRAIT(H, TRAIT_WOODWALKER) && worn_ac < ARMOR_CLASS_MEDIUM)
 						continue
 					if(goobers[H] == ZTAG_TOP)
-						if(worn_ac == ARMOR_CLASS_MEDIUM && prob(30 + (10 * (H.STALUC - 10))))
+						if(worn_ac <= ARMOR_CLASS_MEDIUM && prob(30 + (10 * (H.STALUC - 10))))
 							continue
 						toss_a_guy(H)
 						to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -197,6 +197,79 @@
 				var/obj/structure/flora/newleaf/corner/T = new(NT)
 				T.dir = D
 
+#define ZTAG_UP "up"
+#define ZTAG_TOP "top"
+
+/obj/structure/flora/newtree/attackby(obj/item/I, mob/user, params)
+	if(user.mind && ishuman(user) && I)
+		var/mob/living/L = user
+		if(L.used_intent && L.used_intent.blade_class == BCLASS_CHOP && I.force_dynamic >= 25)
+			var/list/goobers
+			var/turf/Tsource = get_turf(src)
+			var/turf/Tzup = get_step_multiz(Tsource, UP)
+			var/turf/Tztop
+			if(Tzup)
+				Tztop = get_step_multiz(Tzup, UP)
+			if(Tzup)
+				goobers = list()
+				for(var/mob/living/carbon/human/H in get_hearers_in_range(2, Tzup, RECURSIVE_CONTENTS_CLIENT_MOBS))
+					if(!H || !ishuman(H))
+						continue
+					goobers[H] = ZTAG_UP
+			if(Tztop)
+				for(var/mob/living/carbon/human/H in get_hearers_in_range(2, Tztop, RECURSIVE_CONTENTS_CLIENT_MOBS))
+					if(!H || !ishuman(H))
+						continue
+					goobers[H] = ZTAG_TOP
+
+			if(length(goobers))
+				for(var/mob/living/carbon/human/H in goobers)
+					var/worn_ac = H.highest_ac_worn(FALSE, FALSE)
+					if(HAS_TRAIT(H, TRAIT_WOODWALKER) && worn_ac > 0)
+						toss_a_guy(H)
+						to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))
+						continue
+					if(HAS_TRAIT(H, TRAIT_WOODWALKER) && worn_ac < ARMOR_CLASS_MEDIUM)
+						continue
+					if(goobers[H] == ZTAG_TOP)
+						if(worn_ac == ARMOR_CLASS_MEDIUM && prob(30 + (10 * (H.STALUC - 10))))
+							continue
+						toss_a_guy(H)
+						to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))
+					if(goobers[H] == ZTAG_UP)
+						if(worn_ac == ARMOR_CLASS_HEAVY)
+							if(prob(10))
+								continue
+							if(prob(30))
+								toss_a_guy(H)
+								to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))
+							else
+								H.Immobilize(2 SECONDS)
+								H.OffBalance(3 SECONDS)
+								to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))
+						if(worn_ac == ARMOR_CLASS_MEDIUM)
+							if(prob(40))
+								continue
+							if(prob(10))
+								toss_a_guy(H)
+								to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))
+							else
+								H.Immobilize(1 SECONDS)
+								H.OffBalance(1 SECONDS)
+								to_chat(user, span_nicegreen("The tree stirs! Someone is up there!"))
+	. = ..()
+
+#undef ZTAG_UP
+#undef ZTAG_TOP
+
+/obj/structure/flora/newtree/proc/toss_a_guy(mob/living/carbon/human/H)
+	H.Knockdown(2 SECONDS)
+	H.Stun(2 SECONDS)
+	var/dir = pick(GLOB.alldirs)
+	var/range = rand(2, 3)
+	var/turf/T_throw = get_ranged_target_turf(H, dir, range)
+	H.safe_throw_at(T_throw, range, 1, H, force = MOVE_FORCE_EXTREMELY_STRONG)
+	to_chat(H, span_boldwarning("THE TREE SHIFTS UNDERNEATH! I LOST MY BALANCE!"))
 
 ///BRANCHES
 

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -275,11 +275,14 @@
 	return FALSE
 
 /// Returns the highest AC worn, or held in hands.
-/mob/living/carbon/human/proc/highest_ac_worn(check_hands)
+/mob/living/carbon/human/proc/highest_ac_worn(check_hands, check_helmet = TRUE)
 	var/list/slots = list(wear_armor, wear_pants, wear_wrists, wear_shirt, gloves, head, shoes, wear_neck, wear_mask, wear_ring)
+	if(!check_helmet)
+		slots.Remove(head)
 	for(var/slot in slots)
 		if(isnull(slot) || !istype(slot, /obj/item/clothing))
 			slots.Remove(slot)
+
 	
 	var/highest_ac = ARMOR_CLASS_NONE
 


### PR DESCRIPTION
## About The Pull Request

### IN SUMMARY
- if you don't wanna get tossed, don't have medium / heavy armor, don't climb up too high and stand on the branches. Woodwalker helps.

### BORING DETAILS
- Using a CHOP intent with at least 25 damage on the weapon (not your +STR total) will now check for anyone in the tree within 2 tiles of the base.

If the target is at the top of the tree (2 z levels up):
- They'll be thrown off. Heavy armor is guaranteed, Medium & Light armor has a chance to resist it, but it's not very high (the roll is done every hit)

If the target is 1 z level above:
- Heavy armor will have a chance (~30%) to be tossed, or immobilized + offbalanced.
- Medium armor has a lower chance to get tossed and a higher chance to resist it. Their immob / offbalance duration is also shorter.
- Light armor or lower won't be tossed at all (if they're on branches).

If the target has Woodwalker:
- If they're standing on leaves at the time of the chop hit, they're getting tossed no matter what (only way to avoid this is to not have any AC on, so, being naked)
- If they're wearing light armor, they will be unaffected regardless of their height (if they're on branches).


Do note, this does not respect tree "cohesion", meaning you might be 'visually' on another tree's branches but still get thrown off because it was close enough (within 2 tiles).
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="432" height="379" alt="dreamseeker_EXh7tK0g0B" src="https://github.com/user-attachments/assets/a7d57c26-5236-45eb-8dfb-32a1c4ed1853" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
As said in https://github.com/Azure-Peak/Azure-Peak/pull/7132 (which this PR might go well with), the layer of interaction of 'from below to above' is really clunky and unfun (and can't really be devved around), so I'd rather provide tools for players to get them off of weird advantageous positions and also know that they're up there. This might also curtail platebeasts with woodwalker cus some bozo with an axe can hardstun them or straight up yeet them off. 

This might affect wretch survivability, though relying on double-tree-uppies to escape is bleh.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Standing on a tree as it gets chopped will now carry a (very) high risk of getting thrown off. Risk scales with worn armor. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
