### PR TITLE
[Bugfix] - Stop hyperspeed undead saiga

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/creacher/deadites/undead_saiga.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/deadites/undead_saiga.dm
@@ -53,6 +53,8 @@
 		/obj/item/alch/viscera = 1
 	)
 	ai_controller = /datum/ai_controller/undead
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/undead/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
I believe this was making them too fast, default AI giving them extra moves.

## Testing Evidence
Tested, speed seemed okay.

## Why It's Good For The Game
Attempts to fix undead saiga hyperspeed.

## Changelog

:cl:
fix: undead saiga speed
/:cl:

