### PR TITLE
kazengun spellblade loadout

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -2,7 +2,7 @@
 	name = "Sorcerer"
 	tutorial = "You are a learned mage and a scholar, having spent your life studying the arcane and its ways."
 	allowed_sexes = list(MALE, FEMALE)
-	
+
 	outfit = /datum/outfit/job/roguetown/adventurer/mage
 	class_select_category = CLASS_CAT_MAGE
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
@@ -150,7 +150,7 @@
 
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
 	backr = /obj/item/rogueweapon/shield/wood
-	
+
 	switch(subclass_selected)
 		if("blade")
 			var/weapons = list("Longsword", "Rapier", "Sabre", "Iron Arming Sword", "Shortsword", "Hwando", "Steel Dagger")
@@ -169,7 +169,15 @@
 					r_hand = /obj/item/rogueweapon/sword/short
 				if("Hwando")
 					r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
+					shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
 					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+					wrists = null
+					gloves = /obj/item/clothing/gloves/roguetown/eastgloves1
+					neck = null
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
+					head = /obj/item/clothing/head/roguetown/mentorhat
+					backr = null
+					beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
 				if("Steel Dagger")
 					beltr = /obj/item/rogueweapon/huntingknife/idagger/steel
 			if(weapon_choice == "Steel Dagger")
@@ -188,6 +196,9 @@
 					r_hand = /obj/item/rogueweapon/spear/naginata
 					backr = /obj/item/rogueweapon/scabbard/gwstrap
 					armor = /obj/item/clothing/suit/roguetown/armor/basiceast
+					gloves = /obj/item/clothing/gloves/roguetown/eastgloves1
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
+					head = /obj/item/clothing/head/roguetown/mentorhat
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
 		if("macebearer")
 			var/mace_weapons = list("Mace", "Warhammer", "Goedendag", "Iron Axe", "Greataxe")


### PR DESCRIPTION
## About The Pull Request

Makes a proper spellblade loadout for those choosing a kazengun/lingyue weapon.

The hwando gets the special scabbard, but loses the wooden shield, steel coif, bracers, and the gambeson (1:1 with the eastern warrior loadout).

The naginata gets a slightly spruced up form of this, replacing most components with eastern armors of comparable value while keeping the bracers, gambeson, and coif.

## Testing Evidence
Hwando:
<img width="238" height="541" alt="hwandoloadout" src="https://github.com/user-attachments/assets/7218c54a-2721-42e3-b122-b9433681ee28" />

Naginata:
<img width="260" height="481" alt="naginataloadout" src="https://github.com/user-attachments/assets/bf5cebc7-2723-4624-96dc-8e496463c6ce" />

Tested locally, runs flawlessly.

## Why It's Good For The Game

Soul. The way it is right now feels really bad and looks really bad as it is a horrific mishmash of gear. Now almost all the gear is special eastern variants of comparable value. The hwando gets the fancy sheath in exchange for notably worse starting gear (literally equivalent to eastern warrior) to account for the sheath being of a strong value...and also because it just feels proper. While naginata users get the eastern warrior equipment in replacement of their current equipment, but retain the other gear to account for it being on-par with the rest of the loadouts.

## Changelog


:cl:
add: Kazengunese/lingyue spellblades now get a proper eastern loadout when choosing eastern weapons.
/:cl:
