### PR TITLE
Update mask.dm

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -245,6 +245,33 @@
 	desc = "An ordinary brown sack. This one has eyeholes cut into it, bearing a crude chalk drawing of Psydon's cross upon its visage. Unsettling for most."
 	icon_state = "sackmask_psy"
 
+/obj/item/clothing/mask/rogue/facemask
+	name = "iron mask"
+	desc = "A simple, utilitarian mask designed to protect the face from oncoming blows."
+	icon_state = "imask"
+	max_integrity = 100
+	blocksound = PLATEHIT
+	break_sound = 'sound/foley/breaksound.ogg'
+	drop_sound = 'sound/foley/dropsound/armor_drop.ogg'
+	resistance_flags = FIRE_PROOF
+	armor = ARMOR_PLATE
+	flags_inv = HIDEFACE|HIDESNOUT
+	body_parts_covered = FACE
+	block2add = FOV_BEHIND
+	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HIP
+	experimental_onhip = TRUE
+	anvilrepair = /datum/skill/craft/armorsmithing
+	smeltresult = /obj/item/ingot/iron
+	stack_fovs = TRUE
+
+/obj/item/clothing/mask/rogue/facemask/steel
+	name = "steel mask"
+	desc = "Expressionless steel sits where a face ought to be. It is better to be \
+	safe than to be known."
+	icon_state = "smask"
+	max_integrity = 200
+	smeltresult = /obj/item/ingot/steel
+
 /obj/item/clothing/mask/rogue/facemask/steel/confessor
 	name = "strange mask"
 	desc = "It is said that the original version of this mask was used for obscure rituals prior to the fall of the Empire of the Holy Celestia, and now it has been repurposed as a veil for the cunning hand of the Otavan Orthodoxy.<br> <br>Others say it is a piece of heresy, a necessary evil, capable of keeping its user safe from left-handed magicks. You can taste copper whenever you draw breath."
@@ -336,25 +363,6 @@
 	smeltresult = /obj/item/ingot/iron
 	stack_fovs = TRUE
 
-/obj/item/clothing/mask/rogue/facemask
-	name = "iron mask"
-	desc = "A simple, utilitarian mask designed to protect the face from oncoming blows."
-	icon_state = "imask"
-	max_integrity = 100
-	blocksound = PLATEHIT
-	break_sound = 'sound/foley/breaksound.ogg'
-	drop_sound = 'sound/foley/dropsound/armor_drop.ogg'
-	resistance_flags = FIRE_PROOF
-	armor = ARMOR_PLATE
-	flags_inv = HIDEFACE|HIDESNOUT
-	body_parts_covered = FACE
-	block2add = FOV_BEHIND
-	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_HIP
-	experimental_onhip = TRUE
-	anvilrepair = /datum/skill/craft/armorsmithing
-	smeltresult = /obj/item/ingot/iron
-	stack_fovs = TRUE
-
 /obj/item/clothing/mask/rogue/facemask/ComponentInitialize()
 	AddComponent(/datum/component/armour_filtering/positive, TRAIT_FENCERDEXTERITY)
 
@@ -414,14 +422,6 @@
 	desc = "A silver mask, forever locked in a rigor of uncontestable joy. The Order of Saint Xylix can't decide on whether it's meant to represent Psydon's 'mirthfulness,' 'theatricality,' or the unpredictable melding of both."
 	icon_state = "psydonmask"
 	item_state = "psydonmask"
-
-/obj/item/clothing/mask/rogue/facemask/steel
-	name = "steel mask"
-	desc = "Expressionless steel sits where a face ought to be. It is better to be \
-	safe than to be known."
-	icon_state = "smask"
-	max_integrity = 200
-	smeltresult = /obj/item/ingot/steel
 
 /obj/item/clothing/mask/rogue/facemask/steel/graggar
 	name = "vicious jawmask"


### PR DESCRIPTION
## About The Pull Request

Moves base class defines higher up in the file so they're read first and also easier to find for future devs.

No balance changes have been made.

## Testing Evidence

I just moved the defines. Nothing has changed.

## Why It's Good For The Game

It's dumb that the masks that all other armored masks are based on are for some reason _in the middle_ of the file.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
refactor: Moved some defines in mask.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Additional Notes
Does anyone know how to remove just eye protection from a mask? Or do all masks not even have eye protection by default? I was looking at this because I thought it was dumb that the "soldier half-mask" has a worse armor rating when it's still made of steel. Someone seems to have been lazy about how they coded this. I got frustrated when I couldn't find the defines where I thought they would be, hence this change.