### PR TITLE
Longsword Rigid Intents

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -835,11 +835,13 @@
 	attack_verb = list("dazes")
 	animname = "strike"
 	hitsound = list('sound/combat/hits/blunt/daze_hit.ogg')
-	chargetime = 0
 	penfactor = PEN_NONE
-	swingdelay = 6
+	swingdelay = 1 SECONDS
 	damfactor = 1
 	item_d_type = "blunt"
 	intent_effect = /datum/status_effect/debuff/dazed
 	target_parts = list(BODY_ZONE_HEAD)
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
+	candodge = FALSE
+	canparry = FALSE
+	swingdelay_type = SWINGDELAY_CANCEL

--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -658,7 +658,7 @@
 		/datum/intent/sword/thrust/long/deep/halfsword
 	)
 
-/datum/alt_grip/mordhau/zizo
+/datum/alt_grip/mordhau/sword/zizo
 	grip_intents = list(		
 		SWORD_BASH,
 		/datum/intent/effect/daze

--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -437,7 +437,8 @@
 
 /datum/alt_grip/mordhau/sword
 	grip_intents = list(
-		SWORD_BASH,
+		/datum/intent/sword/strike/bash/mordhau,
+		/datum/intent/sword/strike/bash/mordhau/smash,
 		/datum/intent/effect/daze
 	)
 	onmobprop_overrides = list(
@@ -466,14 +467,16 @@
 		),
 	)
 	var_overrides = list(
-		"wlength" = WLENGTH_SHORT
+		"wlength" = WLENGTH_SHORT,
+		"wdefense" = -2
 	)
 
 /datum/alt_grip/mordhau/sword/frei
 
 /datum/alt_grip/mordhau/broadsword
 	grip_intents = list(
-		SWORD_BASH,
+		/datum/intent/sword/strike/bash/mordhau,
+		/datum/intent/sword/strike/bash/mordhau/smash,
 		/datum/intent/effect/daze
 	)
 	onmobprop_overrides = list(
@@ -504,7 +507,8 @@
 
 /datum/alt_grip/mordhau/greatsword
 	grip_intents = list(
-		SWORD_BASH,
+		/datum/intent/sword/strike/bash/mordhau,
+		/datum/intent/sword/strike/bash/mordhau/smash,
 		/datum/intent/effect/daze
 	)
 	onmobprop_overrides = list(
@@ -538,7 +542,8 @@
 
 /datum/alt_grip/mordhau/broadsword/forgotten_blade
 	grip_intents = list(
-		SWORD_BASH,
+		/datum/intent/sword/strike/bash/mordhau,
+		/datum/intent/sword/strike/bash/mordhau/smash,
 		/datum/intent/effect/daze
 	)
 	onmobprop_overrides = list(
@@ -571,6 +576,7 @@
 /datum/alt_grip/mordhau/broadsword/dream_broadsword
 	grip_intents = list(		
 		SWORD_BASH,
+		/datum/intent/sword/strike/bash/mordhau/smash,
 		/datum/intent/effect/daze
 	)
 	onmobprop_overrides = list(
@@ -605,8 +611,10 @@
 	two_handed = TRUE
 	skill_req = SKILL_LEVEL_JOURNEYMAN
 	grip_intents = list(
+		/datum/intent/sword/thrust/long/halfsword/jab,
+		SWORD_BASH,
+		/datum/intent/sword/thrust/long/deep/halfsword,
 		/datum/intent/sword/thrust/long/halfsword,
-		/datum/intent/sword/thrust/long/halfsword/jab
 	)
 	onmobprop_overrides = list(
 		"altgrip" = list(
@@ -637,8 +645,23 @@
 		"wlength" = WLENGTH_SHORT
 	)
 	additive_var_overrides = list(
-		"wdefense" = 2,
-		"force_wielded" = 5
+		"wdefense" = 2
+	)
+
+// I am wary of giving the avantyne longsword much more.
+// The sword has 40 force. I cannot give it the 0.8x damage blunt or it's just a grand mace.
+// Instead, you get to keep new daze and the new stabs but not the new blunt intents or plate pen halfswording.
+/datum/alt_grip/halfsword/zizo 
+	grip_intents = list(
+		/datum/intent/sword/thrust/long/halfsword/jab,
+		SWORD_BASH, 
+		/datum/intent/sword/thrust/long/deep/halfsword
+	)
+
+/datum/alt_grip/mordhau/zizo
+	grip_intents = list(		
+		SWORD_BASH,
+		/datum/intent/effect/daze
 	)
 
 /datum/alt_grip/halfsword/frei

--- a/code/game/objects/items/rogueweapons/melee/alt_grip.dm
+++ b/code/game/objects/items/rogueweapons/melee/alt_grip.dm
@@ -648,17 +648,17 @@
 		"wdefense" = 2
 	)
 
-// I am wary of giving the avantyne longsword much more.
-// The sword has 40 force. I cannot give it the 0.8x damage blunt or it's just a grand mace.
+// Certain swords are especially nuclear like the Martyr and ZIZO swords.
+// The swords have 40 force. I cannot give it the 0.8x damage blunt or it's just a grand mace.
 // Instead, you get to keep new daze and the new stabs but not the new blunt intents or plate pen halfswording.
-/datum/alt_grip/halfsword/zizo 
+/datum/alt_grip/halfsword/lesser
 	grip_intents = list(
 		/datum/intent/sword/thrust/long/halfsword/jab,
 		SWORD_BASH, 
 		/datum/intent/sword/thrust/long/deep/halfsword
 	)
 
-/datum/alt_grip/mordhau/sword/zizo
+/datum/alt_grip/mordhau/sword/lesser
 	grip_intents = list(		
 		SWORD_BASH,
 		/datum/intent/effect/daze

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -433,7 +433,7 @@
 	unequip_delay_self = 0
 	wdefense_wbonus = 7
 	smeltresult = /obj/item/ingot/component/zizo
-	alt_grips = list(/datum/alt_grip/mordhau/sword/zizo, /datum/alt_grip/halfsword/zizo)
+	alt_grips = list(/datum/alt_grip/mordhau/sword/lesser, /datum/alt_grip/halfsword/lesser)
 
 /obj/item/rogueweapon/sword/long/zizo/Initialize()
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -338,7 +338,6 @@
 	inspiration in humenity's darkest hour. Centuries later, it still remains the ideal choice for skewering infidels and monsters alike. </br>'I am the \
 	holder of light, in the dark abyss..' </br>'..I am the holder of order and ward against vileness..' </br>'..let the Gods guide my hand, and let the Inhumen cower before me.'"
 	icon_state = "churchsword"
-	max_blade_int = 250
 	max_integrity = 180
 
 /obj/item/rogueweapon/sword/long/undivided
@@ -348,7 +347,6 @@
 	gleaming, radiant heat, warm my soul, immolate my enemies..' </br>'..and let me vanquish all those who would dare to Divide us, once more.'"
 	icon_state = "seeblade"
 	sheathe_icon = "eclipsum"
-	max_blade_int = 250
 	max_integrity = 180
 	force = 28
 	force_wielded = 33

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -185,7 +185,7 @@
 	force = 25
 	force_wielded = 30
 	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust/long, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut/long, /datum/intent/sword/thrust/long, /datum/intent/sword/chop, /datum/intent/sword/thrust/long/deep)
+	gripped_intents = list(/datum/intent/sword/cut/long, /datum/intent/sword/thrust/long, /datum/intent/sword/chop/long, /datum/intent/sword/thrust/long/deep)
 	alt_grips = list(/datum/alt_grip/mordhau/sword, /datum/alt_grip/halfsword)
 	icon_state = "longsword"
 	icon = 'icons/roguetown/weapons/swords64.dmi'
@@ -433,6 +433,7 @@
 	unequip_delay_self = 0
 	wdefense_wbonus = 7
 	smeltresult = /obj/item/ingot/component/zizo
+	alt_grips = list(/datum/alt_grip/mordhau/sword, /datum/alt_grip/halfsword/zizo)
 
 /obj/item/rogueweapon/sword/long/zizo/Initialize()
 	. = ..()
@@ -2270,8 +2271,8 @@
 	name = "steel shotel"
 	icon_state = "shotel_steel"
 	desc = "A long curved blade of Ranesheni Design."
-	possible_item_intents = list(/datum/intent/sword/cut/zwei, /datum/intent/sword/chop/long) //Shotels get 2 tile reach.
-	gripped_intents = list(/datum/intent/sword/cut/zwei, /datum/intent/sword/chop/long)
+	possible_item_intents = list(/datum/intent/sword/cut/zwei, /datum/intent/sword/chop/shotel) //Shotels get 2 tile reach.
+	gripped_intents = list(/datum/intent/sword/cut/zwei, /datum/intent/sword/chop/shotel)
 	swingsound = BLADEWOOSH_LARGE
 	parrysound = "largeblade"
 	pickup_sound = "brandish_blade"

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -433,7 +433,7 @@
 	unequip_delay_self = 0
 	wdefense_wbonus = 7
 	smeltresult = /obj/item/ingot/component/zizo
-	alt_grips = list(/datum/alt_grip/mordhau/sword, /datum/alt_grip/halfsword/zizo)
+	alt_grips = list(/datum/alt_grip/mordhau/sword/zizo, /datum/alt_grip/halfsword/zizo)
 
 /obj/item/rogueweapon/sword/long/zizo/Initialize()
 	. = ..()

--- a/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords/sword_intents.dm
@@ -75,16 +75,26 @@
 	name = "deep lunge"
 	icon_state = "inlunge"
 	penfactor = PEN_MEDIUM
-	damfactor = 1.1
+	damfactor = 1.2
 	swingdelay = 0.6 SECONDS
 
-/datum/intent/sword/thrust/long/halfsword
+/datum/intent/sword/thrust/long/deep/halfsword
+	name = "deep lunge"
+	icon_state = "inlunge"
+	penfactor = PEN_MEDIUM
+	damfactor = 0.8
+	swingdelay = 0.6 SECONDS
+
+/datum/intent/sword/thrust/long/halfsword // Longsword halfsword - DOES NOT crit through armor like the Freifechter version.
 	name = "halfsword thrust"
 	icon_state = "inimpale"
 	clickcd = CLICK_CD_CHARGED
-	penfactor = PEN_MEDIUM
-	damfactor = 0.8
-	swingdelay = 0.5 SECONDS
+	penfactor = PEN_HEAVY
+	damfactor = 1
+	swingdelay = 1 SECONDS
+	candodge = FALSE
+	canparry = FALSE
+	swingdelay_type = SWINGDELAY_CANCEL
 
 /datum/intent/sword/thrust/long/halfsword/jab
 	name = "jab"
@@ -94,6 +104,7 @@
 	damfactor = 0.8
 	clickcd = CLICK_CD_QUICK
 	swingdelay = 0
+	swingdelay_type = SWINGDELAY_NORMAL
 
 /datum/intent/sword/thrust/blunt
 	blade_class = BCLASS_BLUNT
@@ -117,10 +128,45 @@
 	item_d_type = "blunt"
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
 
-/datum/intent/sword/strike/bash
-	name = "pommel swing"
+/datum/intent/sword/strike/bash/mordhau
+	damfactor = 0.8
+	name = "mordhau bash"
 	icon_state = "inbash"
 	attack_verb = list("bashes", "clubs")
+
+/datum/intent/sword/strike/bash/mordhau/smash
+	name = "mordhau smash"
+	icon_state = "insmash"
+	attack_verb = list("smashes", "pummels", "pounds")
+	chargedrain = 1.8
+	chargetime = 12
+	damfactor = 1
+	desc = "A powerful strike that delivers STR scaling knockback and slowdown to the target. The amount of inflicted knockback scales off your Strength, ranging from X (1 tile) to XII (2 tiles). </br>Cannot inflict any knockback or slowdown if your Strength is below X. </br>Cannot be used consecutively more than every 5 seconds on the same target. </br>Prone targets halve the knockback distance. </br>Not fully charging the attack limits knockback to 1 tile."
+	var/maxrange = 2
+
+/datum/intent/sword/strike/bash/mordhau/smash/spec_on_apply_effect(mob/living/H, mob/living/user, params)
+	var/chungus_khan_str = user.STASTR 
+	if(H.has_status_effect(/datum/status_effect/debuff/yeetcd))
+		return // Recently knocked back, cannot be knocked back again yet
+	if(chungus_khan_str < 10)
+		return // Too weak to have any effect
+	var/scaling = CLAMP((chungus_khan_str - 10), 1, maxrange)
+	H.apply_status_effect(/datum/status_effect/debuff/yeetcd)
+	H.Slowdown(scaling)
+	// Copypasta from knockback proc cuz I don't want the math there
+	var/knockback_tiles = scaling // 1 to 2 tiles based on strength
+	if(H.resting)
+		knockback_tiles = max(1, knockback_tiles / 2)
+	if(user?.client?.chargedprog < 100)
+		knockback_tiles = 1 // Minimal knockback on non-charged smash.
+	var/turf/edge_target_turf = get_edge_target_turf(H, get_dir(user, H))
+	if(istype(edge_target_turf))
+		H.safe_throw_at(edge_target_turf, \
+		knockback_tiles, \
+		scaling, \
+		user, \
+		spin = FALSE, \
+		force = H.move_force)
 
 /datum/intent/sword/strike/penalty
 	name = "heavy blunted swing"
@@ -189,8 +235,13 @@
 	clickcd = CLICK_CD_MELEE
 	swingdelay = 1.2 SECONDS
 	damfactor = 0.95 //slightly nerfed. go use your debuffs dude
-	blade_class = BCLASS_PICK
+	blade_class = BCLASS_PICK //This can crit through armor
 	max_intent_damage = 30
+
+	// If someone feels like reworking Freifechter for the 4th time, I suggest making this a RIGID swing intent
+	candodge = TRUE
+	canparry = TRUE
+	swingdelay_type = SWINGDELAY_NORMAL
 
 /datum/intent/sword/thrust/long/halfsword/lesser
 	name = "halbschwert"
@@ -246,7 +297,7 @@
 /datum/intent/sword/chop/short
 	damfactor = 0.9
 
-/datum/intent/sword/chop/long
+/datum/intent/sword/chop/shotel
 	reach = 2
 
 /datum/intent/sword/cut/light
@@ -254,6 +305,9 @@
 
 /datum/intent/sword/cut/long
 	clickcd = CLICK_CD_QUICK // Longsword 2H cut — faster than default, no extra damage
+
+/datum/intent/sword/chop/long
+	damfactor = 1.2
 
 // Falx sacrifices a bit of damage compared to sabre, but it is similarly fast
 // And have a very slight demolition mod to make it better vs shield

--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -625,6 +625,7 @@
 	override_state = null
 	is_important = TRUE
 	special = /datum/special_intent/martyr_blazing_sweep_sword
+	alt_grips = list(/datum/alt_grip/mordhau/sword/lesser, /datum/alt_grip/halfsword/lesser)
 
 /obj/item/rogueweapon/sword/long/martyr/ComponentInitialize()
 	AddComponent(\

--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -597,8 +597,6 @@
 /obj/item/rogueweapon/sword/long/martyr
 	force = 30
 	force_wielded = 36
-	possible_item_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike)
-	gripped_intents = list(/datum/intent/sword/cut, /datum/intent/sword/thrust, /datum/intent/sword/strike, /datum/intent/sword/chop)
 	icon_state = "martyrsword"
 	item_state = "martyrsword"
 	lefthand_file = 'icons/mob/inhands/weapons/roguemartyr_lefthand.dmi'

--- a/code/modules/jobs/job_types/roguetown/church/martyr.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr.dm
@@ -603,7 +603,6 @@
 	righthand_file = 'icons/mob/inhands/weapons/roguemartyr_righthand.dmi'
 	name = "divine longsword"
 	desc = "A relic from the Holy See's own vaults; a blessed silver longsword, marked with the ten-pointed sigil of Astrata's undivided might. </br>It simmers with godly energies, and will only yield to the hands of those who have taken the Oath."
-	max_blade_int = 200
 	parrysound = "bladedmedium"
 	swingsound = BLADEWOOSH_LARGE
 	pickup_sound = 'sound/foley/equip/swordlarge2.ogg'


### PR DESCRIPTION


## About The Pull Request

Adds some rigid intents to longswords (and greatswords, kind of). 

```
WIELDING (NO BUFF)
1.1x Cut (0 AP) (Quick CD) [UNCHANGED]
1.0x stab (1 AP) (Normal CD) [UNCHANGED]
Chop 1.2x (1 AP) (Normal CD + Delayed) [MODIFIED]
Lunge 1.2x (2 AP) (Normal CD + Delayed) [UNCHANGED]

MORDHAU (-2 DEFENSE)
0.8x Bash (160% integrity damage) [NEW]
1.0x Smash (Charged intent. 160% integrity damage. Maximum of 2 tile knockback) [NEW]
1.0x Daze (Normal CD + Delayed + Rigid) [MODIFIED]

HALFSWORD (+2 DEFENSE)
0.8x stab (1 AP) (Quick CD) [UNCHANGED]
0.6x Bash (160% integrity damage) [FROM 1H BASH]
0.8x Lunge (2 AP) (Normal CD + Delayed) [UNCHANGED]
1.0x Impale (3 AP) (Normal CD + Delayed + Rigid) [NEW]
```

Greatswords only get the Impale intent and Daze intent. Zizo and Martyr longswords do not get the Impale intent or the new blunt intents.

## Testing Evidence

<img width="414" height="215" alt="image" src="https://github.com/user-attachments/assets/4b18978c-83e8-49cc-8e37-e3a1746be537" />


WIELDED
<img width="330" height="201" alt="Screenshot 2026-06-05 160517" src="https://github.com/user-attachments/assets/c5d5e9ea-bbb1-4566-898c-ec692ee2dec5" />

MORDHAU
<img width="340" height="186" alt="Screenshot 2026-06-05 160521" src="https://github.com/user-attachments/assets/8e1ab1f0-74c2-4140-a4d2-18e06a3e3e11" />

HALFSWORD
<img width="311" height="168" alt="Screenshot 2026-06-05 160527" src="https://github.com/user-attachments/assets/f2a065e7-857e-4988-8a4d-92b501be8267" />


## Why It's Good For The Game

People have been talking back and forth about the longsword and I use it quite a lot so I figure I might as well touch it before someone else does.

Mordhau now works for armor cracking at the cost of nuking your parry somewhat. 
Halfsword gives you more defense and more pen but you lose DPS. 
Regular swinging is unchanged except for chop doing the same damage as lunge stab (still one of the worst chops in the game, worse than axes in both pen and damage).

Rigid intents are kinda cool. The greataxes and regular axes have hack, rapiers and sabres have their own stuff. The longsword can have daze/stab as a treat. Note daze DOES NOT have an integrity damage modifier so you don't have to worry about grand mace swords. I thought about that too.

I've probably missed some stuff because a lot of stuff inherits from the longsword. The most immediate concerns were the dreamwalker sword and the Zizo longsword because we don't really need a 40 force longsword with bash to be used as a grand mace 2.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: The longsword's alt-grip intents have been modified. Daze and Impale are now rigid intents that can be interrupted but not parried/dodged
balance: Mordhau reduces your defense by -2. Mordhau now has a 0.8x penalty instead of 0.6x on most swords.
fix: Church longswords inherit from the base longsword's sharpness instead of using outdated values.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
