### PR TITLE
[Bugfix] - Fixes removeallspells to removeallspells. Including mage 2 actions versus the old proc holders.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1081,6 +1081,8 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 /datum/mind/proc/RemoveAllSpells()
 	for(var/datum/S in spell_list)
 		RemoveSpell(S)
+	for(var/datum/SP in current.actions)
+		RemoveSpell(SP)
 
 /datum/mind/proc/transfer_martial_arts(mob/living/new_character)
 	if(!ishuman(new_character))


### PR DESCRIPTION
## About The Pull Request
Probably was missed in the refactor.

## Testing Evidence
<img width="1904" height="826" alt="image" src="https://github.com/user-attachments/assets/59902be0-b9d1-4712-b7d1-e651ce2fc862" />

Pictured : dreamwalker mage associate after picking spells.

## Why It's Good For The Game
Stops things like dreamwalker from having non dreamwalker spells when they shouldn't.

## Changelog

:cl:
fix: Removeallspells proc removes all spells again
/:cl:

