### PR TITLE
Slight Berserker Review

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -178,6 +178,7 @@
 #define BLOCKPANTS		(1<<5)
 #define BLOCKCLOAK		(1<<6)
 #define BULKYBLOCKS		(1<<7)
+#define SAMEWEAR		(1<<8)
 
 //bitflags for clothing coverage - also used for limbs
 #define HEAD		(1<<0)

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -220,6 +220,21 @@
 	name = "berserker's skin"
 	desc = "I've endured enough. The onslaught has lost its meaning."
 	armor = ARMOR_LEATHER
+	blocksound = SOFTUNDERHIT
+	blocking_behavior = SAMEWEAR
+	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker/chest
+	name = "berserker's thickened chest"
+	desc = "The callouses could stop arrows! But only so many."
+	slot_flags = ITEM_SLOT_ARMOR
+	armor = ARMOR_MAILLE
+	resistance_flags = FLAMMABLE
+	blocksound = SOFTHIT
+	blocking_behavior = SAMEWEAR
+	body_parts_covered = COVERAGE_VEST
+	body_parts_inherent = COVERAGE_VEST
+	max_integrity = 180
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/bailiff
 	name = "executioneer's skin"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -49,7 +49,6 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	belt = /obj/item/storage/belt/rogue/leather/rope // more wild look + aura
 	neck = /obj/item/clothing/neck/roguetown/coif/heavypadding //Used to be a reinforced leather coif, but crit resist kinda leaves your head open to shit
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/combat = 1, //Steel variant of the hunting knife. Pseudoantagonist-tier, plus an avenue to hack limbs with.
 		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
@@ -62,27 +61,21 @@
 	if(H.mind)
 		H.set_blindness(0)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/rage)
+		var/list/armor_choices = list("Light Armor", "Bare Skin")
+		var/armor_choice = input(H,"Choose your DEFENSE.", "I CAN TAKE IT!!") as anything in armor_choices
+		switch(armor_choice)
+			if("Light Armor")
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+			if("Bare Skin")
+				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker/chest
+				shirt = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker
 		var/list/main_choices = list("Unarmed Master", "Martial Expert") // Unarmed focuses on master punching and wrestling moves, Martial gives you two expert weapon skills to be flexible
 		var/category_choice = input(H, "Choose your MEANS OF VIOLENCE.", "SMASH OR SLASH!!") as anything in main_choices
 		switch(category_choice)
 			if("Unarmed Master") //still incredibly strong btw, apply punch to skull
-				var/list/unarmed_options = list("Discipline - Unarmed", "Katar", "Knuckledusters", "Punch Dagger", )
-				var/weapon_choice = input(H, "Choose how you PUNCH!", "BREAK THEIR BONES.") as anything in unarmed_options
-				switch(weapon_choice)
-					if("Discipline - Unarmed")
-						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-						ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
-						gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted // apperantly normal barb gets em so for consistency sake
-						armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/berserker
-					if("Katar")
-						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-						beltr = /obj/item/rogueweapon/katar
-					if("Knuckledusters")
-						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-						gloves = /obj/item/clothing/gloves/roguetown/knuckles
-					if("Punch Dagger")
-						H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-						beltr = /obj/item/rogueweapon/katar/punchdagger
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+				ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+				gloves = /obj/item/clothing/gloves/roguetown/bandages/weighted // apperantly normal barb gets em so for consistency sake
 				var/techniques = list("Dropkick - Pushback + Extra Damage", "Chokeslam - Stamina Damage", "Stunner - Dazed Debuff", "Headbutt - Vulnerable Debuff") // cool wrestling moves
 				var/technique_choice = input(H,"Choose your TECHNIQUE.", "TOSS THEM.") as anything in techniques
 				switch(technique_choice)
@@ -94,15 +87,22 @@
 						H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stunner)
 					if("Headbutt - Vulnerable Debuff")
 						H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/headbutt)
+				var/list/unarmed_options = list("Katar", "Knuckledusters", "Punch Dagger")
+				var/weapon_choice = input(H, "Choose how you PUNCH!", "BREAK THEIR BONES.") as anything in unarmed_options
+				switch(weapon_choice)
+					if("Katar")
+						beltr = /obj/item/rogueweapon/katar
+					if("Knuckledusters")
+						gloves = /obj/item/clothing/gloves/roguetown/knuckles
+					if("Punch Dagger")
+						beltr = /obj/item/rogueweapon/katar/punchdagger
 			if("Martial Expert") // designed to compete with unarmed by giving you alternatives to approaching fights- only expert 
 				var/list/martial_options = list("Discipline - Bodybuilder", "Battle Axe", "Grand Mace", "Longsword")
 				var/weapon_choice = input(H, "Choose your WEAPONS of WAR!", "SPILL THEIR ENTRAILS.") as anything in martial_options
 				switch(weapon_choice)
-					if("Discipline - Bodybuilder") //Actually not a meme anymore
+					if("Greatsword") //Actually not a meme anymore
 						H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-						H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_MASTER, TRUE) //they need this to actually do pushups, it's the only way they can fix their armor
 						r_hand = /obj/item/rogueweapon/greatsword/paalloy
-						armor = /obj/item/clothing/suit/roguetown/armor/manual/pushups/leather/good
 						backl = /obj/item/rogueweapon/scabbard/gwstrap
 					if("Battle Axe")
 						H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -790,7 +790,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					return FALSE
 			if(H.wear_armor)
 				if(istype(H.wear_armor, I.type))
-					return FALSE
+					if(!(I.blocking_behavior & SAMEWEAR))
+						return FALSE
 				if(I.blocksound)
 					if(I.blocksound == H.wear_armor.blocksound)
 						return FALSE


### PR DESCRIPTION
## About The Pull Request
Someone kept pestering me about "berserker bad" so I took a look. Generally I'd consider this a bad thing for subversive classes not made by me, but they didn't stop even after I warned them, so:

### THE NEW
- Berserkers can now pick their armor option regardless of weapon or "discipline" choices:
<img width="171" height="125" alt="dreamseeker_MlTdZBa2Fd" src="https://github.com/user-attachments/assets/f3885e2b-ddb0-4110-b577-6c3b0adc3ad5" />

- Picking bare skin will now give them **two** skin armors, taking up both slots. One is the same thing we have, the other is a maille-tier one with low integrity that *only* covers the chest and stomach.
<img width="396" height="224" alt="dreamseeker_KAlPDystAn" src="https://github.com/user-attachments/assets/8a9e7b6b-4ab1-4832-8538-e2e7452ffe09" />

### THE REMOVED
- Muscle builder armor removed. The option is just "Greatsword" now.
- All "Master" skill level options from Unarmed were removed. The user gets Expert, the gloves, and the unarmed weapon option all in one.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Focusing a Berserker's chest (or stomach) exclusively will now require penetration or patience as it will take a few hits to get through the first thick, meaty, calloused layer.
- They no longer have Master skill level with our reworked unarmed that is extremely fringe to get, actually. If you still want it, play Vigilante. I was not comfortable giving them freedom to pick a.. big fat belly of a maille cuirass while also getting Master weapons. The class attracts slimes as it is.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Berserker can now pick its skin armor option freely. Picking it will give an extra layer of 'skin' that has better protection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
