### PR TITLE
[Bugfix] - fix rot surgeries

### DIFF
--- a/code/modules/surgery/surgeries_hearth/cure_black_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_black_rot.dm
@@ -22,6 +22,7 @@
 	skill_min = SKILL_LEVEL_EXPERT
 	preop_sound = 'sound/surgery/scalpel1.ogg'
 	success_sound = 'sound/surgery/scalpel2.ogg'
+	possible_locs = list(BODY_ZONE_CHEST)
 
 /datum/surgery_step/extract_black_rose_residue/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	display_results(user, target, span_userdanger("I carefully attempt to cut out the black ooze from [target]'s flesh..."),

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -22,6 +22,7 @@
 	skill_min = SKILL_LEVEL_APPRENTICE
 	preop_sound = 'sound/surgery/cautery1.ogg'
 	success_sound = 'sound/surgery/cautery2.ogg'
+	possible_locs = list(BODY_ZONE_CHEST)
 
 /datum/surgery_step/burn_rot/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent)
 	display_results(user, target, span_notice("I begin to burn the rot within [target]..."),


### PR DESCRIPTION
## About The Pull Request
- Cure deadite rot now can only be executed by targeting the chest.
- Cure black rot now can only be executed by targeting the chest.

## Testing Evidence
Tested, cut tongue, couldn't excise rot anymore.
Turns out, setitng locs on the surgery and not the surgery steps of a surgery doesn't do anything, it's not checked in the code anywhere!

## Why It's Good For The Game
Bugfix, everything about cure rot says it's supposed to be burning rot from your heart. (And the code attempt of only working on chest that doesn't do anything.)

People were starting to abuse this to cure forms of rot mid combat.

## Changelog
:cl:
fix: cure deadite rot surgery now correctly only works when targeting chest.
fix: cure black rot surgery now correctly only works when targeting chest.
/:cl:

