### PR TITLE
[Fix] Vice Sating timer

### DIFF
--- a/code/datums/character_flaw/addiction.dm
+++ b/code/datums/character_flaw/addiction.dm
@@ -28,7 +28,7 @@
 
 	mob_vice.sated = TRUE
 	mob_vice.time = initial(mob_vice.time) //reset roundstart sate offset to standard
-	mob_vice.next_sate = world.time + mob_vice.time
+	mob_vice.next_sate = world.time + max(mob_vice.time, 1)
 	remove_stress(/datum/stressevent/vice)
 	if(mob_vice.debuff)
 		remove_status_effect(mob_vice.debuff)
@@ -59,9 +59,8 @@
 	var/mob/living/carbon/human/H = user
 	var/oldsated = sated
 	if(oldsated)
-		if(next_sate)
-			if(world.time > next_sate)
-				sated = FALSE
+		if(next_sate && world.time >= next_sate)
+			sated = FALSE
 	if(sated != oldsated)
 		unsate_time = world.time
 		if(needsate_text)


### PR DESCRIPTION
## About The Pull Request

- Makes the tracking vars for vice a little more robust, mainly to dodge cases where we sate a vice, tick happens, vice is unsated. Basically and in essence, just changed a > to >=, and added a minimum value of 1 to the tracker.

## Testing Evidence

- Small tweak, compiles.

## Why It's Good For The Game

Fug Bixes, the return. To not be confused with Say Gex.

## Changelog
:cl:
fix: fixed vice tracking, hopefully
/:cl: