### PR TITLE
toggleable summoned spectacles

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_spectacles.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_spectacles.dm
@@ -81,5 +81,17 @@
 // Golden spectacles summonable lesser varient - with no mechanical effects
 
 /obj/item/clothing/mask/rogue/spectacles/golden_lesser_summoned
-		name = "summoned golden spectacles"
-		icon_state = "goggles"
+	name = "summoned golden spectacles"
+	icon_state = "goggles"
+	break_sound = "glassbreak"
+	attacked_sound = 'sound/combat/hits/onglass/glasshit.ogg'
+	max_integrity = 35
+	integrity_failure = 0.5
+	resistance_flags = FIRE_PROOF
+	body_parts_covered = EYES
+	anvilrepair = /datum/skill/craft/armorsmithing
+	adjustable = CAN_CADJUST
+	var/active_item = FALSE
+
+/obj/item/clothing/mask/rogue/spectacles/golden_lesser_summoned/ComponentInitialize()
+	AddComponent(/datum/component/adjustable_clothing, NECK, null, null, 'sound/foley/equip/rummaging-03.ogg', null, (UPD_HEAD|UPD_MASK))	//Standard mask


### PR DESCRIPTION
## About The Pull Request
summoned golden spectacles were repathed, making them lose the ability to push them up out of your face visually. this restores that behavior without giving them the other benefits of golden spectacles (engineering skill)

## Testing Evidence
tested. works. forgot to get a sc

## Why It's Good For The Game
was requested. apparently these are a vital part of some characters' drip and having them pushed up is important for that. it changes nothing mechanically so why not

## Changelog

:cl:
fix: Summoned golden spectacles can now be adjusted
/:cl: