### PR TITLE
Vizier heal update

### DIFF
--- a/code/modules/spells/spell_types/classunique/vizier/restoration.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/restoration.dm
@@ -5,7 +5,7 @@
 	releasedrain = 50
 	chargedrain = 0
 	chargetime = 0
-	range = 3
+	range = 4
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	sound = list('sound/magic/regression1.ogg','sound/magic/regression2.ogg','sound/magic/regression3.ogg','sound/magic/regression4.ogg')


### PR DESCRIPTION
## About The Pull Request

I've heard that restoration used to be standard range, but was nerfed to be in line with the standard heal range at the time. This is just undoing that.

## Testing Evidence

Compiles and runs fine.

## Why It's Good For The Game

Good for consistency. I cant think of any compelling reason for this specific heal to be shorter in range, when the Vizier class is all about support in the first place.

## Changelog


:cl:

balance: increased the range of restoration to be in line with the current standard for heals

/:cl:

