### PR TITLE
Throne oversight fix

### DIFF
--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -475,7 +475,7 @@ GLOBAL_VAR_INIT(last_crown_announcement_time, -1000)
 	priority_announce("All of the land's prior decrees have been purged!", "DECREES PURGED", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
 
 /proc/become_regent(mob/living/carbon/human/H)
-	priority_announce("[H.name], the [H.get_role_title()], sits as the regent of the realm.", "A New Regent Resides", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
+	priority_announce("[H.real_name], the [H.get_role_title()], sits as the regent of the realm.", "A New Regent Resides", pick('sound/misc/royal_decree.ogg', 'sound/misc/royal_decree2.ogg'), "Captain")
 	SSticker.regentmob = H
 	SSticker.regentday = GLOB.dayspassed
 


### PR DESCRIPTION
## About The Pull Request

- Announcement of a Regent will now use your real name, rather than your alias.

## Testing Evidence

- Compiles.

## Why It's Good For The Game
<img width="405" height="224" alt="Screenshot_1" src="https://github.com/user-attachments/assets/5461dd73-9ae7-4fcd-a30d-a211369a172e" />

## Changelog
:cl:
fix: No more aliases as Regent.
/:cl: