### PR TITLE
Properly gate offensive spells behind human requirement

### DIFF
--- a/code/modules/spells/pantheon/inhumen/baotha.dm
+++ b/code/modules/spells/pantheon/inhumen/baotha.dm
@@ -312,6 +312,7 @@
 	invocation_type = "emote"
 	invocations = list("flicks their wrist, filling the air in front of them with a fine powder.")
 	devotion_cost = 30
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/projectile/blowingdust/cast(list/targets, mob/user = user)
 	switch(user.rmb_intent.name)
@@ -393,6 +394,7 @@
 	recharge_time = 5 MINUTES
 	miracle = TRUE
 	devotion_cost = 75
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/lasthigh/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))

--- a/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -178,6 +178,7 @@
 	invocations = list("BE STILL!!") // VERY loud. do NOT add other invocations, this projectile can FUUUCK people up and needs to be telegraphed.
 	sound = 'sound/magic/blood_net.ogg'
 	range = 8
+	human_req = TRUE
 
 /obj/projectile/magic/unholy_grasp
 	name = "visceral organ net"
@@ -218,6 +219,7 @@
 	sound = 'sound/magic/graggar_silence.ogg'
 	invocations = list("BE SILENT!", "QUIET!", "NOT ANOTHER WORD!")
 	zizo_spell = FALSE // Graggar wants his car back.
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/silence/graggar/cast(list/targets, mob/user = usr)//This one does actually work on mages, fully.
 	if(iscarbon(targets[1]))
@@ -262,6 +264,7 @@
 	releasedrain = 30
 	miracle = TRUE
 	devotion_cost = 70
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/revel_in_slaughter/cast(list/targets, mob/living/user = usr)
 	var/mob/living/carbon/human/human = targets[1]

--- a/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -342,6 +342,7 @@
 	chargedloop = /datum/looping_sound/invokefire
 	recharge_time = 2 MINUTES
 	associated_skill = /datum/skill/magic/holy
+	human_req = TRUE
 	var/delay = 12
 	var/strike_delay = 2
 	var/damage = 20
@@ -538,6 +539,7 @@
 	movement_interrupt = FALSE
 	recharge_time = 6 MINUTES
 	range = 4
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/matthios_equalize/cast(list/targets, mob/living/user)
 	if(ishuman(targets[1]))
@@ -745,6 +747,7 @@
 	movement_interrupt = FALSE
 	recharge_time = 5 MINUTES //This probably should not be on low cooldown
 	range = 4
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/matthios_churn/cast(list/targets, mob/living/user)
 	if(ishuman(targets[1]))
@@ -873,6 +876,7 @@
 	cooldown_time = 45 SECONDS
 	associated_skill = /datum/skill/magic/holy
 	spell_tier = 0
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 	var/min_mammon = 25
 	var/max_mammon = 100
 

--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -47,6 +47,7 @@
 	primary_resource_cost = 30
 	secondary_resource_cost = 10
 	sound = 'sound/magic/zizo_snuff.ogg'
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 	var/snuff_range = 2
 
 /datum/action/cooldown/spell/zizo/snuff_lights/cast(atom/cast_on)
@@ -111,6 +112,7 @@
 	secondary_resource_cost = 15
 	charge_required = FALSE
 	cooldown_time = 30 SECONDS
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
 /datum/action/cooldown/spell/projectile/zizo/profane/cast(atom/cast_on)
 	var/mob/living/user = owner
@@ -417,11 +419,13 @@
 	invocation_type = null
 	invocations = null
 	associated_skill = /datum/skill/magic/holy
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
 // TAME UNDEAD (T3) - I don't know why this is a T3, being just a forced Gravemark on a hostile NPC undead.
 /datum/action/cooldown/spell/tame_undead/zizo
 	associated_skill = /datum/skill/magic/holy
 	primary_resource_cost = 100
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
 // T3: Rituos - Zizo's Lesser Work. A single painful ritual that grants the caster a choice:
 // Progress: Arcyne knowledge (2 minor aspects, 4 utilities). No skeletonization. -- Kunai: I made this more distinctive from Undeath, now it also gives you some traits to give a better progress vibe.
@@ -585,6 +589,7 @@
 	invocations = list("Solve ossa, redite ad pulverem!")
 	invocation_type = INVOCATION_SHOUT
 	sound = 'sound/magic/swap.ogg'
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
 /datum/action/cooldown/spell/zizo/bone_cataclysm/cast(atom/cast_on)
 	. = ..()

--- a/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/divine_blast.dm
@@ -26,6 +26,7 @@
 	associated_skill = /datum/skill/magic/holy
 	miracle = TRUE
 	devotion_cost = 25
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/projectile/divineblast/cast(list/targets, mob/user = user)
 	projectile_type = arc_mode ? projectile_type_arc : initial(projectile_type)

--- a/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
+++ b/code/modules/spells/spell_types/divine/projectiles_single/unholy_blast.dm
@@ -26,6 +26,7 @@
 	associated_skill = /datum/skill/magic/holy
 	miracle = TRUE
 	devotion_cost = 25
+	human_req = TRUE
 
 
 /obj/projectile/energy/unholyblast

--- a/code/modules/spells/spell_types/wizard/cryomancy/frost_blast.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/frost_blast.dm
@@ -31,6 +31,8 @@
 	point_cost = 3
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/line_length = 4
 	var/blast_damage = 36
 	var/push_dist = 2

--- a/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/cryomancy/frost_bolt.dm
@@ -34,6 +34,8 @@
 	point_cost = 3
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/frostbolt
 	name = "frost bolt"
 	icon_state = "ice_2"

--- a/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
@@ -32,6 +32,8 @@
 	spell_tier = 2
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 // --- Arcyne spear projectile ---
 
 /obj/projectile/magic/arcyne_lance

--- a/code/modules/spells/spell_types/wizard/ferramancy/iron_tempest.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/iron_tempest.dm
@@ -36,7 +36,7 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_tier = 2
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
-	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_SAME_Z // Projectile that spawns persistent AOE - same-Z to prevent cross-floor cheese
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z // Projectile that spawns persistent AOE - same-Z to prevent cross-floor cheese
 
 	/// How long the tempest persists
 	var/tempest_duration = 10 SECONDS

--- a/code/modules/spells/spell_types/wizard/ferramancy/sawblade_volley.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/sawblade_volley.dm
@@ -36,6 +36,8 @@
 	spell_tier = 2
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	displayed_damage = 60
 
 	var/spread_step = 8

--- a/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
@@ -40,6 +40,8 @@
 	spell_tier = 2
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/spread_step = 12
 
 /datum/action/cooldown/spell/projectile/stygian_efflorescence/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/arc_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/arc_bolt.dm
@@ -31,6 +31,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/arc_bolt
 	name = "arc bolt"
 	tracer_type = /obj/effect/projectile/tracer/wormhole

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/heavens_strike.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/heavens_strike.dm
@@ -30,6 +30,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_HIGH
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/damage = 60
 	var/telegraph_tick = TELEGRAPH_SKILLSHOT
 	var/npc_simple_damage_mult = 2

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/lightning_bolt.dm
@@ -35,6 +35,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/lightning
 	name = "bolt of lightning"
 	tracer_type = /obj/effect/projectile/tracer/stun

--- a/code/modules/spells/spell_types/wizard/fulgurmancy/thunderstrike.dm
+++ b/code/modules/spells/spell_types/wizard/fulgurmancy/thunderstrike.dm
@@ -35,6 +35,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_HIGH
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /datum/action/cooldown/spell/thunderstrike/cast(atom/cast_on)
 	. = ..()
 	var/mob/living/carbon/human/H = owner

--- a/code/modules/spells/spell_types/wizard/geomancy/boulder_strike.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/boulder_strike.dm
@@ -31,6 +31,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_HIGH
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/boulder
 	name = "boulder"
 	icon = 'icons/obj/magic_projectiles.dmi'

--- a/code/modules/spells/spell_types/wizard/geomancy/earthen_wall.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/earthen_wall.dm
@@ -30,6 +30,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_NONE
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/wall_width = 3
 	var/telegraph_time = 3 SECONDS
 	var/wall_duration = 10 SECONDS

--- a/code/modules/spells/spell_types/wizard/geomancy/ensnare.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/ensnare.dm
@@ -28,6 +28,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/area_of_effect = 1
 	var/ensnare_duration = 5 SECONDS
 	var/delay = 0.8 SECONDS

--- a/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
+++ b/code/modules/spells/spell_types/wizard/geomancy/gravel_blast.dm
@@ -36,6 +36,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /datum/action/cooldown/spell/projectile/gravel_blast/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)
 	. = ..()
 	var/base_angle = to_fire.Angle

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/knock.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/knock.dm
@@ -19,6 +19,7 @@
 	invocation_type = "shout"
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/knock/cast(list/targets, mob/user = usr)
 	playsound(get_turf(user), 'sound/misc/chestopen.ogg', 100, TRUE, -1)

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/silence.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/silence.dm
@@ -22,6 +22,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	zizo_spell = TRUE
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/silence/cast(list/targets, mob/user = usr)
 	if(iscarbon(targets[1]))

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/transform.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/transform.dm
@@ -4,7 +4,7 @@
 	invocations = list("Blood shall feed the flowers!")
 	invocation_type = "shout"
 	overlay_state = "tamebeast"
-	human_req = FALSE
+	human_req = TRUE
 	range = -1
 	include_user = TRUE
 	recharge_time = 120 SECONDS // cause too little is cheaty, too much is pain
@@ -37,7 +37,7 @@
 	invocations = list("Spin and Skitter!")
 	invocation_type = "shout"
 	overlay_state = "tamebeast"
-	human_req = FALSE
+	human_req = TRUE
 	range = -1
 	include_user = TRUE
 	recharge_time = 60 SECONDS

--- a/code/modules/spells/spell_types/wizard/kinesis/fetch.dm
+++ b/code/modules/spells/spell_types/wizard/kinesis/fetch.dm
@@ -30,6 +30,8 @@
 	spell_tier = 2
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/fetch
 	name = "bolt of fetching"
 	icon_state = "cursehand0"

--- a/code/modules/spells/spell_types/wizard/kinesis/repel.dm
+++ b/code/modules/spells/spell_types/wizard/kinesis/repel.dm
@@ -29,6 +29,8 @@
 	spell_tier = 2
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /datum/action/cooldown/spell/projectile/repel/cast(atom/cast_on)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner

--- a/code/modules/spells/spell_types/wizard/kinesis/soulshot.dm
+++ b/code/modules/spells/spell_types/wizard/kinesis/soulshot.dm
@@ -33,6 +33,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_tier = 2
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/soulshot
 	name = "soulshot"
 	tracer_type = /obj/effect/projectile/tracer/bloodsteal

--- a/code/modules/spells/spell_types/wizard/projectiles_single/air_blade.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/air_blade.dm
@@ -33,6 +33,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
 	cost = 3 // Just in case
+	human_req = TRUE
 
 /obj/effect/proc_holder/spell/invoked/projectile/airblade/cast(list/targets, mob/user = user)
 	var/mob/living/carbon/human/H = user

--- a/code/modules/spells/spell_types/wizard/projectiles_single/blood_steal.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/blood_steal.dm
@@ -24,6 +24,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/blood
 	cost = 3
+	human_req = TRUE
 
 /obj/projectile/magic/bloodsteal
 	name = "blood steal"

--- a/code/modules/spells/spell_types/wizard/projectiles_single/greater_arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/greater_arcyne_bolt.dm
@@ -34,6 +34,8 @@
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 	attunement_school = ASPECT_NAME_KINESIS
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/greater_arcyne_bolt
 	name = "greater arcyne bolt"
 	icon = 'icons/obj/magic_projectiles.dmi'

--- a/code/modules/spells/spell_types/wizard/pyromancy/fire_blast.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/fire_blast.dm
@@ -29,6 +29,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/line_length = 4
 	var/blast_damage = 30
 	var/push_dist = 2

--- a/code/modules/spells/spell_types/wizard/pyromancy/fire_curtain.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/fire_curtain.dm
@@ -32,6 +32,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_HIGH
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/curtain_width = 5
 	var/curtain_depth = 2
 	var/hotspot_life = 20 // hotspot subsystem ticks, not deciseconds. 20 ticks × 5 ds/tick = 10 seconds

--- a/code/modules/spells/spell_types/wizard/pyromancy/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/fireball.dm
@@ -32,6 +32,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_tier = 3
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/aoe/fireball/rogue
 	name = "fireball"
 	speed = MAGE_PROJ_VERY_SLOW

--- a/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/pyromancy/spitfire.dm
@@ -31,6 +31,8 @@
 	associated_skill = /datum/skill/magic/arcane
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /obj/projectile/magic/spitfire
 	name = "spitfire"
 	icon_state = "fireball"

--- a/code/modules/spells/spell_types/wizard/telomancy/arcyne_barrage.dm
+++ b/code/modules/spells/spell_types/wizard/telomancy/arcyne_barrage.dm
@@ -34,6 +34,8 @@
 	spell_tier = 4
 	spell_impact_intensity = SPELL_IMPACT_HIGH
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/channel_duration = 10 SECONDS
 	var/pulse_interval = 1 SECONDS
 	var/arc_width = 120

--- a/code/modules/spells/spell_types/wizard/telomancy/arcyne_salvo.dm
+++ b/code/modules/spells/spell_types/wizard/telomancy/arcyne_salvo.dm
@@ -34,6 +34,8 @@
 	spell_tier = 3
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /datum/action/cooldown/spell/projectile/arcyne_salvo/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)
 	. = ..()
 	var/base_angle = to_fire.Angle

--- a/code/modules/spells/spell_types/wizard/telomancy/energetic_blast.dm
+++ b/code/modules/spells/spell_types/wizard/telomancy/energetic_blast.dm
@@ -30,6 +30,8 @@
 	spell_tier = 2
 	spell_impact_intensity = SPELL_IMPACT_MEDIUM
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 	var/line_length = 4
 	var/blast_damage = 55
 	var/push_dist = 3

--- a/code/modules/spells/spell_types/wizard/telomancy/seeker_volley.dm
+++ b/code/modules/spells/spell_types/wizard/telomancy/seeker_volley.dm
@@ -33,6 +33,8 @@
 	attunement_school = ASPECT_NAME_TELOMANCY
 	spell_impact_intensity = SPELL_IMPACT_LOW
 
+	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
+
 /datum/action/cooldown/spell/projectile/seeker_volley/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)
 	. = ..()
 	if(istype(to_fire, /obj/projectile/magic/seeker_orb))


### PR DESCRIPTION
## About The Pull Request
An audit through a bunch of legacy holy and mostly new mage spells to gate all of the offensive ones behind a human requirement, which was added onto light, regen ward but I forgot to add it to every single offensive wizard spells hello???

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1125" height="944" alt="dreamseeker_aLMogwVgxv" src="https://github.com/user-attachments/assets/49dbacf9-bfe9-4a4f-8086-dbf8c39fc80b" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I don't want FPV drone in my game. 

Unless I coded it :)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: A large amount of offensive spells has been audited and should no longer be possible to cast in shapeshifted form. Report any that is missing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
