### PR TITLE
Disgraced MAA (Deserter) Improved

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -163,13 +163,13 @@
 		)
 
 /datum/advclass/wretch/deserter/generic
-	name = "Deserter"
-	tutorial = "You had your post. You had your duty. Dissatisfied, lacking in morale, or simply thinking yourself better than it. - You decided to walk. Now it follows you everywhere you go."
+	name = "Militant"
+	tutorial = "It matters not what cause you swing your weapon for, in the end you fight the same way your ancestors and their ancestors did: clad in metal and intimately intertwined with gore and death."
 	outfit = /datum/outfit/job/roguetown/wretch/desertergeneric
-	maximum_possible_slots = 2 //Ideal role for fraggers. Better to limit it.
+	maximum_possible_slots = -1 //Ideal role for fraggers. Better to limit it... Except you are just a medium armour guy with a weapon. Can you believe that rogue mages are unlimited?
 
 	cmode_music = 'sound/music/cmode/antag/combat_thewall.ogg' // same as new hedgeknight music
-	// Slightly more rounded. These can be nudged as needed.
+	//+9 weighted total, and you *may* get +3 weighted stat points from your chosen archetype for the +12 weighted total. In a world full of wizards and miracleworkers, being a normal soldier sucks.
 	traits_applied = list(TRAIT_MEDIUMARMOR)
 	subclass_stats = list(
 		STATKEY_STR = 2,
@@ -188,13 +188,15 @@
 		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT, // Better at climbing away than your average MaA. Only slightly.
-		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN, // Worse at swimming than the above class.
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT, //Better at climbing away than your average MaA. Only slightly.
+		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN, //Worse at swimming than the above class.
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN, // That saiga was stolen. Probably.
-		/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/riding = SKILL_LEVEL_NOVICE, //No free mount anymore; pick Cavalryman archetype for a mount and better Riding.
 	)
+	subclass_virtues = list(
+		null
+	) //Unlike Disgraced Knight, you don't get a free mount.
 /datum/outfit/job/roguetown/wretch/desertergeneric/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.mind)
@@ -226,45 +228,166 @@
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 				backl = /obj/item/quiver/bolt/standard
 	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders))
+	belt = /obj/item/storage/belt/rogue/leather
+	beltl = /obj/item/rogueweapon/mace/cudgel
+	backr = /obj/item/storage/backpack/rogue/satchel
 	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/movemovemove)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/takeaim)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/hold)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/onfeet)
+//		Pick Sergeant for buff orders.
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
 		var/helmets = list(
-			"Pigface Bascinet" 		= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
-			"Hounskull Bascinet"	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull,
-			"Klappvisier Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/etruscan,
-			"Visored Sallet"		= /obj/item/clothing/head/roguetown/helmet/sallet/visored,
-			"Sugarloaf Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/bucket/crusader,
-			"Knight's Armet"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight,
-			"Knight's Helmet"	= /obj/item/clothing/head/roguetown/helmet/heavy/knight/old,
-			"Knight's Greatplumed Armet"		= /obj/item/clothing/head/roguetown/helmet/heavy/knight/greatplume,
+			"Simple Helmet" 		 	= /obj/item/clothing/head/roguetown/helmet,
+			"Kettle Helmet" 		 	= /obj/item/clothing/head/roguetown/helmet/kettle,
+			"Bascinet Helmet" 		 	= /obj/item/clothing/head/roguetown/helmet/bascinet,
+			"Sallet Helmet" 		 	= /obj/item/clothing/head/roguetown/helmet/sallet,
+			"Winged Helmet" 		 	= /obj/item/clothing/head/roguetown/helmet/winged,
+			//Helmets below are ethnic choices.
+			"Grenzelhoftian Plume Hat"	= /obj/item/clothing/head/roguetown/grenzelhofthat,
+			"Steel Shishak" 			= /obj/item/clothing/head/roguetown/helmet/sallet/shishak,	
+			"Gronnic Ownel Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi/gronn/ownel,
+			"Varangian Owl Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi,
+			"Kulah Khud"				= /obj/item/clothing/head/roguetown/helmet/sallet/raneshen,
+			"Jingasa"					= /obj/item/clothing/head/roguetown/helmet/kettle/jingasa,
 		)
 		var/helmchoice = input(H, "Choose your Helm.", "TAKE UP HELMS") as anything in helmets
 		head = helmets[helmchoice]
 
-		var/armors = list(
-			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
-			"Half-Plate"		= /obj/item/clothing/suit/roguetown/armor/plate/iron,
-			"Scalemail"			= /obj/item/clothing/suit/roguetown/armor/plate/scale,
-		)
+		var/armors = list("Brigandine Set", "Maille Set", "Cuirass Set", "Grenzelhoftian Set", "Steppesman Set", "Gronnic Set", "Varangian Set", "Raneshen Set", "Kazengunite Set", "Otavan Set")
 		var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors
-		armor = armors[armorchoice]
-
+		switch(armorchoice)
+			if("Brigandine Set")
+				neck = /obj/item/clothing/neck/roguetown/gorget/steel
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+				pants = /obj/item/clothing/under/roguetown/brigandinelegs
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
+				gloves = /obj/item/clothing/gloves/roguetown/chain
+				shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
+			if("Maille Set")
+				neck = /obj/item/clothing/neck/roguetown/chaincoif
+				armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				gloves = /obj/item/clothing/gloves/roguetown/chain
+				shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
+			if("Cuirass Set")
+				neck = /obj/item/clothing/neck/roguetown/gorget/steel
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				gloves = /obj/item/clothing/gloves/roguetown/chain
+				shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
+			if("Grenzelhoftian Set")
+				neck = /obj/item/clothing/neck/roguetown/gorget
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/blacksteel //Better chest protection, but your limbs are poorly protected.
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				gloves = /obj/item/clothing/gloves/roguetown/angle/grenzelgloves
+				shoes = /obj/item/clothing/shoes/roguetown/grenzelhoft
+			if("Steppesman Set")
+				neck = /obj/item/clothing/neck/roguetown/chaincoif
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale/steppe
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/chargah
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				gloves = /obj/item/clothing/gloves/roguetown/chain
+				shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot/steppesman
+			if("Gronnic Set")
+				neck = /obj/item/clothing/neck/roguetown/leather
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/gronn
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy //Apparently legit Leðurháls don't get a shirt-slot item at all. Why? 
+				pants = /obj/item/clothing/under/roguetown/chainlegs/gronn
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/splint
+				gloves = /obj/item/clothing/gloves/roguetown/chain/gronn
+				shoes = /obj/item/clothing/shoes/roguetown/boots/leather/atgervi
+			if("Varangian Set")
+				neck = /obj/item/clothing/neck/roguetown/chaincoif/chainmantle
+				armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/atgervi
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+				pants = /obj/item/clothing/under/roguetown/trou/leather/atgervi
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				gloves = /obj/item/clothing/gloves/roguetown/angle/atgervi
+				shoes = /obj/item/clothing/shoes/roguetown/boots/leather/atgervi
+			if("Raneshen Set")
+				neck = /obj/item/clothing/neck/roguetown/chaincoif/full
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/raneshen
+				pants = /obj/item/clothing/under/roguetown/brigandinelegs
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/brigandine
+				gloves = /obj/item/clothing/gloves/roguetown/chain
+				shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced //Legit Desert Rider Janissary gets babouches instead.
+			if("Kazengunite Set")
+				neck = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun
+				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/haraate
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy //Legit Hangyaku-Chonin gets a tunic instead.
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun
+				wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+				gloves = /obj/item/clothing/gloves/roguetown/plate/kote
+				shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/kazengun
+			if("Otavan Set")
+				neck = /obj/item/clothing/neck/roguetown/fencerguard
+				armor = /obj/item/clothing/suit/roguetown/armor/plate/cuirass/fluted //Actual Otavan plate's AC is heavy.
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/otavan
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan
+				wrists = /obj/item/clothing/wrists/roguetown/bracers
+				gloves = /obj/item/clothing/gloves/roguetown/otavan
+				shoes = /obj/item/clothing/shoes/roguetown/boots/otavan
+		var/specialization = list("Offence & Defence", "Mobility & Ranged Combat", "Cavalry", "Field Medicine", "Faith", "Leadership") //Faith and Leadership don't grant stat bonuses.
+		var/specialization_choice = input (H, "Choose your primary training.", "HOW DO YOU KILL?") as anything in specialization
+		switch(specialization_choice)
+			if("Offence & Defence") //Doubles down on Militant's existing strengths.
+				cloak = /obj/item/clothing/cloak/tabard/stabard
+				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_MASTER, TRUE) //It's just +5 more stamina, so it's okay...?
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/misc/swimming, SKILL_LEVEL_EXPERT, TRUE)
+				H.change_stat(STATKEY_STR, 1)
+				H.change_stat(STATKEY_CON, 1)
+				to_chat(H, span_warning("You trained to fight as a part of dense infantry formations. This made you fit, but you didn't have a chance to pick up any other skills."))
+			if("Mobility & Ranged Combat")
+				cloak = /obj/item/clothing/cloak/raincloak/furcloak
+				beltl = /obj/item/quiver/javelin/steel
+				H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/slings, SKILL_LEVEL_JOURNEYMAN, TRUE) //Procure your own weapons.
+				H.change_stat(STATKEY_SPD, 1)
+				H.change_stat(STATKEY_PER, 1)
+				to_chat(H, span_warning("You trained to fight in loose formations, harassing your foes from afar with throwning weapons and swift attacks."))
+			if("Cavalry")
+				cloak = /obj/item/clothing/cloak/tabard
+				ADD_TRAIT(H, TRAIT_EQUESTRIAN, TRAIT_GENERIC)
+				H.adjust_skillrank_up_to(/datum/skill/misc/riding, SKILL_LEVEL_EXPERT, TRUE) //On par with Disgraced Knight.
+				H.change_stat(STATKEY_WIL, 1)
+				H.change_stat(STATKEY_INT, 1)
+				H.change_stat(STATKEY_PER, 1)
+				H.AddSpell(new /obj/effect/proc_holder/spell/self/choose_riding_virtue_mount)
+				to_chat(H, span_warning("You trained in equestrianism, fighting atop mighty steeds and raising yourself above common infantry."))
+			if("Field Medicine") //No TRAIT_MEDICINE_EXPERT, so you can't progress past Expert without the virtue.
+				cloak = /obj/item/clothing/suit/roguetown/shirt/robe/feld
+				beltl = /obj/item/storage/belt/rogue/surgery_bag
+				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_EXPERT, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, SKILL_LEVEL_APPRENTICE, TRUE)
+				H.change_stat(STATKEY_INT, 2)
+				H.change_stat(STATKEY_CON, 1)
+				to_chat(H, span_warning("You were a field chirurgeon, a healer rather than a killer. In time, you learned how to murder and became both."))
+			if("Faith") //Evil Templar - T2 miracleworker, except medium armour-clad. No stat bonuses, and the only bonus skill you gain is Miracles.
+				cloak = /obj/item/clothing/cloak/cape/crusader
+				beltl = /obj/item/clothing/neck/roguetown/psicross //Use loadout.
+				H.adjust_skillrank_up_to(/datum/skill/magic/holy, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				var/datum/devotion/C = new /datum/devotion(H, H.patron)
+				C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_2)
+				to_chat(H, span_warning("Your training in combat was merely a step in your path to becoming a living weapon of your deity."))
+			if("Leadership") //You get orders and complementary Expert Wrestling. This is less-more classic Deserter.
+				cloak = /obj/item/clothing/cloak/tabard/stabard
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/movemovemove)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/takeaim)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/hold)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/onfeet)
+				to_chat(H, span_warning("You trained how to organise and lead your fellow fighters into battles."))
 		wretch_select_bounty(H)
-
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
-	pants = /obj/item/clothing/under/roguetown/chainlegs
-	neck = /obj/item/clothing/neck/roguetown/bevor
-	cloak = /obj/item/clothing/cloak/tabard/stabard/surcoat
-	wrists = /obj/item/clothing/wrists/roguetown/bracers
-	gloves = /obj/item/clothing/gloves/roguetown/chain
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
-	beltl = /obj/item/rogueweapon/mace/cudgel
-	belt = /obj/item/storage/belt/rogue/leather
-	backr = /obj/item/storage/backpack/rogue/satchel
 
 	backpack_contents = list(/obj/item/natural/cloth = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/flashlight/flare/torch/lantern/prelit = 1, /obj/item/rogueweapon/scabbard/sheath = 1)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -2,7 +2,7 @@
 	name = "Disgraced Knight"
 	tutorial = "You were once a venerated and revered knight - now, a traitor who abandoned your liege. You lyve the lyfe of an outlaw, shunned and looked down upon by society."
 	allowed_sexes = list(MALE, FEMALE)
-	
+
 	outfit = /datum/outfit/job/roguetown/wretch/deserter
 	class_select_category = CLASS_CAT_WARRIOR
 	category_tags = list(CTAG_WRETCH)
@@ -228,6 +228,7 @@
 				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 				backl = /obj/item/quiver/bolt/standard
 	add_verb(H, list(/mob/living/carbon/human/mind/proc/setorders))
+	mask = /obj/item/clothing/mask/rogue/facemask/steel
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/rogueweapon/mace/cudgel
 	backr = /obj/item/storage/backpack/rogue/satchel
@@ -242,7 +243,7 @@
 			"Winged Helmet" 		 	= /obj/item/clothing/head/roguetown/helmet/winged,
 			//Helmets below are ethnic choices.
 			"Grenzelhoftian Plume Hat"	= /obj/item/clothing/head/roguetown/grenzelhofthat,
-			"Steel Shishak" 			= /obj/item/clothing/head/roguetown/helmet/sallet/shishak,	
+			"Steel Shishak" 			= /obj/item/clothing/head/roguetown/helmet/sallet/shishak,
 			"Gronnic Ownel Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi/gronn/ownel,
 			"Varangian Owl Helmet"		= /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi,
 			"Kulah Khud"				= /obj/item/clothing/head/roguetown/helmet/sallet/raneshen,
@@ -297,7 +298,7 @@
 			if("Gronnic Set")
 				neck = /obj/item/clothing/neck/roguetown/leather
 				armor = /obj/item/clothing/suit/roguetown/armor/brigandine/gronn
-				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy //Apparently legit Leðurháls don't get a shirt-slot item at all. Why? 
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy //Apparently legit Leðurháls don't get a shirt-slot item at all. Why?
 				pants = /obj/item/clothing/under/roguetown/chainlegs/gronn
 				wrists = /obj/item/clothing/wrists/roguetown/bracers/splint
 				gloves = /obj/item/clothing/gloves/roguetown/chain/gronn


### PR DESCRIPTION
## About The Pull Request
This PR changes Disgraced MAA (Deserter) quite a bit.

- "Deserter" is renamed to "Militant" to accomodate its much more generic and all-encompassing nature.
- Militant is no longer slotcapped. Do you really mean to tell me that Rogue Mage is unslotcapped, but a shouting guy with a sharp stick isn't?
- Militant loses Novice Tracking.
- Militant no longer gets orders (except for recruiting) by default. It's gated behind "Leadership" specialisation.
- Militant gets Novice Riding instead of Journeyman+1 Riding, and no free mount by default. It's gated behind "Cavalry" specialisation.
- Militant gets medium helmets + steel mask instead of heavy helmets + no mask. I mean, it's a MEDIUM ARMOUR guy.
- Militant gets a LOT more armour choices, including ethnic armour pieces that are normally found on Mercenaries and certain Migrants.
- Militant gets to choose from 6 different specialisations, detailed below. 4 of them get you stat bonuses up to +12 weighted total (on par with Disgraced Knights and Heretics), other 2 don't.

Militant Specialisations:

- Offence & Defence. Master Athletics, Expert Wrestling and Swimming, +1 STR and CON. Less-more John Militant.
- Mobility & Ranged Combat. Journeyman Sneaking, Bows, Crossbows and Slings, +1 SPD and PER, a bag of 4 steel javelins for free.
- Cavalry. Trait Equestrian, can summon a free mount like before, Expert Riding, +1 WIL, INT and PER.
- Field Medicine. Expert Medicine, Apprentice Alchemy, +2 INT and +1 CON, a surgeon's bag for free.
- Faith. No stat bonuses, you get T2 miracles on par with Templars or Atgervi Varangians. Basically far worse Heretic. Good for roleplaying a character who's more of a warrior than a cleric.
- Leadership. No stat bonuses, Expert Wrestling and old Deserter orders. It's Deserter like how it was before, almost.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4ceb4ac4-d77a-416b-b091-e05ba78c93e1" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f9c82209-4711-410a-b93a-23781fe69307" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Deserter is a mind-numbingly okay class on par with most Mercenaries. There has never been much of a reason to choose it besides roleplay, and by giving it more fashion options and some extra things to play with, it will hopefully be a slightly more attractive option.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
add: 6 different specialisations for Wretch-Deserter (now called Militant)
balance: no free mount, no Tracking and only Novice Riding for Militants without a specialisation.
balance: Militants get a medium helmet + a steel mask instead of a heavy helmet + no mask.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
