### PR TITLE
[Weather] - nerf the fog density

### DIFF
--- a/code/datums/particle_weathers/datum_types/fog.dm
+++ b/code/datums/particle_weathers/datum_types/fog.dm
@@ -10,10 +10,8 @@
 	drift                  = generator("circle", 0, 3) // Some random movement for variation
 	friction               = 0.3  // shed 30% of velocity and drift every 0.1s
 	//Weather effects, max values
-	maxSpawning           = 120
-	maxSpawning           = 40
+	maxSpawning           = 20
 	wind                   = 5
-
 
 /datum/particle_weather/fog/necra
 	weather_duration_upper = 5 HOURS


### PR DESCRIPTION
## About The Pull Request
- Halves the amount of particles fog spawns.

## Testing Evidence
<img width="690" height="982" alt="image" src="https://github.com/user-attachments/assets/82538ca6-f643-4130-9bd0-fba753e0068e" />

## Why It's Good For The Game
Downstream, ic, ooc, wherever. People do not like the fog. It feels like it lasts too long and it's unpleasant to navigate in. Morover, some light sources don't part fog, and at times I've seen braziers be bugged and not gain their overlay correctly.

This is a bandaid fix to make it slightly less miserable in fog. People should still be able to use it to sneak around the map without it being as obnoxious for those trapped within it without a light.

This could especially lead to cheap deaths at times when NPCs are involved.

## Changelog

:cl:
balance: Fog is less dense
/:cl:
