### PR TITLE
maurice - allows all races to be lunatics, once more

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/lunatic.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/lunatic.dm
@@ -9,14 +9,16 @@
 	var/list/traits_applied
 	traits_applied = list(TRAIT_PSYCHOSIS, TRAIT_NOSTINK, TRAIT_MANIAC_AWOKEN, TRAIT_HOMESTEAD_EXPERT) // Maniac_Awoken no longer has any function other than the flavor text and trait
 	allowed_sexes = list(MALE, FEMALE)
-	forbidden_races = list(RACES_DESPISED)
+
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	outfit = /datum/outfit/job/roguetown/lunatic
 	bypass_lastclass = TRUE
 	bypass_jobban = FALSE
 	min_pq = 100 //the magic of an allowlist server.
 	max_pq = null
-	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by any means, though your very existence invites danger from every corner. It is said that Azure Peak drives those most familiar with it, the most insane."
+	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by \
+	any means, though your very existence invites danger from every corner. It is said that Azure Peak drives those most \
+	familiar with it, the most insane."
 	display_order = JDO_LUNATIC
 	selection_color = JCOLOR_SIDEFOLK
 
@@ -31,7 +33,9 @@
 
 /datum/advclass/lunatic
 	name = "Lunatic"
-	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by any means, though your very existence invites danger from every corner. It is said that Azure Peak drives those most familiar with it, the most insane."
+	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by \
+	any means, though your very existence invites danger from every corner. It is said that Azure Peak drives those most \
+	familiar with it, the most insane."
 	outfit = /datum/outfit/job/roguetown/lunatic/basic
 	category_tags = list(CTAG_LUNATIC)
 	subclass_stats = list(


### PR DESCRIPTION
## About The Pull Request

* Removes the racelock from the Lunatic role, which is essentially Vagabond: Prestige Edition.

## Testing Evidence

* Good to go.

## Why It's Good For The Game

* Lunatics are explicitly noted to be social outcasts and pariahs, and are - in essence - fancier Vagabonds.
* Dakken's fine with it.
* Given how high the PQ minimum is for this particular role, the chance for this being used in a bad way is minimal.

## Changelog

:cl:
fix: Lunatics can be played by any race and creed, once more!
/:cl:
