### PR TITLE
fixes rclicks not working properly

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -597,7 +597,6 @@
 		var/mob/M = target
 		var/list/targetl = list(target)
 		user.visible_message(span_taunt("[user] taunts [M]!"), span_taunt("I taunt [M]!"), ignored_mobs = targetl)
-		targetl.Add(user)
 		user.emote("taunt")
 		if(M.mind)
 			var/mob/living/L = user
@@ -659,7 +658,6 @@
 		var/mob/M = target
 		var/list/targetl = list(target)
 		user.visible_message(span_blue("[user] shoos [M] away."), span_blue("I shoo [M] away."), ignored_mobs = targetl)
-		targetl.Add(user)
 		if(M.mind)
 			var/mob/living/L = user
 			L.play_overhead_private_rclickemote(targetl, "dismiss")
@@ -689,7 +687,6 @@
 		var/mob/M = target
 		var/list/targetl = list(target)
 		user.visible_message(span_yellow("[user] beckons [M] to come closer."), span_yellow("I beckon [M] to come closer."), ignored_mobs = targetl)
-		targetl.Add(user)
 		if(M.mind)
 			var/mob/living/L = user
 			L.play_overhead_private_rclickemote(targetl, "beckon")
@@ -716,7 +713,6 @@
 		var/mob/M = target
 		var/list/targetl = list(target)
 		user.visible_message(span_green("[user] waves friendly at [M]."), span_green("I wave friendly at [M]."), ignored_mobs = targetl)
-		targetl.Add(user)
 		if(M.mind)	// Waving at an NPC doesn't need to show this.
 			var/mob/living/L = user
 			L.play_overhead_private_rclickemote(targetl, "wavefriendly")

--- a/code/modules/mob/living/overhead_effects.dm
+++ b/code/modules/mob/living/overhead_effects.dm
@@ -106,6 +106,8 @@
 			offset_list = SPC.offset_features[OFFSET_HEAD]
 	for(var/mob/M in targets)
 		vis_contents += new /obj/effect/temp_visual/stress_event/invisible(null, M, 'icons/mob/overhead_effects.dmi', iconstate, offset_list, offset, icon_plane)
+	// Seeing it on ourselves gives better feedback that it worked / was seen.
+	vis_contents += new /obj/effect/temp_visual/stress_event/invisible(null, src, 'icons/mob/overhead_effects.dmi', iconstate, offset_list, offset, icon_plane)
 	
 /obj/effect/temp_visual/stress_event
 	icon = 'icons/mob/overhead_effects.dmi'


### PR DESCRIPTION
## About The Pull Request
I got a bit zealous with my code, it should be visible on BOTH the waver and the waved
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="277" height="460" alt="dreamseeker_2aeGWTeL7b" src="https://github.com/user-attachments/assets/56c98c93-bd5c-49ca-9c91-d1bc42691818" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed rclick emotes not showing up on the user correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
