### PR TITLE
bugfixes lacrima

### DIFF
--- a/code/datums/gods/patrons/inhumen/zizo.dm
+++ b/code/datums/gods/patrons/inhumen/zizo.dm
@@ -14,7 +14,6 @@
 					/datum/action/cooldown/spell/tame_undead/zizo						= CLERIC_T3,
 					/datum/action/cooldown/spell/zizo/rituos 							= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/resurrect/zizo				= CLERIC_T3,
-					/datum/action/cooldown/spell/convert_heretic						= CLERIC_T4,
 					/datum/action/cooldown/spell/lacrima/zizo							= CLERIC_T4,	
 	)
 	confess_lines = list(

--- a/code/modules/spells/roguetown/necromancer/lacrima.dm
+++ b/code/modules/spells/roguetown/necromancer/lacrima.dm
@@ -41,13 +41,16 @@
 	return FALSE
 
 /datum/action/cooldown/spell/lacrima/proc/lux_rip(mob/living/carbon/human/target, mob/living/carbon/human/user)
-	var/break_time = 100
-	var/tear_time = 100
+	var/break_time = 13 SECONDS
+	var/tear_time = 7 SECONDS
 
 	if(target == user)
 		return
 	if(!iscarbon(target))
 		to_chat(user, span_info("Their Lux is insufficient or plain worthless for this ritual."))
+		return
+	if(target.stat == DEAD)
+		to_chat(user, span_notice("They're dead."))
 		return
 	if(!target.Adjacent(user))
 		to_chat(user, span_info("I need to be next to [target] to excise their Lux."))
@@ -81,11 +84,13 @@
 		to_chat(target, span_purple("<b>You hear a vicious giggle echoing through your mind. The Dame of Progress is pleased.</b>"))
 		target.add_stress(/datum/stressevent/torn_lux_psydonite)
 		owner.add_stress(/datum/stressevent/dame_favor)
+		owner.playsound_local(owner, 'sound/misc/zizo.ogg', 25, FALSE)
 
 	else if(HAS_TRAIT(target, TRAIT_NOBLE) || HAS_TRAIT(target, TRAIT_CLERGY))
 		to_chat(target, span_purple("<b>You hear a vicious giggle echoing through your mind. The Dame of Progress is pleased.</b>"))
 		target.add_stress(/datum/stressevent/torn_lux_devout)
 		owner.add_stress(/datum/stressevent/dame_favor)
+		owner.playsound_local(owner, 'sound/misc/zizo.ogg', 25, FALSE)
 
 	else
 		target.add_stress(/datum/stressevent/torn_lux)


### PR DESCRIPTION
## About The Pull Request

- Lacrima can no longer be used on dead targets.

## Testing Evidence

Compiles, bugfix.

## Why It's Good For The Game

The Zizo Lux stonks market must crash now, sorry.

## Changelog
:cl:
fix: Lacrima can't be used on dead people.
/:cl: