### PR TITLE
Squire Errant Polishing

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -219,7 +219,8 @@
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1, 
 		/obj/item/rogueweapon/hammer/iron = 1, 
-		/obj/item/rogueweapon/tongs = 1, 
+		/obj/item/polishing_cream = 1,
+		/obj/item/armor_brush = 1, 
 		/obj/item/recipe_book/survival = 1,
 		/obj/item/repair_kit/metal = 1,
 		/obj/item/repair_kit = 1,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -218,12 +218,12 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1, 
-		/obj/item/rogueweapon/hammer/iron = 1, 
-		/obj/item/polishing_cream = 1,
-		/obj/item/armor_brush = 1, 
-		/obj/item/recipe_book/survival = 1,
+		/obj/item/rogueweapon/hammer/iron = 1,
 		/obj/item/repair_kit/metal = 1,
 		/obj/item/repair_kit = 1,
+		/obj/item/armor_brush = 1,
+		/obj/item/polishing_cream = 1,
+		/obj/item/recipe_book/survival = 1,
 	)
 	if(H.mind)
 		var/armors = list("Light Armor","Medium Armor")


### PR DESCRIPTION
## About The Pull Request

Removes tongs (why did they have these? they have no smithing skills) from the Squire Errant, and gives them an armor brush + polishing cream instead, so that they have all the components of the Failed Squire virtue like you might expect.

## Testing Evidence

Tested ingame:
<img width="232" height="277" alt="image" src="https://github.com/user-attachments/assets/4830d1ef-a551-42ef-a415-4c7623208770" />



## Why It's Good For The Game

Lets the squire be a squire, particularly since it wont have the resources of the keep to draw from like an actual squire.


## Changelog

:cl:
balance: Squire Errants now spawn with brush and polishing cream instead of tongs.
/:cl:

