### PR TITLE
murriel - restores the 'high fire resistance' gimmick of bronze via increasing the "fire" var from DR_LIGHT to DR_HEAVY

### DIFF
--- a/code/__DEFINES/armor_defines.dm
+++ b/code/__DEFINES/armor_defines.dm
@@ -163,7 +163,7 @@
 #define ARMOR_BRIGANDINE list("blunt" = DR_HEAVY, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_HEAVY, "fire" = DR_MEDIUM, "acid" = DR_NONE)
 
 // BRONZE - All bronze armor. Not particularly good against any specialized AP intent, but uniquely resistant to fire damage from mage spells and the like. THIS SHOULD BE USING IRON INTEGRITY.
-#define ARMOR_BRONZE list("blunt" = DR_MEDIUM, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_LIGHT, "acid" = DR_LIGHT)
+#define ARMOR_BRONZE list("blunt" = DR_MEDIUM, "slash" = DBLOCK_MEDIUM, "stab" = DBLOCK_MEDIUM, "piercing" = DBLOCK_MEDIUM, "fire" = DR_HEAVY, "acid" = DR_LIGHT)
 
 // MAILLE — Chainmail. Medium: Plate level protection but weak vs Bodkin (100% through)
 #define ARMOR_MAILLE list("blunt" = DR_MEDIUM, "slash" = DBLOCK_HEAVY, "stab" = DBLOCK_HEAVY, "piercing" = DBLOCK_LIGHT, "fire" = DR_LIGHT, "acid" = DR_NONE)


### PR DESCRIPTION
## About The Pull Request

* Increases the fire resistance value of bronze armor from DR_LIGHT to DR_HEAVY.
* This puts it above conventional plate armor in terms of fire resistance, matched with dragonhide and blacksteel..
* And to emphasize, this _only_ touches fire resistance.

## Testing Evidence

* One line change. Should be good to go.

## Why It's Good For The Game

* As the comment in the DEFINE file notes, this _should_ reestablish a firm and appropriate niche for bronze armor _without_ making it overpowered. Checked with Ansari on the matter, just in case, and he's fine with the idea.
* Bronze armor, for reference, has iron-tier durability and two-pip-tier protection across the board. The original niche it had relied on the legacy armor system, which was _(mercifully)_ replaced with Ansari's and Free's overhauled mechanics. This _did_ result in bronze armor getting the short end of the stick, however. This should remedy that qualm.

## Changelog

:cl:
balance: Increases the fire resistance value of bronze armor from LIGHT to HEAVY, making it uniquely adept at protecting against incendiary attacks.
/:cl: