### PR TITLE
up unarmed clickcds (including punching)

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -580,7 +580,7 @@
 	misscost = 3
 	releasedrain = 1
 	swingdelay = 0
-	clickcd = CLICK_CD_FAST // Same speed as katar — fists are the free unarmed weapon
+	clickcd = CLICK_CD_MELEE
 	rmb_ranged = TRUE
 	candodge = TRUE
 	canparry = TRUE

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -10,7 +10,7 @@
 	chargetime = 0
 	swingdelay = 0
 	damfactor = 1.3
-	clickcd = CLICK_CD_FAST
+	clickcd = CLICK_CD_MELEE
 	item_d_type = "slash"
 
 /datum/intent/katar/thrust
@@ -23,16 +23,16 @@
 	penfactor = PEN_MEDIUM // This make them good vs other light armor users
 	// So they don't need extra bonus damage on top
 	chargetime = 0
-	clickcd = CLICK_CD_FAST
+	clickcd = CLICK_CD_MELEE
 	item_d_type = "stab"
 
 /datum/intent/axe/chop/arbelos
 	damfactor = 1.3
-	clickcd = CLICK_CD_QUICK //Quicker than a conventional axe, but slower than a katar.
+	clickcd = CLICK_CD_MELEE
 
 /datum/intent/axe/cut/arbelos
 	damfactor = 1.15
-	clickcd = CLICK_CD_FAST //Same speed as a katar, but with reduced penetration and half-damage. Main appeal's the chopper.
+	clickcd = CLICK_CD_QUICK
 
 /datum/intent/katar/thrust/arbelos
 	penfactor = PEN_LIGHT
@@ -376,11 +376,11 @@
 
 /datum/intent/axe/chop/arbelos
 	damfactor = 1.3
-	clickcd = CLICK_CD_QUICK //Quicker than a conventional axe, but slower than a katar.
+	clickcd = CLICK_CD_MELEE
 
 /datum/intent/axe/cut/arbelos
 	damfactor = 1.15
-	clickcd = CLICK_CD_FAST //Same speed as a katar, but with reduced penetration and half-damage. Main appeal's the chopper.
+	clickcd = CLICK_CD_QUICK
 
 /datum/intent/katar/thrust/arbelos
 	penfactor = PEN_LIGHT
@@ -981,13 +981,13 @@
 /datum/intent/claw/lunge/iron
 	damfactor = 1.2
 	swingdelay = 8
-	clickcd = CLICK_CD_MELEE
+	clickcd = CLICK_CD_QUICK
 	penfactor = PEN_HEAVY
 
 /datum/intent/claw/lunge/steel
 	damfactor = 1.2
 	swingdelay = 12
-	clickcd = CLICK_CD_HEAVY
+	clickcd = CLICK_CD_QUICK
 	penfactor = PEN_HEAVY
 
 /datum/intent/claw/lunge/gronn

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -169,8 +169,6 @@
 				if(UH.used_intent.unarmed)
 					prob2defend = prob2defend - (UH.get_skill_level(/datum/skill/combat/unarmed) * 10)
 					prob2defend = prob2defend + (H.get_skill_level(/datum/skill/combat/unarmed) * 10)
-					if(U.STASPD > L.STASPD) //unarmed is inherently swift
-						prob2defend = prob2defend - ((U.STASPD - L.STASPD) * 10)
 
 
 		if(HAS_TRAIT(L, TRAIT_GUIDANCE))

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -170,19 +170,6 @@
 	else
 		attacker_skill = U.get_skill_level(/datum/skill/combat/unarmed)
 		prob2defend -= (attacker_skill * 20)
-		if(user.STASPD > src.STASPD) //unarmed is inherently swift
-			var/spdmod = ((user.STASPD - src.STASPD) * 10)
-			var/permod = ((src.STAPER - user.STAPER) * 10)
-			var/intmod = ((src.STAINT - user.STAINT) * 3)
-			if(mind)
-				if(permod > 0)
-					spdmod -= permod
-				if(intmod > 0)
-					spdmod -= intmod
-			var/finalmod = spdmod
-			if(mind)
-				finalmod = clamp(spdmod, 0, 30)
-			prob2defend -= finalmod
 
 	// --- Weapon binding! ---
 

--- a/code/modules/spells/spell_types/classunique/spellfist/blade_of_psydon.dm
+++ b/code/modules/spells/spell_types/classunique/spellfist/blade_of_psydon.dm
@@ -61,6 +61,12 @@
 	SIGNAL_HANDLER
 	summoned_blade = null
 
+/datum/intent/katar/cut/spellfist
+	clickcd = CLICK_CD_FAST
+
+/datum/intent/katar/thrust/spellfist
+	clickcd = CLICK_CD_FAST
+
 /obj/item/melee/touch_attack/rogueweapon/bladeofpsydon
 	name = "\improper arcyne katar"
 	desc = "This blade throbs, translucent and iridiscent, blueish arcyne energies running through its translucent surface..."
@@ -69,7 +75,7 @@
 	icon_state = "katar_bound"
 	charges = 20
 	force = 24
-	possible_item_intents = list(/datum/intent/katar/cut, /datum/intent/katar/thrust)
+	possible_item_intents = list(/datum/intent/katar/cut/spellfist, /datum/intent/katar/thrust/spellfist)
 	gripsprite = FALSE
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_HUGE


### PR DESCRIPTION
## About The Pull Request

- All unarmed weapons had their clickCDs were raised to be a bit slower than the dagger, including punches.
- Most unarmed weapons and punching itself has lost swift-balance.

Gronn claws, Solar Fist, Psydon's Punch Dagger kept their swift balance and click cd.

## Testing Evidence

balance testing

## Why It's Good For The Game

unarmed weapon or otherwise have received buffs. it's about time they are brought to the level of real weapons and treated as such for the type of damage they deal on average.
unsure on punching losing swift balance but we'll see. the numbers on unarmed weapons i'm certain of.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: unarmed weapon cd has been raised across the board. lost swift balance.
balance: punching weapon cd has been increased. lost swift balance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
