### PR TITLE
zpellblade tweaks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic_spellblade.dm
@@ -75,7 +75,7 @@
 	var/chant_faction = "zizite"
 	var/extra_blade_weapon
 	if(istype(H.patron, /datum/patron/inhumen/zizo))
-		extra_blade_weapon = "Avantyne Longsword"
+		extra_blade_weapon = "Avantyne Arming Sword"
 	else if(istype(H.patron, /datum/patron/divine/noc))
 		chant_faction = "noccite"
 	var/selection_html = get_spellblade_chant_html(src, H, chant_faction, extra_blade_weapon)
@@ -157,12 +157,12 @@
 			var/list/weapons = list("Kriegmesser", "Longsword", "Rapier", "Sabre", "Steel Arming Sword", "Steel Greatsword", "Steel Dagger")
 			// Inject patron-specific weapon
 			if(istype(H.patron, /datum/patron/inhumen/zizo))
-				weapons.Insert(1, "Avantyne Longsword")
+				weapons.Insert(1, "Avantyne Arming Sword")
 			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			beltr = /obj/item/rogueweapon/scabbard/sword
 			switch(weapon_choice)
-				if("Avantyne Longsword")
-					r_hand = /obj/item/rogueweapon/sword/long/zizo
+				if("Avantyne Arming Sword")
+					r_hand = /obj/item/rogueweapon/sword/zizo
 				if("Kriegmesser")
 					r_hand = /obj/item/rogueweapon/sword/long/kriegmesser
 					backr = /obj/item/rogueweapon/scabbard/gwstrap

--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -103,8 +103,8 @@
 ////////////////
 /datum/action/cooldown/spell/projectile/zizo/profane
 	name = "Profane"
-	desc = "Launch a cursed bone shard that can lodge into victims, slowly poisoning them while embedded. More embedded shards increase the damage (max. 7 DMG over time, 2x vs NPCs). Four bones in your hand (or around) may be consumed to empower the projectile, causing it to fracture into nearby non-Gravemarked enemies and embed regardless."
-	fluff_desc = "An early Cabal sacrament: bone, profaned through Zizo's teachings, proved a willing conduit for Avantyne's anti-life qualities. Splinters touched by Her grace 'bless' the living with lingering agony. Fed exactly 'four' fresh bones, the rite grows unstable, scattering its sacred cruelty to ones who do not bear your mark. Why this occurs is still never fully understood."
+	desc = "Instantly launch a cursed bone shard that pierces any armor and always lodges into its victim."
+	fluff_desc = "An early Cabal sacrament: bone, profaned through Zizo's teachings, proved a willing conduit for Avantyne's anti-life qualities. Splinters touched by Her grace pierce any ward and bury themselves deep in living flesh, a lasting testament to Her cruelty."
 	button_icon_state = "profane"
 	projectile_type = /obj/projectile/magic/profane
 	cast_range = SPELL_RANGE_PROJECTILE
@@ -113,74 +113,6 @@
 	charge_required = FALSE
 	cooldown_time = 30 SECONDS
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN
-
-/datum/action/cooldown/spell/projectile/zizo/profane/cast(atom/cast_on)
-	var/mob/living/user = owner
-	var/original_primary = primary_resource_cost
-	var/original_secondary = secondary_resource_cost
-	var/original_projectile = projectile_type
-
-	if(consume_bones_for_profane(user, 4))
-		primary_resource_cost = 0
-		secondary_resource_cost = 0
-		projectile_type = /obj/projectile/magic/profane/enhanced
-		user.visible_message(span_purple("Lingering bones crumble around [user]'s hand..."), span_purple("Lingering bones enhance your Divine evocation. Blessed four!"))
-	
-	. = ..()
-	projectile_type = original_projectile
-	primary_resource_cost = original_primary
-	secondary_resource_cost = original_secondary
-
-/proc/consume_bones_for_profane(mob/living/user, amount = 4)
-	var/remaining = amount
-
-	for(var/turf/T in range(1, user))
-		if(remaining <= 0)
-			break
-		for(var/obj/item/natural/bone/B in T.contents)
-			if(remaining <= 0)
-				break
-			new /obj/item/ash(T)
-			qdel(B)
-			remaining--
-
-		for(var/obj/item/natural/bundle/bone/BB in T.contents)
-			if(remaining <= 0)
-				break
-			if(QDELETED(BB) || BB.amount <= 0)
-				continue
-			var/take = min(BB.amount, remaining)
-			BB.amount -= take
-			remaining -= take
-			new /obj/item/ash(T)
-			if(BB.amount <= 0)
-				qdel(BB)
-			else if(BB.amount == 1)
-				new /obj/item/natural/bone(get_turf(BB))
-				qdel(BB)
-
-	if(remaining > 0)
-		for(var/obj/item/natural/bone/B in user.contents)
-			if(remaining <= 0)
-				break
-			qdel(B)
-			remaining--
-
-		for(var/obj/item/natural/bundle/bone/BB in user.contents)
-			if(remaining <= 0)
-				break
-			if(QDELETED(BB) || BB.amount <= 0)
-				continue
-			var/take = min(BB.amount, remaining)
-			BB.amount -= take
-			remaining -= take
-			if(BB.amount <= 0)
-				qdel(BB)
-			else if(BB.amount == 1)
-				new /obj/item/natural/bone(user.loc)
-				qdel(BB)
-
-	return remaining <= 0
 
 /obj/item/bone/profane_splinter
 	name = "profaned splinter"
@@ -220,62 +152,6 @@
 	new /obj/item/ash(get_turf(src))
 	qdel(src)
 
-/obj/item/bone/profane_splinter/on_embed(obj/item/bodypart/bp)
-	. = ..()
-	if(bp?.owner)
-		var/mob/living/L = bp.owner
-		L.apply_status_effect(/datum/status_effect/debuff/profane_poison)
-		L.visible_message(span_purple("A cursed splinter buries itself deeper into [L]'s flesh!"), span_purple("The shard buries itself deep inside me!"))
-
-/datum/status_effect/debuff/profane_poison
-	id = "profane_poison"
-	status_type = STATUS_EFFECT_UNIQUE
-	duration = INFINITY
-	tick_interval = 3 SECONDS
-	var/poison_hardcap = 7
-
-/datum/status_effect/debuff/profane_poison/tick()
-	if(!owner)
-		qdel(src)
-		return
-
-	if(owner.stat == DEAD)
-		qdel(src)
-		return
-
-	if(!iscarbon(owner))
-		if(owner.stat == CONSCIOUS)
-			owner.adjustToxLoss(7)
-		return
-
-	var/mob/living/carbon/C = owner
-	var/splinter_count = 0
-
-	for(var/obj/item/bodypart/BP in C.bodyparts)
-		if(!BP.embedded_objects)
-			continue
-
-		for(var/obj/item/I in BP.embedded_objects)
-			if(istype(I, /obj/item/bone/profane_splinter))
-				splinter_count++
-
-	if(splinter_count <= 0)
-		C.visible_message(span_notice("The profane corruption fades from [C] as the final splinter is removed."), span_notice("The profane corruption fades as the final splinter is removed."))
-		qdel(src)
-		return
-
-	if(C.stat != CONSCIOUS)
-		return
-
-	var/tox_damage = min(1 + splinter_count, poison_hardcap)
-	C.adjustToxLoss(tox_damage)
-	if(!C.mind && prob(50))
-		C.adjustToxLoss(tox_damage)
-
-	if(prob(min(splinter_count * 2, 50)))
-		C.emote("pain")
-		C.Immobilize(15)
-
 /obj/projectile/magic/profane
 	name = "profaned bone shard"
 	icon = 'icons/obj/projectiles.dmi'
@@ -283,10 +159,11 @@
 	damage = 15
 	damage_type = BRUTE
 	nodamage = FALSE
+	armor_penetration = PEN_BSTEEL
 	range = SPELL_RANGE_PROJECTILE
 	speed = MAGE_PROJ_FAST
 	accuracy = 40
-	var/embed_chance = 35
+	var/embed_chance = 100
 
 /obj/projectile/magic/profane/on_hit(atom/target, blocked)
 	. = ..()
@@ -310,90 +187,21 @@
 	if(!prob(embed_chance))
 		return
 
-	if(iscarbon(L))
-		var/mob/living/carbon/C = L
-
-		if(!length(C.bodyparts))
-			return
-
-		var/obj/item/bodypart/limb = pick(C.bodyparts)
-		if(!limb)
-			return
-
-		var/obj/item/bone/profane_splinter/S = new
-		limb.add_embedded_object(S, FALSE, TRUE, TRUE)
-		if(!L.has_status_effect(/datum/status_effect/debuff/profane_poison))
-			L.apply_status_effect(/datum/status_effect/debuff/profane_poison)
-			playsound(get_turf(L),pick('sound/combat/fracture/fracturedry (1).ogg','sound/combat/fracture/fracturedry (2).ogg','sound/combat/fracture/fracturedry (3).ogg'),80,TRUE)
+	if(!iscarbon(L))
 		return
 
-	if(istype(L, /mob/living/simple_animal))
-		if(!L.has_status_effect(/datum/status_effect/debuff/profane_poison))
-			L.apply_status_effect(/datum/status_effect/debuff/profane_poison)
-			playsound(get_turf(L),pick('sound/combat/fracture/fracturedry (1).ogg','sound/combat/fracture/fracturedry (2).ogg','sound/combat/fracture/fracturedry (3).ogg'),80,TRUE)
+	var/mob/living/carbon/C = L
 
-/obj/projectile/magic/profane/enhanced
-	name = "empowered profane shard"
-	damage = 20
-	embed_chance = 100
-
-/obj/projectile/magic/profane/enhanced/on_hit(atom/target, blocked)
-	if(!isliving(target))
-		qdel(src)
+	if(!length(C.bodyparts))
 		return
 
-	var/mob/living/main_target = target
-
-	if(main_target.anti_magic_check())
-		visible_message(span_warning("[src] shatters harmlessly against [target]!"))
-		playsound(get_turf(target), 'sound/magic/magic_nulled.ogg', 100)
-		qdel(src)
-		return BULLET_ACT_BLOCK
-
-	try_embed_target(main_target)
-
-	main_target.visible_message(span_purple("[main_target] is struck as the shard fractures outward violently!"),span_purple("The shard explodes into a storm of splinters!"))
-
-	var/mob/living/caster = firer
-	var/faction_tag
-
-	if(caster)
-		faction_tag = "[caster.real_name]_faction"
-
-	if(!main_target || QDELETED(main_target))
-		qdel(src)
+	var/obj/item/bodypart/limb = pick(C.bodyparts)
+	if(!limb)
 		return
 
-	for(var/mob/living/L in view(5, main_target))
-		if(QDELETED(L))
-			continue
-
-		if(L.stat == DEAD)
-			continue
-
-		if(L.resting)
-			continue
-
-		if(L == main_target)
-			continue
-
-		if(L == caster)
-			continue
-
-		if(faction_tag)
-			if(L.mind?.current)
-				if(faction_tag in L.mind.current.faction)
-					continue
-			else
-				if(faction_tag in L.faction)
-					continue
-
-		main_target.Beam(L, icon_state = "chronobolt", icon = 'icons/obj/projectiles.dmi', time = 5, maxdistance = 20)
-		playsound(get_turf(L),pick('sound/combat/fracture/fracturedry (1).ogg','sound/combat/fracture/fracturedry (2).ogg','sound/combat/fracture/fracturedry (3).ogg'),80,TRUE)
-		playsound(get_turf(L),'sound/combat/hits/bladed/genstab (1).ogg',50,TRUE)
-		try_embed_target(L)
-
-	qdel(src)
+	var/obj/item/bone/profane_splinter/S = new
+	limb.add_embedded_object(S, FALSE, TRUE, TRUE)
+	playsound(get_turf(L),pick('sound/combat/fracture/fracturedry (1).ogg','sound/combat/fracture/fracturedry (2).ogg','sound/combat/fracture/fracturedry (3).ogg'),80,TRUE)
 
 // RAISE LESSER SKELETON (T2) - The new 'main' Zizo undeath-raising skill. Summon's durability scales from Miracle skill.
 /datum/action/cooldown/spell/raise_undead_formation/zizo
@@ -679,13 +487,6 @@
 
 		return TRUE
 
-/obj/item/bone/splinter
-	name = "bone splinter"
-	desc = "A jagged shard of shattered bone."
-	icon = 'icons/obj/projectiles.dmi'
-	icon_state = "chronobolt"
-	embedding = list("embed_chance" = 100, "embedded_pain_chance" = 45, "embedded_fall_chance" = 0, "embedded_bloodloss" = 0, "embedded_ignore_throwspeed_threshold" = TRUE)
-
 /datum/action/cooldown/spell/zizo/bone_cataclysm/proc/explode_skeleton(mob/living/S, mob/living/caster, datum/beam/B)
 	if(B)
 		B.End()
@@ -770,7 +571,7 @@
 			if(!length(C.bodyparts))
 				break
 			var/obj/item/bodypart/limb = pick(C.bodyparts)
-			var/obj/item/bone/splinter/P = new
+			var/obj/item/bone/profane_splinter/P = new
 			limb.add_embedded_object(P, FALSE, TRUE)
 		C.apply_status_effect(/datum/status_effect/debuff/clickcd, 8 SECONDS)
 		C.apply_status_effect(/datum/status_effect/debuff/exposed, 10 SECONDS)


### PR DESCRIPTION
## About The Pull Request

- zpellblade doesn't get the zizo longsword, it gets the armingsword now.
- profane shard isn't a DoT anymore, but it pens BSTEEL and has a 100% embed chance (tho this is tentative to being fixed in a seperate pr i plan to make)

## Testing Evidence

balance

## Why It's Good For The Game

never intended for the zpellblade to get the 40force longsword when i buffed it. i added the arming sword back then and that's what they'll use.

profane shard at current after buffs would two shot people. poison DoT is a bit too much for an instacast. rather it work like a halo needler.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: replace zpellblade Zizo longsword with arming sword.
balance: change profane shard into a high pen, 100% embed instacast.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
