### PR TITLE
Add actual description to fermented crab triumph

### DIFF
--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -428,6 +428,7 @@
 
 /datum/loadout_item/triumph_fermented_crab
 	name = "Fermented Crab"
+	desc = "A man thinks he's done, drinks a mouthful of this. Five minutes later he's back in the race."
 	path = /obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab
 	triumph_cost = 5
 	sort_category = "Triumphs"


### PR DESCRIPTION
Add description for triumph_fermented_crab item.

## About The Pull Request

Uses part of the brewing recipe description for fermented crab in loadout

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

So people actually know what this does instead of getting the generic vial description

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
Minor