### PR TITLE
padded gambeson for templar

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -73,7 +73,7 @@
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	cloak = /obj/item/clothing/cloak/tabard/crusader/tief
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 	wrists = /obj/item/clothing/neck/roguetown/psicross/astrata
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	belt = /obj/item/storage/belt/rogue/leather/black


### PR DESCRIPTION
## About The Pull Request

Replaces normal/light gambeson of Templar with a Padded Gambeson (heavy)

## Testing Evidence

linechange

## Why It's Good For The Game

Whilst I couldn't find any reasoning behind nerfing the Templar aside from "Per request" I can safely say that giving them stonekeep-era armor in a server where everyone, even adventurers don plate is not a good idea. The majority of the server does not roleplay faith as it was during then, nobody has a reason to think of the consequences from the church.

To compare -- The Inquisition which hails from Otava, and are seen as heretics are better equipped and more funded than the Holy See which is both a dominant religion in Azuria and the one the crown recognizes as the "state religion". It does not make sense why the entity that crowns the ruler of Azure is weaker than almost everyone, and everything in the game. Whilst I heavily disagree with them being stripped of  everything, and that I wish I could add a normal cuirass to them I think this compromise would sit well with most, if not all. 

This is a low priority PR, its just a line change

## Changelog

:cl:
balance: The Templar light gambeson is replaced with a padded gambeson.
/:cl:
