### PR TITLE
simplemobs can now be guarded/riposted

### DIFF
--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -60,6 +60,39 @@
 		apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
 		H.reset_desert_rider_momentum_tier()
 
+/mob/living/carbon/human/proc/simple_clash(mob/user, obj/item/IM)
+	if(!isliving(user))
+		return
+	var/mob/living/L = user
+	if(user == src)
+		bad_guard(span_warning("I hit myself."))
+		return
+	if(!IM)	
+		visible_message(span_warning("[src] deflects [L]'s strike with [p_their()] bare hands!"))
+		playsound(src, 'sound/combat/clash_struck.ogg', 100)
+		L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
+		L.apply_status_effect(/datum/status_effect/debuff/clickcd, 3 SECONDS)
+		if(L.mind)
+			L.dodgetime = clamp(L.dodgetime + 5, 0, CLICK_CD_HEAVY)
+		L.Slowdown(3)
+		to_chat(src, span_notice("[capitalize(L.p_theyre())] exposed!"))
+		remove_status_effect(/datum/status_effect/buff/clash)
+		apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+		return
+	visible_message(span_suicide("[src] ripostes [L] with \the [IM]!"))
+	playsound(src, 'sound/combat/clash_struck.ogg', 100)
+	L.apply_status_effect(/datum/status_effect/debuff/exposed, 3 SECONDS)
+	L.apply_status_effect(/datum/status_effect/debuff/clickcd, 3 SECONDS)
+	if(L.mind)
+		L.dodgetime = clamp(L.dodgetime + 5, 0, CLICK_CD_HEAVY)
+	dodgetime = clamp(dodgetime - 5, 0, CLICK_CD_DODGE)
+	user.Slowdown(3)
+		
+	to_chat(src, span_notice("[capitalize(L.p_theyre())] exposed!"))
+	remove_status_effect(/datum/status_effect/buff/clash)
+	apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+	return
+
 //This is a gargantuan, clunky proc that is meant to tally stats and weapon properties for the potential disarm.
 //For future coders: Feel free to change this, just make sure someone like Struggler statpack doesn't get 3-fold advantage.
 /mob/living/carbon/human/proc/clash(mob/user, obj/item/IM, obj/item/IU)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -506,6 +506,9 @@
 		if(M.incapacitated())
 			return FALSE
 
+		if(checkguard(M))
+			return FALSE
+
 		if(checkmiss(M))
 			return FALSE
 
@@ -519,6 +522,13 @@
 
 	return TRUE
 
+/mob/living/proc/checkguard(mob/living/simple_animal/attacker)
+	var/mob/living/carbon/human/target = src
+	if(!(ishuman(target) && target.has_status_effect(/datum/status_effect/buff/clash)))
+		return FALSE
+	var/obj/item/IM = target.get_active_held_item()
+	target.simple_clash(attacker, IM)
+	return TRUE
 
 /mob/living/attack_paw(mob/living/carbon/monkey/M)
 	if(isturf(loc) && istype(loc.loc, /area/start))


### PR DESCRIPTION
## About The Pull Request
i hate simplemobs. the reason i hate simplemobs is that they just ignore so much of our combat system. well, they've had it too good for too long, but now they too can be riposted with guard stance.

## Testing Evidence

https://github.com/user-attachments/assets/eb38693c-b00c-4c34-a988-5cdab2fcab5a

## Why It's Good For The Game
currently, pressing the guard button in simplemob combat effectively locks you into kiting the mob doing literally nothing for the entire guard duration, or you get punished (by straining yourself attacking, swapping hands to cancel it and eat the stamhit, etc). having simples ignore such a major part of AP combat feels awful, there's no way to find out it's a thing other than being punished for it, and it's not particularly immersive. this way, you don't have to suppress your muscle memory when fighting animals 

## Changelog

:cl:
add: Simplemobs can now be riposted with guard stance
/:cl:
