### PR TITLE
repaying my karmic debt with silly little ports - adds the 'Handgame' emote verb, and a few little games to play

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -281,26 +281,70 @@
 		if(!hand_games_check(player1,player2))
 			return
 		player1.visible_message(span_notice("[player1] challenges [player2] to Armwrestling!"))
-		//var/scale1 = player1.dna.features["body_size"] //Commented out, as I'm not too sure if we actually have this.
-		//var/scale2 = player2.dna.features["body_size"] //A funny alternative might be to directly tie it to whatever sprite upscale percentage each side has?
-		var/strength1 = player1.get_stat(STAT_STRENGTH)
-		var/strength2 = player2.get_stat(STAT_STRENGTH)
-		if(!hand_games_check(player1,player2))
+
+	var/p1_str = player1.STASTR
+	var/p2_str = player2.STASTR
+	var/winner = 0
+	var/rounds = 14
+
+	for(var/i = 1 to rounds)
+
+		// Has to remain valid, each round.
+		if(!hand_games_check(player1, player2))
+			return
+		// Channel / Struggle moment.
+		if(!do_after(player1, 1 SECONDS, target = player2))
+			player1.visible_message(span_notice("The Armwrestling match is interrupted!"))
+			return
+		// Range check to make sure.
+		if(get_dist(player1, player2) > 1)
+			player1.visible_message(span_warning("You are too far apart!"))
 			return
 
-		var/score1 = (scale1 * strength1)
-		var/score2 = (scale2 * strength2)
+		var/still_near_table = FALSE
+		// Both players must remain near a table.
+		for(var/obj/structure/table/T in range(player1, 1))
+			if(player2 in range(T, 1))
+				still_near_table = TRUE
+				break
 
-		var/competition = pick(score1;player1, score2;player2)
-		if(!do_after(player1, 5 SECONDS, target = player2))
-			player2.visible_message(span_notice("The players cancelled their competition!"))
-			return 0
-		if(!hand_games_check(player1,player2))
+		if(!still_near_table)
+			player1.visible_message(span_warning("The Armwrestling match breaks apart as they leave the table!"))
 			return
-		if(competition == player1)
-			player1.visible_message(span_notice("[player1] manages to overpower [player2] and pin their arm down!"))
-		else
-			player2.visible_message(span_notice("[player2] manages to overpower [player1] and pin their arm down!"))
+
+		//Strength-based stamina damage.
+		var/damage_to_p2 = 10 + max(1, p1_str - p2_str)
+		var/damage_to_p1 = 10 + max(1, p2_str - p1_str)
+
+		player2.stamina_add(damage_to_p2)
+		player1.stamina_add(damage_to_p1)
+		// If both players have the same amount of STR, then they'll deal around 11 stamina damage per loop.
+
+		var/p1_exhausted = player1.stamina >= player1.max_stamina	//var for when stamina damage goes above max stam
+		var/p2_exhausted = player2.stamina >= player2.max_stamina
+
+		if(p1_exhausted && p2_exhausted)	//Matched exhaustion.
+			winner = 3
+			break
+		else if(p1_exhausted)	//Player 2's triumph.
+			winner = 2
+			break
+		else if(p2_exhausted)	//Player 1's triumph.
+			winner = 1
+			break
+
+	if(winner == 1)
+		player2.Knockdown(20)
+		player1.visible_message(span_notice("[player1] slams [player2]'s arm down in victory!"))
+	else if(winner == 2)
+		player1.Knockdown(20)
+		player1.visible_message(span_notice("[player2] slams [player1]'s arm down in victory!"))
+	else if(winner == 3)
+		player1.Knockdown(20)
+		player2.Knockdown(20)
+		player1.visible_message(span_notice("Both challengers collapse from exhaustion!"))
+	else
+		player1.visible_message(span_notice("The Armwrestling match ends in a stalemate!"))
 
 /////// Slaphands! Each player gets a modifier based on their size and can choose the reaction time of their character, then a weighted roll is made. This one gives the advantage to smaller players.
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -297,7 +297,7 @@
 			player1.visible_message(span_notice("The Armwrestling match is interrupted!"))
 			return
 		// Range check to make sure.
-		if(get_dist(player1, player2) > 1)
+		if(get_dist(player1, player2) > 2)
 			player1.visible_message(span_warning("You are too far apart!"))
 			return
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -170,3 +170,194 @@
 
 /mob/living/carbon/human/proc/CloseWings()
 	return
+
+/mob/living/carbon/human/verb/hand_games()
+	set name = "Handgames"
+	set desc = "Challenge another to a variety of handgames, which can either be done while standing next to each other or while across a table."
+	set category = "Emotes"
+
+	if(stat)
+		return
+
+	if((!hand_bodyparts.len))
+		to_chat(src, span_warning("You have no hands to play games with!"))
+		return
+
+	var/list/nearby = list()
+	for(var/mob/living/carbon/human/H in range(src,1))
+		if(H.stat)
+			continue
+		if(H == src)
+			continue
+		if(!H.hand_bodyparts.len)
+			continue
+		nearby |= H
+	for(var/obj/structure/table/T in range(src, 1))
+		for(var/mob/living/carbon/human/H in range(T,1))
+			if(H.stat)
+				continue
+			if(H == src)
+				continue
+			if(!H.hand_bodyparts.len)
+				continue
+			nearby |= H
+
+	if(!nearby.len)
+		to_chat(src, span_warning("There is nobody nearby to play handgames with!"))
+
+	var/partner = tgui_input_list(src, "Who will you challenge with a handgame?", "FRIEND TO FOE.", nearby)
+	if(!partner)
+		return
+	var/choose_game = tgui_alert(src, "Choose a handgame to play with [partner]?", "A TOURNAMENT FOR TWO.", list("Rock, Paper, Shears", "Armwrestling", "Slaphands", "Thumbwars", "I Rescind"))
+
+	if(!choose_game || (choose_game == "I Rescind"))
+		return
+
+	if(choose_game == "Rock, Paper, Shears")
+		game_rps(src,partner)
+
+	if(choose_game == "Armwrestling")
+		game_armwrestle(src,partner)
+
+	if(choose_game == "Slaphands")
+		game_slaphands(src,partner)
+
+	if(choose_game == "Thumbwars")
+		game_thumbwars(src,partner)
+
+// Checks to make sure everything is fine to continue playing.
+
+/mob/living/carbon/human/proc/hand_games_check(var/mob/living/carbon/human/player1, var/mob/living/carbon/human/player2)
+	if(!istype(player1) || !istype(player2))
+		return 0
+	if(player1.stat || player2.stat) //Make sure they're still standing.
+		return 0
+	if(!(player2 in range(player1,2))) //Make sure they're within two spaces still; should allow for cross-table gaming.
+		return 0
+
+	return 1
+
+///// A simple game of Rock Paper Scissors, each player chooses an option and the choices are declared simultaneously.
+
+/mob/living/carbon/human/proc/game_rps(var/mob/living/carbon/human/player1, var/mob/living/carbon/human/player2)
+	if(!hand_games_check(player1,player2))
+		return
+	to_chat(player1, span_notice("Asking [player2] if they want to play Rock, Paper, Shears!"))
+	var/playgame = tgui_alert(player2, "[player1] wants to play Rock, Paper, Shears.", "FORTUNE FAVORS THE WITFUL.", list("Play", "Refuse"))
+	if(!playgame || (playgame == "Refuse"))
+		to_chat(player1, span_warning("[player2] declines to play the game."))
+		return
+	else
+		player1.visible_message(span_notice("[player1] challenges [player2] to Rock, Paper, Shears!"))
+		to_chat(player2, span_warning("[player1] is deciding."))
+		var/choice1 = tgui_alert(player1, "Choose your attack!", "DEAL YOUR HAND.", list("Rock", "Paper", "Shears", "Cancel"))
+		if(choice1 == "Cancel")
+			player1.visible_message(span_notice("[player1] chickens out!"))
+		if(!hand_games_check(player1,player2))
+			return
+		to_chat(player1, span_warning("[player2] is deciding."))
+		var/choice2 = tgui_alert(player2, "Choose your attack!", "DEAL YOUR HAND.", list("Rock", "Paper", "Shears", "Cancel"))
+		if(choice2 == "Cancel")
+			player2.visible_message(span_notice("[player2] chickens out!"))
+		if(!hand_games_check(player1,player2))
+			return
+		if(choice1 == choice2)
+			player1.visible_message(span_notice("[player1] and [player2] both choose [choice1], it's a draw!"))
+		else
+			player1.visible_message(span_notice("[player1] chooses [choice1]!"))
+			player2.visible_message(span_notice("[player2] chooses [choice2]!"))
+
+/////// Armwrestling! Each player gets a modifier based on their size and can choose the strength of their character, then a weighted roll is made.
+
+/mob/living/carbon/human/proc/game_armwrestle(var/mob/living/carbon/human/player1, var/mob/living/carbon/human/player2)
+	if(!hand_games_check(player1,player2))
+		return
+	to_chat(player1, span_notice("Asking [player2] if they want to play Armwrestling!"))
+	var/playgame = tgui_alert(player2, "[player1] wants to play Armwrestling.", "TEST YOUR MIGHT.", list("Play", "Refuse"))
+	if(!playgame || (playgame == "Refuse"))
+		to_chat(player1, span_warning("[player2] declines to play the game."))
+		return
+	else
+		if(!hand_games_check(player1,player2))
+			return
+		player1.visible_message(span_notice("[player1] challenges [player2] to Armwrestling!"))
+		//var/scale1 = player1.dna.features["body_size"] //Commented out, as I'm not too sure if we actually have this.
+		//var/scale2 = player2.dna.features["body_size"] //A funny alternative might be to directly tie it to whatever sprite upscale percentage each side has?
+		var/strength1 = player1.get_stat(STAT_STRENGTH)
+		var/strength2 = player2.get_stat(STAT_STRENGTH)
+		if(!hand_games_check(player1,player2))
+			return
+
+		var/score1 = (scale1 * strength1)
+		var/score2 = (scale2 * strength2)
+
+		var/competition = pick(score1;player1, score2;player2)
+		if(!do_after(player1, 5 SECONDS, target = player2))
+			player2.visible_message(span_notice("The players cancelled their competition!"))
+			return 0
+		if(!hand_games_check(player1,player2))
+			return
+		if(competition == player1)
+			player1.visible_message(span_notice("[player1] manages to overpower [player2] and pin their arm down!"))
+		else
+			player2.visible_message(span_notice("[player2] manages to overpower [player1] and pin their arm down!"))
+
+/////// Slaphands! Each player gets a modifier based on their size and can choose the reaction time of their character, then a weighted roll is made. This one gives the advantage to smaller players.
+
+/mob/living/carbon/human/proc/game_slaphands(var/mob/living/carbon/human/player1, var/mob/living/carbon/human/player2)
+	if(!hand_games_check(player1,player2))
+		return
+	to_chat(player1, span_notice("Asking [player2] if they want to play Slaphands!"))
+	var/playgame = tgui_alert(player2, "[player1] wants to play Slaphands.", "QUICKEST TO THE DRAW.", list("Play", "Refuse"))
+	if(!playgame || (playgame == "Refuse"))
+		to_chat(player1, span_warning("[player2] declines to play the game."))
+		return
+	else
+		if(!hand_games_check(player1,player2))
+			return
+		player1.visible_message(span_notice("[player1] challenges [player2] to Slaphands!"))
+		var/speed1 = player1.get_stat(STAT_SPEED)
+		var/speed2 = player2.get_stat(STAT_SPEED)
+		var/per1 = player1.get_stat(STAT_PERCEPTION)
+		var/per2 = player2.get_stat(STAT_PERCEPTION)
+		if(!hand_games_check(player1,player2))
+			return
+
+		var/score1 = (speed1 + per1)
+		var/score2 = (speed2 + per2)
+
+		var/competition = pick(score1;player1, score2;player2)
+		if(!do_after(player1, 3 SECONDS, target = player2))
+			player2.visible_message(span_notice("The players cancelled their competition!"))
+			return 0
+		if(!hand_games_check(player1,player2))
+			return
+		playsound(player1, 'sound/foley/slap.ogg', 30, 1)
+		if(competition == player1)
+			player1.visible_message(span_notice("[player1] manages to slap [player2]'s hand before they can react!"))
+		else
+			player2.visible_message(span_notice("[player2] manages to slap [player1]'s hand before they can react!"))
+
+///// Thumbwars! This one is pure chance, and - in a pinch - can essentially work like a cointoss.
+
+/mob/living/carbon/human/proc/game_thumbwars(var/mob/living/carbon/human/player1, var/mob/living/carbon/human/player2)
+	if(!hand_games_check(player1,player2))
+		return
+	to_chat(player1, span_notice("Asking [player2] if they want to play Thumbwars!"))
+	var/playgame = tgui_alert(player2, "[player1] wants to play Thumbwars.", "ONE, TWO, THREE, FOUR..", list("Play", "Refuse"))
+	if(!playgame || (playgame == "Refuse"))
+		to_chat(player1, span_warning("[player2] declines to play the game."))
+		return
+	else
+		if(!hand_games_check(player1,player2))
+			return
+		player1.visible_message(span_notice("[player1] challenges [player2] to a thumb war!"))
+		if(!do_after(player1, 5 SECONDS, target = player2))
+			player2.visible_message(span_notice("The players cancelled their thumb war!"))
+			return 0
+		if(!hand_games_check(player1,player2))
+			return
+		if(prob(50))
+			player1.visible_message(span_notice("After a gruelling battle, [player1] eventually manages to subdue the thumb of [player2]!"))
+		else
+			player2.visible_message(span_notice("After a gruelling battle, [player2] eventually manages to subdue the thumb of [player1]!"))


### PR DESCRIPTION
## About The Pull Request

Mashallah, let there be no more _(major)_ balance tweaks from me, going forward.
Instead, here's something a bit more palatable: courtesy of Tenymuri _(from Orche Valley's)_ [pull request](https://github.com/Ochre-Valley/Ochre-Valley/pull/65), here..
* Adds 'Handgames', a new verb in the Emote tab that can be initiated with someone adjacent or across a table.
* Offers four games; Thumbwars, Armwrestling, Handslaps, and good ol' Rock, Paper, Shears!
* Beyond Thumbwars _(which is pure chance)_, the other games factor in various statistics to determine the victor.
* Armwrestling in particular uses a [version of Temperance 13](https://github.com/zeratino/TEMPERANCE13/pull/241), which has much more dramatic flair.

## Testing Evidence

Good to go. The attached pull request can show a more in-depth recording of how it plays in practice.
All I changed - for the most part - was some of the verbage _(to make it a little more fitting to Roguetown's vernacular.)_

## Why It's Good For The Game

At last, the masses needn't lament the inability to authentically play a game of Rock, Paper, Scissors - nor the lack of an armwrestling match that'd result in someone's wrist being wrenched out of its socket.

## Changelog

:cl:
add: Adds Tenymuri's 'handgames' function! Accessible in the Emote tab, this verb allows you to play up to four classic games with another person; either across a table, or adjacent to one-another.
/:cl:
