### PR TITLE
fixes mirror transform

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mirror_transform.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mirror_transform.dm
@@ -29,7 +29,7 @@
 
 /datum/action/cooldown/spell/mirror_transform/cast(atom/cast_on)
 	. = ..()
-	var/mob/living/carbon/human/H = owner
+	var/mob/living/carbon/human/H = cast_on
 	if(!istype(H))
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request
whoever last "fixed" mirror transform didn't actually make it apply to the target instead of the caster lmao

## Testing Evidence
variable change. compiles

## Why It's Good For The Game
i like when spells work. please help me i have 7 open prs

## Changelog

:cl:
fix: Mirror transform now actually applies its effects to the target instead of the caster
/:cl:
