### PR TITLE
hardened leather boot standardization

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -7,12 +7,12 @@
 	crate_type = /obj/structure/closet/crate/chest/merchant
 
 /datum/supply_pack/rogue/light_armor/rough_headband
-	name = "Roughspun Headband"
+	name = "Headband, Roughspun"
 	cost = 25 // 2 cloth + 5 fiber, added 7 for SF pricing
 	contains = list(/obj/item/clothing/head/roguetown/headband/monk/barbarian)
 
 /datum/supply_pack/rogue/light_armor/padded_headband
-	name = "Padded Headband"
+	name = "Headband, Padded"
 	cost = 35 // 4 cloth + 4 fiber, added 10 for SF pricing
 	contains = list(/obj/item/clothing/head/roguetown/headband/monk)
 
@@ -22,7 +22,7 @@
 	contains = list(/obj/item/clothing/head/roguetown/armingcap)
 
 /datum/supply_pack/rogue/light_armor/padded_arming_cap
-	name = "Padded Arming Cap"
+	name = "Arming Cap, Padded"
 	cost = 28 // 2 cloth + 5 fiber, ditto
 	contains = list(/obj/item/clothing/head/roguetown/armingcap/padded)
 
@@ -47,17 +47,17 @@
 	contains = list(/obj/item/clothing/gloves/roguetown/fingerless/shadowgloves/elflock)
 
 /datum/supply_pack/rogue/light_armor/leatherkini
-	name = "Leather Corslet"
+	name = "Corslet, Leather"
 	cost = 21 // you're vuln to gutspill with this
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/bikini)
 
 /datum/supply_pack/rogue/light_armor/hidekini
-	name = "Hide Corslet"
+	name = "Corslet, Hide"
 	cost = 32 // ditto
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/hide/bikini)
 
 /datum/supply_pack/rogue/light_armor/studded_leatherkini
-	name = "Studded Leather Corslet"
+	name = "Corslet, Studded Leather"
 	cost = 43 // ditto
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini)
 
@@ -112,17 +112,17 @@
 	contains = list(/obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket)
 
 /datum/supply_pack/rogue/light_armor/heavy_leather_gloves
-	name = "Heavy Leather Gloves"
+	name = "Hardened Leather Gloves"
 	cost = 20 // No one buying this lmao it costs 1 fur
 	contains = list(/obj/item/clothing/gloves/roguetown/angle)
 
 /datum/supply_pack/rogue/light_armor/heavy_leather_boots
-	name = "Heavy Leather Boots"
+	name = "Hardened Leather Boots"
 	cost = 20
 	contains = list(/obj/item/clothing/shoes/roguetown/boots/leather/reinforced)
 
 /datum/supply_pack/rogue/light_armor/heavy_padded_coif
-	name = "Heavy Padded Coif"
+	name = "Padded Coif, Heavy"
 	cost = 45 // Equivalent to a padded gambeson on the head, so pricier
 	contains = list(/obj/item/clothing/neck/roguetown/coif/heavypadding)
 
@@ -132,12 +132,12 @@
 	contains = list(/obj/item/clothing/neck/roguetown/coif/padded)
 
 /datum/supply_pack/rogue/light_armor/lightgambeson
-	name = "Light Gambeson"
+	name = "Gambeson, Light"
 	cost = 20 // these are actually really easy to make, and have far worse protection and integ than other gambersons.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/light)
 
 /datum/supply_pack/rogue/light_armor/light_arming_jacket
-	name = "Light Arming Jacket"
+	name = "Arming Jacket, Light"
 	cost = 28 // gamberson equiv that trades leg protection to be cheaper.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord/light)
 
@@ -152,12 +152,12 @@
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord)
 
 /datum/supply_pack/rogue/light_armor/padded_gambeson
-	name = "Padded Gambeson"
+	name = "Gambeson, Padded"
 	cost = 60 // Base sellprice of 25
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
 /datum/supply_pack/rogue/light_armor/padded_arming_jacket
-	name = "Padded Arming Jacket"
+	name = "Arming Jacket, Padded"
 	cost = 75 // padded gambeson equiv. that trades leg protection for 75 more integ (375 vs 300), touch pricier.
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/lord/heavy)
 

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -226,7 +226,7 @@
 	AddComponent(/datum/component/armour_filtering/positive, TRAIT_HONORBOUND)
 
 /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
-	name = "heavy leather boots"
+	name = "hardened leather boots"
 	desc = "Sturdy boots stitched together from cured leather. Stylish, firm, and sport a satisfying 'squeek' with each step."
 	icon_state = "alboots"
 	item_state = "alboots"

--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -230,7 +230,7 @@
 	desc = "Sturdy boots stitched together from cured leather. Stylish, firm, and sport a satisfying 'squeek' with each step."
 	icon_state = "alboots"
 	item_state = "alboots"
-	max_integrity = 100			//Half that of iron boots
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
 	armor = ARMOR_LEATHER			//Better than regular leather.
 	color = null
 
@@ -264,6 +264,7 @@
 	item_state = "grenzelboots"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
 	armor = ARMOR_LEATHER
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
 	allowed_race = NON_DWARVEN_RACE_TYPES
 	salvage_amount = 1
 	salvage_result = /obj/item/natural/hide/cured
@@ -581,6 +582,7 @@
 	item_state = "eastsandals"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
 	armor = ARMOR_LEATHER
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
 	sewrepair = TRUE
 
 /obj/item/clothing/shoes/roguetown/armor/rumaclan/shitty

--- a/code/modules/clothing/rogueclothes/gloves/angle.dm
+++ b/code/modules/clothing/rogueclothes/gloves/angle.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/gloves/roguetown/angle
-	name = "heavy leather gloves"
+	name = "hardened leather gloves"
 	desc = "A pair of heavy leather gloves, padded with the fur of a forest-dwelling beaste. The lengthened cuffs help to catch unseen bites from prowling monsters; a blessing, when even a single gnash can spread curses-most-foul."
 	icon_state = "angle"
 	armor = ARMOR_LEATHER

--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 
 
 /datum/outfit/job/roguetown/human/species/elf/dark/drowraider/pre_equip(mob/living/carbon/human/H)
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/shadowpants/drowraider
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/shadowvest/drowraider
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shadowshirt/elflock/drowraider
@@ -178,7 +178,7 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 	equipOutfit(new /datum/outfit/job/roguetown/human/species/elf/dark/drowraider/archer)
 
 /datum/outfit/job/roguetown/human/species/elf/dark/drowraider/archer/pre_equip(mob/living/carbon/human/H)
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/shadowpants/drowraider
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/shadowvest/drowraider
 	shirt = /obj/item/clothing/suit/roguetown/shirt/shadowshirt/elflock/drowraider

--- a/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
@@ -72,7 +72,7 @@
 	neck = /obj/item/clothing/neck/roguetown/coif
 	head = /obj/item/clothing/head/roguetown/helmet/leather
 	mask = /obj/item/clothing/mask/rogue/facemask
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	var/wepchoice = rand(1, 5)
 	switch(wepchoice)
 		if(1)
@@ -113,7 +113,7 @@
 	head = /obj/item/clothing/head/roguetown/helmet/leather
 	neck = /obj/item/clothing/neck/roguetown/coif
 	mask = /obj/item/clothing/mask/rogue/facemask
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	var/wepchoice = rand(1, 2)
 	switch(wepchoice)
 		if(1)
@@ -146,7 +146,7 @@
 	head = /obj/item/clothing/head/roguetown/helmet/skullcap
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
 	mask = /obj/item/clothing/mask/rogue/facemask
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	var/wepchoice = rand(1, 6)
 	switch(wepchoice)
 		if(1)

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
@@ -308,7 +308,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/physician
 	pants = /obj/item/clothing/under/roguetown/trou/leather/courtphysician
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/aalloy
 	gloves = /obj/item/clothing/gloves/roguetown/leather/black
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron/aalloy

--- a/code/modules/roguetown/roguecrafting/leather/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather.dm
@@ -53,7 +53,7 @@
 	sellprice = 10
 
 /datum/crafting_recipe/roguetown/leather/heavygloves
-	name = "heavy leather gloves"
+	name = "hardened leather gloves"
 	display_category = ITEM_CAT_ARMOR_GLOVES
 	result = /obj/item/clothing/gloves/roguetown/angle
 	reqs = list(/obj/item/natural/fur = 1)

--- a/code/modules/roguetown/roguecrafting/leather/leather_footwear_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_footwear_recipes.dm
@@ -14,11 +14,11 @@
 	result = /obj/item/clothing/shoes/roguetown/boots/leather
 
 /datum/crafting_recipe/roguetown/leather/footwear/boots_heavy
-	name = "heavy leather boots"
+	name = "hardened leather boots"
 	result = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	reqs = list(/obj/item/natural/hide/cured = 1,
 				/obj/item/natural/fur = 1)
-	craftdiff = 3	//Same as the heavy leather gloves.
+	craftdiff = 3	//Same as the hardened leather gloves.
 
 /datum/crafting_recipe/roguetown/leather/footwear/boots_heavy_b
 	name = "dress boots"


### PR DESCRIPTION
## About The Pull Request

Ever wondered why the heavy leather boots only had 100 integ, despite being the same price and crafting cost as the heavy leather gloves that had 250? Perhaps lost unique role gear with hardened leather properties (psydonic, otavan, fencer etc) and realized that the only generic equivalent has 50-66% less integ for no apparent reason?
- Now the heavy leather boots use ARMOR_INT_SIDE_HARDLEATHER like other hardened leather items, at 250 integ.
- Replaced with normal leather boots on NPC combatants who would have spawned with them (skeletons, some orcs, some drow).
- The heavy leather boots and gloves have both been renamed to hardened leather boots/gloves, to unify with other items of the same integrity and protection values (many also used 'heavy' in their code, so presumably an incomplete rename sweep in the past)
- Tweaked grenzelhoftian boots to the same integrity, as they did not define their integrity separate from the base boot item and were working with 80 integ despite having hardened-leather protection and needing legendary skill to make / being significantly more expensive.
- Tweaked ruma sandals to the same integrity, as they were inheriting the 300 integrity of steel plate boots, despite having leather protection, being sewable, and layering with the role's innate tattoo armor.

Ever wanted the tailor's silverface to be a little more readable in the light armor section? probably not, but I organized that as well.

## Testing Evidence

Silverface:
<img width="1152" height="698" alt="image" src="https://github.com/user-attachments/assets/a967a868-a4d2-4d41-be5a-12039b21293e" />

Boots:
<img width="568" height="474" alt="image" src="https://github.com/user-attachments/assets/93ea7efe-f90c-4047-969d-0ad7dc28a855" />
<img width="570" height="402" alt="image" src="https://github.com/user-attachments/assets/7b4c161d-1d62-416a-a065-3c87450f6226" />
<img width="575" height="424" alt="image" src="https://github.com/user-attachments/assets/9baf0dde-401c-481f-a2db-4270ef08be4d" />


## Why It's Good For The Game

Consistent integrity values for items with the same role, coverage, and protection stats.

## Changelog

:cl:
balance: Increased the integrity of heavy leather boots (and grenzelhoftian boots) to match that of other heavy/hardened leather items (100 or 80 -> 250). Removed from common NPCs to avoid easy scavenging.
balance: Reduced the integrity of Ruma sandals to match that of other hardened leather items (300 -> 250).
qol: Renamed heavy leather gloves/boots to hardened leather gloves/boots, to match other items with similar stats.
/:cl:
