### PR TITLE
Removes origin lock from prince/duke

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -46,7 +46,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 
 /datum/outfit/job/roguetown/lord
 	job_bitflag = BITFLAG_ROYALTY
-	has_loadout = TRUE
 
 /datum/job/roguetown/lord/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
@@ -107,24 +106,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 			qdel(H.wear_mask)
 			mask = /obj/item/clothing/mask/rogue/lordmask/l
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
-
-/datum/outfit/job/roguetown/lord/choose_loadout(mob/living/carbon/human/H)
-	. = ..()
-	var/client/player = H?.client
-	if(player.prefs)
-		if(!istype(player.prefs.virtue_origin, /datum/virtue/origin/azuria) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/grenzelhoft) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/otava) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/etrusca))
-			var/list/new_origins = list("Azuria" = /datum/virtue/origin/azuria, 
-			"Grenzelhoft" = /datum/virtue/origin/grenzelhoft,
-			"Otava" = /datum/virtue/origin/otava,
-			"Etrusca" = /datum/virtue/origin/etrusca)
-			var/new_origin
-			var/choice = input(player, "Your origins are not compatible with the [SSticker.realm_type_short]. Where do you hail from?", "ANCESTRY") as anything in new_origins
-			if(choice)
-				new_origin = new_origins[choice]
-			else
-				to_chat(player, span_notice("No choice detected. Picking a random compatible origin."))
-				new_origin = pick(/datum/virtue/origin/grenzelhoft, /datum/virtue/origin/otava, /datum/virtue/origin/etrusca)
-			change_origin(H, new_origin, "Royal line")
 
 //	SSticker.rulermob = H
 /**

--- a/code/modules/jobs/job_types/roguetown/nobility/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/prince.dm
@@ -34,25 +34,6 @@
 /datum/outfit/job/roguetown/heir/pre_equip(mob/living/carbon/human/H)
 	..()
 	add_verb(H, /mob/living/carbon/human/proc/declarechampion)
-	has_loadout = TRUE
-
-/datum/outfit/job/roguetown/heir/choose_loadout(mob/living/carbon/human/H)
-	. = ..()
-	var/client/player = H?.client
-	if(player.prefs)
-		if(!istype(player.prefs.virtue_origin, /datum/virtue/origin/azuria) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/grenzelhoft) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/otava) && !istype(player.prefs.virtue_origin, /datum/virtue/origin/etrusca))
-			var/list/new_origins = list("Azuria" = /datum/virtue/origin/azuria,
-			"Grenzelhoft" = /datum/virtue/origin/grenzelhoft,
-			"Otava" = /datum/virtue/origin/otava,
-			"Etrusca" = /datum/virtue/origin/etrusca)
-			var/new_origin
-			var/choice = input(player, "Your origins are not compatible with the [SSticker.realm_type_short]. Where do you hail from?", "ANCESTRY") as anything in new_origins
-			if(choice)
-				new_origin = new_origins[choice]
-			else
-				to_chat(player, span_notice("No choice detected. Picking a random compatible origin."))
-				new_origin = pick(/datum/virtue/origin/grenzelhoft, /datum/virtue/origin/otava, /datum/virtue/origin/etrusca)
-			change_origin(H, new_origin, "Royal line")
 
 /datum/advclass/heir/daring
 	name = "Daring Twit"


### PR DESCRIPTION
## About The Pull Request

Removed the origin lock that prevented characters from being from anywhere but Azure/Etrusca/Otava/Grenzelhoft

## Testing Evidence

<img width="1920" height="1080" alt="dreamseeker_SopVvgzNP1" src="https://github.com/user-attachments/assets/225ed28f-8572-4edd-9f18-9902fdaefe4c" />
<img width="1920" height="1080" alt="dreamseeker_uvgRpRG6Zo" src="https://github.com/user-attachments/assets/f5682381-08b9-4e1d-8123-a5c44168e878" />

## Why It's Good For The Game

Players should be allowed to be creative with their characters. Limiting options kills creativity. If someone rp's badly the reason why they have a claim to the throne, it is an administrative issue, and not a code one.

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->

:cl:
del: Removed origin locks on prince and duke.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
