### PR TITLE
[Cl*ss Edit] Xylixians Acolytes & Missionaries getting instruments. Necrans Missionaries getting Scythe/Shovel

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -695,6 +695,33 @@
 			H.cmode_music = 'sound/music/combat_jester.ogg'
 			var/datum/inspiration/I = new /datum/inspiration(H)
 			I.grant_inspiration(H, bard_tier = BARD_T2)
+			if(H.mind)
+				var/instruments = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman", "Psyaltery", "Flute", "Drum", "Shamisen")
+				var/instrument_choice = tgui_input_list(H, "Choose your instrument.", "TAKE UP ARMS", instruments)
+				H.set_blindness(0)
+				switch(instrument_choice)
+					if("Harp")
+						backr = /obj/item/rogue/instrument/harp
+					if("Lute")
+						backr = /obj/item/rogue/instrument/lute
+					if("Accordion")
+						backr = /obj/item/rogue/instrument/accord
+					if("Guitar")
+						backr = /obj/item/rogue/instrument/guitar
+					if("Hurdy-Gurdy")
+						backr = /obj/item/rogue/instrument/hurdygurdy
+					if("Viola")
+						backr = /obj/item/rogue/instrument/viola
+					if("Vocal Talisman")
+						backr = /obj/item/rogue/instrument/vocals
+					if("Psyaltery")
+						backr = /obj/item/rogue/instrument/psyaltery
+					if("Flute")
+						backr = /obj/item/rogue/instrument/flute
+					if("Drum")
+						backr = /obj/item/rogue/instrument/drum
+					if("Shamisen")
+						backr = /obj/item/rogue/instrument/shamisen
 		if (/datum/patron/divine/pestra)
 			cloak = /obj/item/clothing/cloak/tabard/devotee/pestra
 			H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -660,6 +660,14 @@
 			ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
 			H.adjust_skillrank(/datum/skill/misc/athletics, SKILL_LEVEL_APPRENTICE, TRUE) // digging graves and carrying bodies builds muscles probably.
 			H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
+			var/list/necra_tools = list("Silver Shovel", "Silver Scythe")
+			var/tool_choice = input(H, "A reaper, or a digger?", "HOW WILL YOU APPEASE THE UNDERMAIDEN?") as anything in necra_tools
+			switch(tool_choice) // choose wisely... larp or effectiveness?
+				if("Silver Shovel")
+					l_hand = /obj/item/rogueweapon/shovel/silver
+				if("Silver Scythe") // o lawd we farmin
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
+					l_hand = /obj/item/rogueweapon/scythe/silver
 		if (/datum/patron/divine/malum)
 			head = /obj/item/clothing/head/roguetown/roguehood //placeholder
 			cloak = /obj/item/clothing/cloak/tabard/devotee/malum
@@ -701,27 +709,27 @@
 				H.set_blindness(0)
 				switch(instrument_choice)
 					if("Harp")
-						backr = /obj/item/rogue/instrument/harp
+						l_hand = /obj/item/rogue/instrument/harp
 					if("Lute")
-						backr = /obj/item/rogue/instrument/lute
+						l_hand = /obj/item/rogue/instrument/lute
 					if("Accordion")
-						backr = /obj/item/rogue/instrument/accord
+						l_hand = /obj/item/rogue/instrument/accord
 					if("Guitar")
-						backr = /obj/item/rogue/instrument/guitar
+						l_hand = /obj/item/rogue/instrument/guitar
 					if("Hurdy-Gurdy")
-						backr = /obj/item/rogue/instrument/hurdygurdy
+						l_hand = /obj/item/rogue/instrument/hurdygurdy
 					if("Viola")
-						backr = /obj/item/rogue/instrument/viola
+						l_hand = /obj/item/rogue/instrument/viola
 					if("Vocal Talisman")
-						backr = /obj/item/rogue/instrument/vocals
+						l_hand = /obj/item/rogue/instrument/vocals
 					if("Psyaltery")
-						backr = /obj/item/rogue/instrument/psyaltery
+						l_hand = /obj/item/rogue/instrument/psyaltery
 					if("Flute")
-						backr = /obj/item/rogue/instrument/flute
+						l_hand = /obj/item/rogue/instrument/flute
 					if("Drum")
-						backr = /obj/item/rogue/instrument/drum
+						l_hand = /obj/item/rogue/instrument/drum
 					if("Shamisen")
-						backr = /obj/item/rogue/instrument/shamisen
+						l_hand = /obj/item/rogue/instrument/shamisen
 		if (/datum/patron/divine/pestra)
 			cloak = /obj/item/clothing/cloak/tabard/devotee/pestra
 			H.adjust_skillrank(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
@@ -747,10 +755,10 @@
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Woodstaff")
-				backr = /obj/item/rogueweapon/woodstaff
+				r_hand = /obj/item/rogueweapon/woodstaff
 			if("Quarterstaff")
 				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
-				l_hand = /obj/item/rogueweapon/scabbard/gwstrap
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
 	if(istype(H.patron, /datum/patron/divine))
 		// For now, only Tennites get this. Heretics can have a special treat later
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -660,14 +660,14 @@
 			ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
 			H.adjust_skillrank(/datum/skill/misc/athletics, SKILL_LEVEL_APPRENTICE, TRUE) // digging graves and carrying bodies builds muscles probably.
 			H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
-			var/list/necra_tools = list("Silver Shovel", "Silver Scythe")
+			var/list/necra_tools = list("Shovel", "Scythe")
 			var/tool_choice = input(H, "A reaper, or a digger?", "HOW WILL YOU APPEASE THE UNDERMAIDEN?") as anything in necra_tools
 			switch(tool_choice) // choose wisely... larp or effectiveness?
-				if("Silver Shovel")
-					l_hand = /obj/item/rogueweapon/shovel/silver
-				if("Silver Scythe") // o lawd we farmin
+				if("Shovel")
+					l_hand = /obj/item/rogueweapon/shovel
+				if("Scythe") // o lawd we farmin
 					backr = /obj/item/rogueweapon/scabbard/gwstrap
-					l_hand = /obj/item/rogueweapon/scythe/silver
+					l_hand = /obj/item/rogueweapon/scythe
 		if (/datum/patron/divine/malum)
 			head = /obj/item/clothing/head/roguetown/roguehood //placeholder
 			cloak = /obj/item/clothing/cloak/tabard/devotee/malum

--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -177,6 +177,33 @@
 			var/datum/inspiration/I = new /datum/inspiration(H)
 			I.grant_inspiration(H, bard_tier = BARD_T2)
 			shirt = /obj/item/clothing/suit/roguetown/armor/vestments_padded
+			if(H.mind)
+				var/instruments = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman", "Psyaltery", "Flute", "Drum", "Shamisen")
+				var/instrument_choice = tgui_input_list(H, "Choose your instrument.", "TAKE UP ARMS", instruments)
+				H.set_blindness(0)
+				switch(instrument_choice)
+					if("Harp")
+						backr = /obj/item/rogue/instrument/harp
+					if("Lute")
+						backr = /obj/item/rogue/instrument/lute
+					if("Accordion")
+						backr = /obj/item/rogue/instrument/accord
+					if("Guitar")
+						backr = /obj/item/rogue/instrument/guitar
+					if("Hurdy-Gurdy")
+						backr = /obj/item/rogue/instrument/hurdygurdy
+					if("Viola")
+						backr = /obj/item/rogue/instrument/viola
+					if("Vocal Talisman")
+						backr = /obj/item/rogue/instrument/vocals
+					if("Psyaltery")
+						backr = /obj/item/rogue/instrument/psyaltery
+					if("Flute")
+						backr = /obj/item/rogue/instrument/flute
+					if("Drum")
+						backr = /obj/item/rogue/instrument/drum
+					if("Shamisen")
+						backr = /obj/item/rogue/instrument/shamisen
 		else
 			head = /obj/item/clothing/head/roguetown/roguehood/astrata
 			neck = /obj/item/clothing/neck/roguetown/psicross/astrata


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Shuffled some items around. Gave Xylian Acolytes and Missionaries an instrument of choice as other bards have. Necran adventurers get the same tool Acolytes get. (except not silver)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="635" height="521" alt="image" src="https://github.com/user-attachments/assets/739f304f-9306-42d8-af51-be05705f5aca" />

<img width="285" height="517" alt="image" src="https://github.com/user-attachments/assets/dbbeaebe-2a77-40bf-a152-b6254346e862" />

<img width="311" height="500" alt="image" src="https://github.com/user-attachments/assets/6a477fdb-f19f-453d-888a-63609f50312c" />

<img width="1053" height="590" alt="image" src="https://github.com/user-attachments/assets/92d8022a-b39c-48fd-bebe-ae603577f150" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Finding an instrument to access your class features turn into a huge pain in the ass for Xylix characters, not to mention not all instruments spawn in the map and means you wont be able to use a part of your class. 

The Necran stuff I added it as an afterthough to keep consistent, went with regular as to not make shenanigans with silver.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
qol: Xylix Acolytes  / Missionaries get one instrument of choice.
balance: Necran Missionaries get their (non) silver shovel / Scythe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
