### PR TITLE
gives sahir the ability to pick between staff and swords

### DIFF
--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_sahir.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_sahir.dm
@@ -1,8 +1,8 @@
 /datum/advclass/mercenary/desert_rider_sahir
 	name = "Desert Rider Sahir"
-	tutorial = "You're a Sahir - a wisened Magi from the desert of Raneshen. You have spent your lyfe studying the arcyne arts, and also knows of of the way of the sword - a necessity when one happens upon monstrsities that are resilient to magyck in the desert."
+	tutorial = "You're a Sahir - a wisened Magi from the desert of Raneshen. You have spent your lyfe studying the arcyne arts. Some of your rank knows the way of the sword- a necessity when one happens upon monstrsities that are resilient to magyck in the desert."
 	allowed_sexes = list(MALE, FEMALE)
-	
+
 	outfit = /datum/outfit/job/roguetown/mercenary/desert_rider_sahir
 	class_select_category = CLASS_CAT_RANESHENI
 	category_tags = list(CTAG_MERCENARY)
@@ -16,8 +16,8 @@
 		STATKEY_PER = 2
 	)
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 2, "utilities" = 6, "ward" = TRUE)
+	extra_context = "This subclass chooses between twin shamshirs with Journeyman Swords or a greater staff with Journeyman Staves."
 	subclass_skills = list(
-		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
@@ -35,7 +35,7 @@
 /datum/outfit/job/roguetown/mercenary/desert_rider_sahir/pre_equip(mob/living/carbon/human/H)
 	..()
 
-	// Gear - same as Almah but 1x blade + scholar's pouch
+	// Gear - same as Almah, with a chosen martial focus + scholar's pouch
 	head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/raneshen
 	neck = /obj/item/clothing/neck/roguetown/gorget/copper
 	mask = /obj/item/clothing/mask/rogue/facemask/copper
@@ -47,10 +47,25 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shalal
 	belt = /obj/item/storage/belt/rogue/leather/shalal
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	beltl = /obj/item/rogueweapon/scabbard/sword
-	beltr = /obj/item/rogueweapon/scabbard/sword
-	r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
-	l_hand = /obj/item/rogueweapon/sword/sabre/shamshir
+	if(H.mind)
+		var/weapons = list("Twin Shamshirs", "Greater Staff")
+		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		H.set_blindness(0)
+		switch(weapon_choice)
+			if("Twin Shamshirs")
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				beltl = /obj/item/rogueweapon/scabbard/sword
+				beltr = /obj/item/rogueweapon/scabbard/sword
+				r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
+				l_hand = /obj/item/rogueweapon/sword/sabre/shamshir
+			if("Greater Staff")
+				H.adjust_skillrank_up_to(/datum/skill/combat/staves, SKILL_LEVEL_EXPERT, TRUE)
+				r_hand = /obj/item/rogueweapon/woodstaff/implement/greater
+	else
+		beltl = /obj/item/rogueweapon/scabbard/sword
+		beltr = /obj/item/rogueweapon/scabbard/sword
+		r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
+		l_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary,
 		/obj/item/rogueweapon/huntingknife/idagger/navaja,

--- a/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_sahir.dm
+++ b/code/modules/jobs/job_types/roguetown/sidefolk/mercenary/desert_rider_sahir.dm
@@ -16,7 +16,7 @@
 		STATKEY_PER = 2
 	)
 	subclass_mage_aspects = list("mastery" = FALSE, "major" = 1, "minor" = 2, "utilities" = 6, "ward" = TRUE)
-	extra_context = "This subclass chooses between twin shamshirs with Journeyman Swords or a greater staff with Journeyman Staves."
+	extra_context = "This subclass chooses between twin shamshirs or a more traditional staff."
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
@@ -47,6 +47,17 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shalal
 	belt = /obj/item/storage/belt/rogue/leather/shalal
 	backr = /obj/item/storage/backpack/rogue/satchel/black
+
+	backpack_contents = list(
+		/obj/item/roguekey/mercenary,
+		/obj/item/rogueweapon/huntingknife/idagger/navaja,
+		/obj/item/rogueweapon/scabbard/sheath,
+		/obj/item/clothing/neck/roguetown/shalal,
+		/obj/item/book/spellbook,
+		/obj/item/flashlight/flare/torch,
+		/obj/item/storage/belt/rogue/pouch/coins/poor
+		)
+
 	if(H.mind)
 		var/weapons = list("Twin Shamshirs", "Greater Staff")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
@@ -61,18 +72,5 @@
 			if("Greater Staff")
 				H.adjust_skillrank_up_to(/datum/skill/combat/staves, SKILL_LEVEL_EXPERT, TRUE)
 				r_hand = /obj/item/rogueweapon/woodstaff/implement/greater
-	else
-		beltl = /obj/item/rogueweapon/scabbard/sword
-		beltr = /obj/item/rogueweapon/scabbard/sword
-		r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
-		l_hand = /obj/item/rogueweapon/sword/sabre/shamshir
-	backpack_contents = list(
-		/obj/item/roguekey/mercenary,
-		/obj/item/rogueweapon/huntingknife/idagger/navaja,
-		/obj/item/rogueweapon/scabbard/sheath,
-		/obj/item/clothing/neck/roguetown/shalal,
-		/obj/item/book/spellbook,
-		/obj/item/flashlight/flare/torch,
-		/obj/item/storage/belt/rogue/pouch/coins/poor
-		)
+
 	H.merctype = 4


### PR DESCRIPTION
## About The Pull Request

gives sahir the ability to pick between staff and swords, as the title says. cleared w ansari

## Testing Evidence

checked, works fine

## Why It's Good For The Game

lets people pick their characters a bit better. grenziemage already exists. the difference here is worse starting gear+worse stats vs 1 better rank in skills which gives them the _**extremely niche ability**_ to keep 80-90% parry vs legendary skill. whenever _that_ happens

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: sahir can now pick between two shamshir or a single staff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
