### PR TITLE
[Bugfix] - Forgot to push puzzlebox loot lock

### DIFF
--- a/code/game/objects/items/mundanities.dm
+++ b/code/game/objects/items/mundanities.dm
@@ -99,6 +99,7 @@
 	icon_state = "grimace_box"
 	var/fluff_desc = null
 	var/list/finished_ckeys = list()
+	var/looted_box = FALSE
 	sellprice = 150
 
 	grid_width = 32
@@ -111,12 +112,15 @@
 
 /obj/item/mundane/puzzlebox/impossible/attack_self(mob/living/user)
 	var/ckey = user.ckey
+	if(looted_box)
+		to_chat(user, span_notice("This puzzlebox has already yielded its contents, all that remains past the open slider is an empty void."))
+		return
 	if(ckey in finished_ckeys)
 		to_chat(user, span_warning("I've already tried my hand at [src]."))
 		return
 	playsound(src.loc, 'sound/items/wood_sharpen.ogg', 75, TRUE)
 	playsound(src.loc, 'sound/items/visor.ogg', 75, TRUE)
-	if (alert(user, "My fingers trace the outside of this box. It looks nearly impossible. Do I try to solve it?", "ROGUETOWN", "Yes", "No") != "Yes")
+	if(alert(user, "My fingers trace the outside of this box. It looks nearly impossible. Do I try to solve it?", "ROGUETOWN", "Yes", "No") != "Yes")
 		return
 	if(do_after(user,100, target = src))
 		var/success_chance = clamp(10 + user.STAINT, 10, 30)
@@ -127,6 +131,7 @@
 			playsound(src.loc, 'sound/foley/doors/lockrattle.ogg', 75, TRUE)
 			to_chat(user, span_notice("As I pop open \the [src], I feel a tingling wave run from my head to my feet. Excitement bubbling in my core as two particularly rare rings tumble forth!"))
 			new /obj/effect/spawner/lootdrop/puzzlebox_rings(get_turf(src))
+			looted_box = TRUE
 			finished_ckeys += ckey
 			playsound(src.loc, 'sound/foley/doors/lock.ogg', 75, TRUE)
 			playsound(src.loc, 'sound/items/visor.ogg', 75, TRUE)


### PR DESCRIPTION
## About The Pull Request
- Stops you from being able to complete royal puzzleboxes more than once if you find enough gubbins to try them.

## Testing Evidence
<img width="1398" height="838" alt="image" src="https://github.com/user-attachments/assets/d9a4a7c6-dab0-489f-bf2a-024538f58da9" />

## Why It's Good For The Game
Didn't push this, woops

## Changelog

:cl:
fix: stops players from getting rings x people on the server from royal puzzleboxes
/:cl:

