### PR TITLE
Summon Specs Slight-nerf

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_spectacles.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_spectacles.dm
@@ -1,8 +1,9 @@
 /datum/action/cooldown/spell/conjure_spectacles
 	button_icon = 'icons/mob/actions/mage_conjure.dmi'
 	name = "Conjure Spectacles"
-	desc = "Conjure a set of Spectacles of your choice in your hand.\n\
-	The spectacles will be unsummoned should you conjure a new one or unbind the spell."
+	desc = "Conjure an illusionary set of Spectacles of your choice in your hand.\n\
+	The Spectacles will be unsummoned should you conjure a new one or unbind the spell.\n\
+	Unlike actual Spectacle varients, these won't grant special abilities/sight."
 	button_icon_state = "conjspect"
 	sound = 'sound/magic/whiteflame.ogg'
 	spell_color = GLOW_COLOR_METAL
@@ -36,8 +37,8 @@
 
 	var/list/spectacles = list(
 		"Spectacles" = /obj/item/clothing/mask/rogue/spectacles,
-		"Nocshades" = /obj/item/clothing/mask/rogue/spectacles/inq/summoned,
-		"Golden Spectacles" = /obj/item/clothing/mask/rogue/spectacles/golden/summoned,
+		"Nocshades" = /obj/item/clothing/mask/rogue/spectacles/inq_lesser_summoned,
+		"Golden Spectacles" = /obj/item/clothing/mask/rogue/spectacles/golden_lesser_summoned,
 	)
 
 /datum/action/cooldown/spell/conjure_spectacles/cast(list/targets, mob/living/user = usr)
@@ -66,16 +67,19 @@
 		qdel(src.conjured_spectacles)
 	return ..()
 
-// Nocshades summonable alternative
+//Sorry, it has to be done. No engineering/night vision for no spellcost. You could probably add crafted varients and axe this codenote though if such is done. Considering mages can make worse things than Nocshades.
 
-/obj/item/clothing/mask/rogue/spectacles/inq/summoned
+// Nocshades summonable lesser varient - with no mechanical effects
+
+/obj/item/clothing/mask/rogue/spectacles/inq_lesser_summoned
 	name = "summoned nocshade lens-pair"
 	icon_state = "bglasses"
 	desc = "An argument between the chosen of Noc and the Otavian See has raged on for years,\n\
 	no one truely knows who the original creator of these glasses truely was.\n\
 	But one thing is absolutely for certain, they are quite fashionable."
 		
-// Golden spectacles summonable alternative
+// Golden spectacles summonable lesser varient - with no mechanical effects
 
-/obj/item/clothing/mask/rogue/spectacles/golden/summoned
+/obj/item/clothing/mask/rogue/spectacles/golden_lesser_summoned
 		name = "summoned golden spectacles"
+		icon_state = "goggles"

--- a/code/modules/spells/spell_types/wizard/conjure/conjure_spectacles.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_spectacles.dm
@@ -74,7 +74,7 @@
 /obj/item/clothing/mask/rogue/spectacles/inq_lesser_summoned
 	name = "summoned nocshade lens-pair"
 	icon_state = "bglasses"
-	desc = "An argument between the chosen of Noc and the Otavian See has raged on for years,\n\
+	desc = "An argument between the chosen of Noc and the Otavian Orthodoxy has raged on for years,\n\
 	no one truely knows who the original creator of these glasses truely was.\n\
 	But one thing is absolutely for certain, they are quite fashionable."
 		


### PR DESCRIPTION
## About The Pull Request

no spell cost specs are fine, varients however:

- night vision w/inq marq costing item for no cost + subtyped so you can craft into masks via dupe glitch potentally.
- engineering vision w/skill for no cost beyond being a magos.

yeah this is bad but I don't want to completely nuke the cool factor of this spell. so-

---

this just makes them into regular specs mechanically, sprite-wise they're unchanged as intended and look the part. The spell has also been faintly re-adjusted as a hybrid mix of **conjuring** and **illusionary** magic in its description, for flavor to explain the nerf ingame rather than just slapped on nerfs.
<img width="70" height="70" alt="StillHere" src="https://github.com/user-attachments/assets/58b4c4ef-30c5-4e37-a9f9-8ef22929cf39" />
<img width="71" height="73" alt="StillHereTwo" src="https://github.com/user-attachments/assets/3f153828-4b5e-4b3a-b6e1-3ed13fff4dd0" />


it'll probably be better for people wanting to rock the style since you don't need obscure inquis knowledge to RMB the shades to not be blind with Noc Specs for newer players anyway.

Sorry, it had to be done, mages have enough utility as-is and a flavorful thing I absolutely love shouldn't be used for mechanical advantage in the rare cases it does.

This does not effect short-sighted use, because frankly its whatever.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

As shown above, plus tested ingame, the sprites render in inventory and when worn, There's no mechanical effects beyond what regular spectacles do.

Its bleak sire.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

- Potental duplication crafting exploit is **really bad**, if its possible. due to subtyping.
- You probably shouldn't have artificer specs as any-role neither without cost else it takes away the thing they have going for them with their outfit. More can be mapped in if they need spares.
- Factional purchaces shouldn't be free, if you want actual Nocshades, go ask the inquisitior or work for it. In future someone could code in a cost for crafting if you really want em genuinely as-any-role-with-effort since you can make some horrifying shit as-is that's worse than real Nocshades.
- I love the spell otherwise, its really cool. I just don't think it should be a must-take due to mechanical advantages, this returns it to flavor in a way that shouldn't require ever-jakking it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: summoned spectacles have no more mechanical effects beyond what regular spectacles do. You still look dangerously stylish as-was-intended, they remain a free spell as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
