### PR TITLE
Giltsilk belts now hide crotch

### DIFF
--- a/code/modules/clothing/rogueclothes/storage/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage/storage.dm
@@ -451,6 +451,7 @@
 	name = "giltsilk belt"
 	desc = "A gold adorned belt with the softest of silks barely concealing one's bits."
 	icon_state = "silkbelt"
+	flags_inv = HIDECROTCH
 	var/max_storage = 5
 	sewrepair = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Giltsilk belts now hide the naughty bits on your groin, like most other tabbard-style belts do.
as per the description, "A gold adorned belt with the softest of silks barely concealing one's bits."
Currently, the lewd bits just clip through the sprite in a very jarring way that feels unintended.

## Testing Evidence

Built without errors, ran a test instance, works fine.

## Why It's Good For The Game

less unpleasant sprite clipping when you wear the sexy belt.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: giltsilk belt now covers privates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
