### PR TITLE
Quick Vampire Hotfixes + Balance Tweaks and Codenote changes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_guard_subclasses.dm
@@ -8,7 +8,7 @@
 
 //Jack of all trades fighter, gains expert in their chosen weapon pick
 /datum/advclass/vampguardsman
-	name = "Vampiric Guardsman"
+	name = "Vampiric Footsoldier"
 	tutorial = "You are a seasoned weapon specialist, clad in maille, with years of experience in warfare and battle under your belt, more than any mortal could ever claim."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/other/vampguardsman
@@ -20,7 +20,7 @@
 		STATKEY_INT = 1,
 		STATKEY_CON = 1,
 		STATKEY_PER = 2,
-		// 8, weighted statline, akin to MAA deserter nearly albeit tipped towards the antag-side of scaling.
+		// 8, point statline, akin to MAA deserter nearly albeit tipped towards the antag-side of scaling.
 	)
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
@@ -104,7 +104,7 @@
 
 // Ranger, minifort class. Also doubles as a knockoff assassin, a good tracker for people that run from your conversion horde.
 /datum/advclass/vampskirmisher
-	name = "Vampiric Ranger"
+	name = "Vampiric Skirmisher"
 	tutorial = "You are a professional soldier, light in footwork, yet with years of experience in warfare and archery, far more than most mortals could claim. Your lord's will be done."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/other/vampskirmisher
@@ -115,7 +115,7 @@
 		STATKEY_WIL = 2,
 		STATKEY_STR = 1,
 		STATKEY_PER = 4,
-		// 8 weighted statline, mostly put into perception; no int bonus though, fient them sire.
+		// 8 point statline, mostly put into perception; no int bonus though, fient them sire.
 	)
 	subclass_skills = list(
 		/datum/skill/combat/crossbows = SKILL_LEVEL_MASTER,		//On par with MAA skirmisher
@@ -189,7 +189,7 @@
 		STATKEY_WIL = 2,
 		STATKEY_SPD = 2,
 		STATKEY_PER = 1,
-		// 7 weighted statline, mostly put into speed; no con buff though
+		// 7 point statline, mostly put into speed; no con buff though
 	)
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
@@ -281,12 +281,12 @@
 		STATKEY_SPD = 1,
 		STATKEY_CON = 3, //Trust me, you're going to need it.
 
-		// 8 weighted statline, with a unique backup unarmed choice of just punching people with your bare hands into joining your fold.
+		// 8 point statline, with a unique backup unarmed choice of just punching people with your bare hands into joining your fold.
 		// albeit unlike other unarmed classes, you get no special techniques, no skin armor, miracles, nor a lot of strength for it
 	)
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN, //Less skill than other classes here, but you get more unarmed kicking spots, higher damage and better accuracy and parries without a weapon
+		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT, //Maile punchman, tradeoff is that you have no special techniques vs proper unarmed classes, you lack the miracles + fullplate of icono and the stam regen of monks.
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, //RUN AND BLOW IT TO HELL, You kinda need this as you get no luxuries in raw combat outside of puglist fighting without bombs like everyone else, including just default strength.
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
@@ -334,7 +334,7 @@
 		STATKEY_INT = 2,
 		STATKEY_SPD = 2,
 		STATKEY_WIL = 2,
-		//6 weighted statline, unchanged from adv save for +1 wil so they last longer in combat with music. Due to how strong bardic buffs can be in the hands of vampyres now they get numbers (I.E stam regen, health regen, etc) although they do still feel blue bar (excluding vlord) they have to retain being somewhat weak-ish
+		//6 point statline, unchanged from adv save for +1 wil so they last longer in combat with music. Due to how strong bardic buffs can be in the hands of vampyres now they get numbers (I.E stam regen, health regen, etc) although they do still feel blue bar (excluding vlord) they have to retain being somewhat weak-ish
 	)
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE, //Still not amazing, because you can buff up already pretty stacked classes.
@@ -417,7 +417,7 @@
 		STATKEY_STR = -1,
 		STATKEY_WIL = 2,
 		STATKEY_PER = 3,
-		// 7 weighted statline, mostly put into perception + int, they lack on their baseline speed being slightly higher unlike most mages on top of weaker martal talent
+		// 7 point statline, mostly put into perception + int, they lack on their baseline speed being slightly higher unlike most mages on top of weaker martal talent
 	)
 	subclass_skills = list(
 		/datum/skill/combat/staves = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/jobs/job_types/roguetown/other/vampire_servant_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_servant_subclasses.dm
@@ -24,7 +24,7 @@
 		STATKEY_INT = 2,
 		STATKEY_PER = 2,
 		STATKEY_LCK = 1,
-		// 7 weighted statline, non-combat role but far-better than keep maids. Gets more traits to make up for lack of master crafting skills over the bat.
+		// 7 point statline, non-combat role but far-better than keep maids. Gets more traits to make up for lack of master crafting skills over the bat.
 	)
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN, //So you don't immedately die in a fight if you somehow get into one
@@ -98,7 +98,7 @@
 		STATKEY_CON = 2,
 		STATKEY_STR = 2,
 		STATKEY_LCK = 2,
-		// 8 weighted statline, non-combat role, a straight upgrade to towner smith.
+		// 8 point statline, non-combat role, a straight upgrade to towner smith.
 	)
 	subclass_skills = list(
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
@@ -175,11 +175,11 @@
 	traits_applied = list(TRAIT_MEDICINE_EXPERT, TRAIT_ALCHEMY_EXPERT, TRAIT_NOSTINK, TRAIT_HOMESTEAD_EXPERT, TRAIT_EMPATH, TRAIT_STEELHEARTED) //Medical class, specialises in accidental killings or reviving fallen allies. !!!UNTIL LUX REVIVALS WORK ON VAMPS OR A MAP REWORK HAPPENS. YOU'LL NEED TO EITHER HAVE ZURCH ACCESS OR BREAK INTO THE CLINIC FOR A CHAIR TO REVIVE VAMPS!!!
 	category_tags = list(CTAG_VAMPSERVANT)
 	subclass_stats = list(
-		STATKEY_SPD = 1, //Corpse thievery duty
+		STATKEY_SPD = 2, //Corpse thievery duty
 		STATKEY_INT = 4,
 		STATKEY_PER = 1,
 		STATKEY_LCK = 1,
-		// 7 weighted statline, non-combat role equiv of barber doc kind of.
+		// 8 point statline, non-combat role equiv of barber doc kind of.
 	)
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/jobs/job_types/roguetown/other/vampire_spawn_subclasses.dm
+++ b/code/modules/jobs/job_types/roguetown/other/vampire_spawn_subclasses.dm
@@ -37,7 +37,7 @@
 		STATKEY_PER = 3,
 		STATKEY_LCK = 1,
 		STATKEY_SPD = -1,
-		// 11 (10 without luck) weighted statline, a miniboss of sorts for an expensive vitae cost; intended to command the vampire lord's army. (+1 over old spawn stats)
+		// 11 (10 without luck) point statline, a miniboss of sorts for an expensive vitae cost; intended to command the vampire lord's army. (+1 over old spawn stats)
 	)
 	subclass_skills = list(
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
@@ -201,7 +201,7 @@
 		STATKEY_SPD = 2,
 		STATKEY_PER = 3,
 		STATKEY_LCK = 4, //only the lucky outlive the ranks of common fodder in a vamp's court
-		// 13 (9 without luck factored in for flavor) weighted statline, mostly put into speed + int; still no con buff though, the luckiest person to ever outlyve you by who-knows-how-many-yills
+		// 13 (9 without luck factored in for flavor) point statline, mostly put into speed + int; still no con buff though, the luckiest person to ever outlyve you by who-knows-how-many-yills
 	)
 	subclass_skills = list(
 		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,

--- a/code/modules/vampire_neu/_actions.dm
+++ b/code/modules/vampire_neu/_actions.dm
@@ -28,7 +28,7 @@
 
 	log_game("VAMPIRE TELEPATHY: [(src).real_name] ([(src).ckey]) used vampiric telepathy to say: \"[msg]\"")
 	var/message = span_narsie("<B>[span_purple("VAMPIRE")] - <span style='color:#[voice_color]'>[real_name]</span></B> says: \"[msg]\"")
-	playsound(get_turf(src), 'sound/misc/vampirespell.ogg', 40, FALSE, pressure_affected = FALSE) //Little ping when doing it.
+	playsound(get_turf(src), 'sound/misc/vampirespell.ogg', 40, FALSE, pressure_affected = FALSE, -1) //Little ping when doing it.
 	to_chat(clan?.clan_members, message)
 
 /mob/living/carbon/human/proc/disguise_verb()

--- a/code/modules/vampire_neu/_actions.dm
+++ b/code/modules/vampire_neu/_actions.dm
@@ -28,7 +28,7 @@
 
 	log_game("VAMPIRE TELEPATHY: [(src).real_name] ([(src).ckey]) used vampiric telepathy to say: \"[msg]\"")
 	var/message = span_narsie("<B>[span_purple("VAMPIRE")] - <span style='color:#[voice_color]'>[real_name]</span></B> says: \"[msg]\"")
-	playsound(get_turf(src), 'sound/misc/vampirespell.ogg', 40, FALSE, pressure_affected = FALSE, -1) //Little ping when doing it.
+	src.playsound_local(loc, 'sound/misc/vampirespell.ogg', 50, TRUE) //Que since it takes a bit you might go AFK briefly //Little ping when doing it.
 	to_chat(clan?.clan_members, message)
 
 /mob/living/carbon/human/proc/disguise_verb()

--- a/code/modules/vampire_neu/clan/clan_selection_menu.dm
+++ b/code/modules/vampire_neu/clan/clan_selection_menu.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(vampire_clan_selection_i18n, build_vampire_clan_selection_i18n(
 	. = ..()
 	antag = source_antag
 	vampdude = source_user
-	selected_clan_type = /datum/clan/nosferatu
+	selected_clan_type = /datum/clan/crimson_fang
 
 /datum/vampire_clan_selection_menu/Destroy()
 	antag = null

--- a/code/modules/vampire_neu/clan/clan_selection_menu.dm
+++ b/code/modules/vampire_neu/clan/clan_selection_menu.dm
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(vampire_clan_selection_i18n, build_vampire_clan_selection_i18n(
 	data["clans"] = clans
 	data["selectedClanId"] = selected_is_custom ? "custom" : "[selected_clan_type]"
 	data["pendingCustomName"] = pending_custom_name
-	data["defaultClanName"] = "Nosferatu"
+	data["defaultClanName"] = "Crimson Fang"
 	data["language"] = lang
 	data["i18nOverrides"] = GLOB.vampire_clan_selection_i18n[lang]
 	return data
@@ -119,7 +119,7 @@ GLOBAL_LIST_INIT(vampire_clan_selection_i18n, build_vampire_clan_selection_i18n(
 			else
 				var/clan_type = selected_clan_type
 				if(!is_valid_selectable_clan(clan_type))
-					clan_type = /datum/clan/nosferatu
+					clan_type = /datum/clan/crimson_fang
 				antag.finalize_clan_selection(vampdude, clan_type)
 
 			SStgui.close_uis(src)

--- a/code/modules/vampire_neu/living_modifications.dm
+++ b/code/modules/vampire_neu/living_modifications.dm
@@ -284,10 +284,12 @@
 			ADD_TRAIT(src, TRAIT_DEATHCOMA, TRAIT_VAMPIRE)
 		heal_overall_damage(10, 10)
 		adjust_bloodpool(10)
+		for(var/datum/wound/wound as anything in get_wounds())
+			heal_wound(3)
 	if(HAS_TRAIT(src, TRAIT_DEATHCOMA) && (total_damage <= 0 || (!istype(coffin) || !(src in coffin.contents))))
 		REMOVE_TRAIT(src, TRAIT_DEATHCOMA, TRAIT_VAMPIRE)
 		to_chat(src, span_warning("You have recovered from Torpor."))
-		playsound(get_turf(src), 'sound/misc/vampirespell.ogg', 80, FALSE, pressure_affected = FALSE) //Que since it takes a bit you might go AFK briefly
+		playsound(get_turf(src), 'sound/misc/vampirespell.ogg', 80, FALSE, pressure_affected = FALSE, -1) //Que since it takes a bit you might go AFK briefly
 
 /mob/living/carbon/human/proc/handle_bloodpool_effects()
 	// Apply thirst effects based on bloodpool levels

--- a/code/modules/vampire_neu/living_modifications.dm
+++ b/code/modules/vampire_neu/living_modifications.dm
@@ -282,13 +282,13 @@
 		if(!HAS_TRAIT(src, TRAIT_DEATHCOMA))
 			to_chat(src, span_notice("You enter the horrible slumber of deathless Torpor. You will heal until you are renewed."))
 			ADD_TRAIT(src, TRAIT_DEATHCOMA, TRAIT_VAMPIRE)
-		heal_overall_damage(10, 10)
-		adjust_bloodpool(10)
-		heal_wounds(3)
+		heal_overall_damage(20, 20)
+		//adjust_bloodpool(10)
+		heal_wounds(10)
 	if(HAS_TRAIT(src, TRAIT_DEATHCOMA) && (total_damage <= 0 || (!istype(coffin) || !(src in coffin.contents))))
 		REMOVE_TRAIT(src, TRAIT_DEATHCOMA, TRAIT_VAMPIRE)
 		to_chat(src, span_warning("You have recovered from Torpor."))
-		playsound(get_turf(src), 'sound/misc/vampirespell.ogg', 80, FALSE, pressure_affected = FALSE, -1) //Que since it takes a bit you might go AFK briefly
+		src.playsound_local(loc, 'sound/misc/vampirespell.ogg', 50, TRUE) //Que since it takes a bit you might go AFK briefly
 
 /mob/living/carbon/human/proc/handle_bloodpool_effects()
 	// Apply thirst effects based on bloodpool levels

--- a/code/modules/vampire_neu/living_modifications.dm
+++ b/code/modules/vampire_neu/living_modifications.dm
@@ -284,8 +284,6 @@
 			ADD_TRAIT(src, TRAIT_DEATHCOMA, TRAIT_VAMPIRE)
 		heal_overall_damage(10, 10)
 		adjust_bloodpool(10)
-		for(var/datum/wound/wound as anything in get_wounds())
-			heal_wound(3)
 	if(HAS_TRAIT(src, TRAIT_DEATHCOMA) && (total_damage <= 0 || (!istype(coffin) || !(src in coffin.contents))))
 		REMOVE_TRAIT(src, TRAIT_DEATHCOMA, TRAIT_VAMPIRE)
 		to_chat(src, span_warning("You have recovered from Torpor."))

--- a/code/modules/vampire_neu/living_modifications.dm
+++ b/code/modules/vampire_neu/living_modifications.dm
@@ -284,6 +284,7 @@
 			ADD_TRAIT(src, TRAIT_DEATHCOMA, TRAIT_VAMPIRE)
 		heal_overall_damage(10, 10)
 		adjust_bloodpool(10)
+		heal_wounds(3)
 	if(HAS_TRAIT(src, TRAIT_DEATHCOMA) && (total_damage <= 0 || (!istype(coffin) || !(src in coffin.contents))))
 		REMOVE_TRAIT(src, TRAIT_DEATHCOMA, TRAIT_VAMPIRE)
 		to_chat(src, span_warning("You have recovered from Torpor."))

--- a/code/modules/vampire_neu/vampire.dm
+++ b/code/modules/vampire_neu/vampire.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	rogue_enabled = TRUE
 	show_in_roundend = FALSE
 	show_in_antagpanel = FALSE // Base vampire shouldn't be directly selectable - use Vampire Lord or specific subtypes
-	var/datum/clan/default_clan = /datum/clan/nosferatu
+	var/datum/clan/default_clan = /datum/clan/crimson_fang
 	// New variables for clan selection
 	var/clan_selected = FALSE
 	var/custom_clan_name = ""
@@ -39,7 +39,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	var/max_thralls = 1
 	var/thrall_count = 0
 
-/datum/antagonist/vampire/New(incoming_clan = /datum/clan/nosferatu, forced_clan = FALSE, generation)
+/datum/antagonist/vampire/New(incoming_clan = /datum/clan/crimson_fang, forced_clan = FALSE, generation)
 	. = ..()
 	if(forced_clan)
 		forced = forced_clan
@@ -157,14 +157,14 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	if(clan_selected || !vampdude)
 		return
 	if(!clan_type)
-		clan_type = /datum/clan/nosferatu
+		clan_type = /datum/clan/crimson_fang
 	default_clan = clan_type
 	vampdude.set_clan(default_clan)
 	clan_selected = TRUE
 	after_gain()
 
 /datum/antagonist/vampire/proc/finalize_default_clan_selection(mob/living/carbon/human/vampdude)
-	finalize_clan_selection(vampdude, /datum/clan/nosferatu)
+	finalize_clan_selection(vampdude, /datum/clan/crimson_fang)
 
 /datum/antagonist/vampire/proc/create_custom_clan(mob/living/carbon/human/vampdude, custom_name = null)
 	custom_clan_name = (istext(custom_name) && length(custom_name)) ? custom_name : "Custom Clan"
@@ -267,7 +267,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	name = "Thinblood"
 	show_in_antagpanel = TRUE
 
-/datum/antagonist/vampire/thinblood/New(incoming_clan = /datum/clan/nosferatu, forced_clan = FALSE, generation = GENERATION_THINBLOOD)
+/datum/antagonist/vampire/thinblood/New(incoming_clan = /datum/clan/crimson_fang, forced_clan = FALSE, generation = GENERATION_THINBLOOD)
 	. = ..(incoming_clan, forced_clan, generation)
 
 /// Similarly as before, just a prefab for admins to give them via Traitor Panel
@@ -275,7 +275,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	name = "Licker - Neonate"
 	show_in_antagpanel = TRUE
 
-/datum/antagonist/vampire/licker/New(incoming_clan = /datum/clan/nosferatu, forced_clan = FALSE, generation = GENERATION_NEONATE)
+/datum/antagonist/vampire/licker/New(incoming_clan = /datum/clan/crimson_fang, forced_clan = FALSE, generation = GENERATION_NEONATE)
 	. = ..(incoming_clan, forced_clan, generation)
 
 /// Just a prefab for admins to give them via Traitor Panel, otherwise unused because vars can be normally passed in parent's New()
@@ -283,7 +283,7 @@ GLOBAL_LIST_EMPTY(vampire_objects)
 	name = "Ancillae"
 	show_in_antagpanel = TRUE
 
-/datum/antagonist/vampire/ancillae/New(incoming_clan = /datum/clan/nosferatu, forced_clan = FALSE, generation = GENERATION_ANCILLAE)
+/datum/antagonist/vampire/ancillae/New(incoming_clan = /datum/clan/crimson_fang, forced_clan = FALSE, generation = GENERATION_ANCILLAE)
 	. = ..()
 
 

--- a/tgui/packages/tgui/interfaces/VampireClanSelection.tsx
+++ b/tgui/packages/tgui/interfaces/VampireClanSelection.tsx
@@ -101,7 +101,7 @@ const TRANSLATIONS: Record<string, Record<string, string>> = {
     accept: 'Accept Clan',
     close: 'Close',
     warningDefault:
-      'If no clan is chosen, Nosferatu will be assigned by default.',
+      'If no clan is chosen, Crimson Fangs will be assigned by default.',
   },
 };
 


### PR DESCRIPTION
## About The Pull Request

- Fixes Torpor/Telepathy making audable noises for everyone who wasn't the vampire using it. These were supposed to be client-side noises only. Oops. You no longer can exploit torpor for infinite vitae, why was that a thing?
- Torpor now heals wounds +20 burn/brute + 10 wound points a cycle, making it the fastest free healing a vampire has at the price of it obviously keeping you unconcious and helpless during your time in the coffin. Oh and actually having said coffin to regenerate in, which bares its own *subtly obvious presence.*
- Moves Arsonist `Journeyman` -> `Expert` unarmed, since unarmed combat has changed with other actual proper classes getting unique movesets where arsonist lacks any or even miracles so hopefully it should be more appealing.
- Slight Guardsman/Ranger name changes -> Footman and Skirmisher
- Vampiric Doctor has (2) speed on-par with servantry to help them steal bodies slightly easier.
- Messing up your clan selection will default you to Crimson Fangs instead of the Nosferato because that's literally the hardest clan in the game to play and we shouldn't fuck over newer players that don't know you have to select a clan or experienced players accidentally clicking too fast.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Did a Guest + Own Ckey localhost text, noises weren't audable with volume off, were when back on, only for the vampire.
Torpor works as-intended.
Gave myself vampire, closed the menu, bam I am a Crimson Fang member.
Rest is just single liners or code notes, it won't break shit.


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Because OH GODS A NOISE I DON'T HEAR NORMALLY, VAMPIRES, QUICK CHECK EVERYONE WITH SILVER...

while the vampire just used their default telepathy ability with no way to know this.
Dude, no. *I didn't even intend for this to be a thing, its for the vampire only and it WILL be for the vampire only to hear.*

As for the rest, flipping the balance around a bit, see if we can get an underplayed class, played or not.

*Why did an infinite vitae exploit exist before I touched vampire. I left it initally as I couldn't figure out wound healing but now i know how we genuinely don't need vitae regen with torpor.*

Nosferato is genuinely both the most hardest clan and least attractive.

I know you want to be some sort of semi-attractive vampire to keep people from fragging you on a hint they might get to do funny scenes so I know ya'll probably don't want to default to that.

*I know what you are.*

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: you can no longer heal unintended vampire noises.
balance: Nosferato is no longer the default vampire clan fallback, because why was the hardest clan to play the default sire?
balance: Torpor no longer is only useful for infinite vitae exploits, you no longer gain vitae from but instead heal wounds/damage at an insanely fast rate.
balance: journey -> expert unarmed for vamp arsonist
balance: 1spd -> 2 spd for vamp physician
code: adjusted vampire stat codenotes to be truer. they're points not weighted balance-wise. oops.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
