### PR TITLE
Hard Delete Tracker, disable laggy hard deletes & partial CanReach revert

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -9,6 +9,11 @@
 #define QDEL_HINT_FINDREFERENCE	5 //functionally identical to QDEL_HINT_QUEUE if TESTING is not enabled in _compiler_options.dm.
 								  //if TESTING is enabled, qdel will call this object's find_references() verb.
 #define QDEL_HINT_IFFAIL_FINDREFERENCE 6		//Above but only if gc fails.
+
+// Flags on /datum/qdel_item.qdel_flags
+#define QDEL_ITEM_ADMINS_WARNED (1<<0) //! Set when admins are told about lag-causing qdels in this type.
+#define QDEL_ITEM_SUSPENDED_FOR_LAG (1<<1) //! Set when a type can no longer be hard deleted on failure because of lag it causes.
+
 //defines for the gc_destroyed var
 
 // Defines for the ssgarbage queues

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -9,12 +9,6 @@
 /mob/var/next_move_adjust = 0 //Amount to adjust action/click delays by, + or -
 /mob/var/next_move_modifier = 1 //Value to multiply action/click delays by
 
-// CanReach caching - weakrefs to prevent hard deletes from stale cache entries
-/mob/var/datum/weakref/last_reach_target
-/mob/var/last_reach_result
-/mob/var/last_reach_time
-/mob/var/datum/weakref/last_reach_tool
-
 /mob/var/tmp/list/click_mods
 /mob/var/tmp/click_params
 
@@ -526,21 +520,10 @@
 		if(user.used_intent)
 			usedreach = user.used_intent.reach
 
-	if(ismob(src))
-		var/mob/M = src
-		if(M.last_reach_target?.resolve() == ultimate_target && M.last_reach_time == world.time && M.last_reach_tool?.resolve() == tool)
-			return M.last_reach_result
-
 	if(isturf(ultimate_target))
 		var/reached = Adjacent(ultimate_target)
 		if(!reached && (tool || (!iscarbon(src) && usedreach >= 2)))
 			reached = CheckToolReach(src, ultimate_target, usedreach)
-		if(ismob(src))
-			var/mob/M = src
-			M.last_reach_target = WEAKREF(ultimate_target)
-			M.last_reach_result = reached
-			M.last_reach_time = world.time
-			M.last_reach_tool = WEAKREF(tool)
 		return reached
 
 	// A backwards depth-limited breadth-first-search to see if the target is
@@ -559,12 +542,6 @@
 			closed[target] = TRUE
 			if(isturf(target) || isturf(target.loc) || IsDirectlyAccessible(target)) //Directly accessible atoms
 				if(Adjacent(target) || ( (tool || (!iscarbon(src) && usedreach >= 2)) && CheckToolReach(src, target, usedreach))) //Adjacent or reaching attacks
-					if(ismob(src))
-						var/mob/M = src
-						M.last_reach_target = WEAKREF(ultimate_target)
-						M.last_reach_result = TRUE
-						M.last_reach_time = world.time
-						M.last_reach_tool = WEAKREF(tool)
 					return TRUE
 
 			if (!target.loc)
@@ -575,12 +552,6 @@
 
 		checking = next
 
-	if(ismob(src))
-		var/mob/M = src
-		M.last_reach_target = WEAKREF(ultimate_target)
-		M.last_reach_result = FALSE
-		M.last_reach_time = world.time
-		M.last_reach_tool = WEAKREF(tool)
 	return FALSE
 
 /atom/movable/proc/IsDirectlyAccessible(atom/target)
@@ -622,26 +593,32 @@ GLOBAL_LIST_EMPTY(reach_dummy_pool)
 		return FALSE
 
 	switch(reach)
-		if(0)
-			return FALSE
-		if(1)
+		if(0, 1)
 			return FALSE
 		if(2 to INFINITY)
-			var/obj/effect/dummy = new(start)
-			dummy.name = "reach_check_dummy"
-			dummy.pass_flags |= PASSTABLE
-			dummy.movement_type = FLYING
-			dummy.invisibility = INVISIBILITY_ABSTRACT
+			var/obj/effect/dummy
+			if(length(GLOB.reach_dummy_pool))
+				dummy = GLOB.reach_dummy_pool[GLOB.reach_dummy_pool.len]
+				GLOB.reach_dummy_pool.len--
+				dummy.forceMove(start)
+			else
+				dummy = new(start)
+				dummy.name = "reach_check_dummy"
+				dummy.pass_flags |= PASSTABLE
+				dummy.movement_type = FLYING
+				dummy.invisibility = INVISIBILITY_ABSTRACT
+			. = FALSE
 			for(var/i in 1 to reach)
 				if(dummy.CanReach(there))
-					qdel(dummy)
-					return TRUE
+					. = TRUE
+					break
 				var/turf/T = get_step(dummy, get_dir(dummy, there))
 				if(!T || !dummy.Move(T))
-					qdel(dummy)
-					return FALSE
-			qdel(dummy)
-			return FALSE
+					break
+
+			dummy.moveToNullspace()
+			GLOB.reach_dummy_pool += dummy
+			return .
 
 
 // Default behavior: ignore double clicks (the second click that makes the doubleclick call already calls for a normal click)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -628,6 +628,7 @@ GLOBAL_LIST_EMPTY(reach_dummy_pool)
 			return FALSE
 		if(2 to INFINITY)
 			var/obj/effect/dummy = new(start)
+			dummy.name = "reach_check_dummy"
 			dummy.pass_flags |= PASSTABLE
 			dummy.movement_type = FLYING
 			dummy.invisibility = INVISIBILITY_ABSTRACT

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -535,3 +535,14 @@
 /datum/config_entry/number/sustained_td_delay
 	config_entry_value = 120 SECONDS
 
+/datum/config_entry/flag/hard_deletes_enabled
+	config_entry_value = TRUE
+
+/datum/config_entry/number/hard_deletes_overrun_threshold
+	config_entry_value = 0.5
+	integer = FALSE
+	min_val = 0
+
+/datum/config_entry/number/hard_deletes_overrun_limit
+	config_entry_value = 1
+	min_val = 0

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -52,6 +52,9 @@ SUBSYSTEM_DEF(garbage)
 	var/list/reference_find_on_fail = list()
 	#endif
 
+	/// Toggle for enabling/disabling hard deletes. Objects that don't explicitly request hard deletion with this disabled will leak.
+	var/enable_hard_deletes = FALSE
+	var/list/failed_hard_deletes = list()
 
 /datum/controller/subsystem/garbage/PreInit()
 	queues = new(GC_QUEUE_COUNT)
@@ -61,6 +64,11 @@ SUBSYSTEM_DEF(garbage)
 		queues[i] = list()
 		pass_counts[i] = 0
 		fail_counts[i] = 0
+
+/datum/controller/subsystem/garbage/Initialize(start_timeofday)
+	. = ..()
+	if(CONFIG_GET(flag/hard_deletes_enabled))
+		enable_hard_deletes = TRUE
 
 /datum/controller/subsystem/garbage/stat_entry(msg)
 	var/list/counts = list()
@@ -94,6 +102,8 @@ SUBSYSTEM_DEF(garbage)
 	for(var/path in items)
 		var/datum/qdel_item/I = items[path]
 		dellog += "Path: [path]"
+		if (I.qdel_flags & QDEL_ITEM_SUSPENDED_FOR_LAG)
+			dellog += "\tSUSPENDED FOR LAG"
 		if (I.failures)
 			dellog += "\tFailures: [I.failures]"
 		dellog += "\tqdel() Count: [I.qdels]"
@@ -102,6 +112,8 @@ SUBSYSTEM_DEF(garbage)
 			dellog += "\tTotal Hard Deletes [I.hard_deletes]"
 			dellog += "\tTime Spent Hard Deleting: [I.hard_delete_time]ms"
 			dellog += "\tHighest Time Spent Hard Deleting: [I.hard_delete_max]ms"
+			if (I.hard_deletes_over_threshold)
+				dellog += "\tHard Deletes Over Threshold: [I.hard_deletes_over_threshold]"
 		if (I.slept_destroy)
 			dellog += "\tSleeps: [I.slept_destroy]"
 		if (I.no_respect_force)
@@ -211,8 +223,15 @@ SUBSYSTEM_DEF(garbage)
 				continue
 				#endif
 				I.failures++
+				if(I.qdel_flags & QDEL_ITEM_SUSPENDED_FOR_LAG)
+					#ifdef LEGACY_REFERENCE_TRACKING
+					// We do not have the modern TG ref tracking PR on main
+					// This does nothing, and should not be added to until it is ported
+					#endif
+					continue
 			if (GC_QUEUE_HARDDELETE)
-				HardDelete(D)
+				if(!HardDelete(D))
+					D = null
 				if (MC_TICK_CHECK)
 					break
 				continue
@@ -240,7 +259,12 @@ SUBSYSTEM_DEF(garbage)
 	queue[++queue.len] = list(gctime, refid) // not += for byond reasons
 
 //this is mainly to separate things profile wise.
-/datum/controller/subsystem/garbage/proc/HardDelete(datum/D)
+/datum/controller/subsystem/garbage/proc/HardDelete(datum/D, override = FALSE)
+	if(!D)
+		return
+	if(!enable_hard_deletes && !override)
+		failed_hard_deletes |= D
+		return
 	var/time = world.timeofday
 	var/tick = TICK_USAGE
 	var/ticktime = world.time
@@ -270,10 +294,20 @@ SUBSYSTEM_DEF(garbage)
 		time = TICK_DELTA_TO_MS(tick)/100
 	if (time > highest_del_time)
 		highest_del_time = time
-	if (time > 10)
-		log_game("Error: [type]([refID]) took longer than 1 second to delete (took [time/10] seconds to delete)")
-		message_admins("Error: [type]([refID]) took longer than 1 second to delete (took [time/10] seconds to delete).")
+	// Vanderlin garbage.dm:319-330. `time` is deciseconds (world.timeofday delta).
+	if(time > 1) // >0.1s: postpone the GC regardless of threshold config
 		postpone(time)
+	var/threshold = CONFIG_GET(number/hard_deletes_overrun_threshold)
+	if(threshold && (time > threshold * 10)) // threshold is seconds; time is deciseconds
+		if(!(I.qdel_flags & QDEL_ITEM_ADMINS_WARNED))
+			log_game("Error: [type]([refID]) took longer than [threshold] seconds to delete (took [round(time/10, 0.1)] seconds to delete)")
+			message_admins("Error: [type]([refID]) took longer than [threshold] seconds to delete (took [round(time/10, 0.1)] seconds to delete).")
+			I.qdel_flags |= QDEL_ITEM_ADMINS_WARNED
+		I.hard_deletes_over_threshold++
+		var/overrun_limit = CONFIG_GET(number/hard_deletes_overrun_limit)
+		if(overrun_limit && I.hard_deletes_over_threshold >= overrun_limit)
+			I.qdel_flags |= QDEL_ITEM_SUSPENDED_FOR_LAG
+	return TRUE
 
 /datum/controller/subsystem/garbage/Recover()
 	if (istype(SSgarbage.queues))
@@ -289,9 +323,11 @@ SUBSYSTEM_DEF(garbage)
 	var/hard_deletes = 0 	//Different from failures because it also includes QDEL_HINT_HARDDEL deletions
 	var/hard_delete_time = 0//Total amount of milliseconds spent hard deleting this type.
 	var/hard_delete_max = 0	//Highest time spent hard_deleting this in ms.
+	var/hard_deletes_over_threshold = 0	//Number of times hard deletes took longer than the configured threshold
 	var/no_respect_force = 0//Number of times it's not respected force=TRUE
 	var/no_hint = 0			//Number of times it's not even bother to give a qdel hint
 	var/slept_destroy = 0	//Number of times it's slept in its destroy
+	var/qdel_flags = 0		//Bitfield of QDEL_ITEM_* flags
 	var/list/extra_details	//Lazylist of string metadata about the deleted objects
 
 /datum/qdel_item/New(mytype)
@@ -343,7 +379,7 @@ SUBSYSTEM_DEF(garbage)
 			if (QDEL_HINT_HARDDEL)		//qdel should assume this object won't gc, and queue a hard delete
 				SSgarbage.Queue(D, GC_QUEUE_HARDDELETE)
 			if (QDEL_HINT_HARDDEL_NOW)	//qdel should assume this object won't gc, and hard del it post haste.
-				SSgarbage.HardDelete(D)
+				SSgarbage.HardDelete(D, override = TRUE)
 			#ifdef LEGACY_REFERENCE_TRACKING
 			if (QDEL_HINT_FINDREFERENCE) //qdel will, if LEGACY_REFERENCE_TRACKING is enabled, display all references to this object, then queue the object for deletion.
 				SSgarbage.Queue(D)

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -50,4 +50,29 @@
 	if(harddel_deets_dumped)
 		return
 	harddel_deets_dumped = TRUE
-	return "Effect type: [type] - icon: [icon] - icon_state: [icon_state] - name: \"[name]\" - layer: [layer] - vis_contents: [length(vis_contents)] [loc ? "loc.type: [loc.type] ([loc.x],[loc.y],[loc.z])" : "loc: NULLSPACE"]"
+	var/list/parts = list("Effect type: [type]", "icon: [icon]", "icon_state: \"[icon_state]\"", "name: \"[name]\"", "layer: [layer]", "vis_contents: [length(vis_contents)]")
+	parts += loc ? "loc.type: [loc.type] ([loc.x],[loc.y],[loc.z])" : "loc: NULLSPACE"
+	if(LAZYLEN(datum_components))
+		var/list/comp_types = list()
+		for(var/key in datum_components)
+			comp_types += "[key]"
+		parts += "datum_components: [comp_types.Join(",")]"
+	if(LAZYLEN(comp_lookup))
+		var/list/sig_keys = list()
+		for(var/sig in comp_lookup)
+			sig_keys += "[sig]"
+		parts += "comp_lookup signals: [sig_keys.Join(",")]"
+	if(LAZYLEN(signal_procs))
+		var/list/sig_sources = list()
+		for(var/target in signal_procs)
+			var/sig_entry = signal_procs[target]
+			sig_sources += "[target]:[islist(sig_entry) ? jointext(sig_entry, "+") : sig_entry]"
+		parts += "signal_procs targets: [sig_sources.Join(" ; ")]"
+	if(spatial_grid_key)
+		parts += "spatial_grid_key: [spatial_grid_key]"
+	if(LAZYLEN(important_recursive_contents))
+		var/list/irc_keys = list()
+		for(var/key in important_recursive_contents)
+			irc_keys += "[key]"
+		parts += "important_recursive_contents: [irc_keys.Join(",")]"
+	return parts.Join(" - ")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -65,8 +65,6 @@ GLOBAL_VAR_INIT(mobids, 1)
 		my_skill.current = null
 		QDEL_NULL(skills)
 	client_colours = null
-	last_reach_target = null
-	last_reach_tool = null
 	if(active_storage)
 		active_storage.hide_from(src)
 	ghostize(drawskip=TRUE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -49,8 +49,12 @@ GLOBAL_VAR_INIT(mobids, 1)
 		a_intent.mastermob = null
 	a_intent = null
 	o_intent = null
+	possible_mmb_intents = null
+	QDEL_LIST(possible_spell_intents)
 	QDEL_LIST(possible_a_intents)
 	QDEL_LIST(possible_offhand_intents)
+	QDEL_LIST(possible_rmb_intents)
+	QDEL_NULL(base_intents)
 	QDEL_NULL(mmb_intent)
 	QDEL_NULL(rmb_intent)
 	QDEL_NULL(unarmed_special)

--- a/config/config.txt
+++ b/config/config.txt
@@ -568,3 +568,12 @@ DEFAULT_VIEW_SQUARE 15x15
 ## 1 Puts Border Control into 'learning mode' and will have it automatically whitelist new connections
 ## 2 Puts Border Control into 'enforcing mode' and will have it deny connections that are not already whitelisted.
 BORDER_CONTROL 0
+
+## Whether something with floating refs can be hard deleted
+#HARD_DELETES_ENABLED
+
+## How long in seconds after which a hard delete is treated as causing lag. This can be a float and supports a precision as low as nanoseconds.
+#HARD_DELETES_OVERRUN_THRESHOLD 0.5
+
+## Once a typepath causes overrun from hard deletes this many times, stop hard deleting it on garbage collection failures. (set to 0 to disable)
+#HARD_DELETES_OVERRUN_LIMIT 0


### PR DESCRIPTION
## About The Pull Request
- Trying to nail down what the heck is causing 36 hard deletes and blowing up our CPU and seems to predominantly occur on high pop
- Readd reach dummy pooling instead of the old approach of creating and deleting dummy. This might reduce the qdel / hard delete count significantly
- The can reach and caching added in major optimization passes caused hard delete issues on mob and some issues with Reen's click optimization. After testing vs NPC I found that actual hit rate was closer to 8.5% on local while we were creating multiple weakref with each reach check. I have removed it in its entirety.
- Also, port over changes made by Cheffie from Vanderlin in the PR "Actually modernizes CI flow" that allows hard delete that cost too much resources to be tracked, inform admins, and then suspend hard deletes after that.

Might blow up the server or might alleviates the obj/effect hard delete that seems to be dominating server lag now.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1387" height="572" alt="dreamseeker_fN7mf7wPbZ" src="https://github.com/user-attachments/assets/627dc22b-c797-4d5d-86ec-8c56d1082c05" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This may potentially alleviate the recent issue of massive laggy obj/effect hard deletes.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
:cl:
server: Add better tracking of hard delete
server: Fixed a hard delete with reach dummy introduced from a PR 3 months ago.
server: Disabled hard deletes in imitation of Vanderlin, which should alleviates some of our performance issues especially on highpop 
/:cl:


<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
