### PR TITLE
fix #2 (for silver/psydonic knuckles)

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -1114,7 +1114,7 @@
 /obj/item/rogueweapon/knuckledusters/silver/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
-		pre_blessed = BLESSING_TENNITE,\ //Temporary stopgap to prevent blessings from vanishing mid-transform. Replace with '_NONE' if-or-when this is solved.
+		pre_blessed = BLESSING_TENNITE,\
 		silver_type = SILVER_TENNITE,\
 		added_force = 0,\
 		added_blade_int = 0,\
@@ -1171,7 +1171,7 @@
 /obj/item/rogueweapon/knuckledusters/psy/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
-		pre_blessed = BLESSING_PSYDONIAN,\  //Temporary stopgap to prevent blessings from vanishing mid-transform. Replace with '_NONE' if-or-when this is solved.
+		pre_blessed = BLESSING_PSYDONIAN,\
 		silver_type = SILVER_PSYDONIAN,\ 
 		added_force = 0,\
 		added_blade_int = 0,\

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -1114,7 +1114,7 @@
 /obj/item/rogueweapon/knuckledusters/silver/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
-		pre_blessed = BLESSING_NONE,\
+		pre_blessed = BLESSING_TENNITE,\ //Temporary stopgap to prevent blessings from vanishing mid-transform. Replace with '_NONE' if-or-when this is solved.
 		silver_type = SILVER_TENNITE,\
 		added_force = 0,\
 		added_blade_int = 0,\
@@ -1171,8 +1171,8 @@
 /obj/item/rogueweapon/knuckledusters/psy/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
-		pre_blessed = BLESSING_NONE,\
-		silver_type = SILVER_PSYDONIAN,\
+		pre_blessed = BLESSING_PSYDONIAN,\  //Temporary stopgap to prevent blessings from vanishing mid-transform. Replace with '_NONE' if-or-when this is solved.
+		silver_type = SILVER_PSYDONIAN,\ 
 		added_force = 0,\
 		added_blade_int = 0,\
 		added_int = 50,\


### PR DESCRIPTION
## About The Pull Request

* Similar to the Silver Dagger, the Silver Knuckledusters are now blessed by default.
* This fixes a minor issue with transforming between Knuckledusters and Knuckles.

## Testing Evidence

* One line change. Two, technically.

## Why It's Good For The Game

* Blessings no longer inexplicably vanish under unintended circumstances.

## Changelog

:cl:
fix: Silver Knuckledusters - and their Psydonic variants - should no longer lose their blessings when transformed between states.
/:cl:
