### PR TITLE
[Fix] Restores submissive and oneshottable Boulders

### DIFF
--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -394,11 +394,13 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 	. += span_info("Left-clicking a rock with a stone has a chance to spawn sparks. Sparks can be used to reignite extinguished torches, lampterns, hearths, and other igniteable structures.")
 	. += span_info("Left-clicking a rock with a chisel will turn it into a stone block, which can be used for masonry and construction.")
 
-/obj/item/natural/rock/Initialize(mapload, autodeconstruct)
+/obj/item/natural/rock/Initialize(mapload, autodeconstruct, hp_override)
 	icon_state = "stonebig[rand(1,2)]"
 	if(autodeconstruct)
 		deconstruct()
 		return
+	if(hp_override)
+		obj_integrity = hp_override
 	..()
 
 /obj/item/natural/rock/Crossed(mob/living/L)


### PR DESCRIPTION
## About The Pull Request

- Boulders unearthed by steel picks are once again submissive and oneshottable.

## Testing Evidence

Apparently, Constructs merge ate this rock too. Oops.

## Why It's Good For The Game

Fug Bixes.

## Changelog
:cl:
fix: Restores a lost functionality from another PR
/:cl: