### PR TITLE
[adjusts sun elf beauty] breaks all balance, 1984, its so fucking over. gitban any% speedrun

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -326,7 +326,7 @@
 		if (HAS_TRAIT(src, TRAIT_LEPROSY))
 			. += span_necrosis("A LEPER...")
 
-		if (HAS_TRAIT(src, TRAIT_BEAUTIFUL) || (issunelf(src) && issunelf(user)))
+		if (HAS_TRAIT(src, TRAIT_BEAUTIFUL))
 			switch (pronouns)
 				if (HE_HIM)
 					. += span_beautiful_masc("[m1] handsome!")

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfc.dm
@@ -42,7 +42,7 @@
 	skin_tone_wording = "Skintone"
 	use_skin_tone_wording_for_examine = FALSE
 
-	inherent_traits = list(TRAIT_SILVER_BLESSED, TRAIT_ZOMBIE_IMMUNE, TRAIT_UNLYCKERABLE)
+	inherent_traits = list(TRAIT_SILVER_BLESSED, TRAIT_ZOMBIE_IMMUNE, TRAIT_UNLYCKERABLE, TRAIT_BEAUTIFUL)
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,OLDGREY)
 	default_features = MANDATORY_FEATURE_LIST
 	use_skintones = 1


### PR DESCRIPTION
## About The Pull Request

Makes sun elves beautiful by giving them the trait properly so players can see the race actually gives you that instead of the niché sun elf on sun elf examine.


Its probably good for consistancy we do this, but I'm not opposed to the sovl remaining.
*the only balance implication is... I guess Eoran Trees can heal you now, E'GADS!*

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

It compiles
It builds
Sire its two lines of code sire. ITS TWO LINES OF CODE AAAAAAA- HELP MEEEEEEEEEEEEEEEEEE AGRFHSDGBSJDKBSHGEWGHEFGFGFGDGFGDFDGGGGHHHH-

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I just like consistantly being able to see what traits you have on picking a race instead of it being hidden behind obscure inconsistant mechanics that weren't intended.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: sun elves now have TRAIT_BEAUTIFUL instead of applying exactly the same effects as the trait on a race on race check which was a little consistant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
