### PR TITLE
add special for gragheretic

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -659,6 +659,7 @@
 	max_blade_int = 270
 	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/axe/chop/heavy, /datum/intent/axe/sweep)
 	smeltresult = /obj/item/ingot/component/graggar
+	special = /datum/special_intent/vicious_swipe
 
 /obj/item/rogueweapon/greataxe/steel/doublehead/graggar/Initialize()
 	. = ..()

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -782,7 +782,7 @@ SPECIALS START HERE
 /datum/special_intent/greatsword_swing/apply_hit(turf/T)
 	for(var/mob/living/L in get_hearers_in_view(0, T))
 		if(L != howner)
-	
+
 			L.Slowdown(slow_dur)
 			if(L.mobility_flags & MOBILITY_STAND)
 				var/hitdmg = dam
@@ -800,6 +800,77 @@ SPECIALS START HERE
 
 #undef GAREN_WAVE1
 #undef GAREN_WAVE2
+
+#define VICIOUS_WAVE1 0.4 SECONDS
+#define VICIOUS_WAVE2 0.8 SECONDS
+#define VICIOUS_WAVE3 1.2 SECONDS
+
+/datum/special_intent/vicious_swipe
+	name = "Vicious Swing"
+	desc = "A swing of your blade, in all quadrants. The last two swings expose."
+	tile_coordinates = list(
+		list(-1,0), list(0,0), list(1,0), // front arc
+		list(-1,-2, VICIOUS_WAVE1), list(-1,-1, VICIOUS_WAVE1), list(-1,0, VICIOUS_WAVE1), // left arc
+		list(-1,-2, VICIOUS_WAVE2), list(0,-2, VICIOUS_WAVE2), list(1,-2, VICIOUS_WAVE2), // south arc
+		list(1,-2, VICIOUS_WAVE3), list(1,-1, VICIOUS_WAVE3), list(1,0, VICIOUS_WAVE3) // right arc
+	)
+	respect_dir = TRUE
+	delay = 0.7 SECONDS
+	cooldown = 20 SECONDS
+	requires_wielding = TRUE
+	stamcost = 30
+	pre_icon_state = "trap"
+	post_icon_state = "sweep_fx"
+	sfx_pre_delay = 'sound/combat/wooshes/bladed/wooshlarge (2).ogg'
+	sfx_post_delay = 'sound/combat/sp_axe_swing1.ogg'
+
+	var/dam = 60
+	var/slow_dur = 2
+	var/hitcount = 0
+	var/self_debuffed = FALSE
+	var/self_immob = 2.5 SECONDS
+	var/self_clickcd = 3 SECONDS
+	var/self_vuln = 3 SECONDS
+
+/datum/special_intent/vicious_swipe/post_delay(list/turfs)
+	. = ..()
+	playsound(howner, 'sound/combat/wooshes/bladed/wooshlarge (3).ogg', 100, TRUE)
+
+/datum/special_intent/vicious_swipe/apply_hit(turf/T)
+	for(var/mob/living/L in get_hearers_in_view(0, T))
+		if(L != howner)
+
+			L.Slowdown(slow_dur)
+			if(L.mobility_flags & MOBILITY_STAND)
+				var/hitdmg = dam
+				switch(hitcount)
+					if(2)
+						hitdmg *= 1.5
+					if(3)
+						hitdmg *= 2
+						L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
+					if(4)
+						hitdmg *= 2.5
+				apply_generic_weapon_damage(L, hitdmg, "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT)
+				if(hitcount == 4)	//Last hit deals a bit of extra damage to integrity only + exposes.
+					apply_generic_weapon_damage(L, (dam * 0.8), "slash", BODY_ZONE_CHEST, bclass = BCLASS_CUT, no_pen = TRUE)
+					L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
+			var/sfx = 'sound/combat/sp_gsword_hit.ogg'
+			playsound(T, sfx, 100, TRUE)
+	..()
+
+/datum/special_intent/vicious_swipe/_process_grid(list/turfs, newdelay)
+	if(!self_debuffed)
+		howner.Immobilize(self_immob) //we're committing
+		howner.apply_status_effect(/datum/status_effect/debuff/vulnerable, self_vuln)
+		howner.apply_status_effect(/datum/status_effect/debuff/clickcd, self_clickcd)
+		self_debuffed = TRUE
+	hitcount++
+	. = ..()
+
+#undef VICIOUS_WAVE1
+#undef VICIOUS_WAVE2
+#undef VICIOUS_WAVE3
 
 /datum/special_intent/limbguard
 	name = "Limb Guard"


### PR DESCRIPTION
## About The Pull Request

<img width="373" height="347" alt="NVIDIA_Overlay_TyHBSRBW32" src="https://github.com/user-attachments/assets/6f5f8259-897b-468e-ae3f-75ac1b35c568" />


## Testing Evidence

above. unlike in the gif tho, it only exposes on the penultimate and ultimate strikes

## Why It's Good For The Game

the gragaxe should need a crowd control thingy

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: graghereticaxe special
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
