### PR TITLE
[Miracles] - Heavily improves prayer, shifts some of devotee to baseline regen.

### DIFF
--- a/code/__DEFINES/cleric.dm
+++ b/code/__DEFINES/cleric.dm
@@ -8,13 +8,13 @@
 
 #define CLERIC_REQ_0 0
 #define CLERIC_REQ_1 250
-#define CLERIC_REQ_2 400
+#define CLERIC_REQ_2 500
 #define CLERIC_REQ_3 750
 #define CLERIC_REQ_4 1000
 
-#define CLERIC_REGEN_DEVOTEE 0.3
-#define CLERIC_REGEN_WEAK 0.1 //Would be better to just do away with devotion entirely, but oh well.
-#define CLERIC_REGEN_MINOR 0.5
-#define CLERIC_REGEN_MAJOR 0.8
-#define CLERIC_REGEN_WITCH 0.3
+#define CLERIC_REGEN_DEVOTEE 0.15
+#define CLERIC_REGEN_WEAK 0.25 //Would be better to just do away with devotion entirely, but oh well.
+#define CLERIC_REGEN_MINOR 0.65
+#define CLERIC_REGEN_MAJOR 0.95
+#define CLERIC_REGEN_WITCH 0.45
 #define CLERIC_REGEN_ABSOLVER 5

--- a/code/__DEFINES/cleric.dm
+++ b/code/__DEFINES/cleric.dm
@@ -12,9 +12,9 @@
 #define CLERIC_REQ_3 750
 #define CLERIC_REQ_4 1000
 
-#define CLERIC_REGEN_DEVOTEE 0.15
-#define CLERIC_REGEN_WEAK 0.25 //Would be better to just do away with devotion entirely, but oh well.
-#define CLERIC_REGEN_MINOR 0.65
-#define CLERIC_REGEN_MAJOR 0.95
-#define CLERIC_REGEN_WITCH 0.45
+#define CLERIC_REGEN_DEVOTEE 0.1
+#define CLERIC_REGEN_WEAK 0.3 //Would be better to just do away with devotion entirely, but oh well.
+#define CLERIC_REGEN_MINOR 0.7
+#define CLERIC_REGEN_MAJOR 1
+#define CLERIC_REGEN_WITCH 0.5
 #define CLERIC_REGEN_ABSOLVER 5

--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -1,3 +1,10 @@
+// Multiplier to standardize values per second to how long a prayer loop takes
+#define PRAYER_DEVOTION_TIME_MULT 3
+// Amount of devotion before holy skill is factored in per prayer loop
+#define PRAYER_DEVOTION_BASE 0.5 * PRAYER_DEVOTION_TIME_MULT
+// Amount of devotion per holy skill level per prayer loop
+#define PRAYER_DEVOTION_SKILL 1 * PRAYER_DEVOTION_TIME_MULT
+
 // Cleric Holder Datums
 /datum/devotion
 	/// Mob that owns this datum
@@ -20,8 +27,8 @@
 	var/passive_devotion_gain = 0
 	/// How much progression is gained per process call
 	var/passive_progression_gain = 0
-	/// How much devotion is gained per prayer cycle
-	var/prayer_effectiveness = 2
+	/// How much % devotion is gained per prayer cycle
+	var/prayer_effectiveness = 1
 	/// Spells we have granted thus far
 	var/list/granted_spells
 
@@ -182,10 +189,11 @@
 			break
 		if(!do_after(src, 30))
 			break
-		var/devotion_multiplier = 1
+		// Values standardized for 3 seconds.
+		var/devotion_multiplier = PRAYER_DEVOTION_BASE
 		if(mind)
-			devotion_multiplier += (get_skill_level(/datum/skill/magic/holy) / SKILL_LEVEL_LEGENDARY)
-		var/prayer_effectiveness = round(devotion.prayer_effectiveness * devotion_multiplier)
+			devotion_multiplier += (get_skill_level(/datum/skill/magic/holy) * PRAYER_DEVOTION_TIME_MULT)
+		var/prayer_effectiveness = round(devotion.prayer_effectiveness * devotion_multiplier, 0.1)
 		devotion.update_devotion(prayer_effectiveness, prayer_effectiveness)
 		prayersesh += prayer_effectiveness
 	visible_message("[src] concludes their prayer.", "I conclude my prayer.")
@@ -284,3 +292,7 @@
 	var/datum/component/ore_sight/COS = GetComponent(/datum/component/ore_sight)
 	if(COS)
 		COS.change_range()
+
+#undef PRAYER_DEVOTION_TIME_MULT
+#undef PRAYER_DEVOTION_BASE
+#undef PRAYER_DEVOTION_SKILL


### PR DESCRIPTION
## About The Pull Request
- Increases T2 cleric cap from 400 to 500 devotion to get 250/500/750/1000 devotion cap for the tiers.
- Rehashes praying for devotion from being a flat 1 regen per second despite it being meant to scale with skill.
- Now scales for 0.5 regen per second of prayer + 1 * skill.
- Example, master skill 5 * 1 is 5 per second. 0.5 base. 5.5 per second.
- 3 second per prayer cycle => 16.5 per prayer cycle. (3x 5.5)
- Moved 0.2 regen per second from devotee to all classes to make devotee tax less of a thing. Someone with devotee would regen their devotion 3x as fast as an actual paladin without devotee.
- With the prayer buff, someone with devotee and novice miracle skill regains their devotion 50% faster whilst praying anyways.
- Defines make me happy

## Testing Evidence
<img width="282" height="85" alt="image" src="https://github.com/user-attachments/assets/c0aed4b1-b78a-476d-bed7-040da971f8d6" />

## Why It's Good For The Game
Pending the day we actually remove devotion.. this makes it so praying is actually effective.
Before it could take a missionary 9 real minutes of prayer to reasonably refill their bar, unless they had devotee. None of our other classes have this kind of insane tax, and miracles already have hefty stamina costs. And in some cases, long cooldowns.

Devotee Shouldn't feel mandatory. It was a 60% regen increase for missionary. 400% for paladin. and 37.5% for acolyte. Let's- not be silly.

## Changelog

:cl:
balance: 66% of devotee regen is now basekit for miracle classes with regen.
balance: Prayer is now far more effective for regaining devotion as it scales with miracle skill properly now.
/:cl:

