### PR TITLE
rehomes all poleaxes + changes poleaxe thrust

### DIFF
--- a/code/game/objects/effects/spawners/equipment_spawners.dm
+++ b/code/game/objects/effects/spawners/equipment_spawners.dm
@@ -261,7 +261,7 @@
 	loot = list(
 		/obj/item/rogueweapon/sword/silver = 1,
 		/obj/item/rogueweapon/mace/steel/silver = 1,
-		/obj/item/rogueweapon/greataxe/silver = 1,
+		/obj/item/rogueweapon/greataxe/steel/knight/silver = 1,
 		/obj/item/rogueweapon/flail/sflail/silver = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/silver = 3,
 		/obj/item/rogueweapon/mace/warhammer/steel/silver = 1,

--- a/code/game/objects/effects/spawners/loot_spawners.dm
+++ b/code/game/objects/effects/spawners/loot_spawners.dm
@@ -402,7 +402,7 @@
 		/obj/item/rogueweapon/stoneaxe/woodcut/steel = 1,
 		/obj/item/rogueweapon/sword/silver = 1,
 		/obj/item/rogueweapon/mace/steel/silver = 1,
-		/obj/item/rogueweapon/greataxe/silver = 1,
+		/obj/item/rogueweapon/greataxe/steel/knight/silver = 1,
 		/obj/item/rogueweapon/flail/sflail/silver = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/silver = 3,
 		/obj/item/rogueweapon/mace/warhammer/steel/silver = 1,

--- a/code/game/objects/items/donator_modkit.dm
+++ b/code/game/objects/items/donator_modkit.dm
@@ -524,8 +524,8 @@
 	name = "'Amdir' morphing elixir"
 	target_items = list(
 	/obj/item/rogueweapon/greataxe/steel/knight,
-	/obj/item/rogueweapon/greataxe/silver,
-	/obj/item/rogueweapon/greataxe/psy
+	/obj/item/rogueweapon/greataxe/steel/knight/silver,
+	/obj/item/rogueweapon/greataxe/steel/knight/psy
 
 	)
 	result_item = /obj/item/rogueweapon/example/arra_amdir

--- a/code/game/objects/items/rogueweapons/melee/axe/axe_intents.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axe_intents.dm
@@ -42,6 +42,25 @@
 	blade_class = BCLASS_STAB
 	attack_verb = list("thrusts")
 
+/datum/intent/axe/rangedthrust
+	name = "thrust"
+	blade_class = BCLASS_STAB
+	attack_verb = list("thrusts")
+	animname = "stab"
+	icon_state = "instab"
+	reach = 2
+	clickcd = CLICK_CD_CHARGED
+	recovery = 30
+	warnie = "mobwarning"
+	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
+	penfactor = PEN_MEDIUM
+	item_d_type = "stab"
+	desc = "A committed thrust with the poleaxe's spike. It only bites through armor at full extension, exactly two paces away, and leaves you vulnerable as you recover the swing."
+	swingdelay = 8
+	swingdelay_type = SWINGDELAY_PENALTY
+	effective_range = 2
+	effective_range_type = EFF_RANGE_EXACT
+
 /datum/intent/axe/chop/heavy
 	name = "hack"
 	icon_state = "inhack"

--- a/code/game/objects/items/rogueweapons/melee/axe/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axe/axes.dm
@@ -609,7 +609,7 @@
 
 /obj/item/rogueweapon/greataxe/steel/knight
 	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/mace/strike)
-	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/mace/strike, /datum/intent/mace/rangedthrust)
+	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/mace/strike, /datum/intent/axe/rangedthrust)
 	name = "poleaxe"
 	desc = "A poleaxe, fitted with a reinforced shaft and a beaked axhead of steel. It is the ultimate weapon for a well-seasoned knight, capable of \
 	humbling any foe that may assail their presence. </br>'Away with you, vile beggar!'"
@@ -642,11 +642,8 @@
 	update_icon()
 
 
-/obj/item/rogueweapon/greataxe/silver
-	force = 15
+/obj/item/rogueweapon/greataxe/steel/knight/silver
 	force_wielded = 25
-	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/mace/strike) //When possible, add the longsword's 'alternate grip' mechanic to let people flip this around into a Mace-scaling weapon with swapped damage.
-	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/mace/strike, /datum/intent/mace/rangedthrust) //Axe-equivalent to the Godendag or Grand Mace.
 	name = "silver poleaxe"
 	desc = "A poleaxe, fitted with a reinforced shaft and a beaked axhead of pure silver. It may not stop the darkness; but it will halt \
 	its march, long enough, to shepherd away the defenseless. </br>'O'er the Horizon, the stars and spirals I see; and below it, the horrors \
@@ -658,7 +655,7 @@
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
 
-/obj/item/rogueweapon/greataxe/silver/ComponentInitialize()
+/obj/item/rogueweapon/greataxe/steel/knight/silver/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
 		pre_blessed = BLESSING_NONE,\
@@ -669,11 +666,8 @@
 		added_def = 2,\
 	)
 
-/obj/item/rogueweapon/greataxe/psy
-	force = 15
+/obj/item/rogueweapon/greataxe/steel/knight/psy
 	force_wielded = 25
-	possible_item_intents = list(/datum/intent/axe/cut, /datum/intent/axe/chop, /datum/intent/mace/strike) //When possible, add the longsword's 'alternate grip' mechanic to let people flip this around into a Mace-scaling weapon with swapped damage.
-	gripped_intents = list(/datum/intent/axe/cut/long, /datum/intent/axe/chop/long, /datum/intent/mace/rangedthrust, /datum/intent/mace/strike) //Axe-equivalent to the Godendag or Grand Mace.
 	name = "psydonic poleaxe"
 	desc = "A poleaxe, fitted with a reinforced shaft and a beaked axhead of alloyed silver. As the fragility of swords've \
 	become more apparent, the Psydonic Orders - following the disastrous Massacre of Blastenghyll - have shifted their focus \
@@ -684,7 +678,7 @@
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
 
-/obj/item/rogueweapon/greataxe/psy/ComponentInitialize()
+/obj/item/rogueweapon/greataxe/steel/knight/psy/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
 		pre_blessed = BLESSING_NONE,\
@@ -695,7 +689,7 @@
 		added_def = 2,\
 	)
 
-/obj/item/rogueweapon/greataxe/psy/preblessed/ComponentInitialize()
+/obj/item/rogueweapon/greataxe/steel/knight/psy/preblessed/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
 		pre_blessed = BLESSING_PSYDONIAN,\

--- a/code/modules/jobs/job_types/roguetown/Inquisition/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/inquisitor.dm
@@ -284,7 +284,7 @@
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword/noble, SLOT_BACK_R, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
 		if("Psydonic Poleaxe")
-			H.put_in_hands(new /obj/item/rogueweapon/greataxe/psy/preblessed(H))
+			H.put_in_hands(new /obj/item/rogueweapon/greataxe/steel/knight/psy/preblessed(H))
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap, SLOT_BACK_R, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
 		if("Psydonic Grand Mace")

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
@@ -149,7 +149,7 @@
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap(H), SLOT_BACK_R, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 		if("Psydonic Poleaxe + Shortsword")
-			H.put_in_hands(new /obj/item/rogueweapon/greataxe/psy/preblessed(H))
+			H.put_in_hands(new /obj/item/rogueweapon/greataxe/steel/knight/psy/preblessed(H))
 			H.put_in_hands(new /obj/item/rogueweapon/sword/short/psy/preblessed(H))
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/gwstrap(H), SLOT_BACK_R, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword/noble, SLOT_BELT_R, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -546,7 +546,7 @@
 				r_hand = /obj/item/rogueweapon/stoneaxe/handaxe/silver
 			if("Silver Poleaxe")
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				r_hand = /obj/item/rogueweapon/greataxe/silver
+				r_hand = /obj/item/rogueweapon/greataxe/steel/knight/silver
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
 			if("Silver Spear")
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -1210,7 +1210,7 @@
 	name = "Poleaxe, Silver (+2 Silver, +2 Small Logs)"
 	req_bar = /obj/item/ingot/silver
 	additional_items = list(/obj/item/ingot/silver, /obj/item/ingot/silver, /obj/item/grown/log/tree/small, /obj/item/grown/log/tree/small)
-	created_item = /obj/item/rogueweapon/greataxe/silver
+	created_item = /obj/item/rogueweapon/greataxe/steel/knight/silver
 	display_category = ITEM_CAT_WEAPONS_AXES
 
 /datum/anvil_recipe/weapons/silver/mace


### PR DESCRIPTION
## About The Pull Request

NUFC: poleaxes are now subtyped sanely. same for rangedthrust.

- poleaxe thrust has now a 2-tile sweetspot with yellow intent. but 1x damfactor and it keeps its 2 pip AP.

## Testing Evidence

balance

## Why It's Good For The Game

its actually strong again now, but it shouldnt be that strong. yellow intent + sweetspot keeps it in check while the 1x damfactor doenst nerf it too hard

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: poleaxe stab has 2-tile sweetspot and is delayed. but has 1x damfactor instead of 0.9x.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
