### PR TITLE
fixes siegebows slowdown

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo_bolts.dm
@@ -206,7 +206,7 @@
 		M.visible_message(span_warning("[M] staggers back from the tremendous impact!"))
 		M.apply_status_effect(/datum/status_effect/debuff/staggered, 6 SECONDS)
 		M.apply_status_effect(/datum/status_effect/debuff/exposed, 6 SECONDS) //Done in conjunction with the new Feint testmerge - opens up for a single integrity-destroying attack.
-		M.Slowdown(6 SECONDS)
+		M.Slowdown(6)
 		M.OffBalance(1 SECONDS)
 		M.Immobilize(1 SECONDS)
 		return


### PR DESCRIPTION
## About The Pull Request

yeah it turns out it just starts giving u a fuckton of slowdown for the next 6 seconds which stacks instead of slowing u for 6 seconds

## Testing Evidence

instead of having 60 slowdown when you shoot someone they get 6 slowdown

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

its best you don't get a 2 minute giga slowdown for getting shot

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: fixed siegebow slowdown to actually be 6 seconds
/:cl: