### PR TITLE
bandolier to loadout

### DIFF
--- a/code/datums/loadout/loadout_miscellaneous.dm
+++ b/code/datums/loadout/loadout_miscellaneous.dm
@@ -29,3 +29,9 @@
 	path = /obj/item/storage/backpack/rogue/satchel
 	sort_category = "Miscellaneous"
 	cost = 2
+
+/datum/loadout_item/bandolier
+	name = "Bandolier"
+	path = /obj/item/clothing/cloak/bandolier
+	sort_category = "Miscellaneous"
+	cost = 2


### PR DESCRIPTION
## About The Pull Request

Adds bandoliers to the loadout under Miscellanous.

## Testing Evidence

dude, trust me

## Why It's Good For The Game

they're cute and swaggy. they don't really have anything over tabards and cloaks in terms of storage space or functionality, they're still 2x2 for inventory.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Added bandolier option to loadout, under Miscellaneous.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
