### PR TITLE
Mistwalker Tweaks

### DIFF
--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -589,7 +589,7 @@
 	icon_state = "kazscabyuruku"
 	item_state = "kazscabyuruku"
 	valid_blade = /obj/item/rogueweapon/sword/short/kazengun
-	wdefense = 4
+	wdefense = 7
 	special = null
 
 /obj/item/rogueweapon/scabbard/sheath/kazengun

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -266,7 +266,8 @@
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats/mistwalker
 	name = "seon-mul tattoos"
 	desc = "The flowing clouds of the Ruma are but fleeting shadow across the plains, pale imitation of Xinyi's spiritual alchemy. Imperfect, impotent. Their legend is one writ in avarice and hate.</br></br>Recount yours in love."
-	max_integrity = 400
+	armor = ARMOR_LEATHER
+	max_integrity = 450
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/gladiator
 	name = "gladiator's skin"

--- a/code/modules/clothing/rogueclothes/armor/regenerating.dm
+++ b/code/modules/clothing/rogueclothes/armor/regenerating.dm
@@ -252,7 +252,7 @@
 	icon = 'icons/roguetown/clothing/shirts.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/shirts.dmi'
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_shirts.dmi'
-	allowed_race = NON_DWARVEN_RACE_TYPES
+	//allowed_race = NON_DWARVEN_RACE_TYPES
 	max_integrity = 350
 
 	repairmsg_begin = "The tattoos begin to slowly mend their abuse..."
@@ -262,6 +262,11 @@
 
 	interrupt_damount = 20
 	repair_time = 30 SECONDS
+
+/obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats/mistwalker
+	name = "seon-mul tattoos"
+	desc = "The flowing clouds of the Ruma are but fleeting shadow across the plains, pale imitation of Xinyi's spiritual alchemy. Imperfect, impotent. Their legend is one writ in avarice and hate.</br></br>Recount yours in love."
+	max_integrity = 400
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/disciple/gladiator
 	name = "gladiator's skin"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
@@ -61,19 +61,19 @@
 		)
 
 	if(H.mind)
-		var/armor = list("Ceremonial Robes", "Enchanted Inks")
+		var/armor_options = list("Ceremonial Robes", "Enchanted Inks")
 		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armor
 		var/weapons = list("Ssangsudo +2 CON", "Kanabo +1 STR", "Naginata +2 PER", "Hwando +2 INT", "Longbow +1 SPD")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
-		switch(armor_choice)
+		switch(armor_options)
 			if("Ceremonial Robes")
 				neck = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/black
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/black
 				if(H.dna.species.type in NON_DWARVEN_RACE_TYPES)
 					armor = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
-					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 				else
 					armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket/black
 					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun/black
@@ -104,9 +104,9 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
 				beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
-				H.change_stat(STATKEY_WIL, 2)
+				H.change_stat(STATKEY_INT, 2)
 			if("Longbow +1 SPD") //they still have the expert knives for melee
-				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_MASTER, TRUE) //no dexpert, armor, or innately high SPD-PER - let them have this bone
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_EXPERT, TRUE) //no dexpert, armor, or innately high SPD-PER - let them have this bone
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 				beltr = /obj/item/quiver/arrows
 				H.change_stat(STATKEY_SPD, 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
@@ -119,6 +119,11 @@
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 				beltr = /obj/item/quiver/arrows
 				H.change_stat(STATKEY_SPD, 1)
+			if("Kodachi +1 SPD")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/rogueweapon/sword/short/kazengun
+				beltr = /obj/item/rogueweapon/scabbard/sword/kazengun/kodachi
+				H.change_stat(STATKEY_SPD, 1)
 
 		wretch_select_bounty(H)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
@@ -46,9 +46,7 @@
 	to_chat(H, span_warning("Failed in your duty, outcast from whence you came you wander. Only the steel in your hand can be trusted."))
 
 	head = /obj/item/clothing/head/roguetown/mentorhat
-	gloves = /obj/item/clothing/gloves/roguetown/eastgloves1 //eh could be a regular one too
 	mask = /obj/item/clothing/mask/rogue/facemask/steel/kazengun //let them have this
-	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel
@@ -73,17 +71,28 @@
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/black
 				if(H.dna.species.type in NON_DWARVEN_RACE_TYPES)
 					armor = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
-					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun/black
+					gloves = /obj/item/clothing/gloves/roguetown/eastgloves1
+					shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 				else
 					armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket/black
-					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun/black
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+					gloves = /obj/item/clothing/gloves/roguetown/angle
+					shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced //dwarves like to blow up my patience
 			if("Enchanted Inks")
 				neck = /obj/item/clothing/neck/roguetown/coif/heavypadding/black
 				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats/mistwalker //they don't get stronger swords like ruma, let them have the +50 integ
 				shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
-				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
 				ADD_TRAIT(H, TRAIT_HONORBOUND, TRAIT_GENERIC)
+				if(H.dna.species.type in NON_DWARVEN_RACE_TYPES)
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun/black
+					gloves = /obj/item/clothing/gloves/roguetown/eastgloves1
+					shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
+				else
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+					gloves = /obj/item/clothing/gloves/roguetown/angle
+					shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 		switch(weapon_choice)
 			if("Ssangsudo +2 CON")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
@@ -9,12 +9,12 @@
 	class_select_category = CLASS_CAT_WARRIOR
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_NOPAINSTUN, TRAIT_BLOOD_RESISTANCE, TRAIT_JOURNEYS_END) //no armour, literally made to bleed
-	maximum_possible_slots = 1 //you probably don't want many of these
+	maximum_possible_slots = 2 //you probably don't want many of these - edit: let them bring a friend/rival
 
 	cmode_music = 'sound/music/combat_Kazengun_Firestorm.ogg'
 	subclass_stats = list(
-		STATKEY_STR = 2, //8 weighted with weapon buff, same as berserker
-		STATKEY_CON = 1,
+		STATKEY_STR = 2, //9 weighted with weapon buff, same as berserker
+		STATKEY_CON = 2,
 		STATKEY_WIL = 1
 	)
 	subclass_skills = list(
@@ -22,14 +22,16 @@
 		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN, //wish there was an oni axe or something
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/bows = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_APPRENTICE, //my dynasty is highly learned and we wear all shadow and leave no souls to recount our legend
 		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN, //you'll get real familiar with bleeding
-		/datum/skill/labor/butchering = SKILL_LEVEL_JOURNEYMAN, //flavour and useful for making armour
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE, //social outcast but can still read protective charms
+		/datum/skill/labor/butchering = SKILL_LEVEL_JOURNEYMAN, //flavour and useful for making armour
 	)
 	subclass_stashed_items = list(
         "Sewing Kit" =  /obj/item/repair_kit, //I am sure you'll find a way to repair your bracers
@@ -42,21 +44,11 @@
 	
 	change_origin(H, /datum/virtue/origin/kazengun, "guardian duty")
 	to_chat(H, span_warning("Failed in your duty, outcast from whence you came you wander. Only the steel in your hand can be trusted."))
-	
-	if(H.dna.species.type in NON_DWARVEN_RACE_TYPES)
-		armor = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
-		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
-	else
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket/black
-		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun/black
 
 	head = /obj/item/clothing/head/roguetown/mentorhat
-	gloves = /obj/item/clothing/gloves/roguetown/eastgloves1
-	neck = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun //eh could be a regular one too
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/black
+	gloves = /obj/item/clothing/gloves/roguetown/eastgloves1 //eh could be a regular one too
 	mask = /obj/item/clothing/mask/rogue/facemask/steel/kazengun //let them have this
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/black
-	shoes = /obj/item/clothing/shoes/roguetown/boots
+	shoes = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	belt = /obj/item/storage/belt/rogue/leather/black
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	backl = /obj/item/storage/backpack/rogue/satchel
@@ -69,9 +61,29 @@
 		)
 
 	if(H.mind)
-		var/weapons = list("Ssangsudo +2 CON", "Kanabo +1 STR", "Naginata +2 PER", "Hwando +2 WIL", "Kodachi +1 SPD")
+		var/armor = list("Ceremonial Robes", "Enchanted Inks")
+		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armor
+		var/weapons = list("Ssangsudo +2 CON", "Kanabo +1 STR", "Naginata +2 PER", "Hwando +2 INT", "Longbow +1 SPD")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
+		switch(armor_choice)
+			if("Ceremonial Robes")
+				neck = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/black
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/black
+				if(H.dna.species.type in NON_DWARVEN_RACE_TYPES)
+					armor = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
+				else
+					armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket/black
+					pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun/black
+			if("Enchanted Inks")
+				neck = /obj/item/clothing/neck/roguetown/coif/heavypadding/black
+				armor = /obj/item/clothing/suit/roguetown/armor/regenerating/skin/easttats/mistwalker //they don't get stronger swords like ruma, let them have the +50 integ
+				shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1
+				ADD_TRAIT(H, TRAIT_HONORBOUND, TRAIT_GENERIC)
 		switch(weapon_choice)
 			if("Ssangsudo +2 CON")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
@@ -88,15 +100,15 @@
 				r_hand = /obj/item/rogueweapon/spear/naginata
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 				H.change_stat(STATKEY_PER, 2)
-			if("Hwando +2 WIL")
+			if("Hwando +2 INT")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/rogueweapon/sword/sabre/mulyeog
 				beltr = /obj/item/rogueweapon/scabbard/sword/kazengun
 				H.change_stat(STATKEY_WIL, 2)
-			if("Kodachi +1 SPD") //SPD you can dodge, probably
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
-				r_hand = /obj/item/rogueweapon/sword/short/kazengun
-				beltr = /obj/item/rogueweapon/scabbard/sword/kazengun/kodachi
+			if("Longbow +1 SPD") //they still have the expert knives for melee
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_MASTER, TRUE) //no dexpert, armor, or innately high SPD-PER - let them have this bone
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
+				beltr = /obj/item/quiver/arrows
 				H.change_stat(STATKEY_SPD, 1)
 
 		wretch_select_bounty(H)
@@ -106,6 +118,8 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/black
 	color = CLOTHING_BLACK
 /obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket/black
+	color = CLOTHING_BLACK
+/obj/item/clothing/neck/roguetown/coif/heavypadding/black
 	color = CLOTHING_BLACK
 /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun/black
 	color = CLOTHING_BLACK

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/mistwalker.dm
@@ -60,11 +60,11 @@
 
 	if(H.mind)
 		var/armor_options = list("Ceremonial Robes", "Enchanted Inks")
-		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armor
+		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armor_options
 		var/weapons = list("Ssangsudo +2 CON", "Kanabo +1 STR", "Naginata +2 PER", "Hwando +2 INT", "Longbow +1 SPD")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
-		switch(armor_options)
+		switch(armor_choice)
 			if("Ceremonial Robes")
 				neck = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/black


### PR DESCRIPTION
## About The Pull Request

Tweaks Mistwalker with a slight power boost, a loadout spangle, and a new option to have Ruma-lite skin armor with honorbound restrictions:
- Upped slots to 2.
- 1 more point of CON to bring them up to 9 stat weight.
- Apprentice sneaking and bow skills.
- New armor option - Honorbound (no metal armor on major targetzones) with leather-tier regenerating skin.
- Hwando gives +2 INT instead of +2 WIL now.
- Kodachi scabbard gets bumped to 7 wdef.

- Ruma clan tattoo item's non-dwarf restriction lifted. There shouldn't be any jank aside from them being invisible on short monarchs.
- Small races get proper substitute equipment for what they don't have sprites for (i should have clarified this better)

Tweaking out done with permission from the original creator, Eiren. Big thanks to her for all the hard work!!

## Testing Evidence

<img width="256" height="230" alt="image" src="https://github.com/user-attachments/assets/56bf2b23-b35b-423e-aa41-0eae082d7c7f" />
<img width="468" height="497" alt="image" src="https://github.com/user-attachments/assets/ab78ac10-203d-4ea9-a93e-b6e771ac5473" />



## Why It's Good For The Game

Mistwalkers (especially for a slot-limited role) have always been a slight behind other wretches. This jaks them up a single notch, while also giving them some new options.
Their skin option leaves them way less durable than the otherwise-equivalent berserkers. Should be fine.
Hwando option has been mid because, unlike classes succeptible to pain, they don't really benefit from higher WIL as much. INT can help them play into the sword-saint fantasy a little better.
Kodachi's scabbard wdef bumped up to contend with hwando a little better. Only ninja advs get this, I don't think it'll impact them much with how they rely on DExpert instead.


## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Mistwalkers have received a small buff, alongside an for regenerating skin armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
