### PR TITLE
removes eyeballs falling out

### DIFF
--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -79,11 +79,6 @@
 	. = ..()
 	ADD_TRAIT(affected, TRAIT_CYCLOPS_RIGHT, "[type]")
 	affected.update_fov_angles()
-	if(affected.has_wound(/datum/wound/facial/eyes/left) && affected.has_wound(/datum/wound/facial/eyes/right))
-		var/obj/item/organ/my_eyes = affected.getorganslot(ORGAN_SLOT_EYES)
-		if(my_eyes)
-			my_eyes.Remove(affected)
-			my_eyes.forceMove(affected.drop_location())
 
 /datum/wound/facial/eyes/right/on_mob_loss(mob/living/affected)
 	. = ..()

--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -109,11 +109,6 @@
 	. = ..()
 	ADD_TRAIT(affected, TRAIT_CYCLOPS_LEFT, "[type]")
 	affected.update_fov_angles()
-	if(affected.has_wound(/datum/wound/facial/eyes/left) && affected.has_wound(/datum/wound/facial/eyes/right))
-		var/obj/item/organ/my_eyes = affected.getorganslot(ORGAN_SLOT_EYES)
-		if(my_eyes)
-			my_eyes.Remove(affected)
-			my_eyes.forceMove(affected.drop_location())
 
 /datum/wound/facial/eyes/left/on_mob_loss(mob/living/affected)
 	. = ..()

--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -78,11 +78,15 @@
 /datum/wound/facial/eyes/right/on_mob_gain(mob/living/affected)
 	. = ..()
 	ADD_TRAIT(affected, TRAIT_CYCLOPS_RIGHT, "[type]")
+	if(affected.has_wound(/datum/wound/facial/eyes/left) && affected.has_wound(/datum/wound/facial/eyes/right))
+		ADD_TRAIT(affected, TRAIT_BLIND, "[type]")
 	affected.update_fov_angles()
 
 /datum/wound/facial/eyes/right/on_mob_loss(mob/living/affected)
 	. = ..()
 	REMOVE_TRAIT(affected, TRAIT_CYCLOPS_RIGHT, "[type]")
+	if(!affected.has_wound(/datum/wound/facial/eyes/left) && !affected.has_wound(/datum/wound/facial/eyes/right))
+		REMOVE_TRAIT(affected, TRAIT_BLIND, "[type]")
 	affected.update_fov_angles()
 
 /datum/wound/facial/eyes/right/permanent
@@ -108,12 +112,17 @@
 /datum/wound/facial/eyes/left/on_mob_gain(mob/living/affected)
 	. = ..()
 	ADD_TRAIT(affected, TRAIT_CYCLOPS_LEFT, "[type]")
+	if(affected.has_wound(/datum/wound/facial/eyes/left) && affected.has_wound(/datum/wound/facial/eyes/right))
+		ADD_TRAIT(affected, TRAIT_BLIND, "[type]")
 	affected.update_fov_angles()
 
 /datum/wound/facial/eyes/left/on_mob_loss(mob/living/affected)
 	. = ..()
 	REMOVE_TRAIT(affected, TRAIT_CYCLOPS_LEFT, "[type]")
+	if(!affected.has_wound(/datum/wound/facial/eyes/left) && !affected.has_wound(/datum/wound/facial/eyes/right))
+		REMOVE_TRAIT(affected, TRAIT_BLIND, "[type]")
 	affected.update_fov_angles()
+	
 
 /datum/wound/facial/eyes/left/permanent
 	whp = null


### PR DESCRIPTION
## About The Pull Request

stabbing both eyes out doesn't make your eyes fall out, it instead just blinds you. healable as you would any other wound, but it requires both to be healed for vision to return

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence


<img width="1068" height="508" alt="image" src="https://github.com/user-attachments/assets/036ca188-7014-45a0-9f41-5e6c6d2d5d05" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

more or less healthier for the game, and also because you can just remove peoples eyes the moment they're in the crit threshold. getting blinded for 10 seconds on a crit is also just enough of a malus compared to getting shot in both and losing ur eyes completely. also administrative decision or sm.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: eyestabs no longer cause eyes to fall out if both eyes are crit, instead leaves you completely blind until both wounds are healed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
