### PR TITLE
[Keeper] - Slightly nerf heartbeast attacks again.

### DIFF
--- a/code/modules/roguetown/roguemachine/heartbeast/heart_status_effects.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_status_effects.dm
@@ -82,8 +82,8 @@
 		to_remove = right_leg
 	
 	if(to_remove)
-		C.visible_message(span_userdanger("[C]'s [to_remove.name] is torn off by the tendrils!"))
-		to_remove.dismember(skip_checks = TRUE)
+		C.visible_message(span_userdanger("[C]'s [to_remove.name] is twisted by the tendrils!"))
+		to_remove.dismember(damage = 190)
 
 		var/obj/effect/temp_visual/dir_setting/bloodsplatter/splatter = new(get_turf(C), pick(GLOB.cardinals))
 		splatter.color = "#880000"


### PR DESCRIPTION
## About The Pull Request
- Heartbeast attacks do not ignore dismember checks anymore, but deal 190 damage to a zone instead.

## Testing Evidence
Simple change but tested. Armor stopped dismemberment, attacks could break armor.

## Why It's Good For The Game
Sets it at a number where even the base garments can eat a hit. More forgiving gameplay for keepers so they don't have to wait on the limb reattachment cooldown and have more options for mitigating attacks. Not to mention people invited into the den. 190 is specifically chosen to respect light armor options.

## Changelog

:cl:
balance: Made territorial heartbeast attacks respect armor again, but damages armor heavily.
/:cl:
