### PR TITLE
Wretch Rogue Mage utility buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/roguemage.dm
@@ -1,7 +1,7 @@
 // Rogue Mage, a pure mage adventurer sidegrade to Necromancer without the Necromancer free spells and forced patron.
 /datum/advclass/wretch/roguemage
 	name = "Rogue Mage"
-	tutorial = "They reject your genius, they cast you out, they call you unethical. They do not understand the SACRIFICES you must make. But it does not matter anymore, your power eclipse any of those fools, save for the Court Magos themselves. Show them true magic. Why do I have an eyepatch?"
+	tutorial = "They reject your genius, they cast you out, they call you unethical. They do not understand the SACRIFICES you must make. But it does not matter anymore, your power eclipse any of those fools, save for the Court Magos themselves. Show them true magic."
 	allowed_sexes = list(MALE, FEMALE)
 	
 	outfit = /datum/outfit/job/roguetown/wretch/roguemage
@@ -16,15 +16,21 @@
 		STATKEY_WIL = 1,
 		STATKEY_SPD = 1
 	)
-	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 3, "utilities" = 8, "ward" = TRUE)
+	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 3, "utilities" = 8, "post_aspect_spells" = list(/datum/action/cooldown/spell/message, /datum/action/cooldown/spell/mindlink), "ward" = TRUE)
 	age_mod = /datum/class_age_mod/wretch/rogue_mage
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
 		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT,
@@ -33,9 +39,7 @@
         "Sewing Kit" =  /obj/item/repair_kit,
     )
 
-// Rogue Mage on purpose has nearly the same fit as a Adv Mage / Mage Associate who cast conjure armor roundstart. Call it meta disguise.
 /datum/outfit/job/roguetown/wretch/roguemage/pre_equip(mob/living/carbon/human/H)
-	mask = /obj/item/clothing/mask/rogue/eyepatch // Chuunibyou up to 11.
 	head = /obj/item/clothing/head/roguetown/roguehood/black
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/roguemage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/roguemage.dm
@@ -1,7 +1,7 @@
 // Rogue Mage, a pure mage adventurer sidegrade to Necromancer without the Necromancer free spells and forced patron.
 /datum/advclass/wretch/roguemage
 	name = "Rogue Mage"
-	tutorial = "They reject your genius, they cast you out, they call you unethical. They do not understand the SACRIFICES you must make. But it does not matter anymore, your power eclipse any of those fools, save for the Court Magos themselves. Show them true magic."
+	tutorial = "They reject your genius, they cast you out, they call you unethical. They do not understand the SACRIFICES you must make. But it does not matter anymore, your power eclipse any of those fools, save for the Court Magos themselves. Show them true magic. Why do I have an eyepatch?"
 	allowed_sexes = list(MALE, FEMALE)
 	
 	outfit = /datum/outfit/job/roguetown/wretch/roguemage
@@ -40,6 +40,7 @@
     )
 
 /datum/outfit/job/roguetown/wretch/roguemage/pre_equip(mob/living/carbon/human/H)
+	mask = /obj/item/clothing/mask/rogue/eyepatch // Chuunibyou up to 11.
 	head = /obj/item/clothing/head/roguetown/roguehood/black
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants


### PR DESCRIPTION
## About The Pull Request

Buffs up Rogue Mage to give them:
- Free mindlink + message
- jman knives, apprentice sneaking, swimming, craft and medicine, novice riding.

## Testing Evidence

[screenshot12.webp]

## Why It's Good For The Game

When you look at Mage Associate, Grenzelmage and Naledi, you notice they all have those things above that Rogue Mages do not. Namely, untility skills for crafting time-saving, self-care and flavor, in the case of the Hierophant jman daggers to use what they spawn with, as well with both mercs having two free spells, each totalling 4 points of utility. That puts them over RM's total tally of spellpoints in that category, third minor school aside.

Mages don't nearly rely on gear as much as martial classes do, so any amount of utility you get matters. I decided on Message + Mindlink so that other wretches know they can rely on Rogue Mages as portable radios.

I haven't touched Necromancer since there's another PR open for it, but I can shove the same their way if needed.


## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Rogue Mages receive dagger skill, some utility skills, and innate Message and Mindlink spells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
