### PR TITLE
Nerf Golgatha, Fix Incisions

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -958,7 +958,7 @@
 	id = "censer"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/censerbuff
 	duration = 15 MINUTES
-	effectedstats = list(STATKEY_WIL = 1, STATKEY_CON = 1, STATKEY_FOR = 1)
+	effectedstats = list(STATKEY_WIL = 1, STATKEY_CON = 1, STATKEY_LCK = 1)
 
 #define DIMINISH_FILTER "diminish_glow"
 /datum/status_effect/debuff/diminish

--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -304,7 +304,8 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 			return FALSE
 
 	if(HAS_TRAIT(owner, TRAIT_PSYDONITE) && !passive_healing)
-		heal_wound(0.6)
+		if(!istype(src, /datum/wound/slash/incision))
+			heal_wound(0.6)
 		if(!owner || QDELETED(owner) || QDELETED(src))
 			return FALSE
 
@@ -321,7 +322,8 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 
 	if (HAS_TRAIT(owner, TRAIT_PSYDONITE) && !passive_healing)
 		heal_wound(0.6) // psydonites are supposed to apparently slightly heal wounds whether dead or alive
-
+		if(!istype(src, /datum/wound/slash/incision))
+			heal_wound(0.6)
 	return TRUE
 
 /// Setter for any adjustments we make to our bleed_rate, propagating them to the host bodypart.

--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -444,7 +444,7 @@ Inquisitorial armory down here
 			return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/process_golgatha_rebuke(mob/living/carbon/human/attacker)
+/mob/living/carbon/human/proc/process_golgatha_rebuke(mob/living/attacker)
 	if(!has_active_golgatha())
 		return
 	if(!HAS_TRAIT(src, TRAIT_SILVER_BLESSED)) // only people who is silverblessed can use golgatha's hidden feature
@@ -453,20 +453,15 @@ Inquisitorial armory down here
 		return
 	new /obj/effect/temp_visual/censer_dust(get_turf(attacker))
 	new /obj/effect/temp_visual/censer_dust(get_turf(attacker))
-	attacker.apply_status_effect(/datum/status_effect/syonchurn, src)
-	if(isnull(attacker.mind))
-		attacker.apply_status_effect(/datum/status_effect/debuff/clickcd, 2 SECONDS)
-		attacker.apply_status_effect(/datum/status_effect/debuff/exposed)
-	else
-		attacker.apply_status_effect(/datum/status_effect/debuff/clickcd, 1 SECONDS)
-	if(attacker.mob_biotypes & MOB_UNDEAD)
-		attacker.adjust_fire_stacks(3, /datum/status_effect/fire_handler/fire_stacks/sunder/blessed)
-		attacker.ignite_mob()
+	if(issimple(attacker) || !attacker.mind)
+		attacker.apply_status_effect(/datum/status_effect/syonchurn, src)
+	
+	attacker.adjustFireLoss(9)
 
 #define SYONCHURN_FILTER "syonchurn glow"
 
 /atom/movable/screen/alert/status_effect/syonchurn
-	name = "Syon's Rebuke"
+	name = "Dying Light"
 	desc = "The shard of Syon rejects my hostility against Psydon's anointed! Luminous fragments scour my body and spirit!"
 	icon_state = "supersunder"
 
@@ -476,12 +471,12 @@ Inquisitorial armory down here
 	duration = -1
 	tick_interval = 1 SECONDS
 	examine_text = "<font color='#00fff2'><b>SUBJECTPRONOUN is seared in body and soul by motes of lingering comet dust!</b></font>"
-	effectedstats = list(STATKEY_STR = -2, STATKEY_CON = -2, STATKEY_WIL = -2, STATKEY_SPD = -2)
 	status_type = STATUS_EFFECT_REFRESH
+	effectedstats = list(STATKEY_LCK = -2, STATKEY_SPD = -2)
 	var/datum/weakref/debuffer
 	var/outline_colour = "#70d1e2"
 	var/intensity = 1
-	var/range = 6
+	var/range = 4
 	var/damage_per_tick = 0.5
 	var/agony = 0
 
@@ -523,7 +518,7 @@ Inquisitorial armory down here
 		return
 
 	if(!owner.mind)
-		owner.adjustFireLoss((damage_per_tick * intensity) * 2)
+		owner.adjustFireLoss((damage_per_tick * intensity) * 3)
 
 	owner.adjustFireLoss(damage_per_tick * intensity)
 

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -373,6 +373,9 @@ All foods are distributed among various categories. Use common sense.
 /obj/item/reagent_containers/food/snacks/attack(mob/living/M, mob/living/user, def_zone)
 	if(user.used_intent.type == INTENT_HARM || user.cmode)
 		return ..()
+	if(istype(src, /obj/item/reagent_containers/food/snacks/organ) && M.lying)
+		to_chat(user, span_warning("[M] can't eat this while lying down. What even?"))
+		return FALSE
 	if(!eatverb)
 		eatverb = pick("bite","chew","nibble","gnaw","gobble","chomp")
 	if(iscarbon(M))

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -53,7 +53,8 @@
 		if(blood_volume > BLOOD_VOLUME_SURVIVE)
 			for(var/datum/wound/wound as anything in get_wounds())
 				if(wound?.severity <= WOUND_SEVERITY_MODERATE)
-					wound.heal_wound(0.4)
+					if(!istype(wound, /datum/wound/slash/incision))
+						wound.heal_wound(0.4)
 
 	if(!stat && HAS_TRAIT(src, TRAIT_LYCANRESILENCE) && !HAS_TRAIT(src, TRAIT_PARALYSIS))
 		if(src.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || src.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
@@ -61,7 +62,8 @@
 		handle_wounds()
 		if(blood_volume > BLOOD_VOLUME_SURVIVE)
 			for(var/datum/wound/wound as anything in get_wounds())
-				wound.heal_wound(3)
+				if(!istype(wound, /datum/wound/slash/incision))
+					wound.heal_wound(3)
 
 	if(blood_volume <= BLOOD_VOLUME_SURVIVE && stat)
 		handle_passive_blood()


### PR DESCRIPTION
## About The Pull Request

- Tweaking Golgatha downwards a bit, at the request of @Ollanius, and if it is not enough, the interaction should be removed by Reen or another dev.
- Fixes Incisions healing passively due to Psydonite trait.
- Adds an extra and cheap failsafe toward eating organs mid surgery, because that's very immersion-breaking.

## Testing Evidence

Compiles, just variable changes here and there.

## Why It's Good For The Game

I am being crucified here manne.

## Changelog
:cl:
balance: Makes Golgatha less oppressive.
fix: Incisions won't heal from Psydonite traits.
fix: Organs can only be eaten if you are (or your patient is) not laying down.
/:cl: