### PR TITLE
increase bardiche purchase/crafting costs to steel tier to match its performance

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms/polearms.dm
@@ -925,7 +925,7 @@
 	desc = "A beautiful variant of the halberd. Its reinforced shaft provides it with greater durability against attacks."
 	icon_state = "bardiche"
 	anvilrepair = /datum/skill/craft/weaponsmithing
-	smeltresult = /obj/item/ingot/iron
+	smeltresult = /obj/item/ingot/steel //this is a steel weapon.
 	max_blade_int = 300
 	wdefense = 5
 	wbalance = WBALANCE_HEAVY

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_iron.dm
@@ -124,11 +124,6 @@
 	cost = 50 // 2 Iron Ingot, 1 Small Log, 1 Chain
 	contains = list(/obj/item/rogueweapon/flail/peasantwarflail/iron)
 
-/datum/supply_pack/rogue/iron_weapons/bardiche
-	name = "Bardiche"
-	cost = 45 // 2 Iron Ingot, 1 Small Log
-	contains = list(/obj/item/rogueweapon/halberd/bardiche)
-
 /datum/supply_pack/rogue/iron_weapons/lucerne
 	name = "Lucerne Hammer"
 	cost = 45 // 2 Iron Ingot, 1 Small Log

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
@@ -175,7 +175,7 @@
 	cost = 75 // 2 Steel Ingot, 1 Small Log
 	contains = list(/obj/item/rogueweapon/halberd)
 
-/datum/supply_pack/rogue/iron_weapons/bardiche
+/datum/supply_pack/rogue/steel_weapons/bardiche
 	name = "Bardiche"
 	cost = 75 // 2 Steel Ingot, 1 Small Log
 	contains = list(/obj/item/rogueweapon/halberd/bardiche)

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
@@ -175,6 +175,11 @@
 	cost = 75 // 2 Steel Ingot, 1 Small Log
 	contains = list(/obj/item/rogueweapon/halberd)
 
+/datum/supply_pack/rogue/iron_weapons/bardiche
+	name = "Bardiche"
+	cost = 75 // 2 Steel Ingot, 1 Small Log
+	contains = list(/obj/item/rogueweapon/halberd/bardiche)
+
 /datum/supply_pack/rogue/steel_weapons/eaglebeak
 	name = "Eagle's Beak"
 	cost = 75 // 2 Steel Ingot, 1 Small Log

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -628,13 +628,6 @@
 	created_item = /obj/item/rogueweapon/spear/spellblade
 	display_category = ITEM_CAT_WEAPONS_POLEARMS
 
-/datum/anvil_recipe/weapons/iron/bardiche
-	name = "Bardiche, Iron (+1 Iron, +1 Small Log)"
-	req_bar = /obj/item/ingot/iron
-	additional_items = list(/obj/item/ingot/iron, /obj/item/grown/log/tree/small)
-	created_item = /obj/item/rogueweapon/halberd/bardiche
-	display_category = ITEM_CAT_WEAPONS_POLEARMS
-
 /datum/anvil_recipe/weapons/iron/lucerne
 	name = "Lucerne, Iron (+1 Iron, +1 Small Log)"
 	req_bar = /obj/item/ingot/iron
@@ -919,6 +912,13 @@
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/halberd
+	display_category = ITEM_CAT_WEAPONS_POLEARMS
+
+/datum/anvil_recipe/weapons/steel/bardiche
+	name = "Bardiche, Steel (+1 Steel, +1 Small Log)" //This thing inherits directly from the steel halberd with neutral-to-positive changes. It is thus firmly steel tier.
+	req_bar = /obj/item/ingot/steel
+	additional_items = list(/obj/item/ingot/steel, /obj/item/grown/log/tree/small)
+	created_item = /obj/item/rogueweapon/halberd/bardiche
 	display_category = ITEM_CAT_WEAPONS_POLEARMS
 
 /datum/anvil_recipe/weapons/steel/eaglebeak


### PR DESCRIPTION
## About The Pull Request

Consider, if you will, the humble steel halberd. Costs 75 mam to buy (more or less 120 mam after silverface costs) and is craftable with two steel ingots and journeyman weaponsmithing.

Now, consider the bardiche. Inheriting directly from said halberd in the code, it is very similar. The changes can be summed up as losing 1 point of wdefence (6 ->5), gaining 100 points of sharpness (200->300), and swapping a halberd chop intent for a forward cleave.

You would expect a sidegrade to a steel weapon to also be a steel weapon, but the bardiche has the purchase & crafting costs of an iron weapon instead. It costs 45 mam (~70 after silverface costs), and is craftable with two iron ingots and apprentice weaponsmithing, making it a halberd equivalent at vastly lower cost.


This PR fixes that and makes the costs to buy/craft identical between the two weapons.


## Testing Evidence

<img width="540" height="315" alt="image" src="https://github.com/user-attachments/assets/55c5e5fd-cdd2-4241-ba8f-04646dc1aeb4" />
<img width="580" height="530" alt="image" src="https://github.com/user-attachments/assets/1838a949-e82c-4ded-b4b2-52a929da32f9" />




## Why It's Good For The Game

Steel tier weapons should have steel tier costs.

## Changelog

:cl:
balance: rebalanced bardiche mam/crafting costs to match its performance as a sidegrade weapon to the steel halberd. Mam costs 45 -> 75, craft costs iron -> steel ingots and apprentice -> journeyman weaponsmithing.
/:cl:
