### PR TITLE
[Farming] small farming update

### DIFF
--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -762,10 +762,21 @@
 				if(B)
 					B = new B(user.loc)
 					user.put_in_hands(B)
+					var/bonus_chance = 0
 					if(HAS_TRAIT(user, TRAIT_WOODWALKER))
+						bonus_chance = 75
+					if(user.mind)
+						var/alch_level = user.get_skill_level(/datum/skill/craft/alchemy)
+						var/farm_level = user.get_skill_level(/datum/skill/labor/farming)
+						var/alch_chance = (alch_level / 6) * 100
+						var/farm_chance = (farm_level / 6) * 66
+						bonus_chance = max(bonus_chance, alch_chance, farm_chance)
+					var/got_bonus = FALSE
+					if(prob(bonus_chance))
 						var/obj/item/C = new B.type(user.loc)
 						user.put_in_hands(C)
-					user.visible_message("<span class='notice'>[user] finds [HAS_TRAIT(user, TRAIT_WOODWALKER) ? "two of " : ""][B] in [src].</span>")
+						got_bonus = TRUE
+					user.visible_message(span_notice("[user] harvests [got_bonus ? "two " : ""][B.name] from [src] bush."))
 					return
 			user.visible_message("<span class='warning'>[user] searches through [src].</span>")
 			if(looty.len)

--- a/code/modules/farming/chaff.dm
+++ b/code/modules/farming/chaff.dm
@@ -1,3 +1,5 @@
+#define BASE_SHUCK_TIME 4 SECONDS
+
 /obj/item/natural/chaff
 	icon = 'icons/roguetown/items/produce.dmi'
 	var/foodextracted = null
@@ -5,19 +7,44 @@
 	icon_state = "chaff1"
 	desc = "A farmer's chaff." //english is not my native language, upon searching "chaff" i didn't even get what this is.
 	var/canthresh = TRUE
-	//dropshrink = 0.75
 
 /obj/item/natural/chaff/attack_right(mob/user)
-	if(foodextracted && !user.get_active_held_item())
-		to_chat(user, span_warning("I start to shuck [src]..."))
-		if(move_after(user,40, target = src)) //ROGTODO make this based on farming skill and speed
-			user.visible_message(span_notice("[user] shucks [src]."), \
-								span_notice("I shuck [src]."))
+	if(!isliving(user))
+		return ..()
+	var/mob/living/L = user
+	to_chat(L, span_notice("You begin shucking [src]..."))
+	INVOKE_ASYNC(src, PROC_REF(shuck_loop), L)
+	return TRUE
 
-			var/obj/item/G = new foodextracted(get_turf(src))
-			user.put_in_active_hand(G)
-			new /obj/item/natural/fibers(get_turf(src))
-			qdel(src)
+/obj/item/natural/chaff/proc/shuck_loop(mob/living/user)
+	if(!user || user.stat || !src || QDELETED(src))
+		return
+
+	var/calculated_time = get_farming_do_time(user, BASE_SHUCK_TIME)
+
+	if(!do_after(user, calculated_time, target = src))
+		return
+	var/turf/drop_location = get_turf(src)
+	if(drop_location)
+		new foodextracted(drop_location)
+	to_chat(user, span_notice("You successfully shuck [src]."))
+	if(src in user.contents)
+		user.transferItemToLoc(src, drop_location)
+	var/obj/item/natural/chaff/next_target = find_adjacent_chaff(user)
+	if(next_target)
+		to_chat(user, span_notice("You move on to shucking the next piece of [next_target.name]..."))
+		INVOKE_ASYNC(next_target, PROC_REF(shuck_loop), user)
+	qdel(src)
+
+/obj/item/natural/chaff/proc/find_adjacent_chaff(mob/living/user)
+	if(!user || QDELETED(user))
+		return null
+
+	for(var/obj/item/natural/chaff/W in range(1, user))
+		if(!W || QDELETED(W) || W.gc_destroyed || W == src)
+			continue
+		return W
+	return null
 
 /obj/item/natural/chaff/proc/thresh()
 	if(foodextracted && canthresh)
@@ -76,3 +103,5 @@
 	name = "rice stalks"
 	icon_state = "ricechaff"
 	foodextracted = /obj/item/reagent_containers/food/snacks/grown/rice
+
+#undef BASE_SHUCK_TIME

--- a/code/modules/farming/chaff.dm
+++ b/code/modules/farming/chaff.dm
@@ -34,7 +34,6 @@
 	var/turf/drop_location = get_turf(src)
 	if(drop_location)
 		new foodextracted(drop_location)
-	to_chat(user, span_notice("You successfully shuck [src]."))
 	if(src in user.contents)
 		user.transferItemToLoc(src, drop_location)
 	var/obj/item/natural/chaff/next_target = find_adjacent_chaff(user)

--- a/code/modules/farming/chaff.dm
+++ b/code/modules/farming/chaff.dm
@@ -8,6 +8,13 @@
 	desc = "A farmer's chaff." //english is not my native language, upon searching "chaff" i didn't even get what this is.
 	var/canthresh = TRUE
 
+/obj/item/natural/chaff/get_mechanics_examine(mob/user)
+	. = ..()
+	. += span_info("Right click chaff with an empty hand to shuck chaff into grains by hand.")
+	. += span_info("Use a thresher on the chaff's tile to thresh all the grains on that tile at once.")
+	. += span_info("Use a club on chaff to thresh several grains, easier for stronger individuals and skilled farmers.")
+	. += span_info("Use a pitchfork to move a lot of chaff around at once.")
+
 /obj/item/natural/chaff/attack_right(mob/user)
 	if(!isliving(user))
 		return ..()

--- a/code/modules/roguetown/roguejobs/alchemist/herb_flora.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/herb_flora.dm
@@ -44,10 +44,21 @@
 			if(B)
 				B = new B(user.loc)
 				user.put_in_hands(B)
+				var/bonus_chance = 0
 				if(HAS_TRAIT(user, TRAIT_WOODWALKER))
+					bonus_chance = 50
+				if(user.mind)
+					var/alch_level = user.get_skill_level(/datum/skill/craft/alchemy)
+					var/farm_level = user.get_skill_level(/datum/skill/labor/farming)
+					var/alch_chance = (alch_level / 6) * 100
+					var/farm_chance = (farm_level / 6) * 66
+					bonus_chance = max(bonus_chance, alch_chance, farm_chance)
+				var/got_bonus = FALSE
+				if(prob(bonus_chance))
 					var/obj/item/C = new B.type(user.loc)
 					user.put_in_hands(C)
-				user.visible_message(span_notice("[user] harvests [HAS_TRAIT(user, TRAIT_WOODWALKER) ? "two " : ""][B.name] from [src] bush."))
+					got_bonus = TRUE
+				user.visible_message(span_notice("[user] harvests [got_bonus ? "two " : ""][B.name] from [src] bush."))
 				harvested = TRUE
 				timerid = addtimer(CALLBACK(src, PROC_REF(loot_replenish)), 5 MINUTES, flags = TIMER_STOPPABLE)
 				//add_filter("picked", 1, alpha_mask_filter(icon = icon('icons/effects/picked_overlay.dmi', "picked_overlay_[rand(1,3)]"), flags = MASK_INVERSE))


### PR DESCRIPTION
## About The Pull Request
- Examine tips for chaff
- You can now continuously shuck chaff once you start doing so with a right click.
- Shucking scales with farming skill now.
- Herbs & swampweed may give additional herbs, based on farming/alchemy. Alchemy is more effective.
- Woodwalker no longer guarantees a second herb whilst picking. Down to a 50% chance, 75% for swampweed.
- Highest modifier is used, they do not stack.

## Testing Evidence
<img width="634" height="519" alt="image" src="https://github.com/user-attachments/assets/cec50f67-15c6-4017-ad8b-fe60ea90a4f1" />
**No hard deletes found :)**

## Why It's Good For The Game
Ends the druid/woodwalker monopoly on getting more herbs from plants. Woodwalker should be primarily a treewalking pick/flavor pick, not a virtue to take as an alchemist.

Anyone with expert alchemy basically has built in woodwalker+ now. Legendary is guaranteed.

Woodwalker chances themselves nerfed as to help reinforce the ability for alchemy-focused classes to brew stuff.

Partially commissioned by Novi.

## Changelog
:cl:
add: Chance to receive two herbs when picking herbs based on farming or alchemy skill, whichever is better.
qol: shucking wheat by hand now scans nearby tiles for more wheat to shuck.
balance: woodwalker no longer guarantees two herbs per plant, it is random now.
/:cl:
