### PR TITLE
[PERF] - Readd reach dummy pooling, remove reach caching.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -9,12 +9,6 @@
 /mob/var/next_move_adjust = 0 //Amount to adjust action/click delays by, + or -
 /mob/var/next_move_modifier = 1 //Value to multiply action/click delays by
 
-// CanReach caching - weakrefs to prevent hard deletes from stale cache entries
-/mob/var/datum/weakref/last_reach_target
-/mob/var/last_reach_result
-/mob/var/last_reach_time
-/mob/var/datum/weakref/last_reach_tool
-
 /mob/var/tmp/list/click_mods
 /mob/var/tmp/click_params
 
@@ -526,21 +520,10 @@
 		if(user.used_intent)
 			usedreach = user.used_intent.reach
 
-	if(ismob(src))
-		var/mob/M = src
-		if(M.last_reach_target?.resolve() == ultimate_target && M.last_reach_time == world.time && M.last_reach_tool?.resolve() == tool)
-			return M.last_reach_result
-
 	if(isturf(ultimate_target))
 		var/reached = Adjacent(ultimate_target)
 		if(!reached && (tool || (!iscarbon(src) && usedreach >= 2)))
 			reached = CheckToolReach(src, ultimate_target, usedreach)
-		if(ismob(src))
-			var/mob/M = src
-			M.last_reach_target = WEAKREF(ultimate_target)
-			M.last_reach_result = reached
-			M.last_reach_time = world.time
-			M.last_reach_tool = WEAKREF(tool)
 		return reached
 
 	// A backwards depth-limited breadth-first-search to see if the target is
@@ -559,12 +542,6 @@
 			closed[target] = TRUE
 			if(isturf(target) || isturf(target.loc) || IsDirectlyAccessible(target)) //Directly accessible atoms
 				if(Adjacent(target) || ( (tool || (!iscarbon(src) && usedreach >= 2)) && CheckToolReach(src, target, usedreach))) //Adjacent or reaching attacks
-					if(ismob(src))
-						var/mob/M = src
-						M.last_reach_target = WEAKREF(ultimate_target)
-						M.last_reach_result = TRUE
-						M.last_reach_time = world.time
-						M.last_reach_tool = WEAKREF(tool)
 					return TRUE
 
 			if (!target.loc)
@@ -575,12 +552,6 @@
 
 		checking = next
 
-	if(ismob(src))
-		var/mob/M = src
-		M.last_reach_target = WEAKREF(ultimate_target)
-		M.last_reach_result = FALSE
-		M.last_reach_time = world.time
-		M.last_reach_tool = WEAKREF(tool)
 	return FALSE
 
 /atom/movable/proc/IsDirectlyAccessible(atom/target)
@@ -622,25 +593,33 @@ GLOBAL_LIST_EMPTY(reach_dummy_pool)
 		return FALSE
 
 	switch(reach)
-		if(0)
-			return FALSE
-		if(1)
+		if(0, 1)
 			return FALSE
 		if(2 to INFINITY)
-			var/obj/effect/dummy = new(start)
-			dummy.pass_flags |= PASSTABLE
-			dummy.movement_type = FLYING
-			dummy.invisibility = INVISIBILITY_ABSTRACT
+			var/obj/effect/dummy
+			if(length(GLOB.reach_dummy_pool))
+				dummy = GLOB.reach_dummy_pool[GLOB.reach_dummy_pool.len]
+				GLOB.reach_dummy_pool.len--
+				dummy.forceMove(start)
+			else
+				dummy = new(start)
+				dummy.name = "reach_check_dummy"
+				dummy.pass_flags |= PASSTABLE
+				dummy.movement_type = FLYING
+				dummy.invisibility = INVISIBILITY_ABSTRACT
+
+			. = FALSE
 			for(var/i in 1 to reach)
 				if(dummy.CanReach(there))
-					qdel(dummy)
-					return TRUE
+					. = TRUE
+					break
 				var/turf/T = get_step(dummy, get_dir(dummy, there))
 				if(!T || !dummy.Move(T))
-					qdel(dummy)
-					return FALSE
-			qdel(dummy)
-			return FALSE
+					break
+
+			dummy.moveToNullspace()
+			GLOB.reach_dummy_pool += dummy
+			return .
 
 
 // Default behavior: ignore double clicks (the second click that makes the doubleclick call already calls for a normal click)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -65,8 +65,6 @@ GLOBAL_VAR_INIT(mobids, 1)
 		my_skill.current = null
 		QDEL_NULL(skills)
 	client_colours = null
-	last_reach_target = null
-	last_reach_tool = null
 	if(active_storage)
 		active_storage.hide_from(src)
 	ghostize(drawskip=TRUE)


### PR DESCRIPTION
## About The Pull Request
- Readd reach dummy pooling instead of the old approach of creating and deleting dummy. This might reduce the qdel / hard delete count significantly
- The can reach and caching added in major optimization passes caused hard delete issues on mob and some issues with Reen's click optimization. After testing vs NPC I found that actual hit rate was closer to 8.5% on local while we were creating multiple weakref with each reach check. I have removed it in its entirety.

Might blow up the server or might alleviates the obj/effect hard delete that seems to be dominating server lag now.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1387" height="572" alt="dreamseeker_fN7mf7wPbZ" src="https://github.com/user-attachments/assets/711a1444-b933-4b6a-83a0-00e3fa58381c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
POTENTIALLY fixes lag or lower lag

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Tweaked the CanReach system to hopefully reduce lag and amount of unnecessary weakrefs created and qdeleted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
