### PR TITLE
Restore Arcyne Barrage as a piercing 5 projectiles spell

### DIFF
--- a/code/modules/spells/spell_types/wizard/major_aspects.dm
+++ b/code/modules/spells/spell_types/wizard/major_aspects.dm
@@ -195,11 +195,11 @@
 		/datum/action/cooldown/spell/projectile/seeker_volley,
 		/datum/action/cooldown/spell/greater_cleaning, // placeholder free utility - replace with Recall once implemented
 	)
-	// variants = list(
-	// 	"mastery" = list(
-	// 		VARIANT_ADDITIVE = /datum/action/cooldown/spell/projectile/arcyne_barrage,
-	// 	),
-	// )
+	variants = list(
+		"mastery" = list(
+			VARIANT_ADDITIVE = /datum/action/cooldown/spell/projectile/arcyne_barrage,
+		),
+	)
 
 /datum/magic_aspect/augmentation
 	name = "Augmentation"

--- a/code/modules/spells/spell_types/wizard/telomancy/arcyne_barrage.dm
+++ b/code/modules/spells/spell_types/wizard/telomancy/arcyne_barrage.dm
@@ -3,8 +3,8 @@
 /datum/action/cooldown/spell/projectile/arcyne_barrage
 	button_icon = 'icons/mob/actions/mage_telomancy.dmi'
 	name = "Arcyne Barrage"
-	desc = "The Ultimate Reason of a Telomancer - barrage a general direction with a barrage of arcyne bolts for ten seconds. \
-	The bolts arrive in interleaved pulses. You can walk while channeling but you are greatly slowed down and cannot change your direction. \
+	desc = "The Ultimate Reason of a Telomancer - barrage a direction with pulses of piercing, ricocheting arcyne bolts for ten seconds. The bolts can pierce up to five targets. \
+	You can walk while channeling but you are greatly slowed down and cannot change your direction. \
 	Being stunned, knocked down, or grabbed will break the channeling."
 	button_icon_state = "arcyne_barrage"
 	sound = 'sound/magic/vlightning.ogg'
@@ -37,10 +37,9 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
 
 	var/channel_duration = 10 SECONDS
-	var/pulse_interval = 1 SECONDS
-	var/arc_width = 120
-	var/odd_pulse_step = 10
-	var/even_pulse_step = 10
+	var/pulse_interval = 2 SECONDS
+	var/bolts_per_pulse = 5
+	var/pulse_spread = 120
 	var/channel_slowdown = 3
 
 /datum/action/cooldown/spell/projectile/arcyne_barrage/before_cast(atom/cast_on)
@@ -62,7 +61,7 @@
 	var/end_time = world.time + channel_duration
 	var/pulse_index = 0
 
-	H.visible_message(span_danger("<b>[H] plants their feet and unleashes a storm of arcyne bolts!</b>"))
+	H.visible_message(span_danger("<b>[H] unleashes a storm of arcyne bolts!</b>"))
 	playsound(get_turf(H), 'sound/magic/vlightning.ogg', 100, TRUE)
 	H.add_movespeed_modifier(ARCYNE_BARRAGE_SLOWDOWN_ID, update = TRUE, priority = 100, multiplicative_slowdown = channel_slowdown, movetypes = GROUND)
 
@@ -101,19 +100,11 @@
 		return FALSE
 	return TRUE
 
-/// Fire a single pulse of greater arcyne bolts. Odd pulses hit 0/20/40/60/80/100/120; even pulses hit 10/30/50/70/90/110.
 /datum/action/cooldown/spell/projectile/arcyne_barrage/proc/fire_pulse(mob/living/carbon/human/H, locked_angle, pulse_index)
-	var/is_odd_pulse = (pulse_index % 2) == 1
-	var/start_offset = is_odd_pulse ? 0 : (odd_pulse_step / 2)
-	var/step_size = is_odd_pulse ? odd_pulse_step : even_pulse_step
-	var/arc_start = locked_angle - (arc_width / 2)
-	var/list/angles_to_fire = list()
-	var/current_offset = start_offset
-	while(current_offset <= arc_width)
-		angles_to_fire += (arc_start + current_offset)
-		current_offset += step_size
-	for(var/angle in angles_to_fire)
-		fire_barrage_bolt(H, angle)
+	var/arc_start = locked_angle - (pulse_spread / 2)
+	var/step_size = bolts_per_pulse > 1 ? (pulse_spread / (bolts_per_pulse - 1)) : 0
+	for(var/i in 1 to bolts_per_pulse)
+		fire_barrage_bolt(H, arc_start + (step_size * (i - 1)))
 
 /datum/action/cooldown/spell/projectile/arcyne_barrage/proc/fire_barrage_bolt(mob/living/carbon/human/H, angle)
 	var/obj/projectile/magic/arcyne_barrage_bolt/bolt = new(get_turf(H))
@@ -143,14 +134,17 @@
 	guard_deflectable = TRUE
 	npc_simple_damage_mult = 1.5
 	intdamfactor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
-	ricochets_max = 2
-	ricochet_chance = 80
+	movement_type = UNSTOPPABLE
+	ricochets_max = 5
+	ricochet_chance = 100
 	ricochet_auto_aim_angle = 40
 	ricochet_auto_aim_range = 5
 	ricochet_incidence_leeway = 40
 	ricochet_decay_chance = 1
-	ricochet_decay_damage = 0.8
+	ricochet_decay_damage = 1
 	hitsound = 'sound/combat/hits/blunt/shovel_hit2.ogg'
+	var/hits = 0
+	var/max_hits = 5
 
 /obj/projectile/magic/arcyne_barrage_bolt/on_hit(target)
 	hitsound = pick('sound/combat/hits/blunt/shovel_hit.ogg', 'sound/combat/hits/blunt/shovel_hit2.ogg', 'sound/combat/hits/blunt/shovel_hit3.ogg')
@@ -162,5 +156,12 @@
 			qdel(src)
 			return BULLET_ACT_BLOCK
 	. = ..()
+	if(!ismob(target))
+		return
+	hits++
+	if(hits >= max_hits)
+		qdel(src)
+		return . || BULLET_ACT_HIT
+	return BULLET_ACT_FORCE_PIERCE
 
 #undef ARCYNE_BARRAGE_SLOWDOWN_ID


### PR DESCRIPTION
## About The Pull Request
After attempting to profile arcyne barrage I came to the conclusion I can't even figure out why people crash. So I reworked it to keep the spirit of it. 

It now fires a pulse of 5 projectiles every 2 seconds, each of which pierces up to 5 targets so to hopefully capture the chasos of the old spell without as much performance burden.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="924" height="925" alt="dreamseeker_Oc755B6Fc0" src="https://github.com/user-attachments/assets/ff1d2fd9-16f6-4d55-91dd-e4b398fb55fe" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Return of kino

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Restore and rework arcyne barrage to fire piercing projectiles and less of them for the same effect but hopefully way less lag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
