### PR TITLE
Fixes tanto sheath parrying, makes ruma sheaths repair with carpentry.

### DIFF
--- a/code/game/objects/items/scabbard.dm
+++ b/code/game/objects/items/scabbard.dm
@@ -549,6 +549,7 @@
 	possible_item_intents = list(SHIELD_BASH, SHIELD_SMASH)
 	can_parry = TRUE
 	sewrepair = FALSE
+	anvilrepair = /datum/skill/craft/carpentry
 	wdefense = 8
 	special = /datum/special_intent/limbguard
 
@@ -602,9 +603,10 @@
 	possible_item_intents = list(SHIELD_BASH, SHIELD_BLOCK)
 	can_parry = TRUE
 	sewrepair = FALSE
-	wdefense = 3
+	anvilrepair = /datum/skill/craft/carpentry
+	wdefense = 4
+	max_integrity = 220
 
-	max_integrity = 0
 
 /obj/item/rogueweapon/scabbard/sheath/courtphysician
 	name = "fancy cane"

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/rumaclan.dm
@@ -26,6 +26,7 @@
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/carpentry = SKILL_LEVEL_NOVICE,
 	)
 	extra_context = "This subclass is race-limited from: Dwarves."
 

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/seonjang.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/seonjang.dm
@@ -27,6 +27,7 @@
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/carpentry = SKILL_LEVEL_NOVICE,
 	)
 
 /datum/outfit/job/roguetown/mercenary/seonjang/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

The kanengun tanto sheath is intended to be used to parry, however it has wdef of 3, the same as the dagger that accompanies it. Thus the game totally ignores if if you try to wield it in the offhand as a parrying tool. Also, it has infinite integrity.

This PR boosts the tanto wdef from 3 to 4 so that it actually functions, drops its integrity from infinite to 220 (176 ingame for code reasons, same value as the sword sheaths), and makes both it and the kazengun sword sheaths repair with carpentry skill instead of weaponsmithing.

Ruma Seonjang and Gun-in gained novice carpentry so they don't fumble over their sheaths all the time (still will for swords without a virtue or training). Sasu already had apprentice carpentry.

## Testing Evidence

<img width="581" height="361" alt="image" src="https://github.com/user-attachments/assets/29fe9923-775d-4b85-b680-fa96dd53416d" />
<img width="583" height="194" alt="image" src="https://github.com/user-attachments/assets/8a846671-d718-44d3-97b6-00308a02020e" />
<img width="297" height="37" alt="image" src="https://github.com/user-attachments/assets/5014b801-8dba-4e59-a42f-6a44f948fc95" />
<img width="559" height="46" alt="image" src="https://github.com/user-attachments/assets/cc92de06-2d72-46d8-80c5-8e769f524ef8" />
<img width="581" height="359" alt="image" src="https://github.com/user-attachments/assets/f2021cdd-8260-4580-a0f2-ab724f30f69a" />



## Why It's Good For The Game

Makes an intended mechanic (using the sheath offhand as a far weaker parrying dagger) actually work alongside the dagger it comes with, while preventing infinite integrity cheese. 

Also makes the sheaths a touch nicer for the Ruma to maintain, via removing fumbles for them (but not metal weapons). Plus, more thematic.

## Changelog

:cl:
add: Added novice carpentry to Ruma Seonjang and Gun-in.
balance: Rebalanced ruma sheaths to use carpentry to repair.
fix: Fixed tanto sheath parrying functionality & integrity.
/:cl:
