### PR TITLE
Berserker Rage Rebalance

### DIFF
--- a/code/modules/spells/spell_types/classunique/berserker/berserkrage.dm
+++ b/code/modules/spells/spell_types/classunique/berserker/berserkrage.dm
@@ -21,7 +21,7 @@
 	desc = "GETTING HURT MAKES YOU ANGRY, MAKE THEM HURT BACK- MORE HURT IS MORE ANGRY!"
 	antimagic_allowed = TRUE
 	clothes_req = FALSE
-	recharge_time = 2 MINUTES
+	recharge_time = 3 MINUTES
 	invocations = list("enters a state of furious rage!")
 	invocation_type = "emote"
 
@@ -33,6 +33,8 @@
 	user.apply_status_effect(/datum/status_effect/buff/rage)
 	if(get_buff_value(user) >= 1)
 		user.apply_status_effect(/datum/status_effect/buff/rage_stamina)
+	if(get_buff_value(user) >= 2)
+		user.apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
 	return TRUE
 
 /atom/movable/screen/alert/status_effect/buff/rage
@@ -46,6 +48,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/rage
 	effectedstats = list(STATKEY_STR = 1)
 	duration = 90 SECONDS
+	var/originalcmode = ""
 	var/ragebuff = 0
 	var/outline_colour = "#ca0000"
 
@@ -57,13 +60,27 @@
 		if(!filter)
 			owner.add_filter(RAGE_FILTER, 2, list("type" = "outline", "color" = outline_colour, "alpha" = 120, "size" = 1))
 		owner.emote("rage", forced = TRUE)
+		ADD_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE, id)
+		ADD_TRAIT(owner, TRAIT_PSYCHOSIS, id)
+		ADD_TRAIT(owner, TRAIT_NOCSHADES, id)
+		originalcmode = owner.cmode_music
+		owner.cmode_music = 'sound/music/combat_ozium.ogg'
 		to_chat(owner, span_notice("PAIN FUELS MY RAGE, MY BODY IS READY TO FIGHT!"))
 		playsound(owner, 'sound/combat/hits/burn (2).ogg', 100, TRUE)
 
 /datum/status_effect/buff/rage/on_remove()
 	. = ..()
 	owner.remove_filter(RAGE_FILTER)
+	owner.apply_status_effect(/datum/status_effect/debuff/falter)
+	owner.apply_status_effect(/datum/status_effect/debuff/exposed)
+	REMOVE_TRAIT(owner, TRAIT_CRITICAL_RESISTANCE, id)
+	REMOVE_TRAIT(owner, TRAIT_PSYCHOSIS, id)
+	REMOVE_TRAIT(owner, TRAIT_NOCSHADES, id)
+	owner.cmode_music = originalcmode
 	to_chat(owner, span_warning("Rage subsides."))
+
+/datum/status_effect/buff/rage/tick()
+	update_effects()
 
 /datum/status_effect/buff/rage/proc/update_effects()
 	ragebuff = get_buff_value(owner)
@@ -77,6 +94,22 @@
 		effectedstats = list(STATKEY_CON = 2, STATKEY_WIL = 2, STATKEY_STR = 2)
 	else
 		effectedstats = list(STATKEY_CON = 3, STATKEY_WIL = 3, STATKEY_STR = 3)
+
+/atom/movable/screen/alert/status_effect/debuff/falter
+	name = "Faltering"
+	desc = "<span class='warning'>I've pushed myself to my limit.</span>"
+	icon_state = "debuff"
+
+/datum/status_effect/debuff/falter
+	id = "falter"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/falter
+	effectedstats = list(STATKEY_STR = -2, STATKEY_PER = -2, STATKEY_INT = -2, STATKEY_WIL = -2, STATKEY_CON = -2, STATKEY_SPD = -2)
+	duration = 90 SECONDS
+
+/atom/movable/screen/alert/status_effect/buff/rage
+	name = "RAGE"
+	desc = "YOU'RE MAKING ME ANGRY!"
+	icon_state = "buff"
 
 /atom/movable/screen/alert/status_effect/buff/rage_stamina
 	name = "RAAADRENALINE"


### PR DESCRIPTION
## About The Pull Request


- cooldown from 2 minutes to 3 minutes
- berserker rage buff now updates every tick (i'd imagine there's a better way of doing this) so you can actually get your bigger buffs from taking damage
- now gives critical resistance for the duration, alongside psychosis and nocshades trait (for the red tint and stifling your screen)
- meeting the requirement for t2 rage or above when you activate it grants adrenaline rush on use
- when it ends, it now grants faltering for 90 seconds and exposed for 10 seconds. faltering is a -2 omnistat for the rest of the normal cooldown (90 seconds)

## Testing Evidence

<img width="886" height="818" alt="image" src="https://github.com/user-attachments/assets/1b2ccff1-447d-48f6-9f8a-96e9c059c911" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

berserker is a miracleless shaman with a near identical statsheet while also being antagonistic.

what it has over shaman is `rage` and `skinarmor`

`skinarmor`, despite what people think about it is a sidegrade to armor that excels only in coverage, otherwise it's akin to just wearing leather.

with that in mind, looking to `rage`, the mechanic unique to berserkers and barbarians to a lesser extent would probably be ideal; turning it into a 'do or die' mode where they're weakened after the fact, and more likely to bleed out and succumb to their wounds that they've incurred during.

the thresholds for the buff are also considerably, incredibly high. you can be stuck at t2 while being gutspilled and being given 4 different crits on the chest to bleed out in record time. in the same vein, you can be stuck at t2 while being unable to stand due to a disabled leg. ideally it's probably best they have crit resistance temporarily to alleviate it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: berserker rage cd 2 minutes -> 3 minutes
balance: berserker rage now grants crit resist, nocshades and psychosis for the duration
balance: berserker rage now leaves you exposed when it ends, and gives you a -2 omnistat for 90 seconds
balance: berserker rage now updates itself while active. no longer are you punished for activating it early
balance: berserker rage now grants adrenaline rush if activated while having 225 damage on your body
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
