### PR TITLE
Restore Unique Gem Staff Sprites

### DIFF
--- a/code/game/objects/items/spell_implements/_spell_implement.dm
+++ b/code/game/objects/items/spell_implements/_spell_implement.dm
@@ -53,24 +53,47 @@
 	implement.remove_filter(IMPLEMENT_GLOW_FILTER)
 	implement.add_filter(IMPLEMENT_GLOW_FILTER, 2, list("type" = "outline", "color" = spell_color, "alpha" = glow_alpha, "size" = 1))
 
+GLOBAL_LIST_INIT(implement_choices, list(
+		"lesser" = list(
+			"Toper Staff" = /obj/item/rogueweapon/woodstaff/implement,
+			"Amythorz Staff" = /obj/item/rogueweapon/woodstaff/implement/amethyst,
+			"Wand & Shield" = /obj/item/rogueweapon/wand
+			),
+		"greater" = list(
+			"Gemerald Staff" = /obj/item/rogueweapon/woodstaff/implement/greater,
+			"Rontz Staff" = /obj/item/rogueweapon/woodstaff/implement/greater/ruby,
+			"Blortz Staff" = /obj/item/rogueweapon/woodstaff/implement/greater/quartz,
+			"Saffira Staff" = /obj/item/rogueweapon/woodstaff/implement/greater/sapphire,
+			"Wand & Shield" = /obj/item/rogueweapon/wand/greater
+			),
+		"grand" = list(
+			"Dorpel Staff" = /obj/item/rogueweapon/woodstaff/implement/grand,
+			"Staff of the Riddlesteel" = /obj/item/rogueweapon/woodstaff/implement/grand/riddle,
+			"Wand & Shield" = /obj/item/rogueweapon/wand/grand
+			)
+		))
+
 /// Prompts the user to choose between a wand or staff implement of the given tier.
 /// Returns the chosen implement type path, or staff by default.
 /// If Wand is chosen, additionally puts a wooden shield in H's hands and grants
 /// Apprentice-level Shields skill so the wand+shield loadout is actually usable.
 /proc/choose_implement(mob/living/carbon/human/H, tier = "lesser")
-	var/choice = tgui_input_list(H, "Choose your implement.", "IMPLEMENT", list("Staff", "Wand & Shield"))
+	if(!(tier in GLOB.implement_choices))
+		return null
+	var/choice = tgui_input_list(H, "Choose your implement.", "IMPLEMENT", GLOB.implement_choices[tier])
 	if(!choice)
-		choice = "Staff"
-	var/implement_path
-	switch(tier)
-		if("lesser")
-			implement_path = choice == "Wand & Shield" ? /obj/item/rogueweapon/wand : /obj/item/rogueweapon/woodstaff/implement
-		if("greater")
-			implement_path = choice == "Wand & Shield" ? /obj/item/rogueweapon/wand/greater : /obj/item/rogueweapon/woodstaff/implement/greater
-		if("grand")
-			implement_path = choice == "Wand & Shield" ? /obj/item/rogueweapon/wand/grand : /obj/item/rogueweapon/woodstaff/implement/grand
-		else
-			implement_path = /obj/item/rogueweapon/woodstaff/implement
+		switch(tier)
+			if("lesser")
+				choice = "Toper Staff"
+			if("greater")
+				choice = "Gemerald Staff"
+			if("grand")
+				choice = "Dorpel Staff"
+			else
+				choice = "Toper Staff"
+	if(!(choice in GLOB.implement_choices[tier]))
+		return null
+	var/implement_path = GLOB.implement_choices[tier][choice]
 
 	if(choice == "Wand & Shield" && H)
 		H.put_in_hands(new implement_path(H))

--- a/code/game/objects/items/spell_implements/implement_recipes.dm
+++ b/code/game/objects/items/spell_implements/implement_recipes.dm
@@ -10,7 +10,7 @@
 
 /datum/crafting_recipe/roguetown/arcana/staff/lesser_amethyst
 	name = "lesser staff (amethyst)"
-	result = /obj/item/rogueweapon/woodstaff/implement
+	result = /obj/item/rogueweapon/woodstaff/implement/amythest
 	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
 				/obj/item/roguegem/amethyst = 1)
 
@@ -22,19 +22,19 @@
 
 /datum/crafting_recipe/roguetown/arcana/staff/greater_sapphire
 	name = "greater staff (saffira)"
-	result = /obj/item/rogueweapon/woodstaff/implement/greater
+	result = /obj/item/rogueweapon/woodstaff/implement/greater/sapphire
 	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
 				/obj/item/roguegem/violet = 1)
 
 /datum/crafting_recipe/roguetown/arcana/staff/greater_quartz
 	name = "greater staff (blortz)"
-	result = /obj/item/rogueweapon/woodstaff/implement/greater
+	result = /obj/item/rogueweapon/woodstaff/implement/greater/quartz
 	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
 				/obj/item/roguegem/blue = 1)
 
 /datum/crafting_recipe/roguetown/arcana/staff/greater_ruby
 	name = "greater staff (rontz)"
-	result = /obj/item/rogueweapon/woodstaff/implement/greater
+	result = /obj/item/rogueweapon/woodstaff/implement/greater/ruby
 	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
 				/obj/item/roguegem/ruby = 1)
 
@@ -46,7 +46,7 @@
 
 /datum/crafting_recipe/roguetown/arcana/staff/grand_riddle
 	name = "grand staff (riddle of steel)"
-	result = /obj/item/rogueweapon/woodstaff/implement/grand
+	result = /obj/item/rogueweapon/woodstaff/implement/grand/riddle
 	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
 				/obj/item/riddleofsteel = 1)
 

--- a/code/game/objects/items/spell_implements/implement_recipes.dm
+++ b/code/game/objects/items/spell_implements/implement_recipes.dm
@@ -10,7 +10,7 @@
 
 /datum/crafting_recipe/roguetown/arcana/staff/lesser_amethyst
 	name = "lesser staff (amethyst)"
-	result = /obj/item/rogueweapon/woodstaff/implement/amythest
+	result = /obj/item/rogueweapon/woodstaff/implement/amethyst
 	reqs = list(/obj/item/rogueweapon/woodstaff = 1,
 				/obj/item/roguegem/amethyst = 1)
 

--- a/code/game/objects/items/spell_implements/staff.dm
+++ b/code/game/objects/items/spell_implements/staff.dm
@@ -12,7 +12,7 @@
 	max_integrity = 150
 	sellprice = 34
 
-/obj/item/rogueweapon/woodstaff/amythest
+/obj/item/rogueweapon/woodstaff/implement/amethyst
 	icon_state = "amethyststaff"
 
 /obj/item/rogueweapon/woodstaff/implement/greater
@@ -35,7 +35,6 @@
 	icon_state = "sapphirestaff"
 
 /obj/item/rogueweapon/woodstaff/implement/grand
-	icon_state = "amethyststaff"
 	base_implement_name = "grand staff"
 	name = "grand staff"
 	desc = "A masterwork staff set with a gem of extraordinary quality. The gem captures excess energy dissipated into the air when a spell is cast, giving most of it back to the wielder - arcyne economy refined to an art."

--- a/code/game/objects/items/spell_implements/staff.dm
+++ b/code/game/objects/items/spell_implements/staff.dm
@@ -12,6 +12,9 @@
 	max_integrity = 150
 	sellprice = 34
 
+/obj/item/rogueweapon/woodstaff/amythest
+	icon_state = "amethyststaff"
+
 /obj/item/rogueweapon/woodstaff/implement/greater
 	base_implement_name = "greater staff"
 	name = "greater staff"
@@ -22,7 +25,17 @@
 	max_integrity = 200
 	sellprice = 42
 
+/obj/item/rogueweapon/woodstaff/implement/greater/ruby
+	icon_state = "rubystaff"
+
+/obj/item/rogueweapon/woodstaff/implement/greater/quartz
+	icon_state = "quartzstaff"
+
+/obj/item/rogueweapon/woodstaff/implement/greater/sapphire
+	icon_state = "sapphirestaff"
+
 /obj/item/rogueweapon/woodstaff/implement/grand
+	icon_state = "amethyststaff"
 	base_implement_name = "grand staff"
 	name = "grand staff"
 	desc = "A masterwork staff set with a gem of extraordinary quality. The gem captures excess energy dissipated into the air when a spell is cast, giving most of it back to the wielder - arcyne economy refined to an art."
@@ -31,6 +44,9 @@
 	implement_refund = IMPLEMENT_REFUND_GRAND
 	max_integrity = 250
 	sellprice = 121
+
+/obj/item/rogueweapon/woodstaff/implement/grand/riddle
+	icon_state = "riddlestaff"
 
 /obj/item/rogueweapon/woodstaff/implement/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
when ansari consolidated staves into 3 tiers, many of the old staff sprites went unused, and crafting a staff with a rontz or sapphire would make a gemerald staff. this just adds cosmetic-only (literally the only thing that changes is the iconstate) variants for the existing recipes

## Testing Evidence
<img width="495" height="65" alt="image" src="https://github.com/user-attachments/assets/aa1a67bf-e09b-47ab-8cc4-272a4f830e82" />


<img width="160" height="182" alt="image" src="https://github.com/user-attachments/assets/502dcefe-756b-4b59-baaa-7a48fbe78f2f" />


<img width="481" height="359" alt="image" src="https://github.com/user-attachments/assets/0c854144-2bb4-4964-ab98-dff67a0694f1" />


<img width="595" height="522" alt="image" src="https://github.com/user-attachments/assets/3774a0d7-80c1-4789-8fff-19eff009cf9d" />


<img width="183" height="130" alt="image" src="https://github.com/user-attachments/assets/455b08ee-6b4e-44ee-bde3-e083517570bb" />


<img width="543" height="377" alt="image" src="https://github.com/user-attachments/assets/e323bf4a-42ff-4ca7-94e1-343e25e8decd" />


<img width="608" height="564" alt="image" src="https://github.com/user-attachments/assets/443d7348-6ecd-4e3b-8fad-a1049aceb179" />


<img width="148" height="113" alt="image" src="https://github.com/user-attachments/assets/86e551ef-7791-4f21-8847-e4cb45ba62ee" />


<img width="110" height="107" alt="image" src="https://github.com/user-attachments/assets/a7fc110a-8855-4872-8123-91cec0030e79" />





## Why It's Good For The Game
rontz staff drip. also lets you show off if you make a needlessly expensive grand staff out of a riddlesteel

## Changelog

:cl:
add: Gem staves now have unique sprites again
/:cl:
