### PR TITLE
[MAGE TUNING] Slight Ferramancy and Cryomancy nerf.

### DIFF
--- a/code/modules/spells/spell_types/wizard/cryomancy/_cryomancy_shared.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/_cryomancy_shared.dm
@@ -4,7 +4,7 @@
 // Fire spells shatter frost stacks (handled in fire spell on_hit procs)
 
 #define FROST_OVERLAY_COLOR rgb(136, 191, 255)
-#define FROST_BURST_DAMAGE 50
+#define FROST_BURST_DAMAGE 25
 #define FROST_BURST_IMMUNITY_DURATION (15 SECONDS)
 #define FROST_BURST_IMMUNITY_KEY "frost_burst_immunity"
 

--- a/code/modules/spells/spell_types/wizard/cryomancy/frost_blast.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/frost_blast.dm
@@ -32,7 +32,7 @@
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
 	var/line_length = 4
-	var/blast_damage = 40
+	var/blast_damage = 36
 	var/push_dist = 2
 
 /datum/action/cooldown/spell/frost_blast/cast(atom/cast_on)

--- a/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
@@ -37,7 +37,7 @@
 /obj/projectile/magic/frostbolt
 	name = "frost bolt"
 	icon_state = "ice_2"
-	damage = 33
+	damage = 30
 	npc_simple_damage_mult = 2
 	damage_type = BURN
 	woundclass = BCLASS_BURN
@@ -49,7 +49,7 @@
 
 /obj/projectile/magic/frostbolt/arc
 	name = "arced frost bolt"
-	damage = 25
+	damage = 23
 	arcshot = TRUE
 
 /obj/projectile/magic/frostbolt/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/cryomancy/frozen_mist.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/frozen_mist.dm
@@ -35,7 +35,7 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
 	var/mist_duration = 10 SECONDS
-	var/tick_damage = 10
+	var/tick_damage = 9
 	var/mist_radius = 2 // 5x5
 
 /datum/action/cooldown/spell/frozen_mist/cast(atom/cast_on)
@@ -74,7 +74,7 @@
 	var/mob/living/caster
 	var/datum/action/cooldown/spell/source_spell
 	var/ticks_remaining
-	var/tick_damage = 10
+	var/tick_damage = 9
 	var/effect_radius = 2
 	var/list/mist_visuals = list()
 

--- a/code/modules/spells/spell_types/wizard/cryomancy/ice_burst.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/ice_burst.dm
@@ -43,7 +43,7 @@
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "wipe"
 	speed = MAGE_PROJ_VERY_SLOW
-	damage = 55
+	damage = 50
 	damage_type = BURN
 	woundclass = BCLASS_BURN
 	npc_simple_damage_mult = 2.5
@@ -58,7 +58,7 @@
 
 /obj/projectile/magic/ice_burst/arc
 	name = "arced ice burst"
-	damage = 41
+	damage = 37
 	arcshot = TRUE
 
 /obj/projectile/magic/ice_burst/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/cryomancy/snap_freeze.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/snap_freeze.dm
@@ -36,7 +36,7 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
 	var/delay = TELEGRAPH_HIGH_IMPACT
-	var/damage = 65
+	var/damage = 59
 	var/area_of_effect = 2
 
 /datum/action/cooldown/spell/snap_freeze/cast(atom/cast_on)

--- a/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
@@ -61,7 +61,7 @@
 	range = 5
 	icon = 'icons/obj/magic_projectiles.dmi'
 	icon_state = "stygian"
-	damage = 42
+	damage = 34
 	damage_type = BRUTE
 	woundclass = BCLASS_STAB
 	armor_penetration = PEN_LIGHT
@@ -70,11 +70,11 @@
 	accuracy = 65
 	flag = "piercing"
 	hitsound = 'sound/combat/hits/bladed/genstab (1).ogg'
-	var/reduced_damage = 23
+	var/reduced_damage = 18
 
 /obj/projectile/energy/stygian/arc
 	name = "arced stygian harpe"
-	damage = 32
+	damage = 26
 	arcshot = TRUE
 
 /obj/projectile/energy/stygian/on_hit(target)


### PR DESCRIPTION
## About The Pull Request
After the very vigorous and frankly, at time toxic debate over https://github.com/Azure-Peak/Azure-Peak/pull/7154, I decided to run some local formula based on players sentiment - which consistently point out Ferramancy and Cryomancy as overtuned. I ran the maths and I came to the conclusion that indeed, these two schools are overtuned. Therefore, I did some targeted nerfing. 

- Stygian damage reduced by 20%.
- Frost direct damage reduced by 10% across the board.
- Frost stacking damage reduced from 50 to 25 (50%)!

THIS IS MEANT TO BE COMPLEMENTING https://github.com/Azure-Peak/Azure-Peak/pull/7154, IT IS NOT AN IF OR BUT CHOICE. The fire resistance PR has been TMed for over 5 days and not once have I seen people complain that mage is actually doing shit. The school getting the most flake for being overpowered / underpowered (pyro) is the one still being used en masse and I do not believe anyone on the receiving side has ever called it ineffective.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Mathemtical and simulated tests were run based on the following "perfect play" parameters, which I feel is more predictive of actual combat: 
<img width="569" height="280" alt="EXCEL_tM6TlMqwo0" src="https://github.com/user-attachments/assets/7c7cc9e3-3ab3-461a-85a1-0dbe22d0506f" />
<img width="570" height="336" alt="EXCEL_WozCHTOHxg" src="https://github.com/user-attachments/assets/14313727-1503-422e-9e4a-3831b57595cc" />

Presumptions: 
- Didn't calculate Pyromancy DOT - later on I bolted a presumed 50% of 2.5 damage / tick (Which is conservative and assume you are on 1 stack at all time). Assume that the main rotation is Fireball + Spitfire + Fire Blast with 100% hit rate 
- For Fulgurmancy, the assumed 100% hit rate is on Arc Bolt, LBolt, and then a 25% hit rate on Heaven's Strike (likely overstated for real combat) and 100% hit rate on the OUTER RING damage of Thunderstrike
- Cryomancy, I assumed 100% hit rate on all projectiles since all of them have no damage falloff and is hard to hit 
- Ferramancy was calculated by Stygian - Sawblade only 
- Geomancy was calculated by GBlast - Boulder Strike and Emergence outer radius (15), with blunt modifier
- Telomancy was claculated by full rotation excluding seeker orbs 

Both were computed vs 10 con and 15 con scenario and vs plate (at 20% resist) and padded ratio. Ferramancy assume no damage reduction vs anyone. The numbers I posted isn't fully accurate to my final 

My test show that Pyromancy appears on the surface to be underpowered, but this is because of a methodlogy issue (I badly undercounted the DOT component, which is never reliably predictable) Cryomancy had very overtuned DPS and Fulgurmancy is middle of the pack out of the energetic school. 

That Ferramancy seems slightly overtuned and nearly matched geomancy (which has far more FF hazard) - then I realized I overestimated blade burst (in a real fight I'd say my true hit rate is closer to 20 - 25%). 

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This is a highly reasonable and evidence backed downtune for the two schools that players has noticed as the most used and most powerful. 

I have a lingering belief that Cryo might continue to be overtuned due to it giving an action speed reduction, a speed reduction on top of decent DPS and easy to hit direct fire and a budget of only one easy to hit gigantic AOE. 

I believe Pyro do not need any adjustment. I have seen them blasting skeletons - which are supposed to be 50% more resistant to fire damage by default and causing a great deal of hurt in EORS. 

Fulgurmancy do not need higher DPS, they have better actual hit rate in play due to two hitscan spells and TStrike. Their identity as backlineer is the strongest of Energetic school and inflict massive hurt with low risk of FF during a hyperwar. Their LBolt is extremely debilitating and Arc Bolt, while having the lowest "EDPS" is nearly impossible to miss AND can be arced over allies. 

While physical schools SEEMS to on surface match Energetic school in DPS, in practice, physical schoolers tends to point blank far more aggressively which makes up for their DPS and can synergize heavily with martial whereas energetic schools struggle to synergize with martial except through LBolt CC. They don't race toward the win conditions. 

Ferramancy seems overtuned on a raw DPS point of view and I think the culprit is Stygian.

Geomancy don't seems to need any adjustment atm (And any direction woudl be downward) as they carries massive FF risks (but as a result, also one of the best anti group pressure effect) 

Telomancy seems fine as a sidegrade of Geomancy with less fancy CC and abilities in exchange for far lower FF risks.

I believe this is some much needed balance tuning that also preserves and reinforces each school's niche and identity. After this, the main thing I will consider is whether Cryo needs more downtuning.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Reduced Stygian damage by 20%
balance: Reduced Cryo damage across the board by 10%, shatter damage by 50% due to it consistently showing up as overtuned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
