### PR TITLE
[Fix] Raze is dusting alive NPCs

### DIFF
--- a/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -447,8 +447,9 @@
 		to_chat(L, span_userdanger("You're scorched by flames!"))
 
 		// Vaporize dead NPC / departed player corpses
-		if((L.stat == DEAD && !L.mind) || (!L.key && !L.get_ghost(FALSE, TRUE)))
-			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob/living, dust)), 2 SECONDS)
+		if(L.stat == DEAD)
+			if(!L.mind || (!L.key && !L.get_ghost(FALSE, TRUE)))
+				addtimer(CALLBACK(L, TYPE_PROC_REF(/mob/living, dust)), 2 SECONDS)
 
 	new /obj/effect/hotspot(damage_turf) // This is the actual scary part
 


### PR DESCRIPTION
## About The Pull Request

- Fixes the corpse disposal conditional of Raze by making it check if the target is dead, then if they are valid, then dusting.

## Testing Evidence

It works now.

## Why It's Good For The Game

Fug Bixes.

## Changelog
:cl:
fix: Raze no longer dusts alive mobs
/:cl: