### PR TITLE
Stone knives & axes once again repair with skill used to craft them (inquisition ate my homework edition)

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -25,6 +25,7 @@
 	gripped_intents = list(/datum/intent/axe/chop/stone)
 	resistance_flags = FLAMMABLE
 	special = /datum/special_intent/axe_swing
+	anvilrepair = /datum/skill/craft/crafting
 
 /obj/item/rogueweapon/stoneaxe/getonmobprop(tag)
 	. = ..()
@@ -53,6 +54,7 @@
 	gripped_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/chop/heavy, /datum/intent/axe/bash/battle)
 	minstr = 9
 	wdefense = 4
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/oath
 	force = 30
@@ -77,6 +79,7 @@
 	smeltresult = /obj/item/ingot/steel
 	minstr = 12
 	wdefense = 5
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/oath/getonmobprop(tag)
 	if(tag)
@@ -100,6 +103,7 @@
 	gripped_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/axe/bash)
 	wdefense = 2
 	is_tool = TRUE // set here to exclude battleaxes and such
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/woodcut/woodcutter
 	name = "woodcutter's handaxe"
@@ -143,6 +147,7 @@
 	possible_item_intents = list(/datum/intent/axe/chop/stone)
 	gripped_intents = null
 	thrown_damage_flag = "piercing"		//Checks piercing type like an arrow.
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/hurlbat/getonmobprop(tag)
 	. = ..()
@@ -221,6 +226,7 @@
 	throw_speed = 3 
 	armor_penetration = PEN_LIGHT
 	is_tool = TRUE
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /datum/intent/axe/cut/handaxe
 	damfactor = 1.1
@@ -431,6 +437,7 @@
 	pickup_sound = 'sound/foley/equip/rummaging-03.ogg'
 	gripped_intents = list(/datum/intent/axe/cut,/datum/intent/axe/chop)
 	resistance_flags = FLAMMABLE
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/stoneaxe/woodcut/silver
 	name = "silver war axe"

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -268,6 +268,7 @@
 	max_blade_int = 100
 	max_integrity = 150
 	smeltresult = null
+	anvilrepair = /datum/skill/craft/carpentry
 
 /datum/intent/dagger/cut/wood
 	name = "cut"
@@ -758,6 +759,7 @@
 	equip_delay_self = 0 //No delay when stowing away, without a scabbard.
 	unequip_delay_self = 0 //No delay when drawing.
 	inv_storage_delay = 0 //No delay when retrieving from a storage slot.
+	anvilrepair = /datum/skill/craft/crafting
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/stake
 	name = "silver-tipped stake"
@@ -892,6 +894,7 @@
 	wdefense = 1
 	resistance_flags = FLAMMABLE
 	is_tool = TRUE
+	anvilrepair = /datum/skill/craft/crafting
 
 /obj/item/rogueweapon/huntingknife/stoneknife/kukri
 	name = "jade kukri"
@@ -902,6 +905,7 @@
 	max_blade_int = 50
 	wdefense = 3
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/huntingknife/stoneknife/opalknife
 	name = "opal knife"
@@ -912,6 +916,7 @@
 	max_blade_int = 50
 	wdefense = 3
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	anvilrepair = /datum/skill/craft/weaponsmithing
 
 /obj/item/rogueweapon/huntingknife/idagger/silver/elvish
 	name = "elvish dagger"


### PR DESCRIPTION
## About The Pull Request

Re-adds the stone knife and axe changes from https://github.com/Azure-Peak/Azure-Peak/pull/7411 after merges deleted the edits. Also made wooden stake weapons repair with crafting, as a bonus (carpentry seemed a bit too rare, also for fancier work).

## Testing Evidence

<img width="599" height="436" alt="image" src="https://github.com/user-attachments/assets/5eaf176d-0437-4b0c-a056-4c0b7abdffaf" />
<img width="588" height="195" alt="image" src="https://github.com/user-attachments/assets/967ae72b-80d4-4d32-a60c-c6a7d0ded6ef" />

## Why It's Good For The Game

Same reasons as before, if you can make another stone knife via crafting, fixing the existing one should be equally easy.

## Changelog
:cl:
fix: fixed stone axe/knife repairs not using crafting skill after merges
/:cl:

