### PR TITLE
Rebalance Rune Ward. Remove hardstun

### DIFF
--- a/code/game/objects/structures/rune_ward_structure.dm
+++ b/code/game/objects/structures/rune_ward_structure.dm
@@ -83,10 +83,18 @@
 	icon_state = RUNE_WARD_ICON_STUN
 
 /obj/structure/rune_ward/stun/rune_effect(mob/living/L)
-	to_chat(L, span_danger("<B>The rune locks your muscles in place!</B>"))
+	to_chat(L, span_danger("<B>The rune erupts with arcyne lightning!</B>"))
 	playsound(src, 'sound/magic/lightning.ogg', 80, TRUE)
-	L.electrocute_act(10, src, flags = SHOCK_NOGLOVES)
-	L.Paralyze(6 SECONDS)
+	L.electrocute_act(1, src, 1, flags = SHOCK_NOSTUN)
+	if(!L.mob_timers[MT_LIGHTNING_ADAPTATION] || world.time > L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN)
+		L.Immobilize(0.5 SECONDS)
+		L.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
+		L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 6 SECONDS)
+		L.balloon_alert_to_viewers("<font color='#ffcc00'>shocked! (6s)</font>")
+		L.mob_timers[MT_LIGHTNING_ADAPTATION] = world.time
+	else
+		var/remaining = round((L.mob_timers[MT_LIGHTNING_ADAPTATION] + LIGHTNING_ADAPTATION_COOLDOWN - world.time) / 10)
+		L.balloon_alert_to_viewers("<font color='#ffcc00'>shock adapted ([remaining]s)</font>")
 
 /obj/structure/rune_ward/fire
 	name = "flame rune"
@@ -96,9 +104,8 @@
 	to_chat(L, span_danger("<B>The rune erupts in flames!</B>"))
 	playsound(src, pick('sound/misc/explode/incendiary (1).ogg', 'sound/misc/explode/incendiary (2).ogg'), 80, TRUE)
 	new /obj/effect/hotspot(get_turf(src))
-	L.Knockdown(30)
-	L.Slowdown(2)
-	L.adjust_fire_stacks(5)
+	L.Slowdown(4)
+	L.adjust_fire_stacks(6)
 	L.ignite_mob()
 
 /obj/structure/rune_ward/chill
@@ -109,8 +116,8 @@
 	to_chat(L, span_danger("<B>Frost erupts from the rune and seizes your limbs!</B>"))
 	playsound(src, 'sound/spellbooks/crystal.ogg', 80, TRUE)
 	new /obj/effect/temp_visual/trapice(get_turf(src))
-	L.Paralyze(20)
-	L.adjustFireLoss(30)
+	L.Slowdown(4)
+	L.adjustFireLoss(10)
 	apply_frost_stack(L, 4)
 
 /obj/structure/rune_ward/damage
@@ -123,8 +130,7 @@
 	playsound(src, 'sound/magic/blade_burst.ogg', 80, TRUE)
 	playsound(src, pick('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg'), 80, TRUE)
 	new /obj/effect/temp_visual/blade_burst(get_turf(src))
-	L.Knockdown(30)
-	L.Slowdown(2)
+	L.Slowdown(4)
 	var/mob/living/carbon/human/owner = owner_ref?.resolve()
 	if(ishuman(owner) && ishuman(L))
 		arcyne_strike(owner, L, null, rune_damage, BODY_ZONE_CHEST, \


### PR DESCRIPTION
## About The Pull Request
- Shock runes no longer hard stun and just applies the 6 seconds LBolt plus a bit of lightning 
- Other runes no longer hard stun, have a longer slowdown
- Rebalanced Fire runes to be slightly stronger and frost rune to be slightly weaker    

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="378" height="539" alt="dreamseeker_XAKeUN5mVV" src="https://github.com/user-attachments/assets/cab71aea-2efd-413b-b945-dbf363afc77d" />
<img width="370" height="397" alt="dreamseeker_cWqA3qRNRD" src="https://github.com/user-attachments/assets/e42d7237-337f-466a-be10-29a3f18313bd" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Hard stuns are actually bad.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Shock runes no longer hard stun and just applies the 6 seconds LBolt plus a bit of lightning, Other runes no longer hard stun, have a longer slowdown, Rebalanced Fire runes to be slightly stronger and frost rune to be slightly weaker    
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
