### PR TITLE
fixes regenerating armor not being disrupted by attacks properly

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -65,7 +65,7 @@
 		deltimer(reptimer)
 	disrupttimer = addtimer(CALLBACK(src, PROC_REF(revert_disrupt)), 60 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
 
-/obj/item/clothing/roguetown/armor/regenerating/proc/revert_disrupt()
+/obj/item/clothing/suit/roguetown/armor/regenerating/proc/revert_disrupt()
 	if(is_disrupted)
 		is_disrupted = FALSE
 		to_chat(loc, repairmsg_begin)

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -18,6 +18,9 @@
 	/// Holder for timer
 	var/reptimer
 
+	/// Holder for disruption timer
+	var/disrupttimer
+
 	/// To make repairs relative or not.
 	/// In other words, if you use relative repairing then it will use a different repair interval.
 	/// Repair_time becomes how long it will take on average for the armor to fully repair itself.
@@ -42,6 +45,7 @@
 
 	/// Regen cost vars
 	var/blue_to_integ_ratio = 0
+	var/is_disrupted = FALSE
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/Initialize(mapload)
 	. = ..()
@@ -56,8 +60,16 @@
 	RegisterSignal(L, COMSIG_MOB_ITEM_BEING_ATTACKED, PROC_REF(process_attack))
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/proc/process_attack(mob/living/parent, mob/living/target, mob/user, obj/item/I)
+	is_disrupted = TRUE
 	if(reptimer)
-		reptimer = addtimer(CALLBACK(src, PROC_REF(armour_regen)), 60 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
+		deltimer(reptimer)
+	disrupttimer = addtimer(CALLBACK(src, PROC_REF(revert_disrupt)), 60 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE|TIMER_STOPPABLE)
+
+/obj/item/clothing/roguetown/armor/regenerating/proc/revert_disrupt()
+	if(is_disrupted)
+		is_disrupted = FALSE
+		to_chat(loc, repairmsg_begin)
+		armour_regen()
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
 	..()
@@ -67,6 +79,9 @@
 		to_chat(loc, span_notice(repairmsg_stop))
 		deltimer(reptimer)
 		reptimer = null
+
+	if(is_disrupted)
+		return
 
 	// If relative repair mode is on, use the interval instead of repairing 20% every repair_time seconds
 	var/wait_time = relative_repair_mode ? relative_repair_interval : repair_time


### PR DESCRIPTION
## About The Pull Request
title, the way the code worked overrode its own disruption delay with the regular regen delay, so the code was literally non-functional by intention.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed skin armor not having its regeneration disrupted by attacks properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
