### PR TITLE
[Fix] Poke Spells var error

### DIFF
--- a/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
@@ -21,7 +21,7 @@
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = TRUE
-	weapon_cast_penalized = FALSE
+	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_POKE
 	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_NONE

--- a/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
@@ -21,7 +21,7 @@
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = TRUE
-	weapon_cast_penalized = FALSE
+	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_POKE
 	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_NONE

--- a/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
@@ -28,7 +28,7 @@
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = TRUE
-	weapon_cast_penalized = FALSE
+	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_POKE
 	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_NONE

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/arc_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/arc_bolt.dm
@@ -20,7 +20,7 @@
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = TRUE
-	weapon_cast_penalized = FALSE
+	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_POKE
 	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_NONE

--- a/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
@@ -24,7 +24,7 @@
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = TRUE
-	weapon_cast_penalized = FALSE
+	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_POKE
 	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_NONE

--- a/code/modules/spells/spell_types/wizard/projectiles_single/greater_arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/greater_arcyne_bolt.dm
@@ -22,7 +22,7 @@
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = TRUE
-	weapon_cast_penalized = FALSE
+	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_POKE
 	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_NONE

--- a/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
@@ -20,7 +20,7 @@
 	invocation_type = INVOCATION_SHOUT
 
 	charge_required = TRUE
-	weapon_cast_penalized = FALSE
+	weapon_cast_penalized = TRUE
 	charge_time = CHARGETIME_POKE
 	charge_drain = 1
 	charge_slowdown = CHARGING_SLOWDOWN_NONE


### PR DESCRIPTION
## About The Pull Request

- I was not aware that the end of the discussion about poke spells was for them to also have the additional costs to throttle a bit the Mageblades, and erroneously set those to be exempt from those costs. This fixes that, so enjoy Mageblade's brief return to glory until this is merged.

## Testing Evidence

FALSE to TRUE on some vars, compiles. Fuuuuuuuuuuuuuuuuuuuck.

## Why It's Good For The Game

Trouncing over the original author's final say is not a good thing to be done, even if accidentally/going on half-truths. I'm sorry about this, everyone.

## Changelog
:cl:
fix: fixed a few wrong variable values
/:cl: