### PR TITLE
[Cl*ss Edit] Puts harlequin on par with the minstrel

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/trader/harlequin.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/trader/harlequin.dm
@@ -41,7 +41,15 @@
 		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
+	var/datum/inspiration/I = new /datum/inspiration(H)
+	I.grant_inspiration(H, bard_tier = BARD_T2)
 	if(H.mind)
+		if(HAS_TRAIT(H, TRAIT_PERMAMUTE))
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_chair)
+		else
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/telljoke)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/telltragedy)
 		var/weapons = list("Harp","Lute","Accordion","Guitar","Hurdy-Gurdy","Viola","Vocal Talisman")
 		var/weapon_choice = input(H, "Choose your instrument.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)


### PR DESCRIPTION
indirectly allows for more mime girls.

## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Gives Harlequin (trader class) access to Bard T2 type and the jester's spells (tell Joke/Tragedy or Mime spells if they are mute)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="781" height="648" alt="image" src="https://github.com/user-attachments/assets/cb8f9773-4b76-42a6-9160-065127ff294a" />


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

Well, I like mime girls, so I hope this make more people play them, it also allows people that main Jesters to have a way to play outside the keep, they dont get the super stats nor they get vicious mockery as the other bard classes, nor they get the all powerful z level jumps, but they are with this in a good playable place which should allow people to have some fun. I could see reasons to kick down a notch their speed as a result, but I am open to edits!

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: Gives Harlequin (trader class) access to Bard T2 type and the jester's spells (tell Joke/Tragedy or Mime spells if they are mute)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
