### PR TITLE
Maneateryak

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -72,6 +72,14 @@
 	if(has_buckled_mobs())
 		return
 
+	var/mob/living/victim = AM
+	if(victim == planter)
+		return
+	if(!victim.ambushable() && victim.mind)
+		return
+	if(victim.m_intent == MOVE_INTENT_SNEAK)
+		return
+
 	if(!aggroed)
 		START_PROCESSING(SSobj, src)
 	aggroed = world.time
@@ -83,14 +91,6 @@
 			playsound(src,'sound/misc/eat.ogg', rand(30,60), TRUE)
 			AM.forceMove(src)
 			seednutrition += 10
-		return
-
-	var/mob/living/victim = AM
-	if(victim == planter)
-		return
-	if(!victim.ambushable())
-		return
-	if(victim.m_intent == MOVE_INTENT_SNEAK)
 		return
 
 	buckle_mob(victim, TRUE, check_loc = FALSE)


### PR DESCRIPTION
## About The Pull Request
Maneaters will now no longer be triggered by things walking over them that they refuse to eat. They will now also attack and eat non-ambushable npcs like bandits.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Joined a test server as a druid, walked over a maneater, didn't emerge from the ground. Spawned a bogman npc and kited it over the maneater, it was grabbed and resisted out as expected. Evaporated all of the bogmans blood and threw it onto the maneater, it was instantly consumed. Success.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
You can now once more feed dead and dying bandits to maneaters to grow your own vicious garden. Didn't make sense to me why they would appear out of the ground only to change their mind and not eat the person stepping on them. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Maneaters are no longer revealed by walking over them in cases where they won't attack
fix: Maneaters no longer refuse to eat ambush NPCs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
