### PR TITLE
Fixes Arcyne Ward stacking coverage and increase charge time

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_arcyne_ward.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_arcyne_ward.dm
@@ -167,7 +167,7 @@
 	invocations = list("Psymagia Congrego!")
 	dismiss_invocation = "Psymagia Dissipo!"
 	regen_invocation = "Psymagia Restauro!"
-	charge_time = 5 SECONDS
+	charge_time = 6 SECONDS
 	point_cost = 4
 	spell_tier = 3
 	ward_type = /obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/crystalhide
@@ -178,7 +178,7 @@
 /datum/action/cooldown/spell/regenerate_arcyne_ward
 	name = "Regenerate Arcyne Ward"
 	desc = "Channel a restoration on my active Arcyne Ward, returning it to full integrity. \
-	The channel takes 6 seconds and costs stamina and energy proportional to how damaged the ward is - \
+	The channel takes 10 seconds and costs stamina and energy proportional to how damaged the ward is - \
 	a nearly-full ward costs almost nothing, a shattered one costs nearly as much as a fresh cast. \
 	While channeling this spell, I cannot parry or dodge."
 	button_icon = 'icons/mob/actions/roguespells.dmi'
@@ -196,7 +196,7 @@
 	var/upfront_stamina_cost = 70
 
 	charge_required = TRUE
-	charge_time = 6 SECONDS
+	charge_time = 10 SECONDS
 	charge_drain = 5
 	charge_slowdown = 3
 	charge_sound = 'sound/magic/charging.ogg'
@@ -297,6 +297,7 @@
 		ward.obj_fix(H, full_repair = TRUE)
 	else
 		ward.obj_integrity = ward.max_integrity
+	ward.recalculate_coverage(force_full = TRUE)
 	return TRUE
 
 /datum/action/cooldown/spell/regenerate_arcyne_ward/dragonhide
@@ -325,7 +326,6 @@
 
 	var/datum/action/cooldown/spell/conjure_arcyne_ward/linked_spell
 	var/mob/living/carbon/human/ward_owner
-	var/coverage_locked = FALSE
 	var/dismissed = FALSE
 	var/ward_color = GLOW_COLOR_ARCANE
 	var/arcyne_armor_tier = ARCYNE_WARD_TIER_BASE
@@ -334,13 +334,13 @@
 	ward_owner = H
 	RegisterSignal(H, COMSIG_MOB_EQUIPPED_ITEM, PROC_REF(on_owner_equip_change))
 	RegisterSignal(H, COMSIG_MOB_DROPITEM, PROC_REF(on_owner_equip_change))
-	recalculate_coverage()
+	recalculate_coverage(force_full = TRUE)
 
 /obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/proc/on_owner_equip_change(datum/source, obj/item/item)
 	SIGNAL_HANDLER
 	addtimer(CALLBACK(src, PROC_REF(recalculate_coverage)), 1)
 
-/obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/proc/recalculate_coverage()
+/obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/proc/recalculate_coverage(force_full = FALSE)
 	if(QDELETED(src) || !ward_owner)
 		return
 
@@ -368,18 +368,26 @@
 	if(has_real_armor(H.shoes))
 		new_coverage &= ~(FOOT_LEFT | FOOT_RIGHT)
 
-	if(coverage_locked)
+	if(!force_full)
 		new_coverage &= body_parts_covered_dynamic
 	body_parts_covered_dynamic = new_coverage
 
 /obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/proc/has_real_armor(obj/item/clothing/C, coverage_check)
 	if(!C || !istype(C))
 		return FALSE
-	if(C.armor_class <= ARMOR_CLASS_NONE)
+	if(!piece_is_armor(C))
 		return FALSE
 	if(coverage_check)
 		return (C.body_parts_covered_dynamic & coverage_check)
 	return TRUE
+
+/obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/proc/piece_is_armor(obj/item/clothing/C)
+	if(C.armor_class > ARMOR_CLASS_NONE)
+		return TRUE
+	if(!C.armor)
+		return FALSE
+	return (C.armor.getRating("blunt") > 0 || C.armor.getRating("slash") > 0 \
+		|| C.armor.getRating("stab") > 0 || C.armor.getRating("piercing") > 0)
 
 /obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
 	if(ward_owner && damage_amount > 0)
@@ -389,7 +397,6 @@
 		flash_ward()
 		if(prob(50))
 			do_sparks(2, FALSE, T)
-	coverage_locked = TRUE
 	return ..()
 
 /obj/item/clothing/suit/roguetown/armor/manual/arcyne_ward/proc/flash_ward()


### PR DESCRIPTION
## About The Pull Request
An error made during my refactor 1 month ago resulted in this bug that has only been reported for uhhh, 2 - 3 weeks but I forgot about it. Arcyne Ward is **NOT supposed to stack on top of armor**

- Arcyne Ward no longer stack on top of armor, this is defined by any piece having real armor rating
- When you put on armor, it will remove the coverage again
- Coverage does not restore until the cast of regen / full cast happens. It will only ever **LOSE** coverage from you putting on, or having had armor on during the initial cast
- For balance purpose due to multiple complaints about mid combat regeneration, the conjure time has been changed from 6 seconds to 10 seconds

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="634" height="341" alt="dreamseeker_bPiPY4AxzH" src="https://github.com/user-attachments/assets/2c1018e1-8a63-4576-91b6-52e5ecfab07e" />
<img width="634" height="341" alt="dreamseeker_QmdyjcTVRc" src="https://github.com/user-attachments/assets/d96cba83-ff8d-45fb-965c-0905a7642c22" />
<img width="500" height="300" alt="5QBn9bhIJr" src="https://github.com/user-attachments/assets/cafb8900-8d9a-4338-be94-e706b6640a56" />
<img width="500" height="300" alt="TziHxqW3ko" src="https://github.com/user-attachments/assets/0656a000-1bb3-4a4e-a3ce-77d08187d4fd" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The original intent is for crystalhide / dragonhide / arcyne ward to give drip mage *some* protection to keep viable without replacing any incentives to actually upgrade to armor. Stacking armor obliterates that and gave an unfair advantage to armor maxxing mage. This fixes that. 

I've also received a few complaints about mid combat regen. Remember, a martial have to take off their armor in general to sew in combat and it is not a luxury. Mage can mend for 3 - 4 seconds for 25% and then restore their entire 225 / 300 HP full layers for 6 seconds of standing still, and now just 10. 

This is a **far** better deals than martials get n I will pre-empt anyone complaining this is unfair

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: THIS IS A BUG FIX: Arcyne Ward no longer stack on top of armor, this is defined by any piece having real armor rating. When you put on armor, it will remove the coverage again. Coverage does not restore until the cast of regen / full cast happens. It will only ever **LOSE** coverage from you putting on, or having had armor on during the initial cast
balance: For balance purpose due to multiple complaints about mid combat regeneration, the conjure time for regen / conjuring ward has been changed from 6 seconds to 10 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
