### PR TITLE
[Bronze] - Sigh guess I'll add bronze to the silverface myself.

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_bronze.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_bronze.dm
@@ -90,3 +90,8 @@
 	name = "Bronze-Tipped Whip"
 	cost = 42 // 1 Bronze Ingot + 1 Leather Whip (16% discount)
 	contains = list(/obj/item/rogueweapon/whip/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/javelin
+	name = "Bronze Javelins (x2)"
+	cost = 35 // 1 Bronze Ingot + 1 Small Log
+	contains = list(/obj/item/ammo_casing/caseless/rogue/javelin/bronze, /obj/item/ammo_casing/caseless/rogue/javelin/bronze)

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_bronze.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_bronze.dm
@@ -1,0 +1,92 @@
+// NOTE - special items such as the great khopesh or the winged spear have been omitted. Go to a smith for those.
+// Ditto for ranged weapons.
+
+/datum/supply_pack/rogue/bronze_weapons
+	group = "Weapons (Bronze)"
+	crate_name = "merchant guild's crate"
+	crate_type = /obj/structure/closet/crate/chest/merchant
+
+/datum/supply_pack/rogue/bronze_weapons/sword
+	name = "Bronze Arming Sword"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/rogueweapon/sword/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/katar
+	name = "Bronze Katar"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/rogueweapon/katar/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/gladius
+	name = "Bronze Gladius"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/rogueweapon/sword/short/gladius)
+
+/datum/supply_pack/rogue/bronze_weapons/sabre
+	name = "Bronze Khopesh"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/rogueweapon/sword/sabre/bronzekhopesh)
+
+/datum/supply_pack/rogue/bronze_weapons/dagger
+	name = "Bronze Knife"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/rogueweapon/huntingknife/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/combatknife
+	name = "Bronze Combat Knife"
+	cost = 54 // 2 Bronze Ingots (10% discount)
+	contains = list(/obj/item/rogueweapon/huntingknife/combat/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/messer
+	name = "Bronze Messer"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/rogueweapon/sword/short/messer/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/mace
+	name = "Bronze Mace"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/rogueweapon/mace/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/warhammer
+	name = "Bronze Warclub"
+	cost = 54 // 2 Bronze Ingots (10% discount)
+	contains = list(/obj/item/rogueweapon/mace/warhammer/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/spear
+	name = "Bronze Spear"
+	cost = 60 // 2 Bronze Ingots + 1 Small Log
+	contains = list(/obj/item/rogueweapon/spear/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/falchion
+	name = "Bronze Falchion"
+	cost = 54 // 2 Bronze Ingots (10% discount)
+	contains = list(/obj/item/rogueweapon/sword/falchion/militia/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/broadsword
+	name = "Bronze Broadsword"
+	cost = 60 // 2 Bronze Ingots + 1 Small Log
+	contains = list(/obj/item/rogueweapon/sword/long/broadsword/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/battleaxe
+	name = "Bronze War Axe"
+	cost = 54 // 2 Bronze Ingots (10% discount)
+	contains = list(/obj/item/rogueweapon/stoneaxe/woodcut/bronzebattleaxe)
+
+/datum/supply_pack/rogue/bronze_weapons/axe
+	name = "Bronze Axe"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/rogueweapon/stoneaxe/woodcut/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/bronzeshield
+	name = "Bronze Shield"
+	cost = 60 // 2 Bronze Ingots + 1 Cured Leather
+	contains = list(/obj/item/rogueweapon/shield/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/knuckles
+	name = "Bronze Knuckledusters"
+	cost = 30 // 1 Bronze Ingot
+	contains = list(/obj/item/clothing/gloves/roguetown/knuckles/bronze)
+
+/datum/supply_pack/rogue/bronze_weapons/whip
+	name = "Bronze-Tipped Whip"
+	cost = 42 // 1 Bronze Ingot + 1 Leather Whip (16% discount)
+	contains = list(/obj/item/rogueweapon/whip/bronze)

--- a/code/modules/roguetown/roguemachine/merchant/_goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/_goldface.dm
@@ -62,6 +62,7 @@
 		"Potions",
 		"Weapons (Ranged)",
 		"Weapons (Iron and Shields)",
+		"Weapons (Bronze)",
 		"Weapons (Steel)",
 		"Weapons (Foreign)",
 	)
@@ -112,6 +113,7 @@
 		"Armor (Exotic)",
 		"Weapons (Ranged)",
 		"Weapons (Iron and Shields)",
+		"Weapons (Bronze)",
 		"Weapons (Steel)",
 	)
 	categories_gamer = list()

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1709,6 +1709,7 @@
 #include "code\modules\cargo\packsrogue\merchant\foreign\cultural_raneshen.dm"
 #include "code\modules\cargo\packsrogue\merchant\foreign\cultural_rosawood.dm"
 #include "code\modules\cargo\packsrogue\merchant\foreign\cultural_underdark.dm"
+#include "code\modules\cargo\packsrogue\merchant\weapons\merch_weapons_bronze.dm"
 #include "code\modules\cargo\packsrogue\merchant\weapons\merch_weapons_foreign.dm"
 #include "code\modules\cargo\packsrogue\merchant\weapons\merch_weapons_melee_iron.dm"
 #include "code\modules\cargo\packsrogue\merchant\weapons\merch_weapons_melee_steel.dm"


### PR DESCRIPTION
## About The Pull Request
<img width="972" height="327" alt="image" src="https://github.com/user-attachments/assets/749de086-7abe-40ab-9ebd-6c099df5121a" />

- Adds a bunch of bronze weapons to the silverface.
- Not sure about bronze armor logistics so I've omitted those for now.
- bronze sling bullets are pretty scary, so I've omitted ranged items too. Javs are given an exception since they're cumbersome to use anyways.
- specialty weapons such as the great khopesh and the winged spear remain smith exclusives.

## Testing Evidence
<img width="859" height="223" alt="image" src="https://github.com/user-attachments/assets/c83d2de3-12c7-4c01-a038-ec1d5c5a2d80" />
<img width="838" height="368" alt="image" src="https://github.com/user-attachments/assets/cc22c899-f483-4d89-a6eb-22b091796766" />

(PRICE COMPARISON VERSUS IRON)

## Why It's Good For The Game
Makes bronze a little more accessible when there isn't a smith. Especially for items such as the bronze warclub and the bronze whip which are interesting upgrades for classes that use them.

Prices are generally 30 per ingot base, with a slight discount for multi ingot items or items that are upgrades like whips, shields, because you're probably not recouping any mammon from your old item.

## Changelog
:cl:
add: Bronze weapons in the silverface
/:cl:
