### PR TITLE
Adds Mace Special to Flanged & Greatmaces, + Wretch Skeleton Fixes

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -364,7 +364,6 @@
 	swingsound = BLUNTWOOSH_LARGE
 	minstr = 7
 	wdefense = 3
-	special = /datum/special_intent/ground_smash
 
 	smeltresult = /obj/item/ingot/steel
 	icon_state = "flangedmace"
@@ -428,7 +427,6 @@
 	swingsound = BLUNTWOOSH_LARGE
 	icon_state = "psyflangedmace"
 	is_silver = TRUE
-	special = /datum/special_intent/ground_smash
 	smeltresult = /obj/item/ingot/silverblessed
 
 /obj/item/rogueweapon/mace/cudgel/psy/ComponentInitialize()
@@ -645,7 +643,6 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 	wdefense_wbonus = 5
-	special = /datum/special_intent/ground_smash
 	max_integrity = 300
 
 /obj/item/rogueweapon/mace/goden/steel/paalloy

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -364,6 +364,8 @@
 	swingsound = BLUNTWOOSH_LARGE
 	minstr = 7
 	wdefense = 3
+	special = /datum/special_intent/ground_smash
+
 	smeltresult = /obj/item/ingot/steel
 	icon_state = "flangedmace"
 
@@ -426,6 +428,7 @@
 	swingsound = BLUNTWOOSH_LARGE
 	icon_state = "psyflangedmace"
 	is_silver = TRUE
+	special = /datum/special_intent/ground_smash
 	smeltresult = /obj/item/ingot/silverblessed
 
 /obj/item/rogueweapon/mace/cudgel/psy/ComponentInitialize()
@@ -642,7 +645,7 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 	wdefense_wbonus = 5
-	special = null
+	special = /datum/special_intent/ground_smash
 	max_integrity = 300
 
 /obj/item/rogueweapon/mace/goden/steel/paalloy

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_deathknight.dm
@@ -8,7 +8,7 @@
 	category_tags = list(CTAG_WRETCH)
 	maximum_possible_slots = 2 // Two so that the gimmick isn't overdon
 	applies_post_equipment = TRUE
-	traits_applied = list(TRAIT_HEAVYARMOR)
+	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_BLOODLOSS_IMMUNE, TRAIT_DUSTABLE)
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_CON = 0,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/ancient_spellblade.dm
@@ -8,7 +8,7 @@
 	category_tags = list(CTAG_WRETCH)
 	maximum_possible_slots = 2 // Two so that the gimmick isn't overdone
 	applies_post_equipment = TRUE
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_ARCYNE)
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_ARCYNE, TRAIT_DUSTABLE, TRAIT_BLOODLOSS_IMMUNE)
 	subclass_stats = list(
 		STATKEY_INT = 2,
 		STATKEY_WIL = 2,


### PR DESCRIPTION
## About The Pull Request

- Adds the mace special (ground slam) to the flanged maces, and the great maces, which currently lack them.
- Dusts wretch skeletons (unbound deathknight and spellblade) on death. Currently, they are unrevivable due to jank with skeletonized bodyparts, unless someone cure rots them which turns them into a Regular Human Guy with skin who retains all skeleton perks. Confusing for all parties involved, so it's best to just dust them.
- Gives wretch skeletons bloodloss immune. Currently, special crits with associated bleed (ribcrack, some skullcracks) can cause wretch skeletons to bleed to death. This prevents them from bleeding to death/knockout, though they still do bleed from these. I am unsure of how to fix this, so am applying this as a band-aid that should mechanically fix the issue. (Note: This bleedout isn't present on lich skeletons.)

## Testing Evidence

I spawned in as wretch skelly, used the special on a grand mace, ancient grand mace, and three different types of flanged maces. As a reward for this, I beat my ribs in and was unaffected by the bleeding.