### PR TITLE
Trained and Ready tweaks

### DIFF
--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -111,7 +111,7 @@
 		"Stashed Sling" = list(/obj/item/gun/ballistic/revolver/grenadelauncher/sling, /obj/item/quiver/sling/iron),
 		"Stashed Spear (& Strap)" = list(/obj/item/rogueweapon/spear, /obj/item/rogueweapon/scabbard/gwstrap),
 		"Stashed Mace" = list(/obj/item/rogueweapon/mace),
-		"Stashed Katar" = list(/obj/item/rogueweapon/katar/bronze, /obj/item/clothing/gloves/roguetown/knuckles/bronze),
+		"Stashed Katar" = list(/obj/item/rogueweapon/katar/bronze),
 		"Stashed Knuckles" = list(/obj/item/clothing/gloves/roguetown/knuckles/bronze),
 		"Stashed Axe" = list(/obj/item/rogueweapon/stoneaxe/woodcut),
 		"Stashed Whip" = list(/obj/item/rogueweapon/whip)

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -95,7 +95,6 @@
 	max_choices = 5
 	choice_costs = list(0, 0, 0, 2, 4, 4)
 	extra_choices = list(
-		"Swords Skill (JMAN)" = /datum/skill/combat/swords,
 		"Shield Skill (JMAN)" = /datum/skill/combat/shields,
 		"Dagger Skill (JMAN)" = /datum/skill/combat/knives,
 		"Unarmed Skill (JMAN)" = /datum/skill/combat/unarmed,
@@ -105,12 +104,17 @@
 		"Mace Skill (JMAN)" = /datum/skill/combat/maces,
 		"Polearm Skill (JMAN)" = /datum/skill/combat/polearms,
 		"Staves Skill (JMAN)" = /datum/skill/combat/staves,
-		"Stashed Messer & Parrying Dagger" = list(/obj/item/rogueweapon/sword/short/messer/iron/virtue, /obj/item/rogueweapon/huntingknife/idagger/virtue),
-		"Stashed Shield & Arming Sword" = list(/obj/item/rogueweapon/shield/wood, /obj/item/rogueweapon/sword/iron),
-		"Stashed Quarterstaff & Sling" = list(/obj/item/rogueweapon/woodstaff/quarterstaff/iron, /obj/item/gun/ballistic/revolver/grenadelauncher/sling, /obj/item/quiver/sling/iron),
-		"Stashed Spear & Mace" = list(/obj/item/rogueweapon/spear, /obj/item/rogueweapon/mace, /obj/item/rogueweapon/scabbard/gwstrap),
-		"Stashed Katar & Knuckles" = list(/obj/item/rogueweapon/katar/bronze, /obj/item/clothing/gloves/roguetown/knuckles/bronze),
-		"Stashed Axe & Whip" = list(/obj/item/rogueweapon/stoneaxe/woodcut, /obj/item/rogueweapon/whip)
+		"Stashed Messer" = list(/obj/item/rogueweapon/sword/short/messer/iron/virtue),
+		"Stashed Parrying Dagger" = list(/obj/item/rogueweapon/huntingknife/idagger/virtue),
+		"Stashed Arming Sword" = list(/obj/item/rogueweapon/sword/iron),
+		"Stashed Quarterstaff" = list(/obj/item/rogueweapon/woodstaff/quarterstaff/iron),
+		"Stashed Sling" = list(/obj/item/gun/ballistic/revolver/grenadelauncher/sling, /obj/item/quiver/sling/iron),
+		"Stashed Spear (& Strap)" = list(/obj/item/rogueweapon/spear, /obj/item/rogueweapon/scabbard/gwstrap),
+		"Stashed Mace" = list(/obj/item/rogueweapon/mace),
+		"Stashed Katar" = list(/obj/item/rogueweapon/katar/bronze, /obj/item/clothing/gloves/roguetown/knuckles/bronze),
+		"Stashed Knuckles" = list(/obj/item/clothing/gloves/roguetown/knuckles/bronze),
+		"Stashed Axe" = list(/obj/item/rogueweapon/stoneaxe/woodcut),
+		"Stashed Whip" = list(/obj/item/rogueweapon/whip)
 	)
 
 /datum/virtue/combat/combat_virtue/apply_to_human(mob/living/carbon/human/recipient)

--- a/code/modules/virtues/combat.dm
+++ b/code/modules/virtues/combat.dm
@@ -95,7 +95,7 @@
 	max_choices = 5
 	choice_costs = list(0, 0, 0, 2, 4, 4)
 	extra_choices = list(
-		"Shield Skill (JMAN)" = /datum/skill/combat/shields,
+		"Sword Skill (JMAN)" = /datum/skill/combat/swords,
 		"Dagger Skill (JMAN)" = /datum/skill/combat/knives,
 		"Unarmed Skill (JMAN)" = /datum/skill/combat/unarmed,
 		"Sling Skill (JMAN)" = /datum/skill/combat/slings,


### PR DESCRIPTION
## About The Pull Request
Fourth PR, but seemed like the simplest approach so we can leave this be for a while:
- Stashed options have been split up to be one weapon rather than pairs
- Shield skill has been removed
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="274" height="308" alt="mLDVrSnAYy" src="https://github.com/user-attachments/assets/c3d0a3a6-3ff0-4642-840b-e4fac9807cdd" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The stashes were a holdover cus I wanted to keep the same sort of distribution as the original virtues, but we can move on from that. That part's either a nerf or not, depending on if you were bundling your skill picks exactly the same way as the virtues used to be before.

The virtue *could* have options for stashed armor as well, I feel like that'd make the minimum of 3 options more palatable, but I'm leaving that up in the air for now.

As for shields -- yeah, it seemed like the best way to target most egregious uses of the virtue.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Trained & Ready's stashed weapon options have been split up.
balance: Trained & Ready's Shield skill (and stashed shield) have been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
