### PR TITLE
Small Ballistiares + Legionnarie Tweaks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -202,8 +202,8 @@ LICH SKELETONS
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
 			beltl = /obj/item/quiver/sling/paalloy
 			H.adjust_skillrank(/datum/skill/combat/slings, 1, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE) //Not enough to do shield specials, go legionnaire for that.
-			backr = /obj/item/rogueweapon/shield/bronze/paalloy // the midground for less damage output w/more defensive value
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE) //Not enough to do shield specials w/knifepick or stabs, go legionnaire for that.
+			backr = /obj/item/rogueweapon/shield/bronze/paalloy // the midground for less damage output w/more defensive value vs ranged in turn. Yes you can use the sling with it.
 	var/tabards = list("Black Cloak + Greathood", "Black Jupon", "Black Tabard", "Black Toga")
 	var/tabard_choice = input(H, "Choose your CLOAK.", "BARE YOUR MASTER'S HERALDRY.") as anything in tabards
 	switch(tabard_choice)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -64,7 +64,6 @@ LICH SKELETONS
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/paalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 
-	backr = /obj/item/rogueweapon/shield/bronze/paalloy
 	backl = /obj/item/storage/backpack/rogue/satchel
 
 	backpack_contents = list(
@@ -92,19 +91,23 @@ LICH SKELETONS
 		if("Flail")
 			beltr = /obj/item/rogueweapon/flail/sflail/paflail
 			H.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
-	var/legionnairesidearm = list("A Javelin's Bag", "A Throwing Net", "A Sling With Decrepit Pellets", "An Ancient Dagger")
+	var/legionnairesidearm = list("A Javelin's Bag + Ancient Shield", "A Throwing Net + Ancient Shield", "A Sling With Decrepit Pellets + Wooden Shield", "An Ancient Dagger + Ancient Shield")
 	var/legionnairesidearm_choice = input(H, "Choose your SYDEARM.", "RAGE AGAINST THE LYVING.") as anything in legionnairesidearm
 	switch(legionnairesidearm_choice)
-		if("A Javelin's Bag")
+		if("A Javelin's Bag + Ancient Shield")
 			beltl = /obj/item/quiver/javelin/paalloy
-		if("A Throwing Net")
+			backr = /obj/item/rogueweapon/shield/bronze/paalloy
+		if("A Throwing Net + Ancient Shield")
 			beltl = /obj/item/net
-		if("A Sling With Decrepit Pellets")
+			backr = /obj/item/rogueweapon/shield/bronze/paalloy
+		if("A Sling With Decrepit Pellets + Wooden Shield")
 			H.adjust_skillrank_up_to(/datum/skill/combat/slings, 2, TRUE) //Only apprentice, enough to be annoying
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
 			beltl = /obj/item/quiver/sling/aalloy //Decrepit vs ballistaires, weak but good for harrassment
-		if("An Ancient Dagger")
+			backr = /obj/item/rogueweapon/shield/wood //Weaker, go ballistaire for a good shield w/this
+		if("An Ancient Dagger + Ancient Shield")
 			beltl = /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
+			backr = /obj/item/rogueweapon/shield/bronze/paalloy
 	var/tabards = list("Black Jupon", "Black Tabard", "Black Cloak + Greathood", "Black Toga")
 	var/tabard_choice = input(H, "Choose your CLOAK.", "BARE YOUR MASTER'S HERALDRY.") as anything in tabards
 	switch(tabard_choice)
@@ -171,7 +174,7 @@ LICH SKELETONS
 		/obj/item/storage/belt/rogue/pouch/coins/aalloy = 1 //Hilarious
 	)
 	H.adjust_blindness(-3)
-	var/weapons = list("Bow & 20 Arrows", "Bow & 20 Broadheads", "Longbow & 20 Arrows", "Longbow & 20 Broadheads", "Crossbow & 16 Bolts", "Sling")
+	var/weapons = list("Bow & 20 Arrows", "Bow & 20 Broadheads", "Longbow & 20 Arrows", "Longbow & 20 Broadheads", "Crossbow & 16 Bolts", "Sling + Ancient Shield")
 	var/weapon_choice = input(H, "Choose your MISSILE.", "CONDEMN THE LYVING FROM AFAR.") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
@@ -195,10 +198,12 @@ LICH SKELETONS
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/aalloy
 			beltl = /obj/item/quiver/bolt/paalloy
 			H.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
-		if("Sling")
+		if("Sling + Ancient Shield")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
 			beltl = /obj/item/quiver/sling/paalloy
 			H.adjust_skillrank(/datum/skill/combat/slings, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE) //Not enough to do shield specials, go legionnaire for that.
+			backr = /obj/item/rogueweapon/shield/bronze/paalloy // the midground for less damage output w/more defensive value
 	var/tabards = list("Black Cloak + Greathood", "Black Jupon", "Black Tabard", "Black Toga")
 	var/tabard_choice = input(H, "Choose your CLOAK.", "BARE YOUR MASTER'S HERALDRY.") as anything in tabards
 	switch(tabard_choice)


### PR DESCRIPTION
## About The Pull Request

Legionnarie now gets a weaker wooden shield vs gilbronze if they pick sling + decrepit pellets as their sidearm picks. Otherwise they get the new classic shield they do now. You take a tradeoff so the ranged skele will do it better than you in both ways usually.

Ballistiares gets gilbronze shield w/apprentice shield picks on slings choice, so they stand out more as a midground where they lose offensive rapid potental to down people in armor to instead gain defensive potental/w high ammo for harrassment vs other ranged picks.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

- It builds.
- Picks line up in code.
- It shows ingame
- *accidentally re-discover a bug I've no idea how to fix yet that shell outburst somehow kills you as a lich while exploding your own skeletons as-intended (minus killing you for some reasoning for doing it?) but that's nothing to do with this PR*

<img width="361" height="312" alt="Aeiou" src="https://github.com/user-attachments/assets/762df7bb-ea4f-450a-b6ca-d38c47bfce7d" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Ballistiares should be better than legionnarie with sling (either from sidearm or virtue picks), the shield has decent vs-ranged protection but won't stop a fireball from melting you still, nor will it let you parry nearly-as-well as a legionnarie with one using your knife. **you can use a shield with the sling, vs other ranged weapons as-is.**

`Apprentice` shields is too low to use shield special or be particularly good but it'll help vs ranged or maybe being a bit deadlier if you somehow run out of ammo.

Legionnarie's sidearm pick'll be worse. take a virtue for almost the same damage output if you /really/ want the better shield off-the-bat. I can't stop you.

---

Virtues exist so this "pick" was also already achievable before my first set of tweaks, this just makes it more balanced as a mainstream choice and keeps ballistarries in the game a bit when it comes to their sling choice instead of just being outright worse than taking a *weapon* and just making a sling + rock ammo.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: sling ballistiares gets a shield + apprentice skill in shields to fit them into the defensive-choice for ranged where their other picks of bows + crossbow are more-fitted for offensive.
balance: Legionnarie taking sling gets a wooden shield instead of ancient, slightly less durability and 10% less ranged blocking sacrificed for being able to pressure people at a distance poorly and be able to fight up-close.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
