### PR TITLE
hotfix, speedmerge, etc: someone forgot to set a category for this

### DIFF
--- a/code/datums/loadout/_loadout.dm
+++ b/code/datums/loadout/_loadout.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_EMPTY(loadout_items_by_name)
 	var/list/ckeywhitelist
 	var/donator_unlocked = FALSE
 	var/triumph_cost
-	var/sort_category = "Miscellaneous" 	//Used for sorting loadout items in the menu. Should be one of the following: One per each file
+	var/sort_category = "Misc" 	//Used for sorting loadout items in the menu. Should be one of the following: One per each file
 
 /datum/loadout_item/New()
 	if(isnull(donoritem))

--- a/code/datums/loadout/loadout_miscellaneous.dm
+++ b/code/datums/loadout/loadout_miscellaneous.dm
@@ -18,6 +18,7 @@
 /datum/loadout_item/tarot_deck_majorarcana
 	name = "Tarot Deck (Major Arcana)"
 	path = /obj/item/toy/cards/deck/tarot/majorarcana
+	sort_category = "Misc"
 
 /datum/loadout_item/custom_book
 	name = "Custom Book"


### PR DESCRIPTION
## About The Pull Request
someone forgot to set a category for tarot deck (major arcana) and the default wasn't updated leading to there being two misc categories, this fixes that

## Testing Evidence
text variable change

## Why It's Good For The Game
less categories in the menu = less squished, "miscellaneous" and "misc" existing at once is silly

