### PR TITLE
Stone and wooden tools/weapons repair using the skill that crafts them

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -25,6 +25,7 @@
 	gripped_intents = list(/datum/intent/axe/chop/stone)
 	resistance_flags = FLAMMABLE
 	special = /datum/special_intent/axe_swing
+	anvilrepair = /datum/skill/craft/crafting
 
 /obj/item/rogueweapon/stoneaxe/getonmobprop(tag)
 	. = ..()
@@ -53,6 +54,7 @@
 	gripped_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/chop/heavy, /datum/intent/axe/bash/battle)
 	minstr = 9
 	wdefense = 4
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/oath
 	force = 30
@@ -77,6 +79,7 @@
 	smeltresult = /obj/item/ingot/steel
 	minstr = 12
 	wdefense = 5
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/oath/getonmobprop(tag)
 	if(tag)
@@ -100,6 +103,7 @@
 	gripped_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash)
 	wdefense = 2
 	is_tool = TRUE // set here to exclude battleaxes and such
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/woodcut/woodcutter
 	name = "woodcutter's handaxe"
@@ -143,6 +147,7 @@
 	possible_item_intents = list(/datum/intent/axe/chop/stone)
 	gripped_intents = null
 	thrown_damage_flag = "piercing"		//Checks piercing type like an arrow.
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/hurlbat/getonmobprop(tag)
 	. = ..()
@@ -220,6 +225,7 @@
 	grid_width = 32
 	throw_speed = 3 
 	armor_penetration = PEN_LIGHT
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /datum/intent/axe/cut/handaxe
 	damfactor = 1.1
@@ -365,6 +371,7 @@
 	pickup_sound = 'sound/foley/equip/rummaging-03.ogg'
 	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop)
 	resistance_flags = FLAMMABLE
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/woodcut/silver
 	name = "silver war axe"

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -261,6 +261,7 @@
 	max_blade_int = 100
 	max_integrity = 150
 	smeltresult = null
+	anvilrepair = /datum/skill/craft/carpentry
 
 /datum/intent/dagger/cut/wood
 	name = "cut"
@@ -863,6 +864,7 @@
 	max_blade_int = 100
 	wdefense = 1
 	resistance_flags = FLAMMABLE
+	anvilrepair = /datum/skill/craft/crafting
 
 /obj/item/rogueweapon/huntingknife/stoneknife/kukri
 	name = "jade kukri"
@@ -873,6 +875,7 @@
 	max_blade_int = 50
 	wdefense = 3
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/huntingknife/stoneknife/opalknife
 	name = "opal knife"
@@ -883,6 +886,7 @@
 	max_blade_int = 50
 	wdefense = 3
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/elvish
 	name = "elvish dagger"

--- a/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
@@ -653,6 +653,7 @@
 	max_blade_int = 70
 	smeltresult = null
 	associated_skill = /datum/skill/combat/polearms
+	anvilrepair = /datum/skill/craft/crafting
 	walking_stick = TRUE
 	wdefense = 4
 	max_integrity = 50
@@ -670,6 +671,7 @@
 	dam_icon = 'icons/effects/item_damage32.dmi'
 	icon_state = "cspear"
 	smeltresult = null
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/fishspear
 	force = 20

--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -184,6 +184,7 @@
 	max_integrity = 100
 	hoe_damage = 25
 	work_time = 15 SECONDS
+	anvilrepair = /datum/skill/craft/crafting
 
 /obj/item/rogueweapon/hoe/get_mechanics_examine(mob/user)
 	. = ..()

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -373,6 +373,7 @@
 	desc = "A wooden mallet is an Artificer's second best friend! But it may also come in handy to a Blacksmith or Tailor.."
 	icon_state = "hammer_w"
 	force = 16
+	anvilrepair = /datum/skill/craft/crafting
 
 /obj/item/rogueweapon/hammer/stone	// stone hammer
 	name = "stone hammer"
@@ -380,6 +381,7 @@
 	icon_state = "hammer_r"
 	force = 18
 	max_integrity = 15
+	anvilrepair = /datum/skill/craft/crafting
 
 /obj/item/rogueweapon/hammer/paalloy
 	name = "ancient hammer"


### PR DESCRIPTION
## About The Pull Request

Makes stone & wooden tools/weapons repair using the skill used to craft them.
More specifically, crafting now replaces weaponsmithing for repairing wooden mallets, stone hammers, stone hoes, stone knives, stone axes, and stone spears (it already did for stone swords).
Carpentry replaces weaponsmithing for repairing wooden knives (it already did for wooden maces).


Sidenote, all axes inheriting from stone axes rather than some basic unused parent pains me.

## Testing Evidence

<img width="599" height="670" alt="image" src="https://github.com/user-attachments/assets/31ffadcb-0f6a-435a-a159-58b40de39919" />




## Why It's Good For The Game

Being able to make a new stone hammer with crafting, but being unable to repair the existing one because you lack weaponsmithing, is silly.


## Changelog


:cl:
fix: Stone/wooden tools now repair via the same skill used to make them (usually crafting).
/:cl:
