### PR TITLE
Fixes invisibility not working correctly

### DIFF
--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -278,6 +278,7 @@
 	action_icon = 'icons/mob/actions/gnollmiracles.dmi'
 	overlay_state = "stalk"
 	action_icon_state = "stalk"
+	ignore_stealth_reveal = TRUE
 
 /obj/effect/proc_holder/spell/invoked/invisibility/gnoll/cast(list/targets, mob/living/user)
 	var/mob/living/target = user

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -261,6 +261,7 @@
 	antimagic_allowed = TRUE
 	hide_charge_effect = TRUE
 	cost = 3 // Very useful
+	ignore_stealth_reveal = TRUE
 
 /obj/effect/proc_holder/spell/invoked/invisibility/cast(list/targets, mob/living/user)
 	if(isliving(targets[1]))

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -216,6 +216,8 @@
 
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC | SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 
+	ignore_stealth_reveal = TRUE
+
 /datum/action/cooldown/spell/noc/invisibility/cast(atom/cast_on)
 	. = ..()
 	var/mob/living/spelltarget = cast_on

--- a/code/modules/spells/roguetown/acolyte/xylix.dm
+++ b/code/modules/spells/roguetown/acolyte/xylix.dm
@@ -40,6 +40,7 @@
 	recharge_time = 30 SECONDS
 	var/firstcast = TRUE
 	var/icon/clone_icon
+	ignore_stealth_reveal = TRUE
 
 /obj/effect/proc_holder/spell/invoked/mastersillusion/cast(list/targets, mob/living/carbon/human/user = usr)
 	if(firstcast)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -211,6 +211,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/miracle = FALSE
 	var/devotion_cost = 0
 	var/ignore_cockblock = FALSE //whether or not to ignore TRAIT_SPELLCOCKBLOCK
+	var/ignore_stealth_reveal = FALSE
 	action_icon_state = "spell0"
 	action_icon = 'icons/mob/actions/roguespells.dmi'
 	action_background_icon_state = ""
@@ -604,8 +605,9 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			if(L.has_status_effect(/datum/status_effect/buff/clash))
 				var/mob/living/carbon/human/H = user
 				H.bad_guard(span_warning("I can't focus while casting spells!"), cheesy = TRUE)
-			if(L.get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(L, TRAIT_LIGHT_STEP))
-				L.apply_status_effect(/datum/status_effect/stealth_revealed)
+			if(!ignore_stealth_reveal)
+				if(L.get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(L, TRAIT_LIGHT_STEP))
+					L.apply_status_effect(/datum/status_effect/stealth_revealed)
 		if(action)
 			action.build_all_button_icons()
 		return TRUE

--- a/code/modules/spells/spell_cooldown.dm
+++ b/code/modules/spells/spell_cooldown.dm
@@ -176,6 +176,8 @@
 	var/weapon_penalty_active = FALSE
 	/// If TRUE, this spell ignores armor cooldown penalties (for armored casters like Tithebound).
 	var/ignore_armor_penalty = FALSE
+	/// If TRUE, will -not- trigger stealth reveal mechanics after cast.
+	var/ignore_stealth_reveal = FALSE
 	/// If TRUE, spell charges on button press, then waits for a separate middle-click to cast.
 	/// If FALSE (default), spell uses hold-and-release: hold middle-click to charge, release to cast.
 	var/charge_then_click = FALSE
@@ -886,8 +888,9 @@
 		if(H.has_status_effect(/datum/status_effect/buff/clash))
 			H.bad_guard(span_warning("I can't focus while casting spells!"), cheesy = TRUE)
 
-		if(H.get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(H, TRAIT_LIGHT_STEP))
-			H.apply_status_effect(/datum/status_effect/stealth_revealed)
+		if(!ignore_stealth_reveal)
+			if(H.get_skill_level(/datum/skill/misc/sneaking) >= SKILL_LEVEL_JOURNEYMAN || HAS_TRAIT(H, TRAIT_LIGHT_STEP))
+				H.apply_status_effect(/datum/status_effect/stealth_revealed)
 
 	// Sparks and smoke can only occur if there's an owner to source them from.
 	if(sparks_amt)


### PR DESCRIPTION
## About The Pull Request
Casting invisibility spells (such as Stalk for Gnolls) applied the Revealed status effect, the application of which purges stealth, thus revealing them instantly. Not intended.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fixed invisibility spells / miracles not working correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
