### PR TITLE
Naledi PR post-adjustments (Adven Vizier)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner.dm
@@ -197,11 +197,6 @@
 
 /datum/outfit/job/roguetown/adventurer/refugee/pre_equip(mob/living/carbon/human/H)
 	..()
-	var/list/paths = list("Refugee (Default)", "Seminary Dropout (Hierophant)", "Desert Ascetic (Pontifex)", "Wandering Yogi (Vizier)")
-	var/list/hmm = list("I left for a reason... (Default)", "The Djinn could be anywhere! (Naledi Complex)")
-	var/path = input(H, "Choose your past.", "WHAT DID WAR TAKE FROM YOU?") as anything in paths
-	var/complex = input(H, "How tightly bound to traditions you are?", "I HATE DJINNS!") as anything in hmm
-
 	backl = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/clothing/neck/roguetown/psicross/naledi
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/cloth/monk
@@ -213,15 +208,18 @@
 	head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/black
 	beltr = /obj/item/flashlight/flare/torch/lantern
 
+	var/choice = list("I left for a reason... (Default)", "The Djinn could be anywhere! (Naledi Complex)")
+	var/complex = input(H, "How tightly bound to traditions you are?", "I HATE DJINNS!") as anything in choice
 	switch(complex)
 		if("The Djinn could be anywhere! (Naledi Complex)")
 			ADD_TRAIT(H, TRAIT_NALEDI, TRAIT_GENERIC)
 			mask = /obj/item/clothing/mask/rogue/lordmask/naledi
 		else
 			mask = /obj/item/clothing/mask/rogue/lordmask/tarnished
-	
-	switch(path)
 
+	var/paths = list("Refugee (Default)", "Seminary Dropout (Hierophant)", "Desert Ascetic (Pontifex)", "Wandering Yogi (Vizier)")
+	var/path = input(H, "Choose your past.", "WHAT DID WAR TAKE FROM YOU?") as anything in paths
+	switch(path)
 		if("Refugee (Default)")
 			to_chat(H, span_warning("An asylum-seeker from the war-torn deserts of Naledi, \
 			driven north as your homeland continues to be ravaged by an endless conflict against the Djinn."))
@@ -334,11 +332,16 @@
 			ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
 
 			if(H.mind)
+				var/spells = list("Avant Origin (Acceleration)", "Garde Origin (Divergence)")
+				var/mastery = input(H, "Choose your Origin Mastery.", "FORWARD OR BACKWARD?") as anything in spells
 				grant_poke_spell(H)
 				H.mind.AddSpell(new /datum/action/cooldown/spell/blink/shadowstep)
 				H.mind.AddSpell(new /datum/action/cooldown/spell/vizier/restoration)
-				H.mind.AddSpell(new /datum/action/cooldown/spell/vizier/divergence)
-				H.mind.AddSpell(new /datum/action/cooldown/spell/vizier/acceleration)
+				switch(mastery)
+					if("Garde Origin (Divergence)")
+						H.mind.AddSpell(new /datum/action/cooldown/spell/vizier/divergence)
+					if("Avant Origin (Acceleration)")
+						H.mind.AddSpell(new /datum/action/cooldown/spell/vizier/acceleration)
 				H.mind.AddSpell(new /datum/action/cooldown/spell/bestow_ward)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 				H.mind.AddSpell(new /datum/action/cooldown/spell/conjure_arcyne_ward/crystalhide)

--- a/code/modules/spells/spell_types/classunique/vizier/acceleration.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/acceleration.dm
@@ -4,9 +4,9 @@
 	fluff_desc = "One of the earliest applications of Origin Magick, Acceleration was first devised to hasten crop growth and shorten agricultural cycles. The experiment revealed a fundamental limitation of the art: while a subject's personal timeline can be advanced, the debt incurred cannot be avoided. Reality inevitably reconciles the discrepancy, repaying every stolen moment in equal measure. Though unsuitable for cultivation, the technique found lasting use among Naledi Viziers as a potent, if taxing, combat tool."	
 	button_icon_state = "accel"
 	sound = list('sound/magic/haste.ogg')
-	cast_range = 4
+	cast_range = 6
 	charge_required = FALSE
-	cooldown_time = 5 MINUTES
+	cooldown_time = 2 MINUTES
 	invocations = list("Aggil!")
 	invocation_type = INVOCATION_SHOUT
 
@@ -44,7 +44,7 @@
 	id = "acceleration"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/accel
 	effectedstats = list(STATKEY_SPD = 20)
-	duration = 15 SECONDS
+	duration = 6 SECONDS
 	tick_interval = 1 SECONDS
 	var/afterimage_active = FALSE
 
@@ -93,7 +93,7 @@
 	id = "deceleration"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/decel
 	effectedstats = list(STATKEY_SPD = -20)
-	duration = 15 SECONDS
+	duration = 6 SECONDS
 
 /datum/status_effect/debuff/decel/on_creation(mob/living/new_owner, new_duration = null)
 	if(new_duration)
@@ -104,7 +104,7 @@
 	. = ..()
 
 	ADD_TRAIT(owner, TRAIT_NODEF, "naledi_cat_nonsense")
-	owner.stamina_add(125)
+	owner.stamina_add(100)
 	to_chat(owner, span_red("Everything feels unbearably slow. I am defenseless!"))
 
 /datum/status_effect/debuff/decel/on_remove()

--- a/code/modules/spells/spell_types/classunique/vizier/acceleration.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/acceleration.dm
@@ -7,7 +7,7 @@
 	cast_range = 6
 	charge_required = FALSE
 	cooldown_time = 1.25 MINUTES
-	invocations = list("Aggil! Advance, timeline!")
+	invocations = list("Tasaru'!")
 	invocation_type = INVOCATION_SHOUT
 	primary_resource_type = SPELL_COST_ENERGY
 	primary_resource_cost = 76

--- a/code/modules/spells/spell_types/classunique/vizier/acceleration.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/acceleration.dm
@@ -6,9 +6,11 @@
 	sound = list('sound/magic/haste.ogg')
 	cast_range = 6
 	charge_required = FALSE
-	cooldown_time = 2 MINUTES
-	invocations = list("Aggil!")
+	cooldown_time = 1.25 MINUTES
+	invocations = list("Aggil! Advance, timeline!")
 	invocation_type = INVOCATION_SHOUT
+	primary_resource_type = SPELL_COST_ENERGY
+	primary_resource_cost = 76
 
 /datum/action/cooldown/spell/vizier/acceleration/cast(atom/cast_on)
 	. = ..()
@@ -44,7 +46,7 @@
 	id = "acceleration"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/accel
 	effectedstats = list(STATKEY_SPD = 20)
-	duration = 6 SECONDS
+	duration = 4 SECONDS
 	tick_interval = 1 SECONDS
 	var/afterimage_active = FALSE
 
@@ -93,7 +95,7 @@
 	id = "deceleration"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/decel
 	effectedstats = list(STATKEY_SPD = -20)
-	duration = 6 SECONDS
+	duration = 4 SECONDS
 
 /datum/status_effect/debuff/decel/on_creation(mob/living/new_owner, new_duration = null)
 	if(new_duration)

--- a/code/modules/spells/spell_types/classunique/vizier/divergence.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/divergence.dm
@@ -10,6 +10,8 @@
 	cooldown_time = 60 SECONDS
 	invocations = list("Naf'ir! Diverge, timeline!")
 	invocation_type = INVOCATION_SHOUT
+	primary_resource_type = SPELL_COST_ENERGY
+	primary_resource_cost = 76
 
 /datum/action/cooldown/spell/vizier/divergence/cast(atom/cast_on)
 	. = ..()

--- a/code/modules/spells/spell_types/classunique/vizier/divergence.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/divergence.dm
@@ -8,7 +8,7 @@
 	self_cast_possible = TRUE
 	charge_required = FALSE
 	cooldown_time = 60 SECONDS
-	invocations = list("Naf'ir! Diverge, timeline!")
+	invocations = list("Iftiraq!")
 	invocation_type = INVOCATION_SHOUT
 	primary_resource_type = SPELL_COST_ENERGY
 	primary_resource_cost = 76


### PR DESCRIPTION
## About The Pull Request

- Added missing costs to Vizier spells.
- Adventurer Vizier can only have one 'Naledi Utility spell' choice.
- Accelerate duration reduced from 15 seconds to 4 seconds.
- Cooldown reduced to 1 minute and 15 seconds.

## Testing Evidence

Compiles.

## Why It's Good For The Game

I'm just adjusting some things I couldn't before the merge. There's still some things missing for Pontifex too, but it's a bigger package that I can't just write like tweaking values, and since Vizier's live, balance adjustments have a better priority over job kit improvements.

## Changelog
:cl:
balance: Adjusted adven Vizier values and limited choices.
/:cl: