### PR TITLE
Fix Orison

### DIFF
--- a/code/modules/spells/orison.dm
+++ b/code/modules/spells/orison.dm
@@ -354,7 +354,7 @@
 				holder.remove_reagent(R.type, 0.2 * REAGENTS_EFFECT_MULTIPLIER)
 		var/list/wCount = M.get_wounds()
 		if(wCount.len > 0)
-			M.heal_wounds(2 * REAGENTS_EFFECT_MULTIPLIER)
+			M.heal_wounds(2)
 		..()
 
 /datum/action/cooldown/spell/touch/orison/proc/create_water(obj/item/melee/new_touch_attack/hand, atom/victim, mob/living/carbon/caster, list/modifiers)


### PR DESCRIPTION
## About The Pull Request

I was overzealous with the reagent multiplier

## Testing Evidence

not even a full line change, it compiles

## Why It's Good For The Game

as of now my previous mistake made pestran medicine heals 5 wounds damage per ticks, making it stronger than strong red.
reducing it to 2 by removing the multiplier should be healthy for the game.

