### PR TITLE
Removes smoke cloud from NPC (goblin pyromancer) bottlebombs

### DIFF
--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -80,7 +80,7 @@
 			target.adjustFireLoss(PVE_damage)
 	if(spawn_shard)
 		new /obj/item/natural/glass_shard(T)
-	explosion(T, light_impact_range = 1, flame_range = 2, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
+	explosion(T, light_impact_range = 1, flame_range = 2, smoke = spawn_shard, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
 	return TRUE
 
 /obj/item/bomb/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)


### PR DESCRIPTION
## About The Pull Request
Bottlebombs thrown by npcs with infinite amounts of them, like goblin pyromancers, will no longer spawn a smoke cloud in addition to not spawning glass shards

## Testing Evidence
compiles. it's a 1 word change, if this runtimes it will be an act of psydon

## Why It's Good For The Game
it was this or remove goblin pyromancers entirely.

hot take but having enemies that constantly coat the battlefield in an aura of 'you literally cannot see anything' until they kill themselves and half their allies is not fun nor is it good game design. bottlebombs are normally quite rare, and are in fact annoying as shit to deal with constantly especially in low-paying contracts near town. at least when they don't block off half the screen you can dodge

## Changelog

:cl:
fix: NPC bottlebombs no longer create smoke clouds.
/:cl: