### PR TITLE
Trained & Ready tweak

### DIFF
--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -92,19 +92,20 @@
 /datum/virtue/combat/combat_virtue
 	name = "Trained & Ready"
 	desc = "There are many facets of lyfe that can end it. I've taken to learning some of them, and kept the tools for them close."
+	custom_text = "If choosing a Weapon Skill, your character will be granted Apprentice in that particular discipline. If your class already has Apprentice in that disipline, your skill will be boosted to Journeyman."
 	max_choices = 5
 	choice_costs = list(0, 0, 0, 2, 4, 4)
 	extra_choices = list(
-		"Swords Skill (JMAN)" = /datum/skill/combat/swords,
-		"Shield Skill (JMAN)" = /datum/skill/combat/shields,
-		"Dagger Skill (JMAN)" = /datum/skill/combat/knives,
-		"Unarmed Skill (JMAN)" = /datum/skill/combat/unarmed,
-		"Sling Skill (JMAN)" = /datum/skill/combat/slings,
-		"Axe Skill (JMAN)" = /datum/skill/combat/axes,
-		"Whip Skill (JMAN)" = /datum/skill/combat/whipsflails,
-		"Mace Skill (JMAN)" = /datum/skill/combat/maces,
-		"Polearm Skill (JMAN)" = /datum/skill/combat/polearms,
-		"Staves Skill (JMAN)" = /datum/skill/combat/staves,
+		"Swords Skill" = /datum/skill/combat/swords,
+		"Shield Skill" = /datum/skill/combat/shields,
+		"Dagger Skill" = /datum/skill/combat/knives,
+		"Unarmed Skill" = /datum/skill/combat/unarmed,
+		"Sling Skill" = /datum/skill/combat/slings,
+		"Axe Skill" = /datum/skill/combat/axes,
+		"Whip Skill" = /datum/skill/combat/whipsflails,
+		"Mace Skill" = /datum/skill/combat/maces,
+		"Polearm Skill" = /datum/skill/combat/polearms,
+		"Staves Skill" = /datum/skill/combat/staves,
 		"Stashed Messer & Parrying Dagger" = list(/obj/item/rogueweapon/sword/short/messer/iron/virtue, /obj/item/rogueweapon/huntingknife/idagger/virtue),
 		"Stashed Shield & Arming Sword" = list(/obj/item/rogueweapon/shield/wood, /obj/item/rogueweapon/sword/iron),
 		"Stashed Quarterstaff & Sling" = list(/obj/item/rogueweapon/woodstaff/quarterstaff/iron, /obj/item/gun/ballistic/revolver/grenadelauncher/sling, /obj/item/quiver/sling/iron),
@@ -118,7 +119,10 @@
 	if(triumph_check(recipient))
 		for(var/choice in picked_choices)
 			if(ispath(extra_choices[choice], /datum/skill))
-				recipient.adjust_skillrank_up_to(extra_choices[choice], SKILL_LEVEL_JOURNEYMAN, silent = TRUE)
+				if(recipient.get_skill_level(extra_choices[choice]) < SKILL_LEVEL_APPRENTICE)
+					recipient.adjust_skillrank_up_to(extra_choices[choice], SKILL_LEVEL_APPRENTICE, silent = TRUE)
+				else	
+					recipient.adjust_skillrank_up_to(extra_choices[choice], SKILL_LEVEL_JOURNEYMAN, silent = TRUE)
 			else if(islist(extra_choices[choice]))	//stashed items
 				var/list/stash = extra_choices[choice]
 				for(var/stuff in stash)


### PR DESCRIPTION


## About The Pull Request

The virtue now only gives you JMAN if you already had Apprentice skill, otherwise caps at Apprentice.

## Testing Evidence

Gravetender Sexton, who has 0 sword skill taking the sword virtue:

<img width="357" height="331" alt="image" src="https://github.com/user-attachments/assets/beef53ed-cbba-43b5-a3f6-5606c8afa484" />

Daring Twit prince, who has Apprentice sword skill taking the sword virtue:

<img width="418" height="467" alt="image" src="https://github.com/user-attachments/assets/a5f566df-9f42-4987-ac02-d0d1e694d4ff" />


## Why It's Good For The Game

Alternative to #7326 

Basically just reverts #3860. Less unintended playstyles appearing. Trained & Ready now acts as a way to give yourself extra training in a skill you already have, or give you a bunch of apprentice level skills and free weapons to skip dummy bashing.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Trained & Ready now only gives you Journeyman skill if you already had Apprentice skill, otherwise it caps at Apprentice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
