### PR TITLE
[bugfix] werewolf/gnoll claw special

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -253,7 +253,7 @@
 	parrysound = list('sound/combat/parry/parrygen.ogg')
 	embedding = list("embedded_pain_multiplier" = 0, "embed_chance" = 0, "embedded_fall_chance" = 0)
 	item_flags = DROPDEL
-	special = /datum/special_intent/axe_swing	//Good pairing for area denial for WW's.
+	special = /datum/special_intent/axe_swing/graggarite	//Good pairing for area denial for WW's.
 	experimental_inhand = FALSE
 
 /obj/item/rogueweapon/werewolf_claw/right


### PR DESCRIPTION
## About The Pull Request

Claws special wasn't working cause axe special needs wielding.

## Testing Evidence

Tested. It works now.

## Why It's Good For The Game

Bug

:cl:
fix: Gnoll / Werewolf claws now do have special once again.
/:cl:

