### PR TITLE
[Fix] More Golgatha fixes

### DIFF
--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -453,10 +453,11 @@ Inquisitorial armory down here
 		return
 	new /obj/effect/temp_visual/censer_dust(get_turf(attacker))
 	new /obj/effect/temp_visual/censer_dust(get_turf(attacker))
+	new /obj/effect/temp_visual/frozen_mist_tile(get_turf(attacker))
 	if(issimple(attacker) || !attacker.mind)
 		attacker.apply_status_effect(/datum/status_effect/syonchurn, src)
 	
-	attacker.adjustFireLoss(9)
+	attacker.adjustFireLoss(10)
 
 #define SYONCHURN_FILTER "syonchurn glow"
 
@@ -469,7 +470,7 @@ Inquisitorial armory down here
 	id = "syon_churned"
 	alert_type = /atom/movable/screen/alert/status_effect/syonchurn
 	duration = -1
-	tick_interval = 1 SECONDS
+	tick_interval = 2 SECONDS
 	examine_text = "<font color='#00fff2'><b>SUBJECTPRONOUN is seared in body and soul by motes of lingering comet dust!</b></font>"
 	status_type = STATUS_EFFECT_REFRESH
 	effectedstats = list(STATKEY_LCK = -2, STATKEY_SPD = -2)
@@ -496,8 +497,10 @@ Inquisitorial armory down here
 
 /datum/status_effect/syonchurn/refresh()
 	. = ..()
-	intensity++
-	to_chat(owner, span_boldwarning("The shard's radiance intensifies, scourging me for my aggression!"))
+	if(intensity <= 10)
+		intensity++
+		if(prob(25))
+			to_chat(owner, span_boldwarning("The shard's radiance intensifies, scourging me for my aggression!"))
 
 /datum/status_effect/syonchurn/process()
 	. = ..()
@@ -516,9 +519,6 @@ Inquisitorial armory down here
 		to_chat(owner, span_blue("Away from the Golgatha's radiance, the searing dust fades into nothing."))
 		qdel(src)
 		return
-
-	if(!owner.mind)
-		owner.adjustFireLoss((damage_per_tick * intensity) * 3)
 
 	owner.adjustFireLoss(damage_per_tick * intensity)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -510,6 +510,11 @@
 		if(M.incapacitated())
 			return FALSE
 
+		if(ishuman(src))
+			var/mob/living/carbon/human/H = src
+			if(H.has_active_golgatha())
+				H.process_golgatha_rebuke(M)
+
 		if(checkguard(M))
 			return FALSE
 


### PR DESCRIPTION
## About The Pull Request

- Golgatha's values are wrong and causing NPCs to near-instantly die after one hit.
-> Retaliate damage from 9 to 10.
-> DoT from 1 second to 2 seconds.
-> Intensity now caps at 10x.
-> Removed an odd double-dip conditional in there.
- It should now work against simplemobs properly now, too!

## Testing Evidence

Just value changes, it compiles and I tested on local. Takes a while now for a NPC to drop from that alone, and volfs are now being affected by it too, thank Psydon.

## Why It's Good For The Game

The rebuke effect is supposed to be a cute bonus thing for Syon's relic from the Inquisition freshener update. Some flavor. Not a PvE trivializer. Now one NPC will at least get most of your gear broken before they crumble due to burns. 

## Changelog
:cl:
fix: Golgatha was instakilling carbon NPCs and not working on simplemobs.
/:cl: