### PR TITLE
Swashbuckler gains Leaper and +1 rank in knives (to j-man).

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -205,14 +205,14 @@
 	tutorial = "You are a daring rogue of the seas! Swashbucklers wield agile swordplay and acrobatic prowess - fighting dirty to outmaneuver foes with flair."
 	outfit = /datum/outfit/job/roguetown/adventurer/swashbuckler
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander3.ogg'
-	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_NUTCRACKER, TRAIT_DECEIVING_MEEKNESS)
+	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_NUTCRACKER, TRAIT_DECEIVING_MEEKNESS, TRAIT_LEAPER)
 	subclass_stats = list(
 		STATKEY_SPD = 2,
 		STATKEY_STR = 1,
 		STATKEY_WIL = 1,
 	)
 	subclass_skills = list(
-		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

Swashbuckler gains the leaper trait, and their knife skill goes from apprentice to journeyman.


## Testing Evidence

<img width="607" height="687" alt="image" src="https://github.com/user-attachments/assets/15efe942-7b6f-45a5-9428-e4dde1d51867" />


## Why It's Good For The Game

Open to discussing this one, mostly looking to give them a little extra sauce, since they lack the utility skills of a thief (who gets j-man knives and maces, plus apprentice bows), the music of a bard, the magic of a spellthief, or various graverobbing/alchemy tricks.

Dramatic jumping around is cool and fits the swash, while bringing their knife skill up on par with their sword skill should encourage flexing between parrying dagger use (rather than bucklers that'd scale off swords) and dodge, since they already get dodge expert. Also makes them a bit more of a ranged threat with their tossblades.


## Changelog

:cl:
balance: buffed swashbuckler advent knife skill & jumping
/:cl:
