### PR TITLE
theodore - adds restoration potions as an Expert-tiered alchemic recipe, rosas can now be used for luck- and antidote potions

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/alch_cauldron_recipes.dm
@@ -72,7 +72,14 @@
 	skill_required = SKILL_LEVEL_JOURNEYMAN
 	output_reagents = list(/datum/reagent/medicine/strongstam = 90)
 
+/datum/alch_cauldron_recipe/restoration_potion
+	name = "Elixir of Restoration"
+	smells_like = "fizzling berries"
+	skill_required = SKILL_LEVEL_EXPERT
+	output_reagents = list(/datum/reagent/medicine/restoration = 90)
+
 //S.P.E.C.I.A.L. potions - Expert or above (roundstart Witch etc.)
+
 /datum/alch_cauldron_recipe/str_potion
 	name = "Potion of Mountain Muscles"
 	smells_like = "petrichor"

--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -134,7 +134,7 @@
 	icon_state = "silverdust"
 	sellprice = 20
 	major_pot = /datum/alch_cauldron_recipe/strong_antidote
-	med_pot = /datum/alch_cauldron_recipe/antidote
+	med_pot = /datum/alch_cauldron_recipe/restoration_potion
 	minor_pot = /datum/alch_cauldron_recipe/big_health_potion
 
 /obj/item/alch/magicdust
@@ -251,7 +251,7 @@
 	sellprice = 15
 
 	major_pot = /datum/alch_cauldron_recipe/big_mana_potion
-	med_pot = /datum/alch_cauldron_recipe/con_potion
+	med_pot = /datum/alch_cauldron_recipe/restoration_potion
 	minor_pot = /datum/alch_cauldron_recipe/per_potion
 
 /obj/item/alch/feaudust
@@ -578,6 +578,9 @@
 	muteinmouth = FALSE
 	alternate_worn_layer  = 8.9 //On top of helmet
 	mill_result = /obj/item/reagent_containers/food/snacks/grown/rogue/rosa_petals
+	major_pot = /datum/alch_cauldron_recipe/lck_potion
+	med_pot = /datum/alch_cauldron_recipe/antidote
+	minor_pot = /datum/alch_cauldron_recipe/restoration_potion
 
 /obj/item/alch/rosa/equipped(mob/living/carbon/human/user, slot)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

In short:
* The Marquette-importable potions can now be brewed as an expensive alternative to the strong lifeblood and mana potions.
* Restoration elixirs restore mana _and_ lifeblood at the same time, at halfway the potency between regular and strong potions.
* Silver dust now provides Restoration as a med_point, instead of the Antidote.
* Gold dust now provides Restoration as a med_point, instead of the Constitution Potion.
* Rosas now provide Restoration as a low_point, Antidotes as a med_point, and Luck Potions as a high_point.

## Testing Evidence

Good to go.

## Why It's Good For The Game

* Offers a non-factionlocked way to create Restoration elixirs, at a cost that perfectly compliments its effectiveness.
* Adds alchemical uses - minimal as they may be - to the humble rosa.

## Changelog

:cl:
add: Restoration elixirs are now accessible via an Expert-level alchemic cauldron recipe. These elixirs use gold dust, silver dust, and rosas to brew; in exchange, they restore health and energy at the same time, at a rate halfway between regular-and-strong potions.
add: Rosas can now be used to brew Luck potions, Antidotes, and Restoration elixirs.
code: Gold dust and silver dust can no longer be used for Constitution potions and Antidotes. There's still a wide variety of ingredients that can be used for those two brews; though if it's an issue, do let me know.
/:cl: