### PR TITLE
SUNDERANCE - An alternative to blessed oneshots with stack buildups.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -1584,7 +1584,7 @@
 		_ensure_limb_vis(zone, gender_prefix)
 		var/has_bleed = _has_visible_bleed(BP)
 		var/damage = min(BP.burn_dam + BP.brute_dam, BP.max_damage)
-		if(HAS_TRAIT(H, TRAIT_NOPAIN))
+		if(HAS_TRAIT(H, TRAIT_NOPAIN) && !H.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) && !H.has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
 			_apply_limb_state(zone, (damage || has_bleed) ? "#78a8ba" : null, 0, has_bleed)
 			return
 		var/wound_alpha = clamp(round((damage / BP.max_damage) * 510), 0, 255)

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -261,8 +261,8 @@
 /datum/status_effect/debuff/sunder_stacks
 	id = "sundered"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/sunder_stacks
-	effectedstats = list(STATKEY_STR = -3, STATKEY_WIL = -3, STATKEY_CON = -4, STATKEY_SPD = -3)	//Heavily punishing.
-	duration = 10 SECONDS	//Punishing and tied to the duration of your sundering stacks + a bit extra.
+	effectedstats = list(STATKEY_STR = -1, STATKEY_WIL = -1, STATKEY_CON = -1, STATKEY_SPD = -1, STATKEY_LCK = -1)	//Slightly punishing.
+	duration = 10 SECONDS	//Punishing and tied to the duration of your sundering stacks.
 
 /atom/movable/screen/alert/status_effect/debuff/sunder_stacks
 	name = "Sundered!"

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -261,7 +261,7 @@
 /datum/status_effect/debuff/sunder_stacks
 	id = "sundered"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/sunder_stacks
-	effectedstats = list(STATKEY_STR = -5, STATKEY_WIL = -5, STATKEY_CON = -5, STATKEY_SPD = -3, STATKEY_LCK = -4)	//Heavily punishing.
+	effectedstats = list(STATKEY_STR = -3, STATKEY_WIL = -3, STATKEY_CON = -4, STATKEY_SPD = -3)	//Heavily punishing.
 	duration = 10 SECONDS	//Punishing and tied to the duration of your sundering stacks + a bit extra.
 
 /atom/movable/screen/alert/status_effect/debuff/sunder_stacks

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -258,6 +258,17 @@
 	desc = "My muscles need some sleep to recover."
 	icon_state = "muscles"
 
+/datum/status_effect/debuff/sunder_stacks
+	id = "sundered"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/sunder_stacks
+	effectedstats = list(STATKEY_STR = -5, STATKEY_WIL = -5, STATKEY_CON = -5, STATKEY_SPD = -3, STATKEY_LCK = -4)	//Heavily punishing.
+	duration = 10 SECONDS	//Punishing and tied to the duration of your sundering stacks + a bit extra.
+
+/atom/movable/screen/alert/status_effect/debuff/sunder_stacks
+	name = "Sundered!"
+	desc = "Something has been taken from me, and it will take time to recover."
+	icon_state = "luxstrain"
+
 /datum/status_effect/debuff/devitalised
 	id = "devitalised"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/devitalised

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -180,6 +180,10 @@
 	stressadd = 5
 	desc = span_red("<u>They</u> are here.")
 
+/datum/stressevent/sundercritted
+	stressadd = 5 //Its literally killing you, sire.
+	desc = span_boldred("I CAN FEEL MY SOUL TEARING APART FROM BLESSED FLAMES, I NEED TO GET AWAY!")
+
 /datum/stressevent/nocrowd
 	timer = 2 MINUTES
 	stressadd = 3

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -84,6 +84,8 @@
 
 	///Overall drunkenness - check handle_alcohol() in life.dm for effects
 	var/drunkenness = 0
+	///Overall sunder stacks from critical sunder hits - check handle_sunders() in life.dm for effects
+	var/sunder_stacks = 0
 	///used to halt stamina regen temporarily
 	var/stam_regen_start_time = 0
 	///knocks you down

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -84,7 +84,7 @@
 
 	///Overall drunkenness - check handle_alcohol() in life.dm for effects
 	var/drunkenness = 0
-	///Overall sunder stacks from critical sunder hits - check handle_sunders() in life.dm for effects
+	///Overall sunder stacks from critical sunder hits - check for //WE HANDLE SUNDERSTACKS HERE codenote in life.dm for effects
 	var/sunder_stacks = 0
 	///used to halt stamina regen temporarily
 	var/stam_regen_start_time = 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -684,6 +684,7 @@
 	spill_embedded_objects()
 	set_heartattack(FALSE)
 	drunkenness = 0
+	sunder_stacks = 0
 	. = ..()
 	if(hud_used?.zone_select)
 		hud_used.zone_select.rebuild_limbs()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -62,7 +62,7 @@
 
 /mob/living/carbon/handle_random_events()//BP/WOUND BASED PAIN
 	//Being sundered will shut off no_pain trait, until the sunder flames wear off.
-	if(HAS_TRAIT(src, TRAIT_NOPAIN) && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+	if(HAS_TRAIT(src, TRAIT_NOPAIN) && (!has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed)))
 		return
 	if(!stat)
 		var/painpercent = get_complex_pain() / pain_threshold

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -62,7 +62,7 @@
 
 /mob/living/carbon/handle_random_events()//BP/WOUND BASED PAIN
 	//Being sundered will shut off no_pain trait, until the sunder flames wear off.
-	if(HAS_TRAIT(src, TRAIT_NOPAIN) && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+	if(HAS_TRAIT(src, TRAIT_NOPAIN) && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
 		return
 	if(!stat)
 		var/painpercent = get_complex_pain() / pain_threshold

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -93,7 +93,7 @@
 						addtimer(CALLBACK(src, PROC_REF(Stun), 110), 10)
 						addtimer(CALLBACK(src, PROC_REF(Knockdown), 110), 10)
 						mob_timers["painstun"] = world.time + 160
-					if(prob(probby) && HAS_TRAIT(src, TRAIT_NOPAINSTUN) && has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+					if(prob(probby) && HAS_TRAIT(src, TRAIT_NOPAINSTUN) && (has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed)))
 						Immobilize(10)
 						emote("painscream")
 						to_chat(src, span_userdanger("THE SACRED FLAMES, I FEEL PAIN AGAIN!"))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -165,7 +165,7 @@
 	. = 0
 	var/has_adrenaline = HAS_TRAIT(src, TRAIT_ADRENALINE_RUSH)
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
-		if(limb.status == BODYPART_ROBOTIC || limb.skeletonized && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+		if(limb.status == BODYPART_ROBOTIC || limb.skeletonized && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
 			continue //If we're not sundered, skeletonised limbs do not hurt.
 		var/bodypart_pain = ((limb.brute_dam + limb.burn_dam) / limb.max_damage) * limb.max_pain_damage
 		for(var/datum/wound/wound as anything in limb.wounds)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -61,6 +61,7 @@
 	check_cremation()
 
 /mob/living/carbon/handle_random_events()//BP/WOUND BASED PAIN
+	//Being sundered will shut off no_pain trait, until the sunder flames wear off.
 	if(HAS_TRAIT(src, TRAIT_NOPAIN) && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
 		return
 	if(!stat)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -367,9 +367,9 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 
 //WE HANDLE SUNDERSTACKS HERE
 	if(sunder_stacks)
-		sunder_stacks = max(sunder_stacks - 0.5, 0)
-		apply_status_effect(/datum/status_effect/debuff/sunder_stacks)
-		if(cultslurring < 5) //Fucks up our ability to talk
+		sunder_stacks = max(sunder_stacks - 0.5, 0) //Takes a bit to shrug off
+		apply_status_effect(/datum/status_effect/debuff/sunder_stacks) //You survived an EXTREMELY lethal blow, you might want to keep back for now
+		if(cultslurring < 5) //Fucks up our ability to talk, completely
 			cultslurring += 1.2
 
 		if(sunder_stacks >= 41)
@@ -388,7 +388,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
 				Knockdown(15)
 
-		if(sunder_stacks >= 101)
+		if(sunder_stacks >= 101) //We are beyond the point of lethal, somehow. This will cripple you severely.
 			adjustBruteLoss(1)
 			if(prob(50))
 				blur_eyes(5)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -377,7 +377,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			if(prob(5)) //5% chance of random dizziness
 				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
 				Dizzy(5)
-				jitteriness(5)
 
 		if(sunder_stacks >= 61) //At this point you've taken (2) blows or more and shouldn't be escaping death this easily.
 			adjustBruteLoss(2)
@@ -385,7 +384,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 				confused += 15
 				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
 				Dizzy(25)
-				jitteriness(15)
 			if(prob(5)) //5% chance to collapse randomly
 				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
 				Knockdown(15)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -367,32 +367,34 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 
 //WE HANDLE SUNDERSTACKS HERE
 	if(sunder_stacks)
-		sunder_stacks = max(sunder_stacks - 0.5, 0) //Takes a bit to shrug off
-		apply_status_effect(/datum/status_effect/debuff/sunder_stacks) //You survived an EXTREMELY lethal blow, you might want to keep back for now
-		if(cultslurring < 5) //Fucks up our ability to talk, completely
+		sunder_stacks = max(sunder_stacks - 1, 0) //Takes a bit to shrug off
+		if(cultslurring < 5) //Fucks up our ability to talk, completely until all sunderstacks are gone
 			cultslurring += 1.2
+
+		if(sunder_stacks >= 21)
+			apply_status_effect(/datum/status_effect/debuff/sunder_stacks) //You survived an EXTREMELY lethal blow, you might want to keep back for now
 
 		if(sunder_stacks >= 41)
 			adjustBruteLoss(2)
 			if(prob(3)) //5% chance of random dizziness
-				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
+				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire. No immobilise yet.
 				Dizzy(5)
 
-		if(sunder_stacks >= 61) //At this point you've taken (2) blows or more and shouldn't be escaping death this easily.
+		if(sunder_stacks >= 71) //At this point you've taken (2) blows or more and shouldn't be escaping death this easily.
 			adjustBruteLoss(2)
+			apply_status_effect(/datum/status_effect/debuff/devitalised/lesser) //5 min long debuff, you narrowly escaped death.
 			if(prob(12)) //12% chance to have random movement + stun + dizziness
 				confused += 15
-				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
+				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire.
 				Dizzy(25)
 			if(prob(5)) //5% chance to collapse randomly
-				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
+				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire.
 				Knockdown(15)
 
 		if(sunder_stacks >= 101) //We are beyond the point of lethal, somehow. This will cripple you severely.
 			adjustBruteLoss(1)
 			if(prob(50))
 				blur_eyes(5)
-				Dizzy(5)
 			Dizzy(25)//You are completely fucked up at this point, any more stacks of SUNDER and you're DEAD.
 
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -368,26 +368,24 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 //WE HANDLE SUNDERSTACKS HERE
 	if(sunder_stacks)
 		sunder_stacks = max(sunder_stacks - 0.5, 0)
+		apply_status_effect(/datum/status_effect/debuff/sunder_stacks)
 		if(cultslurring < 5) //Fucks up our ability to talk
 			cultslurring += 1.2
 
-		if(sunder_stacks >= 11 && sunder_stacks < 41 )
-			apply_status_effect(/datum/status_effect/debuff/sunder_stacks)
-
-		if(sunder_stacks >= 41)
+		if(sunder_stacks >= 21)
 			adjustBruteLoss(2)
 			if(prob(5)) //5% chance of random dizziness
 				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
 				Dizzy(5)
-				jitter(5)
+				jitteriness(5)
 
-		if(sunder_stacks >= 81)
+		if(sunder_stacks >= 61) //At this point you've taken (2) blows or more and shouldn't be escaping death this easily.
 			adjustBruteLoss(2)
 			if(prob(12)) //12% chance to have random movement + stun + dizziness
 				confused += 15
 				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
 				Dizzy(25)
-				jitter(15)
+				jitteriness(15)
 			if(prob(5)) //5% chance to collapse randomly
 				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
 				Knockdown(15)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -378,15 +378,15 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			adjustBruteLoss(2)
 			if(prob(3)) //5% chance of random dizziness
 				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire. No immobilise yet.
-				Dizzy(5)
+				Dizzy(3)
 
 		if(sunder_stacks >= 71) //At this point you've taken (2) blows or more and shouldn't be escaping death this easily.
 			adjustBruteLoss(2)
 			apply_status_effect(/datum/status_effect/debuff/devitalised/lesser) //5 min long debuff, you narrowly escaped death.
 			if(prob(12)) //12% chance to have random movement + stun + dizziness
-				confused += 15
+				confused += 8
 				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire.
-				Dizzy(25)
+				Dizzy(15)
 			if(prob(5)) //5% chance to collapse randomly
 				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire.
 				Knockdown(15)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -61,7 +61,7 @@
 	check_cremation()
 
 /mob/living/carbon/handle_random_events()//BP/WOUND BASED PAIN
-	if(HAS_TRAIT(src, TRAIT_NOPAIN))
+	if(HAS_TRAIT(src, TRAIT_NOPAIN) && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
 		return
 	if(!stat)
 		var/painpercent = get_complex_pain() / pain_threshold
@@ -89,6 +89,15 @@
 						Immobilize(10)
 						emote("painscream")
 						stuttering += 5
+						addtimer(CALLBACK(src, PROC_REF(Stun), 110), 10)
+						addtimer(CALLBACK(src, PROC_REF(Knockdown), 110), 10)
+						mob_timers["painstun"] = world.time + 160
+					if(prob(probby) && HAS_TRAIT(src, TRAIT_NOPAINSTUN) && has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+						Immobilize(10)
+						emote("painscream")
+						to_chat(src, span_userdanger("THE SACRED FLAMES, I FEEL PAIN AGAIN!"))
+						stuttering += 5
+						cultslurring += 10 //To indicate this isn't a natural kind of agony
 						addtimer(CALLBACK(src, PROC_REF(Stun), 110), 10)
 						addtimer(CALLBACK(src, PROC_REF(Knockdown), 110), 10)
 						mob_timers["painstun"] = world.time + 160
@@ -155,8 +164,8 @@
 	. = 0
 	var/has_adrenaline = HAS_TRAIT(src, TRAIT_ADRENALINE_RUSH)
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
-		if(limb.status == BODYPART_ROBOTIC || limb.skeletonized)
-			continue
+		if(limb.status == BODYPART_ROBOTIC || limb.skeletonized && !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder) || !has_status_effect(/datum/status_effect/fire_handler/fire_stacks/sunder/blessed))
+			continue //If we're not sundered, skeletonised limbs do not hurt.
 		var/bodypart_pain = ((limb.brute_dam + limb.burn_dam) / limb.max_damage) * limb.max_pain_damage
 		for(var/datum/wound/wound as anything in limb.wounds)
 			bodypart_pain += wound?.woundpain
@@ -375,13 +384,13 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			apply_status_effect(/datum/status_effect/debuff/sunder_stacks) //You survived an EXTREMELY lethal blow, you might want to keep back for now
 
 		if(sunder_stacks >= 41)
-			adjustBruteLoss(2)
+			adjustBruteLoss(1)
 			if(prob(3)) //5% chance of random dizziness
 				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire. No immobilise yet.
 				Dizzy(3)
 
 		if(sunder_stacks >= 71) //At this point you've taken (2) blows or more and shouldn't be escaping death this easily.
-			adjustBruteLoss(2)
+			adjustBruteLoss(1)
 			if(prob(12)) //12% chance to have random movement + stun + dizziness
 				confused += 8
 				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire.

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -372,9 +372,9 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		if(cultslurring < 5) //Fucks up our ability to talk
 			cultslurring += 1.2
 
-		if(sunder_stacks >= 21)
+		if(sunder_stacks >= 41)
 			adjustBruteLoss(2)
-			if(prob(5)) //5% chance of random dizziness
+			if(prob(3)) //5% chance of random dizziness
 				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
 				Dizzy(5)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -365,6 +365,41 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		if(drunkenness >= 101)
 			adjustToxLoss(5) //Let's be honest you shouldn't be alive by now
 
+//WE HANDLE SUNDERSTACKS HERE
+	if(sunder_stacks)
+		sunder_stacks = max(sunder_stacks - 0.5, 0)
+		if(cultslurring < 5) //Fucks up our ability to talk
+			cultslurring += 1.2
+
+		if(sunder_stacks >= 11 && sunder_stacks < 41 )
+			apply_status_effect(/datum/status_effect/debuff/sunder_stacks)
+
+		if(sunder_stacks >= 41)
+			adjustBruteLoss(2)
+			if(prob(5)) //5% chance of random dizziness
+				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
+				Dizzy(5)
+				jitter(5)
+
+		if(sunder_stacks >= 81)
+			adjustBruteLoss(2)
+			if(prob(12)) //12% chance to have random movement + stun + dizziness
+				confused += 15
+				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
+				Dizzy(25)
+				jitter(15)
+			if(prob(5)) //5% chance to collapse randomly
+				vomit(blood = TRUE) // vomiting blood, because you are actually pretty fucked up sire.
+				Knockdown(15)
+
+		if(sunder_stacks >= 101)
+			adjustBruteLoss(1)
+			if(prob(50))
+				blur_eyes(5)
+				Dizzy(5)
+			Dizzy(25)//You are completely fucked up at this point, any more stacks of SUNDER and you're DEAD.
+
+
 //used in human and monkey handle_environment()
 /mob/living/carbon/proc/natural_bodytemperature_stabilization()
 	var/body_temperature_difference = BODYTEMP_NORMAL - bodytemperature

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -382,7 +382,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 
 		if(sunder_stacks >= 71) //At this point you've taken (2) blows or more and shouldn't be escaping death this easily.
 			adjustBruteLoss(2)
-			apply_status_effect(/datum/status_effect/debuff/devitalised/lesser) //5 min long debuff, you narrowly escaped death.
 			if(prob(12)) //12% chance to have random movement + stun + dizziness
 				confused += 8
 				vomit(blood = TRUE, stun = FALSE) // vomiting blood, because you are actually pretty fucked up sire.

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -250,14 +250,14 @@
 			if(lowertext(newletter)=="u")
 				newletter="oo"
 			if(lowertext(newletter)=="c")
-				newletter=" NAR "
+				newletter="lr"
 			if(lowertext(newletter)=="s")
-				newletter=" SIE "
+				newletter="zr"
 		if(prob(25))
 			if(newletter==" ")
-				newletter=" no hope... "
+				newletter=" BURNS... "
 			if(newletter=="H")
-				newletter=" IT COMES... "
+				newletter=" FIRE... "
 
 		switch(rand(1,15))
 			if(1)
@@ -267,9 +267,9 @@
 			if(3)
 				newletter="fth"
 			if(4)
-				newletter="nglu"
+				newletter="zghl"
 			if(5)
-				newletter="glor"
+				newletter="psyzl"
 			else
 				;;
 		newphrase+="[newletter]";counter-=1

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -232,6 +232,7 @@
 	return newphrase
 
 /// Makes you talk like you got cult stunned, which is slurring but with some dark messages
+// Except up, its Psyphied so this is what you get from being sundered instead, thank you whoever left this, I will cook.
 /proc/cultslur(n) // Inflicted on victims of a stun talisman
 	var/phrase = STRIP_HTML_SIMPLE(n,MAX_MESSAGE_LEN)
 	var/leng = length_char(phrase)
@@ -251,13 +252,12 @@
 				newletter="oo"
 			if(lowertext(newletter)=="c")
 				newletter="lr"
+			if(lowertext(newletter)=="e")
+				newletter="do"
+			if(lowertext(newletter)=="zizo") //YOU WISH
+				newletter="psy"
 			if(lowertext(newletter)=="s")
 				newletter="zr"
-		if(prob(25))
-			if(newletter==" ")
-				newletter=" BURNS... "
-			if(newletter=="H")
-				newletter=" FIRE... "
 
 		switch(rand(1,15))
 			if(1)

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -411,7 +411,7 @@
 			used = round(damage_dividend * 20 + (dam / 2))
 			if(prob(used) && owner.sunder_stacks > 100)
 				attempted_wounds += /datum/wound/sunder/chest
-			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
+			if(prob(used) && owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
 				owner.sunder_stacks += 40
 				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
 				owner.add_stress(/datum/stressevent/sundercritted)
@@ -549,7 +549,7 @@
 			used = round(damage_dividend * 20 + (dam / 2), 1)
 			if(prob(used) && owner.sunder_stacks > 100)
 				attempted_wounds += /datum/wound/sunder/head
-			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
+			if(prob(used) && owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
 				owner.sunder_stacks += 40
 				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
 				owner.add_stress(/datum/stressevent/sundercritted)

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -323,8 +323,7 @@
 				attempted_wounds += /datum/wound/sunder
 			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
 				owner.sunder_stacks += 10 //Far less for nonlethal sunders. THIS WILL STILL FUCK YOU UP FROM JUST A FEW.
-				to_chat(owner, span_danger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
-				add_stress(owner, /datum/stressevent/sundercritted)
+				owner.add_stress(/datum/stressevent/sundercritted)
 	// Check if critical resistance applies
 	var/has_crit_attempt = length(attempted_wounds)
 	if(!has_crit_attempt)
@@ -417,7 +416,7 @@
 			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
 				owner.sunder_stacks += 40
 				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
-				add_stress(owner, /datum/stressevent/sundercritted)
+				owner.add_stress(/datum/stressevent/sundercritted)
 	// Check if critical resistance applies
 	var/has_crit_attempt = length(attempted_wounds)
 	if(!has_crit_attempt)
@@ -555,7 +554,7 @@
 			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
 				owner.sunder_stacks += 40
 				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
-				add_stress(owner, /datum/stressevent/sundercritted)
+				owner.add_stress(/datum/stressevent/sundercritted)
 	var/has_crit_attempt = length(attempted_wounds) || try_knockout
 	if(!has_crit_attempt)
 		return FALSE

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -414,7 +414,7 @@
 			if(prob(used) && owner.sunder_stacks > 100 && owner.mind)
 				attempted_wounds += /datum/wound/sunder/chest
 			if(prob(used) && owner.sunder_stacks < 150 && owner.mind) //We don't want too many stacks or we'll never recover.
-				owner.sunder_stacks += 30
+				owner.sunder_stacks += 40
 				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
 				owner.add_stress(/datum/stressevent/sundercritted)
 	// Check if critical resistance applies
@@ -554,7 +554,7 @@
 			if(prob(used) && owner.sunder_stacks > 100 && owner.mind)
 				attempted_wounds += /datum/wound/sunder/head
 			if(prob(used) && owner.sunder_stacks < 150 && owner.mind) //We don't want too many stacks or we'll never recover.
-				owner.sunder_stacks += 30
+				owner.sunder_stacks += 40
 				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
 				owner.add_stress(/datum/stressevent/sundercritted)
 	var/has_crit_attempt = length(attempted_wounds) || try_knockout

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -409,10 +409,12 @@
 	if(bclass in GLOB.sunder_bclasses)
 		if(HAS_TRAIT(owner, TRAIT_SILVER_WEAK) && !owner.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 			used = round(damage_dividend * 20 + (dam / 2))
-			if(prob(used) && owner.sunder_stacks > 100)
+			if(prob(used) && !owner.mind)
 				attempted_wounds += /datum/wound/sunder/chest
-			if(prob(used) && owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
-				owner.sunder_stacks += 40
+			if(prob(used) && owner.sunder_stacks > 100 && owner.mind)
+				attempted_wounds += /datum/wound/sunder/chest
+			if(prob(used) && owner.sunder_stacks < 150 && owner.mind) //We don't want too many stacks or we'll never recover.
+				owner.sunder_stacks += 30
 				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
 				owner.add_stress(/datum/stressevent/sundercritted)
 	// Check if critical resistance applies
@@ -547,10 +549,12 @@
 	if(bclass in GLOB.sunder_bclasses)
 		if(HAS_TRAIT(owner, TRAIT_SILVER_WEAK) && !owner.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 			used = round(damage_dividend * 20 + (dam / 2), 1)
-			if(prob(used) && owner.sunder_stacks > 100)
+			if(prob(used) && !owner.mind)
 				attempted_wounds += /datum/wound/sunder/head
-			if(prob(used) && owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
-				owner.sunder_stacks += 40
+			if(prob(used) && owner.sunder_stacks > 100 && owner.mind)
+				attempted_wounds += /datum/wound/sunder/head
+			if(prob(used) && owner.sunder_stacks < 150 && owner.mind) //We don't want too many stacks or we'll never recover.
+				owner.sunder_stacks += 30
 				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
 				owner.add_stress(/datum/stressevent/sundercritted)
 	var/has_crit_attempt = length(attempted_wounds) || try_knockout

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -321,6 +321,10 @@
 			used = round(damage_dividend * 20 + (dam / 2))
 			if(prob(used))
 				attempted_wounds += /datum/wound/sunder
+			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
+				owner.sunder_stacks += 10 //Far less for nonlethal sunders. THIS WILL STILL FUCK YOU UP FROM JUST A FEW.
+				to_chat(owner, span_danger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
+				add_stress(owner, /datum/stressevent/sundercritted)
 	// Check if critical resistance applies
 	var/has_crit_attempt = length(attempted_wounds)
 	if(!has_crit_attempt)
@@ -408,8 +412,12 @@
 	if(bclass in GLOB.sunder_bclasses)
 		if(HAS_TRAIT(owner, TRAIT_SILVER_WEAK) && !owner.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 			used = round(damage_dividend * 20 + (dam / 2))
-			if(prob(used))
-				attempted_wounds += list(/datum/wound/sunder/chest)
+			if(prob(used) && owner.sunder_stacks > 100)
+				attempted_wounds += /datum/wound/sunder/chest
+			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
+				owner.sunder_stacks += 40
+				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
+				add_stress(owner, /datum/stressevent/sundercritted)
 	// Check if critical resistance applies
 	var/has_crit_attempt = length(attempted_wounds)
 	if(!has_crit_attempt)
@@ -542,8 +550,12 @@
 	if(bclass in GLOB.sunder_bclasses)
 		if(HAS_TRAIT(owner, TRAIT_SILVER_WEAK) && !owner.has_status_effect(STATUS_EFFECT_ANTIMAGIC))
 			used = round(damage_dividend * 20 + (dam / 2), 1)
-			if(prob(used))
+			if(prob(used) && owner.sunder_stacks > 100)
 				attempted_wounds += /datum/wound/sunder/head
+			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
+				owner.sunder_stacks += 40
+				to_chat(owner, span_userdanger("A CRITICAL BLOW SUNDERS ME WITH SACRED FLAME!"))
+				add_stress(owner, /datum/stressevent/sundercritted)
 	var/has_crit_attempt = length(attempted_wounds) || try_knockout
 	if(!has_crit_attempt)
 		return FALSE

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -321,9 +321,7 @@
 			used = round(damage_dividend * 20 + (dam / 2))
 			if(prob(used))
 				attempted_wounds += /datum/wound/sunder
-			if(owner.sunder_stacks < 150) //We don't want too many stacks or we'll never recover.
-				owner.sunder_stacks += 10 //Far less for nonlethal sunders. THIS WILL STILL FUCK YOU UP FROM JUST A FEW.
-				owner.add_stress(/datum/stressevent/sundercritted)
+				owner.add_stress(/datum/stressevent/sundercritted) //You're still being sundered, sire.
 	// Check if critical resistance applies
 	var/has_crit_attempt = length(attempted_wounds)
 	if(!has_crit_attempt)


### PR DESCRIPTION
## About The Pull Request

Replaces Sunder-Criticals on Silver Weakness, from Blessed Silver with a far-less rocket-tag esc-system that's more fair for both sides.

Introducing **SUNDER-STACKS** and a buff to all silver-sunderfire in general

## FIRE CHANGES

<img width="314" height="23" alt="FlamesPain" src="https://github.com/user-attachments/assets/bb7589ea-9e21-4ed2-b541-e07928f2426f" />

---

Being on fire from sunder flames, completely returns your ability to feel pain of any sort while you're burning. This can creep up on you rather quickly if you're not careful. This gives us a bit of leeway to perhaps consider seperating silver blessing to solely Psydonic silver in future, for now enjoy being able to buff your silver a bit more still without being overbaring.

*It also garbles your speech if you fall over (ignore the slurring in this, I forgot to make admin healing remove your slurring stacks, whoops! They're still capped + short enough you won't have a million of them from this, or below) on top of the unique message shown above if paincrit takes you (to avoid spamming your chat)*

***this includes skeletonised limbs, rituos users will feel all of the pain in their body while being sundered.***

https://github.com/user-attachments/assets/ec144ee7-6502-4183-886d-1f98e47a51c4

On its own it can catch you off guard, especally if you're pretty banged up already but it will definitely get you moreso with the latter half:

## SUNDER STACKS

<img width="408" height="19" alt="SacredSunder" src="https://github.com/user-attachments/assets/f12345e1-69eb-49b3-bf97-f0aaf5cc47df" />

---
All successful blows that would inflict `a blessed sunder` from a `blessed and silver weapon` not just any silver weapon, will now apply a mood debuff + slurr your ability to talk during the whole duration of sunderstacks. Instead of instantly killing you.

Any blow will inflict `40` sunderstacks, the level of these also has additional drawbacks that can actually be severely debilitating to be struck by, so you're not entirely off the hook even as a 20 in-all-stats-vlord.

---

`note, these effects do stack with higher teirs, being sundered a lot will severely fuck you up`
*as another note, sunderstacks decrease by 1 every tick, so 40 lasts 40 seconds*

- a hefty debuff of `-1STR, -1WIL, -1CON, -1SPD, -1 LCK` UNTIL your sunderstacks wear off.

above `40` sunderstacks, you recieve these effects:
- +1 brute every second
- 3% chance of dizziness + vomiting blood (without a hardstun)

above `70` sunderstacks (3) blows, you recieve these effects:
- +1 brute every second
- 12% chance of vomiting blood, 8 stacks of confusion (random movement) dizziness
- 5% chance of vomiting blood **and** falling over for 1.5 seconds

over `100` sunderstacks (4) blows, you recieve these effects:
- +1 brute
- 50% chance of blurred vision + dizziness
- Constant Dizziness
- You are now vulnerable to lethal sundercrits, any further criticals without critical resistance shrugging it off (lich) will kill you instantly.

At 100 sunderstacks, this is equiv to taking 3 brute every tick, yes. These hurt a LOT to be exposed to, however such is the price of surviving a lethal sunder wound that would kill you instantly currently. You should definitely seek to heal after a sundering blow with the above point *re-enabling pain.*

The only difference vs before is that sunderstacks `will only buildup under the same logic where a crit attempts itself`, critical resistance will shrug off the killing blow, ***but not the Sunderstack***, liches beware.

---

*as for NPCs, there's a mind check and they die to sunders like they currently do without interacting with the sunderstack mechanic.*

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/116d623d-f04a-4388-a106-4fb47111d451

*Note the hardstuns from this + dizziness have since been toned down/removed. Its STILL quite debilitating however.*

On NPCS - enjoy a small fragging montage to prove this works, sire. (Yes pain override actually makes this good for PVE too)

https://github.com/user-attachments/assets/1b29551d-8ae3-40d4-8510-cba0dfe765f8

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I like not being oneshot through fullplate by the martyr, because a mage set me on fire for 10 seconds.

Jokes aside though, this is a much healthier balance for silver sunders and properly ties up loose ends. It also makes it harder to just solo antagonists because they happen to die instantly if you wack them a few times with a silver sword without any warning beyond an examine and vague change in the firestacks in their chatlog.

Now you sort of know something is critically able to sunder you and have a wind to react, it also fucks your speech up so you can't exactly relay much more than you need help, It also puts cultslurring to use because it was just laying around in the codebase and I gotta cook, sire.

---

Regular silver and such likes should feel less like a joke since you actually can be affected by pain again! Beware silver, as it can bring you back to the weakness of mortality again!

---

I do this for the love of the game, enjoy folks! Its been a fun few years on Azure Peak.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Silver sunders no longer instantly oneshot you pass a certain level of fire damage without any regards for armor, Rocket Tag gameplay is dead once more (not to say this can't onetap skeles with firecrit or severely weaken vampires in their ability to even fight as it should.
balance: Re-done silver sunders. 40 stacks are applied per hit, 100 allows old Sunder kills. Sunderstacks apply debuffing effects as they build up. Bring numbers + gear for monsters, not just blessed silver.
balance: All forms of sundering flames disable your pain immunity, making you subject to paincrit again and enabling you to feel pain. This only applies if you're already silver weak.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
