### PR TITLE
Misc Gripes Fix

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -47,7 +47,7 @@
 #define TRAIT_CYCLOPS_LEFT "Cyclops (Left)" //poked left eye
 #define TRAIT_CYCLOPS_RIGHT "Cyclops (Right)" //poked right eye
 #define TRAIT_INHUMEN_ANATOMY "Inhumen Anatomy" //can't wear hats and shoes
-#define TRAIT_NASTY_EATER "Inhumen Digestion" //can eat rotten food, organs, poison berries, and drink murky water
+#define TRAIT_NASTY_EATER "Inhumen Digestion" //can eat rotten/raw/burned food, organs, and drink murky water. Does NOT protect against actual poisons.
 #define TRAIT_WILD_EATER "Beastly Digestion" //can eat raw and rotten food and drink murky water
 #define TRAIT_INSPIRING_MUSICIAN "Inspiring Musician" // unlocks bardic inspiration stuff
 #define TRAIT_NOFALLDAMAGE1 "Fall Damage Reduction"
@@ -386,7 +386,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_LEECHIMMUNE = "Leeches are reluctant to bite me.",
 	TRAIT_BITERHELM = "Whether through design or symbiosis, I can now bite into others while wearing a visored helmet.",
 	TRAIT_INHUMEN_ANATOMY = "My anatomy is inhumen, preventing me from wearing hats and shoes.",
-	TRAIT_NASTY_EATER = span_dead("I can eat bad food, and water that would be toxic to humen will not affect me."),
+	TRAIT_NASTY_EATER = span_dead("I can stomach rotten, raw, or burned food, organs, and murky water - but true poisons still afflict me."),
 	TRAIT_WILD_EATER = span_info("I can eat raw food and drink from dirty water."),
 	TRAIT_NOFALLDAMAGE1 = span_warning("I can easily handle minor falls."),
 	TRAIT_NOFALLDAMAGE2 = span_warning("I can handle a fall from any height."),

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -269,10 +269,7 @@
 
 		if(H.mind)
 			H.mind?.special_items["Pouch of Coins"] = /obj/item/storage/belt/rogue/pouch/coins/readyuppouch
-			if (HAS_TRAIT(H, TRAIT_MEDIUMARMOR) || HAS_TRAIT(H, TRAIT_HEAVYARMOR))
-				H.mind?.special_items["Metal Scrap (Repair kit)"] = /obj/item/repair_kit/metal/bad
-			else
-				H.mind?.special_items["Fabric Patch (Repair kit)"] = /obj/item/repair_kit/bad
+			set_readyup_repair_kit(H)
 
 		to_chat(M, span_notice("Rising early, you made sure to pack a pouch of coins in your stash and eat a hearty breakfast before starting your day. A true TRIUMPH!"))
 
@@ -314,6 +311,17 @@
 		hugboxify_for_class_selection(H)
 
 	log_admin("[H.key]/([H.real_name]) has joined as [H.mind.assigned_role].")
+
+/// Sets the ready-up repair kit stash entry based on the mob's current armor traits.
+/// Safe to call multiple times — later calls overwrite earlier ones, so loadout-based armor picks can re-run this to upgrade the kit after choose_loadout finishes.
+/datum/job/proc/set_readyup_repair_kit(mob/living/carbon/human/H)
+	if(!H?.mind)
+		return
+	if(HAS_TRAIT(H, TRAIT_MEDIUMARMOR) || HAS_TRAIT(H, TRAIT_HEAVYARMOR))
+		H.mind.special_items -= "Fabric Patch (Repair kit)"
+		H.mind.special_items["Metal Scrap (Repair kit)"] = /obj/item/repair_kit/metal/bad
+	else
+		H.mind.special_items["Fabric Patch (Repair kit)"] = /obj/item/repair_kit/bad
 
 /// Called when a player permanently leaves the round (via returntolobby). Handles slot reopening and respawn delays.
 /datum/job/proc/on_round_removal(mob/M)

--- a/code/modules/jobs/job_types/roguetown/roguetown.dm
+++ b/code/modules/jobs/job_types/roguetown/roguetown.dm
@@ -100,12 +100,20 @@
 		var/datum/triumph_buy/thing = SStriumphs.post_equip_calls[list_key]
 		thing.on_activate(H)
 	if(has_loadout && H.mind)
-		addtimer(CALLBACK(src, PROC_REF(choose_loadout), H), 50)
+		addtimer(CALLBACK(src, PROC_REF(run_loadout_and_finalize), H), 50)
 	return
+
+/datum/outfit/job/roguetown/proc/run_loadout_and_finalize(mob/living/carbon/human/H)
+	choose_loadout(H)
+	// Re-evaluate the readyup repair kit now that loadout-based armor traits (if any) have been applied.
+	// Late joiners skip the readyup bonus entirely, so only refresh the kit when one was actually granted.
+	if(H?.mind && (H.mind.special_items["Fabric Patch (Repair kit)"] || H.mind.special_items["Metal Scrap (Repair kit)"]))
+		var/datum/job/J = SSjob.GetJob(H.mind.assigned_role)
+		J?.set_readyup_repair_kit(H)
 
 /datum/outfit/job/roguetown/proc/choose_loadout(mob/living/carbon/human/H)
 	if(!has_loadout)
 		return
 	if(!H.client)
-		addtimer(CALLBACK(src, PROC_REF(choose_loadout), H), 50)
+		addtimer(CALLBACK(src, PROC_REF(run_loadout_and_finalize), H), 50)
 		return


### PR DESCRIPTION
## About The Pull Request
- Inhumen Digestion no longer have an inaccurate comment in code and inaccurate trait, and tell you you can eat burnt, rotten or raw food and not refers to POISONED food, which got me.
- The on spawn armor / fabric kit bonus now accounts for POST SPAWN class choices properly. So for example a Hangyaku-Kounen would get a scrap kit instead of a fabric kit

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="656" height="336" alt="dreamseeker_uqIFjmud4O" src="https://github.com/user-attachments/assets/4c1016aa-85af-489e-b2ca-2aac2acc017f" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fixes some annoying quirk I noticed

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Inhumen Digestion no longer have an inaccurate comment in code and inaccurate trait description, and tell you you can eat burnt, rotten or raw food and not refers to POISONED food.
fix: The on spawn armor / fabric kit bonus now accounts for POST SPAWN class choices properly. So for example a Hangyaku-Kounen would get a scrap kit instead of a fabric kit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
