### PR TITLE
Snuff Lights minor tweak

### DIFF
--- a/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -61,10 +61,18 @@
 	var/checkrange = snuff_range + skill_level
 
 	for(var/obj/O in range(checkrange, owner))
+		if(istype(O, /obj/item/flashlight/flare/torch/lantern/psycenser))
+			continue
+		if(istype(O, /obj/item/flashlight/flare/light))
+			qdel(O)
 		O.extinguish()
 
 	for(var/mob/M in range(checkrange, owner))
 		for(var/obj/O in M.contents)
+			if(istype(O, /obj/item/flashlight/flare/torch/lantern/psycenser))
+				continue
+			if(istype(O, /obj/item/flashlight/flare/light))
+				qdel(O)
 			O.extinguish()
 
 	var/bonus_duration = 10 SECONDS + ((max(skill_level - 1, 0)) * 30 SECONDS)


### PR DESCRIPTION
## About The Pull Request

- Golgatha is excepted from being extinguished.
- Mage's Light Orbs will be extinguished too.

## Testing Evidence

Just makes an exception for Golgatha, and another for Create Light.

## Why It's Good For The Game

T0 vs Relic, T0 wins = Bad Civilization.

T0 vs Util, T0 wins = Good Civilization.

## Changelog
:cl:
balance: Snuff Lights works on Lights, but can't affect relic lights.
/:cl: