### PR TITLE
[Fix] Bathing and Skin Armor

### DIFF
--- a/code/datums/status_effects/relaxing_bath.dm
+++ b/code/datums/status_effects/relaxing_bath.dm
@@ -57,7 +57,7 @@ dreaming. Still have to go to sleep to learn skills. Also gives healing tickrate
 		else
 			soapy = FALSE
 
-		if((src.wear_armor && !istype(src.wear_armor, /obj/item/clothing/suit/roguetown/armor/regenerating/skin)) || (src.head && src.head.armor?.stab > 70))
+		if((src.wear_armor && !(HAS_TRAIT(src.wear_armor, TRAIT_NODROP))) || (src.head && src.head.armor?.stab > 70))
 			soak_count--
 			if(prob(10))
 				to_chat(src, span_warning("I'm not getting the most out of this with my outer clothes on."))

--- a/code/datums/status_effects/relaxing_bath.dm
+++ b/code/datums/status_effects/relaxing_bath.dm
@@ -57,7 +57,7 @@ dreaming. Still have to go to sleep to learn skills. Also gives healing tickrate
 		else
 			soapy = FALSE
 
-		if(src.wear_armor || src.head && src.head.armor?.stab > 70)
+		if((src.wear_armor || src.head && src.head.armor?.stab > 70) && !istype(src.wear_armor, /obj/item/clothing/suit/roguetown/armor/regenerating/skin))
 			soak_count--
 			if(prob(10))
 				to_chat(src, span_warning("I'm not getting the most out of this with my outer clothes on."))

--- a/code/datums/status_effects/relaxing_bath.dm
+++ b/code/datums/status_effects/relaxing_bath.dm
@@ -57,7 +57,7 @@ dreaming. Still have to go to sleep to learn skills. Also gives healing tickrate
 		else
 			soapy = FALSE
 
-		if((src.wear_armor || src.head && src.head.armor?.stab > 70) && !istype(src.wear_armor, /obj/item/clothing/suit/roguetown/armor/regenerating/skin))
+		if((src.wear_armor && !istype(src.wear_armor, /obj/item/clothing/suit/roguetown/armor/regenerating/skin)) || (src.head && src.head.armor?.stab > 70))
 			soak_count--
 			if(prob(10))
 				to_chat(src, span_warning("I'm not getting the most out of this with my outer clothes on."))


### PR DESCRIPTION
## About The Pull Request

- Skin Armor does not count as "armor" for bathing purposes.

## Testing Evidence

Compiles.

## Why It's Good For The Game

Just an exception added to the line that checks for armor worn.

## Changelog
:cl:
fix: You can bathe with Skin Armor now. No need to take off your skin to bathe anymore.
/:cl: