### PR TITLE
Deflecting ranged gives +2 SPD. Defending melee +1 WIL + 1 CON. No more AR from defending ur own spells

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1825,7 +1825,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/buff/adrenaline_rush
 	duration = 18 SECONDS
 	examine_text = "SUBJECTPRONOUN is amped up!"
-	effectedstats = list(STATKEY_WIL = 1)
+	effectedstats = list(STATKEY_WIL = 1, STATKEY_SPD = 2)
 	var/blood_restore = 30
 
 /datum/status_effect/buff/adrenaline_rush/on_apply()

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1822,10 +1822,11 @@
 
 /datum/status_effect/buff/adrenaline_rush
 	id = "adrrush"
+	status_type = STATUS_EFFECT_REPLACE
 	alert_type = /atom/movable/screen/alert/status_effect/buff/adrenaline_rush
 	duration = 18 SECONDS
 	examine_text = "SUBJECTPRONOUN is amped up!"
-	effectedstats = list(STATKEY_WIL = 1, STATKEY_SPD = 2)
+	effectedstats = list(STATKEY_WIL = 1)
 	var/blood_restore = 30
 
 /datum/status_effect/buff/adrenaline_rush/on_apply()
@@ -1840,10 +1841,23 @@
 
 /datum/status_effect/buff/adrenaline_rush/on_remove()
 	. = ..()
+	clear_adrenaline_rush()
+
+/datum/status_effect/buff/adrenaline_rush/be_replaced()
+	clear_adrenaline_rush()
+	return ..()
+
+/datum/status_effect/buff/adrenaline_rush/proc/clear_adrenaline_rush()
 	REMOVE_TRAIT(owner, TRAIT_ADRENALINE_RUSH, INNATE_TRAIT)
 	var/mob/living/carbon/human/human = owner
 	if(istype(human))
 		human.pain_threshold -= 50
+
+/datum/status_effect/buff/adrenaline_rush/ranged
+	effectedstats = list(STATKEY_SPD = 2)
+
+/datum/status_effect/buff/adrenaline_rush/melee
+	effectedstats = list(STATKEY_WIL = 1, STATKEY_CON = 1)
 
 /datum/status_effect/buff/nocblessing
 	id = "nocblessing"

--- a/code/modules/mob/living/combat/azure_combat.dm
+++ b/code/modules/mob/living/combat/azure_combat.dm
@@ -19,7 +19,7 @@
 			visible_message(span_suicide("[src] clashes into [user]'s hands with \the [IM]!"))
 		playsound(src, pick(used_intent.hitsound), 80)
 		remove_status_effect(/datum/status_effect/buff/clash)
-		apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+		apply_status_effect(/datum/status_effect/buff/adrenaline_rush/melee)
 		return
 	if(!IM)	//We are guarding unarmed but they have a weapon -- no clash, just consume the guard to block the hit.
 		visible_message(span_warning("[src] deflects [H]'s strike with [p_their()] bare hands!"))
@@ -31,7 +31,7 @@
 		H.Slowdown(3)
 		to_chat(src, span_notice("[capitalize(H.p_theyre())] exposed!"))
 		remove_status_effect(/datum/status_effect/buff/clash)
-		apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+		apply_status_effect(/datum/status_effect/buff/adrenaline_rush/melee)
 		return
 	if(H.has_status_effect(/datum/status_effect/buff/clash))	//They also have Riposte active. It'll trigger the special event.
 		clash(user, IM, IU)
@@ -57,7 +57,7 @@
 		
 		to_chat(src, span_notice("[capitalize(H.p_theyre())] exposed!"))
 		remove_status_effect(/datum/status_effect/buff/clash)
-		apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+		apply_status_effect(/datum/status_effect/buff/adrenaline_rush/melee)
 		H.reset_desert_rider_momentum_tier()
 
 /mob/living/carbon/human/proc/simple_clash(mob/user, obj/item/IM)
@@ -77,7 +77,7 @@
 		L.Slowdown(3)
 		to_chat(src, span_notice("[capitalize(L.p_theyre())] exposed!"))
 		remove_status_effect(/datum/status_effect/buff/clash)
-		apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+		apply_status_effect(/datum/status_effect/buff/adrenaline_rush/melee)
 		return
 	visible_message(span_suicide("[src] ripostes [L] with \the [IM]!"))
 	playsound(src, 'sound/combat/clash_struck.ogg', 100)
@@ -90,7 +90,7 @@
 		
 	to_chat(src, span_notice("[capitalize(L.p_theyre())] exposed!"))
 	remove_status_effect(/datum/status_effect/buff/clash)
-	apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+	apply_status_effect(/datum/status_effect/buff/adrenaline_rush/melee)
 	return
 
 //This is a gargantuan, clunky proc that is meant to tally stats and weapon properties for the potential disarm.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -174,7 +174,8 @@
 	if(guard)
 		if(P.on_guard_deflect(src))
 			apply_status_effect(/datum/status_effect/buff/parry_buffer)
-			apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+			if(P.firer != src)
+				apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
 			guard.deflected_spell = TRUE
 			remove_status_effect(/datum/status_effect/buff/clash)
 			return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -172,10 +172,11 @@
 		return FALSE
 	var/datum/status_effect/buff/clash/guard = has_status_effect(/datum/status_effect/buff/clash)
 	if(guard)
+		var/atom/movable/original_firer = P.firer
 		if(P.on_guard_deflect(src))
 			apply_status_effect(/datum/status_effect/buff/parry_buffer)
-			if(P.firer != src)
-				apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+			if(original_firer != src)
+				apply_status_effect(/datum/status_effect/buff/adrenaline_rush/ranged)
 			guard.deflected_spell = TRUE
 			remove_status_effect(/datum/status_effect/buff/clash)
 			return TRUE

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -925,7 +925,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			else
 				playsound(get_turf(target), pick(target.parry_sound), 100)
 		target.apply_status_effect(/datum/status_effect/buff/parry_buffer)
-		target.apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+		if(attacker != target)
+			target.apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
 		guard.deflected_spell = TRUE
 		target.remove_status_effect(/datum/status_effect/buff/clash)
 		// Pseudo-melee punishment: expose the attacker if provided

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -926,7 +926,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 				playsound(get_turf(target), pick(target.parry_sound), 100)
 		target.apply_status_effect(/datum/status_effect/buff/parry_buffer)
 		if(attacker != target)
-			target.apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+			target.apply_status_effect(/datum/status_effect/buff/adrenaline_rush/ranged)
 		guard.deflected_spell = TRUE
 		target.remove_status_effect(/datum/status_effect/buff/clash)
 		// Pseudo-melee punishment: expose the attacker if provided

--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -1590,7 +1590,7 @@
 				playsound(get_turf(target), pick(target.parry_sound), 100)
 		target.apply_status_effect(/datum/status_effect/buff/parry_buffer)
 		if(attacker != target)
-			target.apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+			target.apply_status_effect(/datum/status_effect/buff/adrenaline_rush/ranged)
 		guard.deflected_spell = TRUE
 		target.remove_status_effect(/datum/status_effect/buff/clash)
 		if(attacker && ishuman(attacker))

--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -1589,7 +1589,8 @@
 			else
 				playsound(get_turf(target), pick(target.parry_sound), 100)
 		target.apply_status_effect(/datum/status_effect/buff/parry_buffer)
-		target.apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
+		if(attacker != target)
+			target.apply_status_effect(/datum/status_effect/buff/adrenaline_rush)
 		guard.deflected_spell = TRUE
 		target.remove_status_effect(/datum/status_effect/buff/clash)
 		if(attacker && ishuman(attacker))


### PR DESCRIPTION
## About The Pull Request
I think letting Adrenaline Rush be a way that you can gain a leg up on a mage and catch up to them kiting is a healthy change. You also no longer gain it from deflecting your own spells (kinda cheesy innit)

- Adrenaline rush have two mutually exclusive subtypes now. Melee and Ranged
- Melee Adr Rush grants +1 Wil and +1 Con, from +1 Wil
- Ranged Adr Rush grants +2 SPE. You gain this by deflecting spells.
- You no longer gain Adr Rush from deflecting your own spells

https://github.com/Azure-Peak/Azure-Peak/pull/7394 - MIGHT NOT WORK WITH THIS PR. OOPS. DO NOT TM / MERGE

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1603" height="1151" alt="dreamseeker_rrdKhYvqGn" src="https://github.com/user-attachments/assets/1438ab67-a53e-4297-8830-b4bd4678cee9" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
- Give you a bit more way to battle kiter, at least mage one.
- No more cheese

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: Adrenaline rush have two mutually exclusive subtypes now. Melee and Ranged. Melee Adr Rush grants +1 Wil and +1 Con, from +1 Wil. Ranged Adr Rush grants +2 SPE. You gain this by deflecting spells.
balance: No more adrenaline rush if you deflect a spell fired by yourself.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
