### PR TITLE
Graggar Heart Extraction now checks for an appropriate target

### DIFF
--- a/code/modules/spells/roguetown/ritual_butchery.dm
+++ b/code/modules/spells/roguetown/ritual_butchery.dm
@@ -25,6 +25,10 @@
 		to_chat(user, "<span class='warning'>The weakling still pulses with life! Graggar demands you finish them properly first!</span>")
 		return FALSE
 
+	if(!target.HasSpell(/obj/effect/proc_holder/spell/invoked/extract_heart))
+		to_chat(user, span_warning("They are not Graggar's Chosen!"))
+		return FALSE
+
 	// Calculate actual time based on butchery skill
 	var/skill_modifier = 1 - (user.get_skill_level(/datum/skill/labor/butchering) * 0.1) // 10% reduction per skill level
 	var/actual_time = max(extraction_time * skill_modifier, 7.5 SECONDS) // Minimum 7.5 seconds


### PR DESCRIPTION
## About The Pull Request
IE, one that *also* has the heart extraction spell. This narrows down the target list to mostly the other event's candidates.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
By request, but also this should've been the case a while ago.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Heart Extraction spell now has more strict target checking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
