### PR TITLE
Soulshot damage fix

### DIFF
--- a/code/modules/spells/spell_types/wizard/kinesis/soulshot.dm
+++ b/code/modules/spells/spell_types/wizard/kinesis/soulshot.dm
@@ -73,8 +73,10 @@
 		return . || BULLET_ACT_HIT
 	hits++
 	// Halve damage after the first target
-	if(hits == 1)
-		damage = round(damage * 0.5)
+	if(hits <= 1)
+		damage = 95
+	else
+		damage = round(95 * 0.5)
 	if(hits >= max_hits)
 		qdel(src)
 		return . || BULLET_ACT_HIT


### PR DESCRIPTION
## About The Pull Request

Soulshot now halves its damage after it deals the full amount to the first target, whereas before it dealt halved damage regardless of ordering.

## Testing Evidence
first target:
<img width="218" height="308" alt="image" src="https://github.com/user-attachments/assets/30f54af9-8206-4aef-a2ce-cbc791974016" />
second-fourth:
<img width="200" height="273" alt="image" src="https://github.com/user-attachments/assets/e0455a11-dd24-4686-922e-0f1aa696ec01" />
fifth:
<img width="226" height="291" alt="image" src="https://github.com/user-attachments/assets/c3cfdf62-1c43-46de-b103-d8d0aabbd58a" />


## Why It's Good For The Game

stuff work good is gooderer. The charge time and c/d are kinda underwhelming compared to all other pokes anyway, and for some schools it's their only means of dealing damage.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Soulshot now deals full damage to the first target instead of half.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
