### PR TITLE
Dolabra option for Laborious Apprentice Virtue

### DIFF
--- a/code/modules/virtues/crafter.dm
+++ b/code/modules/virtues/crafter.dm
@@ -126,7 +126,8 @@
 		"Mining Skill (+3, Up to Legendary)" = list(/datum/skill/labor/mining, TRAIT_SMITHING_EXPERT),
 		"Lumberjacking Skill (+3, Up to Legendary)" = /datum/skill/labor/lumberjacking,
 		"Stashed Steel Axe" = /obj/item/rogueweapon/stoneaxe/woodcut/steel/woodcutter,
-		"Stashed Steel Pickaxe" = /obj/item/rogueweapon/pick/steel
+		"Stashed Steel Pickaxe" = /obj/item/rogueweapon/pick/steel,
+		"Stashed Bronze Dolabra" = /obj/item/rogueweapon/pick/bronze ///Less force & integ than the others, but can perform both roles
 	)
 
 /datum/virtue/utility/apprentice/apply_to_human(mob/living/carbon/human/recipient)


### PR DESCRIPTION
## About The Pull Request

Adds a new side-grade option to the Laborious Apprentice virtue: Instead of (or alongside, depending on what sub options you take) a steel pick or axe, you may choose to take a bronze dolabra. Less force and integrity, more versatility and bronze aesthetic.

## Testing Evidence

2 line edit, tested on local without issue.

<img width="391" height="341" alt="selection" src="https://github.com/user-attachments/assets/2a9bc972-7467-44a9-a98e-a6cebe30ab83" />
<img width="438" height="321" alt="stash" src="https://github.com/user-attachments/assets/0a5f0502-ad8c-42c2-90a4-056c3e5f1dfd" />
<img width="1883" height="995" alt="overview" src="https://github.com/user-attachments/assets/29015d3b-b89a-4897-a02e-96f02636f316" />



## Why It's Good For The Game

More sidegrade options makes for more variety and fun in play, and the dolabra is neat. Lets you have a bit more versatility at the cost of not excelling in any specific niche like the existing tool options do.


## Changelog

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
code: changed some code
/:cl:
