### PR TITLE
aue - fixes(?) atgrevi kite shield offset

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/atgervi.dm
@@ -255,7 +255,7 @@
 	if(tag)
 		switch(tag)
 			if("onback")
-				return list("shrink" = 0.7,"sx" = -17,"sy" = -15,"nx" = -15,"ny" = -15,"wx" = -12,"wy" = -15,"ex" = -18,"ey" = -15,"nturn" = 0,"sturn" = 0,"wturn" = 180,"eturn" = 0,"nflip" = 8,"sflip" = 0,"wflip" = 1,"eflip" = 0,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
+				return list("shrink" = 0.7,"sx" = 1,"sy" = 4,"nx" = 1,"ny" = 2,"wx" = 3,"wy" = 3,"ex" = -3,"ey" = 3,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 8,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
 /obj/item/rogueweapon/stoneaxe/woodcut/steel/atgervi
 	name = "bearded axe"


### PR DESCRIPTION
## About The Pull Request

fix

## Testing Evidence

fix

## Why It's Good For The Game

fix

## Changelog

:cl:
code: Atgrevi Kite Shields should now properly be offset when worn on the back, instead of visibly floating off the wearer.
/:cl: