### PR TITLE
[BugFix/Tweak] Fluted half-plate is no longer the same as full-plate

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -301,8 +301,8 @@
 	unequip_delay_self = 6 SECONDS
 
 	max_integrity = ARMOR_INT_CHEST_PLATE_STEEL
-	body_parts_covered = COVERAGE_ALL_BUT_HANDFEET // Less durability than proper plate, more expensive to manufacture, and accurate to the sprite.
-	armor_class = ARMOR_CLASS_HEAVY
+	body_parts_covered = CHEST | VITALS | LEGS // Less durability than proper plate, more expensive to manufacture, and accurate to the sprite.
+	armor_class = ARMOR_CLASS_MEDIUM
 
 // Heretic Graggar Plate
 /obj/item/clothing/suit/roguetown/armor/plate/fluted/graggar


### PR DESCRIPTION
## About The Pull Request

Currently fluted half-plate has the exact same stats as full-plate at half of the cost, while also sharing the exact same traits. 
I've made fluted half-plate share the same traits as half-plate by changing it from heavy armor to medium and giving it the same coverage as the fluted cuirass.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="917" height="227" alt="Screenshot 2026-06-13 132558" src="https://github.com/user-attachments/assets/61e085b2-7745-44bc-9c49-1d1722c4cc73" />


## Why It's Good For The Game

Fluted half-plate having the exact same stats as full plate at half the cost probably wasn't intended.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
fix: Fluted Half-Plate has had its coverage corrected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
