### PR TITLE
Mage Jaks in general

### DIFF
--- a/code/__DEFINES/armor_defines.dm
+++ b/code/__DEFINES/armor_defines.dm
@@ -151,9 +151,9 @@
 // LIGHT ARMOR - Split into two sidegrades: PADDED VS LEATHER
 // PADDED: Best Blunt protection, Bodkin immune. But Axe CHOP (MEDIUM) and most thrusts (LIGHT) get through. 
 // LEATHER: Decent Blunt DR. Axe CHOP (MEDIUM), sword thrust (MEDIUM) and bodkin (HEAVY) get through. Better vs stab than padded, worse vs piercing.
-#define ARMOR_PADDED list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_BSTEEL, "fire" = DR_HEAVY, "acid" = DR_NONE)
-#define ARMOR_LEATHER_NPC list("blunt" = DR_HEAVY, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_MEDIUM, "fire" = DR_SUPER, "acid" = DR_NONE)
-#define ARMOR_LEATHER list("blunt" = DR_ULTRA, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_HEAVY, "fire" = DR_SUPER, "acid" = DR_NONE)
+#define ARMOR_PADDED list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_BSTEEL, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_LEATHER_NPC list("blunt" = DR_HEAVY, "slash" = DBLOCK_LIGHT, "stab" = DBLOCK_LIGHT, "piercing" = DBLOCK_MEDIUM, "fire" = DR_MEDIUM, "acid" = DR_NONE)
+#define ARMOR_LEATHER list("blunt" = DR_ULTRA, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_HEAVY, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 
 // LIGHT ARMOR - SNOWFLAKE. Not comfortable with them, but not touching it atm.
 #define ARMOR_DRAGONSKIN list("blunt" = DR_SUPER, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_HEAVY, "acid" = DR_NONE) // Iconoclast dragon skin. Fire resistant.

--- a/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/arcyne_lance.dm
@@ -50,7 +50,7 @@
 	armor_penetration = PEN_LIGHT
 	movement_type = UNSTOPPABLE
 	range = SPELL_RANGE_PROJECTILE
-	flag = "piercing"
+	flag = "stab"
 	hitsound = 'sound/combat/hits/bladed/genthrust (1).ogg'
 	/// How many mob targets have been pierced
 	var/hits = 0

--- a/code/modules/spells/spell_types/wizard/ferramancy/iron_tempest.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/iron_tempest.dm
@@ -32,6 +32,7 @@
 	charge_slowdown = CHARGING_SLOWDOWN_MEDIUM
 	charge_sound = 'sound/magic/charging.ogg'
 	cooldown_time = 20 SECONDS
+	self_cast_possible = TRUE
 
 	associated_skill = /datum/skill/magic/arcane
 	spell_tier = 2

--- a/code/modules/spells/spell_types/wizard/ferramancy/sawblade_volley.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/sawblade_volley.dm
@@ -26,9 +26,9 @@
 
 	charge_required = TRUE
 	weapon_cast_penalized = TRUE
-	charge_time = CHARGETIME_POKE
+	charge_time = CHARGETIME_MAJOR
 	charge_drain = 1
-	charge_slowdown = CHARGING_SLOWDOWN_SMALL
+	charge_slowdown = CHARGING_SLOWDOWN_MEDIUM
 	charge_sound = 'sound/magic/charging.ogg'
 	cooldown_time = 15 SECONDS
 

--- a/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
+++ b/code/modules/spells/spell_types/wizard/ferramancy/stygian_efflorescence.dm
@@ -70,7 +70,7 @@
 	npc_simple_damage_mult = 1.5
 	speed = MAGE_PROJ_SLOW
 	accuracy = 65
-	flag = "piercing"
+	flag = "stab"
 	hitsound = 'sound/combat/hits/bladed/genstab (1).ogg'
 	var/reduced_damage = 18
 


### PR DESCRIPTION
## About The Pull Request
I got another report that Ferramancy is still extremely popular and OP, despite only 2 out of 4 spelsl being usable for a rotation.

So I decided to tackle it the other way after watching some videos. Compared to most other school, its second big hitter spell (Sawblade Volley) doesn't slowdown as much, and has the charge time of a poke spell and a small slowdown. Whereas most other aspects' rotation slow down the mage when they charge up their heavy hitter. 

This change it so that Sawblade takes 1s instead of 0.5s to charge and slowdown you more, which should help with making it less oppressive in PVP while changing basically nothing about PVE.

**Other Adjustments:**
- Arcyne Lance and Stygian now uses **STAB** instead of **PIERCING** damage, to reinforce them being good vs shitty light and not so good vs plate
- Leather / Padded Armor has been reduced back to DR_MEDIUM vs burn / fire damage, after I did some initial DPS check locally. I'd say they are still good vs NPC right now.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
None

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I balance mages

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Sawblade Volley now slows you down a bit more and take longer to charge up.
balance: Arcyne Lance and Stygian now uses **STAB** instead of **PIERCING** damage, to reinforce them being good vs shitty light and not so good vs plate
balance: Leather and Padded armor reduced back to 2 pips vs burn damage after I ran some DPS checks locally.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
