### PR TITLE
[Fix] Infernal Familiars can't use Hellfyre Wave

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/familiars.dm
+++ b/code/modules/mob/living/simple_animal/friendly/familiars.dm
@@ -456,6 +456,11 @@
 	src.set_light_color(LIGHT_COLOR_FIRE)
 	if(src.light_system == STATIC_LIGHT)
 		src.update_light()
+	ADD_TRAIT(src, TRAIT_NOFIRE, "[type]")
+	ADD_TRAIT(src, TRAIT_NOBREATH, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_TOXIMMUNE, TRAIT_GENERIC)
+	ADD_TRAIT(src, TRAIT_SILVER_WEAK, TRAIT_GENERIC)
+	weather_immunities += "lava"
 
 /mob/living/simple_animal/pet/familiar/infernal/is_aligned_leyline(obj/structure/leyline/ley)
 	return istype(ley, /obj/structure/leyline/normal/decap)

--- a/code/modules/spells/spell_types/familiar_abilities.dm
+++ b/code/modules/spells/spell_types/familiar_abilities.dm
@@ -253,6 +253,7 @@
 	primary_resource_cost = 0
 	cooldown_time = 1 MINUTES
 	familiar = TRUE
+	required_items = null
 
 /obj/effect/proc_holder/spell/self/infernal_surge
 	name = "Infernal Surge"


### PR DESCRIPTION
## About The Pull Request

- Hellfyre Wave can now be used by familiars again, sorry.
- Additionally, they're now fireproof.

## Testing Evidence

I forgor to set the thing to null oops. One line, two at most lumping in the fireproof.

## Why It's Good For The Game

Fug Bixes, Fversight Oixes.

## Changelog
:cl:
fix: fixed an oversight on hellfyre wave, and they cannot be ignited now
/:cl: