### PR TITLE
Axes antag job metachecks for recruit verbs + Fixes brotherhood recruit verb + Adminlogs for it I guess.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -495,9 +495,9 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	else
 		to_chat(user, span_warning("Recruitment cancelled."))
 
-/obj/effect/proc_holder/spell/self/convertrole/proc/can_convert(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
+/obj/effect/proc_holder/spell/self/convertrole/proc/can_convert(mob/living/carbon/human/recruit)
 	//wtf
-	if(QDELETED(recruit) || QDELETED(recruiter))
+	if(QDELETED(recruit))
 		return FALSE
 	//need a mind
 	if(!recruit.mind)
@@ -506,8 +506,10 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	if(!(recruit.job in GLOB.peasant_positions) && \
 		!(recruit.job in GLOB.burgher_positions) && \
 		!(recruit.job in GLOB.wanderer_positions) && \
-		//unique case to re-allow exclusively deserters to recruit fellow antagonists into the brotherhood
-		!(recruiter.job in GLOB.antagonist_positions && recruit.job in GLOB.antagonist_positions))
+		//unique case to re-allow deserters to recruit wretches but technically applies to all-antags + convert verbs.
+		//Its actually kinda lowkey cool and lets antagonists actually pull some genuine espionage.
+		//Think vlord maid getting hired into the keep, bandit somehow convincing nobles to make them a watchman, etc.
+		!(recruit.job in GLOB.antagonist_positions))
 		return FALSE
 	if(recruit.cmode) //We probably don't want to accidentally flashbang this mid-fight.
 		return FALSE

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -495,7 +495,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	else
 		to_chat(user, span_warning("Recruitment cancelled."))
 
-/obj/effect/proc_holder/spell/self/convertrole/proc/can_convert(mob/living/carbon/human/recruit)
+/obj/effect/proc_holder/spell/self/convertrole/proc/can_convert(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
 	//wtf
 	if(QDELETED(recruit))
 		return FALSE
@@ -505,8 +505,11 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	//only migrants and peasants
 	if(!(recruit.job in GLOB.peasant_positions) && \
 		!(recruit.job in GLOB.burgher_positions) && \
-		!(recruit.job in GLOB.atc_positions) && \
-		!(recruit.job in GLOB.wanderer_positions))
+		!(recruit.job in GLOB.wanderer_positions) && \
+		//unique case to re-allow exclusively deserters to recruit fellow wretches into the brotherhood
+		!(recruiter.job == "Wretch" && recruit.job == "Wretch"))
+		return FALSE
+	if(recruit.cmode) //We probably don't want to accidentally flashbang this mid-fight.
 		return FALSE
 	//need to see their damn face
 	if(!recruit.get_face_name(null))
@@ -520,15 +523,17 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	var/prompt = alert(recruit, "Do you wish to become a [new_role]?", "[recruitment_faction] Recruitment", "Yes", "No")
 	if(QDELETED(recruit) || QDELETED(recruiter) || !(recruiter in get_hearers_in_view(recruitment_range, recruit)))
 		return FALSE
-	if(prompt != "Yes")
+	if(prompt != "Yes") //If they deny, we forcesay here.
 		if(refuse_message)
 			recruit.say(refuse_message, forced = "[name]")
 		return FALSE
-	if(accept_message)
+	if(accept_message) //If they accept, we forcesay here.
 		recruit.say(accept_message, forced = "[name]")
-	if(new_role)
+	if(new_role) //We assign our role here. + log it.
 		recruit.job = new_role
 		SEND_SIGNAL(SSdcs, COMSIG_GLOB_ROLE_CONVERTED, recruiter, recruit, new_role)
+		message_admins("ROLE RECRUITMENT: [recruiter.real_name] ([recruiter.ckey]) has converted [recruit.real_name] ([recruit.ckey]) to [new_role]")
+		log_game("ROLE RECRUITMENT: [recruiter.real_name] ([recruiter.ckey]) has converted [recruit.real_name] ([recruit.ckey]) to [new_role]")
 	return TRUE
 
 /obj/effect/proc_holder/spell/self/convertrole/guard

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -497,7 +497,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 
 /obj/effect/proc_holder/spell/self/convertrole/proc/can_convert(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
 	//wtf
-	if(QDELETED(recruit))
+	if(QDELETED(recruit) || QDELETED(recruiter))
 		return FALSE
 	//need a mind
 	if(!recruit.mind)
@@ -506,8 +506,8 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	if(!(recruit.job in GLOB.peasant_positions) && \
 		!(recruit.job in GLOB.burgher_positions) && \
 		!(recruit.job in GLOB.wanderer_positions) && \
-		//unique case to re-allow exclusively deserters to recruit fellow wretches into the brotherhood
-		!(recruiter.job == "Wretch" && recruit.job == "Wretch"))
+		//unique case to re-allow exclusively deserters to recruit fellow antagonists into the brotherhood
+		!(recruiter.job in GLOB.antagonist_positions && recruit.job in GLOB.antagonist_positions))
 		return FALSE
 	if(recruit.cmode) //We probably don't want to accidentally flashbang this mid-fight.
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

- Allows deserters/wretches we give convert-job verbs, to recruit wretches into the brotherhood/whatever other faction we might add as intended so they can use their order verbs again.
- Allows those in antagonist positions to be recruited as watchmen/servantry/brotherhood members.
- Fixes a potental exploit that let you spam people in cmode with recruitment prompts so they can't fight you.
- Also gives admins game logs on job conversion because that code already works.

An unfortunate blanket-PR nessessary to include every position cause IDK how to fix it otherwise.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/f0676890-2397-499c-8504-e43af68be5fa

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

- Roles should work in their abilities to recruit other antags to buff them.
- I shouldn't be able to metacheck antagonists because I can't recruit them.
- Admins should have logs in case a deserter pops off and recruits a hundred people.
- Being able to accidentally hire antagonists to let them commit crimes from the inside out is really cool.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: wretch deserters can recruit fellow wretches again.
fix: recruitment verbs have a cmode check now.
balance: recruit verbs aren't job-shielded from antagonists, letting antagonists now claim role recruitment to blend in.
admin: job recruitment verbs now log to admins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
