### PR TITLE
combat mode toggles sneak and vice versa

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -783,6 +783,8 @@
 /atom/movable/screen/rogmove/proc/toggle(mob/user)
 	if(isobserver(user))
 		return
+	if(user.cmode)
+		user.toggle_cmode()
 	if(user.m_intent == MOVE_INTENT_SNEAK)
 		user.toggle_rogmove_intent(MOVE_INTENT_WALK)
 	else

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -120,6 +120,8 @@
 	var/mob/M = user.mob
 	if(!isliving(M))
 		return
+	if(M.cmode)
+		M.toggle_cmode()
 	if(M.m_intent == MOVE_INTENT_SNEAK)
 		M.toggle_rogmove_intent(MOVE_INTENT_WALK)
 	else

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -760,6 +760,8 @@
 		playsound_local(src, 'sound/misc/combon.ogg', 100)
 		if(length(L.cmode_music_override))
 			SSdroning.play_combat_music(L.cmode_music_override, client)
+		if(L.m_intent == MOVE_INTENT_SNEAK)
+			toggle_rogmove_intent(MOVE_INTENT_WALK, TRUE)
 		else if(L.cmode_music)
 			SSdroning.play_combat_music(L.cmode_music, client)
 		if(client && HAS_TRAIT(src, TRAIT_PSYCHOSIS))

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -213,7 +213,7 @@
 		"Darksight" = TRAIT_DARKVISION,
 		"Light Steps" = TRAIT_LIGHT_STEP,
 		"Stashed Lockpick Ring" = /obj/item/lockpickring/mundane,
-		"Sneak Skill (+2, Up to Legendary)" = /datum/skill/misc/sneaking,
+		"Sneak Skill (+2, Up to Expert)" = /datum/skill/misc/sneaking,
 		"Lockpick Skill (+3, Up to Legendary)" = /datum/skill/misc/lockpicking,
 		"Second Voice"
 		)
@@ -231,7 +231,7 @@
 						recipient.verbs += /mob/living/carbon/human/proc/toggleblindness
 			else if(ispath(extra_choices[choice], /datum/skill))
 				if(extra_choices[choice] == /datum/skill/misc/sneaking)
-					recipient.adjust_skillrank(extra_choices[choice], SKILL_LEVEL_APPRENTICE, silent = TRUE)
+					recipient.adjust_skillrank_up_to(extra_choices[choice], SKILL_LEVEL_EXPERT, silent = TRUE)
 				else if(extra_choices[choice] == /datum/skill/misc/lockpicking)
 					recipient.adjust_skillrank(extra_choices[choice], SKILL_LEVEL_JOURNEYMAN, silent = TRUE)
 			else if(ispath(extra_choices[choice], /obj/item))

--- a/code/modules/virtues/utility.dm
+++ b/code/modules/virtues/utility.dm
@@ -213,7 +213,7 @@
 		"Darksight" = TRAIT_DARKVISION,
 		"Light Steps" = TRAIT_LIGHT_STEP,
 		"Stashed Lockpick Ring" = /obj/item/lockpickring/mundane,
-		"Sneak Skill (+2, Up to Expert)" = /datum/skill/misc/sneaking,
+		"Sneak Skill (+2, Up to Legendary)" = /datum/skill/misc/sneaking,
 		"Lockpick Skill (+3, Up to Legendary)" = /datum/skill/misc/lockpicking,
 		"Second Voice"
 		)
@@ -231,7 +231,7 @@
 						recipient.verbs += /mob/living/carbon/human/proc/toggleblindness
 			else if(ispath(extra_choices[choice], /datum/skill))
 				if(extra_choices[choice] == /datum/skill/misc/sneaking)
-					recipient.adjust_skillrank_up_to(extra_choices[choice], SKILL_LEVEL_EXPERT, silent = TRUE)
+					recipient.adjust_skillrank(extra_choices[choice], SKILL_LEVEL_APPRENTICE, silent = TRUE)
 				else if(extra_choices[choice] == /datum/skill/misc/lockpicking)
 					recipient.adjust_skillrank(extra_choices[choice], SKILL_LEVEL_JOURNEYMAN, silent = TRUE)
 			else if(ispath(extra_choices[choice], /obj/item))


### PR DESCRIPTION
## About The Pull Request

combat mode toggles sneak off
sneak toggles combat mode off

## Testing Evidence


https://github.com/user-attachments/assets/eecffa21-9d84-4231-be91-8cbc15dcf145


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

people fighting while invisible is kinda silly. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: sneak/combat mode toggle one-another
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
