### PR TITLE
[OPTIMIZATION] Optimize Preview Icon by up to 80% / 50% (Live Tested)

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -161,13 +161,29 @@
 
 /mob/living/carbon/set_species(datum/species/mrace, icon_update = TRUE, datum/preferences/pref_load = null)
 	if(mrace && has_dna())
+		var/new_race_type = ispath(mrace) ? mrace : (istype(mrace) ? mrace.type : null)
+		if(!new_race_type)
+			return
+		// Skip same species on species loss / on species gain when the target species match
+		// This reduce the amount of cascading update body call
+		if(dna.species.type == new_race_type)
+			if(GLOB.preview_stress_set_species_shortcircuit_hits != null)
+				GLOB.preview_stress_set_species_shortcircuit_hits++
+			if(pref_load)
+				dna.features = pref_load.features.Copy()
+				dna.body_markings = deepCopyList(pref_load.body_markings)
+				dna.real_name = pref_load.real_name
+				pref_load.apply_customizers_to_character(src)
+				if(ishuman(src))
+					apply_markings_to_body_parts(dna.body_markings, src)
+			return
+		if(GLOB.preview_stress_set_species_fullswap_hits != null)
+			GLOB.preview_stress_set_species_fullswap_hits++
 		var/datum/species/new_race
 		if(ispath(mrace))
 			new_race = new mrace
-		else if(istype(mrace))
-			new_race = mrace
 		else
-			return
+			new_race = mrace
 		deathsound = new_race.deathsound
 		dna.species.on_species_loss(src, new_race, pref_load)
 		var/datum/species/old_species = dna.species

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -167,8 +167,6 @@
 		// Skip same species on species loss / on species gain when the target species match
 		// This reduce the amount of cascading update body call
 		if(dna.species.type == new_race_type)
-			if(GLOB.preview_stress_set_species_shortcircuit_hits != null)
-				GLOB.preview_stress_set_species_shortcircuit_hits++
 			if(pref_load)
 				dna.features = pref_load.features.Copy()
 				dna.body_markings = deepCopyList(pref_load.body_markings)
@@ -177,8 +175,6 @@
 				if(ishuman(src))
 					apply_markings_to_body_parts(dna.body_markings, src)
 			return
-		if(GLOB.preview_stress_set_species_fullswap_hits != null)
-			GLOB.preview_stress_set_species_fullswap_hits++
 		var/datum/species/new_race
 		if(ispath(mrace))
 			new_race = new mrace

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3115,7 +3115,8 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 
 	character.char_accent = char_accent
 
-	apply_customizers_to_character(character)
+	// Customizers are already applied inside set_species() (both the species-change path via
+	// on_species_gain, and the same-species short-circuit). Re-applying here doubled the work.
 
 	if(culinary_preferences)
 		apply_culinary_preferences(character)

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -272,13 +272,18 @@
 	set_resting(FALSE)
 
 /mob/living/carbon/proc/Taurize(taur_type = /obj/item/bodypart/taur/horse, color = "#ffffff")
+	// Same taur part short circuit to save on taurize cost because it occupies up to 8 - 9 ms out of a 20 ms call of preview
+	var/obj/item/bodypart/taur/existing = get_taur_tail()
+	if(existing && existing.type == taur_type && existing.taur_color == color)
+		return
+
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/O = X
 		// drop taur tails too
 		if(O.body_part == LEG_LEFT || O.body_part == LEG_RIGHT || O.body_zone == BODY_ZONE_TAUR)
 			O.drop_limb(1)
 			qdel(O)
-	
+
 	var/obj/item/bodypart/taur/T = new taur_type()
 	T.taur_color = color
 	T.attach_limb(src)

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -254,13 +254,18 @@
 			qdel(O)
 			needs_new_legs = TRUE
 
-	if(needs_new_legs)
-		var/obj/item/bodypart/N
-		N = new /obj/item/bodypart/l_leg
-		N.attach_limb(src)
+	// Short circuit the check for new legs and
+	// icon regeneration when you are not a taur
+	// Which is the majority of characters
+	if(!needs_new_legs)
+		return
 
-		N = new /obj/item/bodypart/r_leg
-		N.attach_limb(src)
+	var/obj/item/bodypart/N
+	N = new /obj/item/bodypart/l_leg
+	N.attach_limb(src)
+
+	N = new /obj/item/bodypart/r_leg
+	N.attach_limb(src)
 
 	// make sure we unapply our clipmasks
 	regenerate_icons()


### PR DESCRIPTION
## About The Pull Request
Did some investigation with my $100 / month intern to optimize preview icon, which I noticed were roughly costing us 240 - 300s despite the entirety of game's update icons costing maybe 650 - 700s total. Which is extremely disproportionate. 

My testing methodology is a preview icon stress test verb that synthetically calls preview 100x time with statistics

This does three things:
- If the preview icon is of the same species, short-circuit the set_species path to avoid expensive calls. This dropped average preview cost from 59.0195 ms to 20.6992 - 22 ms/call approximately. 
- Do not call ensure_not_taur when the body is not a taur. This dropped it from 20 - 22 ms to 11 - 12 ms / call
- In the taur path, also do not call Taurize when the taur type and taur color. This dropped it from 20 - 22 ms (post optimization 1) to 11 - 12 ms /call, roughly symmetrical with a non taur character

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1477" height="887" alt="notepad++_l28ZHQMALp" src="https://github.com/user-attachments/assets/6bb9e25c-635f-458b-9eaf-40a1557c194c" />
<img width="1502" height="919" alt="notepad++_SGMcFLLm2f" src="https://github.com/user-attachments/assets/c6648818-9a5f-4afa-aee2-e10b8d35a32c" />
<img width="1510" height="978" alt="notepad++_dfDJba2dzd" src="https://github.com/user-attachments/assets/8be6dd9c-b388-41ff-bc03-105015c506c9" />
<img width="1501" height="1115" alt="notepad++_bDhGy0xlGe" src="https://github.com/user-attachments/assets/ba1ab1f7-51a4-4925-89e6-44f4f3b4b308" />
<img width="1635" height="1168" alt="notepad++_PDA4nwpXpu" src="https://github.com/user-attachments/assets/ce47be16-623e-4eea-b38e-35017f3348de" />

**LIVE TEST RESULT**
WITHOUT:
<img width="1178" height="93" alt="notepad++_kTBp4K6DVH" src="https://github.com/user-attachments/assets/13fbf578-7a93-48e7-82fa-cc06c3b1d957" />
78.9 ms (I think) per call


WITH:
<img width="1185" height="66" alt="notepad++_zL6WxaUmh8" src="https://github.com/user-attachments/assets/b3088371-d8ca-4f1a-979a-3ea3dcf6176a" />
40.97 per call

Not as dramatic as I hoped, but still halve the cost of preview rendering on average. This is a win.


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Given that preview icon for very little benefits occupy somehow 220 - 300 s out of 4000s, cutting its cost down will give us more significant headroom for me to ruin the server with more economics changes I asked for. 

Or someone else. 

Like downstream things.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Optimized preview icon in the character creator by up to 80% (Around 50% on live). Report odd behaviors, especially with tauric character, species swap.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
