### PR TITLE
Fixes farmers not being able to fertilize crops (Please merge)

### DIFF
--- a/code/modules/farming/soil.dm
+++ b/code/modules/farming/soil.dm
@@ -158,12 +158,16 @@ GLOBAL_LIST_EMPTY(soil_list)
 
 /obj/structure/soil/proc/try_handle_watering(obj/item/attacking_item, mob/user, params)
 	var/water_amount = 0
-	if(water >= MAX_PLANT_WATER * 0.8)
-		to_chat(user, span_warning("The soil is already wet!"))
-		return TRUE
 	if(istype(attacking_item, /obj/item/melee/new_touch_attack/orison))
+		if(water >= MAX_PLANT_WATER * 0.8)
+			to_chat(user, span_warning("The soil is already wet!"))
+			return TRUE
 		water_amount = 300
+		to_chat(user, span_notice("I water the soil with holy water."))
 	if(istype(attacking_item, /obj/item/reagent_containers))
+		if(water >= MAX_PLANT_WATER * 0.8)
+			to_chat(user, span_warning("The soil is already wet!"))
+			return TRUE
 		var/obj/item/reagent_containers/container = attacking_item
 		if(container.reagents.has_reagent(/datum/reagent/water, 10))
 			container.reagents.remove_reagent(/datum/reagent/water, 10)


### PR DESCRIPTION
## About The Pull Request

#7235 Caused a bug where you can't use any item on a crop if the crop is wet. 

## Testing Evidence

<img width="599" height="111" alt="image" src="https://github.com/user-attachments/assets/3f899910-4912-4309-9afc-21c93c13e37d" />


## Why It's Good For The Game

Bugfix

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:

fix: fertilizing crops works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
