### PR TITLE
Mystic Healer update

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -55,6 +55,29 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)
 	
 	if(H.mind)
+		H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/heal)
+		H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/heal/undivided)
+
+	switch(H.patron?.type)
+		if(/datum/patron/divine/undivided)
+			var/list/heal = list("Cure Greater Wounds(Miracle)", "Fortifying Vapors(Medical)")
+			var/highheal_options = input(H, "Choose your healing training.", "Experientia Medica") as anything in heal
+			switch(highheal_options)
+				if("Cure Greater Wounds(Miracle)")
+					H.mind.AddSpell(new /datum/action/cooldown/spell/miracle/heal/undivided)
+				if("Fortifying Vapors(Medical)")
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortifyingvapors)
+		else
+			var/list/heal = list("Cure Wounds(Miracle)", "Fortifying Vapors(Medical)")
+			var/heal_options = input(H, "Choose your healing training.", "Experientia Medica") as anything in heal
+			switch(heal_options)
+				if("Cure Wounds(Miracle)")
+					H.mind.AddSpell(new /datum/action/cooldown/spell/miracle/heal)
+				if("Fortifying Vapors(Medical)")
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortifyingvapors)
+
+
+	if(H.mind)
 		var/weapons = list("lesser staff", "lesser wand", "quarterstaff")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
@@ -192,6 +215,26 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)
 	if(H.mind)
 		H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/bloodmiracle)
+		H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/heal)
+		H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/heal/undivided)
+
+	switch(H.patron?.type)
+		if(/datum/patron/divine/undivided)
+			var/list/heal = list("Cure Greater Wounds(Miracle)", "Fortifying Vapors(Medical)")
+			var/highheal_options = input(H, "Choose your healing training.", "Experientia Medica") as anything in heal
+			switch(highheal_options)
+				if("Cure Greater Wounds(Miracle)")
+					H.mind.AddSpell(new /datum/action/cooldown/spell/miracle/heal/undivided)
+				if("Fortifying Vapors(Medical)")
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortifyingvapors)
+		else
+			var/list/heal = list("Cure Wounds(Miracle)", "Fortifying Vapors(Medical)")
+			var/heal_options = input(H, "Choose your healing training.", "Experientia Medica") as anything in heal
+			switch(heal_options)
+				if("Cure Wounds(Miracle)")
+					H.mind.AddSpell(new /datum/action/cooldown/spell/miracle/heal)
+				if("Fortifying Vapors(Medical)")
+					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortifyingvapors)
 
 	if(H.mind)
 		var/weapons = list("lesser staff", "lesser wand")
@@ -401,4 +444,3 @@
 		if(/datum/patron/divine/xylix)
 			id = /obj/item/clothing/neck/roguetown/luckcharm
 			H.cmode_music = 'sound/music/combat_jester.ogg'
-


### PR DESCRIPTION
## About The Pull Request

Give an additional choice to flavour Mystic and Sage healer studies, made with Hazarawn's blessing!

## Testing Evidence

<img width="1920" height="1080" alt="medica1" src="https://github.com/user-attachments/assets/81e9496c-bd35-4188-852c-67cd16077ae9" />
<img width="1920" height="1080" alt="medica2" src="https://github.com/user-attachments/assets/4fb52844-dd92-4360-b69f-406e9bc56710" />
<img width="1920" height="1080" alt="medica3" src="https://github.com/user-attachments/assets/912c893e-8d4f-42bb-851b-f5ad011e5346" />
<img width="1920" height="1080" alt="medica4" src="https://github.com/user-attachments/assets/fd78040d-7d33-43e2-95d0-8996daa637ce" />
<img width="1920" height="1080" alt="medica5" src="https://github.com/user-attachments/assets/be6cef5e-af22-44a8-8f88-c6072e2a9d80" />


## Why It's Good For The Game
This add more flavour and choice for Mystic and Sage, were they more involved in their studies of the Holy Scriptures or Natural Science.
Fortifying vapours doesn't enjoy the additional healing provided by elevated divine veil research or patron's specific conditional, so it either match Miracle healing(but with the healing spread over twice the duration) or worse if Pestran acolytes or Keepers tend to the HeartBeast

## Changelog
Mystic and Sage now get an additional choice, Miracle Healing or Fortifying Vapors(medical healing)
Undivided Mystic and Sage get a unique list (Undivided Miracle healing or Fortifying Vapors)


:cl:
add: Mystic and Sage get to pick between "Medical" Healing(F.Vapors) and their respective Miracle Healing
/:cl:

