### PR TITLE
fixes wield-only specials

### DIFF
--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -178,7 +178,7 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 /datum/special_intent/proc/check_reqs(mob/living/carbon/human/user, obj/item/I)
 	if(requires_wielding)
 		if(!length(I.gripped_intents) || !I.gripped_intents)	// We have no gripped intents at all
-			to_chat(user, span_warning("I need to be wielding the weapon in both hands!"))
+			to_chat(user, span_warning("This weapon cannot use this Special at all. I should probably tell the Gods (coders)"))
 			return FALSE
 		if(I.wielded)
 			return TRUE

--- a/code/modules/mob/living/combat/special_intents.dm
+++ b/code/modules/mob/living/combat/special_intents.dm
@@ -176,7 +176,10 @@ This allows the devs to draw whatever shape they want at the cost of it feeling 
 	return TRUE
 
 /datum/special_intent/proc/check_reqs(mob/living/carbon/human/user, obj/item/I)
-	if(requires_wielding && length(I.gripped_intents))
+	if(requires_wielding)
+		if(!length(I.gripped_intents) || !I.gripped_intents)	// We have no gripped intents at all
+			to_chat(user, span_warning("I need to be wielding the weapon in both hands!"))
+			return FALSE
 		if(I.wielded)
 			return TRUE
 		else


### PR DESCRIPTION
## About The Pull Request
Fixes Specials that require wielding working while unwielded under some circumstances.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed some rare instances of wield-only specials working with unwielded or unwieldable weapons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
