### PR TITLE
[FIX] Anointed Longsword icon

### DIFF
--- a/code/controllers/subsystem/rogue/triumphs/triumph_modkit.dm
+++ b/code/controllers/subsystem/rogue/triumphs/triumph_modkit.dm
@@ -337,10 +337,10 @@
 
 /obj/item/rogueweapon/example/clericsword
 	name = "anointed longsword"
-	icon = 'icons/roguetown/weapons/swords32.dmi'
+	icon = 'icons/roguetown/weapons/swords64.dmi'
 	desc = "A cleric's longsword, adorned with a blade of cold iron and blessed to smite evil. Though this blessed alloy lacks the strength to \
 	sunder those who bare greater curses, it nevertheless channels enough power to dispell the lesser curses of mindless fiends-and-foes. </br>'Strike \
-	true, my child, for thy blade is thine God..'"
+	true, my child, for thy blade is thine God...'"
 	icon_state = "crusaderlongsword"
 	sheathe_icon = "crusaderlongsword"
 


### PR DESCRIPTION
## About The Pull Request

Sword was using 32 file. Should use 64.

## Testing Evidence

nah
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bug bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: The anointed longsword triumph kit works now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
