### PR TITLE
egor - adds dropshrink to a wide variety of additional items

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -9,6 +9,7 @@
 	experimental_inhand = TRUE
 	possible_item_intents = list(/datum/intent/use) //If this affects candles lighting anything, remove this entire line to fix it.
 	light_color = LIGHT_COLOR_FIRE
+	dropshrink = 0.85
 	heat = 1000
 	var/wax = 1000
 	var/lit = FALSE

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -314,6 +314,7 @@
 	extinguishable = FALSE
 	weather_resistant = TRUE
 	experimental_onhip = FALSE //Looks a little wonky due to how belts overlay with hip items. Reenable if you wish, but be mindful of that fact.
+	dropshrink = 0.8
 
 /obj/item/flashlight/flare/torch/lantern/afterattack(atom/movable/A, mob/user, proximity)
 	. = ..()
@@ -426,7 +427,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	light_color = "#ffb272ff"
 	on = FALSE
-
 	slot_flags = ITEM_SLOT_HEAD
 	flags_inv = HIDEFACE|HIDEEARS|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	body_parts_covered = FULL_HEAD|NECK
@@ -434,13 +434,13 @@
 	block2add = FOV_BEHIND
 	equip_delay_self = 3 SECONDS
 	unequip_delay_self = 3 SECONDS
-
 	force = 1
 	on_damage = 3
 	wdefense = 1 //The pumpkin has a chance of getting in the way of strikes.
 	fuel = 0 MINUTES
 	should_self_destruct = FALSE
 	sellprice = 8 //Allows a minor business to bloom from them. This may require adjustments.
+	dropshrink = null
 
 /obj/item/flashlight/flare/torch/lantern/pumpkin/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/ritechalk.dm
+++ b/code/game/objects/items/ritechalk.dm
@@ -1,10 +1,11 @@
 /obj/item/ritechalk
-	name = "Ritual Chalk"
+	name = "ritual chalk"
 	icon_state = "chalk"
 	desc = "Simple white chalk. A useful tool for rites."
 	icon = 'icons/roguetown/misc/rituals.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	experimental_inhand = TRUE
+	dropshrink = 0.6
 
 /obj/item/ritechalk/attack_self(mob/living/user)
 	if(!HAS_TRAIT(user, TRAIT_RITUALIST))

--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -626,6 +626,7 @@
 	var/compiled_pages = null
 	var/list/page_texts = list()
 	var/qdel_source = FALSE
+	dropshrink = 0.8
 
 /obj/item/manuscript/examine()
 	. = ..()
@@ -645,7 +646,7 @@
 		return
 	var/obj/item/paper/P = I
 	if(!(P.info))
-		to_chat(user, "the paper needs to contain text to be added to a manuscript!")
+		to_chat(user, "The paper needs to contain text to be added to a manuscript!")
 		return
 	if(number_of_pages == 8)
 		to_chat(user, "The manuscript pile cannot surpass 8 pages!")
@@ -766,3 +767,4 @@
 	desc = "Apply on a written manuscript to create a book."
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "book_crafting_kit"
+	dropshrink = 0.7

--- a/code/game/objects/items/rogueitems/bouquet.dm
+++ b/code/game/objects/items/rogueitems/bouquet.dm
@@ -9,12 +9,14 @@
 
 	grid_width = 32
 	grid_height = 64
+	dropshrink = 0.9
 
 /obj/item/bouquet/rosa
 	name = "rosa bouquet"
 	desc = "Affections bundled together in string."
 	item_state = "bouquet_rosa"
 	icon_state = "bouquet_rosa"
+	dropshrink = 0.9
 
 /obj/item/bouquet/salvia
 	name = "salvia bouquet"

--- a/code/game/objects/items/rogueitems/flintsparker.dm
+++ b/code/game/objects/items/rogueitems/flintsparker.dm
@@ -15,6 +15,7 @@
 	resistance_flags = FIRE_PROOF
 	grid_height = 32
 	grid_width = 32
+	dropshrink = 0.8
 
 /obj/item/flint/attack_self(mob/living/user)
 	if(world.time < flintcd + 10)

--- a/code/game/objects/items/rogueitems/hair_dye.dm
+++ b/code/game/objects/items/rogueitems/hair_dye.dm
@@ -7,7 +7,6 @@
     var/uses_remaining = 30
     grid_width = 32
     grid_height = 32
-	dropshrink = 0.8
 
 /obj/item/hair_dye_cream/attack(mob/living/M, mob/living/user)
     if(!ishuman(M))

--- a/code/game/objects/items/rogueitems/hair_dye.dm
+++ b/code/game/objects/items/rogueitems/hair_dye.dm
@@ -7,6 +7,7 @@
     var/uses_remaining = 30
     grid_width = 32
     grid_height = 32
+	dropshrink = 0.8
 
 /obj/item/hair_dye_cream/attack(mob/living/M, mob/living/user)
     if(!ishuman(M))

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -27,6 +27,7 @@
 	var/playing = FALSE
 	grid_height = 64
 	grid_width = 32
+	dropshrink = 0.8
 
 /obj/item/rogue/instrument/equipped(mob/living/user, slot)
 	. = ..()

--- a/code/game/objects/items/rogueitems/keyrings.dm
+++ b/code/game/objects/items/rogueitems/keyrings.dm
@@ -18,6 +18,7 @@
 	experimental_inhand = TRUE
 	experimental_onhip = TRUE
 	component_type = /datum/component/storage/concrete/roguetown/keyring
+	dropshrink = 0.85
 
 /obj/item/storage/keyring/get_mechanics_examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/rogueitems/magic/mageitems.dm
+++ b/code/game/objects/items/rogueitems/magic/mageitems.dm
@@ -200,6 +200,7 @@
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state = "mimic_trinket"
 	possible_item_intents = list(/datum/intent/use)
+	dropshrink = 0.6
 	var/duration = 10 MINUTES
 	var/oldicon
 	var/oldicon_state

--- a/code/game/objects/items/rogueitems/magic/magic_resources.dm
+++ b/code/game/objects/items/rogueitems/magic/magic_resources.dm
@@ -24,6 +24,7 @@
 	grid_width = 32
 	grid_height = 32
 	var/tier = 0 //used for determining potency for mob healing
+	dropshrink = 0.85
 
 /obj/item/magic/familiar
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
@@ -119,6 +120,7 @@
 	icon_state = "runedartifact"
 	desc = "An old stone from age long ago, marked with glowing sigils."
 	w_class = WEIGHT_CLASS_SMALL
+	dropshrink = 0.8
 
 /obj/item/magic/artifact/Initialize()
 	.=..()

--- a/code/game/objects/items/rogueitems/natural/animals.dm
+++ b/code/game/objects/items/rogueitems/natural/animals.dm
@@ -10,6 +10,7 @@
 	resistance_flags = FLAMMABLE
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
 	sellprice = 8
+	dropshrink = 0.9
 
 /obj/item/natural/hide/get_mechanics_examine(mob/user)
 	. = ..()
@@ -43,6 +44,7 @@
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'
 	color = "#5c5243"
 	experimental_inhand = TRUE
+	dropshrink = 0.9
 
 /obj/item/natural/fur/goat
 	desc = "Fur from a humble gote."
@@ -211,6 +213,7 @@
 	resistance_flags = FLAMMABLE
 	w_class = WEIGHT_CLASS_SMALL
 	sellprice = 20
+	dropshrink = 0.6
 
 /obj/item/natural/rabbitsfoot
 	name = "rabbit's foot"

--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -174,6 +174,7 @@
 	spitoutmouth = FALSE
 	experimental_inhand = TRUE
 	bundletype = /obj/item/natural/bundle/cloth
+	dropshrink = 0.9
 	sellprice = 4
 	detail_tag = "_soaked"
 	var/wet = 0
@@ -542,6 +543,7 @@
 	icon2step = 10
 	grid_width = 32
 	grid_height = 32
+	dropshrink = 0.9
 
 /obj/item/natural/bundle/stick
 	name = "bundle of sticks"

--- a/code/game/objects/items/rogueitems/natural/feather.dm
+++ b/code/game/objects/items/rogueitems/natural/feather.dm
@@ -16,6 +16,7 @@
 	muteinmouth = TRUE
 	spitoutmouth = FALSE
 	w_class = WEIGHT_CLASS_TINY
+	dropshrink = 0.75
 
 /obj/item/natural/feather/get_mechanics_examine(mob/user)
 	. = ..()
@@ -72,3 +73,4 @@
 	muteinmouth = TRUE
 	spitoutmouth = FALSE
 	w_class = WEIGHT_CLASS_TINY
+	dropshrink = 0.75

--- a/code/game/objects/items/rogueitems/natural/glass.dm
+++ b/code/game/objects/items/rogueitems/natural/glass.dm
@@ -80,6 +80,7 @@
 	icon1step = 2
 	icon2 = "glasspane2"
 	icon2step = 3
+	dropshrink = 0.9
 
 /obj/item/natural/bundle/glass/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
 	if(!..()) //was it caught by a mob?
@@ -108,6 +109,7 @@
 	attack_verb = list("stabbed", "slashed", "sliced", "cut")
 	max_integrity = 40
 	smeltresult = /obj/item/natural/glass
+	dropshrink = 0.8
 
 /obj/item/natural/glass_shard/Initialize()
 	. = ..()

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -31,6 +31,7 @@
 	var/can_repair = TRUE
 	grid_width = 32
 	grid_height = 32
+	dropshrink = 0.75
 
 /obj/item/needle/examine()
 	. = ..()

--- a/code/game/objects/items/rogueitems/parasols.dm
+++ b/code/game/objects/items/rogueitems/parasols.dm
@@ -19,7 +19,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	grid_width = 32
 	grid_height = 64
-
+	dropshrink = 0.75
 	var/active_item = FALSE
 
 /obj/item/rogueweapon/mace/parasol/Initialize()

--- a/code/game/objects/items/rogueitems/ropechainbola/chain.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola/chain.dm
@@ -27,3 +27,4 @@
 	sewrepair = FALSE
 	anvilrepair = /datum/skill/craft/blacksmithing
 	resistance_flags = FIRE_PROOF
+	dropshrink = null

--- a/code/game/objects/items/rogueitems/ropechainbola/rope.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola/rope.dm
@@ -19,6 +19,7 @@
 	grid_width = 32
 	grid_height = 64
 	var/matthios_chains = FALSE
+	dropshrink = 0.9
 
 /obj/item/rope/Initialize()
 	. = ..()

--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -12,6 +12,7 @@
 	throw_speed = 1
 	throw_range = 1
 	grind_results = list(/datum/reagent/lye = 10)
+	dropshrink = 0.7
 	var/cleanspeed = 20 //as fast as 5 arcyne Prestidigitation
 	var/uses = 100
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -107,6 +107,7 @@
 	resistance_flags = NONE
 	max_integrity = 300
 	component_type = /datum/component/storage/concrete/grid/meatsack
+	dropshrink = 0.8
 
 /obj/item/storage/meatbag/attack_right(mob/user)
 	. = ..()

--- a/code/game/objects/items/surgery_bag.dm
+++ b/code/game/objects/items/surgery_bag.dm
@@ -3,6 +3,7 @@
 	desc = "Made to hold everything a people-butcher will need. Contains a list of implements... what even IS a Sisrat?"
 	icon = 'icons/roguetown/clothing/storage.dmi'
 	mob_overlay_icon = null
+	dropshrink = 0.9
 	icon_state = "surgery_bag"
 	slot_flags = ITEM_SLOT_HIP
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -15,6 +15,7 @@
 	salvage_result = null
 	alternate_worn_layer = NECK_LAYER
 	no_loot_taint = TRUE
+	dropshrink = 0.4
 	var/overarmor
 
 /obj/item/clothing/ring/MiddleClick(mob/user, params)

--- a/code/modules/reagents/reagent_containers/lux.dm
+++ b/code/modules/reagents/reagent_containers/lux.dm
@@ -9,6 +9,7 @@
 	list_reagents = list(/datum/reagent/vitae = 5)
 	grind_results = list(/datum/reagent/vitae = 5)
 	sellprice = 90
+	dropshrink = 0.7
 
 /datum/reagent/vitae
 	name = "Vitae"
@@ -35,6 +36,7 @@
 	icon_state = "lux_impure"
 	item_state = "lux_impure"
 	sellprice = 15
+	dropshrink = 0.7
 
 /obj/item/reagent_containers/lux_moss
 	name = "corrupted lux"
@@ -43,3 +45,4 @@
 	icon_state = "mosslux"
 	item_state = "mosslux"
 	sellprice = 1
+	dropshrink = 0.7

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -9,6 +9,7 @@
 	sellprice = 10
 	grid_width = 32
 	grid_height = 32
+	dropshrink = 0.75
 
 /obj/item/reagent_containers/powder/spice
 	name = "spice"

--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -3,6 +3,7 @@
 	desc = ""
 	icon = 'icons/roguetown/misc/alchemy.dmi'
 	icon_state = "irondust"
+	dropshrink = 0.75
 	w_class = WEIGHT_CLASS_TINY
 	experimental_inhand = TRUE
 	/*

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -166,7 +166,7 @@
 	icon_state = "brush_0"
 	w_class = WEIGHT_CLASS_SMALL
 	smeltresult = null
-	dropshrink = 0.8
+	dropshrink = 0.6
 	grid_width = 32
 	grid_height = 64
 	var/roughness = 0 // 0  for a fine brush, 1 for a coarse brush

--- a/code/modules/roguetown/roguejobs/fisher/leeches.dm
+++ b/code/modules/roguetown/roguejobs/fisher/leeches.dm
@@ -3,6 +3,7 @@
 /obj/item/natural/worms/leech
 	name = "leech"
 	desc = "A disgusting, blood-sucking parasite."
+	dropshrink = 0.8
 	icon = 'icons/roguetown/items/surgery.dmi'
 	icon_state = "leech"
 	baitpenalty = 0

--- a/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
+++ b/code/modules/roguetown/roguejobs/mages/enchanting_scrolls.dm
@@ -12,6 +12,7 @@ T1 Enchantments below here*/
 	possible_item_intents = list(/datum/intent/use)
 	grid_width = 64
 	grid_height = 32
+	dropshrink = 0.8
 
 /obj/item/enchantmentscroll/attack_obj(obj/item/O, mob/living/user)
 	if(O.unenchantable)

--- a/code/modules/roguetown/roguejobs/miner/rogueores.dm
+++ b/code/modules/roguetown/roguejobs/miner/rogueores.dm
@@ -138,6 +138,7 @@
 	var/datum/anvil_recipe/currecipe
 	grid_width = 64
 	grid_height = 32
+	dropshrink = 0.8
 
 /obj/item/ingot/examine()
 	. += ..()

--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -311,7 +311,7 @@ var/list/used_colors
 	desc = "A sizeable brush made of the finest mane-hairs. Thick dye adheres to it well."
 	icon_state = "dbrush"
 	w_class = WEIGHT_CLASS_SMALL
-	dropshrink = 0.8
+	dropshrink = 0.7
 	grid_width = 32
 	grid_height = 32
 

--- a/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_tick.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_tick.dm
@@ -17,6 +17,7 @@
 		"cheeseFishingMod" = 0 // Just for the funny gimmick of a chance for rats and rouses.
 	)
 	baitresilience = 5
+	dropshrink = 0.85
 
 /obj/item/leechtick_bloated
 	icon_state = "leechthick"

--- a/code/modules/roguetown/roguemachine/scomm/rontzring.dm
+++ b/code/modules/roguetown/roguemachine/scomm/rontzring.dm
@@ -5,7 +5,7 @@
 	icon_state = "mattcoin"
 	desc = "A faded coin with a ruby laid into its center."
 	gripped_intents = null
-	dropshrink = 0.75
+	dropshrink = 0.4
 	possible_item_intents = list(INTENT_GENERIC)
 	force = 10
 	throwforce = 10

--- a/code/modules/roguetown/roguemachine/scomm/scomstone.dm
+++ b/code/modules/roguetown/roguemachine/scomm/scomstone.dm
@@ -5,7 +5,7 @@
 	icon_state = "ring_scom"
 	desc = "A heavy ring made of metal. There is a gem embedded in the center - dim, but alive."
 	gripped_intents = null
-	dropshrink = 0.75
+	dropshrink = 0.6
 	possible_item_intents = list(INTENT_GENERIC)
 	force = 10
 	throwforce = 10

--- a/modular/Neu_Food/code/others/honey.dm
+++ b/modular/Neu_Food/code/others/honey.dm
@@ -4,7 +4,7 @@
 	name = "honey"
 	icon = 'modular/Neu_Food/icons/others/honey.dmi'
 	icon_state = "honeycomb"
-	dropshrink = 0.8
+	dropshrink = 0.75
 	bitesize = 3
 	possible_transfer_amounts = list()
 	list_reagents = list(/datum/reagent/consumable/honey = 5, /datum/reagent/consumable/nutriment = SNACK_DECENT)


### PR DESCRIPTION
## About The Pull Request

Testmerge this beforehand, if possible, to gauge general opinions.

Partial port from [this](https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1658) pull request.
In short:
* Adds dropshrink values to a wide variety of miscellaneous items, sans weapons and armor.

## Testing Evidence

Good to go. The other pull request has some nice shots.

## Why It's Good For The Game

* Makes some items a lot less oversized when viewed outside of the inventory space.
* Allows for more adjustments for table-related spreads.

## Changelog

:cl:
code: Tweaks a lot of dropshrink values for a wide variety of items. Ping @Dongwaiver on the 'cord if anything looks a little too off.
/:cl: