### PR TITLE
Arming jacket niche + add leather helm to silverface

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -136,7 +136,7 @@
 	cost = 20 // these are actually really easy to make, and have far worse protection and integ than other gambersons.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/light)
 
-/datum/supply_pack/rogue/light_armor/arming_jacket
+/datum/supply_pack/rogue/light_armor/light_arming_jacket
 	name = "Light Arming Jacket"
 	cost = 28 // gamberson equiv that trades leg protection to be cheaper.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord/light)
@@ -156,7 +156,7 @@
 	cost = 60 // Base sellprice of 25
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
-/datum/supply_pack/rogue/light_armor/arming_jacket
+/datum/supply_pack/rogue/light_armor/padded_arming_jacket
 	name = "Padded Arming Jacket"
 	cost = 75 // padded gambeson equiv. that trades leg protection for 75 more integ (375 vs 300), touch pricier.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy)

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -67,7 +67,7 @@
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
 /datum/supply_pack/rogue/light_armor/leather_gorget
-	name = "Leather Gorget"
+	name = "Hardened Leather Gorget"
 	cost = 30 // Base sellprice of 10
 	contains = list(/obj/item/clothing/neck/roguetown/leather)
 
@@ -75,6 +75,11 @@
 	name = "Hardened Leather Bracers"
 	cost = 30 // Base sellprice of 10
 	contains = list(/obj/item/clothing/wrists/roguetown/bracers/leather/heavy)
+
+/datum/supply_pack/rogue/light_armor/leather_helmet
+	name = "Hardened Leather Helmet"
+	cost = 35 // Base sellprice of 15
+	contains = list(/obj/item/clothing/head/roguetown/helmet/leather/advanced)
 
 /datum/supply_pack/rogue/light_armor/heavy_leather_pants
 	name = "Hardened Leather Pants"
@@ -128,7 +133,7 @@
 
 /datum/supply_pack/rogue/light_armor/lightgambeson
 	name = "Light Gambeson"
-	cost = 24 // these are actually really easy to make
+	cost = 22 // these are actually really easy to make, and have far worse protection and integ than other gambersons.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/light)
 
 /datum/supply_pack/rogue/light_armor/paddedcoif
@@ -143,7 +148,7 @@
 
 /datum/supply_pack/rogue/light_armor/arming_jacket
 	name = "Arming Jacket"
-	cost = 40 // superior gambeson. idk if its on par w/ the actual padded one or not
+	cost = 40 // gamberson equiv that trades leg protection and a third more price for 50 more integ (300 vs 250). Or padded gamberson that trades leg protection for being a third cheaper, to look at it another way.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord)
 
 /datum/supply_pack/rogue/light_armor/heavy_leather_boots
@@ -153,7 +158,7 @@
 
 /datum/supply_pack/rogue/light_armor/arming_jacket
 	name = "Padded Arming Jacket"
-	cost = 58 // padded gambeson equiv. but it lacks leg prot?
+	cost = 60 // padded gambeson equiv. that trades leg protection for 50 more integ (350 vs 300)
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy)
 
 /datum/supply_pack/rogue/light_armor/grenzel_hat

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -8,12 +8,12 @@
 
 /datum/supply_pack/rogue/light_armor/rough_headband
 	name = "Roughspun Headband"
-	cost = 28 // 2 cloth + 5 fiber, added 10 for SF pricing
+	cost = 25 // 2 cloth + 5 fiber, added 7 for SF pricing
 	contains = list(/obj/item/clothing/head/roguetown/headband/monk/barbarian)
 
 /datum/supply_pack/rogue/light_armor/padded_headband
 	name = "Padded Headband"
-	cost = 34 // 4 cloth + 4 fiber, ditto
+	cost = 35 // 4 cloth + 4 fiber, added 10 for SF pricing
 	contains = list(/obj/item/clothing/head/roguetown/headband/monk)
 
 /datum/supply_pack/rogue/light_armor/arming_cap
@@ -60,11 +60,6 @@
 	name = "Studded Leather Corslet"
 	cost = 43 // ditto
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini)
-
-/datum/supply_pack/rogue/light_armor/padded_gambeson
-	name = "Padded Gambeson"
-	cost = 60 // Base sellprice of 25
-	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
 /datum/supply_pack/rogue/light_armor/leather_gorget
 	name = "Hardened Leather Gorget"
@@ -121,25 +116,30 @@
 	cost = 20 // No one buying this lmao it costs 1 fur
 	contains = list(/obj/item/clothing/gloves/roguetown/angle)
 
+/datum/supply_pack/rogue/light_armor/heavy_leather_boots
+	name = "Heavy Leather Boots"
+	cost = 20
+	contains = list(/obj/item/clothing/shoes/roguetown/boots/leather/reinforced)
+
 /datum/supply_pack/rogue/light_armor/heavy_padded_coif
 	name = "Heavy Padded Coif"
 	cost = 45 // Equivalent to a padded gambeson on the head, so pricier
 	contains = list(/obj/item/clothing/neck/roguetown/coif/heavypadding)
 
-/datum/supply_pack/rogue/light_armor/sewingkit
-	name = "Sewing Kit"
-	cost = 40
-	contains = list(/obj/item/repair_kit)
-
-/datum/supply_pack/rogue/light_armor/lightgambeson
-	name = "Light Gambeson"
-	cost = 22 // these are actually really easy to make, and have far worse protection and integ than other gambersons.
-	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/light)
-
 /datum/supply_pack/rogue/light_armor/paddedcoif
 	name = "Padded Coif"
 	cost = 26 // ditto
 	contains = list(/obj/item/clothing/neck/roguetown/coif/padded)
+
+/datum/supply_pack/rogue/light_armor/lightgambeson
+	name = "Light Gambeson"
+	cost = 20 // these are actually really easy to make, and have far worse protection and integ than other gambersons.
+	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/light)
+
+/datum/supply_pack/rogue/light_armor/arming_jacket
+	name = "Light Arming Jacket"
+	cost = 28 // gamberson equiv that trades leg protection to be cheaper.
+	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord/light)
 
 /datum/supply_pack/rogue/light_armor/gambeson
 	name = "Gambeson"
@@ -151,14 +151,14 @@
 	cost = 40 // gamberson equiv that trades leg protection and a third more price for 50 more integ (300 vs 250). Or padded gamberson that trades leg protection for being a third cheaper, to look at it another way.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord)
 
-/datum/supply_pack/rogue/light_armor/heavy_leather_boots
-	name = "Heavy Leather Boots"
-	cost = 20
-	contains = list(/obj/item/clothing/shoes/roguetown/boots/leather/reinforced)
+/datum/supply_pack/rogue/light_armor/padded_gambeson
+	name = "Padded Gambeson"
+	cost = 60 // Base sellprice of 25
+	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
 /datum/supply_pack/rogue/light_armor/arming_jacket
 	name = "Padded Arming Jacket"
-	cost = 60 // padded gambeson equiv. that trades leg protection for 50 more integ (350 vs 300)
+	cost = 75 // padded gambeson equiv. that trades leg protection for 75 more integ (375 vs 300), touch pricier.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy)
 
 /datum/supply_pack/rogue/light_armor/grenzel_hat
@@ -175,3 +175,8 @@
 	name = "Spellsinger Robes"
 	cost = 90// high material cost, high skill req (6). this is probably overtuned but its also Maybe Fine.
 	contains = list(/obj/item/clothing/suit/roguetown/shirt/robe/spellcasterrobe)
+
+/datum/supply_pack/rogue/light_armor/sewingkit
+	name = "Sewing Kit"
+	cost = 40
+	contains = list(/obj/item/repair_kit)

--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -62,7 +62,7 @@
 	desc = "A collared jacket, intended to be worn underneath plate armor. The thicker padding ensures that any gaps left within its alloyed shell are thoroughly protected - lest an unforseen bowstrike, landing true, ruptures the vulnerable flesh beneath."
 	icon_state = "dgamb"
 	body_parts_covered = COVERAGE_ALL_BUT_HANDLEGS
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER + 50 //50 more integ than a padded gamberson, at the cost of leg protection
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER + 75 //75 more integ than a padded gamberson, at the cost of leg protection
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy/silkjacket
 	name = "besilked jacket"

--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -37,6 +37,14 @@
 	allowed_sex = list(MALE, FEMALE)
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //50 more integ than a gamberson, at the cost of leg protection
 
+/obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
+	name = "light arming jacket"
+	desc = "A lightweight collared jacket, purpose-woven for skirmishes and battle. The modest weight and streamlined form make it ideal for wearing under a cuirass or elegant halfplate."
+	icon_state = "dgamb"
+	body_parts_covered = COVERAGE_ALL_BUT_HANDLEGS
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM //50 more integrity and superior protection vs a light gamberson, and cheaper than a proper gamberson with the same integrity.
+
+
 /obj/item/clothing/suit/roguetown/armor/gambeson/shadowrobe
 	name = "stalker robe"
 	desc = "A thick robe in royal purple, befitting the hand, while remaining easy for them to slip about in.."

--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -35,6 +35,7 @@
 	color = null
 	chunkcolor = null
 	allowed_sex = list(MALE, FEMALE)
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER //50 more integ than a gamberson, at the cost of leg protection
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/shadowrobe
 	name = "stalker robe"
@@ -53,8 +54,7 @@
 	desc = "A collared jacket, intended to be worn underneath plate armor. The thicker padding ensures that any gaps left within its alloyed shell are thoroughly protected - lest an unforseen bowstrike, landing true, ruptures the vulnerable flesh beneath."
 	icon_state = "dgamb"
 	body_parts_covered = COVERAGE_ALL_BUT_HANDLEGS
-	armor = ARMOR_PADDED
-	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER + 50 //50 more integ than a padded gamberson, at the cost of leg protection
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy/silkjacket
 	name = "besilked jacket"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltwarriors.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltwarriors.dm
@@ -149,7 +149,7 @@
 	l_hand = /obj/item/rogueweapon/sword
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
 	neck = /obj/item/clothing/neck/roguetown/gorget/

--- a/code/modules/jobs/job_types/roguetown/courtier/suitor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/suitor.dm
@@ -109,7 +109,7 @@
 	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 	pants = /obj/item/clothing/under/roguetown/tights/black
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 	shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
 	saiga_shoes = /obj/item/clothing/shoes/roguetown/horseshoes/gold
 	belt = /obj/item/storage/belt/rogue/leather/black

--- a/code/modules/jobs/job_types/roguetown/other/tester.dm
+++ b/code/modules/jobs/job_types/roguetown/other/tester.dm
@@ -23,7 +23,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	belt = /obj/item/storage/belt/rogue/leather
-	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
+	armor = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
 	if(prob(50))
 		armor = /obj/item/clothing/suit/roguetown/armor/gambeson
 	neck = /obj/item/roguekey/mercenary

--- a/code/modules/jobs/job_types/roguetown/other/vampire_spawn_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_spawn_subclasses.dm
@@ -241,7 +241,7 @@
 				belt = /obj/item/storage/belt/rogue/leather/black //stylish belt
 				mask = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/vampire_noble //regal appearance
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
-				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 				r_hand = /obj/item/rogueweapon/scabbard/sword/royal
 				armor = /obj/item/clothing/suit/roguetown/shirt/dress/royal/princess
 				ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
@@ -250,14 +250,14 @@
 				belt = /obj/item/storage/belt/rogue/leather/black //stylish belt
 				mask = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/vampire_noble //regal appearance
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
-				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 				r_hand = /obj/item/rogueweapon/scabbard/sword/royal
 				armor = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince
 				ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
 			if("Noble (Light Armor + Skilled Appraisal)")
 				head = /obj/item/clothing/head/roguetown/chaperon/noble //nobility look
 				cloak = /obj/item/clothing/suit/roguetown/armor/longcoat
-				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 				belt = /obj/item/storage/belt/rogue/leather/steel //similar to spymaster hand
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
 				mask = /obj/item/clothing/mask/rogue/shepherd/shadowmask //hidden face
@@ -267,7 +267,7 @@
 				head = /obj/item/clothing/head/roguetown/nyle/consortcrown //suitor/consort look
 				armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 				cloak = /obj/item/clothing/cloak/half/red
-				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 				belt = /obj/item/storage/belt/rogue/leather //on-par with valiant
 				wrists = /obj/item/clothing/wrists/roguetown/bracers
 				mask = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/vampire_noble

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/forlorn.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/forlorn.dm
@@ -47,7 +47,7 @@
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine		// They're brigandinejaks. ergo have them start w/the whole thing
 	belt = /obj/item/storage/belt/rogue/leather
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/underdweller.dm
@@ -43,7 +43,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	mask = /obj/item/clothing/mask/rogue/ragmask
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	belt = /obj/item/storage/belt/rogue/leather/black		//Should give these guys a unique miners belt at some point..
 	neck = /obj/item/clothing/neck/roguetown/chaincoif

--- a/code/modules/mob/living/carbon/human/npc/soldiers/border_reivers.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/border_reivers.dm
@@ -168,7 +168,7 @@
 	H.STAINT = rand(9,10)
 	//Chest Gear
 	add_random_reiver_cloak(H)
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 	add_random_reiver_armor(H)
 	//Head Gear
 	neck = /obj/item/clothing/neck/roguetown/leather
@@ -268,7 +268,7 @@
 	H.STAINT = rand(8,9)
 	//Chest Gear
 	add_random_reiver_cloak(H)
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
 	//Head Gear
 	neck = /obj/item/clothing/neck/roguetown/leather
 	add_random_reiver_lowgearhelmet(H)
@@ -352,7 +352,7 @@
 	H.STAINT = rand(10,11)
 	//Chest Gear
 	add_random_reiver_cloak(H)
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/heavy
 	//Head Gear
 	neck = /obj/item/clothing/neck/roguetown/chaincoif

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -954,6 +954,16 @@
 	craftdiff = 4
 	sellprice = 14
 
+/datum/crafting_recipe/roguetown/sewing/larmingjacket
+	name = "light arming jacket" //its a gambeson without leg cover
+	category = "Gambesons"
+	display_category = ITEM_CAT_ARMOR_LIGHT
+	result = /obj/item/clothing/suit/roguetown/armor/gambeson/lord/light
+	reqs = list(/obj/item/natural/cloth = 3,
+				/obj/item/natural/fibers = 2)
+	tools = list(/obj/item/needle)
+	craftdiff = 2 //because if it was 3, you'd just make the proper arming jacket
+
 /datum/crafting_recipe/roguetown/sewing/gambeson
 	name = "gambeson"
 	category = "Gambesons"
@@ -971,7 +981,7 @@
 	display_category = ITEM_CAT_ARMOR_LIGHT
 	result = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
 	reqs = list(/obj/item/natural/cloth = 3,
-				/obj/item/natural/fibers = 2)
+				/obj/item/natural/fibers = 3)
 	tools = list(/obj/item/needle)
 	craftdiff = 3
 
@@ -1094,8 +1104,8 @@
 	display_category = ITEM_CAT_ARMOR_LIGHT
 	result = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy)
 	reqs = list(/obj/item/natural/cloth = 5,
-				/obj/item/natural/fibers = 4)
-	craftdiff = 3
+				/obj/item/natural/fibers = 5)
+	craftdiff = 4 //highest possible light-armor integ on a shirt layer, so should take some work
 
 /datum/crafting_recipe/roguetown/sewing/monkwraps
 	name = "padded arm wrappings"


### PR DESCRIPTION
## About The Pull Request

Arming jacket (and padded version) was identical to a gambeson aside from lacking leg coverage and being more expensive.
This PR gives arming jackets a moderate integ advantage over the gambeson of the same tier, as a trade off for losing the leg cover. Also adds a light arming jacket and bumps role starter jackets down a tier, so starting gear for all roles is unchanged.

Works out the the following comparison:

light gambeson = 20mam, 200 integ, worse protection (-3 pips vs pierce, -2 pips vs blunt, -1 pip vs slash)
light arming jacket = 28 mam, 250 integ, no leg cover
gambeson = 32mam, 250 integ
arming jacket = 40mam, 300 integ, no leg cover
padded gambeson = 60 mam, 300 integ
padded arming jacket = 75mam, 375 integ, no leg cover

When it comes to sewing skill requirements to craft, light gamb remains at novice, light jacket was added at apprentice, gambeson, arming jacket, and padded gambeson remain at journeyman, and the padded jacket was nudged up to expert.


The PR also adds leather helmets to the tailor silverface, resulting in the following options:

roughspun headband: 25 mam, 250 integ, head/skull/ears, leather protection
padded headband: 35 mam, 300 integ, head/skull/ears, leather protection
leather helm: 35 mam, 250 integ, head/skull/ears/nose, leather protection



## Testing Evidence
Roles spawn with adjusted gear (to keep starter integ the same):
<img width="1828" height="432" alt="image" src="https://github.com/user-attachments/assets/aee69ca8-c799-43d7-a72e-7f00be2b31d8" />

Silverface has the helmet and light arming jacket (also the normal one, since that was apparently bugged):
<img width="1236" height="784" alt="image" src="https://github.com/user-attachments/assets/410d809a-4886-4a7d-bf62-e6b94b35a4fe" />

Arming jackets have the new integ:
<img width="577" height="258" alt="image" src="https://github.com/user-attachments/assets/444d55ea-8800-4d84-9088-fa321c26d596" />
<img width="567" height="256" alt="image" src="https://github.com/user-attachments/assets/279f5564-f4c6-4830-b622-e2b219106de9" />
<img width="574" height="262" alt="image" src="https://github.com/user-attachments/assets/a421f696-44e8-45aa-9670-43989ce3e261" />


## Why It's Good For The Game

Arming jackets being worse (and more expensive) gambesons gave them no real niche.

Silverface already carried the rest of the leather gear, along with headbands that have equivalent protection rating and better integ.

## Changelog

:cl:
add: Added leather helms to tailor silverface as sidegrade vs headbands, trading integ to get nose coverage.
add: Added light arming jackets, with identical stats to current arming jacket.
balance: rebalanced arming jackets to not just be worse gambesons, now they have a noticable integ advantage to make up for lack of leg coverage. Adjusted role starter gear to be untouched in effectiveness by this change.
/:cl:

