### PR TITLE
add: strap

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -340,6 +340,7 @@
 				beltr = /obj/item/rogueweapon/whip
 			if("Spear")
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
 					r_hand = /obj/item/rogueweapon/spear/psyspear/old
 				else


### PR DESCRIPTION
## About The Pull Request
spear-paladins now get a greatweapon strap instead of a shield. polearms are 2-hand weapons, and as is you have Literally Nowhere to put your weapon if you pick spearpally

## Testing Evidence
<img width="277" height="506" alt="image" src="https://github.com/user-attachments/assets/d87c99f3-3094-4001-b04a-917e60fd79ac" />

## Why It's Good For The Game
every other class gets somewhere to put their weapon. spear should as well. and you're going to be ditching your shield anyway, and a shield and GWstrap are about the same value from a silverface, so it's not really changing anything balancewise

## Changelog

:cl:
add: Paladins who pick the spear loadout now get a greatweapon strap instead of a shield
/:cl: