### PR TITLE
Slight Reach Weapon Defense Review

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -65,7 +65,7 @@
 	attack_verb = list("thrusts")
 	animname = "stab"
 	icon_state = "instab"
-	reach = 2
+	reach = 1
 	clickcd = CLICK_CD_CHARGED
 	recovery = 30
 	warnie = "mobwarning"

--- a/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
@@ -955,8 +955,8 @@
 	icon_state = "glaive"
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel
-	max_blade_int = 160
-	wdefense = 9
+	max_blade_int = 200
+	wdefense = 7
 
 /obj/item/rogueweapon/halberd/glaive/getonmobprop(tag)
 	. = ..()

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -156,7 +156,7 @@
 				prob2defend -= 5
 			if(intenty.masteritem.wlength == WLENGTH_SHORT)
 				prob2defend -= 10
-			if(intenty.masteritem.wbalance == WBALANCE_HEAVY)
+			if(used_weapon.wbalance == WBALANCE_HEAVY)
 				prob2defend -= 10
 			if(intenty.masteritem.wbalance == WBALANCE_SWIFT)	// We are trying to guard against a swiftoid up close with a polearm
 				prob2defend -= 5

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -138,6 +138,30 @@
 			if(mainhand && !offhand && def_swift_capable) // We're one-handing a swift-balanced weapon (rapiers, sabers, etc). Small parry boost (1 wdef equiv.)
 				prob2defend += 10
 
+		if(intenty && intenty.reach > 1)
+			if(get_dist(H, U) < intenty.reach)
+				if(intenty.masteritem.wbalance == WBALANCE_HEAVY)	// We are inside a polearm's ineffective range, and it's heavy
+					prob2defend += 10
+				if(used_weapon.wlength <= WLENGTH_NORMAL)	// We are using a shorter-end weapon (most are long nowadays)
+					prob2defend += 10
+		
+		var/using_reach = FALSE
+		for(var/datum/intent/int in H.possible_a_intents)
+			if(int.reach > 1)
+				using_reach = TRUE	// Our active defensive weapon has reach
+				break
+		
+		if(using_reach && intenty.masteritem && get_dist(H, U) < 2)
+			if(intenty.masteritem.wlength < WLENGTH_NORMAL)	// We are trying to guard against someone who has gotten close to us
+				prob2defend -= 5
+			if(intenty.masteritem.wlength == WLENGTH_SHORT)
+				prob2defend -= 10
+			if(intenty.masteritem.wbalance == WBALANCE_HEAVY)
+				prob2defend -= 10
+			if(intenty.masteritem.wbalance == WBALANCE_SWIFT)	// We are trying to guard against a swiftoid up close with a polearm
+				prob2defend -= 5
+
+
 	if(intenty.masteritem)
 		attacker_skill = U.get_skill_level(intenty.masteritem.associated_skill)
 


### PR DESCRIPTION
## About The Pull Request
Polearms (& Greatswords to an extent) have been sitting there with abnormally high wdef for a while, despite having the innate advantage of reach.

With these changes:

### IF YOU ARE DEFENDING AGAINST REACH
If the defender is **>adjacent<** to the attacker:
- If the defender's weapon has normal or short length, they will get a +1 wdef bonus.
- If the attacker's weapon is heavy, the defender will get a +1 wdef bonus.

### IF YOU ARE DEFENDING WITH A REACH WEAPON
If the attacker is **>adjacent<** to us:
- If the attacker's weapon is normal length, the defender will suffer a -0.5 wdef penalty.
 - Short-length weapons will incur an extra penalty.
- If OUR reach weapon is heavy, we'll suffer a -1 wdef penalty.
- If the attacker's weapon is swift, we'll suffer another -0.5 wdef penalty.

### UNFORTUNATE CAVEAT
There's no way to sensibly distinguish a "polearm" from any random weapon that happens to have a reach intent (that's all that's required for these new boons / penalties to come into play), so there might be weapons that take some strays here.

### MISC CHANGES
- Removed the reach from grand mace stab. I don't think we want that weapon to suffer from all of these just because of 1 random intent.
- Glaive now has more normal sharpness and more normal wdef. (7 & 230)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

### I DIDN'T READ ALL DAT
Me get close to reach weapon user, me get better defense and offense

Me use reach weapon, me not want them close! Worse defense! Worse attack... I keep away.

## Testing Evidence
god I hate this section in these jaks it's like a bunch of %-ages but I'll get some debug logs up later
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
In essence this makes 'sweetspot' for polearms (and reach weapons in general as there's no way to distinguish those) the desired location in general, but only if they're facing someone wielding shorter / normal weapons, or swiftoids, who become generally-speaking, very effective polearm counters.

(btw most weapons like axes and longswords got inflated to being considered "long" so this won't apply as often as you might think, a consequence of really really wanting to hit those hands / feet)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
CL Pending
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
