### PR TITLE
Mystic - i gave weapon and protection choice but didn't gave everything that should have been given

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -26,7 +26,6 @@
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN, // average weapon skill for an adventurer role
 	)
 
 /datum/outfit/job/roguetown/adventurer/mystic/pre_equip(mob/living/carbon/human/H)
@@ -41,8 +40,6 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/backpack
-	r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
-	l_hand = /obj/item/rogueweapon/scabbard/gwstrap
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
@@ -56,6 +53,23 @@
 		)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)
+	
+	if(H.mind)
+		var/weapons = list("lesser staff", "lesser wand", "Quarterstaff")
+		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("lesser staff")
+				r_hand = /obj/item/rogueweapon/woodstaff/implement
+				H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE)
+			if("lesser wand")
+				r_hand = /obj/item/rogueweapon/wand
+				l_hand = /obj/item/rogueweapon/shield/wood
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 2, TRUE)
+			if("quarterstaff")
+				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
+				H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE)
+
+
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
 			neck = /obj/item/clothing/neck/roguetown/psicross
@@ -130,7 +144,6 @@
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 	)
 
 /datum/outfit/job/roguetown/adventurer/resilient/pre_equip(mob/living/carbon/human/H)
@@ -179,6 +192,19 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)
 	if(H.mind)
 		H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/bloodmiracle)
+
+	if(H.mind)
+		var/weapons = list("lesser staff", "lesser wand")
+		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("lesser staff")
+				r_hand = /obj/item/rogueweapon/woodstaff/implement
+				H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE)
+			if("lesser wand")
+				r_hand = /obj/item/rogueweapon/wand
+				l_hand = /obj/item/rogueweapon/shield/wood
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 2, TRUE)
+
 	switch(H.patron?.type)
 		if(/datum/patron/old_god)
 			neck = /obj/item/clothing/neck/roguetown/psicross
@@ -282,6 +308,7 @@
 			if("Shortsword + shield")
 				r_hand = /obj/item/rogueweapon/sword/short
 				beltr = /obj/item/rogueweapon/scabbard/sword
+				backr = /obj/item/rogueweapon/shield/wood
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/shields, 3, TRUE)
 			if("Quarterstaff")

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -158,7 +158,6 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backr = /obj/item/rogueweapon/woodstaff
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,


### PR DESCRIPTION
## About The Pull Request

Fixing my own errors and aiding the full caster doing their caster thing is good

## Testing Evidence

it compiles and could run roguetest without blowing my pc

## Why It's Good For The Game

Luminary picking the sword and shield option not gaining a basic shield is sad
Mystic and Sage gaining the choice of picking their own weapon with corresponding skill level or casting tool so they cast better cast their supportive spells is good

## Changelog
Mystic get to pick between basic casting implement or iron quarterstaff
Sage get to pick a basic casting implement
Luminary S&S option now give the second S

:cl:
change: Mystic get to pick basic staff or basic wand+shield or quarterstaff on spawn
change: Sage get to pick basic staff or basic wand + shield on spawn
fix: Luminary sword and shield option now give a wooden shield
/:cl:

