### PR TITLE
Fixes berzerker weapon options

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -97,7 +97,7 @@
 					if("Punch Dagger")
 						beltr = /obj/item/rogueweapon/katar/punchdagger
 			if("Martial Expert") // designed to compete with unarmed by giving you alternatives to approaching fights- only expert 
-				var/list/martial_options = list("Discipline - Bodybuilder", "Battle Axe", "Grand Mace", "Longsword")
+				var/list/martial_options = list("Greatsword", "Battle Axe", "Grand Mace", "Longsword")
 				var/weapon_choice = input(H, "Choose your WEAPONS of WAR!", "SPILL THEIR ENTRAILS.") as anything in martial_options
 				switch(weapon_choice)
 					if("Greatsword") //Actually not a meme anymore


### PR DESCRIPTION
## About The Pull Request

Martial weapon selection list had a vestigial bodybuilder option that did nothing, and did not have an option to select their greatsword. This fixes that.


## Testing Evidence

One line edit, works ingame:
<img width="414" height="335" alt="image" src="https://github.com/user-attachments/assets/09f71a06-35d1-4576-a1c1-fe0afd8bc485" />
<img width="583" height="258" alt="image" src="https://github.com/user-attachments/assets/a4460721-066f-4b97-a143-21f4ca510119" />


## Why It's Good For The Game

Bugfix so they cant spawn without a main weapon, plus can get big sword access.

## Changelog

:cl:
fix: berzerker wretch weapon option fix (no non-functional bodybuilder option, yes now-functional greatsword option).
/:cl:

