### PR TITLE
Infernal Watchers Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/watcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/infernal/watcher.dm
@@ -49,7 +49,7 @@
 	aggressive = 1
 //	stat_attack = UNCONSCIOUS
 	ranged = TRUE
-	ranged_cooldown = 40
+	ranged_cooldown_time = 80
 	projectiletype = /obj/projectile/magic/aoe/fireball/rogue
 	ranged_message = "stares"
 


### PR DESCRIPTION
## About The Pull Request
since ai 2, it became very apparent that infernal watchers were SUPER overtuned, being able to wipe full parties and stunlock lone combatants. this turned out to be partially because they were using the wrong variable for their projectile cooldown, so it was... never actually being set. oops! this also increases the cooldown because it was previously being "set" (nonfunctional, but i'm talking about the _intended_ cooldown here) to only slightly slower than the fucked up and evil machinegun. it feels much better to fight now

## Testing Evidence
tested on local; screenshots would just be a bunch of combat logs. it works, they still fuck you up rather quickly with the fire, it's just not an instant death sentence

## Why It's Good For The Game
watchers should not be more dangerous than fiends. watchers should not instantly obliterate you. using the correct variable instead of the wrong one is good