### PR TITLE
[Fix] Decceleration oversight

### DIFF
--- a/code/modules/spells/spell_types/classunique/vizier/acceleration.dm
+++ b/code/modules/spells/spell_types/classunique/vizier/acceleration.dm
@@ -84,7 +84,7 @@
 			qdel(after_image_component)
 		afterimage_active = FALSE
 
-	owner.apply_status_effect(/datum/status_effect/debuff/decel, 14 SECONDS)
+	owner.apply_status_effect(/datum/status_effect/debuff/decel, 4 SECONDS)
 
 	to_chat(owner, span_red("Time catches up with me, with its toll."))
 


### PR DESCRIPTION
## About The Pull Request

- This is slowing you down for 14 seconds instead of the intended 4 seconds.

## Testing Evidence

I am a goober, changed a var from 14 to 4.

## Why It's Good For The Game

I don't know how I missed this when doing my previous adjustment, fucked up.

## Changelog
:cl:
fix: Fixes accel's deaccel having the wrong value
/:cl: