### PR TITLE
hag addendum 1.5: bogfixer

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -264,6 +264,7 @@
 #define TRAIT_HARDSOLE		"Hard Sole"
 #define TRAIT_AZURENATIVE "Azure Native"
 #define TRAIT_BOGWALKER "Bogwalker"
+#define TRAIT_NOPVE "Natural Accord"
 #define TRAIT_SLEUTH	"Sleuth"
 #define TRAIT_HARDSHELL "Hardshell"
 #define TRAIT_WOODWALKER "Woodwalker"
@@ -506,6 +507,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_DETACHED = span_info("Nothing could move me. Any emotion I show is a facade."),
 	TRAIT_AZURENATIVE = span_info("I've grown up and lived all my lyfe in these lands. I can only trigger ambushes if I sprint through them."),
 	TRAIT_BOGWALKER = span_info("The bog's blessing graces me. Kneestingers and leeches will not harm me, and I cannot trigger ambushes within the bog unless sprinting."),
+	TRAIT_NOPVE = span_info("I am a true force of nature. No critter or creechur would dare harm me, and I can exert enough influence to deflect the ire of simple-minded mortals as well."),
 	TRAIT_SLEUTH = span_info("I can spot my tracked Mark's trail without needing to approach it, and can spot them at a distance. I can track more frequently, and the act is not impaired by movement. I can examine tracks right away."),
 	TRAIT_HARDSHELL = span_info("The bulk of this armor prevents me from parrying effectively, but I can still move out of the way."),
 	TRAIT_MATTHIOS_EYES = span_notice("I have a sense for what the most valuable item someone has is. I can also tell if someone is hoarding mammons, and with blessed gilded spectacles, I can even see how much they have in their bank."),

--- a/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
+++ b/code/game/objects/items/rogueitems/natural/clothfibersthorn.dm
@@ -455,7 +455,7 @@
 		if(L.m_intent == MOVE_INTENT_RUN)
 			prob2break = 100
 		if(prob(prob2break))
-			if(L.m_intent == MOVE_INTENT_RUN || !(HAS_TRAIT(L, TRAIT_AZURENATIVE) || HAS_TRAIT(L, TRAIT_WOODWALKER) || (HAS_TRAIT(L, TRAIT_BOGWALKER) && istype(get_area(L), /area/rogue/outdoors/bog))))
+			if(L.m_intent == MOVE_INTENT_RUN || !(HAS_TRAIT(L, TRAIT_AZURENATIVE) || HAS_TRAIT(L, TRAIT_NOPVE) || HAS_TRAIT(L, TRAIT_WOODWALKER) || (HAS_TRAIT(L, TRAIT_BOGWALKER) && istype(get_area(L), /area/rogue/outdoors/bog))))
 				playsound(src,'sound/items/seedextract.ogg', 100, FALSE)
 				qdel(src)
 				if (L.alpha == 0 && L.rogue_sneaking) // not anymore you're not

--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -312,7 +312,7 @@
 		if (L.is_flying()) //if you're flying you shouldn't break things on the ground
 			prob2break = 0
 		if(prob(prob2break))
-			if(L.m_intent == MOVE_INTENT_RUN || !(HAS_TRAIT(L, TRAIT_AZURENATIVE) || HAS_TRAIT(L, TRAIT_WOODWALKER) || (HAS_TRAIT(L, TRAIT_BOGWALKER) && istype(get_area(L), /area/rogue/outdoors/bog))))
+			if(L.m_intent == MOVE_INTENT_RUN || !(HAS_TRAIT(L, TRAIT_AZURENATIVE) || HAS_TRAIT(L, TRAIT_NOPVE) || HAS_TRAIT(L, TRAIT_WOODWALKER) || (HAS_TRAIT(L, TRAIT_BOGWALKER) && istype(get_area(L), /area/rogue/outdoors/bog))))
 				playsound(src,'sound/items/seedextract.ogg', 100, FALSE)
 				qdel(src)
 				if (L.alpha == 0 && L.rogue_sneaking) // not anymore you're not

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -338,7 +338,7 @@
 		if(L.m_intent == MOVE_INTENT_SNEAK)
 			return
 		else
-			if(L.m_intent == MOVE_INTENT_RUN || !(HAS_TRAIT(L, TRAIT_AZURENATIVE) || (HAS_TRAIT(L, TRAIT_BOGWALKER) && istype(get_area(L), /area/rogue/outdoors/bog))))
+			if(L.m_intent == MOVE_INTENT_RUN || !(HAS_TRAIT(L, TRAIT_AZURENATIVE) || HAS_TRAIT(L, TRAIT_NOPVE) || (HAS_TRAIT(L, TRAIT_BOGWALKER) && istype(get_area(L), /area/rogue/outdoors/bog))))
 				playsound(A.loc, "plantcross", 100, FALSE, -1)
 				var/oldx = A.pixel_x
 				animate(A, pixel_x = oldx+1, time = 0.5)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons.dm
@@ -94,7 +94,7 @@
 		/datum/hag_boon/trait/sharper_blades,
 		/datum/hag_boon/trait/guidance,
 		/datum/hag_boon/trait/good_trainer,
-		/datum/hag_boon/trait/counter_counterspell,
+		// /datum/hag_boon/trait/counter_counterspell,
 		/datum/hag_boon/trait/keen_ears,
 		/datum/hag_boon/trait/hard_dismember,
 		/datum/hag_boon/trait/no_pain,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_traits.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_boons/hag_boons_traits.dm
@@ -130,11 +130,11 @@
 	desc = "Grants an affinity for training others, allowing training up to equal level in weaponry skills."
 	points = 75
 
-/datum/hag_boon/trait/counter_counterspell
-	name = "Trait - Counter Counterspell"
-	trait_to_apply = TRAIT_COUNTERCOUNTERSPELL
-	desc = "Prevents Counterspells from affecting the bearer."
-	points = 40
+// /datum/hag_boon/trait/counter_counterspell
+// 	name = "Trait - Counter Counterspell"
+// 	trait_to_apply = TRAIT_COUNTERCOUNTERSPELL
+// 	desc = "Prevents Counterspells from affecting the bearer."
+// 	points = 40
 
 /datum/hag_boon/trait/keen_ears
 	name = "Trait - Keen Ears"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_class.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_class.dm
@@ -10,7 +10,7 @@
 						  TRAIT_ZOMBIE_IMMUNE, TRAIT_NOMOOD,
 						  TRAIT_UNLYCKERABLE, TRAIT_BOGWALKER,
 						  TRAIT_DARKVISION, TRAIT_NOHUNGER,
-						  TRAIT_TECHNOPHOBE)
+						  TRAIT_TECHNOPHOBE, TRAIT_NOPVE)
 	reset_stats = TRUE
 	subclass_stats = list(
 		STATKEY_STR = -7,
@@ -37,6 +37,12 @@
 		/datum/skill/craft/sewing = SKILL_LEVEL_MASTER,
 		/datum/skill/craft/cooking = SKILL_LEVEL_MASTER,
 	)
+	subclass_languages = list(
+		/datum/language/oldazurian, // (gerson voice) you're old!
+		/datum/language/beast, // fucked up nature spirit gaming
+		/datum/language/celestial, // old enough to know the OG celestial, probably
+		/datum/language/abyssal // you can send people to the dream you can presumably communicate with its denizens
+	)
 	category_tags = list(CTAG_HAG)
 	cmode_music = 'sound/music/combat_graggar.ogg'
 
@@ -50,11 +56,14 @@
 	shoes = /obj/item/clothing/shoes/roguetown/sandals
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/aalloy
 	beltr = /obj/item/roguekey/hag
+	backpack_contents = list(
+		/obj/item/handmirror = 1
+	)
 	if(H.mind)
 		H.verbs |= /mob/living/carbon/human/proc/commune_with_roots
 		H.verbs |= /mob/living/carbon/human/proc/toggle_guarded
 		H.ambushable = FALSE
-		H.faction |= list(FACTION_HAG, FACTION_SPIDERS, FACTION_TROLLS)
+		H.faction |= list(FACTION_HAG)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/wildshape/hag_true_form)
 		H.set_patron(/datum/patron/mossmother)
 		H.AddComponent(/datum/component/hag_curio_tracker)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hag_class/hag_structures/hag_mirror.dm
@@ -51,14 +51,14 @@
 		return
 	
 	var/mob/living/carbon/human/target = null
-	for(var/mob/living/carbon/human/HL in GLOB.player_list) 
+	for(var/mob/living/carbon/human/HL in GLOB.mob_list) 
 		if(HL.real_name == input)
 			if(HAS_TRAIT(HL, TRAIT_ANTISCRYING))
 				to_chat(user, span_warning("They are not within the gaze of the mirror."))
 				return
 			target = HL
 	if(!target)
-		to_chat(user, span_warning("They are not within the gaze of the mirror; either they've travelled afar, or they've fallen victim to the fog."))
+		to_chat(user, span_warning("They are not within the gaze of the mirror; they may be destroyed, utterly."))
 		return
 
 	target.throw_alert("hagscry", /atom/movable/screen/alert/hagscry, override = TRUE)
@@ -115,14 +115,14 @@
 		return
 	
 	var/mob/living/carbon/human/target = null
-	for(var/mob/living/carbon/human/HL in GLOB.player_list) 
+	for(var/mob/living/carbon/human/HL in GLOB.mob_list) 
 		if(HL.real_name == input)
 			if(HAS_TRAIT(HL, TRAIT_ANTISCRYING))
 				to_chat(user, span_warning("The gaze of the roots is rebuffed by a ward!"))
 				return
 			target = HL
 	if(!target)
-		to_chat(user, span_warning("They are not within the gaze of the mirror; either they've travelled afar, or they've fallen victim to the fog."))
+		to_chat(user, span_warning("They are not within the gaze of the mirror; they may be destroyed, utterly."))
 		return
 
 	target.throw_alert("hagscry", /atom/movable/screen/alert/hagscry, override = TRUE)

--- a/code/modules/mob/living/ambush.dm
+++ b/code/modules/mob/living/ambush.dm
@@ -89,6 +89,8 @@ GLOBAL_LIST_INIT(melee_combat_skills, list( \
 	if(!always)
 		if(HAS_TRAIT(src, TRAIT_AZURENATIVE))
 			return FALSE
+		if(HAS_TRAIT(src, TRAIT_NOPVE))
+			return FALSE
 		if(HAS_TRAIT(src, TRAIT_BOGWALKER) && istype(get_area(src), /area/rogue/outdoors/bog))
 			return FALSE
 		if(world.time > last_client_interact + 0.3 SECONDS)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1039,6 +1039,8 @@ GLOBAL_VAR_INIT(mobids, 1)
 		if(!("[REF(target)]" in faction_src))
 			faction_target -= "[REF(target)]" //same thing here.
 		return faction_check(faction_src, faction_target, TRUE)
+	if(HAS_TRAIT(target, TRAIT_NOPVE))
+		return TRUE // don't bother checking anyone who's exempt from pve entirely
 	// Avoid lit allocations by scanning factions directly for better perf.
 	var/list/their_faction = target.faction
 	var/their_name = target.name


### PR DESCRIPTION
## About The Pull Request
hag addendum 2 is coming but the small, easy changes from it have been atomized to here for faster implementation
- hags now get some bonus languages, mostly related to their nature as ancient fucked up nature spirits (beastspeak, abyssal, celestial, and old azurian)
- hags are now completely exempt from PVE via a trait, as discussed in the discord. people keep mapping in static enemies, many right outside hag trees, and it is just never fun to encounter an enemy you can't fight and be removed from the round for 5+ minutes because of it. this does NOT apply to your mirebeast form - once you become frag-capable, you're a valid target
- counter counterspell trait boon removed (commented out) since counterspell does not exist post Mage 2. it's literally a useless boon and diluted the trait pool (all trait boons are crafted with the same 3 items and then are picked randomly from a pool, so every 'unwanted' trait meant you had to craft more to get the one you want)
- fixed the hag scrying mirror behaving inconsistently when people went AFK vs being dead or far-travelling. it shouldn't be affected by players going AFK or dying anymore, you can still find them.
- hags now get a hand mirror (a normal one, not the scrying variant) in their bag at roundstart. you can pick one from the loadout, but you shouldn't have to since it's so important for the class (they get the mirror magic trait for a reason!). If you didn't pick one in loadout, good luck getting one, since you're soft-locked out of the economy with the technophobe trait.

## Testing Evidence
the name of this trait has since been changed
<img width="613" height="66" alt="image" src="https://github.com/user-attachments/assets/61b29ecc-7238-4b93-ae56-4455032a3482" />

<img width="345" height="182" alt="image" src="https://github.com/user-attachments/assets/4da2e127-148c-4e86-a912-5214ff57a19d" />

enemies still aggro if you attack _them_
<img width="608" height="232" alt="image" src="https://github.com/user-attachments/assets/585d01b3-8770-453c-8766-d2518a4a109c" />


## Why It's Good For The Game
- hags being languagemogged by literally any class that grants a bonus language is weird. if you want to know relevant regional languages, take intellectual, but you should definitely be able to know stuff like beastish and old azurian without it
- hags are not a PVE class. they have 3 str and 8 spd, they have no way to fight back against mobs. if you're getting targeted by a player, that's one thing, but a random skeleton encounter should not be fucking with your round plans, especially when they're mapped in right outside your tree you enter the map from. thank you, whoever mapped that in.
- traits that do Literally Nothing shouldn't be given out
- bugfixes good
- you shouldn't need to spend loadout points to get a class-vital item

## Changelog

:cl:
add: Hags now get some thematic languages for free, as well as a hand mirror in their bag
add: New trait that exempts hags from PVE entirely
del: Removed counter counterspell boon, since that trait does literally nothing - counterspell was removed from the game!
fix: Hag scrying should no longer break when your target goes AFK or dies
/:cl:
