### PR TITLE
Slurbowcraft

### DIFF
--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -236,14 +236,15 @@
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 3
 
-/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
+/datum/crafting_recipe/roguetown/engineering/crossbow/slurbow
 	name = "slurbow"
 	category = "Weapons"
-	result = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	result = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
 	reqs = list(
 		/obj/item/ingot/steel = 1,
 		/obj/item/natural/fibers = 1,
-		/obj/item/natural/wood/plank = 2,
+		/obj/item/natural/wood/plank = 1,
+		/obj/item/grown/log/tree/small = 1,
 	)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering

--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -236,6 +236,19 @@
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 3
 
+/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
+	name = "slurbow"
+	category = "Weapons"
+	result = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+	reqs = list(
+		/obj/item/ingot/steel = 1,
+		/obj/item/natural/fibers = 1,
+		/obj/item/natural/wood/plank = 2,
+	)
+	structurecraft = /obj/machinery/artificer_table
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 3
+
 /datum/crafting_recipe/roguetown/engineering/twentybolts
 	name = "crossbow bolt (x20)"
 	category = "Ammo"


### PR DESCRIPTION
## About The Pull Request

Adds the slurbow to the engineering crafting list.

## Testing Evidence

<img width="422" height="193" alt="Screenshot 2026-05-21 183125" src="https://github.com/user-attachments/assets/9e56c4a9-0e77-4e88-b9d8-889079dc03dc" />
<img width="336" height="265" alt="Screenshot 2026-05-21 183152" src="https://github.com/user-attachments/assets/de781c48-4ad0-43cb-9d07-1f5348799d9b" />

## Why It's Good For The Game

I like the slurbow, and it's already available from the silverface, so why not allow engineers to make it?

## Changelog

:cl:
add: slurbow to engineering, swaps 1 plank for 1 small log in the recipe
/:cl:
