### PR TITLE
Update cure wound and reduces Graggar's heal time by 20%(no not the regen duration, the heal strenght)

### DIFF
--- a/code/datums/gods/patrons/inhumen/graggar.dm
+++ b/code/datums/gods/patrons/inhumen/graggar.dm
@@ -45,7 +45,7 @@
 	var/bonus = 0
 
 	for(var/obj/effect/decal/cleanable/blood/blood in oview(5, target))
-		bonus = min(bonus + 0.1, 2.5)
+		bonus = min(bonus + 0.1, 2)
 	
 	if(!bonus)
 		return

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -63,7 +63,7 @@
 	invocation_type = INVOCATION_NONE
 
 	charge_required = FALSE
-	cooldown_time = 15 SECONDS
+	cooldown_time = 10 SECONDS
 
 	spell_requirements = SPELL_REQUIRES_HUMAN | SPELL_REQUIRES_SAME_Z
 

--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -44,7 +44,7 @@
 	<li><b>Xylix:</b> 50% chance of a random +40% to +100% bonus.</li>\
 	<li><b>Undivided:</b> Always +80% with no conditions.</li>\
 	<li><b>Baotha:</b> +20% if the target is drunk or on drugs. +20% if experiencing withdrawal. Up to +80% additional from wound pain and bleeding. Up to +120% total.</li>\
-	<li><b>Graggar:</b> Up to +100% scaling with nearby blood decals.</li>\
+	<li><b>Graggar:</b> Up to +80% scaling with nearby blood decals.</li>\
 	<li><b>Matthios:</b> +100% if the target has the Freeman trait.</li>\
 	<li><b>Zizo:</b> Up to +200% scaling with nearby bones and bone bundles.</li>\
 	</ul>"


### PR DESCRIPTION
## About The Pull Request

Bring back the cooldown to the original cooldown, and bring ever so slightly down graggar's max conditional to 2

## Testing Evidence
1 character change

## Why It's Good For The Game

We live in a world that is not perfect, same for the current state of miracle., there are effectively 2 schools of miracles casters, the Healers(T3 undivided, T3 Pestran, T2 Astratan(god this is a fucking mess, please someone reminds me why Undivided has the best utility miracles out there AND Fortify?) and the others than can slowly and painfuly patch your 300+ brute and burn damage across most body parts. the devotion cost stay the same but you will at the **very least** be able to keep your friends from instantly dying because you have to spend half of the regen duration doing nothing(yeah you already gave them water/red and stitched their bleeding wounds).

Or you could say i fix an undocumented change, while the 15 devotion cost per cast make all regen tiers with devotee unable to fully make each cast devotion-positive(in other words you will always lose a bit of devotion by keeping the healing active, bishop and heretics probably might still be positive but eh, thats their whole schtick for being good miracle casters.)

Many people also complained about gnolls healing themselves in an absurdly fast amount of time, tuning slightly down graggar's max conditional to 2(so about -20%)

## Changelog


:cl:
qol: Remove 5 seconds from Miracle's CD
qol: lower graggar's maximum conditional reduced by 0.5(down to 2)
/:cl:


