### PR TITLE
Rebalance Pestran Medicine.

### DIFF
--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -354,7 +354,7 @@
 				holder.remove_reagent(R.type, 0.2 * REAGENTS_EFFECT_MULTIPLIER)
 		var/list/wCount = M.get_wounds()
 		if(wCount.len > 0)
-			M.heal_wounds(2 * REAGENTS_EFFECT_MULTIPLIER)
+			M.heal_wounds(2)
 		..()
 
 /datum/action/cooldown/spell/touch/orison/proc/create_water(obj/item/melee/new_touch_attack/hand, atom/victim, mob/living/carbon/caster, list/modifiers)


### PR DESCRIPTION
## About The Pull Request

it was too good at stabilizing patient, now it's will be slower

## Testing Evidence

single line change, it compiles with no problem

## Why It's Good For The Game

stabilizing dying players is good, stabilizing dying players SUPER FAST isn't good(unless you double Fortified or Divine Rebirth)

## Changelog


:cl:
change: pestran medicine's wound healing is no longer multiplied by 2.5
/:cl:

