### PR TITLE
Mystic and Sage Healing Miracle choice - FIX - PSYDON GO BACK TO SLEEP EDITION

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mystic.dm
@@ -67,6 +67,8 @@
 					H.mind.AddSpell(new /datum/action/cooldown/spell/miracle/heal/undivided)
 				if("Fortifying Vapors(Medical)")
 					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortifyingvapors)
+		if(/datum/patron/old_god)
+			H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/heal)
 		else
 			var/list/heal = list("Cure Wounds(Miracle)", "Fortifying Vapors(Medical)")
 			var/heal_options = input(H, "Choose your healing training.", "Experientia Medica") as anything in heal
@@ -227,6 +229,8 @@
 					H.mind.AddSpell(new /datum/action/cooldown/spell/miracle/heal/undivided)
 				if("Fortifying Vapors(Medical)")
 					H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortifyingvapors)
+		if(/datum/patron/old_god)
+			H.mind.RemoveSpell(/datum/action/cooldown/spell/miracle/heal)
 		else
 			var/list/heal = list("Cure Wounds(Miracle)", "Fortifying Vapors(Medical)")
 			var/heal_options = input(H, "Choose your healing training.", "Experientia Medica") as anything in heal


### PR DESCRIPTION
shitshitshit

## About The Pull Request

I forgot to add a check for old god hum..... Daddy is home i guess?
It wouldn't be something made by me without fucking it up mid-way!

## Testing Evidence

just a few lines, it should compile just fine

## Why It's Good For The Game

Psydon having Respite at T1 is more than enough

## Changelog


:cl:
add: check for old god, so psydonite doesn't receive miracle or F.Vapors
/:cl:
