### PR TITLE
becky - removes silver longsword from Cleric, replaces it with an unsundering alternative

### DIFF
--- a/code/controllers/subsystem/rogue/triumphs/triumph_modkit.dm
+++ b/code/controllers/subsystem/rogue/triumphs/triumph_modkit.dm
@@ -251,6 +251,14 @@
 		)
 	result_item = /obj/item/rogueweapon/example/sengese
 
+/obj/item/enchantingkit/weapon/triumph_weaponkit_clericsword
+	name = "'Clerical' longsword morphing elixir"
+	desc = "A small container of special morphing dust, perfect to make a specific item. It can be used to alter the appearance of a Steel Longsword."
+	target_items = list(
+		/obj/item/rogueweapon/sword/long,
+		)
+	result_item = /obj/item/rogueweapon/example/clericsword
+
 //////////////////////////////
 // TRIUMPH-RESKIN EXAMPLES! //
 //////////////////////////////
@@ -326,6 +334,15 @@
 	a lethal implement, if entrusted to the hands of a wielder whose skill in swordsmanship lays unmatched."
 	icon_state = "sengese"
 	sheathe_icon = "sgeneric"
+
+/obj/item/rogueweapon/example/clericsword
+	name = "anointed longsword"
+	icon = 'icons/roguetown/weapons/swords32.dmi'
+	desc = "A cleric's longsword, adorned with a blade of cold iron and blessed to smite evil. Though this blessed alloy lacks the strength to \
+	sunder those who bare greater curses, it nevertheless channels enough power to dispell the lesser curses of mindless fiends-and-foes. </br>'Strike \
+	true, my child, for thy blade is thine God..'"
+	icon_state = "crusaderlongsword"
+	sheathe_icon = "crusaderlongsword"
 
 ////////////////////////////////////////////////////
 // ! TO BE ARCHIVED / REPLACED WITH BETTER CODE!  //

--- a/code/datums/loadout/loadout_triumph.dm
+++ b/code/datums/loadout/loadout_triumph.dm
@@ -332,6 +332,12 @@
 	triumph_cost = 3
 	sort_category = "Triumphs"
 
+/datum/loadout_item/triumph_weaponkit_clericsword
+	name = "Morphing Elixir, 'Clerical Longsword'"
+	path = /obj/item/enchantingkit/weapon/triumph_weaponkit_clericsword
+	triumph_cost = 3
+	sort_category = "Triumphs"
+
 //////////////////
 //  PERFUMES !  //
 //////////////////

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -318,7 +318,7 @@
 	thrown_bclass = BCLASS_BLUNT
 
 /obj/item/rogueweapon/sword/long/cleric
-	name = "blessed longsword"
+	name = "crusaders longsword"
 	desc = "A crusader's longsword, adorned with a blade of cold iron and blessed to smite evil. Though this blessed alloy lacks the strength to \
 	sunder those who bare greater curses, it nevertheless channels enough power to dispell the lesser curses of mindless fiends-and-foes. </br>'Strike \
 	true, my child, for thy blade is thine God..'"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -333,16 +333,16 @@
 			if("Axe")
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
-		var/oaths = list("Cleric - Medicine Training + Supplies","Crusader - Silver Longsword + Surcoat","None")
+		var/oaths = list("Cleric - Medicine Training + Supplies","Crusader - Blessed Longsword + Surcoat","None")
 		var/oath_choice = input(H, "Choose your OATH.", "PROFESS YOUR BLESSINGS.") as anything in oaths
 		switch(oath_choice)
 			if("Cleric - Medicine Training + Supplies")
 				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_APPRENTICE, TRUE)
 				l_hand = /obj/item/needle/thorn/cleric //Unique to the Cleric. Far worse than a traditional iron needle, but better than a regular thorn needle - with 10 uses, instead of 5 (or 20, in the former's case).
 				beltl = /obj/item/reagent_containers/glass/bottle/rogue/healthpot //No cloth, but a basic potion of lifeblood - similar to the Sorcerer's manna potion. Take the 'Physician's Apprentice' virtue for that, uncapped skills, and more.
-			if("Crusader - Silver Longsword + Surcoat")
-				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE) //Essentially turns it into the old Monster Hunter, in terms of balance.
-				beltl = /obj/item/rogueweapon/sword/long/silver //Functionally, inflicts silverbane at the cost of -5 damage. Likely won't be a balancing issue, unless we start seeing +5-10 Clerics overnight.
+			if("Crusader - Unique Longsword + Surcoat")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE) 
+				beltl = /obj/item/rogueweapon/sword/long/cleric //Essentially, a silver longsword without the ability to sunder antagonists. Should it deal lesser sunder to mindless unholy foes, later? Perhaps.
 				switch(H.patron?.type)
 					if(/datum/patron/old_god)
 						l_hand = /obj/item/clothing/cloak/tabard/stabard/crusader/t

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -333,7 +333,7 @@
 			if("Axe")
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
-		var/oaths = list("Cleric - Medicine Training + Supplies","Crusader - Blessed Longsword + Surcoat","None")
+		var/oaths = list("Cleric - Medicine Training + Supplies","Crusader - Unique Longsword + Surcoat","None")
 		var/oath_choice = input(H, "Choose your OATH.", "PROFESS YOUR BLESSINGS.") as anything in oaths
 		switch(oath_choice)
 			if("Cleric - Medicine Training + Supplies")


### PR DESCRIPTION
## About The Pull Request

You're all going to hate me for this, I know. It has to be done, however.
In short:
* Removes the Silver Longsword from the Cleric. Selecting the 'Crusader' option now awards the Crusader Longsword, instead.
* Crusader's Longswords look very similar to Silver Longswords and inherit their unique stats, sans the ability to sunder.
* Likewise, this can also be taken as a new Triumph reskin - albeit, without the mechanical benefits, as an 'anointed' sword.

<img width="655" height="330" alt="aurgesword" src="https://github.com/user-attachments/assets/cb964599-bf9d-43cf-a7fb-3d649ee7ea7b" />

## Testing Evidence

One line. Good to go.

## Why It's Good For The Game

<img width="534" height="755" alt="aurgh" src="https://github.com/user-attachments/assets/75fbdefe-8940-4f51-b7dd-f7137ba6e227" />

I originally added this as an experiment, and it seems to not be the _best_ idea in hindsight.
Chiefly..
* This was originally added with the justification that Clerics were weighed similarly to Monster Hunters, without accounting for the fact that Clerics get better starting equipment and access to miracles.
* Likewise, the idea of unrestricted silver access to Adventurers came before the addition of Sunder, which has made silver weapons much more powerful - and in general, coveted for use - against antagonists.
* Having potentially ten-to-twenty extra silver weapons introduced into the economy without any means of restriction or cost sets a _very_ bad precedent, and _(as voiced by other developers and antagonist-heavy players)_ not a good idea.

To compensate..
* The Exorcist will be getting a bit of supplemental love, in due time. Note that they'll remain the premiere option for those - both clerical and mundane - that want to bare silver against the foes of Psydonia.. albeit, with a five-slot capacity.
* The Clerics will still be able to rep the aesthetics of a Silver Longsword, and reap most of its raw mechanical benefits; a defense-heavy longsword still works quite well in fighting the unholy.
* Cold iron as an alloy might be given the ability to sunder mindless and lesser foes, later on - for now, however, this is a stopgap.

## Changelog

:cl:
balance: Replaces the Cleric's Silver Longsword with the Crusader's Longsword, an unsundering analogue that retains all of the Silver Longsword's other mechanical quirks (ala higher defense, lower offense).
add: Adds a variant of the Blessed Longsword as a new Triumph reskin option - the 'Anointed / Clerical Longsword'.
/:cl: