### PR TITLE
Battleaxes your heretics - [woodcutting axe -> battleaxe parity w/ psyheretic/templar]

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -44,7 +44,9 @@
 	to_chat(H, span_warning("You father your unholy cause through the most time-tested of ways: hard, heavy steel in both arms and armor."))
 	H.set_blindness(0)
 	if(H.mind)
-		var/weapons = list("Longsword", "Mace", "Flail", "Axe", "Billhook")
+		var/weapons = list("Longsword", "Mace", "Flail", "Battle Axe", "Billhook")
+		if(!HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT)) //Remove Regular Axe BEFORE choice, is picked (so we don't mislead)
+			weapons += "Steel Axe"
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Longsword")
@@ -67,7 +69,10 @@
 					beltr = /obj/item/rogueweapon/flail/sflail/psyflail
 				else
 					beltr = /obj/item/rogueweapon/flail/sflail
-			if("Axe")
+			if("Steel Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+				beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+			if("Battle Axe")
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
 					beltr = /obj/item/rogueweapon/stoneaxe/battle/psyaxe

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/heretic.dm
@@ -72,7 +72,7 @@
 				if(HAS_TRAIT(H, TRAIT_PSYDONIAN_GRIT))
 					beltr = /obj/item/rogueweapon/stoneaxe/battle/psyaxe
 				else
-					beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel
+					beltr = /obj/item/rogueweapon/stoneaxe/battle
 			if("Billhook")
 				l_hand = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_EXPERT, TRUE)


### PR DESCRIPTION
## About The Pull Request

Changes the woodcutting axe heretics get for picking axe with an actual weapon, since its your main choice and virtually what you'll be using most of the round. Especally as a Tennite heretic or Baothan since those lack armaments rites atm.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

ITS A FEW LINES SIRE, ITS ONE LINE AA- AARGHGHJFGHF- HELP MEEEEEEEEE-

- Spawned in as Psydonic Heretic -> only battleaxe in list (You already only got this)
- Spawned in as Non-Psydonic Heretic -> Steel axe added to list (its at the bottom and I'd rather not do a hacky technique to put it above the billhook but for now its below polearms)
- Spawned in as Non-Psydonic -> Got intended battleaxe -> As Psydonic -> Intended Psydonic one.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

You shouldn't get memed on with a... *steel axe fitted for cutting wood* as your main choice of weapon, with absolutely no parity with most combat roles or even templar.

Since battleaxes have hack intent now, the distinction is clear enough to justify them getting this as a pick. Hopefully this should encourage more builds of heretic that aren't all longsword/flail/mace (I wish more people used polearm heretic, its based as heck NGL).

YOU CAN STILL Pick the OG one, unless you're a Psydonite because you get only a battleaxe as you did before since there's no equiv. `ENDVRE AS HE DOES`

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
balance: woodcutting axe w/ battleaxe choices for regular heretics.
balance: Psyheretics retain and only get the battleaxe choice as they did before under "Axe"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
