### PR TITLE
Changes Mortar & Pestle to a Crafting instead of Alchemy recipe

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -6,22 +6,6 @@
 	subtype_reqs = TRUE
 	structurecraft = /obj/structure/fluff/alch
 
-/datum/crafting_recipe/roguetown/alchemy/mortar
-	name = "alchemical mortar"
-	result = /obj/item/reagent_containers/glass/mortar
-	reqs = list(/obj/item/natural/stone = 1)
-	craftdiff = 2
-	structurecraft = null
-	verbage_simple = "create"
-
-/datum/crafting_recipe/roguetown/alchemy/pestle
-	name = "stone pestle"
-	result = /obj/item/pestle
-	reqs = list(/obj/item/natural/stone = 1)
-	craftdiff = 2
-	structurecraft = null
-	verbage_simple = "create"
-
 /datum/crafting_recipe/roguetown/alchemy/bbomb
 	name = "bottle bomb"
 	category = "Table"

--- a/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/weapons_tools.dm
@@ -601,3 +601,20 @@
 				/obj/item/natural/stoneblock = 3)
 	skillcraft = /datum/skill/craft/carpentry
 	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/survival/mortar
+	name = "alchemical mortar"
+	result = /obj/item/reagent_containers/glass/mortar
+	reqs = list(/obj/item/natural/stone = 1)
+	craftdiff = 1
+	structurecraft = null
+	verbage_simple = "create"
+
+/datum/crafting_recipe/roguetown/survival/pestle
+	name = "stone pestle"
+	result = /obj/item/pestle
+	reqs = list(/obj/item/natural/stone = 1)
+	craftdiff = 1
+	structurecraft = null
+	verbage_simple = "create"
+


### PR DESCRIPTION
## About The Pull Request

Changes the craft difficulty of mortar & pestle from 2 -> 1, and their crafting skill from Alchemy to Crafting.

## Testing Evidence

<img width="769" height="208" alt="image" src="https://github.com/user-attachments/assets/7c9554cb-fc5a-441e-97b5-dfc6fa515833" />

## Why It's Good For The Game

The mortar and pestle's ability to grind things up gate several crafting recipes wholly disconnected from alchemy, so it's silly that their crafting is completely gated behind your class having alchemy skill. Let farmers grind their crops, let engineers make coal dust, and the extremely rare ceramics player mix glass.