### PR TITLE
deathsight fixes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -111,7 +111,7 @@
 
 	var/threat_region = "" // Key used to look up threat region this area belongs to
 	/// Message used for deathsight. Try to be deliberately obtuse but not too obtuse.
-	var/deathsight_message = "a locale wreathed in enigmatic fog"
+	var/deathsight_message
 
 	var/coven_protected = FALSE
 	/// Whether or not an area protects against Necra's vengeful fog

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -352,6 +352,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	first_time_text = "The Dwarven Quarter"
 	soundenv = 16
 	converted_type = /area/rogue/indoors/shelter/town/dwarf
+
 /area/rogue/indoors/shelter/town/dwarf
 	icon_state = "dwarf"
 	droning_sound = 'sound/music/area/dwarf.ogg'
@@ -371,12 +372,13 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(list(/area/rogue/indoors
 	name = "dream realm"
 	icon_state = "dream"
 	first_time_text = "Abyssal Dream"
+	deathsight_message = "a vast, endless dreamscape"
 
 
 
 /area/rogue/indoors/deathsedge
 	name = "Death's Precipice"
-	deathsight_message = "an place bordering necra's grasp"
+	deathsight_message = "a place bordering necra's grasp"
 	necra_area = TRUE
 	droning_sound = 'sound/music/area/underworlddrone.ogg'
 	droning_sound_dusk = null

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -181,4 +181,6 @@ GLOBAL_LIST_EMPTY(last_words)
 	var/area/A = get_area(src)
 	if(!A)
 		return "an unknown locale, wreathed in enigmatic fog" // fallback if we can't find the area somehow?? -- This was not clear enough for me ICly that it's somewhere I shouldn't care about, now it should
+	if(!A.deathsight_message)
+		return "[A.name], a place with no deathsight message set. Report this to the devs!"
 	return A.deathsight_message


### PR DESCRIPTION
## About The Pull Request
Currently, characters with deathsight will often see deaths in areas with no deathsight message set, leading it to say "a locale wreathed in enigmatic fog." That's cool for immersion or whatever, but much of the time it's places that _should_ have one set (for example, the event area actually does have one set - it's "a place shielded from mortal gaze"), so this PR changes the default to something that is both obviously a bug and gives the name of the area so we can fix it when it happens. It also fixes one case of a deathmessageless area already, and fixes a typo in the necra's domain death message.

Once this is TM'd, it'll be updated to fix any reports that come in, and once it's fullmerged, the thread for it will stay open and deathsight fixes will be added to the very irregular proofreading PRS this one does.

## Testing Evidence
it is understandably pretty hard to test this on local, that's why it needs a TM. compiles, though

## Why It's Good For The Game
people adding new areas and forgetting to set their deathsight message leading to bodies that are harder to recover is bad actually, and way too easy to slip through the cracks right now

## Changelog
:cl:
qol: Dying in an area with no deathsight message set will now give a message that is more obviously a code error, and gives the name of the area so we can actually fix reports of it.
/:cl: