### PR TITLE
[Dreamwalker] - Simple clarification change.

### DIFF
--- a/code/modules/antagonists/roguetown/villain/dreamwalker/dreamwalker_gear.dm
+++ b/code/modules/antagonists/roguetown/villain/dreamwalker/dreamwalker_gear.dm
@@ -366,7 +366,7 @@
 	new shard_type(center, shard_duration, shard_amount, chosen_spawn)
 	
 	if(prob(40))
-		to_chat(L, span_notice("A shard of your armor shatters onto the floor!"))
+		L.visible_message(span_boldnotice("[L.name] sheds a fragile looking shard of their armor. It seems to yearn to return to the whole."))
 
 /datum/component/dreamwalker_repair/proc/is_tile_valid(turf/T)
 	if(!T || istransparentturf(T) || T.density)
@@ -419,7 +419,7 @@
 
 /obj/effect/temp_visual/dream_shard
 	name = "dream shard"
-	desc = "A jagged fragment of iridescent reality. It pulses with restorative energy."
+	desc = "Looks fragile, smashable even. A grouping of jagged fragments of iridescence. They pulse with restorative energy."
 	icon_state = "dream_shards"
 	layer = ABOVE_OBJ_LAYER
 	plane = GAME_PLANE


### PR DESCRIPTION
## About The Pull Request
Attempts to make it more obvious you can break shard to deny them from dreamwalkers.
May need additional visual feedback or indicators later. But let's see if this helps.

## Testing Evidence
Simple change, tested, seems to work.

## Why It's Good For The Game
Qol Yay


## Changelog

:cl:
qol: Clarified dreamwalker shards being destructible.
/:cl:
