### PR TITLE
remove arcanic melds + tweak familiar pricing

### DIFF
--- a/code/game/objects/items/rogueitems/magic/magic_resources.dm
+++ b/code/game/objects/items/rogueitems/magic/magic_resources.dm
@@ -51,38 +51,6 @@
 	. = ..()
 	src.filters += filter(type = "drop_shadow", x=0, y=0, size=1, offset = 2, color = GLOW_COLOR_ARCANE)
 
-// MELD
-/obj/item/magic/melded
-	name = "arcane meld"
-	icon_state = "wessence"
-	desc = "You should not be seeing this"
-	w_class = WEIGHT_CLASS_SMALL
-	sellprice = T1SELLPRICE
-
-/obj/item/magic/melded/t1
-	name = "arcanic meld"
-	icon_state = "meld"
-	desc = "A melding of infernal ash, fairy dust and elemental mote."
-	sellprice = T1MELDSELLPRICE
-
-/obj/item/magic/melded/t2
-	name = "dense arcanic meld"
-	icon_state = "dmeld"
-	desc = "A melding of hellhound fang, iridescent scales and elemental shard."
-	sellprice = T2MELDSELLPRICE
-
-/obj/item/magic/melded/t3
-	name = "sorcerous weave"
-	icon_state = "weave"
-	desc = "A melding of infernal core, heartwood core and elemental fragment."
-	sellprice = T3MELDSELLPRICE
-
-/obj/item/magic/melded/t4
-	name = "magical confluence"
-	icon_state = "confluence"
-	desc = "A melding of abyssal flame, sylvan essence and elemental relic."
-	sellprice = T4MELDSELLPRICE
-
 //mapfetchable items
 /obj/item/magic/obsidian
 	name = "obsidian fragment"

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -194,7 +194,7 @@
 		if(user.get_skill_level(/datum/skill/craft/engineering) >= 3)
 			toggle_mode(user)
 			return
-	if(istype(I, /obj/item/magic/melded/t1) && !powered)
+	if(istype(I, /obj/item/magic/infernal/core) && !powered)
 		user.visible_message(span_notice("[user] starts carefully setting [I] into place as a power source."))
 		if(do_after(user, 5 SECONDS, target = src))
 			qdel(I)

--- a/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
+++ b/code/modules/roguetown/roguejobs/mages/arcana_crafting.dm
@@ -37,28 +37,27 @@
 	result = /obj/item/sendingstonesummoner
 	reqs = list(/obj/item/natural/stone = 2,
 				/obj/item/roguegem/amethyst = 2,
-				/obj/item/magic/melded/t1 = 1)
+				/obj/item/magic/fae/iridescentscale = 1)
 
 /datum/crafting_recipe/roguetown/arcana/voidlamptern
 	name = "void lamptern"
 	result = /obj/item/flashlight/flare/torch/lantern/voidlamptern
 	reqs = list(/obj/item/flashlight/flare/torch/lantern = 1,
-				/obj/item/magic/voidstone = 1,
-				/obj/item/magic/melded/t1 = 1)
+				/obj/item/magic/voidstone = 1)
 
 /datum/crafting_recipe/roguetown/arcana/nomagiccollar
 	name = "mana binding collar"
 	result = /obj/item/clothing/neck/roguetown/collar/leather/nomagic
 	reqs = list(/obj/item/clothing/neck/roguetown/collar = 1,
 				/obj/item/roguegem/diamond = 1,
-				/obj/item/magic/melded/t2 = 1)
+				/obj/item/magic/voidstone = 1)
 
 /datum/crafting_recipe/roguetown/arcana/nomagicglove
 	name = "mana binding gloves"
 	result = /obj/item/clothing/gloves/roguetown/nomagic
 	reqs = list(/obj/item/clothing/gloves/roguetown/leather = 1,
 				/obj/item/roguegem/diamond = 1,
-				/obj/item/magic/melded/t3 = 1)
+				/obj/item/magic/voidstone = 1)
 	craftdiff = SKILL_LEVEL_JOURNEYMAN
 
 /datum/crafting_recipe/roguetown/arcana/temporalhourglass
@@ -66,7 +65,7 @@
 	result = /obj/item/hourglass/temporal
 	reqs = list(/obj/item/natural/wood/plank = 4,
 				/obj/item/magic/leyline = 1,
-				/obj/item/magic/melded/t2 = 1)
+				/obj/item/magic/fae/heartwoodcore = 1)
 	craftdiff = SKILL_LEVEL_JOURNEYMAN
 
 /datum/crafting_recipe/roguetown/arcana/shimmeringlens
@@ -74,14 +73,14 @@
 	result = /obj/item/clothing/ring/active/shimmeringlens
 	reqs = list(/obj/item/magic/fae/iridescentscale = 1,
 				/obj/item/magic/leyline = 1,
-				/obj/item/magic/melded/t2 = 1)
+				/obj/item/magic/elemental/fragment = 1)
 	craftdiff = SKILL_LEVEL_JOURNEYMAN
 
 /datum/crafting_recipe/roguetown/arcana/mimictrinket
 	name = "mimic trinket"
 	result = /obj/item/mimictrinket
 	reqs = list(/obj/item/natural/wood/plank = 2,
-				/obj/item/magic/melded/t1 = 1)
+				/obj/item/magic/fae/iridescentscale = 1)
 
 /datum/crafting_recipe/roguetown/arcana/forge
 	name = "infernal forge"
@@ -98,34 +97,6 @@
 	reqs = list(/obj/item/clothing/ring/gold = 1,
 				/obj/item/magic/voidstone = 1)
 	craftdiff = SKILL_LEVEL_EXPERT
-
-/datum/crafting_recipe/roguetown/arcana/meldt1
-	name = "arcanic meld"
-	result = /obj/item/magic/melded/t1
-	reqs = list(/obj/item/magic/infernal/ash = 1,
-				/obj/item/magic/fae/fairydust = 1,
-				/obj/item/magic/elemental/mote = 1)
-
-/datum/crafting_recipe/roguetown/arcana/meldt2
-	name = "dense arcanic meld"
-	result = /obj/item/magic/melded/t2
-	reqs = list(/obj/item/magic/infernal/fang = 1,
-				/obj/item/magic/fae/iridescentscale = 1,
-				/obj/item/magic/elemental/shard = 1)
-
-/datum/crafting_recipe/roguetown/arcana/meldt3
-	name = "sorcerous weave"
-	result = /obj/item/magic/melded/t3
-	reqs = list(/obj/item/magic/infernal/core = 1,
-				/obj/item/magic/fae/heartwoodcore = 1,
-				/obj/item/magic/elemental/fragment = 1)
-
-/datum/crafting_recipe/roguetown/arcana/meldt4
-	name = "magical confluence"
-	result = /obj/item/magic/melded/t4
-	reqs = list(/obj/item/magic/infernal/flame = 1,
-				/obj/item/magic/fae/sylvanessence = 1,
-				/obj/item/magic/elemental/relic = 1)
 
 // ========== Fission (downgrade, same realm) ==========
 // Lesser: 1 T2 → 2 T1. Greater: 1 T3 → 2 T2. Grand: 1 T4 → 1 T3.

--- a/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/binding.dm
@@ -71,7 +71,6 @@
 	desc = "Bind a lesser infernal to your service: a being of daemonic hatred, specializing in fiery destruction."
 	blacklisted = FALSE
 	mob_to_bind = /mob/living/simple_animal/pet/familiar/infernal
-	required_atoms = list(/obj/item/magic/infernal/fang = 2)
 	invocation = "Appare, spiritus infernus!"
 
 /datum/runeritual/binding/fae
@@ -79,7 +78,6 @@
 	desc =	 "Bind a lesser fae to your service: a being of natural whimsy, specializing in mobility and alchemy."
 	blacklisted = FALSE
 	mob_to_bind = /mob/living/simple_animal/pet/familiar/fae
-	required_atoms = list(/obj/item/magic/fae/iridescentscale = 2)
 	invocation = "Appare, spiritus silvae!"
 
 /datum/runeritual/binding/elemental
@@ -87,7 +85,6 @@
 	desc = "Bind a lesser elemental to your service: a creature of earthen durability, specializing in world-manipulation and repairs."
 	blacklisted = FALSE
 	mob_to_bind = /mob/living/simple_animal/pet/familiar/elemental
-	required_atoms = list(/obj/item/magic/elemental/shard = 2)
 	invocation = "Appare, spiritus terrae!"
 
 /datum/runeritual/binding/void

--- a/code/modules/roguetown/roguejobs/mages/rituals/summons.dm
+++ b/code/modules/roguetown/roguejobs/mages/rituals/summons.dm
@@ -350,7 +350,7 @@
 	tier = 5
 	req_invokers = 3
 	alignment = "void"
-	required_atoms = list(/obj/item/magic/artifact = 5, /obj/item/magic/melded/t4 = 1, /obj/item/magic/voidstone = 3, /obj/item/magic/leyline = 3)
+	required_atoms = list(/obj/item/magic/artifact = 5, /obj/item/magic/fae/sylvanessence = 1, /obj/item/magic/infernal/flame = 1, /obj/item/magic/elemental/relic = 1, /obj/item/magic/voidstone = 3, /obj/item/magic/leyline = 3)
 	primary_mobs = list(/mob/living/simple_animal/hostile/retaliate/rogue/voiddragon)
 	base_primary_count = 1
 	gone_wrong_extra = 0


### PR DESCRIPTION
## About The Pull Request
removes arcanic melds. adjusts recipes using them to use appropriate-tiered planar materials (usually one tier up from the meld they used to require). makes familiar-binding free for everything but the void drakeling

## Testing Evidence
var changes; compiles 

## Why It's Good For The Game
arcanic melds are a vestige of the old vanderlin summoning system that do not fit with the MGL2 iteration of the concept. eating up 3 of your summons, one for each plane, when all the other recipes are designed to eat clean 4/2/1/1 bundles of planar materials is not good and leaves you with weird amounts of leftovers. familiar-binding, also, happens less than it should, when there are people wanting to summon them; this should help with that

## Changelog

:cl:
del: Removed arcanic melds, replaced them with thematically-appropriate planar materials. Artificer armor is now powered by an infernal core like the infernal engines and infernal forge are.
qol: Familiar-binding is now free, except for the most hubristic of pursuits.
/:cl:
